### PR TITLE
jobs: remove jobs.MaybeGenerateForcedRetryableError

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -274,7 +274,7 @@ func backup(
 					return nil
 				}
 				jobsprofiler.StorePerNodeProcessorProgressFraction(
-					ctx, execCtx.ExecCfg().InternalDB, job.ID(), prog, execCtx.ExecCfg().Settings.Version)
+					ctx, execCtx.ExecCfg().InternalDB, job.ID(), prog)
 			case <-ctx.Done():
 				return ctx.Err()
 			}
@@ -1964,7 +1964,7 @@ func (b *backupResumer) CollectProfile(ctx context.Context, execCtx interface{})
 		aggStatsCopy = b.mu.perNodeAggregatorStats.DeepCopy()
 	}()
 	return bulkutil.FlushTracingAggregatorStats(ctx, b.job.ID(),
-		p.ExecCfg().InternalDB, aggStatsCopy, p.ExecCfg().Settings.Version)
+		p.ExecCfg().InternalDB, aggStatsCopy)
 }
 
 func (b *backupResumer) deleteCheckpoint(

--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -219,7 +219,7 @@ func distBackup(
 	defer close(progCh)
 	defer close(tracingAggCh)
 	execCfg := execCtx.ExecCfg()
-	jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, jobID, execCfg.Settings.Version)
+	jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, jobID)
 
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -2550,7 +2550,7 @@ func (r *restoreResumer) CollectProfile(ctx context.Context, execCtx interface{}
 		aggStatsCopy = r.mu.perNodeAggregatorStats.DeepCopy()
 	}()
 	return bulkutil.FlushTracingAggregatorStats(ctx, r.job.ID(),
-		p.ExecCfg().InternalDB, aggStatsCopy, p.ExecCfg().Settings.Version)
+		p.ExecCfg().InternalDB, aggStatsCopy)
 }
 
 // dropDescriptors implements the OnFailOrCancel logic.

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -317,7 +317,7 @@ func distRestore(
 		defer recv.Release()
 
 		execCfg := execCtx.ExecCfg()
-		jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, md.jobID, execCfg.Settings.Version)
+		jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, md.jobID)
 
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -303,7 +303,7 @@ func startDistChangefeed(
 			finishedSetupFn = func(flowinfra.Flow) { resultsCh <- tree.Datums(nil) }
 		}
 
-		jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, jobID, execCfg.Settings.Version)
+		jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, jobID)
 
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx

--- a/pkg/ccl/streamingccl/replicationutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/replicationutils/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/replicationutils",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/kv/kvpb",

--- a/pkg/ccl/streamingccl/replicationutils/utils.go
+++ b/pkg/ccl/streamingccl/replicationutils/utils.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -175,9 +174,9 @@ func ReplicatedTimeFromProgress(p *jobspb.Progress) hlc.Timestamp {
 // LoadIngestionProgress loads the latest persisted stream ingestion progress.
 // The method returns nil if the progress does not exist yet.
 func LoadIngestionProgress(
-	ctx context.Context, db isql.DB, jobID jobspb.JobID, cv clusterversion.Handle,
+	ctx context.Context, db isql.DB, jobID jobspb.JobID,
 ) (*jobspb.StreamIngestionProgress, error) {
-	progress, err := jobs.LoadJobProgress(ctx, db, jobID, cv)
+	progress, err := jobs.LoadJobProgress(ctx, db, jobID)
 	if err != nil || progress == nil {
 		return nil, err
 	}
@@ -193,9 +192,9 @@ func LoadIngestionProgress(
 // LoadReplicationProgress loads the latest persisted stream replication progress.
 // The method returns nil if the progress does not exist yet.
 func LoadReplicationProgress(
-	ctx context.Context, db isql.DB, jobID jobspb.JobID, cv clusterversion.Handle,
+	ctx context.Context, db isql.DB, jobID jobspb.JobID,
 ) (*jobspb.StreamReplicationProgress, error) {
-	progress, err := jobs.LoadJobProgress(ctx, db, jobID, cv)
+	progress, err := jobs.LoadJobProgress(ctx, db, jobID)
 	if err != nil || progress == nil {
 		return nil, err
 	}

--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "//pkg/cloud",
         "//pkg/cloud/externalconn",
         "//pkg/cloud/externalconn/connectionpb",
-        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobsprofiler",

--- a/pkg/ccl/streamingccl/streamingest/replication_execution_details_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_execution_details_test.go
@@ -344,7 +344,7 @@ func TestEndToEndFrontierExecutionDetailFile(t *testing.T) {
 
 	ingestionJobID := jobspb.JobID(123)
 	require.NoError(t, persistStreamIngestionPartitionSpecs(ctx, &execCfg,
-		ingestionJobID, streamIngestionsSpecs, execCfg.Settings.Version))
+		ingestionJobID, streamIngestionsSpecs))
 
 	// Now, let's persist some frontier entries.
 	frontierEntries := execinfrapb.FrontierEntries{ResolvedSpans: []jobspb.ResolvedSpan{
@@ -369,9 +369,9 @@ func TestEndToEndFrontierExecutionDetailFile(t *testing.T) {
 	frontierBytes, err := protoutil.Marshal(&frontierEntries)
 	require.NoError(t, err)
 	require.NoError(t, execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		return jobs.WriteChunkedFileToJobInfo(ctx, frontierEntriesFilename, frontierBytes, txn, ingestionJobID, execCfg.Settings.Version)
+		return jobs.WriteChunkedFileToJobInfo(ctx, frontierEntriesFilename, frontierBytes, txn, ingestionJobID)
 	}))
-	require.NoError(t, generateSpanFrontierExecutionDetailFile(ctx, &execCfg, ingestionJobID, true /* skipBehindBy */, execCfg.Settings.Version))
+	require.NoError(t, generateSpanFrontierExecutionDetailFile(ctx, &execCfg, ingestionJobID, true /* skipBehindBy */))
 	files := listExecutionDetails(t, srv, ingestionJobID)
 	require.Len(t, files, 1)
 	data, err := checkExecutionDetails(t, srv, ingestionJobID, files[0])

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -1186,14 +1186,12 @@ func TestLoadProducerAndIngestionProgress(t *testing.T) {
 	c.WaitUntilReplicatedTime(srcTime, jobspb.JobID(replicationJobID))
 
 	srcDB := c.SrcSysServer.ExecutorConfig().(sql.ExecutorConfig).InternalDB
-	producerProgress, err := replicationutils.LoadReplicationProgress(ctx, srcDB, jobspb.JobID(producerJobID),
-		c.SrcSysServer.ExecutorConfig().(sql.ExecutorConfig).Settings.Version)
+	producerProgress, err := replicationutils.LoadReplicationProgress(ctx, srcDB, jobspb.JobID(producerJobID))
 	require.NoError(t, err)
 	require.Equal(t, jobspb.StreamReplicationProgress_NOT_FINISHED, producerProgress.StreamIngestionStatus)
 
 	destDB := c.DestSysServer.ExecutorConfig().(sql.ExecutorConfig).InternalDB
-	ingestionProgress, err := replicationutils.LoadIngestionProgress(ctx, destDB, jobspb.JobID(replicationJobID),
-		c.DestSysServer.ExecutorConfig().(sql.ExecutorConfig).Settings.Version)
+	ingestionProgress, err := replicationutils.LoadIngestionProgress(ctx, destDB, jobspb.JobID(replicationJobID))
 	require.NoError(t, err)
 	require.Equal(t, jobspb.Replicating, ingestionProgress.ReplicationStatus)
 }

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -113,7 +113,7 @@ func startDistIngestion(
 		return errors.Wrap(err, "failed to update job progress")
 	}
 	jobsprofiler.StorePlanDiagram(ctx, execCtx.ExecCfg().DistSQLSrv.Stopper, planner.initialPlan, execCtx.ExecCfg().InternalDB,
-		ingestionJob.ID(), execCtx.ExecCfg().Settings.Version)
+		ingestionJob.ID())
 
 	replanOracle := sql.ReplanOnCustomFunc(
 		measurePlanChange,
@@ -467,7 +467,7 @@ func (p *replicationFlowPlanner) constructPlanGenerator(
 		if !p.createdInitialPlan() {
 			// Only persist the initial plan as it's the only plan that actually gets
 			// executed.
-			if err := persistStreamIngestionPartitionSpecs(ctx, execCtx.ExecCfg(), ingestionJobID, streamIngestionSpecs, execCtx.ExecCfg().Settings.Version); err != nil {
+			if err := persistStreamIngestionPartitionSpecs(ctx, execCtx.ExecCfg(), ingestionJobID, streamIngestionSpecs); err != nil {
 				return nil, nil, err
 			}
 		}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -525,7 +525,7 @@ func (sf *streamIngestionFrontier) maybePersistFrontierEntries() error {
 	}
 
 	if err = sf.FlowCtx.Cfg.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		return jobs.WriteChunkedFileToJobInfo(ctx, frontierEntriesFilename, frontierBytes, txn, jobID, sf.EvalCtx.Settings.Version)
+		return jobs.WriteChunkedFileToJobInfo(ctx, frontierEntriesFilename, frontierBytes, txn, jobID)
 	}); err != nil {
 		return err
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/replicationutils"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamclient"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -319,7 +318,6 @@ func newStreamIngestionDataProcessor(
 		cutoverProvider: &cutoverFromJobProgress{
 			jobID: jobspb.JobID(spec.JobID),
 			db:    flowCtx.Cfg.DB,
-			cv:    flowCtx.Cfg.Settings.Version,
 		},
 		buffer:           &streamIngestionBuffer{},
 		cutoverCh:        make(chan struct{}),
@@ -1255,11 +1253,10 @@ type cutoverProvider interface {
 type cutoverFromJobProgress struct {
 	db    isql.DB
 	jobID jobspb.JobID
-	cv    clusterversion.Handle
 }
 
 func (c *cutoverFromJobProgress) cutoverReached(ctx context.Context) (bool, error) {
-	ingestionProgress, err := replicationutils.LoadIngestionProgress(ctx, c.db, c.jobID, c.cv)
+	ingestionProgress, err := replicationutils.LoadIngestionProgress(ctx, c.db, c.jobID)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/ccl/streamingccl/streamproducer/producer_job.go
+++ b/pkg/ccl/streamingccl/streamproducer/producer_job.go
@@ -99,7 +99,7 @@ func (p *producerJobResumer) Resume(ctx context.Context, execCtx interface{}) er
 		case <-p.timer.Ch():
 			p.timer.MarkRead()
 			p.timer.Reset(streamingccl.StreamReplicationStreamLivenessTrackFrequency.Get(execCfg.SV()))
-			progress, err := replicationutils.LoadReplicationProgress(ctx, execCfg.InternalDB, p.job.ID(), execCfg.Settings.Version)
+			progress, err := replicationutils.LoadReplicationProgress(ctx, execCfg.InternalDB, p.job.ID())
 			if knobs := execCfg.StreamingTestingKnobs; knobs != nil && knobs.AfterResumerJobLoad != nil {
 				err = knobs.AfterResumerJobLoad(err)
 			}

--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -49,7 +49,6 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/isql",
-        "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/protoreflect",
         "//pkg/sql/sem/builtins",

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -87,7 +87,7 @@ func (r *Registry) maybeDumpTrace(resumerCtx context.Context, resumer Resumer, j
 		r.ID().String(), timeutil.Now().Format("20060102_150405.00"))
 	td := jobspb.TraceData{CollectedSpans: sp.GetConfiguredRecording()}
 	if err := r.db.Txn(dumpCtx, func(ctx context.Context, txn isql.Txn) error {
-		return WriteProtobinExecutionDetailFile(dumpCtx, resumerTraceFilename, &td, txn, jobID, r.settings.Version)
+		return WriteProtobinExecutionDetailFile(dumpCtx, resumerTraceFilename, &td, txn, jobID)
 	}); err != nil {
 		log.Warning(dumpCtx, "failed to write trace on resumer trace file")
 	}

--- a/pkg/jobs/execution_detail_utils_test.go
+++ b/pkg/jobs/execution_detail_utils_test.go
@@ -51,7 +51,7 @@ func TestReadWriteListExecutionDetailFiles(t *testing.T) {
 			// Generate random data of size between 15 bytes and 5 MiB.
 			data := make([]byte, 15+rand.Intn(5*1024*1024-15))
 			randutil.ReadTestdataBytes(rng, data)
-			err := WriteExecutionDetailFile(ctx, filename, data, txn, jobspb.JobID(123), ts.ClusterSettings().Version)
+			err := WriteExecutionDetailFile(ctx, filename, data, txn, jobspb.JobID(123))
 			if err != nil {
 				return err
 			}
@@ -59,11 +59,11 @@ func TestReadWriteListExecutionDetailFiles(t *testing.T) {
 		}
 
 		// Write a binpb format file.
-		return WriteProtobinExecutionDetailFile(ctx, "testproto", msg, txn, jobspb.JobID(123), ts.ClusterSettings().Version)
+		return WriteProtobinExecutionDetailFile(ctx, "testproto", msg, txn, jobspb.JobID(123))
 	}))
 
 	// List the files.
-	listedFiles, err := ListExecutionDetailFiles(ctx, ts.InternalDB().(isql.DB), jobspb.JobID(123), ts.ClusterSettings().Version)
+	listedFiles, err := ListExecutionDetailFiles(ctx, ts.InternalDB().(isql.DB), jobspb.JobID(123))
 	require.NoError(t, err)
 	require.ElementsMatch(t, append(filenames,
 		"testproto~cockroach.sql.jobs.jobspb.BackupDetails.binpb.txt",
@@ -76,7 +76,7 @@ func TestReadWriteListExecutionDetailFiles(t *testing.T) {
 				// Skip the text version of the binpb file.
 				continue
 			}
-			readData, err := ReadExecutionDetailFile(ctx, filename, txn, jobspb.JobID(123), s.ClusterSettings().Version)
+			readData, err := ReadExecutionDetailFile(ctx, filename, txn, jobspb.JobID(123))
 			require.NoError(t, err)
 			if strings.HasSuffix(filename, "binpb") {
 				// For the binpb file, unmarshal the data and compare it to the original message.

--- a/pkg/jobs/job_info_storage.go
+++ b/pkg/jobs/job_info_storage.go
@@ -235,10 +235,7 @@ func (i InfoStorage) Write(ctx context.Context, infoKey string, value []byte) er
 	if value == nil {
 		return errors.AssertionFailedf("missing value (infoKey %q)", infoKey)
 	}
-	if err := i.write(ctx, infoKey, value); err != nil {
-		return MaybeGenerateForcedRetryableError(ctx, i.txn.KV(), err)
-	}
-	return nil
+	return i.write(ctx, infoKey, value)
 }
 
 // Delete removes the info record for the provided infoKey.

--- a/pkg/jobs/job_info_storage.go
+++ b/pkg/jobs/job_info_storage.go
@@ -238,7 +238,7 @@ func (i InfoStorage) Write(ctx context.Context, infoKey string, value []byte) er
 		return errors.AssertionFailedf("missing value (infoKey %q)", infoKey)
 	}
 	if err := i.write(ctx, infoKey, value); err != nil {
-		return MaybeGenerateForcedRetryableError(ctx, i.txn.KV(), err, i.cv)
+		return MaybeGenerateForcedRetryableError(ctx, i.txn.KV(), err)
 	}
 	return nil
 }

--- a/pkg/jobs/job_info_storage.go
+++ b/pkg/jobs/job_info_storage.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -31,19 +30,18 @@ import (
 type InfoStorage struct {
 	j   *Job
 	txn isql.Txn
-	cv  clusterversion.Handle
 }
 
 // InfoStorage returns a new InfoStorage with the passed in job and txn.
 func (j *Job) InfoStorage(txn isql.Txn) InfoStorage {
-	return InfoStorage{j: j, txn: txn, cv: j.registry.settings.Version}
+	return InfoStorage{j: j, txn: txn}
 }
 
 // InfoStorageForJob returns a new InfoStorage with the passed in
 // job ID and txn. It avoids loading the job record. The resulting
 // job_info writes will not check the job session ID.
-func InfoStorageForJob(txn isql.Txn, jobID jobspb.JobID, cv clusterversion.Handle) InfoStorage {
-	return InfoStorage{j: &Job{id: jobID}, txn: txn, cv: cv}
+func InfoStorageForJob(txn isql.Txn, jobID jobspb.JobID) InfoStorage {
+	return InfoStorage{j: &Job{id: jobID}, txn: txn}
 }
 
 func (i InfoStorage) checkClaimSession(ctx context.Context) error {

--- a/pkg/jobs/job_info_utils_test.go
+++ b/pkg/jobs/job_info_utils_test.go
@@ -68,11 +68,11 @@ func TestReadWriteChunkedFileToJobInfo(t *testing.T) {
 				randutil.ReadTestdataBytes(rng, tt.data)
 			}
 			require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-				err := WriteChunkedFileToJobInfo(ctx, tt.name, tt.data, txn, jobspb.JobID(123), s.ClusterSettings().Version)
+				err := WriteChunkedFileToJobInfo(ctx, tt.name, tt.data, txn, jobspb.JobID(123))
 				if err != nil {
 					return err
 				}
-				got, err := ReadChunkedFileToJobInfo(ctx, tt.name, txn, jobspb.JobID(123), s.ClusterSettings().Version)
+				got, err := ReadChunkedFileToJobInfo(ctx, tt.name, txn, jobspb.JobID(123))
 				if err != nil {
 					return err
 				}
@@ -133,7 +133,7 @@ func TestOverwriteChunkingWithVariableLengths(t *testing.T) {
 			tt.data = generateData(tt.numChunks)
 			// Write the first file, this will generate a certain number of chunks.
 			require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-				return WriteChunkedFileToJobInfo(ctx, tt.name, tt.data, txn, jobspb.JobID(123), s.ClusterSettings().Version)
+				return WriteChunkedFileToJobInfo(ctx, tt.name, tt.data, txn, jobspb.JobID(123))
 			}))
 
 			// Overwrite the file with fewer chunks, this should delete the extra
@@ -144,11 +144,11 @@ func TestOverwriteChunkingWithVariableLengths(t *testing.T) {
 					tt.data = generateData(lessChunks)
 					var got []byte
 					require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-						err := WriteChunkedFileToJobInfo(ctx, tt.name, tt.data, txn, jobspb.JobID(123), s.ClusterSettings().Version)
+						err := WriteChunkedFileToJobInfo(ctx, tt.name, tt.data, txn, jobspb.JobID(123))
 						if err != nil {
 							return err
 						}
-						got, err = ReadChunkedFileToJobInfo(ctx, tt.name, txn, jobspb.JobID(123), s.ClusterSettings().Version)
+						got, err = ReadChunkedFileToJobInfo(ctx, tt.name, txn, jobspb.JobID(123))
 						return err
 					}))
 					require.Equal(t, tt.data, got)
@@ -162,11 +162,11 @@ func TestOverwriteChunkingWithVariableLengths(t *testing.T) {
 				tt.data = generateData(moreChunks)
 				var got []byte
 				require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-					err := WriteChunkedFileToJobInfo(ctx, tt.name, tt.data, txn, jobspb.JobID(123), s.ClusterSettings().Version)
+					err := WriteChunkedFileToJobInfo(ctx, tt.name, tt.data, txn, jobspb.JobID(123))
 					if err != nil {
 						return err
 					}
-					got, err = ReadChunkedFileToJobInfo(ctx, tt.name, txn, jobspb.JobID(123), s.ClusterSettings().Version)
+					got, err = ReadChunkedFileToJobInfo(ctx, tt.name, txn, jobspb.JobID(123))
 					return err
 				}))
 				require.Equal(t, tt.data, got)

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -19,7 +19,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security/username"

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -1077,12 +1077,10 @@ func FormatRetriableExecutionErrorLogToStringArray(
 }
 
 // GetJobTraceID returns the current trace ID of the job from the job progress.
-func GetJobTraceID(
-	ctx context.Context, db isql.DB, jobID jobspb.JobID, cv clusterversion.Handle,
-) (tracingpb.TraceID, error) {
+func GetJobTraceID(ctx context.Context, db isql.DB, jobID jobspb.JobID) (tracingpb.TraceID, error) {
 	var traceID tracingpb.TraceID
 	if err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		jobInfo := InfoStorageForJob(txn, jobID, cv)
+		jobInfo := InfoStorageForJob(txn, jobID)
 		progressBytes, exists, err := jobInfo.GetLegacyProgress(ctx)
 		if err != nil {
 			return err
@@ -1106,14 +1104,14 @@ func GetJobTraceID(
 // LoadJobProgress returns the job progress from the info table. Note that the
 // progress can be nil if none is recorded.
 func LoadJobProgress(
-	ctx context.Context, db isql.DB, jobID jobspb.JobID, cv clusterversion.Handle,
+	ctx context.Context, db isql.DB, jobID jobspb.JobID,
 ) (*jobspb.Progress, error) {
 	var (
 		progressBytes []byte
 		exists        bool
 	)
 	if err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		infoStorage := InfoStorageForJob(txn, jobID, cv)
+		infoStorage := InfoStorageForJob(txn, jobID)
 		var err error
 		progressBytes, exists, err = infoStorage.GetLegacyProgress(ctx)
 		return err

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1193,13 +1193,13 @@ func checkTraceFiles(
 
 	recordings := make([][]byte, 0)
 	execCfg := s.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig)
-	edFiles, err := jobs.ListExecutionDetailFiles(ctx, execCfg.InternalDB, jobID, execCfg.Settings.Version)
+	edFiles, err := jobs.ListExecutionDetailFiles(ctx, execCfg.InternalDB, jobID)
 	require.NoError(t, err)
 	require.Len(t, edFiles, expectedNumFiles)
 
 	require.NoError(t, execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		for _, f := range edFiles {
-			data, err := jobs.ReadExecutionDetailFile(ctx, f, txn, jobID, execCfg.Settings.Version)
+			data, err := jobs.ReadExecutionDetailFile(ctx, f, txn, jobID)
 			if err != nil {
 				return err
 			}
@@ -3691,7 +3691,7 @@ func TestLoadJobProgress(t *testing.T) {
 	_, err := r.CreateJobWithTxn(ctx, rec, 7, nil)
 	require.NoError(t, err)
 
-	p, err := jobs.LoadJobProgress(ctx, s.InternalDB().(isql.DB), 7, s.ClusterSettings().Version)
+	p, err := jobs.LoadJobProgress(ctx, s.InternalDB().(isql.DB), 7)
 	require.NoError(t, err)
 	require.Equal(t, []float32{7.1}, p.GetDetails().(*jobspb.Progress_Import).Import.ReadProgress)
 }

--- a/pkg/jobs/jobsprofiler/BUILD.bazel
+++ b/pkg/jobs/jobsprofiler/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/jobs/jobsprofiler",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobsprofiler/profilerconstants",

--- a/pkg/jobs/jobsprofiler/profiler.go
+++ b/pkg/jobs/jobsprofiler/profiler.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprofiler/profilerconstants"
@@ -30,12 +29,7 @@ import (
 // table. The generation of the plan diagram and persistence to the info table
 // are done asynchronously and this method does not block on their completion.
 func StorePlanDiagram(
-	ctx context.Context,
-	stopper *stop.Stopper,
-	p *sql.PhysicalPlan,
-	db isql.DB,
-	jobID jobspb.JobID,
-	cv clusterversion.Handle,
+	ctx context.Context, stopper *stop.Stopper, p *sql.PhysicalPlan, db isql.DB, jobID jobspb.JobID,
 ) {
 	if err := stopper.RunAsyncTask(ctx, "jobs-store-plan-diagram", func(ctx context.Context) {
 		var cancel func()
@@ -51,7 +45,7 @@ func StorePlanDiagram(
 			}
 
 			dspKey := profilerconstants.MakeDSPDiagramInfoKey(timeutil.Now().UnixNano())
-			infoStorage := jobs.InfoStorageForJob(txn, jobID, cv)
+			infoStorage := jobs.InfoStorageForJob(txn, jobID)
 			return infoStorage.Write(ctx, dspKey, []byte(diagURL.String()))
 		})
 		// Don't log the error if the context has been canceled. This will likely be
@@ -76,10 +70,9 @@ func StorePerNodeProcessorProgressFraction(
 	db isql.DB,
 	jobID jobspb.JobID,
 	perComponentProgress map[execinfrapb.ComponentID]float32,
-	cv clusterversion.Handle,
 ) {
 	if err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		infoStorage := jobs.InfoStorageForJob(txn, jobID, cv)
+		infoStorage := jobs.InfoStorageForJob(txn, jobID)
 		for componentID, fraction := range perComponentProgress {
 			key := profilerconstants.MakeNodeProcessorProgressInfoKey(componentID.FlowID.String(),
 				componentID.SQLInstanceID.String(), componentID.ID)

--- a/pkg/jobs/jobsprofiler/profiler.go
+++ b/pkg/jobs/jobsprofiler/profiler.go
@@ -37,10 +37,6 @@ func StorePlanDiagram(
 	jobID jobspb.JobID,
 	cv clusterversion.Handle,
 ) {
-	if !cv.IsActive(ctx, clusterversion.V23_1) {
-		return
-	}
-
 	if err := stopper.RunAsyncTask(ctx, "jobs-store-plan-diagram", func(ctx context.Context) {
 		var cancel func()
 		ctx, cancel = stopper.WithCancelOnQuiesce(ctx)
@@ -82,9 +78,6 @@ func StorePerNodeProcessorProgressFraction(
 	perComponentProgress map[execinfrapb.ComponentID]float32,
 	cv clusterversion.Handle,
 ) {
-	if !cv.IsActive(ctx, clusterversion.V23_1) {
-		return
-	}
 	if err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		infoStorage := jobs.InfoStorageForJob(txn, jobID, cv)
 		for componentID, fraction := range perComponentProgress {

--- a/pkg/jobs/jobsprofiler/profiler_test.go
+++ b/pkg/jobs/jobsprofiler/profiler_test.go
@@ -96,7 +96,7 @@ func TestProfilerStorePlanDiagram(t *testing.T) {
 			testutils.SucceedsSoon(t, func() error {
 				var count int
 				err = execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-					infoStorage := jobs.InfoStorageForJob(txn, jobID, execCfg.Settings.Version)
+					infoStorage := jobs.InfoStorageForJob(txn, jobID)
 					return infoStorage.Iterate(ctx, profilerconstants.DSPDiagramInfoKeyPrefix,
 						func(infoKey string, value []byte) error {
 							count++
@@ -143,19 +143,19 @@ func TestStorePerNodeProcessorProgressFraction(t *testing.T) {
 	n2proc1.ID = 1
 
 	jobsprofiler.StorePerNodeProcessorProgressFraction(ctx, s.InternalDB().(isql.DB),
-		jobID, map[execinfrapb.ComponentID]float32{n1proc1: 0.95, n2proc1: 0.50}, s.ClusterSettings().Version)
+		jobID, map[execinfrapb.ComponentID]float32{n1proc1: 0.95, n2proc1: 0.50})
 
 	// Update n2proc1.
 	jobsprofiler.StorePerNodeProcessorProgressFraction(ctx, s.InternalDB().(isql.DB),
-		jobID, map[execinfrapb.ComponentID]float32{n2proc1: 0.70}, s.ClusterSettings().Version)
+		jobID, map[execinfrapb.ComponentID]float32{n2proc1: 0.70})
 	// Update n1proc1.
 	jobsprofiler.StorePerNodeProcessorProgressFraction(ctx, s.InternalDB().(isql.DB),
-		jobID, map[execinfrapb.ComponentID]float32{n1proc1: 1.00}, s.ClusterSettings().Version)
+		jobID, map[execinfrapb.ComponentID]float32{n1proc1: 1.00})
 
 	var persistedProgress map[string]string
 	err := s.ExecutorConfig().(sql.ExecutorConfig).InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		persistedProgress = make(map[string]string)
-		infoStorage := jobs.InfoStorageForJob(txn, jobID, s.ClusterSettings().Version)
+		infoStorage := jobs.InfoStorageForJob(txn, jobID)
 		return infoStorage.Iterate(ctx, profilerconstants.NodeProcessorProgressInfoKeyPrefix,
 			func(infoKey string, value []byte) error {
 				f, err := strconv.ParseFloat(string(value), 32)
@@ -219,7 +219,7 @@ func TestTraceRecordingOnResumerCompletion(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		recordings := make([][]byte, 0)
 		execCfg := s.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig)
-		edFiles, err := jobs.ListExecutionDetailFiles(ctx, execCfg.InternalDB, jobspb.JobID(jobID), s.ClusterSettings().Version)
+		edFiles, err := jobs.ListExecutionDetailFiles(ctx, execCfg.InternalDB, jobspb.JobID(jobID))
 		if err != nil {
 			return err
 		}
@@ -232,7 +232,7 @@ func TestTraceRecordingOnResumerCompletion(t *testing.T) {
 
 		return execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			for _, f := range traceFiles {
-				data, err := jobs.ReadExecutionDetailFile(ctx, f, txn, jobspb.JobID(jobID), s.ClusterSettings().Version)
+				data, err := jobs.ReadExecutionDetailFile(ctx, f, txn, jobspb.JobID(jobID))
 				if err != nil {
 					return err
 				}

--- a/pkg/jobs/utils.go
+++ b/pkg/jobs/utils.go
@@ -19,8 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
 )
@@ -122,46 +120,4 @@ func JobCoordinatorID(
 		return 0, errors.AssertionFailedf("expected coordinator ID to be an int, got %T", row[0])
 	}
 	return int32(coordinatorID), nil
-}
-
-// isJobTypeColumnDoesNotExistError returns true if the error is of the form
-// `column "job_type" does not exist`.
-func isJobTypeColumnDoesNotExistError(err error) bool {
-	return pgerror.GetPGCode(err) == pgcode.UndefinedColumn &&
-		strings.Contains(err.Error(), "column \"job_type\" does not exist")
-}
-
-// isJobInfoTableDoesNotExistError returns true if the error is of the form
-// `related "job_info" does not exist`.
-func isJobInfoTableDoesNotExistError(err error) bool {
-	return pgerror.GetPGCode(err) == pgcode.UndefinedTable &&
-		strings.Contains(err.Error(), "relation \"system.job_info\" does not exist")
-}
-
-// MaybeGenerateForcedRetryableError returns a
-// TransactionRetryWithProtoRefreshError that will cause the txn to be retried
-// if the error is because of an undefined job_type column or missing job_info
-// table.
-//
-// In https://github.com/cockroachdb/cockroach/issues/106762 we noticed that if
-// a query is executed with an AS OF SYSTEM TIME clause that picks a transaction
-// timestamp before the job_type migration, then parts of the jobs
-// infrastructure will attempt to query the job_type column even though it
-// doesn't exist at the transaction's timestamp.
-//
-// As a short term fix, when we encounter an `UndefinedTable` or
-// `UndefinedColumn` error we generate a synthetic retryable error so that the
-// txn is pushed to a higher timestamp at which the upgrade will have completed
-// and the table/column will be visible. The longer term fix is being tracked in
-// https://github.com/cockroachdb/cockroach/issues/106764.
-func MaybeGenerateForcedRetryableError(ctx context.Context, txn *kv.Txn, err error) error {
-	if err != nil && isJobTypeColumnDoesNotExistError(err) {
-		return txn.GenerateForcedRetryableErr(ctx, "synthetic error "+
-			"to push timestamp to after the `job_type` upgrade has run")
-	}
-	if err != nil && isJobInfoTableDoesNotExistError(err) {
-		return txn.GenerateForcedRetryableErr(ctx, "synthetic error "+
-			"to push timestamp to after the `job_info` upgrade has run")
-	}
-	return err
 }

--- a/pkg/jobs/utils.go
+++ b/pkg/jobs/utils.go
@@ -154,18 +154,12 @@ func isJobInfoTableDoesNotExistError(err error) bool {
 // txn is pushed to a higher timestamp at which the upgrade will have completed
 // and the table/column will be visible. The longer term fix is being tracked in
 // https://github.com/cockroachdb/cockroach/issues/106764.
-func MaybeGenerateForcedRetryableError(
-	ctx context.Context, txn *kv.Txn, err error, cv clusterversion.Handle,
-) error {
-	if err == nil || !cv.IsActive(ctx, clusterversion.V23_1) {
-		return err
-	}
-
-	if isJobTypeColumnDoesNotExistError(err) {
+func MaybeGenerateForcedRetryableError(ctx context.Context, txn *kv.Txn, err error) error {
+	if err != nil && isJobTypeColumnDoesNotExistError(err) {
 		return txn.GenerateForcedRetryableErr(ctx, "synthetic error "+
 			"to push timestamp to after the `job_type` upgrade has run")
 	}
-	if isJobInfoTableDoesNotExistError(err) {
+	if err != nil && isJobInfoTableDoesNotExistError(err) {
 		return txn.GenerateForcedRetryableErr(ctx, "synthetic error "+
 			"to push timestamp to after the `job_info` upgrade has run")
 	}

--- a/pkg/server/autoconfig/BUILD.bazel
+++ b/pkg/server/autoconfig/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/server/autoconfig",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/security/username",

--- a/pkg/server/autoconfig/auto_config_env_runner.go
+++ b/pkg/server/autoconfig/auto_config_env_runner.go
@@ -146,7 +146,7 @@ func (r *envRunner) maybeRunNextTask(
 
 	err = execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) (resErr error) {
 		// Re-check if there any other started task already.
-		otherTaskID, _, err := getCurrentlyStartedTaskID(ctx, txn, r.envID, execCfg.Settings.Version)
+		otherTaskID, _, err := getCurrentlyStartedTaskID(ctx, txn, r.envID)
 		if err != nil {
 			return err
 		}
@@ -161,7 +161,7 @@ func (r *envRunner) maybeRunNextTask(
 		}
 
 		// Find the latest completed task.
-		lastTaskID, err := getLastCompletedTaskID(ctx, txn, r.envID, execCfg.Settings.Version)
+		lastTaskID, err := getLastCompletedTaskID(ctx, txn, r.envID)
 		if err != nil {
 			return err
 		}
@@ -190,7 +190,7 @@ func (r *envRunner) maybeRunNextTask(
 		// maybeWaitForCurrentTaskJob(), which is an optimization. Storing
 		// the job ID is not strictly required for sequencing the tasks.
 		if err := writeStartMarker(ctx, txn,
-			InfoKeyTaskRef{Environment: r.envID, Task: nextTaskID}, jobID, execCfg.Settings.Version); err != nil {
+			InfoKeyTaskRef{Environment: r.envID, Task: nextTaskID}, jobID); err != nil {
 			return errors.Wrapf(err, "unable to write start marker for task %d", nextTaskID)
 		}
 
@@ -219,7 +219,7 @@ func (r *envRunner) maybeWaitForCurrentTaskJob(
 
 	if err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		var err error
-		prevTaskID, prevJobID, err = getCurrentlyStartedTaskID(ctx, txn, r.envID, execCfg.Settings.Version)
+		prevTaskID, prevJobID, err = getCurrentlyStartedTaskID(ctx, txn, r.envID)
 		return err
 	}); err != nil {
 		return errors.Wrap(err, "checking latest task job")

--- a/pkg/server/autoconfig/auto_config_task.go
+++ b/pkg/server/autoconfig/auto_config_task.go
@@ -78,7 +78,7 @@ func (r *taskRunner) OnFailOrCancel(ctx context.Context, execCtx interface{}, jo
 	if err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		return markTaskComplete(ctx, txn,
 			InfoKeyTaskRef{Environment: r.envID, Task: r.task.TaskID},
-			[]byte("task error"), execCfg.Settings.Version)
+			[]byte("task error"))
 	}); err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func execSimpleSQL(
 		log.Infof(ctx, "finished executing txn statements")
 		return markTaskComplete(ctx, txn,
 			InfoKeyTaskRef{Environment: envID, Task: taskID},
-			[]byte("task success"), execCfg.Settings.Version)
+			[]byte("task success"))
 	})
 }
 

--- a/pkg/server/autoconfig/task_markers.go
+++ b/pkg/server/autoconfig/task_markers.go
@@ -142,11 +142,7 @@ func (tr *InfoKeyTaskRef) decodeInternal(prefix, infoKey string) error {
 // writeStartMarker writes a start marker for the given task ID and
 // also writes its job ID into the value part.
 func writeStartMarker(
-	ctx context.Context,
-	txn isql.Txn,
-	taskRef InfoKeyTaskRef,
-	jobID jobspb.JobID,
-	cv clusterversion.Handle,
+	ctx context.Context, txn isql.Txn, taskRef InfoKeyTaskRef, jobID jobspb.JobID, cv clusterversion.Handle,
 ) error {
 	infoStorage := jobs.InfoStorageForJob(txn, jobs.AutoConfigRunnerJobID, cv)
 	return infoStorage.Write(ctx,
@@ -213,11 +209,7 @@ func getLastCompletedTaskID(
 // markTaskCompletes transactionally removes the task's start marker
 // and creates a completion marker.
 func markTaskComplete(
-	ctx context.Context,
-	txn isql.Txn,
-	taskRef InfoKeyTaskRef,
-	completionValue []byte,
-	cv clusterversion.Handle,
+	ctx context.Context, txn isql.Txn, taskRef InfoKeyTaskRef, completionValue []byte, cv clusterversion.Handle,
 ) error {
 	infoStorage := jobs.InfoStorageForJob(txn, jobs.AutoConfigRunnerJobID, cv)
 

--- a/pkg/server/autoconfig/task_markers.go
+++ b/pkg/server/autoconfig/task_markers.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -142,9 +141,9 @@ func (tr *InfoKeyTaskRef) decodeInternal(prefix, infoKey string) error {
 // writeStartMarker writes a start marker for the given task ID and
 // also writes its job ID into the value part.
 func writeStartMarker(
-	ctx context.Context, txn isql.Txn, taskRef InfoKeyTaskRef, jobID jobspb.JobID, cv clusterversion.Handle,
+	ctx context.Context, txn isql.Txn, taskRef InfoKeyTaskRef, jobID jobspb.JobID,
 ) error {
-	infoStorage := jobs.InfoStorageForJob(txn, jobs.AutoConfigRunnerJobID, cv)
+	infoStorage := jobs.InfoStorageForJob(txn, jobs.AutoConfigRunnerJobID)
 	return infoStorage.Write(ctx,
 		taskRef.EncodeStartMarkerKey(),
 		[]byte(strconv.FormatUint(uint64(jobID), 10)))
@@ -153,9 +152,9 @@ func writeStartMarker(
 // getCurrentlyStartedTaskID retrieves the ID of the last task which
 // has a start marker in job_info.
 func getCurrentlyStartedTaskID(
-	ctx context.Context, txn isql.Txn, env EnvironmentID, cv clusterversion.Handle,
+	ctx context.Context, txn isql.Txn, env EnvironmentID,
 ) (prevTaskID TaskID, prevJobID jobspb.JobID, err error) {
-	infoStorage := jobs.InfoStorageForJob(txn, jobs.AutoConfigRunnerJobID, cv)
+	infoStorage := jobs.InfoStorageForJob(txn, jobs.AutoConfigRunnerJobID)
 
 	if err := infoStorage.GetLast(ctx,
 		InfoKeyStartPrefix(env),
@@ -185,9 +184,9 @@ func getCurrentlyStartedTaskID(
 // getLastCompletedTaskID retrieves the task ID of the last task which
 // has a completion marker in job_info.
 func getLastCompletedTaskID(
-	ctx context.Context, txn isql.Txn, env EnvironmentID, cv clusterversion.Handle,
+	ctx context.Context, txn isql.Txn, env EnvironmentID,
 ) (lastTaskID TaskID, err error) {
-	infoStorage := jobs.InfoStorageForJob(txn, jobs.AutoConfigRunnerJobID, cv)
+	infoStorage := jobs.InfoStorageForJob(txn, jobs.AutoConfigRunnerJobID)
 
 	if err := infoStorage.GetLast(ctx,
 		InfoKeyCompletionPrefix(env),
@@ -209,9 +208,9 @@ func getLastCompletedTaskID(
 // markTaskCompletes transactionally removes the task's start marker
 // and creates a completion marker.
 func markTaskComplete(
-	ctx context.Context, txn isql.Txn, taskRef InfoKeyTaskRef, completionValue []byte, cv clusterversion.Handle,
+	ctx context.Context, txn isql.Txn, taskRef InfoKeyTaskRef, completionValue []byte,
 ) error {
-	infoStorage := jobs.InfoStorageForJob(txn, jobs.AutoConfigRunnerJobID, cv)
+	infoStorage := jobs.InfoStorageForJob(txn, jobs.AutoConfigRunnerJobID)
 
 	// Remove the start marker.
 	if err := infoStorage.Delete(ctx, taskRef.EncodeStartMarkerKey()); err != nil {

--- a/pkg/server/job_profiler.go
+++ b/pkg/server/job_profiler.go
@@ -71,7 +71,7 @@ func (s *statusServer) RequestJobProfilerExecutionDetails(
 			return nil, errors.Newf("execution details can only be requested on a cluster with version >= %s",
 				clusterversion.V23_2.String())
 		}
-		e := makeJobProfilerExecutionDetailsBuilder(execCfg.SQLStatusServer, execCfg.InternalDB, jobID, execCfg.JobRegistry, execCfg.Settings.Version)
+		e := makeJobProfilerExecutionDetailsBuilder(execCfg.SQLStatusServer, execCfg.InternalDB, jobID, execCfg.JobRegistry)
 
 		// TODO(adityamaru): When we start collecting more information we can consider
 		// parallelize the collection of the various pieces.
@@ -111,15 +111,14 @@ type executionDetailsBuilder struct {
 	db       isql.DB
 	jobID    jobspb.JobID
 	registry *jobs.Registry
-	cv       clusterversion.Handle
 }
 
 // makeJobProfilerExecutionDetailsBuilder returns an instance of an executionDetailsBuilder.
 func makeJobProfilerExecutionDetailsBuilder(
-	srv serverpb.SQLStatusServer, db isql.DB, jobID jobspb.JobID, registry *jobs.Registry, cv clusterversion.Handle,
+	srv serverpb.SQLStatusServer, db isql.DB, jobID jobspb.JobID, registry *jobs.Registry,
 ) executionDetailsBuilder {
 	e := executionDetailsBuilder{
-		srv: srv, db: db, jobID: jobID, registry: registry, cv: cv,
+		srv: srv, db: db, jobID: jobID, registry: registry,
 	}
 	return e
 }
@@ -141,7 +140,7 @@ func (e *executionDetailsBuilder) addLabelledGoroutines(ctx context.Context) {
 	}
 	filename := fmt.Sprintf("goroutines.%s.txt", timeutil.Now().Format("20060102_150405.00"))
 	if err := e.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		return jobs.WriteExecutionDetailFile(ctx, filename, resp.Data, txn, e.jobID, e.cv)
+		return jobs.WriteExecutionDetailFile(ctx, filename, resp.Data, txn, e.jobID)
 	}); err != nil {
 		log.Errorf(ctx, "failed to write goroutine for job %d: %v", e.jobID, err.Error())
 	}
@@ -162,7 +161,7 @@ func (e *executionDetailsBuilder) addDistSQLDiagram(ctx context.Context) {
 		if err := e.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			return jobs.WriteExecutionDetailFile(ctx, filename,
 				[]byte(fmt.Sprintf(`<meta http-equiv="Refresh" content="0; url=%s">`, dspDiagramURL)),
-				txn, e.jobID, e.cv)
+				txn, e.jobID)
 		}); err != nil {
 			log.Errorf(ctx, "failed to write DistSQL diagram for job %d: %v", e.jobID, err.Error())
 		}
@@ -173,7 +172,7 @@ func (e *executionDetailsBuilder) addDistSQLDiagram(ctx context.Context) {
 // that captures the active tracing spans of a job on all nodes in the cluster.
 func (e *executionDetailsBuilder) addClusterWideTraces(ctx context.Context) {
 	z := zipper.MakeInternalExecutorInflightTraceZipper(e.db.Executor())
-	traceID, err := jobs.GetJobTraceID(ctx, e.db, e.jobID, e.cv)
+	traceID, err := jobs.GetJobTraceID(ctx, e.db, e.jobID)
 	if err != nil {
 		log.Warningf(ctx, "failed to fetch job trace ID: %+v", err.Error())
 		return
@@ -186,7 +185,7 @@ func (e *executionDetailsBuilder) addClusterWideTraces(ctx context.Context) {
 
 	filename := fmt.Sprintf("trace.%s.zip", timeutil.Now().Format("20060102_150405.00"))
 	if err := e.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		return jobs.WriteExecutionDetailFile(ctx, filename, zippedTrace, txn, e.jobID, e.cv)
+		return jobs.WriteExecutionDetailFile(ctx, filename, zippedTrace, txn, e.jobID)
 	}); err != nil {
 		log.Errorf(ctx, "failed to write traces for job %d: %v", e.jobID, err.Error())
 	}

--- a/pkg/server/job_profiler.go
+++ b/pkg/server/job_profiler.go
@@ -116,11 +116,7 @@ type executionDetailsBuilder struct {
 
 // makeJobProfilerExecutionDetailsBuilder returns an instance of an executionDetailsBuilder.
 func makeJobProfilerExecutionDetailsBuilder(
-	srv serverpb.SQLStatusServer,
-	db isql.DB,
-	jobID jobspb.JobID,
-	registry *jobs.Registry,
-	cv clusterversion.Handle,
+	srv serverpb.SQLStatusServer, db isql.DB, jobID jobspb.JobID, registry *jobs.Registry, cv clusterversion.Handle,
 ) executionDetailsBuilder {
 	e := executionDetailsBuilder{
 		srv: srv, db: db, jobID: jobID, registry: registry, cv: cv,

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -3951,7 +3951,7 @@ func (s *statusServer) GetJobProfilerExecutionDetails(
 	execCfg := s.sqlServer.execCfg
 	var data []byte
 	if err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		data, err = jobs.ReadExecutionDetailFile(ctx, req.Filename, txn, jobID, execCfg.Settings.Version)
+		data, err = jobs.ReadExecutionDetailFile(ctx, req.Filename, txn, jobID)
 		return err
 	}); err != nil {
 		return nil, err
@@ -3972,7 +3972,7 @@ func (s *statusServer) ListJobProfilerExecutionDetails(
 
 	jobID := jobspb.JobID(req.JobId)
 	execCfg := s.sqlServer.execCfg
-	files, err := jobs.ListExecutionDetailFiles(ctx, execCfg.InternalDB, jobID, execCfg.Settings.Version)
+	files, err := jobs.ListExecutionDetailFiles(ctx, execCfg.InternalDB, jobID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1047,7 +1047,7 @@ func populateSystemJobsTableRows(
 		params...,
 	)
 	if err != nil {
-		return matched, jobs.MaybeGenerateForcedRetryableError(ctx, p.Txn(), err, p.execCfg.Settings.Version)
+		return matched, jobs.MaybeGenerateForcedRetryableError(ctx, p.Txn(), err)
 	}
 
 	cleanup := func(ctx context.Context) {
@@ -1060,7 +1060,7 @@ func populateSystemJobsTableRows(
 	for {
 		hasNext, err := it.Next(ctx)
 		if !hasNext || err != nil {
-			return matched, jobs.MaybeGenerateForcedRetryableError(ctx, p.Txn(), err, p.execCfg.Settings.Version)
+			return matched, jobs.MaybeGenerateForcedRetryableError(ctx, p.Txn(), err)
 		}
 
 		currentRow := it.Cur()

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1047,7 +1047,7 @@ func populateSystemJobsTableRows(
 		params...,
 	)
 	if err != nil {
-		return matched, jobs.MaybeGenerateForcedRetryableError(ctx, p.Txn(), err)
+		return matched, err
 	}
 
 	cleanup := func(ctx context.Context) {
@@ -1060,7 +1060,7 @@ func populateSystemJobsTableRows(
 	for {
 		hasNext, err := it.Next(ctx)
 		if !hasNext || err != nil {
-			return matched, jobs.MaybeGenerateForcedRetryableError(ctx, p.Txn(), err)
+			return matched, err
 		}
 
 		currentRow := it.Cur()

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -270,7 +270,7 @@ func distImport(
 		}
 
 		execCfg := execCtx.ExecCfg()
-		jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, job.ID(), execCtx.ExecCfg().Settings.Version)
+		jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, job.ID())
 
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx

--- a/pkg/sql/jobs_profiler_execution_details.go
+++ b/pkg/sql/jobs_profiler_execution_details.go
@@ -43,9 +43,9 @@ func (p *planner) GenerateExecutionDetailsJSON(
 	payload := j.Payload()
 	switch payload.Type() {
 	case jobspb.TypeBackup:
-		executionDetailsJSON, err = constructBackupExecutionDetails(ctx, jobID, execCfg.InternalDB, execCfg.Settings.Version)
+		executionDetailsJSON, err = constructBackupExecutionDetails(ctx, jobID, execCfg.InternalDB)
 	default:
-		executionDetailsJSON, err = constructDefaultExecutionDetails(ctx, jobID, execCfg.InternalDB, execCfg.Settings.Version)
+		executionDetailsJSON, err = constructDefaultExecutionDetails(ctx, jobID, execCfg.InternalDB)
 	}
 
 	return executionDetailsJSON, err
@@ -60,12 +60,12 @@ type defaultExecutionDetails struct {
 }
 
 func constructDefaultExecutionDetails(
-	ctx context.Context, jobID jobspb.JobID, db isql.DB, cv clusterversion.Handle,
+	ctx context.Context, jobID jobspb.JobID, db isql.DB,
 ) ([]byte, error) {
 	executionDetails := &defaultExecutionDetails{}
 	err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		// Populate the latest DSP diagram URL.
-		infoStorage := jobs.InfoStorageForJob(txn, jobID, cv)
+		infoStorage := jobs.InfoStorageForJob(txn, jobID)
 		err := infoStorage.GetLast(ctx, profilerconstants.DSPDiagramInfoKeyPrefix, func(infoKey string, value []byte) error {
 			executionDetails.PlanDiagram = string(value)
 			return nil
@@ -94,13 +94,13 @@ type backupExecutionDetails struct {
 }
 
 func constructBackupExecutionDetails(
-	ctx context.Context, jobID jobspb.JobID, db isql.DB, cv clusterversion.Handle,
+	ctx context.Context, jobID jobspb.JobID, db isql.DB,
 ) ([]byte, error) {
 	var annotatedURL url.URL
 	marshallablePerComponentProgress := make(map[string]float32)
 	if err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		// Read the latest DistSQL diagram.
-		infoStorage := jobs.InfoStorageForJob(txn, jobID, cv)
+		infoStorage := jobs.InfoStorageForJob(txn, jobID)
 		var distSQLURL string
 		if err := infoStorage.GetLast(ctx, profilerconstants.DSPDiagramInfoKeyPrefix, func(infoKey string, value []byte) error {
 			distSQLURL = string(value)

--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -165,7 +165,7 @@ func TestAlreadyRunningJobsAreHandledProperly(t *testing.T) {
 RETURNING id;`, firstID).Scan(&secondID))
 	// Insert the job payload and progress into the `system.job_info` table.
 	err := tc.Server(0).InternalDB().(isql.DB).Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		infoStorage := jobs.InfoStorageForJob(txn, secondID, tc.Server(0).ClusterSettings().Version)
+		infoStorage := jobs.InfoStorageForJob(txn, secondID)
 		if err := infoStorage.WriteLegacyPayload(ctx, firstPayload); err != nil {
 			return err
 		}

--- a/pkg/util/bulk/BUILD.bazel
+++ b/pkg/util/bulk/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/sql/execinfrapb",

--- a/pkg/util/bulk/aggregator_stats.go
+++ b/pkg/util/bulk/aggregator_stats.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -86,7 +85,6 @@ func FlushTracingAggregatorStats(
 	jobID jobspb.JobID,
 	db isql.DB,
 	perNodeAggregatorStats ComponentAggregatorStats,
-	cv clusterversion.Handle,
 ) error {
 	return db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		clusterWideAggregatorStats := make(map[string]TracingAggregatorEvent)
@@ -110,7 +108,7 @@ func FlushTracingAggregatorStats(
 					continue
 				}
 
-				if err := jobs.WriteProtobinExecutionDetailFile(ctx, filename, msg, txn, jobID, cv); err != nil {
+				if err := jobs.WriteProtobinExecutionDetailFile(ctx, filename, msg, txn, jobID); err != nil {
 					return err
 				}
 
@@ -137,6 +135,6 @@ func FlushTracingAggregatorStats(
 		}
 
 		filename := fmt.Sprintf("aggregatorstats.%s.txt", asOf)
-		return jobs.WriteExecutionDetailFile(ctx, filename, clusterWideSummary.Bytes(), txn, jobID, cv)
+		return jobs.WriteExecutionDetailFile(ctx, filename, clusterWideSummary.Bytes(), txn, jobID)
 	})
 }


### PR DESCRIPTION
Revert 3/3 commits from #113864 and then delete jobs.MaybeGenerateForcedRetryableError since it is not needed on master as master (24.1) will never run the 22.2 to 23.1 upgrade.

Epic: none.