### PR TITLE
asim: add lease preference testing

### DIFF
--- a/pkg/kv/kvserver/asim/assertion/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/assertion/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/assertion",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/asim/history",
         "//pkg/kv/kvserver/asim/metrics",
         "//pkg/roachpb",

--- a/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
+++ b/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
@@ -412,20 +412,26 @@ func TestDataDriven(t *testing.T) {
 						Stores:    stores,
 					})
 				case "conformance":
-					var under, over, unavailable, violating int
+					var under, over, unavailable, violating, leaseViolating, leaseLessPref int
 					under = assertion.ConformanceAssertionSentinel
 					over = assertion.ConformanceAssertionSentinel
 					unavailable = assertion.ConformanceAssertionSentinel
 					violating = assertion.ConformanceAssertionSentinel
+					leaseLessPref = assertion.ConformanceAssertionSentinel
+					leaseViolating = assertion.ConformanceAssertionSentinel
 					scanIfExists(t, d, "under", &under)
 					scanIfExists(t, d, "over", &over)
 					scanIfExists(t, d, "unavailable", &unavailable)
 					scanIfExists(t, d, "violating", &violating)
+					scanIfExists(t, d, "lease-violating", &leaseViolating)
+					scanIfExists(t, d, "lease-less-preferred", &leaseLessPref)
 					assertions = append(assertions, assertion.ConformanceAssertion{
-						Underreplicated: under,
-						Overreplicated:  over,
-						Violating:       violating,
-						Unavailable:     unavailable,
+						Underreplicated:           under,
+						Overreplicated:            over,
+						ViolatingConstraints:      violating,
+						Unavailable:               unavailable,
+						ViolatingLeasePreferences: leaseViolating,
+						LessPreferredLeases:       leaseLessPref,
 					})
 				}
 				return ""

--- a/pkg/kv/kvserver/asim/tests/default_settings.go
+++ b/pkg/kv/kvserver/asim/tests/default_settings.go
@@ -129,10 +129,12 @@ func (f randTestingFramework) defaultBasicRangesGen() gen.BasicRanges {
 func defaultAssertions() []assertion.SimulationAssertion {
 	return []assertion.SimulationAssertion{
 		assertion.ConformanceAssertion{
-			Underreplicated: 0,
-			Overreplicated:  0,
-			Violating:       0,
-			Unavailable:     0,
+			Underreplicated:           0,
+			Overreplicated:            0,
+			ViolatingConstraints:      0,
+			Unavailable:               0,
+			ViolatingLeasePreferences: 0,
+			LessPreferredLeases:       0,
 		},
 	}
 }

--- a/pkg/kv/kvserver/asim/tests/rand_gen.go
+++ b/pkg/kv/kvserver/asim/tests/rand_gen.go
@@ -328,10 +328,10 @@ func constructSetZoneConfigEventWithConformanceAssertion(
 		},
 		AssertionEvent: event.NewAssertionEvent([]assertion.SimulationAssertion{
 			assertion.ConformanceAssertion{
-				Underreplicated: 0,
-				Overreplicated:  0,
-				Violating:       0,
-				Unavailable:     0,
+				Underreplicated:      0,
+				Overreplicated:       0,
+				ViolatingConstraints: 0,
+				Unavailable:          0,
 			},
 		}),
 		DurationToAssert: durationToAssert,

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_lease_preferences
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_lease_preferences
@@ -1,0 +1,52 @@
+# This test demonstrates setting and asserting on lease preferences. The
+# cluster topology is identical to example_conformance.
+gen_cluster nodes=5
+----
+
+set_locality node=1 locality=region=a
+----
+
+set_locality node=2 locality=region=a
+----
+
+set_locality node=3 locality=region=b
+----
+
+set_locality node=4 locality=region=b
+----
+
+set_locality node=5 locality=region=b
+----
+
+# Setup three span configs, the first span config should produce no violations
+# as all the voters are required to be in the same region as the preference.
+# The second span config lease preferences will be only satisfiable by a less
+# preferred preference (not the first preference in the preference list). The
+# last span config will be impossible to satisfy, so should produce a violation.
+set_span_config 
+[0,1000): num_replicas=3 num_voters=3 constraints={'+region=b':3} lease_preferences=[['+region=b']]
+----
+
+set_span_config 
+[1000,2000): num_replicas=3 num_voters=3 constraints={'+region=b':3} lease_preferences=[['+region=a'],['+region=b']]
+----
+
+set_span_config 
+[2000,10000): num_replicas=3 num_voters=3 constraints={'+region=b':3} lease_preferences=[['+region=c']]
+----
+
+assertion type=conformance lease-violating=1 lease-less-preferred=1
+----
+
+eval duration=10m
+----
+OK
+
+topology
+----
+a
+  └── [1 2]
+b
+  └── [3 4 5]
+
+# vim:ft=sh

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/events
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/events
@@ -16,13 +16,13 @@ sample1: start running
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:3 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<constraints:<key:"region" value:"US_East" > > lease_preferences:<constraints:<key:"region" value:"US_East" > > 
 	executed at: 2022-03-21 11:10:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 	executed at: 2022-03-21 11:10:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:5 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<num_replicas:2 constraints:<key:"region" value:"US_East" > > lease_preferences:<constraints:<key:"region" value:"US_East" > > 
 	executed at: 2022-03-21 11:20:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 sample1: pass
 ----------------------------------
@@ -32,13 +32,13 @@ sample2: start running
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:3 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<constraints:<key:"region" value:"US_East" > > lease_preferences:<constraints:<key:"region" value:"US_East" > > 
 	executed at: 2022-03-21 11:10:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 	executed at: 2022-03-21 11:10:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:5 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<num_replicas:2 constraints:<key:"region" value:"US_East" > > lease_preferences:<constraints:<key:"region" value:"US_East" > > 
 	executed at: 2022-03-21 11:20:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 sample2: pass
 ----------------------------------
@@ -48,13 +48,13 @@ sample3: start running
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:3 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<constraints:<key:"region" value:"US_East" > > lease_preferences:<constraints:<key:"region" value:"US_East" > > 
 	executed at: 2022-03-21 11:10:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 	executed at: 2022-03-21 11:10:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:5 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<num_replicas:2 constraints:<key:"region" value:"US_East" > > lease_preferences:<constraints:<key:"region" value:"US_East" > > 
 	executed at: 2022-03-21 11:20:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 sample3: pass
 ----------------------------------

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_event
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_event
@@ -84,7 +84,7 @@ US_West
 			failed:   conformance unavailable=0 under=0 over=0 violating=0 
   actual unavailable=0 under=0, over=0 violating=1
 violating constraints:
-  r1:{0000000000-9999999999} [(n17,s17):14, (n18,s18):13, (n22,s22):7] applying num_voters=3 voter_constraints=[+region=US_West] lease_preferences=[+region=US_West]
+  r1:{0000000000-9999999999} [(n17,s17):14, (n18,s18):13, (n22,s22):7] applying num_voters=3 voter_constraints=[+region=US_West] lease_preferences=[{[+region=US_West]}]
 	executed at: 2022-03-21 11:25:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:5 voter_constraints:<num_replicas:2 constraints:<key:"region" value:"EU" > > lease_preferences:<constraints:<key:"region" value:"EU" > > 
 	executed at: 2022-03-21 11:30:00

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_event
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_event
@@ -56,76 +56,76 @@ US_West
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:3 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<constraints:<key:"region" value:"EU" > > lease_preferences:<constraints:<key:"region" value:"EU" > > 
 	executed at: 2022-03-21 11:05:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 	executed at: 2022-03-21 11:05:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:5 voter_constraints:<num_replicas:2 constraints:<key:"region" value:"US_West" > > lease_preferences:<constraints:<key:"region" value:"US_West" > > 
 	executed at: 2022-03-21 11:10:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 	executed at: 2022-03-21 11:10:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:3 num_voters:3 voter_constraints:<constraints:<key:"region" value:"EU" > > lease_preferences:<constraints:<key:"region" value:"EU" > > 
 	executed at: 2022-03-21 11:15:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 	executed at: 2022-03-21 11:15:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:5 voter_constraints:<num_replicas:2 constraints:<key:"region" value:"US_West" > > lease_preferences:<constraints:<key:"region" value:"US_West" > > 
 	executed at: 2022-03-21 11:20:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 	executed at: 2022-03-21 11:20:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:3 num_voters:3 voter_constraints:<constraints:<key:"region" value:"US_West" > > lease_preferences:<constraints:<key:"region" value:"US_West" > > 
 	executed at: 2022-03-21 11:25:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
-			failed:   conformance unavailable=0 under=0 over=0 violating=0 
-  actual unavailable=0 under=0, over=0 violating=1
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
+			failed:   conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
+  actual unavailable=0 under=0, over=0 violating=1 lease-violating=0 lease-less-preferred=0
 violating constraints:
   r1:{0000000000-9999999999} [(n17,s17):14, (n18,s18):13, (n22,s22):7] applying num_voters=3 voter_constraints=[+region=US_West] lease_preferences=[{[+region=US_West]}]
 	executed at: 2022-03-21 11:25:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:5 voter_constraints:<num_replicas:2 constraints:<key:"region" value:"EU" > > lease_preferences:<constraints:<key:"region" value:"EU" > > 
 	executed at: 2022-03-21 11:30:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 	executed at: 2022-03-21 11:30:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:3 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<constraints:<key:"region" value:"EU" > > lease_preferences:<constraints:<key:"region" value:"EU" > > 
 	executed at: 2022-03-21 11:35:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 	executed at: 2022-03-21 11:35:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:5 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<num_replicas:2 constraints:<key:"region" value:"US_West" > > lease_preferences:<constraints:<key:"region" value:"US_West" > > 
 	executed at: 2022-03-21 11:40:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 	executed at: 2022-03-21 11:40:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:3 num_voters:3 voter_constraints:<constraints:<key:"region" value:"EU" > > lease_preferences:<constraints:<key:"region" value:"EU" > > 
 	executed at: 2022-03-21 11:45:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 	executed at: 2022-03-21 11:45:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:5 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<num_replicas:2 constraints:<key:"region" value:"US_West" > > lease_preferences:<constraints:<key:"region" value:"US_West" > > 
 	executed at: 2022-03-21 11:50:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 	executed at: 2022-03-21 11:50:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:5 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<num_replicas:2 constraints:<key:"region" value:"EU" > > lease_preferences:<constraints:<key:"region" value:"EU" > > 
 	executed at: 2022-03-21 11:55:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 	executed at: 2022-03-21 11:55:00
 		event: set span config event with span={0000000000-9999999999}, config=range_min_bytes:134217728 range_max_bytes:536870912 gc_policy:<ttl_seconds:14400 > num_replicas:5 num_voters:3 constraints:<num_replicas:1 constraints:<key:"region" value:"US_East" > > constraints:<num_replicas:1 constraints:<key:"region" value:"US_West" > > constraints:<num_replicas:1 constraints:<key:"region" value:"EU" > > voter_constraints:<constraints:<key:"region" value:"EU" > > lease_preferences:<constraints:<key:"region" value:"EU" > > 
 	executed at: 2022-03-21 12:00:00
 		event: assertion checking event
-			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 
+			1. assertion=conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
 			passed
 sample1: pass
 ----------------------------------

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges
@@ -189,8 +189,8 @@ US
     └── [11 12 13 14 15]
 no events were scheduled
 sample2: failed assertion
-  conformance unavailable=0 under=0 over=0 violating=0 
-  actual unavailable=0 under=0, over=9 violating=0
+  conformance unavailable=0 under=0 over=0 violating=0 lease-violating=0 lease-less-preferred=0 
+  actual unavailable=0 under=0, over=9 violating=0 lease-violating=0 lease-less-preferred=0
 over replicated:
   r120:000001{8921-9080} [(n8,s8):2, (n15,s15):3] applying ttl_seconds=0 num_replicas=1 num_voters=1
   r133:000002{0988-1147} [(n3,s3):2, (n5,s5):3] applying ttl_seconds=0 num_replicas=1 num_voters=1

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -149,12 +149,12 @@ func calcReplicaMetrics(d calcReplicaMetricsInput) ReplicaMetrics {
 		validLeaseType = d.leaseStatus.Lease.Type()
 		if validLeaseOwner {
 			livenessLease = keys.NodeLivenessSpan.Overlaps(d.desc.RSpan().AsRawSpanWithNoLocals())
-			switch checkStoreAgainstLeasePreferences(
+			switch CheckStoreAgainstLeasePreferences(
 				d.storeID, d.storeAttrs, d.nodeAttrs,
 				d.nodeLocality, d.conf.LeasePreferences) {
-			case leasePreferencesViolating:
+			case LeasePreferencesViolating:
 				violatingLeasePreferences = true
-			case leasePreferencesLessPreferred:
+			case LeasePreferencesLessPreferred:
 				lessPreferredLease = true
 			}
 		}

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -543,14 +543,14 @@ func (r *Replica) leasePostApplyLocked(
 	// lease is valid and owned by the replica before processing.
 	if iAmTheLeaseHolder && leaseChangingHands &&
 		LeaseCheckPreferencesOnAcquisitionEnabled.Get(&r.store.cfg.Settings.SV) {
-		preferenceStatus := checkStoreAgainstLeasePreferences(r.store.StoreID(), r.store.Attrs(),
+		preferenceStatus := CheckStoreAgainstLeasePreferences(r.store.StoreID(), r.store.Attrs(),
 			r.store.nodeDesc.Attrs, r.store.nodeDesc.Locality, r.mu.conf.LeasePreferences)
 		switch preferenceStatus {
-		case leasePreferencesOK, leasePreferencesLessPreferred:
+		case LeasePreferencesOK, LeasePreferencesLessPreferred:
 			// We could also enqueue the lease when we are a less preferred
 			// leaseholder, however the replicate queue will eventually get to it and
 			// we already satisfy _some_ preference.
-		case leasePreferencesViolating:
+		case LeasePreferencesViolating:
 			log.VEventf(ctx, 2,
 				"acquired lease violates lease preferences, enqueuing for transfer [lease=%v preferences=%v]",
 				newLease, r.mu.conf.LeasePreferences)

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1550,20 +1550,20 @@ func (r *Replica) hasCorrectLeaseTypeRLocked(lease roachpb.Lease) bool {
 	return hasExpirationLease == r.shouldUseExpirationLeaseRLocked()
 }
 
-// leasePreferencesStatus represents the state of satisfying lease preferences.
-type leasePreferencesStatus int
+// LeasePreferencesStatus represents the state of satisfying lease preferences.
+type LeasePreferencesStatus int
 
 const (
-	_ leasePreferencesStatus = iota
-	// leasePreferencesViolating indicates the checked store does not satisfy any
+	_ LeasePreferencesStatus = iota
+	// LeasePreferencesViolating indicates the checked store does not satisfy any
 	// lease preference applied.
-	leasePreferencesViolating
-	// leasePreferencesLessPreferred indicates the checked store satisfies _some_
+	LeasePreferencesViolating
+	// LeasePreferencesLessPreferred indicates the checked store satisfies _some_
 	// preference, however not the most preferred.
-	leasePreferencesLessPreferred
-	// leasePreferencesOK indicates the checked store satisfies the first
+	LeasePreferencesLessPreferred
+	// LeasePreferencesOK indicates the checked store satisfies the first
 	// preference, or no lease preferences are applied.
-	leasePreferencesOK
+	LeasePreferencesOK
 )
 
 // LeaseViolatesPreferences checks if this replica owns the lease and if it
@@ -1584,30 +1584,30 @@ func (r *Replica) LeaseViolatesPreferences(ctx context.Context, conf *roachpb.Sp
 	storeAttrs := r.store.Attrs()
 	nodeAttrs := r.store.nodeDesc.Attrs
 	nodeLocality := r.store.nodeDesc.Locality
-	preferenceStatus := checkStoreAgainstLeasePreferences(
+	preferenceStatus := CheckStoreAgainstLeasePreferences(
 		storeID, storeAttrs, nodeAttrs, nodeLocality, preferences)
-	return preferenceStatus == leasePreferencesViolating
+	return preferenceStatus == LeasePreferencesViolating
 }
 
-// checkStoreAgainstLeasePreferences returns whether the given store would
+// CheckStoreAgainstLeasePreferences returns whether the given store would
 // violate, be less preferred or ok, leaseholder, according the the lease
 // preferences.
-func checkStoreAgainstLeasePreferences(
+func CheckStoreAgainstLeasePreferences(
 	storeID roachpb.StoreID,
 	storeAttrs, nodeAttrs roachpb.Attributes,
 	nodeLocality roachpb.Locality,
 	preferences []roachpb.LeasePreference,
-) leasePreferencesStatus {
+) LeasePreferencesStatus {
 	if len(preferences) == 0 {
-		return leasePreferencesOK
+		return LeasePreferencesOK
 	}
 	for i, preference := range preferences {
 		if constraint.CheckConjunction(storeAttrs, nodeAttrs, nodeLocality, preference.Constraints) {
 			if i > 0 {
-				return leasePreferencesLessPreferred
+				return LeasePreferencesLessPreferred
 			}
-			return leasePreferencesOK
+			return LeasePreferencesOK
 		}
 	}
-	return leasePreferencesViolating
+	return LeasePreferencesViolating
 }

--- a/pkg/spanconfig/spanconfigtestutils/utils.go
+++ b/pkg/spanconfig/spanconfigtestutils/utils.go
@@ -144,6 +144,11 @@ func ParseZoneConfig(t testing.TB, s string) zonepb.ZoneConfig {
 			part = strings.TrimPrefix(part, "voter_constraints=")
 			require.NoError(t, yaml.UnmarshalStrict([]byte(part), &cl))
 			config.VoterConstraints = cl.Constraints
+		case strings.HasPrefix(part, "lease_preferences="):
+			cl := []zonepb.LeasePreference{}
+			part = strings.TrimPrefix(part, "lease_preferences=")
+			require.NoError(t, yaml.UnmarshalStrict([]byte(part), &cl))
+			config.LeasePreferences = cl
 		default:
 			t.Fatalf("unrecognized suffix for %s, expected 'num_replicas=', 'num_voters=', 'constraints=', or 'voter_constraints='", part)
 		}
@@ -645,7 +650,7 @@ func PrintSpanConfigDiffedAgainstDefaults(conf roachpb.SpanConfig) string {
 		diffs = append(diffs, fmt.Sprintf("voter_constraints=%v", conf.VoterConstraints))
 	}
 	if !reflect.DeepEqual(conf.LeasePreferences, defaultConf.LeasePreferences) {
-		diffs = append(diffs, fmt.Sprintf("lease_preferences=%v", conf.VoterConstraints))
+		diffs = append(diffs, fmt.Sprintf("lease_preferences=%v", conf.LeasePreferences))
 	}
 	if !reflect.DeepEqual(conf.GCPolicy.ProtectionPolicies, defaultConf.GCPolicy.ProtectionPolicies) {
 		sort.Slice(conf.GCPolicy.ProtectionPolicies, func(i, j int) bool {


### PR DESCRIPTION
Add support for parsing and asserting on lease preferences in simulator
tests. This commit adds support for asserting on the number of leases
violating preferences and the number of leases on store's with less
preferred localities/attributes.

Resolves: https://github.com/cockroachdb/cockroach/issues/111838
Release note: None