### PR TITLE
settings: store unencoded ClusterVersion in version setting

### DIFF
--- a/pkg/clusterversion/BUILD.bazel
+++ b/pkg/clusterversion/BUILD.bazel
@@ -45,7 +45,6 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/util/leaktest",
-        "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//require",

--- a/pkg/clusterversion/clusterversion_test.go
+++ b/pkg/clusterversion/clusterversion_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,13 +42,10 @@ func TestClusterVersionOnChange(t *testing.T) {
 			Internal: 4,
 		},
 	}
-	encoded, err := protoutil.Marshal(&newCV)
-	require.NoError(t, err)
-
 	var capturedV ClusterVersion
 	handle.SetOnChange(func(ctx context.Context, newVersion ClusterVersion) {
 		capturedV = newVersion
 	})
-	cvs.SetInternal(ctx, &sv, encoded)
+	cvs.SetInternal(ctx, &sv, newCV)
 	require.Equal(t, newCV, capturedV)
 }

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -43,7 +43,14 @@ func init() {
 
 var _ settings.ClusterVersionImpl = &dummyVersion{}
 
-func (d *dummyVersion) ClusterVersionImpl() {}
+// Encode is part of the ClusterVersionImpl interface.
+func (d *dummyVersion) Encode() []byte {
+	encoded, err := d.Marshal()
+	if err != nil {
+		panic(err)
+	}
+	return encoded
+}
 
 // Unmarshal is part of the protoutil.Message interface.
 func (d *dummyVersion) Unmarshal(data []byte) error {
@@ -887,12 +894,8 @@ func TestSystemOnlyDisallowedOnVirtualCluster(t *testing.T) {
 func setDummyVersion(dv dummyVersion, vs *settings.VersionSetting, sv *settings.Values) error {
 	// This is a bit round about because the VersionSetting doesn't get updated
 	// through the updater, like most other settings. In order to set it, we set
-	// the internal encoded state by hand.
-	encoded, err := protoutil.Marshal(&dv)
-	if err != nil {
-		return err
-	}
-	vs.SetInternal(context.Background(), sv, encoded)
+	// the internal state by hand.
+	vs.SetInternal(context.Background(), sv, &dv)
 	return nil
 }
 

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -95,9 +95,9 @@ func (p *planner) getCurrentEncodedVersionSettingValue(
 						return errors.AssertionFailedf("no value found for version setting")
 					}
 
-					localRawVal := []byte(s.Get(&st.SV))
+					localVal := s.GetInternal(&st.SV)
 					if err := checkClusterSettingValuesAreEquivalent(
-						localRawVal, kvRawVal,
+						localVal.Encode(), kvRawVal,
 					); err != nil {
 						// NB: errors.Wrapf(nil, ...) returns nil.
 						// nolint:errwrap


### PR DESCRIPTION
We currently store the `ClusterVersion` as a protobuf encoded `[]byte`. This requires unmarshaling in hot paths like `IsActive`.

This change switches to storing the `ClusterVersion` directly.

Fixes: #113385
Release note: None