### PR TITLE
roachprod: remove default port assumption in start and start-sql

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -569,16 +569,6 @@ environment variables to the cockroach process.
 			install.NumRacksOption(numRacks),
 		}
 
-		// Always pick a random available port when starting virtual
-		// clusters. We do not expose the functionality of choosing a
-		// specific port for separate-process deployments; for
-		// shared-process, the port will always be based on the system
-		// tenant service.
-		//
-		// TODO(renato): remove this once #111052 is addressed.
-		startOpts.SQLPort = 0
-		startOpts.AdminUIPort = 0
-
 		startOpts.Target = install.StartSharedProcessForVirtualCluster
 		if externalProcessNodes != "" {
 			startOpts.Target = install.StartServiceForVirtualCluster

--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/test",
+        "//pkg/roachprod/config",
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/testutils/sqlutils",

--- a/pkg/cmd/roachtest/roachtestutil/utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils.go
@@ -10,10 +10,48 @@
 
 package roachtestutil
 
-import "github.com/cockroachdb/cockroach/pkg/roachprod/install"
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+)
 
 // SystemInterfaceSystemdUnitName is a convenience function that
 // returns the systemd unit name for the system interface
 func SystemInterfaceSystemdUnitName() string {
 	return install.VirtualClusterLabel(install.SystemInterfaceName, 0)
+}
+
+// DefaultPGUrl is a wrapper over ExternalPGUrl that calls it with the arguments
+// that *almost* all roachtests want: single tenant and only a single node.
+// This wrapper will also make fixing #63145 in the future easier as we can
+// add "password authenticated" to the above.
+func DefaultPGUrl(
+	ctx context.Context, c cluster.Cluster, l *logger.Logger, node option.NodeListOption,
+) (string, error) {
+	pgurl, err := c.ExternalPGUrl(ctx, l, node, "", 0)
+	if err != nil {
+		return "", err
+	}
+	return pgurl[0], nil
+}
+
+// SetDefaultSQLPort sets the SQL port to the default of 26257 if it is
+// a non-local cluster. Local clusters don't support changing the port.
+func SetDefaultSQLPort(c cluster.Cluster, opts install.StartOpts) {
+	if !c.IsLocal() {
+		opts.SQLPort = config.DefaultSQLPort
+	}
+}
+
+// SetDefaultAdminUIPort sets the AdminUI port to the default of 26258 if it is
+// a non-local cluster. Local clusters don't support changing the port.
+func SetDefaultAdminUIPort(c cluster.Cluster, opts install.StartOpts) {
+	if !c.IsLocal() {
+		opts.AdminUIPort = config.DefaultAdminUIPort
+	}
 }

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/errors"
@@ -48,7 +49,9 @@ func registerActiveRecord(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		startOpts := option.DefaultStartOptsInMemory()
+		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
@@ -94,7 +95,9 @@ func registerDatabaseDrop(r registry.Registry) {
 				runTPCE(ctx, t, c, tpceOptions{
 					start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
-						if err := c.StartE(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings, c.Range(1, crdbNodes)); err != nil {
+						startOpts := option.DefaultStartOptsNoBackups()
+						roachtestutil.SetDefaultSQLPort(c, startOpts.RoachprodOpts)
+						if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
 							t.Fatal(err)
 						}
 					},
@@ -196,6 +199,8 @@ func registerDatabaseDrop(r registry.Registry) {
 			runTPCE(ctx, t, c, tpceOptions{
 				start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					startOpts := option.DefaultStartOptsNoBackups()
+					roachtestutil.SetDefaultSQLPort(c, startOpts.RoachprodOpts)
+					roachtestutil.SetDefaultAdminUIPort(c, startOpts.RoachprodOpts)
 					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
 					if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
 						t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/grafana"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -70,6 +71,7 @@ func registerElasticIO(r registry.Registry) {
 
 			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(workAndPromNode))
 			startOpts := option.DefaultStartOptsNoBackups()
+			roachtestutil.SetDefaultAdminUIPort(c, startOpts.RoachprodOpts)
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
 				"--vmodule=io_load_listener=2")
 			settings := install.MakeClusterSettings()

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
@@ -93,7 +94,9 @@ func registerIndexBackfill(r registry.Registry) {
 						// is not running.
 						c.Run(ctx, c.All(), fmt.Sprintf("cp %s ./cockroach", path))
 						settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
-						if err := c.StartE(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings, c.Range(1, crdbNodes)); err != nil {
+						startOpts := option.DefaultStartOptsNoBackups()
+						roachtestutil.SetDefaultSQLPort(c, startOpts.RoachprodOpts)
+						if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
 							t.Fatal(err)
 						}
 					},
@@ -150,6 +153,8 @@ func registerIndexBackfill(r registry.Registry) {
 			runTPCE(ctx, t, c, tpceOptions{
 				start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					startOpts := option.DefaultStartOptsNoBackups()
+					roachtestutil.SetDefaultSQLPort(c, startOpts.RoachprodOpts)
+					roachtestutil.SetDefaultAdminUIPort(c, startOpts.RoachprodOpts)
 					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
 					if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
 						t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
+++ b/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/grafana"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -70,6 +71,8 @@ func registerIntentResolutionOverload(r registry.Registry) {
 			startOpts := option.DefaultStartOptsNoBackups()
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
 				"--vmodule=io_load_listener=2")
+			roachtestutil.SetDefaultSQLPort(c, startOpts.RoachprodOpts)
+			roachtestutil.SetDefaultAdminUIPort(c, startOpts.RoachprodOpts)
 			settings := install.MakeClusterSettings()
 			c.Start(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes))
 			setAdmissionControl(ctx, t, c, true)

--- a/pkg/cmd/roachtest/tests/alterpk.go
+++ b/pkg/cmd/roachtest/tests/alterpk.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -104,10 +105,14 @@ func registerAlterPK(r registry.Registry) {
 		const duration = 10 * time.Minute
 
 		roachNodes, loadNode := setupTest(ctx, t, c)
-
+		pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Node(1))
+		if err != nil {
+			t.Fatal(err)
+		}
 		cmd := fmt.Sprintf(
-			"./cockroach workload fixtures import tpcc --warehouses=%d --db=tpcc",
+			"./cockroach workload fixtures import tpcc --warehouses=%d --db=tpcc '%s'",
 			warehouses,
+			pgurl,
 		)
 		if err := c.RunE(ctx, c.Node(roachNodes[0]), cmd); err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -26,7 +26,7 @@ import (
 const asyncpgRunTestCmd = `
 source venv/bin/activate && 
 cd /mnt/data1/asyncpg && 
-PGPORT=26257 PGHOST=localhost PGUSER=root PGDATABASE=defaultdb python3 setup.py test > asyncpg.stdout
+PGPORT={pgport:1} PGHOST=localhost PGUSER=root PGDATABASE=defaultdb python3 setup.py test > asyncpg.stdout
 `
 
 var asyncpgReleaseTagRegex = regexp.MustCompile(`^(?P<major>v\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)

--- a/pkg/cmd/roachtest/tests/autoupgrade.go
+++ b/pkg/cmd/roachtest/tests/autoupgrade.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -73,9 +74,12 @@ func registerAutoUpgrade(r registry.Registry) {
 
 		decommissionAndStop := func(node int) error {
 			t.WorkerStatus("decommission")
-			port := fmt.Sprintf("{pgport:%d}", node)
+			pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Node(node))
+			if err != nil {
+				return err
+			}
 			if err := c.RunE(ctx, c.Node(node),
-				fmt.Sprintf("./cockroach node decommission %d --insecure --port=%s", node, port)); err != nil {
+				fmt.Sprintf("./cockroach node decommission %d --insecure --url=%s", node, pgurl)); err != nil {
 				return err
 			}
 			t.WorkerStatus("stop")

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -335,11 +335,15 @@ func registerBackup(r registry.Registry) {
 			m := c.NewMonitor(ctx)
 			m.Go(func(ctx context.Context) error {
 				t.Status(`running backup`)
+				pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Node(1))
+				if err != nil {
+					return err
+				}
 				// Tick once before starting the backup, and once after to capture the
 				// total elapsed time. This is used by roachperf to compute and display
 				// the average MB/sec per node.
 				tick()
-				c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
+				c.Run(ctx, c.Node(1), `./cockroach sql --insecure --url=`+pgurl+` -e "
 				BACKUP bank.bank TO 'gs://`+backupTestingBucket+`/`+dest+`?AUTH=implicit'"`)
 				tick()
 

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -632,7 +632,7 @@ func newCDCTester(ctx context.Context, t test.Test, c cluster.Cluster) cdcTester
 	}
 	tester.logger = changefeedLogger
 
-	startOpts, settings := makeCDCBenchOptions()
+	startOpts, settings := makeCDCBenchOptions(c)
 
 	// With a target_duration of 10s, we won't see slow span logs from changefeeds untils we are > 100s
 	// behind, which is well above the 60s targetSteadyLatency we have in some tests.

--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -167,7 +168,7 @@ func formatSI(num int64) string {
 }
 
 // makeCDCBenchOptions creates common cluster options for CDC benchmarks.
-func makeCDCBenchOptions() (option.StartOpts, install.ClusterSettings) {
+func makeCDCBenchOptions(c cluster.Cluster) (option.StartOpts, install.ClusterSettings) {
 	opts := option.DefaultStartOpts()
 	settings := install.MakeClusterSettings()
 	settings.ClusterSettings["kv.rangefeed.enabled"] = "true"
@@ -209,6 +210,9 @@ func makeCDCBenchOptions() (option.StartOpts, install.ClusterSettings) {
 	// Scheduled backups may interfere with performance, disable them.
 	opts.RoachprodOpts.ScheduleBackups = false
 
+	// Prom helpers assume AdminUIPort is at 26258
+	roachtestutil.SetDefaultAdminUIPort(c, opts.RoachprodOpts)
+
 	// Backpressure writers when rangefeed clients can't keep up. This gives more
 	// reliable results, since we can otherwise randomly hit timeouts and incur
 	// catchup scans.
@@ -248,7 +252,7 @@ func runCDCBenchScan(
 
 	// Start data nodes first to place data on them. We'll start the changefeed
 	// coordinator later, since we don't want any data on it.
-	opts, settings := makeCDCBenchOptions()
+	opts, settings := makeCDCBenchOptions(c)
 
 	switch protocol {
 	case cdcBenchMuxProtocol:
@@ -408,7 +412,7 @@ func runCDCBenchWorkload(
 
 	// Start data nodes first to place data on them. We'll start the changefeed
 	// coordinator later, since we don't want any data on it.
-	opts, settings := makeCDCBenchOptions()
+	opts, settings := makeCDCBenchOptions(c)
 	settings.ClusterSettings["kv.rangefeed.enabled"] = strconv.FormatBool(cdcEnabled)
 
 	switch protocol {

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -499,12 +499,15 @@ func (rd *replicationDriver) setupC2C(
 	// TODO(msbutler): allow for backups once this test stabilizes a bit more.
 	srcStartOps := option.DefaultStartOptsNoBackups()
 	srcStartOps.RoachprodOpts.InitTarget = 1
+
+	roachtestutil.SetDefaultAdminUIPort(c, srcStartOps.RoachprodOpts)
 	srcClusterSetting := install.MakeClusterSettings(install.SecureOption(true))
 	c.Start(ctx, t.L(), srcStartOps, srcClusterSetting, srcCluster)
 
 	// TODO(msbutler): allow for backups once this test stabilizes a bit more.
 	dstStartOps := option.DefaultStartOptsNoBackups()
 	dstStartOps.RoachprodOpts.InitTarget = rd.rs.srcNodes + 1
+	roachtestutil.SetDefaultAdminUIPort(c, dstStartOps.RoachprodOpts)
 	dstClusterSetting := install.MakeClusterSettings(install.SecureOption(true))
 	c.Start(ctx, t.L(), dstStartOps, dstClusterSetting, dstCluster)
 

--- a/pkg/cmd/roachtest/tests/connection_latency.go
+++ b/pkg/cmd/roachtest/tests/connection_latency.go
@@ -42,21 +42,29 @@ func runConnectionLatencyTest(
 	err = c.StartE(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings)
 	require.NoError(t, err)
 
+	urlTemplate := func(user string) string {
+		if password {
+			return fmt.Sprintf("postgres://testuser:123@%s:{pgport:1}?sslmode=require&sslrootcert=certs/ca.crt", user)
+		}
+
+		return fmt.Sprintf("postgres://testuser@%s:{pgport:1}?sslcert=certs/client.testuser.crt&sslkey=certs/client.testuser.key&sslrootcert=certs/ca.crt&sslmode=require", user)
+	}
+
 	var passwordFlag string
 	// Only create the user once.
 	t.L().Printf("creating testuser")
 	if password {
-		err = c.RunE(ctx, c.Node(1), `./cockroach sql --certs-dir certs -e "CREATE USER testuser WITH PASSWORD '123' CREATEDB"`)
+		err = c.RunE(ctx, c.Node(1), `./cockroach sql --certs-dir certs --port={pgport:1} -e "CREATE USER testuser WITH PASSWORD '123' CREATEDB"`)
 		require.NoError(t, err)
-		err = c.RunE(ctx, c.Node(1), "./workload init connectionlatency --user testuser --password '123' --secure")
+		err = c.RunE(ctx, c.Node(1), fmt.Sprintf("./workload init connectionlatency --user testuser --password '123' --secure '%s'", urlTemplate("localhost")))
 		require.NoError(t, err)
 		passwordFlag = "--password 123 "
 	} else {
 		// NB: certs for `testuser` are created by `roachprod start --secure`.
-		err = c.RunE(ctx, c.Node(1), `./cockroach sql --certs-dir certs -e "CREATE USER testuser CREATEDB"`)
+		err = c.RunE(ctx, c.Node(1), `./cockroach sql --certs-dir certs --port={pgport:1} -e "CREATE USER testuser CREATEDB"`)
 		require.NoError(t, err)
 		require.NoError(t, err)
-		err = c.RunE(ctx, c.Node(1), "./workload init connectionlatency --user testuser --secure")
+		err = c.RunE(ctx, c.Node(1), fmt.Sprintf("./workload init connectionlatency --user testuser --secure '%s'", urlTemplate("localhost")))
 		require.NoError(t, err)
 	}
 
@@ -66,21 +74,11 @@ func runConnectionLatencyTest(
 		externalIps, err := c.ExternalIP(ctx, t.L(), roachNodes)
 		require.NoError(t, err)
 
-		if password {
-			urlTemplate := "postgres://testuser:123@%s:26257?sslmode=require&sslrootcert=certs/ca.crt"
-			for _, u := range externalIps {
-				url := fmt.Sprintf(urlTemplate, u)
-				urls = append(urls, fmt.Sprintf("'%s'", url))
-			}
-			urlString = strings.Join(urls, " ")
-		} else {
-			urlTemplate := "postgres://testuser@%s:26257?sslcert=certs/client.testuser.crt&sslkey=certs/client.testuser.key&sslrootcert=certs/ca.crt&sslmode=require"
-			for _, u := range externalIps {
-				url := fmt.Sprintf(urlTemplate, u)
-				urls = append(urls, fmt.Sprintf("'%s'", url))
-			}
-			urlString = strings.Join(urls, " ")
+		for _, u := range externalIps {
+			url := urlTemplate(u)
+			urls = append(urls, fmt.Sprintf("'%s'", url))
 		}
+		urlString = strings.Join(urls, " ")
 
 		t.L().Printf("running workload in %q against urls:\n%s", locality, strings.Join(urls, "\n"))
 

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -150,7 +151,12 @@ func runDrainAndDecommission(
 	for i := 1; i <= nodes; i++ {
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(i))
 	}
-	c.Run(ctx, c.Node(pinnedNode), `./cockroach workload init kv --drop --splits 1000`)
+	pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Nodes(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Run(ctx, c.Node(pinnedNode),
+		fmt.Sprintf(`./cockroach workload init kv --drop --splits 1000 '%s'`, pgurl))
 
 	run := func(stmt string) {
 		db := c.Conn(ctx, t.L(), pinnedNode)
@@ -200,7 +206,11 @@ func runDrainAndDecommission(
 		m.Go(func() error {
 			drain := func(id int) error {
 				t.Status(fmt.Sprintf("draining node %d", id))
-				return c.RunE(ctx, c.Node(id), "./cockroach node drain --insecure")
+				pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Node(id))
+				if err != nil {
+					t.Fatal(err)
+				}
+				return c.RunE(ctx, c.Node(id), fmt.Sprintf("./cockroach node drain --insecure --url=%s", pgurl))
 			}
 			return drain(id)
 		})
@@ -214,7 +224,11 @@ func runDrainAndDecommission(
 		id := nodes - 3
 		decom := func(id int) error {
 			t.Status(fmt.Sprintf("decommissioning node %d", id))
-			return c.RunE(ctx, c.Node(id), "./cockroach node decommission --self --insecure")
+			pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Node(id))
+			if err != nil {
+				t.Fatal(err)
+			}
+			return c.RunE(ctx, c.Node(id), fmt.Sprintf("./cockroach node decommission --self --insecure --url=%s", pgurl))
 		}
 		return decom(id)
 	})
@@ -260,7 +274,8 @@ func runDecommission(
 
 		c.Start(ctx, t.L(), withDecommissionVMod(startOpts), install.MakeClusterSettings(), c.Node(i))
 	}
-	c.Run(ctx, c.Node(pinnedNode), fmt.Sprintf(`./workload init kv --drop {pgurl:%d}`, pinnedNode))
+	c.Run(ctx, c.Node(pinnedNode),
+		fmt.Sprintf(`./workload init kv --drop {pgurl:%d}`, pinnedNode))
 
 	h := newDecommTestHelper(t, c)
 
@@ -1121,9 +1136,13 @@ func runDecommissionSlow(ctx context.Context, t test.Test, c cluster.Cluster) {
 		m.Go(func(ctx context.Context) error {
 			decom := func(id int) error {
 				t.Status(fmt.Sprintf("decommissioning node %d", id))
+				pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Node(id))
+				if err != nil {
+					t.Fatal(err)
+				}
 				return c.RunE(ctx,
 					c.Node(id),
-					fmt.Sprintf("./cockroach node decommission %d --insecure --checks=skip", id),
+					fmt.Sprintf("./cockroach node decommission %d --insecure --checks=skip --url=%s", id, pgurl),
 				)
 			}
 			return decom(id)
@@ -1461,7 +1480,11 @@ func execCLI(
 	args := []string{"./cockroach"}
 	args = append(args, extraArgs...)
 	args = append(args, "--insecure")
-	args = append(args, fmt.Sprintf("--port={pgport:%d}", runNode))
+	pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Node(runNode))
+	if err != nil {
+		t.Fatal(err)
+	}
+	args = append(args, fmt.Sprintf("--url=%s", pgurl))
 	result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(runNode), args...)
 	t.L().Printf("%s\n", result.Stdout)
 	return result.Stdout, err

--- a/pkg/cmd/roachtest/tests/drop.go
+++ b/pkg/cmd/roachtest/tests/drop.go
@@ -43,7 +43,11 @@ func registerDrop(r registry.Registry) {
 		m := c.NewMonitor(ctx, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
 			t.WorkerStatus("importing TPCC fixture")
-			c.Run(ctx, c.Node(1), tpccImportCmd(warehouses))
+			pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Nodes(1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.Run(ctx, c.Node(1), tpccImportCmd(warehouses, pgurl))
 
 			// Don't open the DB connection until after the data has been imported.
 			// Otherwise the ALTER TABLE query below might fail to find the

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -1289,6 +1289,8 @@ func (f *blackholeFailer) Cleanup(ctx context.Context) {
 }
 
 func (f *blackholeFailer) Fail(ctx context.Context, nodeID int) {
+	pgport := fmt.Sprintf("{pgport:%d}", nodeID)
+
 	// When dropping both input and output, make sure we drop packets in both
 	// directions for both the inbound and outbound TCP connections, such that we
 	// get a proper black hole. Only dropping one direction for both of INPUT and
@@ -1300,15 +1302,15 @@ func (f *blackholeFailer) Fail(ctx context.Context, nodeID int) {
 	// outages in the wild.
 	if f.input && f.output {
 		// Inbound TCP connections, both received and sent packets.
-		f.c.Run(ctx, f.c.Node(nodeID), `sudo iptables -A INPUT -p tcp --dport 26257 -j DROP`)
-		f.c.Run(ctx, f.c.Node(nodeID), `sudo iptables -A OUTPUT -p tcp --sport 26257 -j DROP`)
+		f.c.Run(ctx, f.c.Node(nodeID), fmt.Sprintf(`sudo iptables -A INPUT -p tcp --dport %s -j DROP`, pgport))
+		f.c.Run(ctx, f.c.Node(nodeID), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --sport %s -j DROP`, pgport))
 		// Outbound TCP connections, both sent and received packets.
-		f.c.Run(ctx, f.c.Node(nodeID), `sudo iptables -A OUTPUT -p tcp --dport 26257 -j DROP`)
-		f.c.Run(ctx, f.c.Node(nodeID), `sudo iptables -A INPUT -p tcp --sport 26257 -j DROP`)
+		f.c.Run(ctx, f.c.Node(nodeID), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --dport %s -j DROP`, pgport))
+		f.c.Run(ctx, f.c.Node(nodeID), fmt.Sprintf(`sudo iptables -A INPUT -p tcp --sport %s -j DROP`, pgport))
 	} else if f.input {
-		f.c.Run(ctx, f.c.Node(nodeID), `sudo iptables -A INPUT -p tcp --dport 26257 -j DROP`)
+		f.c.Run(ctx, f.c.Node(nodeID), fmt.Sprintf(`sudo iptables -A INPUT -p tcp --dport %s -j DROP`, pgport))
 	} else if f.output {
-		f.c.Run(ctx, f.c.Node(nodeID), `sudo iptables -A OUTPUT -p tcp --dport 26257 -j DROP`)
+		f.c.Run(ctx, f.c.Node(nodeID), fmt.Sprintf(`sudo iptables -A OUTPUT -p tcp --dport %s -j DROP`, pgport))
 	}
 }
 
@@ -1319,6 +1321,8 @@ func (f *blackholeFailer) FailPartial(ctx context.Context, nodeID int, peerIDs [
 	require.NoError(f.t, err)
 
 	for _, peerIP := range peerIPs {
+		pgport := fmt.Sprintf("{pgport:%d}", nodeID)
+
 		// When dropping both input and output, make sure we drop packets in both
 		// directions for both the inbound and outbound TCP connections, such that
 		// we get a proper black hole. Only dropping one direction for both of INPUT
@@ -1331,20 +1335,20 @@ func (f *blackholeFailer) FailPartial(ctx context.Context, nodeID int, peerIDs [
 		if f.input && f.output {
 			// Inbound TCP connections, both received and sent packets.
 			f.c.Run(ctx, f.c.Node(nodeID), fmt.Sprintf(
-				`sudo iptables -A INPUT -p tcp -s %s --dport 26257 -j DROP`, peerIP))
+				`sudo iptables -A INPUT -p tcp -s %s --dport %s -j DROP`, peerIP, pgport))
 			f.c.Run(ctx, f.c.Node(nodeID), fmt.Sprintf(
-				`sudo iptables -A OUTPUT -p tcp -d %s --sport 26257 -j DROP`, peerIP))
+				`sudo iptables -A OUTPUT -p tcp -d %s --sport %s -j DROP`, peerIP, pgport))
 			// Outbound TCP connections, both sent and received packets.
 			f.c.Run(ctx, f.c.Node(nodeID), fmt.Sprintf(
-				`sudo iptables -A OUTPUT -p tcp -d %s --dport 26257 -j DROP`, peerIP))
+				`sudo iptables -A OUTPUT -p tcp -d %s --dport %s -j DROP`, peerIP, pgport))
 			f.c.Run(ctx, f.c.Node(nodeID), fmt.Sprintf(
-				`sudo iptables -A INPUT -p tcp -s %s --sport 26257 -j DROP`, peerIP))
+				`sudo iptables -A INPUT -p tcp -s %s --sport %s -j DROP`, peerIP, pgport))
 		} else if f.input {
 			f.c.Run(ctx, f.c.Node(nodeID), fmt.Sprintf(
-				`sudo iptables -A INPUT -p tcp -s %s --dport 26257 -j DROP`, peerIP))
+				`sudo iptables -A INPUT -p tcp -s %s --dport %s -j DROP`, peerIP, pgport))
 		} else if f.output {
 			f.c.Run(ctx, f.c.Node(nodeID), fmt.Sprintf(
-				`sudo iptables -A OUTPUT -p tcp -d %s --dport 26257 -j DROP`, peerIP))
+				`sudo iptables -A OUTPUT -p tcp -d %s --dport %s -j DROP`, peerIP, pgport))
 		}
 	}
 }

--- a/pkg/cmd/roachtest/tests/flowable.go
+++ b/pkg/cmd/roachtest/tests/flowable.go
@@ -170,7 +170,7 @@ grep "force-commit" . -lr | xargs sed -i 's/-- force-commit//g'`,
 }
 
 const flowableParams = `
-jdbc.url=jdbc:postgresql://127.0.0.1:26257/flowable?sslmode=disable
+jdbc.url=jdbc:postgresql://127.0.0.1:{pgport:1}/flowable?sslmode=disable
 jdbc.driver=org.postgresql.Driver
 jdbc.username=flowable
 jdbc.password

--- a/pkg/cmd/roachtest/tests/gopg.go
+++ b/pkg/cmd/roachtest/tests/gopg.go
@@ -106,7 +106,7 @@ func registerGopg(r registry.Registry) {
 
 		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node,
 			fmt.Sprintf(
-				`cd %s && PGPORT=26257 PGUSER=root PGSSLMODE=disable PGDATABASE=postgres go test -v ./... 2>&1 | %s | tee %s`,
+				`cd %s && PGPORT={pgport:1} PGUSER=root PGSSLMODE=disable PGDATABASE=postgres go test -v ./... 2>&1 | %s | tee %s`,
 				destPath, removeColorCodes, resultsFilePath),
 		)
 

--- a/pkg/cmd/roachtest/tests/gorm.go
+++ b/pkg/cmd/roachtest/tests/gorm.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/stretchr/testify/require"
@@ -104,7 +105,11 @@ func registerGORM(r registry.Registry) {
 		ignorelistName, ignoredFailures := "gormIgnorelist", gormIgnorelist
 		t.L().Printf("Running cockroach version %s, using blocklist %s, using ignorelist %s", version, blocklistName, ignorelistName)
 
-		err = c.RunE(ctx, node, `./cockroach sql -e "CREATE DATABASE gorm" --insecure`)
+		pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Node(1))
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = c.RunE(ctx, node, fmt.Sprintf(`./cockroach sql -e "CREATE DATABASE gorm" --insecure --url=%s`, pgurl))
 		require.NoError(t, err)
 
 		t.Status("downloading go dependencies for tests")
@@ -125,7 +130,7 @@ func registerGORM(r registry.Registry) {
 			ctx,
 			node,
 			fmt.Sprintf(`cd %s && rm migrate_test.go &&
-				GORM_DIALECT="postgres" GORM_DSN="user=root password= dbname=gorm host=localhost port=26257 sslmode=disable"
+				GORM_DIALECT="postgres" GORM_DSN="user=root password= dbname=gorm host=localhost port={pgport:1} sslmode=disable"
 				go test -v ./... 2>&1 | %s/bin/go-junit-report > %s`,
 				gormTestPath, goPath, resultsPath),
 		)

--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 )
 
@@ -93,7 +94,9 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		startOpts := option.DefaultStartOptsInMemory()
+		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.All())
 
 		if opt.dbSetupFunc != nil {
 			opt.dbSetupFunc(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -141,11 +141,15 @@ func registerImportTPCC(r registry.Registry) {
 		m.Go(hc.Runner)
 
 		tick, perfBuf := initBulkJobPerfArtifacts(testName, timeout)
-		workloadStr := `./cockroach workload fixtures import tpcc --warehouses=%d --csv-server='http://localhost:8081'`
+		workloadStr := `./cockroach workload fixtures import tpcc --warehouses=%d --csv-server='http://localhost:8081' '%s'`
 		m.Go(func(ctx context.Context) error {
 			defer dul.Done()
 			defer hc.Done()
-			cmd := fmt.Sprintf(workloadStr, warehouses)
+			pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Nodes(1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			cmd := fmt.Sprintf(workloadStr, warehouses, pgurl)
 			// Tick once before starting the import, and once after to capture the
 			// total elapsed time. This is used by roachperf to compute and display
 			// the average MB/sec per node.
@@ -355,13 +359,22 @@ func registerImportDecommissioned(r registry.Registry) {
 		// Decommission a node.
 		nodeToDecommission := 2
 		t.Status(fmt.Sprintf("decommissioning node %d", nodeToDecommission))
-		c.Run(ctx, c.Node(nodeToDecommission), `./cockroach node decommission --insecure --self --wait=all`)
+		pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Node(nodeToDecommission))
+		if err != nil {
+			t.Fatal(err)
+		}
+		c.Run(ctx, c.Node(nodeToDecommission),
+			fmt.Sprintf(`./cockroach node decommission --insecure --self --wait=all --url=%s`, pgurl))
 
 		// Wait for a bit for node liveness leases to expire.
 		time.Sleep(10 * time.Second)
 
 		t.Status("running workload")
-		c.Run(ctx, c.Node(1), tpccImportCmd(warehouses))
+		pgurl, err = roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Nodes(1))
+		if err != nil {
+			t.Fatal(err)
+		}
+		c.Run(ctx, c.Node(1), tpccImportCmd(warehouses, pgurl))
 	}
 
 	r.Add(registry.TestSpec{

--- a/pkg/cmd/roachtest/tests/jasyncsql.go
+++ b/pkg/cmd/roachtest/tests/jasyncsql.go
@@ -93,7 +93,7 @@ func registerJasyncSQL(r registry.Registry) {
 		_ = c.RunE(
 			ctx,
 			node,
-			`cd /mnt/data1/jasync-sql && PGUSER=root PGHOST=localhost PGPORT=26257 PGDATABASE=defaultdb ./gradlew :postgresql-async:test`,
+			`cd /mnt/data1/jasync-sql && PGUSER=root PGHOST=localhost PGPORT={pgport:1} PGDATABASE=defaultdb ./gradlew :postgresql-async:test`,
 		)
 
 		_ = c.RunE(ctx, node, `mkdir -p ~/logs/report/jasyncsql-results`)

--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/stretchr/testify/require"
 )
@@ -40,7 +41,9 @@ func registerKnex(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		startOpts := option.DefaultStartOptsInMemory()
+		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		require.NoError(t, err)

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -554,7 +555,12 @@ func registerKVGracefulDraining(r registry.Registry) {
 			// Initialize the database with a lot of ranges so that there are
 			// definitely a large number of leases on the node that we shut down
 			// before it starts draining.
-			c.Run(ctx, c.Node(1), "./cockroach workload init kv --splits 100")
+			pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Nodes(1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.Run(ctx, c.Node(1),
+				fmt.Sprintf("./cockroach workload init kv --splits 100 '%s'", pgurl))
 
 			m := c.NewMonitor(ctx, c.Nodes(1, nodes))
 			m.ExpectDeath()

--- a/pkg/cmd/roachtest/tests/libpq.go
+++ b/pkg/cmd/roachtest/tests/libpq.go
@@ -104,7 +104,7 @@ func registerLibPQ(r registry.Registry) {
 		result, err := c.RunWithDetailsSingleNode(
 			ctx, t.L(),
 			node,
-			fmt.Sprintf(`cd %s && PGPORT=26257 PGUSER=root PGSSLMODE=disable PGDATABASE=postgres go test -list "%s"`, libPQPath, testListRegex),
+			fmt.Sprintf(`cd %s && PGPORT={pgport:1} PGUSER=root PGSSLMODE=disable PGDATABASE=postgres go test -list "%s"`, libPQPath, testListRegex),
 		)
 		require.NoError(t, err)
 
@@ -131,7 +131,7 @@ func registerLibPQ(r registry.Registry) {
 		_ = c.RunE(
 			ctx,
 			node,
-			fmt.Sprintf("cd %s && PGPORT=26257 PGUSER=root PGSSLMODE=disable PGDATABASE=postgres go test -run %s -v 2>&1 | %s/bin/go-junit-report > %s",
+			fmt.Sprintf("cd %s && PGPORT={pgport:1} PGUSER=root PGSSLMODE=disable PGDATABASE=postgres go test -run %s -v 2>&1 | %s/bin/go-junit-report > %s",
 				libPQPath, allowedTestsRegExp, goPath, resultsPath),
 		)
 

--- a/pkg/cmd/roachtest/tests/liquibase.go
+++ b/pkg/cmd/roachtest/tests/liquibase.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 )
 
@@ -35,7 +36,9 @@ func registerLiquibase(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
+		startOpts := option.DefaultStartOpts()
+		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -852,6 +852,7 @@ func (sc *systemTableContents) loadShowResults(
 	showCmd := roachtestutil.NewCommand("%s sql", test.DefaultCockroachPath).
 		Flag("certs-dir", "certs").
 		Flag("e", fmt.Sprintf("%q", query)).
+		Flag("port", fmt.Sprintf("{pgport:%d}", sc.roachNode)).
 		String()
 
 	node := sc.cluster.Node(sc.roachNode)

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -46,7 +46,6 @@ func registerSchemaChangeMixedVersions(r registry.Registry) {
 	})
 }
 
-// runSchemaChangeMixedVersions runs through randomized schema change processes in a mixed-version state.
 func runSchemaChangeMixedVersions(
 	ctx context.Context, t test.Test, c cluster.Cluster, maxOps int, concurrency int,
 ) {

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -59,7 +59,7 @@ func runMultiTenantTPCH(
 		}
 		for queryNum := 1; queryNum <= tpch.NumQueries; queryNum++ {
 			cmd := fmt.Sprintf("./workload run tpch %s --secure "+
-				"--concurrency=1 --db=tpch --max-ops=%d --queries=%d",
+				"--concurrency=1 --db=tpch --max-ops=%d --queries=%d {pgurl:1}",
 				url, numRunsPerQuery, queryNum)
 			result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(1), cmd)
 			workloadOutput := result.Stdout + result.Stderr

--- a/pkg/cmd/roachtest/tests/mvcc_gc.go
+++ b/pkg/cmd/roachtest/tests/mvcc_gc.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -122,9 +123,17 @@ func runMVCCGC(ctx context.Context, t test.Test, c cluster.Cluster) {
 		t.Fatalf("failed to up-replicate cluster: %s", err)
 	}
 
+	pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Nodes(1))
+	if err != nil {
+		t.Fatal(err)
+	}
 	m := c.NewMonitor(ctx)
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(1), "./cockroach", "workload", "init", "kv", "--cycle-length", "20000")
+		cmd := roachtestutil.NewCommand("./cockroach workload init kv").
+			Flag("cycle-length", 20000).
+			Arg("%s", pgurl).
+			String()
+		c.Run(ctx, c.Node(1), cmd)
 
 		execSQLOrFail("alter database kv configure zone using gc.ttlseconds = $1", 120)
 
@@ -136,8 +145,15 @@ func runMVCCGC(ctx context.Context, t test.Test, c cluster.Cluster) {
 		wlFailure := make(chan error)
 		go func() {
 			defer close(wlFailure)
-			err := c.RunE(wlCtx, c.Node(1), "./cockroach", "workload", "run", "kv", "--cycle-length", "20000",
-				"--max-block-bytes", "2048", "--min-block-bytes", "2048", "--read-percent", "0", "--max-rate", "1800")
+			cmd = roachtestutil.NewCommand("./cockroach workload run kv").
+				Flag("cycle-length", 20000).
+				Flag("max-block-bytes", 2048).
+				Flag("min-block-bytes", 2048).
+				Flag("read-percent", 0).
+				Flag("max-rate", 1800).
+				Arg("{pgurl%s}", c.Node(1)).
+				String()
+			err := c.RunE(wlCtx, c.Node(1), cmd)
 			wlFailure <- err
 		}()
 
@@ -624,8 +640,13 @@ func sendBatchRequest(
 	if randomSeed != 0 {
 		debugEnv = fmt.Sprintf("COCKROACH_RANDOM_SEED=%d ", randomSeed)
 	}
+	cmd := roachtestutil.NewCommand("./cockroach debug send-kv-batch").
+		Arg(requestFileName).
+		Option("insecure").
+		Flag("host", fmt.Sprintf("localhost:{pgport:%d}", node)).
+		String()
 	res, err := c.RunWithDetailsSingleNode(
-		ctx, t.L(), c.Node(node), debugEnv+"./cockroach debug send-kv-batch --insecure", requestFileName)
+		ctx, t.L(), c.Node(node), debugEnv+cmd)
 	if err != nil {
 		return kvpb.BatchResponse{}, err
 	}

--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -133,9 +134,12 @@ func runNetworkAuthentication(ctx context.Context, t test.Test, c cluster.Cluste
 			if timeutil.Since(tStart) > 30*time.Second {
 				t.L().Printf("still waiting for leases to move")
 				// The leases have not moved yet, so display some progress.
-				dumpRangesCmd := fmt.Sprintf(`./cockroach sql --certs-dir %s -e 'TABLE crdb_internal.ranges'`, certsDir)
+				dumpRangesCmd := roachtestutil.NewCommand("./cockroach sql -e 'TABLE crdb_internal.ranges'").
+					Flag("certs-dir", certsDir).
+					Flag("port", "{pgport:1}").
+					String()
 				t.L().Printf("SQL: %s", dumpRangesCmd)
-				err := c.RunE(ctx, c.Node(1), dumpRangesCmd)
+				err = c.RunE(ctx, c.Node(1), dumpRangesCmd)
 				require.NoError(t, err)
 			}
 

--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -50,12 +50,12 @@ func registerNodeJSPostgres(r registry.Registry) {
 
 		err = repeatRunE(ctx, t, c, node, "create sql user",
 			fmt.Sprintf(
-				`./cockroach sql --certs-dir certs -e "CREATE USER %s CREATEDB"`, user,
+				`./cockroach sql --certs-dir certs --port={pgport:1} -e "CREATE USER %s CREATEDB"`, user,
 			))
 		require.NoError(t, err)
 
 		err = repeatRunE(ctx, t, c, node, "create test database",
-			`./cockroach sql --certs-dir certs -e "CREATE DATABASE postgres_node_test"`,
+			`./cockroach sql --certs-dir certs --port={pgport:1} -e "CREATE DATABASE postgres_node_test"`,
 		)
 		require.NoError(t, err)
 
@@ -148,7 +148,7 @@ echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.co
 		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node,
 			fmt.Sprintf(
 				`cd /mnt/data1/node-postgres/ && sudo \
-PGPORT=26257 PGUSER=%s PGSSLMODE=require PGDATABASE=postgres_node_test \
+PGPORT={pgport:1} PGUSER=%s PGSSLMODE=require PGDATABASE=postgres_node_test \
 PGSSLCERT=$HOME/certs/client.%s.crt PGSSLKEY=$HOME/certs/client.%s.key PGSSLROOTCERT=$HOME/certs/ca.crt yarn test`,
 				user, user, user,
 			),

--- a/pkg/cmd/roachtest/tests/pgjdbc.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc.go
@@ -237,7 +237,7 @@ func registerPgjdbc(r registry.Registry) {
 
 const pgjdbcDatabaseParams = `
 server=localhost
-port=26257
+port={pgport:1}
 secondaryServer=localhost
 secondaryPort=5433
 secondaryServer2=localhost

--- a/pkg/cmd/roachtest/tests/pgx.go
+++ b/pkg/cmd/roachtest/tests/pgx.go
@@ -117,7 +117,7 @@ func registerPgx(r registry.Registry) {
 			ctx, c, t, node,
 			"run pgx test suite",
 			"cd /mnt/data1/pgx && "+
-				"PGX_TEST_DATABASE='postgresql://root:@localhost:26257/pgx_test' go test -v 2>&1 | "+
+				"PGX_TEST_DATABASE='postgresql://root:@localhost:{pgport:1}/pgx_test' go test -v 2>&1 | "+
 				"`go env GOPATH`/bin/go-junit-report",
 		)
 

--- a/pkg/cmd/roachtest/tests/pop.go
+++ b/pkg/cmd/roachtest/tests/pop.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +34,9 @@ func registerPop(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		startOpts := option.DefaultStartOptsInMemory()
+		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.All())
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/psycopg.go
+++ b/pkg/cmd/roachtest/tests/psycopg.go
@@ -112,7 +112,7 @@ func registerPsycopg(r registry.Registry) {
 			`cd /mnt/data1/psycopg/ &&
 			export PSYCOPG2_TESTDB=defaultdb &&
 			export PSYCOPG2_TESTDB_USER=root &&
-			export PSYCOPG2_TESTDB_PORT=26257 &&
+			export PSYCOPG2_TESTDB_PORT={pgport:1} &&
 			export PSYCOPG2_TESTDB_HOST=localhost &&
 			make check PYTHON_VERSION=3`,
 		)

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
@@ -51,7 +52,9 @@ func registerRubyPG(r registry.Registry) {
 		}
 		node := c.Node(1)
 		t.Status("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOptsInMemory(), install.MakeClusterSettings(), c.All())
+		startOpts := option.DefaultStartOptsInMemory()
+		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/slow_drain.go
+++ b/pkg/cmd/roachtest/tests/slow_drain.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -118,9 +119,13 @@ func runSlowDrain(ctx context.Context, t test.Test, c cluster.Cluster, duration 
 		m.Go(func(ctx context.Context) error {
 			drain := func(id int) error {
 				t.Status(fmt.Sprintf("draining node %d", id))
+				pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Node(id))
+				if err != nil {
+					t.Fatal(err)
+				}
 				return c.RunE(ctx,
 					c.Node(id),
-					fmt.Sprintf("./cockroach node drain %d --insecure --drain-wait=%s", id, duration.String()),
+					fmt.Sprintf("./cockroach node drain %d --insecure --drain-wait=%s --url=%s", id, duration.String(), pgurl),
 				)
 			}
 			return drain(id)

--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -146,7 +146,7 @@ func runSQLAlchemy(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// will fail. And it is safe to swallow it here.
 	result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node,
 		`source venv/bin/activate && cd /mnt/data1/sqlalchemy-cockroachdb/ && pytest --maxfail=0 \
-		--dburi='cockroachdb://root@localhost:26257/defaultdb?sslmode=disable&disable_cockroachdb_telemetry=true' \
+		--dburi='cockroachdb://root@localhost:{pgport:1}/defaultdb?sslmode=disable&disable_cockroachdb_telemetry=true' \
 		test/test_suite_sqlalchemy.py
 	`)
 

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -179,7 +179,11 @@ func setupTPCC(
 			// Do nothing.
 		case usingImport:
 			t.Status("loading fixture" + estimatedSetupTimeStr)
-			c.Run(ctx, crdbNodes[:1], tpccImportCmd(opts.Warehouses, opts.ExtraSetupArgs))
+			pgurl, err := roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Nodes(1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.Run(ctx, crdbNodes[:1], tpccImportCmd(opts.Warehouses, opts.ExtraSetupArgs, pgurl))
 		case usingInit:
 			t.Status("initializing tables" + estimatedSetupTimeStr)
 			extraArgs := opts.ExtraSetupArgs
@@ -1288,6 +1292,11 @@ func loadTPCCBench(
 	var pgurl string
 	if b.SharedProcessMT {
 		pgurl = fmt.Sprintf("{pgurl%s:%s}", roachNodes[:1], appTenantName)
+	} else {
+		pgurl, err = roachtestutil.DefaultPGUrl(ctx, c, t.L(), c.Nodes(1))
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	cmd := tpccImportCmd(loadWarehouses, loadArgs, pgurl)
 	if err = c.RunE(ctx, roachNodes[:1], cmd); err != nil {

--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -147,6 +147,7 @@ func runTPCE(ctx context.Context, t test.Test, c cluster.Cluster, opts tpceOptio
 			t.Status("installing cockroach")
 			startOpts := option.DefaultStartOpts()
 			startOpts.RoachprodOpts.StoreCount = opts.ssds
+			roachtestutil.SetDefaultSQLPort(c, startOpts.RoachprodOpts)
 			settings := install.MakeClusterSettings(install.NumRacksOption(racks))
 			c.Start(ctx, t.L(), startOpts, settings, crdbNodes)
 		}

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -575,6 +575,11 @@ func smithcmpTestRun(
 	if err := c.RunE(ctx, firstNode, fmt.Sprintf("curl %s > %s", configURL, configFile)); err != nil {
 		t.Fatal(err)
 	}
+	// smithcmp cannot access the pgport env variable, so we must edit the config file here
+	// to tell it the port to use.
+	if err := c.RunE(ctx, firstNode, fmt.Sprintf(`port=$(echo -n {pgport:1}) && sed -i "s|26257|$port|g" %s`, configFile)); err != nil {
+		t.Fatal(err)
+	}
 	cmd := fmt.Sprintf("./%s %s", tpchVecSmithcmp, configFile)
 	if err := c.RunE(ctx, firstNode, cmd); err != nil {
 		t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -294,7 +294,7 @@ const typeORMConfigJSON = `
     "name": "cockroachdb",
     "type": "cockroachdb",
     "host": "localhost",
-    "port": 26257,
+    "port": {pgport:1},
     "username": "root",
     "password": "",
     "database": "defaultdb"

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -682,10 +682,8 @@ func DefaultStartOpts() install.StartOpts {
 		ScheduleBackups:    false,
 		ScheduleBackupArgs: "",
 		InitTarget:         1,
-		// TODO(renato): change the defaults below to `0` (i.e., pick a
-		// random available port) once #111052 is addressed.
-		SQLPort:     config.DefaultSQLPort,
-		AdminUIPort: config.DefaultAdminUIPort,
+		SQLPort:            0,
+		AdminUIPort:        0,
 	}
 }
 

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -298,7 +298,6 @@ func workerRun(
 
 func runInit(gen workload.Generator, urls []string, dbName string) error {
 	ctx := context.Background()
-
 	initDB, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously, the default sql port and admin ui port were set to 26257
and 26258 respectively in start and start-sql. This change now removes
that default assignment and now randomly assigns an available open port.

Many roachtests rely on this default port assumption and fail after this
change. To fix this, we now explicity specify the port when applicable.
Some roachtests use a third party library, where the port cannot be easily
passed in and is hardcoded. In these cases, we retain the previous behaviour
by specifying StartOpts.RoachprodOpts.SQLPort.

Epic: None
Fixes: #111052
Release note: none