### PR TITLE
sql/telemetry: give more descriptive names for statement logging and use atomic counter types where appropriate

### DIFF
--- a/pkg/ccl/telemetryccl/telemetry_logging_test.go
+++ b/pkg/ccl/telemetryccl/telemetry_logging_test.go
@@ -291,7 +291,7 @@ func TestBulkJobTelemetryLogging(t *testing.T) {
 		},
 	}
 
-	sql.TelemetryMaxEventFrequency.Override(context.Background(), &testCluster.Server(0).ApplicationLayer().ClusterSettings().SV, 10)
+	sql.TelemetryMaxStatementEventFrequency.Override(context.Background(), &testCluster.Server(0).ApplicationLayer().ClusterSettings().SV, 10)
 
 	// Run all the queries, one after the previous one is finished.
 	var jobID int

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -461,7 +461,7 @@ func NewServer(
 		idxRecommendationsCache: idxrecommendations.NewIndexRecommendationsCache(cfg.Settings),
 	}
 
-	telemetryLoggingMetrics := newTelemetryLoggingmetrics(cfg.TelemetryLoggingTestingKnobs, cfg.Settings)
+	telemetryLoggingMetrics := newTelemetryLoggingMetrics(cfg.TelemetryLoggingTestingKnobs, cfg.Settings)
 	telemetryLoggingMetrics.registerOnTelemetrySamplingModeChange(cfg.Settings)
 	s.TelemetryLoggingMetrics = telemetryLoggingMetrics
 

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -300,7 +300,7 @@ func (p *planner) maybeLogStatementInternal(
 			txnID = p.txn.ID().String()
 		}
 
-		if telemetryMetrics.shouldEmitLog(telemetryMetrics.timeNow(), txnID, forceLog, stmtCount) {
+		if telemetryMetrics.shouldEmitStatementLog(telemetryMetrics.timeNow(), txnID, forceLog, stmtCount) {
 			var queryLevelStats execstats.QueryLevelStats
 			if stats, ok := p.instrumentation.GetQueryLevelStats(); ok {
 				queryLevelStats = *stats

--- a/pkg/sql/telemetry_logging.go
+++ b/pkg/sql/telemetry_logging.go
@@ -105,7 +105,7 @@ type TelemetryLoggingMetrics struct {
 	Knobs *TelemetryLoggingTestingKnobs
 
 	// skippedQueryCount is used to produce the count of non-sampled queries.
-	skippedQueryCount uint64
+	skippedQueryCount atomic.Uint64
 }
 
 func newTelemetryLoggingmetrics(
@@ -275,9 +275,9 @@ func (t *TelemetryLoggingMetrics) isTracing(_ *tracing.Span, tracingEnabled bool
 }
 
 func (t *TelemetryLoggingMetrics) resetSkippedQueryCount() (res uint64) {
-	return atomic.SwapUint64(&t.skippedQueryCount, 0)
+	return t.skippedQueryCount.Swap(0)
 }
 
 func (t *TelemetryLoggingMetrics) incSkippedQueryCount() {
-	atomic.AddUint64(&t.skippedQueryCount, 1)
+	t.skippedQueryCount.Add(1)
 }

--- a/pkg/sql/telemetry_logging.go
+++ b/pkg/sql/telemetry_logging.go
@@ -27,7 +27,7 @@ import (
 // are logged to the telemetry channel.
 const defaultMaxEventFrequency = 8
 
-var TelemetryMaxEventFrequency = settings.RegisterIntSetting(
+var TelemetryMaxStatementEventFrequency = settings.RegisterIntSetting(
 	settings.ApplicationLevel,
 	"sql.telemetry.query_sampling.max_event_frequency",
 	"the max event frequency at which we sample executions for telemetry, "+
@@ -108,7 +108,7 @@ type TelemetryLoggingMetrics struct {
 	skippedQueryCount atomic.Uint64
 }
 
-func newTelemetryLoggingmetrics(
+func newTelemetryLoggingMetrics(
 	knobs *TelemetryLoggingTestingKnobs, st *cluster.Settings,
 ) *TelemetryLoggingMetrics {
 	t := TelemetryLoggingMetrics{Knobs: knobs, st: st}
@@ -195,7 +195,7 @@ func (t *TelemetryLoggingMetrics) timeNow() time.Time {
 	return timeutil.Now()
 }
 
-// shouldEmitLog returns true if the stmt should be logged to telemetry. The last emitted time
+// shouldEmitStatementLog returns true if the stmt should be logged to telemetry. The last emitted time
 // tracked by telemetry logging metrics will be updated to the given time if any of the following
 // are met:
 //   - The telemetry mode is set to "transaction" AND the stmt is the first in
@@ -203,10 +203,10 @@ func (t *TelemetryLoggingMetrics) timeNow() time.Time {
 //     of time has elapsed.
 //   - The telemetry mode is set to "statement" AND the required amount of time has elapsed
 //   - The txn is not being tracked and the stmt is being forced to log.
-func (t *TelemetryLoggingMetrics) shouldEmitLog(
+func (t *TelemetryLoggingMetrics) shouldEmitStatementLog(
 	newTime time.Time, txnExecutionID string, force bool, stmtPosInTxn int,
 ) (shouldEmit bool) {
-	maxEventFrequency := TelemetryMaxEventFrequency.Get(&t.st.SV)
+	maxEventFrequency := TelemetryMaxStatementEventFrequency.Get(&t.st.SV)
 	requiredTimeElapsed := time.Second / time.Duration(maxEventFrequency)
 	isTxnMode := telemetrySamplingMode.Get(&t.st.SV) == telemetryModeTransaction
 	txnsLimit := int(telemetryTrackedTxnsLimit.Get(&t.st.SV))

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -419,7 +419,7 @@ func TestTelemetryLogging(t *testing.T) {
 	}
 
 	for _, tc := range testData {
-		TelemetryMaxEventFrequency.Override(context.Background(), &s.ClusterSettings().SV, tc.stubMaxEventFrequency)
+		TelemetryMaxStatementEventFrequency.Override(context.Background(), &s.ClusterSettings().SV, tc.stubMaxEventFrequency)
 		if tc.enableInjectTxErrors {
 			_, err := db.DB.ExecContext(context.Background(), "SET inject_retry_errors_enabled = 'true'")
 			require.NoError(t, err)
@@ -919,7 +919,7 @@ func TestNoTelemetryLogOnTroubleshootMode(t *testing.T) {
 	db.Exec(t, "CREATE TABLE t();")
 
 	stubMaxEventFrequency := int64(1)
-	TelemetryMaxEventFrequency.Override(context.Background(), &s.ClusterSettings().SV, stubMaxEventFrequency)
+	TelemetryMaxStatementEventFrequency.Override(context.Background(), &s.ClusterSettings().SV, stubMaxEventFrequency)
 
 	/*
 		Testing Cases:
@@ -1035,7 +1035,7 @@ func TestTelemetryLogJoinTypesAndAlgorithms(t *testing.T) {
 		");")
 
 	stubMaxEventFrequency := int64(1000000)
-	TelemetryMaxEventFrequency.Override(context.Background(), &s.ClusterSettings().SV, stubMaxEventFrequency)
+	TelemetryMaxStatementEventFrequency.Override(context.Background(), &s.ClusterSettings().SV, stubMaxEventFrequency)
 
 	testData := []struct {
 		name                   string
@@ -1528,7 +1528,7 @@ func TestFunctionBodyRedacted(t *testing.T) {
 	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;`)
 	db.Exec(t, `CREATE TABLE kv (k STRING, v INT)`)
 	stubMaxEventFrequency := int64(1000000)
-	TelemetryMaxEventFrequency.Override(context.Background(), &s.ClusterSettings().SV, stubMaxEventFrequency)
+	TelemetryMaxStatementEventFrequency.Override(context.Background(), &s.ClusterSettings().SV, stubMaxEventFrequency)
 
 	stmt := `CREATE FUNCTION f() RETURNS INT 
 LANGUAGE SQL 


### PR DESCRIPTION
## Commit 1: [sql/telemetry: swap TelemetryLogging skippedQueryCount to atomic uint](https://github.com/cockroachdb/cockroach/commit/97b96454be19ae15e143aa511f4f86e6dd1dbea7)
Previously the `skippedQueryCount` field was typed as a plain
uint64 and used atomic.LoadInt64 and atomic.SwapUint64 under the
hood to update its value. This patch updates `skippedQueryCount`
to be of type `atomic.Uint64` to use the more ergonomic and
less error prone atomic functions for the uint64 type.

Epic: none

Release note: None


## Commit 2: [sql: more specific naming for telemetry statement sampling vars](https://github.com/cockroachdb/cockroach/commit/6244bf002973befaea1e234ae46d708acbbb3e24)
We are introducing the logging of transaction events in a following
commit. This patch renames a couple of items used for telemetry
logging that will be used exclusively for statement logging. They
are given more specific names to indicate they are used to log
statement events in order to differentiate them from incoming txn
level logging utils.

Renames:
- func `shouldEmitLog` -> `shouldEmitStatementLog`
- cluster setting `TelemetryMaxEventFrequency` ->
  `TelemetryMaxStatementEventFrequency`
  (note that the sql name for this cluster setting remains unchanged)

Release note: None

Epic: none