### PR TITLE
release-23.2: backport distributed token bucket changes for provisioned tenants

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "tenantcostclient",
     srcs = [
         "limiter.go",
+        "metrics.go",
         "tenant_side.go",
         "test_utils.go",
         "token_bucket.go",
@@ -23,6 +24,7 @@ go_library(
         "//pkg/sql/execinfra",
         "//pkg/sql/sqlliveness",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/quotapool",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
@@ -93,6 +95,7 @@ go_test(
         "//pkg/util/ioctx",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/stop",

--- a/pkg/ccl/multitenantccl/tenantcostclient/limiter.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/limiter.go
@@ -141,6 +141,11 @@ type limiterReconfigureArgs struct {
 	// NewRate is the new token fill rate for the bucket.
 	NewRate tenantcostmodel.RU
 
+	// MaxTokens is the maximum number of tokens that can be present in the
+	// bucket. Tokens beyond this limit are discarded. If MaxTokens = 0, then
+	// no limit is enforced.
+	MaxTokens tenantcostmodel.RU
+
 	// NotifyThreshold is the AvailableRU level below which a low RU notification
 	// will be sent.
 	NotifyThreshold tenantcostmodel.RU
@@ -159,6 +164,7 @@ func (l *limiter) Reconfigure(now time.Time, cfg limiterReconfigureArgs) {
 		l.qp.tb.Reconfigure(now, tokenBucketReconfigureArgs{
 			NewTokens: cfg.NewTokens,
 			NewRate:   cfg.NewRate,
+			MaxTokens: cfg.MaxTokens,
 		})
 		l.maybeNotifyLocked(now)
 

--- a/pkg/ccl/multitenantccl/tenantcostclient/limiter_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/limiter_test.go
@@ -163,4 +163,13 @@ func TestLimiterNotify(t *testing.T) {
 	}
 	checkNotification()
 	check("0.00 RU filling @ 0.00 RU/s")
+
+	// Ensure that MaxTokens is enforced.
+	args = limiterReconfigureArgs{
+		NewTokens: 100,
+		MaxTokens: 50,
+	}
+	lim.Reconfigure(ts.Now(), args)
+	checkNoNotification()
+	check("50.00 RU filling @ 0.00 RU/s")
 }

--- a/pkg/ccl/multitenantccl/tenantcostclient/limiter_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/limiter_test.go
@@ -171,5 +171,5 @@ func TestLimiterNotify(t *testing.T) {
 	}
 	lim.Reconfigure(ts.Now(), args)
 	checkNoNotification()
-	check("50.00 RU filling @ 0.00 RU/s")
+	check("50.00 RU filling @ 0.00 RU/s (limited to 50.00 RU)")
 }

--- a/pkg/ccl/multitenantccl/tenantcostclient/limiter_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/limiter_test.go
@@ -14,8 +14,11 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcostmodel"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
 
 // TestLimiterNotify tests that low RU notifications are sent at the expected
@@ -28,8 +31,11 @@ func TestLimiterNotify(t *testing.T) {
 	ts := timeutil.NewManualTime(start)
 	ch := make(chan struct{}, 100)
 
+	var met metrics
+	met.Init()
+
 	var lim limiter
-	lim.Init(ts, ch)
+	lim.Init(&met, ts, ch)
 	lim.Reconfigure(start, limiterReconfigureArgs{NewRate: 100})
 
 	check := func(expected string) {
@@ -172,4 +178,42 @@ func TestLimiterNotify(t *testing.T) {
 	lim.Reconfigure(ts.Now(), args)
 	checkNoNotification()
 	check("50.00 RU filling @ 0.00 RU/s (limited to 50.00 RU)")
+}
+
+// TestLimiterMetrics tests that limiter metrics are updated.
+func TestLimiterMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	start := timeutil.Now()
+	ts := timeutil.NewManualTime(start)
+	ch := make(chan struct{}, 100)
+
+	var met metrics
+	met.Init()
+
+	var lim limiter
+	lim.Init(&met, ts, ch)
+
+	ensureMetricValue := func(metric *metric.Gauge, expected int64) {
+		testutils.SucceedsWithin(t, func() error {
+			val := metric.Value()
+			if val == expected {
+				return nil
+			}
+			return errors.New("metric doesn't have expected value")
+		}, 30*time.Second)
+	}
+
+	// Create a blocking request and wait until the metric reflects that.
+	go func() {
+		if err := lim.Wait(ctx, 1000); err != nil {
+			t.Errorf("failed to wait: %v", err)
+		}
+	}()
+	ensureMetricValue(met.CurrentBlocked, 1)
+
+	// Unblock the request and ensure the metric changes.
+	lim.Reconfigure(ts.Now(), limiterReconfigureArgs{NewTokens: 1000})
+	ensureMetricValue(met.CurrentBlocked, 0)
 }

--- a/pkg/ccl/multitenantccl/tenantcostclient/metrics.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/metrics.go
@@ -1,0 +1,30 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package tenantcostclient
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+var (
+	metaCurrentBlocked = metric.Metadata{
+		Name:        "tenant.cost_client.blocked_requests",
+		Help:        "Number of requests currently blocked by the rate limiter",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+)
+
+// metrics manage the metrics used by the tenant cost client.
+type metrics struct {
+	CurrentBlocked *metric.Gauge
+}
+
+// Init initializes the tenant cost client metrics.
+func (m *metrics) Init() {
+	m.CurrentBlocked = metric.NewGauge(metaCurrentBlocked)
+}

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
@@ -583,11 +583,6 @@ func (c *tenantSideCostController) handleTokenBucketResponse(
 	c.run.fallbackRate = resp.FallbackRate
 	c.run.fallbackRateStart = time.Time{}
 
-	// Don't process granted RUs if none were requested.
-	if req.RequestedRU == 0 {
-		return
-	}
-
 	// Process granted RUs.
 	now := c.timeSource.Now()
 	granted := tenantcostmodel.RU(resp.GrantedRU)
@@ -614,44 +609,46 @@ func (c *tenantSideCostController) handleTokenBucketResponse(
 		c.run.trickleDeadline = time.Time{}
 	}
 
-	// If zero tokens were granted, then the token bucket server is completely
-	// dry. Configure the token bucket to have a zero rate and to not send low RU
-	// notifications (since that would just spam the server). The local token
-	// bucket won't be refilled until the next regularly scheduled consumption
-	// reporting interval.
 	var cfg limiterReconfigureArgs
-	if granted > 0 {
+
+	// Directly add tokens to the bucket if they're immediately available.
+	// Configure a token trickle if the tokens are only available over time.
+	if resp.TrickleDuration == 0 {
 		// Calculate the threshold at which a low RU notification will be sent.
 		notifyThreshold := granted * notifyFraction
 		if notifyThreshold < bufferRUs {
 			notifyThreshold = bufferRUs
 		}
 
-		// Directly add tokens to the bucket if they're immediately available.
-		// Configure a token trickle if the tokens are only available over time.
-		if resp.TrickleDuration == 0 {
-			// We received a batch of tokens to use as needed. Set up the token
-			// bucket to notify us when the tokens are running low.
-			cfg.NewTokens = granted
-			cfg.NewRate = 0
-			cfg.NotifyThreshold = notifyThreshold
-		} else {
-			// We received a batch of tokens that can only be used over the
-			// TrickleDuration. Set up the token bucket to notify us a bit before
-			// this period elapses.
-			timerDuration := resp.TrickleDuration - anticipation
-			if timerDuration <= 0 {
-				timerDuration = (resp.TrickleDuration + 1) / 2
-			}
-			c.run.trickleTimer = c.timeSource.NewTimer()
-			c.run.trickleTimer.Reset(timerDuration)
-			c.run.trickleCh = c.run.trickleTimer.Ch()
-			c.run.trickleDeadline = now.Add(resp.TrickleDuration)
+		// We received a batch of tokens to use as needed. Set up the token
+		// bucket to notify us when the tokens are running low.
+		cfg.NewTokens = granted
+		cfg.NewRate = 0
 
-			cfg.NewRate = granted / tenantcostmodel.RU(resp.TrickleDuration.Seconds())
-			cfg.MaxTokens = bufferRUs + granted
+		// Configure the low RU notification threshold. However, if the server
+		// could not even grant the RUs that were requested, then avoid triggering
+		// extra calls to the server. The next call to the server will be made by
+		// the next regularly scheduled consumption reporting interval.
+		if req.RequestedRU == resp.GrantedRU {
+			cfg.NotifyThreshold = notifyThreshold
 		}
+	} else {
+		// We received a batch of tokens that can only be used over the
+		// TrickleDuration. Set up the token bucket to notify us a bit before
+		// this period elapses.
+		timerDuration := resp.TrickleDuration - anticipation
+		if timerDuration <= 0 {
+			timerDuration = (resp.TrickleDuration + 1) / 2
+		}
+		c.run.trickleTimer = c.timeSource.NewTimer()
+		c.run.trickleTimer.Reset(timerDuration)
+		c.run.trickleCh = c.run.trickleTimer.Ch()
+		c.run.trickleDeadline = now.Add(resp.TrickleDuration)
+
+		cfg.NewRate = granted / tenantcostmodel.RU(resp.TrickleDuration.Seconds())
+		cfg.MaxTokens = bufferRUs + granted
 	}
+
 	c.limiter.Reconfigure(now, cfg)
 	c.run.lastRate = float64(cfg.NewRate)
 

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
@@ -463,7 +463,8 @@ func (c *tenantSideCostController) onTick(ctx context.Context, newTime time.Time
 	if !c.run.fallbackRateStart.IsZero() && !newTime.Before(c.run.fallbackRateStart) {
 		log.Infof(ctx, "switching to fallback rate %.10g", c.run.fallbackRate)
 		c.limiter.Reconfigure(c.timeSource.Now(), limiterReconfigureArgs{
-			NewRate: tenantcostmodel.RU(c.run.fallbackRate),
+			NewRate:   tenantcostmodel.RU(c.run.fallbackRate),
+			MaxTokens: bufferRUs + tenantcostmodel.RU(c.run.fallbackRate*c.run.targetPeriod.Seconds()),
 		})
 		c.run.fallbackRateStart = time.Time{}
 	}
@@ -589,7 +590,7 @@ func (c *tenantSideCostController) handleTokenBucketResponse(
 
 	// Process granted RUs.
 	now := c.timeSource.Now()
-	granted := resp.GrantedRU
+	granted := tenantcostmodel.RU(resp.GrantedRU)
 
 	// Shut down any trickle previously in-progress trickle.
 	if c.run.trickleTimer != nil {
@@ -608,7 +609,7 @@ func (c *tenantSideCostController) handleTokenBucketResponse(
 		// and even if it occurs, the usage is still counted. The only effect is
 		// some extra debt accumulation, which is fine.
 		if since := c.run.trickleDeadline.Sub(now); since > 0 {
-			granted += c.run.lastRate * since.Seconds()
+			granted += tenantcostmodel.RU(c.run.lastRate * since.Seconds())
 		}
 		c.run.trickleDeadline = time.Time{}
 		c.run.trickleThreshold = 0
@@ -622,7 +623,7 @@ func (c *tenantSideCostController) handleTokenBucketResponse(
 	var cfg limiterReconfigureArgs
 	if granted > 0 {
 		// Calculate the threshold at which a low RU notification will be sent.
-		notifyThreshold := tenantcostmodel.RU(granted * notifyFraction)
+		notifyThreshold := granted * notifyFraction
 		if notifyThreshold < bufferRUs {
 			notifyThreshold = bufferRUs
 		}
@@ -632,7 +633,7 @@ func (c *tenantSideCostController) handleTokenBucketResponse(
 		if resp.TrickleDuration == 0 {
 			// We received a batch of tokens to use as needed. Set up the token
 			// bucket to notify us when the tokens are running low.
-			cfg.NewTokens = tenantcostmodel.RU(granted)
+			cfg.NewTokens = granted
 			cfg.NewRate = 0
 			cfg.NotifyThreshold = notifyThreshold
 		} else {
@@ -649,7 +650,8 @@ func (c *tenantSideCostController) handleTokenBucketResponse(
 			c.run.trickleDeadline = now.Add(resp.TrickleDuration)
 			c.run.trickleThreshold = notifyThreshold
 
-			cfg.NewRate = tenantcostmodel.RU(granted / resp.TrickleDuration.Seconds())
+			cfg.NewRate = granted / tenantcostmodel.RU(resp.TrickleDuration.Seconds())
+			cfg.MaxTokens = bufferRUs + granted
 		}
 	}
 	c.limiter.Reconfigure(now, cfg)

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
@@ -168,7 +168,12 @@ func newTenantSideCostController(
 		responseChan:    make(chan *kvpb.TokenBucketResponse, 1),
 		lowRUNotifyChan: make(chan struct{}, 1),
 	}
-	c.limiter.Init(timeSource, c.lowRUNotifyChan)
+
+	// Initialize metrics.
+	c.metrics.Init()
+
+	// Start with filled burst buffer.
+	c.limiter.Init(&c.metrics, timeSource, c.lowRUNotifyChan)
 	c.limiter.Reconfigure(timeSource.Now(), limiterReconfigureArgs{
 		NewTokens:       bufferRUs,
 		NotifyThreshold: bufferRUs,
@@ -240,6 +245,7 @@ func init() {
 }
 
 type tenantSideCostController struct {
+	metrics              metrics
 	timeSource           timeutil.TimeSource
 	testInstr            TestInstrumentation
 	settings             *cluster.Settings

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -129,6 +129,7 @@ func (ts *testState) start(t *testing.T) {
 	// Fix settings so that the defaults can be changed without updating the test.
 	tenantcostclient.TargetPeriodSetting.Override(ctx, &ts.settings.SV, 10*time.Second)
 	tenantcostclient.CPUUsageAllowance.Override(ctx, &ts.settings.SV, 10*time.Millisecond)
+	tenantcostclient.InitialRequestSetting.Override(ctx, &ts.settings.SV, 10000)
 
 	ts.stopper = stop.NewStopper()
 	var err error
@@ -158,6 +159,12 @@ func (ts *testState) start(t *testing.T) {
 		ctx, ts.stopper, instanceID, sessionID, externalUsageFn, nextLiveInstanceIDFn,
 	); err != nil {
 		t.Fatal(err)
+	}
+
+	// Wait for main loop to start in order to avoid race conditions where a test
+	// starts before the main loop has been initialized.
+	if !ts.eventWait.WaitForEvent(tenantcostclient.MainLoopStarted) {
+		t.Fatal("did not receive event MainLoopStarted")
 	}
 }
 
@@ -785,9 +792,9 @@ func TestWaitingRU(t *testing.T) {
 		st, tenantID, testProvider, timeSource, eventWait)
 	require.NoError(t, err)
 
-	// Immediately consume the initial 10K RUs.
+	// Immediately consume the initial 5K RUs.
 	require.NoError(t, ctrl.OnResponseWait(ctx,
-		tenantcostmodel.TestingRequestInfo(1, 1, 10237952, 0), tenantcostmodel.ResponseInfo{}))
+		tenantcostmodel.TestingRequestInfo(1, 1, 5117952, 0), tenantcostmodel.ResponseInfo{}))
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -778,10 +778,8 @@ func TestWaitingRU(t *testing.T) {
 
 	// Disable CPU consumption so that it doesn't interfere with test.
 	st := cluster.MakeTestingClusterSettings()
-	tenantcostclient.CPUUsageAllowance.Override(context.Background(), &st.SV, time.Second)
+	tenantcostclient.CPUUsageAllowance.Override(ctx, &st.SV, time.Second)
 
-	// Refill the token bucket at a fixed 100 RU/s so that we can limit
-	// non-determinism in the test.
 	testProvider := newTestProvider()
 	testProvider.configure(testProviderConfig{ProviderError: true})
 
@@ -816,6 +814,8 @@ func TestWaitingRU(t *testing.T) {
 	resp := tenantcostmodel.TestingResponseInfo(false, 0, 0, 0)
 
 	testutils.SucceedsWithin(t, func() error {
+		// Refill the token bucket at a fixed 100 RU/s so that we can limit
+		// non-determinism in the test.
 		tenantcostclient.TestingSetRate(ctrl, fillRate)
 
 		var doneCount int64

--- a/pkg/ccl/multitenantccl/tenantcostclient/test_utils.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/test_utils.go
@@ -20,9 +20,13 @@ type TestInstrumentation interface {
 type TestEventType int
 
 const (
+	// MainLoopStarted indicates that the main loop has finished initializing the
+	// controller and is waiting for work.
+	MainLoopStarted TestEventType = 1 + iota
+
 	// TickProcessed indicates that the main loop completed the processing of a
 	// tick.
-	TickProcessed TestEventType = 1 + iota
+	TickProcessed
 
 	// LowRUNotification indicates that the main loop handled a "low RU"
 	// notification from the token bucket.

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
@@ -1,10 +1,5 @@
 # Test that the controller reports consumption as expected.
 
-# Wait for initial 10K RUs to be granted.
-wait-for-event
-token-bucket-response
-----
-
 # With no usage, consumption gets reported only every 40s.
 advance
 40s

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/debt
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/debt
@@ -1,17 +1,12 @@
 # Test token bucket that has gone into debt.
 
-# Wait for initial 10K RUs to be granted.
-wait-for-event
-token-bucket-response
-----
-
 # Set up throttling at 1000 RU/s.
 configure
 throttle: 1000
 ----
 
-# Issue 6K write that triggers fetch of more RU and also sets throttle rate.
-write bytes=6141952
+# Issue 2K RU write that triggers fetch of more RU and also sets throttle rate.
+write bytes=2045952
 ----
 
 wait-for-event
@@ -20,11 +15,11 @@ token-bucket-response
 
 token-bucket
 ----
-4000.00 RU filling @ 1000.00 RU/s
+3000.00 RU filling @ 1000.00 RU/s
 
-# Consume 6K RUs that causes bucket to go into debt.
+# Consume 5K RUs that causes bucket to go into debt.
 cpu
-18s
+15s
 ----
 
 advance wait=true

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/debt
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/debt
@@ -15,7 +15,7 @@ token-bucket-response
 
 token-bucket
 ----
-3000.00 RU filling @ 1000.00 RU/s
+3000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
 
 # Consume 5K RUs that causes bucket to go into debt.
 cpu
@@ -29,7 +29,7 @@ advance wait=true
 
 token-bucket
 ----
-0.00 RU filling @ 1000.00 RU/s (996.67 waiting debt @ 498.33 RU/s)
+0.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (996.67 waiting debt @ 498.33 RU/s)
 
 # Verify that a small write doesn't have to wait a second for the entire debt
 # to be paid.
@@ -51,7 +51,7 @@ await label=w1
 
 token-bucket
 ----
-47.17 RU filling @ 1000.00 RU/s (946.83 waiting debt @ 498.33 RU/s)
+47.17 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (946.83 waiting debt @ 498.33 RU/s)
 
 # Consume enough RUs that the debt cannot be paid within debtApplySecs.
 pgwire-egress
@@ -65,7 +65,7 @@ advance wait=true
 
 token-bucket
 ----
--1399.67 RU filling @ 1000.00 RU/s (2000.00 waiting debt @ 1000.00 RU/s)
+-1399.67 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (2000.00 waiting debt @ 1000.00 RU/s)
 
 # Advance and ensure that waiting debt is reduced.
 advance
@@ -75,7 +75,7 @@ advance
 
 token-bucket
 ----
--1399.67 RU filling @ 1000.00 RU/s (1600.00 waiting debt @ 1000.00 RU/s)
+-1399.67 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (1600.00 waiting debt @ 1000.00 RU/s)
 
 advance wait=true
 1s
@@ -84,7 +84,7 @@ advance wait=true
 
 token-bucket
 ----
--1399.67 RU filling @ 1000.00 RU/s (600.00 waiting debt @ 300.00 RU/s)
+-1399.67 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (600.00 waiting debt @ 300.00 RU/s)
 
 # Advance again and ensure that both available RUs and waiting debt are reduced.
 advance wait=true
@@ -94,4 +94,4 @@ advance wait=true
 
 token-bucket
 ----
--699.67 RU filling @ 1000.00 RU/s (300.00 waiting debt @ 150.00 RU/s)
+-699.67 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (300.00 waiting debt @ 150.00 RU/s)

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/external-io
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/external-io
@@ -1,10 +1,5 @@
 # Test external IO ingress and egress.
 
-# Wait for initial 10K RUs to be granted.
-wait-for-event
-token-bucket-response
-----
-
 # Set up throttling at 1K RU/s.
 configure
 throttle: 1000
@@ -12,7 +7,7 @@ throttle: 1000
 
 # Perform external IO egress that triggers fetch of more RU and sets up
 # throttling.
-external-egress bytes=6144000
+external-egress bytes=1024000
 ----
 
 wait-for-event

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/external-io
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/external-io
@@ -16,7 +16,7 @@ token-bucket-response
 
 token-bucket
 ----
-4000.00 RU filling @ 1000.00 RU/s
+4000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
 
 # Perform 1G bytes of external IO ingress, which should not affect RU.
 external-ingress bytes=1024000000000
@@ -24,7 +24,7 @@ external-ingress bytes=1024000000000
 
 token-bucket
 ----
-4000.00 RU filling @ 1000.00 RU/s
+4000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
 
 # Block on external IO.
 external-egress bytes=6144000 label=e1
@@ -40,7 +40,7 @@ not-completed label=e1
 
 token-bucket
 ----
-4000.00 RU filling @ 1000.00 RU/s (6000.00 waiting RU)
+4000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (6000.00 waiting RU)
 
 # Fill token bucket with an additional 2K RU, which should unblock the waiting
 # external IO operation.
@@ -54,4 +54,4 @@ await label=e1
 
 token-bucket
 ----
-0.00 RU filling @ 1000.00 RU/s
+0.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback
@@ -1,11 +1,6 @@
 # Tests in this file verify the enacting of the fallback rate when token bucket
 # requests are erroring out.
 
-# Wait for initial 10K RUs to be granted.
-wait-for-event
-token-bucket-response
-----
-
 configure
 fallback_rate: 1000
 ----

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback
@@ -44,7 +44,7 @@ advance wait=true
 
 token-bucket
 ----
-3000.00 RU filling @ 1000.00 RU/s
+3000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
 
 # Issue another 5K write which must wait until the fallback rate adds 2K to the
 # bucket in order to complete.
@@ -66,7 +66,7 @@ not-completed label=w1
 
 token-bucket
 ----
-4000.00 RU filling @ 1000.00 RU/s (5000.00 waiting RU)
+4000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (5000.00 waiting RU)
 
 # Advance another second and ensure that the write request was completed.
 advance wait=true
@@ -79,7 +79,7 @@ await label=w1
 
 token-bucket
 ----
-0.00 RU filling @ 1000.00 RU/s
+0.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
 
 wait-for-event
 token-bucket-response-error

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback-throttled
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback-throttled
@@ -21,7 +21,7 @@ token-bucket-response
 # Response sets up throttled rate of 100 RU/s.
 token-bucket
 ----
-2000.00 RU filling @ 100.00 RU/s
+2000.00 RU filling @ 100.00 RU/s (limited to 6000.00 RU)
 
 # Force error on next fetch.
 configure
@@ -52,7 +52,7 @@ advance wait=true
 
 token-bucket
 ----
-3100.00 RU filling @ 1000.00 RU/s
+3100.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
 
 # Advance 1 second and ensure bucket is replenished at fallback rate.
 advance wait=true
@@ -62,7 +62,7 @@ advance wait=true
 
 token-bucket
 ----
-4100.00 RU filling @ 1000.00 RU/s
+4100.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
 
 wait-for-event
 token-bucket-response-error

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback-throttled
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback-throttled
@@ -29,15 +29,11 @@ error: true
 ----
 
 # Advance time to 90% of the trickle rate duration (10s), which will trigger a
-# low RU notification and token bucket request (which will fail).
+# token bucket request (which will fail).
 advance
 9s
 ----
 00:00:09.000
-
-wait-for-event
-low-ru
-----
 
 # Expect failure of the token bucket request.
 wait-for-event

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback-throttled
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/fallback-throttled
@@ -1,18 +1,13 @@
 # Tests in this file verify the enacting of the fallback rate when token bucket
 # requests start erroring out while we are being throttled.
 
-# Wait for initial 10K RUs to be granted.
-wait-for-event
-token-bucket-response
-----
-
 configure
 throttle: 100
 fallback_rate: 1000
 ----
 
-# Issue an 8K write that triggers fetch of more RU and also sets fallback rate.
-write bytes=8189952
+# Issue a 3K write that triggers fetch of more RU and also sets fallback rate.
+write bytes=3069952
 ----
 
 wait-for-event

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/large-request
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/large-request
@@ -51,10 +51,6 @@ advance
 00:00:09.000
 
 wait-for-event
-low-ru
-----
-
-wait-for-event
 token-bucket-response
 ----
 

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/large-request
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/large-request
@@ -31,7 +31,7 @@ not-completed label=w1
 
 token-bucket
 ----
-5000.00 RU filling @ 1000.00 RU/s (15000.00 waiting RU)
+5000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (15000.00 waiting RU)
 
 # Advance time to just short of trickle renewal and trigger tick event.
 advance wait=true
@@ -41,7 +41,7 @@ advance wait=true
 
 token-bucket
 ----
-13750.00 RU filling @ 1000.00 RU/s (15000.00 waiting RU)
+13750.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (15000.00 waiting RU)
 
 # Now advance time to trigger trickle renewal (but do not trigger tick in order
 # to avoid a race that makes test non-deterministic).
@@ -65,7 +65,7 @@ timers
 
 token-bucket
 ----
-14000.00 RU filling @ 1100.00 RU/s (15000.00 waiting RU)
+14000.00 RU filling @ 1100.00 RU/s (limited to 16000.00 RU) (15000.00 waiting RU)
 
 # One more second to fulfill waiting write.
 advance
@@ -78,7 +78,7 @@ await label=w1
 
 token-bucket
 ----
-100.00 RU filling @ 1100.00 RU/s
+100.00 RU filling @ 1100.00 RU/s (limited to 16000.00 RU)
 
 # Un-throttle central token bucket and ensure that another large write goes
 # through after requesting more RUs.

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/large-request
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/large-request
@@ -3,16 +3,12 @@
 #    notification threshold.
 #  - the bucket has more RUs available than the notification threshold.
 
-wait-for-event
-token-bucket-response
-----
-
 configure
 throttle: 1000
 ----
 
-# Fire off a write that needs significantly more than the 10000 initial RUs.
-write bytes=20477952 label=w1
+# Fire off a write that needs significantly more than the initial RUs.
+write bytes=15357952 label=w1
 ----
 
 timers
@@ -35,7 +31,7 @@ not-completed label=w1
 
 token-bucket
 ----
-10000.00 RU filling @ 1000.00 RU/s (20000.00 waiting RU)
+5000.00 RU filling @ 1000.00 RU/s (15000.00 waiting RU)
 
 # Advance time to just short of trickle renewal and trigger tick event.
 advance wait=true
@@ -45,7 +41,7 @@ advance wait=true
 
 token-bucket
 ----
-18750.00 RU filling @ 1000.00 RU/s (20000.00 waiting RU)
+13750.00 RU filling @ 1000.00 RU/s (15000.00 waiting RU)
 
 # Now advance time to trigger trickle renewal (but do not trigger tick in order
 # to avoid a race that makes test non-deterministic).
@@ -69,7 +65,7 @@ timers
 
 token-bucket
 ----
-19000.00 RU filling @ 1100.00 RU/s (20000.00 waiting RU)
+14000.00 RU filling @ 1100.00 RU/s (15000.00 waiting RU)
 
 # One more second to fulfill waiting write.
 advance

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-ru
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-ru
@@ -1,0 +1,44 @@
+# This test verifies that after the server does not fully grant a request, the
+# client will not trigger low RU notifications.
+
+# When throttle = -1, the server will refuse to grant any RUs, either directly
+# or via a trickle.
+configure
+throttle: -1
+----
+
+# Issue 1K RU write to force token bucket request.
+write bytes=1021952
+----
+
+wait-for-event
+token-bucket-response
+----
+
+token-bucket
+----
+4000.00 RU filling @ 0.00 RU/s
+
+# Allow server to grant more RUs.
+configure
+throttle: 0
+----
+
+# Issue another 1K RU write and expect no low RU notification and therefore no
+# call to the server.
+write bytes=1021952
+----
+
+token-bucket
+----
+3000.00 RU filling @ 0.00 RU/s
+
+# Advance time and ensure there's no change to the bucket.
+advance wait=true
+1s
+----
+00:00:01.000
+
+token-bucket
+----
+3000.00 RU filling @ 0.00 RU/s

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-ru-race
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-ru-race
@@ -1,11 +1,6 @@
 # This test verifies that a low RU notification still triggers a token bucket
 # request, even if another token bucket request is already in progress.
 
-# Wait for initial 10K RUs to be granted.
-wait-for-event
-token-bucket-response
-----
-
 # Force token bucket provider to block until the unblock-request command is
 # issued.
 configure
@@ -19,9 +14,9 @@ advance wait=true
 ----
 00:00:40.000
 
-# Fire off a 6K write. This will trigger a low RU notification, which will
+# Fire off a 1K write. This will trigger a low RU notification, which will
 # happen while the token bucket request is still in progress.
-write bytes=6141952
+write bytes=1021952
 ----
 
 wait-for-event

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-throttling
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-throttling
@@ -51,10 +51,6 @@ advance
 00:00:09.000
 
 wait-for-event
-low-ru
-----
-
-wait-for-event
 token-bucket-response
 ----
 

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-throttling
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-throttling
@@ -15,7 +15,7 @@ token-bucket-response
 
 token-bucket
 ----
-2000.00 RU filling @ 1.00 RU/s
+2000.00 RU filling @ 1.00 RU/s (limited to 5010.00 RU)
 
 # Issue another 4K RU write that should block.
 write bytes=4093952 label=w1
@@ -39,7 +39,7 @@ not-completed label=w1
 
 token-bucket
 ----
-2008.00 RU filling @ 1.00 RU/s (4000.00 waiting RU)
+2008.00 RU filling @ 1.00 RU/s (limited to 5010.00 RU) (4000.00 waiting RU)
 
 # Advance 1 more second, which should trigger a token bucket request to extend
 # the trickle duration. Note that the trickle grant will not have been fully
@@ -60,7 +60,7 @@ token-bucket-response
 
 token-bucket
 ----
-2009.00 RU filling @ 1.10 RU/s (4000.00 waiting RU)
+2009.00 RU filling @ 1.10 RU/s (limited to 5011.00 RU) (4000.00 waiting RU)
 
 advance
 1991s

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-throttling
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/low-throttling
@@ -1,17 +1,12 @@
 # Throttle at an extremely limited rate.
 
-# Wait for initial 10K RUs to be granted.
-wait-for-event
-token-bucket-response
-----
-
 # Set up throttling at just 1 RU/s.
 configure
 throttle: 1
 ----
 
-# Issue 8K RU write to force fetch more RU.
-write bytes=8189952
+# Issue 3K RU write to force fetch more RU.
+write bytes=3069952
 ----
 
 wait-for-event

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/no-ru
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/no-ru
@@ -1,18 +1,13 @@
 # Test case when provider is completely out of RUs.
 
-# Wait for initial 10K RUs to be granted.
-wait-for-event
-token-bucket-response
-----
-
 # When throttle = -1, the provider will refuse to grant any RUs, either directly
 # or via a trickle.
 configure
 throttle: -1
 ----
 
-# Issue 10K RU write to force token bucket request.
-write bytes=10237952 label=w1
+# Issue 5K RU write to force token bucket request.
+write bytes=5117952 label=w1
 ----
 
 wait-for-event

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/throttling
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/throttling
@@ -16,7 +16,7 @@ token-bucket-response
 
 token-bucket
 ----
-2000.00 RU filling @ 1000.00 RU/s
+2000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
 
 # Issue 4K RU write that should block as long as it takes to accumulate 2K RUs
 # with a 1K fill rate.
@@ -38,7 +38,7 @@ await label=w1
 
 token-bucket
 ----
-0.00 RU filling @ 1000.00 RU/s
+0.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU)
 
 # Create 20K debt in bucket.
 pgwire-egress
@@ -57,7 +57,7 @@ advance wait=true
 
 token-bucket
 ----
--19000.00 RU filling @ 1000.00 RU/s (1000.00 waiting debt @ 500.00 RU/s)
+-19000.00 RU filling @ 1000.00 RU/s (limited to 15000.00 RU) (1000.00 waiting debt @ 500.00 RU/s)
 
 # The debt in the token bucket is greater than what one trickle duration can
 # cover. Ensure that another write blocks for entire trickle duration, plus
@@ -80,7 +80,7 @@ token-bucket-response
 # trickle, as well as the RU from the new trickle.
 token-bucket
 ----
--15000.00 RU filling @ 1100.00 RU/s
+-15000.00 RU filling @ 1100.00 RU/s (limited to 16000.00 RU)
 
 timers
 ----

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/throttling
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/throttling
@@ -1,18 +1,13 @@
 # By default, the test provider grants all RUs immediately. Test cases where it
 # instead throttles usage to a limited rate.
 
-# Wait for initial 10K RUs to be granted.
-wait-for-event
-token-bucket-response
-----
-
 # Set up throttling at 1K RU/s.
 configure
 throttle: 1000
 ----
 
-# Issue 8K RU write to consume all tokens in the bucket and create 2K debt.
-write bytes=8189952
+# Issue 3K RU write to consume all tokens in the bucket and create 2K debt.
+write bytes=3069952
 ----
 
 wait-for-event

--- a/pkg/ccl/multitenantccl/tenantcostclient/token_bucket.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/token_bucket.go
@@ -289,6 +289,9 @@ func (tb *tokenBucket) AvailableTokens(now time.Time) tenantcostmodel.RU {
 func (tb *tokenBucket) String(now time.Time) string {
 	tb.update(now)
 	s := fmt.Sprintf("%.2f RU filling @ %.2f RU/s", tb.available, tb.rate)
+	if tb.limit > 0 {
+		s += fmt.Sprintf(" (limited to %.2f RU)", tb.limit)
+	}
 	if tb.waitingDebt > 0 {
 		s += fmt.Sprintf(" (%.2f waiting debt @ %.2f RU/s)", tb.waitingDebt, tb.waitingDebtRate)
 	}

--- a/pkg/ccl/multitenantccl/tenantcostclient/token_bucket_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/token_bucket_test.go
@@ -125,15 +125,15 @@ func TestTokenBucket(t *testing.T) {
 	}
 	check("-30.00 RU filling @ +Inf RU/s")
 	tb.Reconfigure(ts.Now(), args)
-	check("50.00 RU filling @ 10.00 RU/s")
+	check("50.00 RU filling @ 10.00 RU/s (limited to 50.00 RU)")
 	ts.Advance(time.Second)
-	check("50.00 RU filling @ 10.00 RU/s")
+	check("50.00 RU filling @ 10.00 RU/s (limited to 50.00 RU)")
 	ts.Advance(time.Second)
 	tb.RemoveTokens(ts.Now(), 15)
-	check("35.00 RU filling @ 10.00 RU/s")
+	check("35.00 RU filling @ 10.00 RU/s (limited to 50.00 RU)")
 	ts.Advance(2 * time.Second)
 	fulfill(10)
-	check("40.00 RU filling @ 10.00 RU/s")
+	check("40.00 RU filling @ 10.00 RU/s (limited to 50.00 RU)")
 
 	// Fulfill amount > limit.
 	if ok, tryAgainAfter := tb.TryToFulfill(ts.Now(), 60); ok {
@@ -141,10 +141,10 @@ func TestTokenBucket(t *testing.T) {
 	} else if exp := 2 * time.Second; tryAgainAfter.Round(time.Millisecond) != exp {
 		t.Fatalf("tryAgainAfter: expected %s, got %s", exp, tryAgainAfter)
 	}
-	check("40.00 RU filling @ 10.00 RU/s")
+	check("40.00 RU filling @ 10.00 RU/s (limited to 50.00 RU)")
 	ts.Advance(1 * time.Second)
 	fulfill(60)
-	check("0.00 RU filling @ 10.00 RU/s (10.00 waiting debt @ 5.00 RU/s)")
+	check("0.00 RU filling @ 10.00 RU/s (limited to 50.00 RU) (10.00 waiting debt @ 5.00 RU/s)")
 	ts.Advance(8 * time.Second)
 	if available := tb.AvailableTokens(ts.Now()); available != 50.0 {
 		t.Fatalf("AvailableTokens: expected %.2f, got %.2f", 50.0, available)

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     tags = ["ccl_test"],
     deps = [
         "//pkg/kv/kvpb",
+        "//pkg/roachpb",
         "//pkg/testutils/datapathutils",
         "//pkg/util/leaktest",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/tenant_token_bucket.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/tenant_token_bucket.go
@@ -21,10 +21,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
+// movingAvgFactor is the weight applied to a new "sample" of the current number
+// of RUs in the bucket (with one sample per Request call).
+const movingAvgFactor = 0.25
+
+// debtLimitMultiple is a multiple of the default debt limit (number of tokens
+// refilled in target period). This is used to allow grants that temporarily
+// exceed the default debt limit in the case where multiple tenant instances are
+// competing and RUCurrentAvg has not yet stabilized at a level that provides
+// the right grant size to each of them.
+const debtLimitMultiple = 1.5
+
 // State of the distributed token bucket.
 type State struct {
 	// RUBurstLimit is the burst limit in RUs.
-	// TODO(radu): this is ignored for now.
 	RUBurstLimit float64
 
 	// RURefillRate is the refill rate in RUs/second.
@@ -33,9 +43,13 @@ type State struct {
 	// RUCurrent is the available (burst) RUs.
 	RUCurrent float64
 
-	// CurrentShareSum is the sum of the last reported share value for
-	// each active SQL pod for the tenant.
-	CurrentShareSum float64
+	// RUCurrentAvg is the average number of (burst) RUs in the bucket when
+	// requests arrive. This is used to smooth out the size of trickle grants
+	// made to competing tenant instances.
+	// NOTE: This field is serialized as the current_share_sum column in the
+	// system.tenant_usage table. That column is unused and reusing it avoids
+	// a system table schema change.
+	RUCurrentAvg float64
 }
 
 // fallbackRateTimeFrame is a time frame used to calculate a fallback rate.
@@ -52,6 +66,7 @@ func (s *State) Update(since time.Duration) {
 	if since > 0 {
 		s.RUCurrent += s.RURefillRate * since.Seconds()
 	}
+	s.clampToLimit()
 }
 
 // Request processes a request for more tokens and updates the State
@@ -61,17 +76,27 @@ func (s *State) Request(
 ) kvpb.TokenBucketResponse {
 	var res kvpb.TokenBucketResponse
 
+	// Compute the exponential moving average (EMA) of the number of RUs in the
+	// bucket when Request is called.
+	s.RUCurrentAvg = movingAvgFactor*s.RUCurrent + (1-movingAvgFactor)*s.RUCurrentAvg
+
 	// Calculate the fallback rate.
 	res.FallbackRate = s.RURefillRate
 	if s.RUCurrent > 0 {
 		res.FallbackRate += s.RUCurrent / fallbackRateTimeFrame.Seconds()
 	}
 	if log.V(1) {
-		log.Infof(ctx, "token bucket request (tenant=%d requested=%g current=%g)", req.TenantID, req.RequestedRU, s.RUCurrent)
+		log.Infof(ctx, "token bucket request (tenant=%d requested=%g current=%g, avg=%g)",
+			req.TenantID, req.RequestedRU, s.RUCurrent, s.RUCurrentAvg)
 	}
 
 	needed := req.RequestedRU
+	if needed > s.RUCurrent && s.RURefillRate == 0 {
+		// No way to refill tokens, so don't allow taking on debt.
+		needed = s.RUCurrent
+	}
 	if needed <= 0 {
+		// Grant zero tokens.
 		return res
 	}
 
@@ -84,46 +109,62 @@ func (s *State) Request(
 		return res
 	}
 
-	var grantedTokens float64
+	var granted float64
 
+	// There are not enough tokens in the bucket, so take on debt and return a
+	// trickle grant that needs to be consumed over the target request period.
 	if s.RUCurrent > 0 {
-		grantedTokens = s.RUCurrent
+		// Consume remaining available tokens.
+		granted = s.RUCurrent
 		needed -= s.RUCurrent
 	}
 
-	availableRate := s.RURefillRate
+	// The trickle grant algorithm tries to ensure that the rate of token grants
+	// does not exceed the token bucket refill rate. This is challenging when
+	// there are multiple tenant instances requesting tokens at constantly
+	// shifting intervals and rates. The solution is to ensure a *statistical*
+	// guarantee rather than a *hard* guarantee. Over time, the *average* rate of
+	// token consumption should not exceed the token bucket refill rate, even if
+	// at any given time, it may temporarily exceed it.
+	//
+	// The way this is accomplished is quite simple. We track the average number
+	// of request units that are present in the bucket when Request is called
+	// (RUCurrentAvg). This is typically a negative number, as the bucket will be
+	// in debt when trickle grants are made. The grant increases the average debt
+	// to the maximum allowed level - the number of tokens that would refill the
+	// bucket during the target request period.
+	//
+	// As an example, say that RUCurrentAvg starts at 0 and the refill rate is
+	// 1000 RU/s. Tenant instance #1 requests 1000 RU/s with a target request
+	// period of 10 seconds. It is granted the entire 1000 RU/s rate with a 10-
+	// second trickle. Four seconds later, instance #2 also requests 1000 RU/s.
+	// The bucket has -6000 RUs available, and RUCurrentAvg is updated to the
+	// EMA of -6000 * 0.2 = -1200. Instance #2 is therefore granted 880 RU/s.
+	// This temporarily exceeds the token bucket refill rate. However, over time
+	// the EMA will converge towards -5000 and each instance will get 500 RU/s.
+	refill := req.TargetRequestPeriod.Seconds() * s.RURefillRate
+	available := refill
+
+	if debtAvg := -s.RUCurrentAvg; debtAvg > 0 {
+		// Clamp available RUs to average.
+		available -= debtAvg
+	}
+
 	if debt := -s.RUCurrent; debt > 0 {
-		// We pre-distribute tokens over the next TargetRefillPeriod; any debt over
-		// that is a systematic error we need to account for.
-		debt -= req.TargetRequestPeriod.Seconds() * s.RURefillRate
-		if debt > 0 {
-			// Say that we want to pay the debt over the next RefillPeriod (but use at
-			// most 95% of the rate for the debt).
-			// TODO(radu): make this configurable?
-			debtRate := debt / req.TargetRequestPeriod.Seconds()
-			availableRate -= debtRate
-			availableRate = math.Max(availableRate, 0.05*s.RURefillRate)
-		}
+		// Don't allow debt to exceed max limit.
+		available = math.Min(available, refill*debtLimitMultiple-debt)
 	}
-	// TODO(radu): support multiple instances by giving out only a share of the rate.
-	// Without this, all instances will get roughly equal rates even if they have
-	// different levels of load (in addition, we are heavily relying on the debt
-	// mechanism above).
-	allowedRate := availableRate
-	duration := time.Duration(float64(time.Second) * (needed / allowedRate))
-	if duration <= req.TargetRequestPeriod {
-		grantedTokens += needed
-	} else {
-		// We don't want to plan ahead for more than the target period; give out
-		// fewer tokens.
-		duration = req.TargetRequestPeriod
-		grantedTokens += allowedRate * duration.Seconds()
-	}
-	s.RUCurrent -= grantedTokens
-	res.GrantedRU = grantedTokens
-	res.TrickleDuration = duration
+
+	needed = math.Min(needed, math.Max(available, 0))
+
+	// Compute the grant and adjust the current RU balance.
+	granted += needed
+	s.RUCurrent -= granted
+	res.GrantedRU = granted
+	res.TrickleDuration = req.TargetRequestPeriod
 	if log.V(1) {
-		log.Infof(ctx, "request granted over time (tenant=%d granted=%g trickle=%s)", req.TenantID, res.GrantedRU, res.TrickleDuration)
+		log.Infof(ctx, "request granted over time (tenant=%d granted=%g trickle=%s)",
+			req.TenantID, res.GrantedRU, res.TrickleDuration)
 	}
 	return res
 }
@@ -133,10 +174,11 @@ func (s *State) Request(
 // Arguments:
 //
 //   - availableRU is the amount of Request Units that the tenant can consume at
-//     will. Also known as "burst RUs".
+//     will. Also known as "burst RUs". If this is -1 (or any negative number),
+//     the bucket's available tokens are not updated.
 //
 //   - refillRate is the amount of Request Units per second that the tenant
-//     receives.
+//     receives. If this is 0, the bucket does not refill on its own.
 //
 //   - maxBurstRU is the maximum amount of Request Units that can be accumulated
 //     from the refill rate, or 0 if there is no limit.
@@ -166,11 +208,21 @@ func (s *State) Reconfigure(
 ) {
 	// TODO(radu): adjust available RUs according to asOf and asOfConsumedUnits
 	// and add tests.
-	s.RUCurrent = availableRU
+	if availableRU >= 0 {
+		s.RUCurrent = availableRU
+	}
 	s.RURefillRate = refillRate
 	s.RUBurstLimit = maxBurstRU
+	s.clampToLimit()
 	log.Infof(
 		ctx, "token bucket for tenant %s reconfigured: available=%g refill-rate=%g burst-limit=%g",
 		tenantID.String(), s.RUCurrent, s.RURefillRate, s.RUBurstLimit,
 	)
+}
+
+// clampToLimit limits current RUs in the bucket to the burst limit.
+func (s *State) clampToLimit() {
+	if s.RUBurstLimit > 0 && s.RUCurrent > s.RUBurstLimit {
+		s.RUCurrent = s.RUBurstLimit
+	}
 }

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/fallback
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/fallback
@@ -1,25 +1,36 @@
 # Tests for the fallback rate.
 
-init
+reconfigure
+limit: 1000
 rate: 1000
-initial: 0
+current: 0
 ----
+Burst Limit: 1000
+Refill Rate: 1000
 Current RUs: 0
+Average RUs: 0
 
 # Fallback rate should be just the base rate 1000.
 request
 ru: 10
 ----
 Granted: 10 RU
-Trickle duration: 10ms
+Trickle duration: 10s
 Fallback rate: 1000 RU/s
+Burst Limit: 1000
+Refill Rate: 1000
 Current RUs: -10
+Average RUs: 0
 
-init
+reconfigure
+limit: 5000000
 rate: 500
-initial: 3600000
+current: 3600000
 ----
+Burst Limit: 5000000
+Refill Rate: 500
 Current RUs: 3600000
+Average RUs: 0
 
 # Fallback rate should be the base rate 500 plus 1000.
 request
@@ -28,4 +39,7 @@ ru: 10
 Granted: 10 RU
 Trickle duration: 0s
 Fallback rate: 1500 RU/s
+Burst Limit: 5000000
+Refill Rate: 500
 Current RUs: 3599990
+Average RUs: 900000

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/reconfigure
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/reconfigure
@@ -1,0 +1,103 @@
+# Try to reconfigure with limit = 50 and current > limit.
+reconfigure
+limit: 50
+rate: 100
+current: 100
+----
+Burst Limit: 50
+Refill Rate: 100
+Current RUs: 50
+Average RUs: 0
+
+# Ensure that update respects the limit.
+update
+10s
+----
+Burst Limit: 50
+Refill Rate: 100
+Current RUs: 50
+Average RUs: 0
+
+# Request tokens and go into debt.
+request
+ru: 100
+----
+Granted: 100 RU
+Trickle duration: 10s
+Fallback rate: 100.0138889 RU/s
+Burst Limit: 50
+Refill Rate: 100
+Current RUs: -50
+Average RUs: 12.5
+
+request
+ru: 100
+----
+Granted: 100 RU
+Trickle duration: 10s
+Fallback rate: 100 RU/s
+Burst Limit: 50
+Refill Rate: 100
+Current RUs: -150
+Average RUs: -3.125
+
+# Update limit, but don't update current RUs.
+reconfigure
+limit: 100
+rate: 100
+current: -1
+----
+Burst Limit: 100
+Refill Rate: 100
+Current RUs: -150
+Average RUs: -3.125
+
+# Ensure that update respects the burst limit.
+update
+10s
+----
+Burst Limit: 100
+Refill Rate: 100
+Current RUs: 100
+Average RUs: -3.125
+
+# No token refill, set current.
+reconfigure
+limit: 5000000
+rate: 0
+current: 5000000
+----
+Burst Limit: 5000000
+Refill Rate: 0
+Current RUs: 5000000
+Average RUs: -3.125
+
+request
+ru: 1000000
+----
+Granted: 1000000 RU
+Trickle duration: 0s
+Fallback rate: 1388.888889 RU/s
+Burst Limit: 5000000
+Refill Rate: 0
+Current RUs: 4000000
+Average RUs: 1249997.656
+
+# Limit of 0 = unlimited.
+reconfigure
+limit: 0
+rate: 1000000
+current: -1
+----
+Burst Limit: 0
+Refill Rate: 1000000
+Current RUs: 4000000
+Average RUs: 1249997.656
+
+update
+10s
+----
+Burst Limit: 0
+Refill Rate: 1000000
+Current RUs: 14000000
+Average RUs: 1249997.656

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/request
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/request
@@ -1,8 +1,12 @@
-init
+reconfigure
+limit: 1000
 rate: 100
-initial: 1000
+current: 1000
 ----
+Burst Limit: 1000
+Refill Rate: 100
 Current RUs: 1000
+Average RUs: 0
 
 request
 ru: 10
@@ -10,7 +14,10 @@ ru: 10
 Granted: 10 RU
 Trickle duration: 0s
 Fallback rate: 100.2777778 RU/s
+Burst Limit: 1000
+Refill Rate: 100
 Current RUs: 990
+Average RUs: 250
 
 request
 ru: 890
@@ -18,17 +25,22 @@ ru: 890
 Granted: 890 RU
 Trickle duration: 0s
 Fallback rate: 100.275 RU/s
+Burst Limit: 1000
+Refill Rate: 100
 Current RUs: 100
+Average RUs: 435
 
-# We have 100 available, and it will take 1s for another 100 to become
-# available.
+# Go into debt.
 request
 ru: 200
 ----
 Granted: 200 RU
-Trickle duration: 1s
+Trickle duration: 10s
 Fallback rate: 100.0277778 RU/s
+Burst Limit: 1000
+Refill Rate: 100
 Current RUs: -100
+Average RUs: 351.25
 
 # Request a very large value. We only grant what we get over the next request
 # period (10s by default).
@@ -38,47 +50,115 @@ ru: 10000
 Granted: 1000 RU
 Trickle duration: 10s
 Fallback rate: 100 RU/s
+Burst Limit: 1000
+Refill Rate: 100
 Current RUs: -1100
+Average RUs: 238.4375
 
-# If we keep requesting, we will enter into debt and less will be granted.
+# Try to request enough that we hit max debt levels. Note that we're temporarily
+# giving out more than the configured rate while Average RUs stabilizes.
 request
 ru: 1000
 ----
-Granted: 900 RU
+Granted: 400 RU
 Trickle duration: 10s
 Fallback rate: 100 RU/s
-Current RUs: -2000
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -1500
+Average RUs: -96.171875
 
-request
-ru: 1000
-----
-Granted: 50 RU
-Trickle duration: 10s
-Fallback rate: 100 RU/s
-Current RUs: -2050
-
+# Fast-forward 10 seconds.
 update
 10s
 ----
-Current RUs: -1050
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -500
+Average RUs: -96.171875
+
+# Make a request that is limited by average RUs.
+request
+ru: 1000
+----
+Granted: 802.8710938 RU
+Trickle duration: 10s
+Fallback rate: 100 RU/s
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -1302.871094
+Average RUs: -197.1289062
+
+# Make another request that should be granted.
+request
+ru: 100
+----
+Granted: 100 RU
+Trickle duration: 10s
+Fallback rate: 100 RU/s
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -1402.871094
+Average RUs: -473.5644531
+
+# Fast-forward 10 seconds.
+update
+10s
+----
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -402.8710938
+Average RUs: -473.5644531
 
 request
 ru: 100
 ----
 Granted: 100 RU
-Trickle duration: 1.052631578s
+Trickle duration: 10s
 Fallback rate: 100 RU/s
-Current RUs: -1150
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -502.8710938
+Average RUs: -455.8911133
 
 update
 10s
 ----
-Current RUs: -150
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: 497.1289062
+Average RUs: -455.8911133
 
+request
+ru: 500
+----
+Granted: 500 RU
+Trickle duration: 10s
+Fallback rate: 100.1380914 RU/s
+Burst Limit: 1000
+Refill Rate: 100
+Current RUs: -2.87109375
+Average RUs: -217.6361084
+
+# No token refill, don't update current RUs.
+reconfigure
+limit: 1000
+rate: 0
+current: -1
+----
+Burst Limit: 1000
+Refill Rate: 0
+Current RUs: -2.87109375
+Average RUs: -217.6361084
+
+# Try to request tokens, expect 0 grant.
 request
 ru: 100
 ----
-Granted: 100 RU
-Trickle duration: 1s
-Fallback rate: 100 RU/s
-Current RUs: -250
+Granted: 0 RU
+Trickle duration: 0s
+Fallback rate: 0 RU/s
+Burst Limit: 1000
+Refill Rate: 0
+Current RUs: -2.87109375
+Average RUs: -163.9448547

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/update
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/testdata/update
@@ -1,40 +1,66 @@
-init
+reconfigure
+limit: 1000000000
 rate: 1000
 ----
+Burst Limit: 1000000000
+Refill Rate: 1000
 Current RUs: 0
+Average RUs: 0
 
 update
 1s
 ----
+Burst Limit: 1000000000
+Refill Rate: 1000
 Current RUs: 1000
+Average RUs: 0
 
 update
 0s
 ----
+Burst Limit: 1000000000
+Refill Rate: 1000
 Current RUs: 1000
+Average RUs: 0
 
 update
 -5s
 ----
+Burst Limit: 1000000000
+Refill Rate: 1000
 Current RUs: 1000
+Average RUs: 0
 
 update
 10s
 ----
+Burst Limit: 1000000000
+Refill Rate: 1000
 Current RUs: 11000
+Average RUs: 0
 
 update
 72h
 ----
+Burst Limit: 1000000000
+Refill Rate: 1000
 Current RUs: 259211000
+Average RUs: 0
 
-init
-initial: 1234
+reconfigure
+limit: 10000
 rate: 10
+current: 1234
 ----
+Burst Limit: 10000
+Refill Rate: 10
 Current RUs: 1234
+Average RUs: 0
 
 update
 10s
 ----
+Burst Limit: 10000
+Refill Rate: 10
 Current RUs: 1334
+Average RUs: 0

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/cleanup
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/cleanup
@@ -21,7 +21,7 @@ instance_id: 9
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=6835937.5
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 3
@@ -47,7 +47,7 @@ instance_id: 3
 
 inspect tenant=13
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=5781250
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 2
@@ -73,7 +73,7 @@ next_live_instance_id: 9
 
 wait-inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10030000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10030000  ru-current-avg=7634453.125
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:05:00.000
 First active instance: 3
@@ -94,7 +94,7 @@ next_live_instance_id: 3
 
 wait-inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10060000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10060000  ru-current-avg=8240839.84375
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:10:00.000
 First active instance: 3
@@ -115,7 +115,7 @@ next_live_instance_id: 5
 
 wait-inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10090000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10090000  ru-current-avg=8703129.88281
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:15:00.000
 First active instance: 5
@@ -123,7 +123,7 @@ First active instance: 5
 
 inspect tenant=13
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=5781250
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 2

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/configure
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/configure
@@ -17,7 +17,7 @@ max_burst_ru: 5000
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=5000  ru-refill-rate=100  ru-current=1000  current-share-sum=0
+Bucket state: ru-burst-limit=5000  ru-refill-rate=100  ru-current=1000  ru-current-avg=0
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 0
@@ -39,7 +39,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=5000  ru-refill-rate=100  ru-current=1000  current-share-sum=0
+Bucket state: ru-burst-limit=5000  ru-refill-rate=100  ru-current=1000  ru-current-avg=250
 Consumption: ru=10 kvru=10  reads=20 in 2 batches (30 bytes)  writes=40 in 2 batches (50 bytes)  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -57,7 +57,7 @@ refill_rate: 100
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=2000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=2000  ru-current-avg=250
 Consumption: ru=10 kvru=10  reads=20 in 2 batches (30 bytes)  writes=40 in 2 batches (50 bytes)  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:01:00.000
 First active instance: 1

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/instances
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/instances
@@ -17,7 +17,7 @@ instance_id: 10
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=2500000
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 10
@@ -29,7 +29,7 @@ instance_id: 10
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=4375000
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 10
@@ -41,7 +41,7 @@ instance_id: 20
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=5781250
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 10
@@ -54,7 +54,7 @@ instance_id: 15
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=6835937.5
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 10
@@ -68,7 +68,7 @@ instance_id: 1
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=7626953.125
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/metrics
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/metrics
@@ -68,7 +68,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=5781250
 Consumption: ru=1110 kvru=888  reads=2220 in 222 batches (3330 bytes)  writes=4440 in 333 batches (5550 bytes)  pod-cpu-usage: 6660 secs  pgwire-egress=7770 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/requests
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/requests
@@ -16,11 +16,11 @@ token-bucket-request tenant=5
 instance_id: 1
 ru: 10
 ----
-10 RUs granted over 100ms. Fallback rate: 100 RU/s
+10 RUs granted over 10s. Fallback rate: 100 RU/s
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=-10  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=-10  ru-current-avg=1875000
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -39,7 +39,7 @@ ru: 500
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=490  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=490  ru-current-avg=1406497.5
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:10.000
 First active instance: 1
@@ -70,7 +70,7 @@ ru: 10
 # Last update time for the tenant is unchanged. The per-instance time does get updated.
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=230  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=230  ru-current-avg=791306.71875
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:10.000
 First active instance: 1
@@ -89,7 +89,7 @@ instance_id: 1
 # The current RU amount stays the same.
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=230  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=230  ru-current-avg=593537.539062
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:10.000
 First active instance: 1
@@ -108,7 +108,7 @@ instance_id: 1
 # RU refilling resumed.
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=330  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=330  ru-current-avg=445235.654297
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:11.000
 First active instance: 1

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/seqnum
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/seqnum
@@ -20,7 +20,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=2500000
 Consumption: ru=10 kvru=10  reads=20 in 1 batches (30 bytes)  writes=40 in 3 batches (50 bytes)  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -46,7 +46,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=4375000
 Consumption: ru=20 kvru=20  reads=40 in 2 batches (60 bytes)  writes=80 in 6 batches (100 bytes)  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -72,7 +72,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=5781250
 Consumption: ru=20 kvru=20  reads=40 in 2 batches (60 bytes)  writes=80 in 6 batches (100 bytes)  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -97,7 +97,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=6835937.5
 Consumption: ru=20 kvru=20  reads=40 in 2 batches (60 bytes)  writes=80 in 6 batches (100 bytes)  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -123,7 +123,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=7626953.125
 Consumption: ru=30 kvru=40  reads=60 in 3 batches (90 bytes)  writes=120 in 9 batches (150 bytes)  pod-cpu-usage: 180 secs  pgwire-egress=210 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1
@@ -149,7 +149,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  current-share-sum=0
+Bucket state: ru-burst-limit=0  ru-refill-rate=100  ru-current=10000000  ru-current-avg=8220214.84375
 Consumption: ru=40 kvru=70  reads=80 in 4 batches (120 bytes)  writes=160 in 12 batches (200 bytes)  pod-cpu-usage: 240 secs  pgwire-egress=280 bytes  external-egress=0 bytes  external-ingress=0 bytes
 Last update: 00:00:00.000
 First active instance: 1

--- a/pkg/ccl/multitenantccl/tenantcostserver/token_bucket.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/token_bucket.go
@@ -103,7 +103,6 @@ func (s *instance) TokenBucketRequest(
 			instance.Seq = in.SeqNum
 		}
 
-		// TODO(radu): update shares.
 		*result = tenant.Bucket.Request(ctx, in)
 
 		instance.LastUpdate.Time = now

--- a/pkg/multitenant/tenant_usage.go
+++ b/pkg/multitenant/tenant_usage.go
@@ -36,10 +36,11 @@ type TenantUsageServer interface {
 	// Arguments:
 	//
 	//  - availableRU is the amount of Request Units that the tenant can consume at
-	//    will. Also known as "burst RUs".
+	//    will. Also known as "burst RUs". If this is -1 (or any negative number),
+	//    the bucket's available tokens are not updated.
 	//
 	//  - refillRate is the amount of Request Units per second that the tenant
-	//    receives.
+	//    receives. If this is 0, the bucket does not refill on its own.
 	//
 	//  - maxBurstRU is the maximum amount of Request Units that can be accumulated
 	//    from the refill rate, or 0 if there is no limit.


### PR DESCRIPTION
This backport consists of 4 PR's that fix various problems with the distributed
token bucket that governs tenant request unit usage. Today we only use it for
on-demand capacity, where the token bucket has significant available burst
capacity and no refill rate. In the future, we'd like to use this to implement
provisioned capacity, where burst capacity is near zero but the refill rate is
greater than 1000 RU/second. However, experimentation with the token bucket
revealed various bugs and undesirable behaviors when using it for provisioned
capacity; these PR's fix the known issues.

Release justification: All changes in this PR will only affect Serverless clusters;
this code will not run in non-Serverless clusters (including multi-tenant clusters,
e.g. for physical replication). These is a high-priority business need for these fixes.

Backport:
  * 1/1 commits from "tenantcostclient: add limit support to token bucket" (#112383)
  * 1/1 commits from "tenantcostserver: update token bucket debt algorithm" (#112909)
  * 4/4 commits from "tenantcostclient: improve token bucket client" (#113236)
  * 1/1 commits from "tenantcostclient: add blocked requests metric" (#113512)

Please see individual PRs for details.

/cc @cockroachdb/release
