### PR TITLE
clusterversion: remove TestingBinaryVersion and TestingBinaryMinSupportedVersion

### DIFF
--- a/pkg/ccl/backupccl/restore_old_sequences_test.go
+++ b/pkg/ccl/backupccl/restore_old_sequences_test.go
@@ -68,8 +68,8 @@ func TestRestoreOldSequences(t *testing.T) {
 func restoreOldSequencesTest(exportDir string, isSchemaOnly bool) func(t *testing.T) {
 	return func(t *testing.T) {
 		params := base.TestServerArgs{}
-		params.Settings = cluster.MakeTestingClusterSettingsWithVersions(clusterversion.TestingBinaryVersion,
-			clusterversion.TestingBinaryMinSupportedVersion, false /* initializeVersion */)
+		params.Settings = cluster.MakeTestingClusterSettingsWithVersions(clusterversion.Latest.Version(),
+			clusterversion.MinSupported.Version(), false /* initializeVersion */)
 		const numAccounts = 1000
 		_, sqlDB, dir, cleanup := backupRestoreTestSetupWithParams(t, singleNode, numAccounts,
 			InitManualReplication, base.TestClusterArgs{ServerArgs: params})

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/local_test_util_test.go
@@ -58,13 +58,13 @@ func runTest(t *testing.T, variant sharedtestutil.TestVariant, test sharedtestut
 	defer close(resumeChannel)
 	defer close(completedChannel)
 
-	bv := clusterversion.TestingBinaryVersion
-	msv := clusterversion.TestingBinaryMinSupportedVersion
+	bv := clusterversion.Latest.Version()
+	msv := clusterversion.MinSupported.Version()
 
 	// If there are any non-empty errors expected on the upgrade, then we're
 	// expecting it to fail.
 	expectingUpgradeToFail := test.ExpUpgradeErr[variant][0] != ""
-	finalUpgradeVersion := clusterversion.TestingBinaryVersion
+	finalUpgradeVersion := clusterversion.Latest.Version()
 	if expectingUpgradeToFail {
 		finalUpgradeVersion = msv
 	}

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/sharedtestutil/util.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeinterlockccl/sharedtestutil/util.go
@@ -47,7 +47,7 @@ var Tests = map[string]TestConfig{
 		ExpUpgradeErr: [NumConfigs][]string{
 			{""},
 			{"pq: upgrade failed due to active SQL servers with incompatible binary version",
-				fmt.Sprintf("sql server 2 is running a binary version %s which is less than the attempted upgrade version", clusterversion.TestingBinaryMinSupportedVersion.String())},
+				fmt.Sprintf("sql server 2 is running a binary version %s which is less than the attempted upgrade version", clusterversion.MinSupported.String())},
 		},
 		ExpStartupErr: [NumConfigs]string{
 			"",

--- a/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
+++ b/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
@@ -207,7 +207,7 @@ func TestServerReport(t *testing.T) {
 		"cluster.label":                            "<redacted>",
 		"diagnostics.reporting.send_crash_reports": "false",
 		"server.time_until_store_dead":             "1m30s",
-		"version":                                  clusterversion.TestingBinaryVersion.String(),
+		"version":                                  clusterversion.Latest.String(),
 		"cluster.secret":                           "<redacted>",
 	} {
 		got, ok := last.AlteredSettings[key]

--- a/pkg/ccl/serverccl/tenant_migration_test.go
+++ b/pkg/ccl/serverccl/tenant_migration_test.go
@@ -29,8 +29,8 @@ import (
 func TestValidateTargetTenantClusterVersion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	prev := clusterversion.ClusterVersion{Version: clusterversion.TestingBinaryMinSupportedVersion}
-	cur := clusterversion.ClusterVersion{Version: clusterversion.TestingBinaryVersion}
+	prev := clusterversion.ClusterVersion{Version: clusterversion.MinSupported.Version()}
+	cur := clusterversion.ClusterVersion{Version: clusterversion.Latest.Version()}
 	// In cases where we use prev as the binary version for the test, set the
 	// minimum supported version to prev's binary version - 1 Major version.
 	prevMsv := clusterversion.ClusterVersion{
@@ -137,8 +137,8 @@ func TestValidateTargetTenantClusterVersion(t *testing.T) {
 func TestBumpTenantClusterVersion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	prev := clusterversion.ClusterVersion{Version: clusterversion.TestingBinaryMinSupportedVersion}
-	cur := clusterversion.ClusterVersion{Version: clusterversion.TestingBinaryVersion}
+	prev := clusterversion.ClusterVersion{Version: clusterversion.MinSupported.Version()}
+	cur := clusterversion.ClusterVersion{Version: clusterversion.Latest.Version()}
 	// In cases where we use prev as the binary version for the test, set the
 	// minimum supported version to prev's binary version - 1 Major version.
 	prevMsv := clusterversion.ClusterVersion{

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -52,7 +52,7 @@ func loadTestData(
 ) storage.Engine {
 	ctx := context.Background()
 
-	verStr := fmt.Sprintf("v%s", clusterversion.TestingBinaryVersion.String())
+	verStr := fmt.Sprintf("v%s", clusterversion.Latest.String())
 	name := fmt.Sprintf("%s_v%s_%d_%d_%d_%d", dirPrefix, verStr, numKeys, numBatches, batchTimeSpan, valueBytes)
 	dir := testfixtures.ReuseOrGenerate(tb, name, func(dir string) {
 		eng, err := storage.Open(

--- a/pkg/ccl/streamingccl/replicationutils/utils_test.go
+++ b/pkg/ccl/streamingccl/replicationutils/utils_test.go
@@ -53,8 +53,8 @@ func TestScanSST(t *testing.T) {
 	require.True(t, roachpb.Key("ca").Compare(roachpb.Key("c")) > 0)
 
 	cs := cluster.MakeTestingClusterSettingsWithVersions(
-		clusterversion.TestingBinaryVersion,
-		clusterversion.TestingBinaryMinSupportedVersion,
+		clusterversion.Latest.Version(),
+		clusterversion.MinSupported.Version(),
 		true, /* initializeVersion */
 	)
 	data, start, end := storageutils.MakeSST(t, cs, []interface{}{

--- a/pkg/cli/declarative_print_rules_test.go
+++ b/pkg/cli/declarative_print_rules_test.go
@@ -32,7 +32,7 @@ func TestDeclarativeRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		version := clusterversion.TestingBinaryVersion
+		version := clusterversion.Latest.Version()
 		versionString := strings.Split(version.String(), "-")[0]
 		opOut, err := c.RunWithCapture(fmt.Sprintf("debug declarative-print-rules %s op", versionString))
 		if err != nil {

--- a/pkg/clusterversion/setting.go
+++ b/pkg/clusterversion/setting.go
@@ -208,7 +208,7 @@ func (cv *clusterVersionSetting) ValidateBinaryVersions(
 
 // SettingsListDefault is part of the VersionSettingImpl interface.
 func (cv *clusterVersionSetting) SettingsListDefault() string {
-	return Latest.Version().String()
+	return Latest.String()
 }
 
 func (cv *clusterVersionSetting) validateBinaryVersions(

--- a/pkg/clusterversion/setting_test.go
+++ b/pkg/clusterversion/setting_test.go
@@ -25,8 +25,8 @@ import (
 func TestMakeMetricsAndRegisterOnVersionChangeCallback(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	s1 := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.TestingBinaryVersion, clusterversion.TestingBinaryMinSupportedVersion, true)
-	s2 := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.TestingBinaryVersion, clusterversion.TestingBinaryMinSupportedVersion, true)
+	s1 := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.Latest.Version(), clusterversion.MinSupported.Version(), true)
+	s2 := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.Latest.Version(), clusterversion.MinSupported.Version(), true)
 
 	m1 := clusterversion.MakeMetricsAndRegisterOnVersionChangeCallback(&s1.SV)
 	m2 := clusterversion.MakeMetricsAndRegisterOnVersionChangeCallback(&s2.SV)
@@ -35,7 +35,7 @@ func TestMakeMetricsAndRegisterOnVersionChangeCallback(t *testing.T) {
 	require.Equal(t, int64(0), m2.PreserveDowngradeLastUpdated.Value())
 
 	// Test that the metrics returned are independent.
-	clusterversion.PreserveDowngradeVersion.Override(ctx, &s1.SV, clusterversion.TestingBinaryVersion.String())
+	clusterversion.PreserveDowngradeVersion.Override(ctx, &s1.SV, clusterversion.Latest.String())
 	testutils.SucceedsSoon(t, func() error {
 		if int64(0) >= m1.PreserveDowngradeLastUpdated.Value() {
 			return errors.New("metric is zero. expected positive number.")
@@ -44,7 +44,7 @@ func TestMakeMetricsAndRegisterOnVersionChangeCallback(t *testing.T) {
 	})
 	require.Equal(t, int64(0), m2.PreserveDowngradeLastUpdated.Value())
 
-	clusterversion.PreserveDowngradeVersion.Override(ctx, &s2.SV, clusterversion.TestingBinaryVersion.String())
+	clusterversion.PreserveDowngradeVersion.Override(ctx, &s2.SV, clusterversion.Latest.String())
 	testutils.SucceedsSoon(t, func() error {
 		if int64(0) >= m2.PreserveDowngradeLastUpdated.Value() {
 			return errors.New("metric is zero. expected positive number.")

--- a/pkg/clusterversion/testutils.go
+++ b/pkg/clusterversion/testutils.go
@@ -10,18 +10,8 @@
 
 package clusterversion
 
-// TestingBinaryVersion is a binary version that tests can use when they don't
-// want to go through a Settings object.
-// TODO(radu): remove this.
-var TestingBinaryVersion = Latest.Version()
-
-// TestingBinaryMinSupportedVersion is a minimum supported version that
-// tests can use when they don't want to go through a Settings object.
-// TODO(radu): remove this.
-var TestingBinaryMinSupportedVersion = MinSupported.Version()
-
 // TestingClusterVersion is a ClusterVersion that tests can use when they don't
 // want to go through a Settings object.
 var TestingClusterVersion = ClusterVersion{
-	Version: TestingBinaryVersion,
+	Version: Latest.Version(),
 }

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2532,15 +2532,15 @@ func TestStartableJobMixedVersion(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettingsWithVersions(
-		clusterversion.TestingBinaryVersion,
-		clusterversion.TestingBinaryMinSupportedVersion,
+		clusterversion.Latest.Version(),
+		clusterversion.MinSupported.Version(),
 		false, /* initializeVersion */
 	)
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Settings: st,
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
-				BinaryVersionOverride:          clusterversion.TestingBinaryMinSupportedVersion,
+				BinaryVersionOverride:          clusterversion.MinSupported.Version(),
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
 			},
 		},

--- a/pkg/jobs/jobstest/utils.go
+++ b/pkg/jobs/jobstest/utils.go
@@ -148,7 +148,7 @@ func GetJobsTableSchema(env scheduledjobs.JobSchedulerEnv) string {
 var DummyClusterID = uuid.UUID{1}
 
 // DummyClusterVersion is used while instantiating dummy schedules
-var DummyClusterVersion = clusterversion.ClusterVersion{Version: clusterversion.TestingBinaryVersion}
+var DummyClusterVersion = clusterversion.ClusterVersion{Version: clusterversion.Latest.Version()}
 
 // AddDummyScheduleDetails augments passed in details with a dummy clusterID and CreationClusterVersion.
 func AddDummyScheduleDetails(details jobspb.ScheduleDetails) jobspb.ScheduleDetails {

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range_bench_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range_bench_test.go
@@ -215,7 +215,7 @@ func setupData(
 ) (storage.Engine, string) {
 	// Include the current version in the fixture name, or we may inadvertently
 	// run against a left-over fixture that is no longer supported.
-	verStr := fmt.Sprintf("v%s", clusterversion.TestingBinaryVersion.String())
+	verStr := fmt.Sprintf("v%s", clusterversion.Latest.String())
 	orderStr := "linear"
 	if opts.randomKeyOrder {
 		orderStr = "random"

--- a/pkg/kv/kvserver/kvstorage/cluster_version_test.go
+++ b/pkg/kv/kvserver/kvstorage/cluster_version_test.go
@@ -97,7 +97,7 @@ func TestClusterVersionWriteSynthesize(t *testing.T) {
 	// stores with. create a store.
 	// For example's sake, let's assume that minV is 1.0. Then binV is 1.1 and
 	// development versions are 1.0-1 and 1.0-2.
-	minV := clusterversion.TestingBinaryMinSupportedVersion
+	minV := clusterversion.MinSupported.Version()
 	binV := minV
 	binV.Minor += 1
 

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -79,7 +79,7 @@ func TestBaseQueueConcurrent(t *testing.T) {
 			Clock:             hlc.NewClockForTesting(nil),
 			AmbientCtx:        log.MakeTestingAmbientContext(tr),
 			DefaultSpanConfig: roachpb.TestingDefaultSpanConfig(),
-			Settings:          cluster.MakeTestingClusterSettingsWithVersions(clusterversion.TestingBinaryVersion, clusterversion.TestingBinaryVersion, true),
+			Settings:          cluster.MakeTestingClusterSettingsWithVersions(clusterversion.Latest.Version(), clusterversion.Latest.Version(), true),
 		},
 	}
 

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -234,7 +234,7 @@ func setupMVCCPebble(b testing.TB, dir string, lBaseMaxBytes int64, readOnly boo
 func setupData(
 	ctx context.Context, b *testing.B, emk engineMaker, opts benchDataOptions,
 ) (storage.Engine, string) {
-	verStr := fmt.Sprintf("v%s", clusterversion.TestingBinaryVersion.String())
+	verStr := fmt.Sprintf("v%s", clusterversion.Latest.String())
 	orderStr := "linear"
 	if opts.randomKeyOrder {
 		orderStr = "random"

--- a/pkg/kv/kvserver/rebalance_objective_test.go
+++ b/pkg/kv/kvserver/rebalance_objective_test.go
@@ -244,7 +244,7 @@ func TestRebalanceObjectiveManager(t *testing.T) {
 	// supported on this version.
 	t.Run("store cpu unsupported version", func(t *testing.T) {
 		st := cluster.MakeTestingClusterSettingsWithVersions(
-			clusterversion.TestingBinaryVersion,
+			clusterversion.Latest.Version(),
 			clusterversion.ByKey(clusterversion.TODO_Delete_V22_2), false)
 		require.NoError(t, st.Version.SetActiveVersion(ctx, clusterversion.ClusterVersion{
 			Version: clusterversion.ByKey(clusterversion.TODO_Delete_V22_2),

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -298,7 +298,7 @@ var raftStepDownOnRemoval = util.ConstantWithMetamorphicTestBool("raft-step-down
 
 // TestStoreConfig has some fields initialized with values relevant in tests.
 func TestStoreConfig(clock *hlc.Clock) StoreConfig {
-	return testStoreConfig(clock, clusterversion.TestingBinaryVersion)
+	return testStoreConfig(clock, clusterversion.Latest.Version())
 }
 
 // TestStoreConfigWithVersion is the same as TestStoreConfig but allows to pass a cluster version.

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -1793,7 +1793,7 @@ func TestVersionCheckBidirectional(t *testing.T) {
 
 	ctx := context.Background()
 	v1 := roachpb.Version{Major: 1}
-	v2 := clusterversion.TestingBinaryVersion
+	v2 := clusterversion.Latest.Version()
 
 	testData := []struct {
 		name          string

--- a/pkg/rpc/heartbeat_test.go
+++ b/pkg/rpc/heartbeat_test.go
@@ -262,8 +262,8 @@ func TestTenantVersionCheck(t *testing.T) {
 	clock := timeutil.NewManualTime(timeutil.Unix(0, 5))
 	maxOffset := time.Nanosecond
 	st := cluster.MakeTestingClusterSettingsWithVersions(
-		clusterversion.TestingBinaryVersion,
-		clusterversion.TestingBinaryMinSupportedVersion,
+		clusterversion.Latest.Version(),
+		clusterversion.MinSupported.Version(),
 		true /* initialize */)
 	heartbeat := &HeartbeatService{
 		clock:              clock,

--- a/pkg/rpc/nodedialer/nodedialer_test.go
+++ b/pkg/rpc/nodedialer/nodedialer_test.go
@@ -292,7 +292,7 @@ func newTestServer(
 	if useHeartbeat {
 		hb = &heartbeatService{
 			clock:         clock,
-			serverVersion: clusterversion.TestingBinaryVersion,
+			serverVersion: clusterversion.Latest.Version(),
 		}
 		rpc.RegisterHeartbeatServer(s, hb)
 	}

--- a/pkg/server/autoconfig/auto_config_test.go
+++ b/pkg/server/autoconfig/auto_config_test.go
@@ -52,7 +52,7 @@ type testTask struct {
 var endProfileTask = autoconfigpb.Task{
 	TaskID:      autoconfigpb.TaskID(math.MaxUint64),
 	Description: "end of configuration profile",
-	MinVersion:  clusterversion.TestingBinaryVersion,
+	MinVersion:  clusterversion.Latest.Version(),
 	Payload: &autoconfigpb.Task_SimpleSQL{
 		SimpleSQL: &autoconfigpb.SimpleSQL{},
 	},
@@ -62,7 +62,7 @@ var testTasks = []testTask{
 	{task: autoconfigpb.Task{
 		TaskID:      123,
 		Description: "test task that creates a system table",
-		MinVersion:  clusterversion.TestingBinaryVersion,
+		MinVersion:  clusterversion.Latest.Version(),
 		Payload: &autoconfigpb.Task_SimpleSQL{
 			SimpleSQL: &autoconfigpb.SimpleSQL{
 				UsernameProto: username.NodeUserName().EncodeProto(),
@@ -80,7 +80,7 @@ var testTasks = []testTask{
 	{task: autoconfigpb.Task{
 		TaskID:      345,
 		Description: "test task that fails with an error",
-		MinVersion:  clusterversion.TestingBinaryVersion,
+		MinVersion:  clusterversion.Latest.Version(),
 		Payload: &autoconfigpb.Task_SimpleSQL{
 			SimpleSQL: &autoconfigpb.SimpleSQL{
 				TransactionalStatements: []string{"SELECT invalid"},
@@ -90,7 +90,7 @@ var testTasks = []testTask{
 	{task: autoconfigpb.Task{
 		TaskID:      456,
 		Description: "test task that creates another system table",
-		MinVersion:  clusterversion.TestingBinaryVersion,
+		MinVersion:  clusterversion.Latest.Version(),
 		Payload: &autoconfigpb.Task_SimpleSQL{
 			SimpleSQL: &autoconfigpb.SimpleSQL{
 				UsernameProto:           username.NodeUserName().EncodeProto(),
@@ -261,7 +261,7 @@ func TestAutoConfigWaitAtStartupTimesOut(t *testing.T) {
 			{task: autoconfigpb.Task{
 				TaskID:      123,
 				Description: "test task that takes longer than the maxWait",
-				MinVersion:  clusterversion.TestingBinaryVersion,
+				MinVersion:  clusterversion.Latest.Version(),
 				Payload: &autoconfigpb.Task_SimpleSQL{
 					SimpleSQL: &autoconfigpb.SimpleSQL{
 						UsernameProto: username.NodeUserName().EncodeProto(),
@@ -316,7 +316,7 @@ func TestAutoConfigWaitAtStartup(t *testing.T) {
 			{task: autoconfigpb.Task{
 				TaskID:      123,
 				Description: "create-test-table",
-				MinVersion:  clusterversion.TestingBinaryVersion,
+				MinVersion:  clusterversion.Latest.Version(),
 				Payload: &autoconfigpb.Task_SimpleSQL{
 					SimpleSQL: &autoconfigpb.SimpleSQL{
 						UsernameProto: username.NodeUserName().EncodeProto(),

--- a/pkg/server/connectivity_test.go
+++ b/pkg/server/connectivity_test.go
@@ -326,7 +326,7 @@ func TestJoinVersionGate(t *testing.T) {
 		return nil
 	})
 
-	var newVersion = clusterversion.TestingBinaryVersion
+	var newVersion = clusterversion.Latest.Version()
 	var oldVersion = prev(newVersion)
 
 	knobs := base.TestingKnobs{

--- a/pkg/server/migration_test.go
+++ b/pkg/server/migration_test.go
@@ -231,8 +231,9 @@ func TestMigrationPurgeOutdatedReplicas(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 
 	migrationServer := s.MigrationServer().(*migrationServer)
+	version := clusterversion.Latest.Version()
 	if _, err := migrationServer.PurgeOutdatedReplicas(context.Background(), &serverpb.PurgeOutdatedReplicasRequest{
-		Version: &clusterversion.TestingBinaryVersion,
+		Version: &version,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -251,8 +252,8 @@ func TestUpgradeHappensAfterMigrations(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettingsWithVersions(
-		clusterversion.TestingBinaryVersion,
-		clusterversion.TestingBinaryMinSupportedVersion,
+		clusterversion.Latest.Version(),
+		clusterversion.MinSupported.Version(),
 		false, /* initializeVersion */
 	)
 	automaticUpgrade := make(chan struct{})
@@ -261,7 +262,7 @@ func TestUpgradeHappensAfterMigrations(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &TestingKnobs{
 				DisableAutomaticVersionUpgrade: automaticUpgrade,
-				BinaryVersionOverride:          clusterversion.TestingBinaryMinSupportedVersion,
+				BinaryVersionOverride:          clusterversion.MinSupported.Version(),
 			},
 			UpgradeManager: &upgradebase.TestingKnobs{
 				AfterRunPermanentUpgrades: func() {
@@ -270,7 +271,7 @@ func TestUpgradeHappensAfterMigrations(t *testing.T) {
 					for i := 0; i < N; i++ {
 						runtime.Gosched()
 					}
-					require.True(t, st.Version.ActiveVersion(ctx).Less(clusterversion.TestingBinaryVersion))
+					require.True(t, st.Version.ActiveVersion(ctx).Less(clusterversion.Latest.Version()))
 				},
 			},
 		},

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -69,8 +69,8 @@ func TestBootstrapCluster(t *testing.T) {
 	defer e.Close()
 
 	initCfg := initServerCfg{
-		minSupportedVersion:     clusterversion.TestingBinaryMinSupportedVersion,
-		latestVersion:           clusterversion.TestingBinaryVersion,
+		minSupportedVersion:     clusterversion.MinSupported.Version(),
+		latestVersion:           clusterversion.Latest.Version(),
 		defaultSystemZoneConfig: *zonepb.DefaultZoneConfigRef(),
 		defaultZoneConfig:       *zonepb.DefaultSystemZoneConfigRef(),
 	}
@@ -252,8 +252,8 @@ func TestCorruptedClusterID(t *testing.T) {
 
 	cv := clusterversion.TestingClusterVersion
 	initCfg := initServerCfg{
-		minSupportedVersion:     clusterversion.TestingBinaryMinSupportedVersion,
-		latestVersion:           clusterversion.TestingBinaryVersion,
+		minSupportedVersion:     clusterversion.MinSupported.Version(),
+		latestVersion:           clusterversion.Latest.Version(),
 		defaultSystemZoneConfig: *zonepb.DefaultZoneConfigRef(),
 		defaultZoneConfig:       *zonepb.DefaultSystemZoneConfigRef(),
 	}

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -166,7 +166,7 @@ func TestClusterVersionPersistedOnJoin(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	var newVersion = clusterversion.TestingBinaryVersion
+	var newVersion = clusterversion.Latest.Version()
 	var oldVersion = prev(newVersion)
 
 	// Starts 3 nodes that have cluster versions set to be oldVersion and
@@ -212,7 +212,7 @@ func TestClusterVersionUpgrade(t *testing.T) {
 
 	ctx := context.Background()
 
-	var newVersion = clusterversion.TestingBinaryVersion
+	var newVersion = clusterversion.Latest.Version()
 	var oldVersion = prev(newVersion)
 
 	disableUpgradeCh := make(chan struct{})
@@ -350,7 +350,7 @@ func TestAllVersionsAgree(t *testing.T) {
 		TestCluster: tcRaw,
 	}
 
-	exp := clusterversion.TestingBinaryVersion.String()
+	exp := clusterversion.Latest.String()
 
 	// The node bootstrapping the cluster starts at TestingBinaryVersion, the
 	// others start at TestingMinimumSupportedVersion and it takes them a gossip
@@ -376,8 +376,8 @@ func TestAllVersionsAgree(t *testing.T) {
 // equal the TestingBinaryMinSupportedVersion to avoid rot in tests using this
 // (as we retire old versions).
 func v0v1() (roachpb.Version, roachpb.Version) {
-	v1 := clusterversion.TestingBinaryMinSupportedVersion
-	v0 := clusterversion.TestingBinaryMinSupportedVersion
+	v1 := clusterversion.MinSupported.Version()
+	v0 := clusterversion.MinSupported.Version()
 	if v0.Minor > 0 {
 		v0.Minor--
 	} else {

--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -206,7 +206,7 @@ func backupSuccess(t *testing.T, factory TestServerFactory, cs CumulativeTestCas
 		}
 
 		// Upgrade the cluster if applicable.
-		tdb.Exec(t, "SET CLUSTER SETTING VERSION = $1", clusterversion.TestingBinaryVersion.String())
+		tdb.Exec(t, "SET CLUSTER SETTING VERSION = $1", clusterversion.Latest.String())
 
 		// Restore the backup of the database taken mid-successful-schema-change
 		// in various ways, check that it ends up in the same state as present.

--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -375,7 +375,7 @@ func pause(t *testing.T, factory TestServerFactory, cs CumulativeTestCaseSpec) {
 			t.Logf("job %d is paused", jobID)
 
 			// Upgrade the cluster, if applicable.
-			tdb.Exec(t, "SET CLUSTER SETTING VERSION=$1", clusterversion.TestingBinaryVersion.String())
+			tdb.Exec(t, "SET CLUSTER SETTING VERSION=$1", clusterversion.Latest.String())
 
 			// Resume the job and check that it succeeds.
 			tdb.Exec(t, "RESUME JOB $1", jobID)

--- a/pkg/sql/sqlliveness/slinstance/slinstance_test.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance_test.go
@@ -41,8 +41,8 @@ func TestSQLInstance(t *testing.T) {
 	var ambientCtx log.AmbientContext
 	clock := hlc.NewClockForTesting(timeutil.NewManualTime(timeutil.Unix(0, 42)))
 	settings := cluster.MakeTestingClusterSettingsWithVersions(
-		clusterversion.TestingBinaryVersion,
-		clusterversion.TestingBinaryMinSupportedVersion,
+		clusterversion.Latest.Version(),
+		clusterversion.MinSupported.Version(),
 		true /* initializeVersion */)
 	slinstance.DefaultTTL.Override(ctx, &settings.SV, 20*time.Millisecond)
 	slinstance.DefaultHeartBeat.Override(ctx, &settings.SV, 10*time.Millisecond)
@@ -110,8 +110,8 @@ func TestSQLInstanceRelease(t *testing.T) {
 
 	clock := hlc.NewClockForTesting(timeutil.NewManualTime(timeutil.Unix(0, 42)))
 	settings := cluster.MakeTestingClusterSettingsWithVersions(
-		clusterversion.TestingBinaryVersion,
-		clusterversion.TestingBinaryMinSupportedVersion,
+		clusterversion.Latest.Version(),
+		clusterversion.MinSupported.Version(),
 		true /* initializeVersion */)
 	slinstance.DefaultTTL.Override(ctx, &settings.SV, 20*time.Millisecond)
 	slinstance.DefaultHeartBeat.Override(ctx, &settings.SV, 10*time.Millisecond)

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -62,7 +62,7 @@ func setupMVCCInMemPebbleWithSeparatedIntents(b testing.TB) Engine {
 func setupPebbleInMemPebbleForLatestRelease(b testing.TB, _ string) Engine {
 	ctx := context.Background()
 	s := cluster.MakeClusterSettings()
-	if err := clusterversion.Initialize(ctx, clusterversion.TestingBinaryVersion,
+	if err := clusterversion.Initialize(ctx, clusterversion.Latest.Version(),
 		&s.SV); err != nil {
 		b.Fatalf("failed to set current cluster version: %+v", err)
 	}

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -280,7 +280,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 		ctx,
 		ltc.Eng,
 		initialValues,
-		clusterversion.TestingBinaryVersion,
+		clusterversion.Latest.Version(),
 		1, /* numStores */
 		splits,
 		ltc.Clock.PhysicalNow(),

--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -256,8 +256,8 @@ func TestPostJobInfoTableQueryDuplicateJobInfo(t *testing.T) {
 
 	settingsForUpgrade := func() *cluster.Settings {
 		settings := cluster.MakeTestingClusterSettingsWithVersions(
-			clusterversion.TestingBinaryVersion,
-			clusterversion.TestingBinaryMinSupportedVersion,
+			clusterversion.Latest.Version(),
+			clusterversion.MinSupported.Version(),
 			false, // initializeVersion
 		)
 		require.NoError(t, clusterversion.Initialize(ctx,
@@ -290,7 +290,7 @@ func TestPostJobInfoTableQueryDuplicateJobInfo(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			Server: &server.TestingKnobs{
-				BinaryVersionOverride:          clusterversion.TestingBinaryMinSupportedVersion,
+				BinaryVersionOverride:          clusterversion.MinSupported.Version(),
 				DisableAutomaticVersionUpgrade: make(chan struct{}),
 			},
 			UpgradeManager: &upgradebase.TestingKnobs{
@@ -349,7 +349,7 @@ FROM system.job_info WHERE job_id = $1 AND info_key = 'legacy_payload')`, jobID)
 			TenantID: roachpb.MustMakeTenantID(10),
 			TestingKnobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
-					BinaryVersionOverride:          clusterversion.TestingBinaryMinSupportedVersion,
+					BinaryVersionOverride:          clusterversion.MinSupported.Version(),
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
@@ -466,7 +466,7 @@ func TestConcurrentMigrationAttempts(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// We're going to be migrating from the MinSupportedVersion to imaginary future versions.
-	current := clusterversion.TestingBinaryMinSupportedVersion
+	current := clusterversion.MinSupported.Version()
 	versions := []roachpb.Version{current}
 	for i := int32(1); i <= 4; i++ {
 		v := current
@@ -681,7 +681,7 @@ func TestPrecondition(t *testing.T) {
 		version.Internal += 1
 		return version
 	}
-	v0 := clusterversion.TestingBinaryMinSupportedVersion
+	v0 := clusterversion.MinSupported.Version()
 	v0_fence := fence(v0)
 	v1 := next(v0)
 	v1_fence := fence(v1)

--- a/pkg/upgrade/upgrades/builtins_test.go
+++ b/pkg/upgrade/upgrades/builtins_test.go
@@ -46,7 +46,7 @@ func TestIsAtLeastVersionBuiltin(t *testing.T) {
 	)
 	defer tc.Stopper().Stop(ctx)
 
-	v := clusterversion.Latest.Version().String()
+	v := clusterversion.Latest.String()
 	// Check that the builtin returns false when comparing against the new
 	// version because we are still on the bootstrap version.
 	sqlDB.CheckQueryResults(t, "SELECT crdb_internal.is_at_least_version('"+v+"')", [][]string{{"false"}})

--- a/pkg/upgrade/upgrades/first_upgrade_test.go
+++ b/pkg/upgrade/upgrades/first_upgrade_test.go
@@ -43,7 +43,7 @@ func TestFirstUpgrade(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	var (
-		v0 = clusterversion.TestingBinaryMinSupportedVersion
+		v0 = clusterversion.MinSupported.Version()
 		v1 = clusterversion.ByKey(clusterversion.BinaryVersionKey)
 	)
 
@@ -148,7 +148,7 @@ func TestFirstUpgradeRepair(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	var (
-		v0 = clusterversion.TestingBinaryMinSupportedVersion
+		v0 = clusterversion.MinSupported.Version()
 		v1 = clusterversion.ByKey(clusterversion.BinaryVersionKey)
 	)
 

--- a/pkg/upgrade/upgrades/grant_execute_to_public_test.go
+++ b/pkg/upgrade/upgrades/grant_execute_to_public_test.go
@@ -43,7 +43,7 @@ func TestGrantExecuteToPublicOnAllFunctions(t *testing.T) {
 	skip.UnderRace(t)
 
 	var (
-		v0 = clusterversion.TestingBinaryMinSupportedVersion
+		v0 = clusterversion.MinSupported.Version()
 		v1 = clusterversion.ByKey(clusterversion.BinaryVersionKey)
 	)
 	ctx := context.Background()
@@ -122,7 +122,7 @@ func BenchmarkGrantExecuteToPublicOnAllFunctions(b *testing.B) {
 	defer log.Scope(b).Close(b)
 
 	var (
-		v0 = clusterversion.TestingBinaryMinSupportedVersion
+		v0 = clusterversion.MinSupported.Version()
 		v1 = clusterversion.ByKey(clusterversion.BinaryVersionKey)
 	)
 

--- a/pkg/upgrade/upgrades/permanent_upgrades.go
+++ b/pkg/upgrade/upgrades/permanent_upgrades.go
@@ -111,7 +111,7 @@ func populateVersionSetting(
 	if v == (roachpb.Version{}) {
 		// The cluster was bootstrapped at v1.0 (or even earlier), so just use
 		// the TestingBinaryMinSupportedVersion of the binary.
-		v = clusterversion.TestingBinaryMinSupportedVersion
+		v = clusterversion.MinSupported.Version()
 	}
 
 	b, err := protoutil.Marshal(&clusterversion.ClusterVersion{Version: v})

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -158,9 +158,8 @@ func (og *operationGenerator) getSupportedDeclarativeOp(
 ) (opType, error) {
 	for {
 		op := opType(og.params.declarativeOps.Int())
-		if !clusterversion.TestingBinaryMinSupportedVersion.Equal(
-			clusterversion.ByKey(opDeclarativeVersion[op])) {
-			notSupported, err := isClusterVersionLessThan(ctx, tx, clusterversion.ByKey(opDeclarativeVersion[op]))
+		if opVerKey := opDeclarativeVersion[op]; opVerKey != clusterversion.MinSupported {
+			notSupported, err := isClusterVersionLessThan(ctx, tx, opVerKey.Version())
 			if err != nil {
 				return op, err
 			}


### PR DESCRIPTION
The change is mostly mechanical, no functional changes.

Informs: #112629
Release note: None