### PR TITLE
kvfollowerreadccl: skip shared-process under deadlock in a test

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -904,6 +905,11 @@ func TestSecondaryTenantFollowerReadsRouting(t *testing.T) {
 		{name: "latency-based", sharedProcess: false, validLatencyFunc: true},
 		{name: "locality-based", sharedProcess: false, validLatencyFunc: false},
 	} {
+		if syncutil.DeadlockEnabled && testCase.sharedProcess {
+			// TODO(yuzefovich): unskipping shared-process config under deadlock
+			// is tracked by #113555.
+			continue
+		}
 		t.Run(testCase.name, func(t *testing.T) {
 			const numNodes = 4
 			gatewayNode := 3


### PR DESCRIPTION
This commit skips `shared-process` config of
`TestSecondaryTenantFollowerReadsRouting` when running under deadlock. For some reason in that setup the range cache is not as we expect.

Informs: #113555
Informs: #113733

Epic: None

Release note: None