### PR TITLE
kv: fix redaction in split logging

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -595,7 +595,7 @@ func (r *Replica) executeAdminCommandWithDescriptor(
 // The supplied RangeDescriptor is used as a form of optimistic lock. See the
 // comment of "AdminSplit" for more information on this pattern.
 func (r *Replica) AdminMerge(
-	ctx context.Context, args kvpb.AdminMergeRequest, reason string,
+	ctx context.Context, args kvpb.AdminMergeRequest, reason redact.RedactableString,
 ) (kvpb.AdminMergeResponse, *kvpb.Error) {
 	var reply kvpb.AdminMergeResponse
 

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
 	"go.etcd.io/raft/v3"
 	"go.etcd.io/raft/v3/raftpb"
 	"go.etcd.io/raft/v3/tracker"
@@ -68,9 +69,9 @@ const mergeApplicationTimeout = 5 * time.Second
 var sendSnapshotTimeout = envutil.EnvOrDefaultDuration(
 	"COCKROACH_RAFT_SEND_SNAPSHOT_TIMEOUT", 1*time.Hour)
 
-// AdminSplit divides the range into into two ranges using args.SplitKey.
+// AdminSplit divides the range into two ranges using args.SplitKey.
 func (r *Replica) AdminSplit(
-	ctx context.Context, args kvpb.AdminSplitRequest, reason string,
+	ctx context.Context, args kvpb.AdminSplitRequest, reason redact.RedactableString,
 ) (reply kvpb.AdminSplitResponse, _ *kvpb.Error) {
 	if len(args.SplitKey) == 0 {
 		return kvpb.AdminSplitResponse{}, kvpb.NewErrorf("cannot split range with no key provided")
@@ -100,8 +101,8 @@ func maybeDescriptorChangedError(
 	return false, nil
 }
 
-func splitSnapshotWarningStr(rangeID roachpb.RangeID, status *raft.Status) string {
-	var s string
+func splitSnapshotWarningStr(rangeID roachpb.RangeID, status *raft.Status) redact.RedactableString {
+	var s redact.RedactableString
 	if status != nil && status.RaftState == raft.StateLeader {
 		for replicaID, pr := range status.Progress {
 			if replicaID == status.Lead {
@@ -113,7 +114,7 @@ func splitSnapshotWarningStr(rangeID roachpb.RangeID, status *raft.Status) strin
 				// This follower is in good working order.
 				continue
 			}
-			s += fmt.Sprintf("; r%d/%d is ", rangeID, replicaID)
+			s += redact.Sprintf("; r%d/%d is ", rangeID, replicaID)
 			switch pr.State {
 			case tracker.StateSnapshot:
 				// If the Raft snapshot queue is backed up, replicas can spend
@@ -127,7 +128,7 @@ func splitSnapshotWarningStr(rangeID roachpb.RangeID, status *raft.Status) strin
 				s += "being probed (may or may not need a Raft snapshot)"
 			default:
 				// Future proofing.
-				s += "in unknown state " + pr.State.String()
+				s += redact.Sprintf("in unknown state %s", redact.Safe(pr.State))
 			}
 		}
 	}
@@ -172,7 +173,7 @@ func splitTxnAttempt(
 	splitKey roachpb.RKey,
 	expiration hlc.Timestamp,
 	oldDesc *roachpb.RangeDescriptor,
-	reason string,
+	reason redact.RedactableString,
 ) error {
 	txn.SetDebugName(splitTxnName)
 
@@ -210,7 +211,7 @@ func splitTxnAttempt(
 	}
 
 	// Log the split into the range event log.
-	if err := store.logSplit(ctx, txn, *leftDesc, *rightDesc, reason, true /* logAsync */); err != nil {
+	if err := store.logSplit(ctx, txn, *leftDesc, *rightDesc, reason.StripMarkers(), true /* logAsync */); err != nil {
 		return err
 	}
 
@@ -298,7 +299,7 @@ func (r *Replica) adminSplitWithDescriptor(
 	args kvpb.AdminSplitRequest,
 	desc *roachpb.RangeDescriptor,
 	delayable bool,
-	reason string,
+	reason redact.RedactableString,
 	findFirstSafeKey bool,
 ) (kvpb.AdminSplitResponse, error) {
 	var err error
@@ -430,7 +431,7 @@ func (r *Replica) adminSplitWithDescriptor(
 		return reply, errors.Wrap(err, "unable to allocate range id for right hand side")
 	}
 
-	var extra string
+	var extra redact.RedactableString
 	if delayable {
 		extra += maybeDelaySplitToAvoidSnapshot(ctx, (*splitDelayHelper)(r))
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -13409,13 +13409,13 @@ func TestSplitSnapshotWarningStr(t *testing.T) {
 	}
 
 	status := upToDateRaftStatus(replicas(1, 3, 5))
-	assert.Equal(t, "", splitSnapshotWarningStr(12, status))
+	assert.EqualValues(t, "", splitSnapshotWarningStr(12, status))
 
 	pr := status.Progress[2]
 	pr.State = tracker.StateProbe
 	status.Progress[2] = pr
 
-	assert.Equal(
+	assert.EqualValues(
 		t,
 		"; r12/2 is being probed (may or may not need a Raft snapshot)",
 		splitSnapshotWarningStr(12, status),
@@ -13423,7 +13423,7 @@ func TestSplitSnapshotWarningStr(t *testing.T) {
 
 	pr.State = tracker.StateSnapshot
 
-	assert.Equal(
+	assert.EqualValues(
 		t,
 		"; r12/2 is being probed (may or may not need a Raft snapshot)",
 		splitSnapshotWarningStr(12, status),

--- a/pkg/kv/kvserver/split/objective.go
+++ b/pkg/kv/kvserver/split/objective.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/redact"
 )
 
 // SplitObjective is a type that specifies a load based splitting objective.
@@ -27,7 +28,7 @@ const (
 	SplitCPU
 )
 
-// String returns a human readable string representation of the dimension.
+// String returns a human-readable string representation of the dimension.
 func (d SplitObjective) String() string {
 	switch d {
 	case SplitQPS:
@@ -39,13 +40,16 @@ func (d SplitObjective) String() string {
 	}
 }
 
+// SafeValue implements the redact.SafeValue interface.
+func (SplitObjective) SafeValue() {}
+
 // Format returns a formatted string for a value.
-func (d SplitObjective) Format(value float64) string {
+func (d SplitObjective) Format(value float64) redact.SafeString {
 	switch d {
 	case SplitQPS:
-		return fmt.Sprintf("%.1f", value)
+		return redact.SafeString(fmt.Sprintf("%.1f", value))
 	case SplitCPU:
-		return string(humanizeutil.Duration(time.Duration(int64(value))))
+		return humanizeutil.Duration(time.Duration(int64(value)))
 	default:
 		panic(fmt.Sprintf("cannot format value: unknown objective with ordinal %d", d))
 	}

--- a/pkg/kv/kvserver/split_delay_helper_test.go
+++ b/pkg/kv/kvserver/split_delay_helper_test.go
@@ -68,7 +68,7 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 			raftStatus:  nil,
 		}
 		s := maybeDelaySplitToAvoidSnapshot(ctx, h)
-		assert.Equal(t, "", s)
+		assert.EqualValues(t, "", s)
 		assert.EqualValues(t, 0, h.slept)
 	})
 
@@ -90,7 +90,7 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 			raftStatus:  nil,
 		}
 		s := maybeDelaySplitToAvoidSnapshot(ctx, h)
-		assert.Equal(t, "; delayed by 0.0s to resolve: replica is raft follower (without success)", s)
+		assert.EqualValues(t, "; delayed by 0.0s to resolve: replica is raft follower (without success)", s)
 		assert.EqualValues(t, 0, h.slept)
 	})
 
@@ -102,7 +102,7 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 			raftStatus:  statusWithState(raft.StateFollower),
 		}
 		s := maybeDelaySplitToAvoidSnapshot(ctx, h)
-		assert.Equal(t, "; delayed by 0.0s to resolve: replica is raft follower (without success)", s)
+		assert.EqualValues(t, "; delayed by 0.0s to resolve: replica is raft follower (without success)", s)
 		assert.EqualValues(t, 0, h.slept)
 	})
 
@@ -114,7 +114,7 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 				raftStatus:  statusWithState(state),
 			}
 			s := maybeDelaySplitToAvoidSnapshot(ctx, h)
-			assert.Equal(t, "; delayed by 5.5s to resolve: not leader ("+state.String()+") (without success)", s)
+			assert.EqualValues(t, "; delayed by 5.5s to resolve: not leader ("+state.String()+") (without success)", s)
 		})
 	}
 
@@ -130,7 +130,7 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 		}
 		s := maybeDelaySplitToAvoidSnapshot(ctx, h)
 		// We try to wake up the follower once, but then give up on it.
-		assert.Equal(t, "; delayed by 1.3s to resolve: r1/2 inactive", s)
+		assert.EqualValues(t, "; delayed by 1.3s to resolve: r1/2 inactive", s)
 		assert.Less(t, int64(h.slept), int64(2*h.TickDuration()))
 	})
 
@@ -153,7 +153,7 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 				raftStatus:  st,
 			}
 			s := maybeDelaySplitToAvoidSnapshot(ctx, h)
-			assert.Equal(t, "; delayed by 5.5s to resolve: replica r1/2 not caught up: "+
+			assert.EqualValues(t, "; delayed by 5.5s to resolve: replica r1/2 not caught up: "+
 				state.String()+" match=0 next=0 paused (without success)", s)
 		})
 	}
@@ -169,7 +169,7 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 			raftStatus:  st,
 		}
 		s := maybeDelaySplitToAvoidSnapshot(ctx, h)
-		assert.Equal(t, "", s)
+		assert.EqualValues(t, "", s)
 		assert.EqualValues(t, 0, h.slept)
 	})
 
@@ -192,6 +192,6 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 			}
 		}
 		s := maybeDelaySplitToAvoidSnapshot(ctx, h)
-		assert.Equal(t, "; delayed by 2.5s to resolve: replica r1/2 not caught up: StateProbe match=0 next=0", s)
+		assert.EqualValues(t, "; delayed by 2.5s to resolve: replica r1/2 not caught up: StateProbe match=0 next=0", s)
 	})
 }

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -107,6 +107,9 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"SpanAccess": {},
 						"SpanScope":  {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/split": {
+						"SplitObjective": {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities": {
 						"ID": {},
 					},


### PR DESCRIPTION
This commit improves the redaction in `"initiating a split of this range ..."` logs. Previously, these logs would omit the entire "reason" and "extra" fields, which hindered their utility. This log line is important for debugging, so this commit improves it to redact only the necessary information (almost nothing).

The redacted log lines look like:
```
I231109 05:39:54.401617 59582 kv/kvserver/replica_command.go:440 ⋮ [T1,Vsystem,n1,split,s1,r95/1:‹×›] 1135  initiating a split of this range at key /Tenant/2/Table/114/1/‹×› [r96] (load at key /Tenant/2/Table/114/1/‹×› (cpu 906ms, 2268.57 batches/sec, 2261.55 raft mutations/sec))
```
or like:
```
I231109 05:41:29.113805 73695 kv/kvserver/replica_command.go:440 ⋮ [T1,Vsystem,n1,split,s1,r95/1:‹×›] 7390  initiating a split of this range at key /Tenant/2/Table/114/1/‹×› [r101] (512 MiB above threshold size 512 MiB)
```

The second commit then does the same for range merges.

Spotted during a support investigation.

Epic: None
Release note: None