### PR TITLE
release-23.1: changefeedccl: Improve error handling

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/iterutil",
         "//pkg/util/log",
+        "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ],


### PR DESCRIPTION
Backport 1/2 commits from #106421.

/cc @cockroachdb/release

changefeedccl: Treat kv decoding errors as terminal 

Treat key/value decoding errors as terminal.
Produce loud errors when encountering such an error.

Fixes #106384

Release note: None

Release justification: observability improvement (to address customer escalation).
