### PR TITLE
kvstreamer: speed up recently added test

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -589,7 +589,7 @@ ALTER TABLE t SPLIT AT SELECT generate_series(1, 30000, 3000);
 	kvGRPCCallsRegex := regexp.MustCompile(`KV gRPC calls: (\d+,)`)
 	for inOrder := range []bool{false, true} {
 		runner.Exec(t, `SET streamer_always_maintain_ordering = $1;`, inOrder)
-		for i := 0; i < 5; i++ {
+		for i := 0; i < 2; i++ {
 			var gRPCCalls int
 			var err error
 			rows := runner.QueryStr(t, `EXPLAIN ANALYZE SELECT length(blob) FROM t@t_v_idx WHERE v = '1';`)


### PR DESCRIPTION
We'll now run each query twice instead of five times to make the test faster. In my manual testing, second run was noticeably slower than the first one, so I think that's the minimum we should keep.

Fixes: #114131.

Release note: None