### PR TITLE
cli: deprecate the cockroach connect functionality

### DIFF
--- a/pkg/cli/connect.go
+++ b/pkg/cli/connect.go
@@ -38,7 +38,8 @@ var connectCmd = &cobra.Command{
 	Short: "Create certificates for securely connecting with clusters\n",
 	Long: `
 Bootstrap security certificates for connecting to new or existing clusters.`,
-	RunE: UsageAndErr,
+	RunE:       UsageAndErr,
+	Deprecated: "self generated certificates are no longer support functionality use '--insecure' instead",
 }
 
 func init() {
@@ -54,8 +55,9 @@ var connectInitCmd = &cobra.Command{
 Connects to other nodes and negotiates an initialization bundle for use with
 secure inter-node connections.
 `,
-	Args: cobra.NoArgs,
-	RunE: clierrorplus.MaybeDecorateError(runConnectInit),
+	Args:       cobra.NoArgs,
+	RunE:       clierrorplus.MaybeDecorateError(runConnectInit),
+	Deprecated: "self generated certificates are no longer support functionality use '--insecure' instead",
 }
 
 // runConnectInit connects to other nodes and negotiates an initialization bundle

--- a/pkg/cli/connect_join.go
+++ b/pkg/cli/connect_join.go
@@ -35,10 +35,11 @@ import (
 const nodeJoinTimeout = 1 * time.Minute
 
 var connectJoinCmd = &cobra.Command{
-	Use:   "join <join-token>",
-	Short: "request the TLS certs for a new node from an existing node",
-	Args:  cobra.MinimumNArgs(1),
-	RunE:  clierrorplus.MaybeDecorateError(runConnectJoin),
+	Use:        "join <join-token>",
+	Short:      "request the TLS certs for a new node from an existing node",
+	Args:       cobra.MinimumNArgs(1),
+	RunE:       clierrorplus.MaybeDecorateError(runConnectJoin),
+	Deprecated: "self generated certificates are no longer support functionality use '--insecure' instead",
 }
 
 func requestPeerCA(


### PR DESCRIPTION
Cockroach connect is going to be removed in a future release. It was never completely finished and there is no public documentation about the feature.

Epic: none

Release note (cli change): Deprecate the cockroach connect functionality.