### PR TITLE
Fix small typos

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -4884,7 +4884,7 @@ func TestBackupRestoreIncrementalAddTableMissing(t *testing.T) {
 	)
 }
 
-func TestBackupRestoreIncrementalTrucateTable(t *testing.T) {
+func TestBackupRestoreIncrementalTruncateTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -56,7 +56,7 @@ func StartServiceForVirtualCluster(
 		startCluster = sc
 	} else {
 		// If we are starting a service in external process mode, `Start`
-		// is called on the nodes where the SQL server procesed should be
+		// is called on the nodes where the SQL server processed should be
 		// created.
 		ec, err := newCluster(l, externalCluster, clusterSettingsOpts...)
 		if err != nil {

--- a/pkg/sql/create_external_connection.go
+++ b/pkg/sql/create_external_connection.go
@@ -30,7 +30,7 @@ import (
 
 const externalConnectionOp = "CREATE EXTERNAL CONNECTION"
 
-type createExternalConectionNode struct {
+type createExternalConnectionNode struct {
 	n *tree.CreateExternalConnection
 }
 
@@ -38,10 +38,10 @@ type createExternalConectionNode struct {
 func (p *planner) CreateExternalConnection(
 	ctx context.Context, n *tree.CreateExternalConnection,
 ) (planNode, error) {
-	return &createExternalConectionNode{n: n}, nil
+	return &createExternalConnectionNode{n: n}, nil
 }
 
-func (c *createExternalConectionNode) startExec(params runParams) error {
+func (c *createExternalConnectionNode) startExec(params runParams) error {
 	return params.p.createExternalConnection(params, c.n)
 }
 
@@ -170,6 +170,6 @@ func logAndSanitizeExternalConnectionURI(ctx context.Context, externalConnection
 	return nil
 }
 
-func (c *createExternalConectionNode) Next(_ runParams) (bool, error) { return false, nil }
-func (c *createExternalConectionNode) Values() tree.Datums            { return nil }
-func (c *createExternalConectionNode) Close(_ context.Context)        {}
+func (c *createExternalConnectionNode) Next(_ runParams) (bool, error) { return false, nil }
+func (c *createExternalConnectionNode) Values() tree.Datums            { return nil }
+func (c *createExternalConnectionNode) Close(_ context.Context)        {}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -387,7 +387,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&controlSchedulesNode{}):                    "control schedules",
 	reflect.TypeOf(&createDatabaseNode{}):                      "create database",
 	reflect.TypeOf(&createExtensionNode{}):                     "create extension",
-	reflect.TypeOf(&createExternalConectionNode{}):             "create external connection",
+	reflect.TypeOf(&createExternalConnectionNode{}):            "create external connection",
 	reflect.TypeOf(&createFunctionNode{}):                      "create function",
 	reflect.TypeOf(&createIndexNode{}):                         "create index",
 	reflect.TypeOf(&createSequenceNode{}):                      "create sequence",

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -442,7 +442,7 @@ func (t ClockTimestamp) String() string { return t.ToTimestamp().String() }
 // SafeValue implements the redact.SafeValue interface.
 func (t ClockTimestamp) SafeValue() {}
 
-// IsEmpty retruns true if t is an empty ClockTimestamp.
+// IsEmpty returns true if t is an empty ClockTimestamp.
 func (t ClockTimestamp) IsEmpty() bool { return Timestamp(t).IsEmpty() }
 
 // Forward is like Timestamp.Forward, but for ClockTimestamps.


### PR DESCRIPTION
This commit fixes a few typos.

Epic: None