### PR TITLE
release-23.2: spec: move machine type, zone, local ssd defaults out of the TestSpec and the registry

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -922,9 +922,13 @@ func (f *clusterFactory) newCluster(
 	defer setStatus("idle")
 
 	providerOptsContainer := vm.CreateProviderOptionsContainer()
+	params := spec.RoachprodClusterConfig{
+		UseIOBarrierOnLocalSSD: cfg.useIOBarrier,
+		PreferredArch:          cfg.arch,
+	}
 	// The ClusterName is set below in the retry loop to ensure
 	// that each create attempt gets a unique cluster name.
-	createVMOpts, providerOpts, err := cfg.spec.RoachprodOpts("", cfg.useIOBarrier, cfg.arch)
+	createVMOpts, providerOpts, err := cfg.spec.RoachprodOpts(params)
 	if err != nil {
 		// We must release the allocation because cluster creation is not possible at this point.
 		cfg.alloc.Release()

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -928,6 +928,7 @@ func (f *clusterFactory) newCluster(
 		PreferredArch:          cfg.arch,
 	}
 	params.Defaults.MachineType = instanceType
+	params.Defaults.Zones = zonesF
 
 	// The ClusterName is set below in the retry loop to ensure
 	// that each create attempt gets a unique cluster name.

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -929,6 +929,7 @@ func (f *clusterFactory) newCluster(
 	}
 	params.Defaults.MachineType = instanceType
 	params.Defaults.Zones = zonesF
+	params.Defaults.PreferLocalSSD = localSSDArg
 
 	// The ClusterName is set below in the retry loop to ensure
 	// that each create attempt gets a unique cluster name.

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -922,10 +922,13 @@ func (f *clusterFactory) newCluster(
 	defer setStatus("idle")
 
 	providerOptsContainer := vm.CreateProviderOptionsContainer()
+
 	params := spec.RoachprodClusterConfig{
 		UseIOBarrierOnLocalSSD: cfg.useIOBarrier,
 		PreferredArch:          cfg.arch,
 	}
+	params.Defaults.MachineType = instanceType
+
 	// The ClusterName is set below in the retry loop to ensure
 	// that each create attempt gets a unique cluster name.
 	createVMOpts, providerOpts, err := cfg.spec.RoachprodOpts(params)

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestClusterNodes(t *testing.T) {
-	c := &clusterImpl{spec: spec.MakeClusterSpec(spec.GCE, "", 10)}
+	c := &clusterImpl{spec: spec.MakeClusterSpec(spec.GCE, 10)}
 	opts := func(opts ...option.Option) []option.Option {
 		return opts
 	}

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -83,7 +83,7 @@ func TestShouldPost(t *testing.T) {
 		{false, 1, "token", "master", true, ""},
 	}
 
-	reg := makeTestRegistry(spec.GCE, "", "", false)
+	reg := makeTestRegistry(spec.GCE, "", false)
 	for _, c := range testCases {
 		t.Setenv("GITHUB_API_TOKEN", c.envGithubAPIToken)
 		t.Setenv("TC_BUILD_BRANCH", c.envTcBuildBranch)
@@ -198,7 +198,7 @@ func TestCreatePostRequest(t *testing.T) {
 		},
 	}
 
-	reg := makeTestRegistry(spec.GCE, "", "", false)
+	reg := makeTestRegistry(spec.GCE, "", false)
 	for idx, c := range testCases {
 		t.Run(fmt.Sprintf("%d", idx+1), func(t *testing.T) {
 			clusterSpec := reg.MakeClusterSpec(1, spec.Arch(c.arch))

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -83,7 +83,7 @@ func TestShouldPost(t *testing.T) {
 		{false, 1, "token", "master", true, ""},
 	}
 
-	reg := makeTestRegistry(spec.GCE, false)
+	reg := makeTestRegistry(spec.GCE)
 	for _, c := range testCases {
 		t.Setenv("GITHUB_API_TOKEN", c.envGithubAPIToken)
 		t.Setenv("TC_BUILD_BRANCH", c.envTcBuildBranch)
@@ -198,7 +198,7 @@ func TestCreatePostRequest(t *testing.T) {
 		},
 	}
 
-	reg := makeTestRegistry(spec.GCE, false)
+	reg := makeTestRegistry(spec.GCE)
 	for idx, c := range testCases {
 		t.Run(fmt.Sprintf("%d", idx+1), func(t *testing.T) {
 			clusterSpec := reg.MakeClusterSpec(1, spec.Arch(c.arch))

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -83,7 +83,7 @@ func TestShouldPost(t *testing.T) {
 		{false, 1, "token", "master", true, ""},
 	}
 
-	reg := makeTestRegistry(spec.GCE, "", false)
+	reg := makeTestRegistry(spec.GCE, false)
 	for _, c := range testCases {
 		t.Setenv("GITHUB_API_TOKEN", c.envGithubAPIToken)
 		t.Setenv("TC_BUILD_BRANCH", c.envTcBuildBranch)
@@ -198,7 +198,7 @@ func TestCreatePostRequest(t *testing.T) {
 		},
 	}
 
-	reg := makeTestRegistry(spec.GCE, "", false)
+	reg := makeTestRegistry(spec.GCE, false)
 	for idx, c := range testCases {
 		t.Run(fmt.Sprintf("%d", idx+1), func(t *testing.T) {
 			clusterSpec := reg.MakeClusterSpec(1, spec.Arch(c.arch))

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -120,7 +120,7 @@ Examples:
    roachtest list --suite weekly --owner kv
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := makeTestRegistry(cloud, instanceType, zonesF, localSSDArg)
+			r := makeTestRegistry(cloud, zonesF, localSSDArg)
 			tests.RegisterTests(&r)
 
 			filter, err := makeTestFilter(args)

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -120,7 +120,7 @@ Examples:
    roachtest list --suite weekly --owner kv
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := makeTestRegistry(cloud, zonesF, localSSDArg)
+			r := makeTestRegistry(cloud, localSSDArg)
 			tests.RegisterTests(&r)
 
 			filter, err := makeTestFilter(args)

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -120,7 +120,7 @@ Examples:
    roachtest list --suite weekly --owner kv
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := makeTestRegistry(cloud, localSSDArg)
+			r := makeTestRegistry(cloud)
 			tests.RegisterTests(&r)
 
 			filter, err := makeTestFilter(args)

--- a/pkg/cmd/roachtest/main_test.go
+++ b/pkg/cmd/roachtest/main_test.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 func makeRegistry(names ...string) testRegistryImpl {
-	r := makeTestRegistry(spec.GCE, "", false /* preferSSD */)
+	r := makeTestRegistry(spec.GCE, false /* preferSSD */)
 	dummyRun := func(context.Context, test.Test, cluster.Cluster) {}
 
 	for _, name := range names {

--- a/pkg/cmd/roachtest/main_test.go
+++ b/pkg/cmd/roachtest/main_test.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 func makeRegistry(names ...string) testRegistryImpl {
-	r := makeTestRegistry(spec.GCE, false /* preferSSD */)
+	r := makeTestRegistry(spec.GCE)
 	dummyRun := func(context.Context, test.Test, cluster.Cluster) {}
 
 	for _, name := range names {

--- a/pkg/cmd/roachtest/main_test.go
+++ b/pkg/cmd/roachtest/main_test.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 func makeRegistry(names ...string) testRegistryImpl {
-	r := makeTestRegistry(spec.GCE, "", "", false /* preferSSD */)
+	r := makeTestRegistry(spec.GCE, "", false /* preferSSD */)
 	dummyRun := func(context.Context, test.Test, cluster.Cluster) {}
 
 	for _, name := range names {
@@ -38,7 +38,7 @@ func makeRegistry(names ...string) testRegistryImpl {
 			Name:             name,
 			Owner:            OwnerUnitTest,
 			Run:              dummyRun,
-			Cluster:          spec.MakeClusterSpec(spec.GCE, "", 0),
+			Cluster:          spec.MakeClusterSpec(spec.GCE, 0),
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),
 		})

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -185,7 +185,7 @@ func addBenchFlags(benchCmd *cobra.Command) {
 // runTests is the main function for the run and bench commands.
 // Assumes initRunFlagsBinariesAndLibraries was called.
 func runTests(register func(registry.Registry), filter *registry.TestFilter) error {
-	r := makeTestRegistry(cloud, localSSDArg)
+	r := makeTestRegistry(cloud)
 	//lint:ignore SA1019 deprecated
 	rand.Seed(globalSeed)
 

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -185,7 +185,7 @@ func addBenchFlags(benchCmd *cobra.Command) {
 // runTests is the main function for the run and bench commands.
 // Assumes initRunFlagsBinariesAndLibraries was called.
 func runTests(register func(registry.Registry), filter *registry.TestFilter) error {
-	r := makeTestRegistry(cloud, instanceType, zonesF, localSSDArg)
+	r := makeTestRegistry(cloud, zonesF, localSSDArg)
 	//lint:ignore SA1019 deprecated
 	rand.Seed(globalSeed)
 

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -185,7 +185,7 @@ func addBenchFlags(benchCmd *cobra.Command) {
 // runTests is the main function for the run and bench commands.
 // Assumes initRunFlagsBinariesAndLibraries was called.
 func runTests(register func(registry.Registry), filter *registry.TestFilter) error {
-	r := makeTestRegistry(cloud, zonesF, localSSDArg)
+	r := makeTestRegistry(cloud, localSSDArg)
 	//lint:ignore SA1019 deprecated
 	rand.Seed(globalSeed)
 

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -66,10 +66,6 @@ type ClusterSpec struct {
 	// their compatible clouds.
 	Cloud string
 
-	// TODO(radu): defaultZones is the default zones specification (unless
-	// overridden by GCE.Zones or AWS.Zones); it does not belong in the spec.
-	defaultZones string
-
 	Arch      vm.CPUArch // CPU architecture; auto-chosen if left empty
 	NodeCount int
 	// CPUs is the number of CPUs per node.
@@ -242,11 +238,15 @@ type RoachprodClusterConfig struct {
 	// does not specify the corresponding option.
 	Defaults struct {
 		// MachineType, if set, is the default machine type (used unless the
-		// ClusterSpec overrides it for the current cloud).
+		// ClusterSpec specifies a machine type for the current cloud).
 		//
-		// If it is not set (and the ClusterSpec doesn't specify a machine type for
-		// the current cloud), a machine type is determined automatically.
+		// If it is not set (and the ClusterSpec doesn't specify one either), a
+		// machine type is determined automatically.
 		MachineType string
+
+		// Zones, if set, is the default zone configuration (unless the test
+		// specifies a zone configuration for the current cloud).
+		Zones string
 	}
 }
 
@@ -364,7 +364,7 @@ func (s *ClusterSpec) RoachprodOpts(
 		}
 	}
 
-	zonesStr := s.defaultZones
+	zonesStr := params.Defaults.Zones
 	switch s.Cloud {
 	case AWS:
 		if s.AWS.Zones != "" {

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -231,16 +231,31 @@ func getAzureOpts(machineType string, zones []string) vm.ProviderOpts {
 	return opts
 }
 
+// RoachprodClusterConfig contains general roachprod cluster configuration that
+// does not depend on the test. It is used in conjunction with ClusterSpec to
+// determine the final configuration.
+type RoachprodClusterConfig struct {
+	// UseIOBarrierOnLocalSSD is set if we don't want to mount local SSDs with the
+	// `-o nobarrier` flag.
+	UseIOBarrierOnLocalSSD bool
+
+	// PreferredArch is the preferred CPU architecture; it is not guaranteed
+	// (depending on cloud and on other requirements on machine type).
+	PreferredArch vm.CPUArch
+}
+
 // RoachprodOpts returns the opts to use when calling `roachprod.Create()`
 // in order to create the cluster described in the spec.
 func (s *ClusterSpec) RoachprodOpts(
-	clusterName string, useIOBarrier bool, arch vm.CPUArch,
+	params RoachprodClusterConfig,
 ) (vm.CreateOpts, vm.ProviderOpts, error) {
+	useIOBarrier := params.UseIOBarrierOnLocalSSD
+	arch := params.PreferredArch
 
 	createVMOpts := vm.DefaultCreateOpts()
 	// N.B. We set "usage=roachtest" as the default, custom label for billing tracking.
 	createVMOpts.CustomLabels = map[string]string{"usage": "roachtest"}
-	createVMOpts.ClusterName = clusterName
+	createVMOpts.ClusterName = "" // Will be set later.
 	if s.Lifetime != 0 {
 		createVMOpts.Lifetime = s.Lifetime
 	}

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -66,11 +66,6 @@ type ClusterSpec struct {
 	// their compatible clouds.
 	Cloud string
 
-	// TODO(radu): defaultInstanceType is the default machine type used (unless
-	// overridden by GCE.MachineType or AWS.MachineType); it does not belong in
-	// the spec.
-	defaultInstanceType string
-
 	// TODO(radu): defaultZones is the default zones specification (unless
 	// overridden by GCE.Zones or AWS.Zones); it does not belong in the spec.
 	defaultZones string
@@ -116,8 +111,8 @@ type ClusterSpec struct {
 }
 
 // MakeClusterSpec makes a ClusterSpec.
-func MakeClusterSpec(cloud string, instanceType string, nodeCount int, opts ...Option) ClusterSpec {
-	spec := ClusterSpec{Cloud: cloud, defaultInstanceType: instanceType, NodeCount: nodeCount}
+func MakeClusterSpec(cloud string, nodeCount int, opts ...Option) ClusterSpec {
+	spec := ClusterSpec{Cloud: cloud, NodeCount: nodeCount}
 	defaultOpts := []Option{CPU(4), nodeLifetime(12 * time.Hour), ReuseAny()}
 	for _, o := range append(defaultOpts, opts...) {
 		o(&spec)
@@ -242,6 +237,17 @@ type RoachprodClusterConfig struct {
 	// PreferredArch is the preferred CPU architecture; it is not guaranteed
 	// (depending on cloud and on other requirements on machine type).
 	PreferredArch vm.CPUArch
+
+	// Defaults contains configuration values that are used when the ClusterSpec
+	// does not specify the corresponding option.
+	Defaults struct {
+		// MachineType, if set, is the default machine type (used unless the
+		// ClusterSpec overrides it for the current cloud).
+		//
+		// If it is not set (and the ClusterSpec doesn't specify a machine type for
+		// the current cloud), a machine type is determined automatically.
+		MachineType string
+	}
 }
 
 // RoachprodOpts returns the opts to use when calling `roachprod.Create()`
@@ -285,7 +291,7 @@ func (s *ClusterSpec) RoachprodOpts(
 	createVMOpts.Arch = string(arch)
 	ssdCount := s.SSDs
 
-	machineType := s.defaultInstanceType
+	machineType := params.Defaults.MachineType
 	switch s.Cloud {
 	case AWS:
 		if s.AWS.MachineType != "" {

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -59,6 +59,24 @@ func (m MemPerCPU) String() string {
 	return "unknown"
 }
 
+// LocalSSDSetting controls whether test cluster nodes use an instance-local SSD
+// as storage.
+type LocalSSDSetting int
+
+const (
+	// LocalSSDDefault is the default mode, when the test does not have any
+	// preference. A local SSD may or may not be used, depending on --local-ssd
+	// flag and machine type.
+	LocalSSDDefault LocalSSDSetting = iota
+
+	// LocalSSDDisable means that we will never use a local SSD.
+	LocalSSDDisable
+
+	// LocalSSDPreferOn means that we prefer to use a local SSD. It is not a
+	// guarantee (depending on other constraints on machine type).
+	LocalSSDPreferOn
+)
+
 // ClusterSpec represents a test's description of what its cluster needs to
 // look like. It becomes part of a clusterConfig when the cluster is created.
 type ClusterSpec struct {
@@ -74,7 +92,7 @@ type ClusterSpec struct {
 	SSDs                 int
 	RAID0                bool
 	VolumeSize           int
-	PreferLocalSSD       bool
+	LocalSSD             LocalSSDSetting
 	Geo                  bool
 	Lifetime             time.Duration
 	ReusePolicy          clusterReusePolicy
@@ -247,6 +265,11 @@ type RoachprodClusterConfig struct {
 		// Zones, if set, is the default zone configuration (unless the test
 		// specifies a zone configuration for the current cloud).
 		Zones string
+
+		// PreferLocalSSD is the default local SSD mode (unless the test specifies a
+		// preference). If true, we try to use a local SSD if allowed by the machine
+		// type. If false, we never use a local SSD.
+		PreferLocalSSD bool
 	}
 }
 
@@ -257,6 +280,14 @@ func (s *ClusterSpec) RoachprodOpts(
 ) (vm.CreateOpts, vm.ProviderOpts, error) {
 	useIOBarrier := params.UseIOBarrierOnLocalSSD
 	arch := params.PreferredArch
+
+	preferLocalSSD := params.Defaults.PreferLocalSSD
+	switch s.LocalSSD {
+	case LocalSSDDisable:
+		preferLocalSSD = false
+	case LocalSSDPreferOn:
+		preferLocalSSD = true
+	}
 
 	createVMOpts := vm.DefaultCreateOpts()
 	// N.B. We set "usage=roachtest" as the default, custom label for billing tracking.
@@ -314,11 +345,11 @@ func (s *ClusterSpec) RoachprodOpts(
 			var err error
 			switch s.Cloud {
 			case AWS:
-				machineType, selectedArch, err = SelectAWSMachineType(s.CPUs, s.Mem, s.PreferLocalSSD && s.VolumeSize == 0, arch)
+				machineType, selectedArch, err = SelectAWSMachineType(s.CPUs, s.Mem, preferLocalSSD && s.VolumeSize == 0, arch)
 			case GCE:
 				machineType, selectedArch = SelectGCEMachineType(s.CPUs, s.Mem, arch)
 			case Azure:
-				machineType, err = SelectAzureMachineType(s.CPUs, s.Mem, s.PreferLocalSSD)
+				machineType, err = SelectAzureMachineType(s.CPUs, s.Mem, preferLocalSSD)
 			}
 
 			if err != nil {
@@ -337,7 +368,7 @@ func (s *ClusterSpec) RoachprodOpts(
 		// - if no particular volume size is requested, and,
 		// - on AWS, if the machine type supports it.
 		// - on GCE, if the machine type is not ARM64.
-		if s.PreferLocalSSD && s.VolumeSize == 0 && (s.Cloud != AWS || awsMachineSupportsSSD(machineType)) &&
+		if preferLocalSSD && s.VolumeSize == 0 && (s.Cloud != AWS || awsMachineSupportsSSD(machineType)) &&
 			(s.Cloud != GCE || selectedArch != vm.ArchARM64) {
 			// Ensure SSD count is at least 1 if UseLocalSSD is true.
 			if ssdCount == 0 {

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -157,10 +157,24 @@ func ReuseTagged(tag string) Option {
 	}
 }
 
-// PreferLocalSSD specifies whether to prefer using local SSD, when possible.
-func PreferLocalSSD(prefer bool) Option {
+// PreferLocalSSD specifies that we use instance-local SSDs whenever possible
+// (depending on other constraints on machine type).
+//
+// By default, a test cluster may or may not use a local SSD depending on
+// --local-ssd flag and machine type.
+func PreferLocalSSD() Option {
 	return func(spec *ClusterSpec) {
-		spec.PreferLocalSSD = prefer
+		spec.LocalSSD = LocalSSDPreferOn
+	}
+}
+
+// DisableLocalSSD specifies that we never use instance-local SSDs.
+//
+// By default, a test cluster may or may not use a local SSD depending on
+// --local-ssd flag and machine type.
+func DisableLocalSSD() Option {
+	return func(spec *ClusterSpec) {
+		spec.LocalSSD = LocalSSDDisable
 	}
 }
 

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -80,13 +80,6 @@ func Geo() Option {
 	}
 }
 
-// DefaultZones sets the default zones (set with the --zones flag).
-func DefaultZones(zones string) Option {
-	return func(spec *ClusterSpec) {
-		spec.defaultZones = zones
-	}
-}
-
 func nodeLifetime(lifetime time.Duration) Option {
 	return func(spec *ClusterSpec) {
 		spec.Lifetime = lifetime

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -27,7 +27,6 @@ import (
 type testRegistryImpl struct {
 	m                map[string]*registry.TestSpec
 	cloud            string
-	preferSSD        bool
 	snapshotPrefixes map[string]struct{}
 
 	promRegistry *prometheus.Registry
@@ -36,10 +35,9 @@ type testRegistryImpl struct {
 var _ registry.Registry = (*testRegistryImpl)(nil)
 
 // makeTestRegistry constructs a testRegistryImpl and configures it with opts.
-func makeTestRegistry(cloud string, preferSSD bool) testRegistryImpl {
+func makeTestRegistry(cloud string) testRegistryImpl {
 	return testRegistryImpl{
 		cloud:            cloud,
-		preferSSD:        preferSSD,
 		m:                make(map[string]*registry.TestSpec),
 		snapshotPrefixes: make(map[string]struct{}),
 		promRegistry:     prometheus.NewRegistry(),
@@ -73,14 +71,7 @@ func (r *testRegistryImpl) Add(spec registry.TestSpec) {
 // MakeClusterSpec makes a cluster spec. It should be used over `spec.MakeClusterSpec`
 // because this method also adds options baked into the registry.
 func (r *testRegistryImpl) MakeClusterSpec(nodeCount int, opts ...spec.Option) spec.ClusterSpec {
-	// NB: we need to make sure that `opts` is appended at the end, so that it
-	// overrides the SSD setting from the registry.
-	var finalOpts []spec.Option
-	if r.preferSSD {
-		finalOpts = append(finalOpts, spec.PreferLocalSSD(true))
-	}
-	finalOpts = append(finalOpts, opts...)
-	return spec.MakeClusterSpec(r.cloud, nodeCount, finalOpts...)
+	return spec.MakeClusterSpec(r.cloud, nodeCount, opts...)
 }
 
 const testNameRE = "^[a-zA-Z0-9-_=/,]+$"

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -27,7 +27,6 @@ import (
 type testRegistryImpl struct {
 	m                map[string]*registry.TestSpec
 	cloud            string
-	zones            string
 	preferSSD        bool
 	snapshotPrefixes map[string]struct{}
 
@@ -37,12 +36,9 @@ type testRegistryImpl struct {
 var _ registry.Registry = (*testRegistryImpl)(nil)
 
 // makeTestRegistry constructs a testRegistryImpl and configures it with opts.
-func makeTestRegistry(
-	cloud string, zones string, preferSSD bool,
-) testRegistryImpl {
+func makeTestRegistry(cloud string, preferSSD bool) testRegistryImpl {
 	return testRegistryImpl{
 		cloud:            cloud,
-		zones:            zones,
 		preferSSD:        preferSSD,
 		m:                make(map[string]*registry.TestSpec),
 		snapshotPrefixes: make(map[string]struct{}),
@@ -78,13 +74,10 @@ func (r *testRegistryImpl) Add(spec registry.TestSpec) {
 // because this method also adds options baked into the registry.
 func (r *testRegistryImpl) MakeClusterSpec(nodeCount int, opts ...spec.Option) spec.ClusterSpec {
 	// NB: we need to make sure that `opts` is appended at the end, so that it
-	// overrides the SSD and zones settings from the registry.
+	// overrides the SSD setting from the registry.
 	var finalOpts []spec.Option
 	if r.preferSSD {
 		finalOpts = append(finalOpts, spec.PreferLocalSSD(true))
-	}
-	if r.zones != "" {
-		finalOpts = append(finalOpts, spec.DefaultZones(r.zones))
 	}
 	finalOpts = append(finalOpts, opts...)
 	return spec.MakeClusterSpec(r.cloud, nodeCount, finalOpts...)

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -27,7 +27,6 @@ import (
 type testRegistryImpl struct {
 	m                map[string]*registry.TestSpec
 	cloud            string
-	instanceType     string // optional
 	zones            string
 	preferSSD        bool
 	snapshotPrefixes map[string]struct{}
@@ -39,11 +38,10 @@ var _ registry.Registry = (*testRegistryImpl)(nil)
 
 // makeTestRegistry constructs a testRegistryImpl and configures it with opts.
 func makeTestRegistry(
-	cloud string, instanceType string, zones string, preferSSD bool,
+	cloud string, zones string, preferSSD bool,
 ) testRegistryImpl {
 	return testRegistryImpl{
 		cloud:            cloud,
-		instanceType:     instanceType,
 		zones:            zones,
 		preferSSD:        preferSSD,
 		m:                make(map[string]*registry.TestSpec),
@@ -89,7 +87,7 @@ func (r *testRegistryImpl) MakeClusterSpec(nodeCount int, opts ...spec.Option) s
 		finalOpts = append(finalOpts, spec.DefaultZones(r.zones))
 	}
 	finalOpts = append(finalOpts, opts...)
-	return spec.MakeClusterSpec(r.cloud, r.instanceType, nodeCount, finalOpts...)
+	return spec.MakeClusterSpec(r.cloud, nodeCount, finalOpts...)
 }
 
 const testNameRE = "^[a-zA-Z0-9-_=/,]+$"

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -23,9 +23,8 @@ import (
 
 func TestMakeTestRegistry(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "preferSSD", func(t *testing.T, preferSSD bool) {
-		r := makeTestRegistry(spec.AWS, "zone123", preferSSD)
+		r := makeTestRegistry(spec.AWS, preferSSD)
 		require.Equal(t, preferSSD, r.preferSSD)
-		require.Equal(t, "zone123", r.zones)
 		require.Equal(t, spec.AWS, r.cloud)
 
 		s := r.MakeClusterSpec(100, spec.Geo(), spec.CPU(12),
@@ -50,7 +49,7 @@ func TestMakeTestRegistry(t *testing.T) {
 // TestPrometheusMetricParser tests that the registry.PromSub()
 // helper properly converts a string into a metric name that Prometheus can read.
 func TestPrometheusMetricParser(t *testing.T) {
-	r := makeTestRegistry(spec.AWS, "zone123", true)
+	r := makeTestRegistry(spec.AWS, true)
 	f := r.PromFactory()
 
 	rawName := "restore/nodes=4/duration"

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -16,40 +16,43 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMakeTestRegistry(t *testing.T) {
-	testutils.RunTrueAndFalse(t, "preferSSD", func(t *testing.T, preferSSD bool) {
-		r := makeTestRegistry(spec.AWS, preferSSD)
-		require.Equal(t, preferSSD, r.preferSSD)
-		require.Equal(t, spec.AWS, r.cloud)
+	r := makeTestRegistry(spec.AWS)
+	require.Equal(t, spec.AWS, r.cloud)
 
-		s := r.MakeClusterSpec(100, spec.Geo(), spec.CPU(12),
-			spec.PreferLocalSSD(true))
-		require.EqualValues(t, 100, s.NodeCount)
-		require.True(t, s.Geo)
-		require.EqualValues(t, 12, s.CPUs)
-		require.True(t, s.PreferLocalSSD)
+	s := r.MakeClusterSpec(100, spec.Geo(), spec.CPU(12),
+		spec.PreferLocalSSD())
+	require.EqualValues(t, 100, s.NodeCount)
+	require.True(t, s.Geo)
+	require.EqualValues(t, 12, s.CPUs)
+	require.Equal(t, spec.LocalSSDPreferOn, s.LocalSSD)
 
-		s = r.MakeClusterSpec(100, spec.CPU(4), spec.TerminateOnMigration())
-		require.EqualValues(t, 100, s.NodeCount)
-		require.EqualValues(t, 4, s.CPUs)
-		require.True(t, s.TerminateOnMigration)
+	s = r.MakeClusterSpec(100, spec.Geo(), spec.CPU(12),
+		spec.DisableLocalSSD())
+	require.Equal(t, spec.LocalSSDDisable, s.LocalSSD)
 
-		s = r.MakeClusterSpec(10, spec.CPU(16), spec.Arch(vm.ArchARM64))
-		require.EqualValues(t, 10, s.NodeCount)
-		require.EqualValues(t, 16, s.CPUs)
-		require.EqualValues(t, vm.ArchARM64, s.Arch)
-	})
+	s = r.MakeClusterSpec(100, spec.Geo(), spec.CPU(12))
+	require.Equal(t, spec.LocalSSDDefault, s.LocalSSD)
+
+	s = r.MakeClusterSpec(100, spec.CPU(4), spec.TerminateOnMigration())
+	require.EqualValues(t, 100, s.NodeCount)
+	require.EqualValues(t, 4, s.CPUs)
+	require.True(t, s.TerminateOnMigration)
+
+	s = r.MakeClusterSpec(10, spec.CPU(16), spec.Arch(vm.ArchARM64))
+	require.EqualValues(t, 10, s.NodeCount)
+	require.EqualValues(t, 16, s.CPUs)
+	require.EqualValues(t, vm.ArchARM64, s.Arch)
 }
 
 // TestPrometheusMetricParser tests that the registry.PromSub()
 // helper properly converts a string into a metric name that Prometheus can read.
 func TestPrometheusMetricParser(t *testing.T) {
-	r := makeTestRegistry(spec.AWS, true)
+	r := makeTestRegistry(spec.AWS)
 	f := r.PromFactory()
 
 	rawName := "restore/nodes=4/duration"

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -23,10 +23,9 @@ import (
 
 func TestMakeTestRegistry(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "preferSSD", func(t *testing.T, preferSSD bool) {
-		r := makeTestRegistry(spec.AWS, "foo", "zone123", preferSSD)
+		r := makeTestRegistry(spec.AWS, "zone123", preferSSD)
 		require.Equal(t, preferSSD, r.preferSSD)
 		require.Equal(t, "zone123", r.zones)
-		require.Equal(t, "foo", r.instanceType)
 		require.Equal(t, spec.AWS, r.cloud)
 
 		s := r.MakeClusterSpec(100, spec.Geo(), spec.CPU(12),
@@ -51,7 +50,7 @@ func TestMakeTestRegistry(t *testing.T) {
 // TestPrometheusMetricParser tests that the registry.PromSub()
 // helper properly converts a string into a metric name that Prometheus can read.
 func TestPrometheusMetricParser(t *testing.T) {
-	r := makeTestRegistry(spec.AWS, "foo", "zone123", true)
+	r := makeTestRegistry(spec.AWS, "zone123", true)
 	f := r.PromFactory()
 
 	rawName := "restore/nodes=4/duration"

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -43,7 +43,7 @@ const defaultParallelism = 10
 
 func mkReg(t *testing.T) testRegistryImpl {
 	t.Helper()
-	return makeTestRegistry(spec.GCE, false /* preferSSD */)
+	return makeTestRegistry(spec.GCE)
 }
 
 func nilLogger() *logger.Logger {
@@ -377,7 +377,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			r := makeTestRegistry(spec.GCE, false /* preferSSD */)
+			r := makeTestRegistry(spec.GCE)
 			err := r.prepareSpec(&c.spec)
 			if !testutils.IsError(err, c.expectedErr) {
 				t.Fatalf("expected %q, but found %q", c.expectedErr, err.Error())

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -43,7 +43,7 @@ const defaultParallelism = 10
 
 func mkReg(t *testing.T) testRegistryImpl {
 	t.Helper()
-	return makeTestRegistry(spec.GCE, "", false /* preferSSD */)
+	return makeTestRegistry(spec.GCE, false /* preferSSD */)
 }
 
 func nilLogger() *logger.Logger {
@@ -377,7 +377,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			r := makeTestRegistry(spec.GCE, "", false /* preferSSD */)
+			r := makeTestRegistry(spec.GCE, false /* preferSSD */)
 			err := r.prepareSpec(&c.spec)
 			if !testutils.IsError(err, c.expectedErr) {
 				t.Fatalf("expected %q, but found %q", c.expectedErr, err.Error())

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -43,7 +43,7 @@ const defaultParallelism = 10
 
 func mkReg(t *testing.T) testRegistryImpl {
 	t.Helper()
-	return makeTestRegistry(spec.GCE, "", "", false /* preferSSD */)
+	return makeTestRegistry(spec.GCE, "", false /* preferSSD */)
 }
 
 func nilLogger() *logger.Logger {
@@ -318,7 +318,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 		Name:             `timeout`,
 		Owner:            OwnerUnitTest,
 		Timeout:          10 * time.Millisecond,
-		Cluster:          spec.MakeClusterSpec(spec.GCE, "", 0),
+		Cluster:          spec.MakeClusterSpec(spec.GCE, 0),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -355,7 +355,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 				Name:             "a",
 				Owner:            OwnerUnitTest,
 				Run:              dummyRun,
-				Cluster:          spec.MakeClusterSpec(spec.GCE, "", 0),
+				Cluster:          spec.MakeClusterSpec(spec.GCE, 0),
 				CompatibleClouds: registry.AllExceptAWS,
 				Suites:           registry.Suites(registry.Nightly),
 			},
@@ -367,7 +367,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 				Name:             "illegal *[]",
 				Owner:            OwnerUnitTest,
 				Run:              dummyRun,
-				Cluster:          spec.MakeClusterSpec(spec.GCE, "", 0),
+				Cluster:          spec.MakeClusterSpec(spec.GCE, 0),
 				CompatibleClouds: registry.AllExceptAWS,
 				Suites:           registry.Suites(registry.Nightly),
 			},
@@ -377,7 +377,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			r := makeTestRegistry(spec.GCE, "", "", false /* preferSSD */)
+			r := makeTestRegistry(spec.GCE, "", false /* preferSSD */)
 			err := r.prepareSpec(&c.spec)
 			if !testutils.IsError(err, c.expectedErr) {
 				t.Fatalf("expected %q, but found %q", c.expectedErr, err.Error())
@@ -404,7 +404,7 @@ func runExitCodeTest(t *testing.T, injectedError error) error {
 	r.Add(registry.TestSpec{
 		Name:             "boom",
 		Owner:            OwnerUnitTest,
-		Cluster:          spec.MakeClusterSpec(spec.GCE, "", 0),
+		Cluster:          spec.MakeClusterSpec(spec.GCE, 0),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -80,7 +80,7 @@ func registerFailover(r registry.Registry) {
 				Owner:               registry.OwnerKV,
 				Benchmark:           true,
 				Timeout:             60 * time.Minute,
-				Cluster:             r.MakeClusterSpec(10, spec.CPU(2), spec.PreferLocalSSD(false), spec.ReuseNone()), // uses disk stalls
+				Cluster:             r.MakeClusterSpec(10, spec.CPU(2), spec.DisableLocalSSD(), spec.ReuseNone()), // uses disk stalls
 				CompatibleClouds:    registry.AllExceptAWS,
 				Suites:              registry.Suites(registry.Nightly),
 				Leases:              leases,
@@ -137,7 +137,7 @@ func registerFailover(r registry.Registry) {
 			if failureMode == failureModeDiskStall {
 				// Use PDs in an attempt to work around flakes encountered when using
 				// SSDs. See #97968.
-				clusterOpts = append(clusterOpts, spec.PreferLocalSSD(false))
+				clusterOpts = append(clusterOpts, spec.DisableLocalSSD())
 				// Don't reuse the cluster for tests that call dmsetup to avoid
 				// spurious flakes from previous runs. See #107865
 				clusterOpts = append(clusterOpts, spec.ReuseNone())

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -568,7 +568,7 @@ func (hw hardwareSpecs) makeClusterSpecs(r registry.Registry, backupCloud string
 		// TODO(miral): This now returns an error instead of panicking, so even though
 		// we haven't panicked here before, we should handle the error. Moot if this is
 		// removed as per TODO above.
-		s.AWS.MachineType, _, _ = spec.SelectAWSMachineType(s.CPUs, s.Mem, s.PreferLocalSSD && s.VolumeSize == 0, vm.ArchAMD64)
+		s.AWS.MachineType, _, _ = spec.SelectAWSMachineType(s.CPUs, s.Mem, false /* shouldSupportLocalSSD */, vm.ArchAMD64)
 		s.AWS.MachineType = strings.Replace(s.AWS.MachineType, "d.", ".", 1)
 		s.Arch = vm.ArchAMD64
 	}

--- a/pkg/cmd/roachtest/tests/tpcc_test.go
+++ b/pkg/cmd/roachtest/tests/tpcc_test.go
@@ -26,16 +26,16 @@ func TestTPCCSupportedWarehouses(t *testing.T) {
 		buildVersion *version.Version
 		expected     int
 	}{
-		{"gce", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v2.1.0`), 1300},
-		{"gce", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 1250},
-		{"gce", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v19.1.0`), 1250},
+		{"gce", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v2.1.0`), 1300},
+		{"gce", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 1250},
+		{"gce", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v19.1.0`), 1250},
 
-		{"aws", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 2100},
-		{"aws", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v19.1.0`), 2100},
+		{"aws", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 2100},
+		{"aws", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v19.1.0`), 2100},
 
-		{"nope", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v2.1.0`), expectPanic},
-		{"gce", spec.MakeClusterSpec(spec.GCE, "", 5, spec.CPU(160)), version.MustParse(`v2.1.0`), expectPanic},
-		{"gce", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v1.0.0`), expectPanic},
+		{"nope", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v2.1.0`), expectPanic},
+		{"gce", spec.MakeClusterSpec(spec.GCE, 5, spec.CPU(160)), version.MustParse(`v2.1.0`), expectPanic},
+		{"gce", spec.MakeClusterSpec(spec.GCE, 4, spec.CPU(16)), version.MustParse(`v1.0.0`), expectPanic},
 	}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
Backport 4/4 commits from #111811.

/cc @cockroachdb/release

Release justification: test-only change, keeping roachtest in updated on release branches.

---

This set of commits makes more progress towards #104029 and - more generally - not baking in any flag configuration into the registry itself.

#### spec: move RoachprodOpts args to separate struct

Epic: none
Release note: None

#### spec: move default machine type from ClusterSpec to RoachprodClusterConfig

This is much more logical and allows the removal of the parameter from
the registry.

Epic: none
Release note: None

#### spec: move default zones to RoachprodClusterConfig

Remove the default zones from `ClusterSpec` (and the registry), and
add it to `RoachprodClusterConfig`.

Epic: none
Release note: None

#### spec: move local SSD preference to RoachprodClusterConfig

We change the boolean in the TestSpec to a tri-state (default, prefer
on, disable). This way we can apply the default when creating the
cluster.

Epic: none
Release note: None
