### PR TITLE
cli: deprecate the cockroach connect functionality

### DIFF
--- a/pkg/cli/connect.go
+++ b/pkg/cli/connect.go
@@ -39,6 +39,8 @@ var connectCmd = &cobra.Command{
 	Long: `
 Bootstrap security certificates for connecting to new or existing clusters.`,
 	RunE: UsageAndErr,
+	Deprecated: "self generated certificates are no longer supported functionality.\n" +
+		"Use a CA generated certificate for production cluster or --insecure for test clusters instead.\n",
 }
 
 func init() {
@@ -56,6 +58,8 @@ secure inter-node connections.
 `,
 	Args: cobra.NoArgs,
 	RunE: clierrorplus.MaybeDecorateError(runConnectInit),
+	Deprecated: "self generated certificates are no longer supported functionality.\n" +
+		"Use a CA generated certificate for production cluster or --insecure for test clusters instead.\n",
 }
 
 // runConnectInit connects to other nodes and negotiates an initialization bundle

--- a/pkg/cli/connect_join.go
+++ b/pkg/cli/connect_join.go
@@ -39,6 +39,8 @@ var connectJoinCmd = &cobra.Command{
 	Short: "request the TLS certs for a new node from an existing node",
 	Args:  cobra.MinimumNArgs(1),
 	RunE:  clierrorplus.MaybeDecorateError(runConnectJoin),
+	Deprecated: "self generated certificates are no longer supported functionality.\n" +
+		"Use a CA generated certificate for production cluster or --insecure for test clusters instead.\n",
 }
 
 func requestPeerCA(

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1256,8 +1256,6 @@ func TestFlagUsage(t *testing.T) {
 Available Commands:
   start             start a node in a multi-node cluster
   start-single-node start a single-node cluster
-  connect           Create certificates for securely connecting with clusters
-
   init              initialize a cluster
   cert              create ca, node, and client certs
   sql               open a sql shell


### PR DESCRIPTION
Cockroach connect is going to be removed in a future release. It was never completely finished and there is no public documentation about the feature.

Epic: none

Release note (cli change): Deprecate the cockroach connect functionality.