### PR TITLE
release-23.1: roachtest: cleanup allocate cluster function and follow-up fixes

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -103,7 +103,6 @@ go_test(
         "//pkg/roachprod/vm/gce",
         "//pkg/testutils",
         "//pkg/testutils/echotest",
-        "//pkg/util/quotapool",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/version",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -786,7 +786,7 @@ type clusterFactory struct {
 	namePrefix string
 	// counter is incremented with every new cluster. It's used as part of the cluster's name.
 	// Accessed atomically.
-	counter uint64
+	counter atomic.Uint64
 	// The registry with whom all clustered will be registered.
 	r *clusterRegistry
 	// artifactsDir is the directory in which the cluster creation log file will be placed.
@@ -832,7 +832,7 @@ func (f *clusterFactory) genName(cfg clusterConfig) string {
 	if cfg.nameOverride != "" {
 		return cfg.nameOverride
 	}
-	count := atomic.AddUint64(&f.counter, 1)
+	count := f.counter.Add(1)
 	return makeClusterName(
 		fmt.Sprintf("%s-%02d-%s", f.namePrefix, count, cfg.spec.String()))
 }

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -279,7 +279,7 @@ func runTests(register func(registry.Registry), args []string, benchOnly bool) e
 			skipInit:               skipInit,
 			goCoverEnabled:         goCoverEnabled,
 		},
-		lopt, nil /* clusterAllocator */)
+		lopt)
 
 	// Make sure we attempt to clean up. We run with a non-canceled ctx; the
 	// ctx above might be canceled in case a signal was received. If that's

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -618,10 +618,9 @@ func (r *testRunner) runWorker(
 				// N.B. we do not count reuse attempt error toward clusterCreateErr.
 				// Let's attempt to create a fresh one.
 				testToRun.canReuseCluster = false
-				// Destroy the cluster since we're unable to reuse it.
-				// NB: This is a hack. If we destroy the cluster, the allocation quota will get released back into the pool.
-				// Thus, we can't immediately create a fresh cluster since another worker might grab the quota before us.
-				// Instead, we transfer the allocation quota to the new cluster and pretend the old one didn't have any.
+				// We need an allocation quota to start a new cluster; steal it from the
+				// old cluster before we destroy it (we know the cluster configurations
+				// will be identical).
 				testToRun.alloc = c.destroyState.alloc
 				c.destroyState.alloc = nil
 				c.Destroy(context.Background(), closeLogger, l)

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -287,7 +287,11 @@ func (r *testRunner) Run(
 			}
 		}
 	}
-	clusterAllocator := defaultClusterAllocator(r, clustersOpt, lopt)
+
+	clusterFactory := newClusterFactory(
+		clustersOpt.user, clustersOpt.clusterID, lopt.artifactsDir,
+		r.cr, numConcurrentClusterCreations(),
+	)
 
 	// Seed the default rand source so that different runs get different cluster
 	// IDs.
@@ -322,9 +326,9 @@ func (r *testRunner) Run(
 			err := r.runWorker(
 				ctx, fmt.Sprintf("w%d", i) /* name */, r.work, qp,
 				r.stopper.ShouldQuiesce(),
-				clustersOpt.debugMode,
-				lopt.artifactsDir, lopt.literalArtifactsDir, lopt.tee, lopt.stdout,
-				clusterAllocator,
+				clusterFactory,
+				clustersOpt,
+				lopt,
 				topt,
 				l,
 			)
@@ -411,91 +415,72 @@ func generateRunID(cOpts clustersOpt) string {
 	return fmt.Sprintf("%s-%s", cOpts.user, cOpts.clusterID)
 }
 
-// defaultClusterAllocator is used by workers to create new clusters (or to attach
-// to an existing one).
-//
-// N.B. the resulting clusterAllocatorFn reuses the same clusterFactory to allocate clusters.
-func defaultClusterAllocator(
-	r *testRunner, clustersOpt clustersOpt, lopt loggingOpt,
-) clusterAllocatorFn {
-	clusterFactory := newClusterFactory(
-		clustersOpt.user, clustersOpt.clusterID, lopt.artifactsDir, r.cr, numConcurrentClusterCreations())
-
-	allocateCluster := func(
-		ctx context.Context,
-		t registry.TestSpec,
-		arch vm.CPUArch,
-		alloc *quotapool.IntAlloc,
-		artifactsDir string,
-		wStatus *workerStatus,
-	) (*clusterImpl, *vm.CreateOpts, error) {
-		wStatus.SetStatus(fmt.Sprintf("creating cluster (arch=%q)", arch))
-		defer wStatus.SetStatus("")
-
-		if clustersOpt.preAllocateClusterFn != nil {
-			if err := clustersOpt.preAllocateClusterFn(ctx, t, arch); err != nil {
-				return nil, nil, err
-			}
-		}
-
-		existingClusterName := clustersOpt.clusterName
-		if existingClusterName != "" {
-			// Logs for attaching to a cluster go to a dedicated log file.
-			logPath := filepath.Join(artifactsDir, runnerLogsDir, "cluster-create", existingClusterName+".log")
-			clusterL, err := logger.RootLogger(logPath, lopt.tee)
-			if err != nil {
-				return nil, nil, err
-			}
-			defer clusterL.Close()
-			opt := attachOpt{
-				skipValidation: r.config.skipClusterValidationOnAttach,
-				skipStop:       r.config.skipClusterStopOnAttach,
-				skipWipe:       r.config.skipClusterWipeOnAttach,
-			}
-			// TODO(srosenberg): we need to think about validation here. Attaching to an incompatible cluster, e.g.,
-			// using arm64 AMI with amd64 binary, would result in obscure errors. The test runner ensures compatibility
-			// during cluster reuse, whereas attachment via CLI (e.g., via roachprod) does not.
-			lopt.l.PrintfCtx(ctx, "Attaching to existing cluster %s for test %s", existingClusterName, t.Name)
-			c, err := attachToExistingCluster(ctx, existingClusterName, clusterL, t.Cluster, opt, r.cr)
-			if err == nil {
-				// Pretend pre-existing's cluster architecture matches the desired one; see the above TODO wrt validation.
-				c.arch = arch
-				return c, nil, nil
-			}
-			if !errors.Is(err, errClusterNotFound) {
-				return nil, nil, err
-			}
-			// Fall through to create new cluster with name override.
-			lopt.l.PrintfCtx(
-				ctx, "Creating new cluster with custom name %q for test %s: %s (arch=%q)",
-				clustersOpt.clusterName, t.Name, t.Cluster, arch,
-			)
-		} else {
-			lopt.l.PrintfCtx(ctx, "Creating new cluster for test %s: %s (arch=%q)", t.Name, t.Cluster, arch)
-		}
-
-		cfg := clusterConfig{
-			nameOverride: clustersOpt.clusterName, // only set if we hit errClusterFound above
-			spec:         t.Cluster,
-			artifactsDir: artifactsDir,
-			username:     clustersOpt.user,
-			localCluster: clustersOpt.typ == localCluster,
-			alloc:        alloc,
-			arch:         arch,
-		}
-		return clusterFactory.newCluster(ctx, cfg, wStatus.SetStatus, lopt.tee)
-	}
-	return allocateCluster
-}
-
-type clusterAllocatorFn func(
+func (r *testRunner) allocateCluster(
 	ctx context.Context,
+	clusterFactory *clusterFactory,
+	clustersOpt clustersOpt,
+	lopt loggingOpt,
 	t registry.TestSpec,
 	arch vm.CPUArch,
 	alloc *quotapool.IntAlloc,
-	artifactsDir string,
 	wStatus *workerStatus,
-) (*clusterImpl, *vm.CreateOpts, error)
+) (*clusterImpl, *vm.CreateOpts, error) {
+	wStatus.SetStatus(fmt.Sprintf("creating cluster (arch=%q)", arch))
+	defer wStatus.SetStatus("")
+
+	if clustersOpt.preAllocateClusterFn != nil {
+		if err := clustersOpt.preAllocateClusterFn(ctx, t, arch); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	existingClusterName := clustersOpt.clusterName
+	if existingClusterName != "" {
+		// Logs for attaching to a cluster go to a dedicated log file.
+		logPath := filepath.Join(lopt.artifactsDir, runnerLogsDir, "cluster-create", existingClusterName+".log")
+		clusterL, err := logger.RootLogger(logPath, lopt.tee)
+		if err != nil {
+			return nil, nil, err
+		}
+		defer clusterL.Close()
+		opt := attachOpt{
+			skipValidation: r.config.skipClusterValidationOnAttach,
+			skipStop:       r.config.skipClusterStopOnAttach,
+			skipWipe:       r.config.skipClusterWipeOnAttach,
+		}
+		// TODO(srosenberg): we need to think about validation here. Attaching to an incompatible cluster, e.g.,
+		// using arm64 AMI with amd64 binary, would result in obscure errors. The test runner ensures compatibility
+		// during cluster reuse, whereas attachment via CLI (e.g., via roachprod) does not.
+		lopt.l.PrintfCtx(ctx, "Attaching to existing cluster %s for test %s", existingClusterName, t.Name)
+		c, err := attachToExistingCluster(ctx, existingClusterName, clusterL, t.Cluster, opt, r.cr)
+		if err == nil {
+			// Pretend pre-existing's cluster architecture matches the desired one; see the above TODO wrt validation.
+			c.arch = arch
+			return c, nil, nil
+		}
+		if !errors.Is(err, errClusterNotFound) {
+			return nil, nil, err
+		}
+		// Fall through to create new cluster with name override.
+		lopt.l.PrintfCtx(
+			ctx, "Creating new cluster with custom name %q for test %s: %s (arch=%q)",
+			clustersOpt.clusterName, t.Name, t.Cluster, arch,
+		)
+	} else {
+		lopt.l.PrintfCtx(ctx, "Creating new cluster for test %s: %s (arch=%q)", t.Name, t.Cluster, arch)
+	}
+
+	cfg := clusterConfig{
+		nameOverride: clustersOpt.clusterName, // only set if we hit errClusterFound above
+		spec:         t.Cluster,
+		artifactsDir: lopt.artifactsDir,
+		username:     clustersOpt.user,
+		localCluster: clustersOpt.typ == localCluster,
+		alloc:        alloc,
+		arch:         arch,
+	}
+	return clusterFactory.newCluster(ctx, cfg, wStatus.SetStatus, lopt.tee)
+}
 
 // runWorker runs tests in a loop until work is exhausted.
 //
@@ -514,37 +499,24 @@ type clusterAllocatorFn func(
 //
 // runWorker returns either error (other than cluster provisioning) or the count of cluster provisioning errors.
 //
-// Args:
-// name: The worker's name, to be used as a prefix for log messages.
-// artifactsRootDir: The artifacts dir. Each test's logs are going to be under a
+// The worker's name will be used as a prefix for log messages.
 //
-//	run_<n> dir. If empty, test log files will not be created.
-//
-// literalArtifactsDir: The literal on-agent path where artifacts are stored.
-//
-//	Only used for teamcity[publishArtifacts] messages.
-//
-// stdout: The Writer to use for messages that need to go to stdout (e.g. the
-//
-//	"=== RUN" and "--- FAIL" lines).
-//
-// teeOpt: The teeing option for future test loggers.
-// l: The logger to use for more verbose messages.
+// Each test's logs are going to be under a <test-name>/run_<n> dir inside
+// lotp.artifactsDir. If empty, test log files will not be created.
 func (r *testRunner) runWorker(
 	ctx context.Context,
 	name string,
 	work *workPool,
 	qp *quotapool.IntPool,
 	interrupt <-chan struct{},
-	debugMode debugMode,
-	artifactsRootDir string,
-	literalArtifactsDir string,
-	teeOpt logger.TeeOptType,
-	stdout io.Writer,
-	allocateCluster clusterAllocatorFn,
+	clusterFactory *clusterFactory,
+	clustersOpt clustersOpt,
+	lopt loggingOpt,
 	topt testOpts,
 	l *logger.Logger,
 ) error {
+	stdout := lopt.stdout
+
 	ctx = logtags.AddTag(ctx, name, nil /* value */)
 	wStatus := r.addWorker(ctx, name)
 	defer func() {
@@ -709,7 +681,9 @@ func (r *testRunner) runWorker(
 			// Create a new cluster if can't reuse or reuse attempt failed.
 			// N.B. non-reusable cluster would have been destroyed above.
 			wStatus.SetTest(nil /* test */, testToRun)
-			c, vmCreateOpts, clusterCreateErr = allocateCluster(ctx, testToRun.spec, arch, testToRun.alloc, artifactsRootDir, wStatus)
+			c, vmCreateOpts, clusterCreateErr = r.allocateCluster(
+				ctx, clusterFactory, clustersOpt, lopt,
+				testToRun.spec, arch, testToRun.alloc, wStatus)
 			if clusterCreateErr != nil {
 				atomic.AddInt32(&r.numClusterErrs, 1)
 				shout(ctx, l, stdout, "Unable to create (or reuse) cluster for test %s due to: %s.",
@@ -720,6 +694,7 @@ func (r *testRunner) runWorker(
 		}
 		// Prepare the test's logger. Always set this up with real files, using a
 		// temp dir if necessary. This simplifies testing.
+		artifactsRootDir := lopt.artifactsDir
 		if artifactsRootDir == "" {
 			artifactsRootDir, _ = os.MkdirTemp("", "roachtest-logger")
 		}
@@ -733,9 +708,9 @@ func (r *testRunner) runWorker(
 		// Map artifacts/TestFoo/run_?/** => TestFoo/run_?/**, i.e. collect the artifacts
 		// for this test exactly as they are laid out on disk (when the time
 		// comes).
-		artifactsSpec := fmt.Sprintf("%s/%s/** => %s/%s", filepath.Join(literalArtifactsDir, escapedTestName), runSuffix, escapedTestName, runSuffix)
+		artifactsSpec := fmt.Sprintf("%s/%s/** => %s/%s", filepath.Join(lopt.literalArtifactsDir, escapedTestName), runSuffix, escapedTestName, runSuffix)
 
-		testL, err := logger.RootLogger(logPath, teeOpt)
+		testL, err := logger.RootLogger(logPath, lopt.tee)
 		if err != nil {
 			return err
 		}
@@ -754,7 +729,7 @@ func (r *testRunner) runWorker(
 			l:                      testL,
 			versionsBinaryOverride: topt.versionsBinaryOverride,
 			skipInit:               topt.skipInit,
-			debug:                  debugMode.IsDebug(),
+			debug:                  clustersOpt.debugMode.IsDebug(),
 			goCoverEnabled:         topt.goCoverEnabled,
 		}
 		github := newGithubIssues(r.config.disableIssue, c, vmCreateOpts)
@@ -868,7 +843,7 @@ func (r *testRunner) runWorker(
 				failureMsg += t.failureMsg()
 			}
 			if c != nil {
-				switch debugMode {
+				switch clustersOpt.debugMode {
 				case DebugKeepAlways, DebugKeepOnFailure:
 					// Save the cluster for future debugging.
 					c.Save(ctx, failureMsg, l)
@@ -892,7 +867,7 @@ func (r *testRunner) runWorker(
 			if t.spec.Benchmark {
 				getPerfArtifacts(ctx, c, t)
 			}
-			if debugMode == DebugKeepAlways {
+			if clustersOpt.debugMode == DebugKeepAlways {
 				c.Save(ctx, "cluster saved since --debug-always set", l)
 				c = nil
 			}

--- a/pkg/cmd/roachtest/work_pool.go
+++ b/pkg/cmd/roachtest/work_pool.go
@@ -110,8 +110,16 @@ func (p *workPool) getTestToRun(
 		} else {
 			return ttr, nil
 		}
+		// We failed to find a test that can reuse this cluster. A fresh cluster will need to be allocated.
+		// The existing cluster will be destroyed _before_ a fresh one is created.
+		// N.B. we must release the allocation quota before invoking 'selectTest' below, otherwise a deadlock may occur.
+		qp.Release(ttr.alloc)
+		// N.B. we transferred the allocation quota from the existing cluster in order to try to allocate a fresh one, so
+		// when the cluster is destroyed, don't release it again.
+		c.destroyState.alloc = nil
+		ttr.alloc = nil
 	}
-
+	// invariant: testToRunRes.noWork || !testToRunRes.canReuseCluster
 	return p.selectTest(ctx, qp)
 }
 

--- a/pkg/cmd/roachtest/work_pool.go
+++ b/pkg/cmd/roachtest/work_pool.go
@@ -113,11 +113,12 @@ func (p *workPool) getTestToRun(
 		// We failed to find a test that can reuse this cluster. A fresh cluster will need to be allocated.
 		// The existing cluster will be destroyed _before_ a fresh one is created.
 		// N.B. we must release the allocation quota before invoking 'selectTest' below, otherwise a deadlock may occur.
-		qp.Release(ttr.alloc)
-		// N.B. we transferred the allocation quota from the existing cluster in order to try to allocate a fresh one, so
-		// when the cluster is destroyed, don't release it again.
-		c.destroyState.alloc = nil
-		ttr.alloc = nil
+		if c.destroyState.alloc != nil {
+			qp.Release(c.destroyState.alloc)
+			// N.B. we transferred the allocation quota from the existing cluster in order to try to allocate a fresh one, so
+			// when the cluster is destroyed, don't release it again.
+			c.destroyState.alloc = nil
+		}
 	}
 	// invariant: testToRunRes.noWork || !testToRunRes.canReuseCluster
 	return p.selectTest(ctx, qp)


### PR DESCRIPTION
Backport:
  * 2/2 commits from "roachtest: clean up allocate cluster function" (#111534)
  * 1/1 commits from "roachtest: fix reused cluster wipe failure handling" (#112143)
  * 1/1 commits from "roachtest: fix deadlock in `getTestToRun`" (#112250)
  * 1/1 commits from "roachtest: _actually_ fix deadlock in `getTestToRun`" (#112447)

Please see individual PRs for details.

/cc @cockroachdb/release


Release justification: test-only change, keeping roachtest in updated on release branches.
