### PR TITLE
release-23.2: team: ignore TEAMS.yaml

### DIFF
--- a/pkg/internal/team/.gitignore
+++ b/pkg/internal/team/.gitignore
@@ -1,0 +1,3 @@
+# This file is generated and ignored on master; ignoring it here as well hides
+# the file when switching branches.
+TEAMS.yaml


### PR DESCRIPTION
This file is now created by `dev gen go` on `master`. Ignoring it in release branches allows us to now worry about it when switching branches.

Release justification: not a code change

Epic: CRDB-8035
Release note: None