### PR TITLE
sctest: Do not modify line if line is not single DDL statement

### DIFF
--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -932,6 +932,7 @@ func TestCompareLegacyAndDeclarative(t *testing.T) {
 			"RELEASE SAVEPOINT cockroach_restart;  -- move txn into DONE state",
 			"SELECT 1;  -- expect to be ignored",
 			"COMMIT;",
+			"CREATE TABLE t11 (i INT NOT NULL); ALTER TABLE t11 ALTER PRIMARY KEY USING COLUMNS (i); -- multi-statement implicit txn",
 
 			// statements that will be altered due to known behavioral differences in LSC vs DSC.
 			"ALTER TABLE t1 ADD COLUMN xyz INT DEFAULT 30, ALTER PRIMARY KEY USING COLUMNS (j), DROP COLUMN i; -- unimplemented in legacy schema changer; expect to skip this line",

--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -955,6 +955,7 @@ func TestCompareLegacyAndDeclarative(t *testing.T) {
 			"CREATE TABLE t10 (i INT NOT NULL, j INT NOT NULL, k INT NOT NULL, PRIMARY KEY (i, k) USING HASH WITH (bucket_count=3));",
 			"INSERT INTO t10 VALUES (0, 1, 2);",
 			"ALTER TABLE t10 ALTER PRIMARY KEY USING COLUMNS (i, k) USING HASH;  -- expect to be rewritten to have `DROP COLUMN IF EXISTS old-shard-col` appended to it",
+			"ALTER TABLE t10 ALTER PRIMARY KEY USING COLUMNS (i, k); -- ditto",
 			"ALTER TABLE t10 ALTER PRIMARY KEY USING COLUMNS (j) USING HASH;  -- expect to not be rewritten because old-shard-col is used",
 		},
 	}

--- a/pkg/sql/schemachanger/sctest/comparator.go
+++ b/pkg/sql/schemachanger/sctest/comparator.go
@@ -192,12 +192,14 @@ func modifyBlacklistedStmt(
 }
 
 // modifyAlterPKWithSamePKColsButDifferentSharding modifies any ALTER PK stmt in
-// `line` if the current/old primary index is hash-sharded and the new primary
-// index is also hash-sharded on the same key columns (but with a different
-// "bucket_count") by appending a `DROP COLUMN IF EXISTS
-// crdb_intenral_old_cols_shard` to it, so that legacy schema changer will
-// converge to declarative schema changer (in which ALTER PK will already drop
-// the old shard column).
+// `line` if the current/old primary index is hash-sharded and ALTER PK would
+// leave the shard column unused, in which case the declarative schema changer
+// would also drop it (but legacy schema changer wouldn't).
+// To have a converged behavior, if `parsedStmts` contains such a ALTER PK, we
+// would append a `ALTER TABLE .. DROP COLUMN IF EXISTS old-shard-col` to it, so
+// that legacy schema changer will also have that old shard column dropped.
+// See commentary on `needsToDropOldShardColFn` for criteria of such ALTER PK.
+//
 // The returned boolean indicates if such a modification happened.
 func modifyAlterPKWithSamePKColsButDifferentSharding(
 	ctx context.Context, t *testing.T, parsedStmts statements.Statements, conn *gosql.Conn,
@@ -246,8 +248,9 @@ WHERE id = '%v'::REGCLASS;`, name.String()))
 
 	// needsToDropOldShardColFn is a helper to determine if we need to drop the old
 	// shard column from the old PK after altering to the new PK.
-	// Currently, we do if both the old and new PK are hash-sharded on the same
-	// columns with different shard buckets.
+	// Currently, we do if (the old PK is hash-sharded) && (the new PK is key'ed on
+	// same columns as the old PK) && (new PK is not hash-sharded || new PK is
+	// hash-sharded but with a different bucket_count).
 	needsToDropOldShardColFn := func(
 		tableName *tree.UnresolvedObjectName, newPKColumns tree.IndexElemList, newPKShardingDef *tree.ShardedIndexDef, newPKStorageParams tree.StorageParams,
 	) (needsToDrop bool, oldShardColToDrop string) {
@@ -278,14 +281,14 @@ WHERE id = '%v'::REGCLASS;`, name.String()))
 			return true
 		}
 
-		if newPKShardingDef == nil {
-			return false, ""
-		}
 		isSharded, shardColName, shardBuckets, columnNames := getPKShardingInfo(tableName)
 		if !isSharded {
 			return false, ""
 		}
-		if !sameColumns(columnNames, newPKColumns) || sameShardBuckets(int32(shardBuckets), newPKShardingDef, newPKStorageParams) {
+		if !sameColumns(columnNames, newPKColumns) {
+			return false, ""
+		}
+		if newPKShardingDef != nil && sameShardBuckets(int32(shardBuckets), newPKShardingDef, newPKStorageParams) {
 			return false, ""
 		}
 		return true, shardColName


### PR DESCRIPTION
Fixed two flaws in the comparator testing framework:
1. do not attempt to modify input line if line is not single DDL statement
2. ensure we modify line to drop old-shard-column if old pk is sharded but new pk is not

Informs #113351 
