### PR TITLE
github-pull-request-make: bump timeouts for `maybe-stress{,race}`

### DIFF
--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -279,9 +279,9 @@ func main() {
 			target, ok := os.LookupEnv(targetEnv)
 			var duration time.Duration
 			if ok && target == "stressrace" {
-				duration = (30 * time.Minute) / time.Duration(len(pkgs))
+				duration = (40 * time.Minute) / time.Duration(len(pkgs))
 			} else {
-				duration = (20 * time.Minute) / time.Duration(len(pkgs))
+				duration = (30 * time.Minute) / time.Duration(len(pkgs))
 			}
 			minDuration := (2 * time.Minute) * time.Duration(len(pkg.tests))
 			if duration < minDuration {


### PR DESCRIPTION
We're seeing relatively frequent timeouts.

Epic: none
Release note: None