### PR TITLE
sql: do not require system table privileges to use SHOW STATISTICS

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2461,3 +2461,33 @@ SELECT statistics_name, created FROM
 [SHOW STATISTICS FOR TABLE t107651]
 ----
 __auto__  2023-09-15 17:00:00 -0400 -0400
+
+# Test that a non-admin can use SHOW STATISTICS.
+
+statement ok
+CREATE TABLE tab_test_privileges (a INT PRIMARY KEY);
+
+statement ok
+INSERT INTO tab_test_privileges VALUES (1);
+
+statement ok
+CREATE STATISTICS tab_test_privileges_stat ON a FROM tab_test_privileges;
+
+user testuser
+
+query error testuser has no privileges on relation tab_test_privileges
+SELECT statistics_name, created FROM [SHOW STATISTICS FOR TABLE tab_test_privileges]
+
+user root
+
+statement ok
+GRANT SELECT ON tab_test_privileges TO testuser
+
+user testuser
+
+query T
+SELECT statistics_name FROM [SHOW STATISTICS FOR TABLE tab_test_privileges]
+----
+tab_test_privileges_stat
+
+user root

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exprutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -142,10 +143,16 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 						FROM system.table_statistics
 						WHERE "tableID" = $1
 						ORDER BY "createdAt", "columnIDs", "statisticID"`, partialPredicateCol, fullStatisticIDCol)
-			rows, err := p.InternalSQLTxn().QueryBuffered(
+
+			// There is a privilege check above to make sure the user has any
+			// privilege on the table being inspected. We use the node user to execute
+			// the query against the system table so that SHOW STATISTICS does not
+			// _also_ need privileges on the system.table_statistics table.
+			rows, err := p.InternalSQLTxn().QueryBufferedEx(
 				ctx,
 				"read-table-stats",
 				p.txn,
+				sessiondata.NodeUserSessionDataOverride,
 				stmt,
 				desc.GetID(),
 			)


### PR DESCRIPTION
See the docs at: https://www.cockroachlabs.com/docs/stable/show-statistics
They say that no special privileges are needed.

Epic: None

Release note (bug fix): The SHOW STATISTICS command previously incorrectly
required the user to have the admin role. It was intended to only
require the user to have any privilege on the table being inspected.
This is now fixed.