### PR TITLE
kv: add test only verification for lock table invariants

### DIFF
--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "lock_table.go",
         "lock_table_waiter.go",
         "metrics.go",
+        "verifiable_lock_table.go",
         ":keylocks_interval_btree.go",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency",

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -742,6 +742,10 @@ type lockTable interface {
 
 	// String returns a debug string representing the state of the lockTable.
 	String() string
+
+	// TestingSetMaxLocks updates the locktable's lock limit. This can be used to
+	// force the locktable to exceed its limit and clear locks.
+	TestingSetMaxLocks(maxLocks int64)
 }
 
 // lockTableGuard is a handle to a request as it waits on conflicting locks in a

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -160,7 +160,9 @@ func (c *Config) initDefaults() {
 func NewManager(cfg Config) Manager {
 	cfg.initDefaults()
 	m := new(managerImpl)
-	lt := newLockTable(cfg.MaxLockTableSize, cfg.RangeDesc.RangeID, cfg.Clock, cfg.Settings)
+	lt := maybeWrapInVerifyingLockTable(
+		newLockTable(cfg.MaxLockTableSize, cfg.RangeDesc.RangeID, cfg.Clock, cfg.Settings),
+	)
 	*m = managerImpl{
 		st: cfg.Settings,
 		// TODO(nvanbenschoten): move pkg/storage/spanlatch to a new
@@ -648,7 +650,7 @@ func (m *managerImpl) TestingTxnWaitQueue() *txnwait.Queue {
 
 // TestingSetMaxLocks implements the TestingAccessor interface.
 func (m *managerImpl) TestingSetMaxLocks(maxLocks int64) {
-	m.lt.(*lockTableImpl).setMaxKeysLocked(maxLocks)
+	m.lt.TestingSetMaxLocks(maxLocks)
 }
 
 func (r *Request) isSingle(m kvpb.Method) bool {

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -206,7 +206,7 @@ func TestLockTableBasic(t *testing.T) {
 				ltImpl.enabled = true
 				ltImpl.enabledSeq = 1
 				ltImpl.minKeysLocked = 0
-				lt = ltImpl
+				lt = maybeWrapInVerifyingLockTable(ltImpl)
 				txnsByName = make(map[string]*enginepb.TxnMeta)
 				txnCounter = uint128.FromInts(0, 0)
 				requestsByName = make(map[string]Request)
@@ -1259,10 +1259,11 @@ type workloadExecutor struct {
 
 func newWorkLoadExecutor(items []workloadItem, concurrency int) *workloadExecutor {
 	const maxLocks = 100000
-	lt := newLockTable(
+	ltImpl := newLockTable(
 		maxLocks, roachpb.RangeID(3), hlc.NewClockForTesting(nil), cluster.MakeTestingClusterSettings(),
 	)
-	lt.enabled = true
+	ltImpl.enabled = true
+	lt := maybeWrapInVerifyingLockTable(ltImpl)
 	return &workloadExecutor{
 		lm:           spanlatch.Manager{},
 		lt:           lt,

--- a/pkg/kv/kvserver/concurrency/verifiable_lock_table.go
+++ b/pkg/kv/kvserver/concurrency/verifiable_lock_table.go
@@ -1,0 +1,127 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package concurrency
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+)
+
+// verifiableLockTable is a lock table that is able to verify structural and
+// correctness properties.
+type verifiableLockTable interface {
+	lockTable
+	// verify ensures structural and correctness properties hold for each of the
+	// locks stored in the lock table. Verification is expensive and should only
+	// be performed for test builds.
+	verify()
+
+	// verifyKey ensures structural and correctness properties hold for all locks
+	// stored in the lock table for the given key.
+	verifyKey(roachpb.Key)
+}
+
+type verifyingLockTable struct {
+	lt verifiableLockTable
+}
+
+var _ lockTable = &verifyingLockTable{}
+
+// maybeWrapInVerifyingLockTable wraps the supplied lock table to perform
+// verification for test-only builds.
+func maybeWrapInVerifyingLockTable(lt lockTable) lockTable {
+	if buildutil.CrdbTestBuild {
+		return &verifyingLockTable{lt: lt.(verifiableLockTable)}
+	}
+	return lt
+}
+
+// Enable implements the lockTable interface.
+func (v verifyingLockTable) Enable(sequence roachpb.LeaseSequence) {
+	defer v.lt.verify()
+	v.lt.Enable(sequence)
+}
+
+// Clear implements the lockTable interface.
+func (v verifyingLockTable) Clear(disable bool) {
+	defer v.lt.verify()
+	v.lt.Clear(disable)
+}
+
+// ScanAndEnqueue implements the lockTable interface.
+func (v verifyingLockTable) ScanAndEnqueue(
+	req Request, guard lockTableGuard,
+) (lockTableGuard, *Error) {
+	defer v.lt.verify()
+	return v.lt.ScanAndEnqueue(req, guard)
+}
+
+// ScanOptimistic implements the lockTable interface.
+func (v verifyingLockTable) ScanOptimistic(req Request) lockTableGuard {
+	defer v.lt.verify()
+	return v.lt.ScanOptimistic(req)
+}
+
+// Dequeue implements the lockTable interface.
+func (v verifyingLockTable) Dequeue(guard lockTableGuard) {
+	defer v.lt.verify()
+	v.lt.Dequeue(guard)
+}
+
+// AddDiscoveredLock implements the lockTable interface.
+func (v verifyingLockTable) AddDiscoveredLock(
+	foundLock *roachpb.Lock,
+	seq roachpb.LeaseSequence,
+	consultTxnStatusCache bool,
+	guard lockTableGuard,
+) (bool, error) {
+	defer v.lt.verifyKey(foundLock.Key)
+	return v.lt.AddDiscoveredLock(foundLock, seq, consultTxnStatusCache, guard)
+}
+
+// AcquireLock implements the lockTable interface.
+func (v verifyingLockTable) AcquireLock(acq *roachpb.LockAcquisition) error {
+	defer v.lt.verifyKey(acq.Key)
+	return v.lt.AcquireLock(acq)
+}
+
+// UpdateLocks implements the lockTable interface.
+func (v verifyingLockTable) UpdateLocks(up *roachpb.LockUpdate) error {
+	defer v.lt.verify()
+	return v.lt.UpdateLocks(up)
+}
+
+// PushedTransactionUpdated implements the lockTable interface.
+func (v verifyingLockTable) PushedTransactionUpdated(txn *roachpb.Transaction) {
+	v.lt.PushedTransactionUpdated(txn)
+}
+
+// QueryLockTableState implements the lockTable interface.
+func (v verifyingLockTable) QueryLockTableState(
+	span roachpb.Span, opts QueryLockTableOptions,
+) ([]roachpb.LockStateInfo, QueryLockTableResumeState) {
+	return v.lt.QueryLockTableState(span, opts)
+}
+
+// Metrics implements the lockTable interface.
+func (v verifyingLockTable) Metrics() LockTableMetrics {
+	return v.lt.Metrics()
+}
+
+// String implements the lockTable interface.
+func (v verifyingLockTable) String() string {
+	return v.lt.String()
+}
+
+// TestingSetMaxLocks implements the lockTable interface.
+func (v verifyingLockTable) TestingSetMaxLocks(maxKeysLocked int64) {
+	v.lt.TestingSetMaxLocks(maxKeysLocked)
+}


### PR DESCRIPTION
This patch adds verification for per-lock invariants, and verifies all locks in the lock table on public interface boundaries. Examples of invariants that we check:

1. All locks should be compatible with one another.
2. All active waiters are waiting for legit reasons.
3. Queued locking requests are stored in sorted sequence number order.
4. Invariants around distinguished waiter.
5. Locking requests wait queue invariants if the lock isn't held.
6. Waiting state invariants.

Fixes #108843

Release note: None