### PR TITLE
kvserver: add replication delay and per replicated-to store stats

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -236,6 +236,7 @@ go_library(
         "@io_etcd_go_raft_v3//tracker",
         "@io_opentelemetry_go_otel//attribute",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_x_exp//slices",
         "@org_golang_x_time//rate",
     ],
 )

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -368,12 +368,11 @@ func (r *Replica) InitQuotaPool(quota uint64) error {
 		return err
 	}
 
-	r.mu.proposalQuotaBaseIndex = appliedIndex
+	r.mu.proposalQuotaAndDelayTracker.init(context.Background(), appliedIndex)
 	if r.mu.proposalQuota != nil {
 		r.mu.proposalQuota.Close("re-creating")
 	}
 	r.mu.proposalQuota = quotapool.NewIntPool(r.rangeStr.String(), quota)
-	r.mu.quotaReleaseQueue = nil
 	return nil
 }
 
@@ -397,7 +396,7 @@ func (r *Replica) GetProposalQuota() *quotapool.IntPool {
 func (r *Replica) QuotaReleaseQueueLen() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return len(r.mu.quotaReleaseQueue)
+	return r.mu.proposalQuotaAndDelayTracker.getQuotaReleaseQueueLen()
 }
 
 func (r *Replica) NumPendingProposals() int {

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -755,19 +755,7 @@ type Replica struct {
 		// replicas have persisted the corresponding entry into their logs.
 		proposalQuota *quotapool.IntPool
 
-		// The base index is the index up to (including) which quota was already
-		// released. That is, the first element in quotaReleaseQueue below is
-		// released as the base index moves up by one, etc.
-		proposalQuotaBaseIndex kvpb.RaftIndex
-
-		// Once the leader observes a proposal come 'out of Raft', we add the size
-		// of the associated command to a queue of quotas we have yet to release
-		// back to the quota pool. At that point ownership of the quota is
-		// transferred from r.mu.proposals to this queue.
-		// We'll release the respective quota once all replicas have persisted the
-		// corresponding entry into their logs (or once we give up waiting on some
-		// replica because it looks like it's dead).
-		quotaReleaseQueue []*quotapool.IntAlloc
+		proposalQuotaAndDelayTracker
 
 		// Counts calls to Replica.tick()
 		ticks int
@@ -1573,13 +1561,16 @@ func (r *Replica) State(ctx context.Context) kvserverpb.RangeInfo {
 	ri.NumDropped = uint64(r.mu.droppedMessages)
 	if r.mu.proposalQuota != nil {
 		ri.ApproximateProposalQuota = int64(r.mu.proposalQuota.ApproximateQuota())
-		ri.ProposalQuotaBaseIndex = int64(r.mu.proposalQuotaBaseIndex)
-		ri.ProposalQuotaReleaseQueue = make([]int64, len(r.mu.quotaReleaseQueue))
-		for i, a := range r.mu.quotaReleaseQueue {
+		ri.ProposalQuotaBaseIndex = int64(r.mu.proposalQuotaAndDelayTracker.getProposalQuotaBaseIndex())
+		ri.ProposalQuotaReleaseQueue =
+			make([]int64, r.mu.proposalQuotaAndDelayTracker.getQuotaReleaseQueueLen())
+		i := 0
+		r.mu.proposalQuotaAndDelayTracker.iterateQuotaQueue(func(a *quotapool.IntAlloc) {
 			if a != nil {
 				ri.ProposalQuotaReleaseQueue[i] = int64(a.Acquired())
 			}
-		}
+			i++
+		})
 	}
 	ri.RangeMaxBytes = r.mu.conf.RangeMaxBytes
 	if r.mu.tenantID != (roachpb.TenantID{}) {

--- a/pkg/kv/kvserver/replica_application_decoder.go
+++ b/pkg/kv/kvserver/replica_application_decoder.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"go.etcd.io/raft/v3/raftpb"
@@ -129,7 +130,7 @@ func (d *replicaDecoder) retrieveLocalProposals() (anyLocal bool) {
 		// this slice until we saw a local proposal under a populated
 		// b.r.mu.proposalQuota. We can bring it back.
 		if d.r.mu.proposalQuota != nil {
-			d.r.mu.quotaReleaseQueue = append(d.r.mu.quotaReleaseQueue, alloc)
+			d.r.mu.proposalQuotaAndDelayTracker.enqueueAlloc(alloc, timeutil.Now())
 		}
 	}
 	return anyLocal

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -174,6 +174,12 @@ func (sm *replicaStateMachine) ApplySideEffects(
 	sm.r.prepareLocalResult(ctx, cmd)
 	if log.ExpensiveLogEnabled(ctx, 2) {
 		log.VEventf(ctx, 2, "%v", cmd.localResult.String())
+		sm.r.mu.Lock()
+		storeID, delay := sm.r.mu.proposalQuotaAndDelayTracker.lastStoreToProgress(cmd.Index())
+		sm.r.mu.Unlock()
+		if storeID != 0 {
+			log.VEventf(ctx, 2, "last store %v with delay %v", storeID, delay)
+		}
 	}
 
 	// Handle the ReplicatedEvalResult, executing any side effects of the last

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -100,12 +100,9 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 			// After the proposal quota is enabled all entries applied by this replica
 			// will be appended to the quotaReleaseQueue. The proposalQuotaBaseIndex
 			// and the quotaReleaseQueue together track status.Applied exactly.
-			r.mu.proposalQuotaBaseIndex = kvpb.RaftIndex(status.Applied)
+			r.mu.proposalQuotaAndDelayTracker.init(ctx, kvpb.RaftIndex(status.Applied))
 			if r.mu.proposalQuota != nil {
 				log.Fatal(ctx, "proposalQuota was not nil before becoming the leader")
-			}
-			if releaseQueueLen := len(r.mu.quotaReleaseQueue); releaseQueueLen != 0 {
-				log.Fatalf(ctx, "len(r.mu.quotaReleaseQueue) = %d, expected 0", releaseQueueLen)
 			}
 
 			// Raft may propose commands itself (specifically the empty
@@ -127,8 +124,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 			// We unblock all ongoing and subsequent quota acquisition goroutines
 			// (if any) and release the quotaReleaseQueue so its allocs are pooled.
 			r.mu.proposalQuota.Close("leader change")
-			r.mu.proposalQuota.Release(r.mu.quotaReleaseQueue...)
-			r.mu.quotaReleaseQueue = nil
+			r.mu.proposalQuota.Release(r.mu.proposalQuotaAndDelayTracker.drain()...)
 			r.mu.proposalQuota = nil
 			r.mu.lastUpdateTimes = nil
 			r.mu.replicaFlowControlIntegration.onBecameFollower(ctx)
@@ -149,17 +145,19 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	// commitIndex is used to determine whether a newly added replica has fully
 	// caught up.
 	commitIndex := kvpb.RaftIndex(status.Commit)
-	// Initialize minIndex to the currently applied index. The below progress
-	// checks will only decrease the minIndex. Given that the quotaReleaseQueue
-	// cannot correspond to values beyond the applied index there's no reason
-	// to consider progress beyond it as meaningful.
-	minIndex := kvpb.RaftIndex(status.Applied)
+	appliedIndex := kvpb.RaftIndex(status.Applied)
 
+	r.mu.proposalQuotaAndDelayTracker.prepareForReplicaIteration(
+		appliedIndex, now, r.mu.proposalQuota.Len() > 0)
 	r.mu.internalRaftGroup.WithProgress(func(id uint64, _ raft.ProgressType, progress tracker.Progress) {
 		rep, ok := r.mu.state.Desc.GetReplicaDescriptorByID(roachpb.ReplicaID(id))
 		if !ok {
 			return
 		}
+
+		// TODO(sumeer): should we add some observability for stores that are
+		// inactive, or behind the proposalQuotaBaseIndex, or paused, that are
+		// resulting in a range not having quorum.
 
 		// Only consider followers that are active. Inactive ones don't decrease
 		// minIndex - i.e. they don't hold up releasing quota.
@@ -211,7 +209,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 		// Only consider followers who are in advance of the quota base
 		// index. This prevents a follower from coming back online and
 		// preventing throughput to the range until it has caught up.
-		if kvpb.RaftIndex(progress.Match) < r.mu.proposalQuotaBaseIndex {
+		if kvpb.RaftIndex(progress.Match) < r.mu.proposalQuotaAndDelayTracker.getProposalQuotaBaseIndex() {
 			return
 		}
 		if _, paused := r.mu.pausedFollowers[roachpb.ReplicaID(id)]; paused {
@@ -222,9 +220,8 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 			// See #79215.
 			return
 		}
-		if progress.Match > 0 && kvpb.RaftIndex(progress.Match) < minIndex {
-			minIndex = kvpb.RaftIndex(progress.Match)
-		}
+		r.mu.proposalQuotaAndDelayTracker.updateReplicaAtStore(
+			rep.StoreID, kvpb.RaftIndex(progress.Match))
 		// If this is the most recently added replica, and it has caught up, clear
 		// our state that was tracking it. This is unrelated to managing proposal
 		// quota, but this is a convenient place to do so.
@@ -234,31 +231,13 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 		}
 	})
 
-	if r.mu.proposalQuotaBaseIndex < minIndex {
-		// We've persisted at least minIndex-r.mu.proposalQuotaBaseIndex entries
-		// to the raft log on all 'active' replicas and applied at least minIndex
-		// entries locally since last we checked, so we are able to release the
-		// difference back to the quota pool.
-		numReleases := minIndex - r.mu.proposalQuotaBaseIndex
-
+	toRelease := r.mu.proposalQuotaAndDelayTracker.finishReplicaIteration(ctx)
+	if len(toRelease) > 0 {
 		// NB: Release deals with cases where allocs being released do not originate
 		// from this incarnation of quotaReleaseQueue, which can happen if a
 		// proposal acquires quota while this replica is the raft leader in some
 		// term and then commits while at a different term.
-		r.mu.proposalQuota.Release(r.mu.quotaReleaseQueue[:numReleases]...)
-		r.mu.quotaReleaseQueue = r.mu.quotaReleaseQueue[numReleases:]
-		r.mu.proposalQuotaBaseIndex += numReleases
-	}
-	// Assert the sanity of the base index and the queue. Queue entries should
-	// correspond to applied entries. It should not be possible for the base
-	// index and the not yet released applied entries to not equal the applied
-	// index.
-	releasableIndex := r.mu.proposalQuotaBaseIndex + kvpb.RaftIndex(len(r.mu.quotaReleaseQueue))
-	if releasableIndex != kvpb.RaftIndex(status.Applied) {
-		log.Fatalf(ctx, "proposalQuotaBaseIndex (%d) + quotaReleaseQueueLen (%d) = %d"+
-			" must equal the applied index (%d)",
-			r.mu.proposalQuotaBaseIndex, len(r.mu.quotaReleaseQueue), releasableIndex,
-			status.Applied)
+		r.mu.proposalQuota.Release(toRelease...)
 	}
 
 	// Tick the replicaFlowControlIntegration interface. This is as convenient a
@@ -266,4 +245,436 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	// flow control integration layer considers raft progress state for
 	// individual replicas, and whether they've been recently active.
 	r.mu.replicaFlowControlIntegration.onRaftTicked(ctx)
+}
+
+// TODO(sumeer): this is completely untested. Add tests after initial
+// review/sanity check.
+
+// proposalQuotaAndDelayTracker tracks the (a) pending quota to be returned to
+// the quota pool, and (b) various delay stats per replica, at the leader. (b)
+// is done in a best-effort manner. The stats include:
+//   - delay incurred per-entry in reaching quorum and the replica/store
+//     responsible
+//   - per-store mean delay in persisting raft log entries
+//   - duration of quota pool exhaustion caused by a store
+//   - quota consumed due to a store
+//
+// We put this functionality in one place since doing all this tracking
+// requires maintaining some state per raft log entry (and GC'ing that entry
+// state when the quota is released, since by then no one cares about that
+// entry), and state per store.
+type proposalQuotaAndDelayTracker struct {
+	// The base index is the index up to (including) which quota was already
+	// released. That is, the first element in quotaReleaseQueue below is
+	// released as the base index moves up by one, etc.
+	proposalQuotaBaseIndex kvpb.RaftIndex
+	// Once the leader observes a proposal come 'out of Raft', we add the size
+	// of the associated command to a queue of quotas we have yet to release
+	// back to the quota pool. At that point ownership of the quota is
+	// transferred from Replica.mu.proposals to this queue.
+	//
+	// We'll release the respective quota once all replicas have persisted the
+	// corresponding entry into their logs (or once we give up waiting on some
+	// replica because it looks like it's dead).
+	//
+	// The tail of the quotaReleaseQueue is entries for which we have not yet
+	// been given ownership of the quota, since that happens for entries that
+	// have been applied. The tail consists of entries that are being locally
+	// appended to the raft log.
+	quotaReleaseQueue []queueEntry
+	// numQuotaEntries tracks the prefix of quotaReleaseQueue for which we have
+	// been handed ownership of the quota.
+	numQuotaEntries int
+	// iterState is used for replica iteration.
+	iterState struct {
+		iterStartTimeNanos int64
+		appliedIndex       kvpb.RaftIndex
+		toReleaseScratch   []*quotapool.IntAlloc
+	}
+	// quotaConsumed is the sum of the bytes in quotaReleaseQueue[:numQuotaEntries].
+	quotaConsumed int64
+	// quotaUnavailableStart is the start time of when quota was unavailable. An
+	// empty time represents quota is available.
+	quotaUnavailableStart time.Time
+	// storeState tracks state for each active replica. We key by StoreID since
+	// there is at most one replica per StoreID.
+	storeState map[roachpb.StoreID]*perStoreTrackerState
+}
+
+type queueEntry struct {
+	// alloc is nil if there was no quota allocated, or we have not yet been
+	// given ownership of the quota.
+	alloc *quotapool.IntAlloc
+	// queuedUnixNanos represents the time when the entry was added to the local
+	// raft log. We count delay from this time.
+	queuedUnixNanos int64
+	// latestProgressMatchIndex is updated whenever etcd/raft's
+	// tracker.Progress.Match for a replica advances up to the entry,
+	// representing that the replica has been sent the entry.
+	// tracker.Progress.Match does not imply that the replica has persisted the
+	// entry, but Raft flow control limits the entries en route to a replica to
+	// a small amount. We assume here that whenever a replica's
+	// tracker.Progress.Match advances up to this entry, it will soon be
+	// persisted (this may not be a good assumption for slowness outliers, but
+	// reasonable for chronic slowness). We track only the latest replica to
+	// advance up to this index since that is potentially the slow one, if
+	// quorum is delayed. This value is updated only until the entry is applied
+	// to the local state machine, since (a) we know that quorum has been
+	// achieved at that point, (b) it is used only for computing the return
+	// value in lastStoreToProgress(), which is called after local application
+	// for tracing.
+	//
+	// TODO(sumeer): is there a signal of what has been persisted in a replica,
+	// instead of using tracker.Progress.Match.
+	latestProgressMatchIndex struct {
+		storeID   roachpb.StoreID
+		unixNanos int64
+	}
+}
+
+// perStoreTrackerState is the state maintained per replica (actually per
+// store, since there can't be multiple replicas at a store).
+type perStoreTrackerState struct {
+	// iterTimeNanos is the iteration time when this replica was last considered
+	// active. It is used to GC replica entries.
+	iterTimeNanos int64
+	// notProgressedIndex is the latest value of etcd/raft's
+	// tracker.Progress.Match observed for this replica plus one. This is
+	// upper-bounded by proposalQuotaBaseIndex + len(quotaReleaseQueue).
+	// Unlike quotaConsumedStartIndex, notProgressedIndex is not monotonic,
+	// since it can decrease due to failures.
+	notProgressedIndex kvpb.RaftIndex
+	// quotaConsumedStartIndex is the first raft entry index whose quota counts
+	// towards this store. This is upper-bounded by proposalQuotaBaseIndex +
+	// numQuotaEntries. Monotonically non-decreasing.
+	quotaConsumedStartIndex kvpb.RaftIndex
+	perStoreStats
+}
+
+// perStoreStats is the stats in perStoreTrackerState.
+type perStoreStats struct {
+	// quotaConsumed is the quota consumed (a gauge) that can be attributed to
+	// this replica. It is always <= proposalQuotaAndDelayTracker.quotaConsumed.
+	// This is used for two purposes: (a) when the quotapool is full whether
+	// this store is one of those responsible, (b) to aggregate the quota
+	// consumed by this store across all ranges.
+	quotaConsumed int64
+	// quotaUnavailableDuration is the duration that quota was unavailable due
+	// to this replica.
+	quotaUnavailableDuration time.Duration
+	// progressMatchDuration and progressMatchCount can be used to compute the
+	// mean duration before tracker.Progress.Match advanced past each entry in
+	// the raft log. This is not useful for outliers. Outliers are currently
+	// handled via queueEntry.latestProgressMatchIndex and tracing. If that is
+	// insufficient, we could change this to a histogram.
+	progressMatchDuration time.Duration
+	progressMatchCount    int64
+}
+
+func (ss *perStoreStats) merge(other perStoreStats) {
+	ss.quotaConsumed += other.quotaConsumed
+	ss.quotaUnavailableDuration += other.quotaUnavailableDuration
+	ss.progressMatchDuration += other.progressMatchDuration
+	ss.progressMatchCount += other.progressMatchCount
+}
+
+// init the tracker, when the local replica becomes the leader.
+func (pq *proposalQuotaAndDelayTracker) init(
+	ctx context.Context, proposalQuotaBaseIndex kvpb.RaftIndex,
+) {
+	if queueLen := len(pq.quotaReleaseQueue); queueLen != 0 || pq.numQuotaEntries != 0 {
+		log.Fatalf(ctx, "len(quotaReleaseQueue) = %d, expected 0", queueLen)
+	}
+	*pq = proposalQuotaAndDelayTracker{}
+	pq.proposalQuotaBaseIndex = proposalQuotaBaseIndex
+	pq.storeState = map[roachpb.StoreID]*perStoreTrackerState{}
+}
+
+// drain the tracker, when the local replica becomes a follower.
+func (pq *proposalQuotaAndDelayTracker) drain() []*quotapool.IntAlloc {
+	toRelease := pq.releaseQuotaEntries(kvpb.RaftIndex(pq.numQuotaEntries))
+	*pq = proposalQuotaAndDelayTracker{}
+	return toRelease
+}
+
+// Internal helper.
+func (pq *proposalQuotaAndDelayTracker) isActive() bool {
+	return pq.storeState != nil
+}
+
+func (pq *proposalQuotaAndDelayTracker) getProposalQuotaBaseIndex() kvpb.RaftIndex {
+	return pq.proposalQuotaBaseIndex
+}
+
+func (pq *proposalQuotaAndDelayTracker) getQuotaReleaseQueueLen() int {
+	return pq.numQuotaEntries
+}
+
+// iterateQuotaQueue is for reading the entries that have quota.
+func (pq *proposalQuotaAndDelayTracker) iterateQuotaQueue(f func(alloc *quotapool.IntAlloc)) {
+	for i := 0; i < pq.numQuotaEntries; i++ {
+		f(pq.quotaReleaseQueue[i].alloc)
+	}
+}
+
+// raftAppend is called when [minIndex, maxIndex] are being appended to the
+// local raft log. The callee will start tracking the delay from the latest
+// time an index is mentioned in raftAppend -- this is because previous
+// appends may be overwritten if quorum was never achieved.
+func (pq *proposalQuotaAndDelayTracker) raftAppend(
+	minIndex, maxIndex kvpb.RaftIndex, now time.Time,
+) {
+	if !pq.isActive() {
+		return
+	}
+	desiredQueueLen := int(maxIndex - pq.proposalQuotaBaseIndex)
+	queueLen := len(pq.quotaReleaseQueue)
+	if queueLen > desiredQueueLen {
+		truncatedLen := desiredQueueLen
+		if truncatedLen < pq.numQuotaEntries {
+			panic("entry already applied")
+		}
+		notProgressIndexUpperBound := kvpb.RaftIndex(truncatedLen) + pq.proposalQuotaBaseIndex + 1
+		pq.quotaReleaseQueue = pq.quotaReleaseQueue[:truncatedLen]
+		for _, ss := range pq.storeState {
+			if ss.notProgressedIndex > notProgressIndexUpperBound {
+				ss.notProgressedIndex = notProgressIndexUpperBound
+			}
+		}
+	} else if cap(pq.quotaReleaseQueue) < desiredQueueLen {
+		qrq := make([]queueEntry, desiredQueueLen, 2*desiredQueueLen)
+		copy(qrq, pq.quotaReleaseQueue)
+		pq.quotaReleaseQueue = qrq
+	} else {
+		pq.quotaReleaseQueue = pq.quotaReleaseQueue[:desiredQueueLen]
+	}
+	startIndex := int(minIndex - pq.proposalQuotaBaseIndex - 1)
+	nowInNanos := now.UnixNano()
+	for i := startIndex; i < desiredQueueLen; i++ {
+		if pq.quotaReleaseQueue[i].alloc != nil {
+			// This should not happen, since this entry has already been applied.
+			// Should we ignore, given this is best-effort bookkeeping?
+			panic("entry already applied")
+		}
+		pq.quotaReleaseQueue[i] = queueEntry{
+			queuedUnixNanos: nowInNanos,
+		}
+	}
+}
+
+// enqueueAlloc is called to enqueue an alloc for an entry whose quota is
+// being transferred to this tracker.
+// REQUIRES: isActive()
+func (pq *proposalQuotaAndDelayTracker) enqueueAlloc(alloc *quotapool.IntAlloc, now time.Time) {
+	if len(pq.quotaReleaseQueue) > pq.numQuotaEntries {
+		pq.quotaReleaseQueue[pq.numQuotaEntries].alloc = alloc
+	} else {
+		pq.quotaReleaseQueue = append(pq.quotaReleaseQueue, queueEntry{
+			alloc:           alloc,
+			queuedUnixNanos: now.UnixNano(),
+		})
+	}
+	pq.numQuotaEntries++
+	entryIndex := pq.proposalQuotaBaseIndex + kvpb.RaftIndex(pq.numQuotaEntries)
+	if alloc != nil {
+		acquired := int64(alloc.Acquired())
+		pq.quotaConsumed += acquired
+		for _, ss := range pq.storeState {
+			if entryIndex < ss.quotaConsumedStartIndex {
+				panic("quotaConsumedStartIndex upper bound was violated")
+			}
+			ss.quotaConsumed += acquired
+		}
+	}
+}
+
+// prepareForReplicaIteration prepares the tracker for iteration over the
+// replicas. An iteration causes quota release and updating of various stats.
+func (pq *proposalQuotaAndDelayTracker) prepareForReplicaIteration(
+	appliedIndex kvpb.RaftIndex, now time.Time, isQueueEmpty bool,
+) {
+	pq.iterState.iterStartTimeNanos = now.UnixNano()
+	pq.iterState.appliedIndex = appliedIndex
+	if !isQueueEmpty {
+		if pq.quotaUnavailableStart.IsZero() {
+			pq.quotaUnavailableStart = now
+		} else {
+			// Quota was already unavailable, so extend the unavailable duration.
+
+			// 0.9 is somewhat arbitrary. We want to capture replicas that are close
+			// to quota exhaustion.
+			fullThreshold := int64(0.9 * float64(pq.quotaConsumed))
+			duration := now.Sub(pq.quotaUnavailableStart)
+			pq.quotaUnavailableStart = now
+			for _, ss := range pq.storeState {
+				if ss.quotaConsumed > fullThreshold {
+					ss.quotaUnavailableDuration += duration
+				}
+			}
+		}
+	} else if !pq.quotaUnavailableStart.IsZero() {
+		pq.quotaUnavailableStart = time.Time{}
+	}
+}
+
+// updateReplicaAtStore is called for each replica that is considered active,
+// during iteration over the replicas.
+//
+// REQUIRES: progressMatchIndex >= pq.proposalQuotaBaseIndex.
+func (pq *proposalQuotaAndDelayTracker) updateReplicaAtStore(
+	storeID roachpb.StoreID, progressMatchIndex kvpb.RaftIndex,
+) {
+	notProgressIndex := progressMatchIndex + 1
+	upperBoundNotProgressIndex :=
+		pq.proposalQuotaBaseIndex + 1 + kvpb.RaftIndex(len(pq.quotaReleaseQueue))
+	if upperBoundNotProgressIndex > notProgressIndex {
+		notProgressIndex = upperBoundNotProgressIndex
+	}
+	quotaConsumedStartIndex := notProgressIndex
+	upperBoundQuotaConsumedStartIndex :=
+		pq.proposalQuotaBaseIndex + 1 + kvpb.RaftIndex(pq.numQuotaEntries)
+	if upperBoundQuotaConsumedStartIndex > quotaConsumedStartIndex {
+		quotaConsumedStartIndex = upperBoundQuotaConsumedStartIndex
+	}
+	ss := pq.storeState[storeID]
+	if ss == nil {
+		// New active replica.
+		ss = &perStoreTrackerState{
+			iterTimeNanos:           pq.iterState.iterStartTimeNanos,
+			notProgressedIndex:      notProgressIndex,
+			quotaConsumedStartIndex: quotaConsumedStartIndex,
+			perStoreStats: perStoreStats{
+				quotaConsumed: pq.quotaConsumed,
+			},
+		}
+		for i := 0; kvpb.RaftIndex(i)+pq.proposalQuotaBaseIndex+1 < ss.quotaConsumedStartIndex; i++ {
+			if pq.quotaReleaseQueue[i].alloc != nil {
+				ss.quotaConsumed -= int64(pq.quotaReleaseQueue[i].alloc.Acquired())
+			}
+		}
+		pq.storeState[storeID] = ss
+		// We don't fiddle with progressMatchDuration, progressMatchCount, or for
+		// the queue entries the queueEntry.lastProgressMatchIndex since those are
+		// updated when notProgressedIndex advances, and here we have initialized
+		// notProgressedIndex.
+		return
+	}
+	// Common case. Existing active replica.
+	ss.iterTimeNanos = pq.iterState.iterStartTimeNanos
+	prevNotProgressedIndex := ss.notProgressedIndex
+	ss.notProgressedIndex = notProgressIndex
+	for i := prevNotProgressedIndex; i < notProgressIndex; i++ {
+		j := i - pq.proposalQuotaBaseIndex - 1
+		ss.progressMatchDuration += time.Duration(
+			pq.iterState.iterStartTimeNanos - pq.quotaReleaseQueue[j].queuedUnixNanos)
+		ss.progressMatchCount++
+		pq.quotaReleaseQueue[j].latestProgressMatchIndex.storeID = storeID
+		pq.quotaReleaseQueue[j].latestProgressMatchIndex.unixNanos = pq.iterState.iterStartTimeNanos
+	}
+	prevQuotaConsumedStartIndex := ss.quotaConsumedStartIndex
+	ss.quotaConsumedStartIndex = quotaConsumedStartIndex
+	for i := prevQuotaConsumedStartIndex; i < quotaConsumedStartIndex; i++ {
+		j := i - pq.proposalQuotaBaseIndex - 1
+		entry := pq.quotaReleaseQueue[j]
+		if entry.alloc != nil {
+			ss.quotaConsumed -= int64(entry.alloc.Acquired())
+		}
+	}
+}
+
+// finishReplicaIteration is called at the end of replica iteration. Returns
+// the allocs to release to the quotapool.
+func (pq *proposalQuotaAndDelayTracker) finishReplicaIteration(
+	ctx context.Context,
+) []*quotapool.IntAlloc {
+	// Initialize toReleaseIndex to the currently applied index. The below
+	// progress checks will only decrease the toReleaseIndex. Given that the
+	// quotaReleaseQueue cannot have allocs beyond the applied index there's no
+	// reason to consider progress beyond it as meaningful.
+	toReleaseIndex := pq.iterState.appliedIndex
+	for s, ss := range pq.storeState {
+		if ss.iterTimeNanos != pq.iterState.iterStartTimeNanos {
+			// Remove ones that were not iterated over.
+			delete(pq.storeState, s)
+		} else if ss.notProgressedIndex <= toReleaseIndex {
+			toReleaseIndex = ss.notProgressedIndex - 1
+		}
+	}
+	if pq.proposalQuotaBaseIndex < toReleaseIndex {
+		// We've persisted at least toReleaseIndex-pq.proposalQuotaBaseIndex
+		// entries to the raft log on all 'active' replicas and applied these
+		// entries locally, so we are able to release these back to the quota
+		// pool.
+		numReleases := toReleaseIndex - pq.proposalQuotaBaseIndex
+		return pq.releaseQuotaEntries(numReleases)
+	}
+	// Assert the sanity of the base index and the queue. Queue entries should
+	// correspond to applied entries. It should not be possible for the base
+	// index and the not yet released applied entries to not equal the applied
+	// index.
+	releasableIndex := pq.proposalQuotaBaseIndex + kvpb.RaftIndex(pq.numQuotaEntries)
+	if releasableIndex != pq.iterState.appliedIndex {
+		log.Fatalf(ctx, "proposalQuotaBaseIndex (%d) + quotaReleaseQueueLen (%d) = %d"+
+			" must equal the applied index (%d)",
+			pq.proposalQuotaBaseIndex, len(pq.quotaReleaseQueue), releasableIndex,
+			pq.iterState.appliedIndex)
+	}
+	return nil
+}
+
+// Internal helper.
+func (pq *proposalQuotaAndDelayTracker) releaseQuotaEntries(
+	numReleases kvpb.RaftIndex,
+) []*quotapool.IntAlloc {
+	pq.iterState.toReleaseScratch = pq.iterState.toReleaseScratch[:0]
+	for i := kvpb.RaftIndex(0); i < numReleases; i++ {
+		pq.iterState.toReleaseScratch = append(
+			pq.iterState.toReleaseScratch, pq.quotaReleaseQueue[i].alloc)
+	}
+	pq.quotaReleaseQueue = pq.quotaReleaseQueue[numReleases:]
+	pq.proposalQuotaBaseIndex += numReleases
+	pq.numQuotaEntries -= int(numReleases)
+	return pq.iterState.toReleaseScratch
+}
+
+// lastStoreToProgress is called to retrieve information about the last store
+// that progressed past a raft entry. It is used in per-request tracing. It is
+// best-effort, and StoreID == 0 means no data.
+func (pq *proposalQuotaAndDelayTracker) lastStoreToProgress(
+	raftIndex kvpb.RaftIndex,
+) (storeID roachpb.StoreID, delay time.Duration) {
+	if raftIndex <= pq.proposalQuotaBaseIndex ||
+		raftIndex > pq.proposalQuotaBaseIndex+kvpb.RaftIndex(len(pq.quotaReleaseQueue)) {
+		return 0, 0
+	}
+	entry := pq.quotaReleaseQueue[raftIndex-pq.proposalQuotaBaseIndex-1]
+	duration := entry.latestProgressMatchIndex.unixNanos - entry.queuedUnixNanos
+	if duration < 0 {
+		duration = 0
+	}
+	return entry.latestProgressMatchIndex.storeID, time.Duration(duration)
+}
+
+type storeQueueAndDelayStats struct {
+	roachpb.StoreID
+	numReplicas int
+	perStoreStats
+}
+
+// getAndResetStoreStats should be called periodically, to retrieve gauges and
+// delta stats. The deltas tracked in the tracker will be reset to 0.
+func (pq *proposalQuotaAndDelayTracker) getAndResetStoreStats(
+	scratch []storeQueueAndDelayStats,
+) []storeQueueAndDelayStats {
+	scratch = scratch[:0]
+	for s, ss := range pq.storeState {
+		scratch = append(scratch, storeQueueAndDelayStats{
+			StoreID:       s,
+			numReplicas:   1,
+			perStoreStats: ss.perStoreStats,
+		})
+		qc := ss.perStoreStats.quotaConsumed
+		ss.perStoreStats = perStoreStats{quotaConsumed: qc}
+	}
+	return scratch
 }

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -897,6 +897,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		}
 	}
 
+	var appendMinIndex, appendMaxIndex kvpb.RaftIndex
 	if hasMsg(msgStorageAppend) {
 		if msgStorageAppend.Snapshot != nil {
 			if inSnap.Desc == nil {
@@ -1017,6 +1018,10 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 				}
 			}
 
+			if n := len(m.Entries); n > 0 {
+				appendMinIndex = kvpb.RaftIndex(m.Entries[0].Index)
+				appendMaxIndex = kvpb.RaftIndex(m.Entries[n-1].Index)
+			}
 			if state, err = s.StoreEntries(ctx, state, m, cb, &stats.append); err != nil {
 				return stats, errors.Wrap(err, "while storing log entries")
 			}
@@ -1026,6 +1031,9 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// Update protected state - last index, last term, raft log size, and raft
 	// leader ID.
 	r.mu.Lock()
+	if appendMaxIndex > 0 {
+		r.mu.proposalQuotaAndDelayTracker.raftAppend(appendMinIndex, appendMaxIndex, stats.tBegin)
+	}
 	// TODO(pavelkalinnikov): put logstore.RaftState to r.mu directly.
 	r.mu.lastIndexNotDurable = state.LastIndex
 	r.mu.lastTermNotDurable = state.LastTerm

--- a/pkg/kv/kvserver/replica_raft_overload.go
+++ b/pkg/kv/kvserver/replica_raft_overload.go
@@ -350,7 +350,7 @@ func (r *Replica) updatePausedFollowersLocked(ctx context.Context, ioThresholdMa
 			})
 			return prs
 		},
-		minLiveMatchIndex: r.mu.proposalQuotaBaseIndex,
+		minLiveMatchIndex: r.mu.proposalQuotaAndDelayTracker.getProposalQuotaBaseIndex(),
 		seed:              seed,
 	}
 	r.mu.pausedFollowers, _ = computeExpendableOverloadedFollowers(ctx, d)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -97,6 +97,7 @@ import (
 	"github.com/cockroachdb/redact"
 	prometheusgo "github.com/prometheus/client_model/go"
 	"go.etcd.io/raft/v3"
+	"golang.org/x/exp/slices"
 	"golang.org/x/time/rate"
 )
 
@@ -3402,6 +3403,7 @@ func (s *Store) ComputeMetricsPeriodically(
 		e.StoreId = int32(s.StoreID())
 		log.StructuredEvent(ctx, &e)
 	}
+	s.computeAndLogReplicationStatsPeriodically(ctx)
 	return m, nil
 }
 
@@ -3411,6 +3413,50 @@ func (s *Store) ComputeMetricsPeriodically(
 func (s *Store) ComputeMetrics(ctx context.Context) error {
 	_, err := s.computeMetrics(ctx)
 	return err
+}
+
+func (s *Store) computeAndLogReplicationStatsPeriodically(ctx context.Context) {
+	var stats []storeQueueAndDelayStats
+	statsPerStore := map[roachpb.StoreID]*storeQueueAndDelayStats{}
+	newStoreReplicaVisitor(s).Visit(func(rep *Replica) bool {
+		rep.mu.Lock()
+		stats = rep.mu.proposalQuotaAndDelayTracker.getAndResetStoreStats(stats)
+		rep.mu.Unlock()
+		for i := range stats {
+			ss := statsPerStore[stats[i].StoreID]
+			if ss == nil {
+				ss = &storeQueueAndDelayStats{StoreID: stats[i].StoreID}
+				statsPerStore[stats[i].StoreID] = ss
+			}
+			ss.merge(stats[i].perStoreStats)
+			ss.numReplicas += stats[i].numReplicas
+		}
+		return true
+	})
+	storesAndStats := make([]*storeQueueAndDelayStats, 0, len(statsPerStore))
+	for _, ss := range statsPerStore {
+		storesAndStats = append(storesAndStats, ss)
+	}
+	// Top-5 quotapool full durations.
+	slices.SortFunc(storesAndStats, func(a, b *storeQueueAndDelayStats) bool {
+		return a.quotaUnavailableDuration > b.quotaUnavailableDuration
+	})
+	var buf strings.Builder
+	for i := 0; i < len(storesAndStats) && i < 5; i++ {
+		ss := storesAndStats[i]
+		if ss.quotaUnavailableDuration == 0 {
+			break
+		}
+		if buf.Len() == 0 {
+			fmt.Fprintf(&buf, "quotapool full durations caused by stores:")
+		}
+		fmt.Fprintf(&buf, " (%v dur: %v)", ss.StoreID, ss.quotaUnavailableDuration)
+	}
+	if buf.Len() != 0 {
+		log.Infof(ctx, "%s", redact.SafeString(buf.String()))
+	}
+	// TODO(sumeer): top-5: progressMatchDuration/progressMatchCount,
+	// quotaConsumed/numReplicas.
 }
 
 // ClusterNodeCount returns this store's view of the number of nodes in the


### PR DESCRIPTION
proposalQuotaAndDelayTracker is introduced to track stats on a per range basis at the leader. These stats include:
- Delay incurred per raft entry in reaching quorum and the replica/store responsible for the largest delay. This is used in tracing.
- Per replica/store mean delay in persisting raft log entries. This can be easily replaced with a histogram if desired.
- Per replica/store proposal quota consumed.
- Per replica/store duration where it was responsible for proposal quota exhaustion.

These stats are aggregated across all ranges on a local store, for which the local store is a leader, per store that is replicated to (including the local store). The top-k replicated-to stores responsible for some undesired behavior are periodically logged.

The overall objective here is to give more visibility into where the slowness is in the replication path, since the slowness may not be at the store evaluating the proposal. And to provide such visibility both for individual requests (via tracing) and aggregated across stores. The aggregations could help quickly pinpoint slow stores or slow paths to stores, which may otherwise be harder to figure out in large clusters.

Epic: none

Release note: None