### PR TITLE
dev: add a shorthand for sql-bootstrap-data

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -107,6 +107,7 @@ var buildTargetMapping = map[string]string{
 	"smith":                "//pkg/cmd/smith:smith",
 	"smithcmp":             "//pkg/cmd/smithcmp:smithcmp",
 	"smithtest":            "//pkg/cmd/smithtest:smithtest",
+	"sql-bootstrap-data":   "//pkg/cmd/sql-bootstrap-data:sql-bootstrap-data",
 	"staticcheck":          "@co_honnef_go_tools//cmd/staticcheck:staticcheck",
 	"swagger":              "@com_github_go_swagger_go_swagger//cmd/swagger:swagger",
 	"tests":                "//pkg:all_tests",

--- a/pkg/cmd/sql-bootstrap-data/main.go
+++ b/pkg/cmd/sql-bootstrap-data/main.go
@@ -26,8 +26,8 @@ import (
 // (but still supported) versions.
 //
 // To run:
-//   bazel build //pkg/cmd/sql-bootstrap-data:sql-bootstrap-data
-//   _bazel/bin/pkg/cmd/sql-bootstrap-data/sql-bootstrap-data_/sql-bootstrap-data
+//   ./dev build sql-bootstrap-data
+//   ./bin/sql-bootstrap-data
 
 func main() {
 	version := clusterversion.Latest.ReleaseSeries()
@@ -36,7 +36,8 @@ func main() {
 	// tenant); the tenant-specific prefix is stripped out of the keys.
 	tenantKeys, tenantHash := bootstrap.GetAndHashInitialValuesToString(12345)
 
-	fmt.Printf("\n// Add the following declarations at the end of initial_values.go:\n")
+	fmt.Printf("\n// Commit the generated files and " +
+		" add the following declarations to the end of initial_values.go:\n")
 	writeDataFile(version, "system.keys", systemKeys)
 	writeDataFile(version, "system.sha256", systemHash)
 	writeDataFile(version, "tenant.keys", tenantKeys)

--- a/pkg/sql/catalog/bootstrap/initial_values.go
+++ b/pkg/sql/catalog/bootstrap/initial_values.go
@@ -135,6 +135,9 @@ func (f hardCodedInitialValues) build(
 // The following variables hold hardcoded bootstrap data for older versions (as
 // produced by the final release version). For each version, we have system and
 // non-system keys, and each set of keys has an associated SHA-256.
+//
+// These files can be auto-generated for the latest version with the
+// sql-bootstrap-data CLI tool (see pkg/cmd/sql-bootstrap-data).
 
 //go:embed data/23_1_system.keys
 var v23_1_system_keys string


### PR DESCRIPTION
This patch adds a `dev` shorthand for the `sql-bootstrap-data` CLI tool.

Informs: #112629

Release note: None