### PR TITLE
roachtest: fix secondary-index-multi-version test

### DIFF
--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -67,7 +67,7 @@ INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12);
 			node, db := h.RandomDB(r, h.Context().ToVersionNodes)
 			l.Printf("connecting to n%d", node)
 
-			if _, err := db.Exec(`DELETE FROM t WHERE x = 13`); err != nil {
+			if _, err := db.Exec(`DELETE FROM t WHERE x = 13 OR x = 20`); err != nil {
 				return err
 			}
 			if _, err := db.Exec(`INSERT INTO t VALUES (13, 14, 15, 16)`); err != nil {


### PR DESCRIPTION
In the new framework, a cluster can get upgraded multiple times across different versions. Therefore we need to clean up the rows that are added after finalization, before adding new rows in the mixed version state.

fixes https://github.com/cockroachdb/cockroach/issues/114128
fixes https://github.com/cockroachdb/cockroach/issues/114127

Release note: None