### PR TITLE
roachprod: kill() creates log directory if it doesn't exist

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -534,6 +534,7 @@ func (c *SyncedCluster) kill(
 		// awk process match its own output from `ps`.
 		cmd := fmt.Sprintf(`
 mkdir -p %[1]s
+mkdir -p %[2]s
 echo ">>> roachprod %[1]s: $(date)" >> %[2]s/roachprod.log
 ps axeww -o pid -o command >> %[2]s/roachprod.log
 pids=$(ps axeww -o pid -o command | \


### PR DESCRIPTION
Before, kill() would make too strong of a assumption that a logs directory always existed. This is not always true, and would sometimes cause c.Wipe() to fail and prevent cluster reuse.

Now, we create a logs directory if one doesn't exist.

Epic: none
Release note: none
Fixes: #110484