### PR TITLE
dbconsole: add KV admission slots exhaustion chart

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
@@ -110,27 +110,23 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="KV Admission Slots"
+      title="KV Admission Slots Exhausted"
       sources={nodeSources}
       tenantSource={tenantSource}
       showMetricsInTooltip={true}
     >
-      <Axis label="slots">
+      <Axis label="duration (micros/sec)">
         {nodeIDs.map(nid => (
-          <>
-            <Metric
-              key={nid}
-              name="cr.node.admission.granter.total_slots.kv"
-              title={"Total Slots " + nodeDisplayName(nodeDisplayNameByID, nid)}
-              sources={[nid]}
-            />
-            <Metric
-              key={nid}
-              name="cr.node.admission.granter.used_slots.kv"
-              title={"Used Slots " + nodeDisplayName(nodeDisplayNameByID, nid)}
-              sources={[nid]}
-            />
-          </>
+          <Metric
+            key={nid}
+            name="cr.node.admission.granter.slots_exhausted_duration.kv"
+            title={
+              "Admission Slots Exhausted " +
+              nodeDisplayName(nodeDisplayNameByID, nid)
+            }
+            sources={[nid]}
+            nonNegativeRate
+          />
         ))}
       </Axis>
     </LineGraph>,


### PR DESCRIPTION
This patch replaces the total slots and used slots with a graph of admission slot exhaustion duration. This is a better indicator of CPU resource exhaustion in AC.

Fixes: #113773.

Release note: None