### PR TITLE
clisqlclient: omit VC name from CLI prompt if only system VC is present

### DIFF
--- a/pkg/cli/clisqlclient/BUILD.bazel
+++ b/pkg/cli/clisqlclient/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/security/pprompt",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/scanner",
+        "//pkg/sql/sem/catconstants",
         "//pkg/util/version",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/cli/clisqlclient/api.go
+++ b/pkg/cli/clisqlclient/api.go
@@ -112,8 +112,8 @@ type ServerInfo struct {
 	ClusterID string
 	// Organization is the cluster organization of the remote server.
 	Organization string
-	// VirtualClusterName is the name of the virtual cluster the SQL
-	// client is connected to.
+	// VirtualClusterName is the name of the virtual cluster the SQL client is
+	// connected to. Empty if no application VCs have been defined.
 	VirtualClusterName string
 }
 

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -36,7 +36,9 @@ eexpect "http://127.0.0.1:8080"
 eexpect "(sql)"
 eexpect "root"
 eexpect ":26257/movr"
-eexpect "movr>"
+# Check that the system tenant's name is not printed in the prompt since we
+# don't have any application tenants.
+eexpect ":26257/movr>"
 send_eof
 eexpect eof
 end_test


### PR DESCRIPTION
Previously, we would always show the name of the virtual cluster that CLI is connected to in the prompt. However, this is quite confusing in case the cluster doesn't have any secondary VCs, so this commit omits the name from the prompt in that case.

Fixes: #113997.

Release note: None