### PR TITLE
kvstreamer: improve memory utilization when eager limit is reached

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -231,9 +231,14 @@ type Streamer struct {
 	// budget at which point the streamer stops sending non-head-of-the-line
 	// requests eagerly.
 	eagerMemUsageLimitBytes int64
-	budget                  *budget
-	lockStrength            lock.Strength
-	lockDurability          lock.Durability
+	// headOfLineOnlyFraction controls the fraction of the available streamer's
+	// memory budget that will be used to set the TargetBytes limit on
+	// head-of-the-line request in case the "eager" memory usage limit has been
+	// exceeded. In such case, only head-of-the-line request will be sent.
+	headOfLineOnlyFraction float64
+	budget                 *budget
+	lockStrength           lock.Strength
+	lockDurability         lock.Durability
 
 	streamerStatistics
 
@@ -387,13 +392,19 @@ func NewStreamer(
 	if txn.Type() != kv.LeafTxn {
 		panic(errors.AssertionFailedf("RootTxn is given to the Streamer"))
 	}
+	// sd can be nil in tests.
+	headOfLineOnlyFraction := 0.8
+	if sd != nil {
+		headOfLineOnlyFraction = sd.StreamerHeadOfLineOnlyFraction
+	}
 	s := &Streamer{
-		distSender:     distSender,
-		stopper:        stopper,
-		sd:             sd,
-		budget:         newBudget(acc, limitBytes),
-		lockStrength:   lockStrength,
-		lockDurability: lockDurability,
+		distSender:             distSender,
+		stopper:                stopper,
+		sd:                     sd,
+		headOfLineOnlyFraction: headOfLineOnlyFraction,
+		budget:                 newBudget(acc, limitBytes),
+		lockStrength:           lockStrength,
+		lockDurability:         lockDurability,
 	}
 
 	if kvPairsRead == nil {
@@ -1168,6 +1179,18 @@ func (w *workerCoordinator) issueRequestsForAsyncProcessing(
 		// significantly in size.
 		if targetBytes < singleRangeReqs.minTargetBytes {
 			targetBytes = singleRangeReqs.minTargetBytes
+		}
+		if headOfLine && w.s.budget.mu.acc.Used() > w.s.eagerMemUsageLimitBytes {
+			// Given that the eager memory usage limit has already been
+			// exceeded, we won't issue any more requests for now, so rather
+			// than use the estimate on the response size, this head-of-the-line
+			// batch will use most of the available budget, as controlled by the
+			// session variable.
+			if headOfLineOnly := int64(float64(availableBudget) * w.s.headOfLineOnlyFraction); headOfLineOnly > targetBytes {
+				targetBytes = headOfLineOnly
+				// Ensure that we won't issue any more requests for now.
+				budgetIsExhausted = true
+			}
 		}
 		if targetBytes+responsesOverhead > availableBudget {
 			// We don't have enough budget to account for both the TargetBytes

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3653,6 +3653,10 @@ func (m *sessionDataMutator) SetStreamerOutOfOrderEagerMemoryUsageFraction(val f
 	m.data.StreamerOutOfOrderEagerMemoryUsageFraction = val
 }
 
+func (m *sessionDataMutator) SetStreamerHeadOfLineOnlyFraction(val float64) {
+	m.data.StreamerHeadOfLineOnlyFraction = val
+}
+
 func (m *sessionDataMutator) SetMultipleActivePortalsEnabled(val bool) {
 	m.data.MultipleActivePortalsEnabled = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5597,6 +5597,7 @@ standard_conforming_strings                                on
 statement_timeout                                          0
 streamer_always_maintain_ordering                          off
 streamer_enabled                                           on
+streamer_head_of_line_only_fraction                        0.8
 streamer_in_order_eager_memory_usage_fraction              0.5
 streamer_out_of_order_eager_memory_usage_fraction          0.8
 strict_ddl_atomicity                                       off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2915,6 +2915,7 @@ standard_conforming_strings                                on                  N
 statement_timeout                                          0                   NULL      NULL        NULL        string
 streamer_always_maintain_ordering                          off                 NULL      NULL        NULL        string
 streamer_enabled                                           on                  NULL      NULL        NULL        string
+streamer_head_of_line_only_fraction                        0.8                 NULL      NULL        NULL        string
 streamer_in_order_eager_memory_usage_fraction              0.5                 NULL      NULL        NULL        string
 streamer_out_of_order_eager_memory_usage_fraction          0.8                 NULL      NULL        NULL        string
 strict_ddl_atomicity                                       off                 NULL      NULL        NULL        string
@@ -3083,6 +3084,7 @@ standard_conforming_strings                                on                  N
 statement_timeout                                          0                   NULL  user     NULL      0s                  0s
 streamer_always_maintain_ordering                          off                 NULL  user     NULL      off                 off
 streamer_enabled                                           on                  NULL  user     NULL      on                  on
+streamer_head_of_line_only_fraction                        0.8                 NULL  user     NULL      0.8                 0.8
 streamer_in_order_eager_memory_usage_fraction              0.5                 NULL  user     NULL      0.5                 0.5
 streamer_out_of_order_eager_memory_usage_fraction          0.8                 NULL  user     NULL      0.8                 0.8
 strict_ddl_atomicity                                       off                 NULL  user     NULL      off                 off
@@ -3251,6 +3253,7 @@ standard_conforming_strings                                NULL    NULL     NULL
 statement_timeout                                          NULL    NULL     NULL     NULL        NULL
 streamer_always_maintain_ordering                          NULL    NULL     NULL     NULL        NULL
 streamer_enabled                                           NULL    NULL     NULL     NULL        NULL
+streamer_head_of_line_only_fraction                        NULL    NULL     NULL     NULL        NULL
 streamer_in_order_eager_memory_usage_fraction              NULL    NULL     NULL     NULL        NULL
 streamer_out_of_order_eager_memory_usage_fraction          NULL    NULL     NULL     NULL        NULL
 strict_ddl_atomicity                                       NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -153,6 +153,7 @@ standard_conforming_strings                                on
 statement_timeout                                          0
 streamer_always_maintain_ordering                          off
 streamer_enabled                                           on
+streamer_head_of_line_only_fraction                        0.8
 streamer_in_order_eager_memory_usage_fraction              0.5
 streamer_out_of_order_eager_memory_usage_fraction          0.8
 strict_ddl_atomicity                                       off

--- a/pkg/sql/sessiondatapb/session_data.proto
+++ b/pkg/sql/sessiondatapb/session_data.proto
@@ -127,6 +127,11 @@ message SessionData {
   // streamer's memory budget that might be used for issuing requests eagerly,
   // in the OutOfOrder mode.
   double streamer_out_of_order_eager_memory_usage_fraction = 29;
+  // StreamerHeadOfLineOnlyFraction controls the fraction of the available
+  // streamer's memory budget that will be used to set the TargetBytes limit on
+  // head-of-the-line request in case the "eager" memory usage limit has been
+  // exceeded.
+  double streamer_head_of_line_only_fraction = 30;
 }
 
 // DataConversionConfig contains the parameters that influence the output

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2862,6 +2862,31 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`streamer_head_of_line_only_fraction`: {
+		GetStringVal: makeFloatGetStringValFn(`streamer_head_of_line_only_fraction`),
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatFloatAsPostgresSetting(evalCtx.SessionData().StreamerHeadOfLineOnlyFraction), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return "0.8"
+		},
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			f, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				return err
+			}
+			// Note that we permit fractions above 1.0 to allow for giving
+			// head-of-the-line batch more memory that is available - this will
+			// put the budget in debt.
+			if f < 0 {
+				return pgerror.New(pgcode.InvalidParameterValue, "streamer_head_of_line_only_fraction must be non-negative")
+			}
+			m.SetStreamerHeadOfLineOnlyFraction(f)
+			return nil
+		},
+	},
+
+	// CockroachDB extension.
 	`multiple_active_portals_enabled`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`multiple_active_portals_enabled`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {


### PR DESCRIPTION
We recently merged a change to limit how many batches the streamer can issue eagerly (namely, when 50% or 80% of memory - depending on the streamer mode - is used, we send only head-of-the-line batches). This addition was made to make sure that there is enough budget available for processing head-of-the-line batch so that we don't degrade to processing it one Get / Scan at a time.

However, we kept the estimating logic for TargetBytes parameter for that head-of-the-line batch the same. This seems suboptimal, so this commit extends the recent change to take advantage of the now-pre-reserved budget by using a fraction (0.8 by default) of the available budget as the TargetBytes limit for the batch.  This should reduce the number of gRPCs necessary overall. The rationale for not using the whole available budget is that we might have non-head-of-line batches in flight, and we might have under-estimated amount of memory that we needed to keep their responses, so if the budget is fully used up, responses to those batches could be dropped, and we want to avoid that.

This change is mostly beneficial in the InOrder mode. For example, on the query from TestStreamerVaryingResponseSizes it brings down the number of gRPCs with InOrder mode from 50-55 range to 30-40 range.

Epic: None

Release note: None