### PR TITLE
server: bump timeout in TestServerControllerWaitForDefaultCluster

### DIFF
--- a/pkg/server/server_controller_test.go
+++ b/pkg/server/server_controller_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -139,7 +139,7 @@ func TestServerControllerWaitForDefaultCluster(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	sqlRunner := sqlutils.MakeSQLRunner(db)
-	if util.RaceEnabled {
+	if skip.Duress() {
 		sqlRunner.Exec(t, "SET CLUSTER SETTING server.controller.mux_virtual_cluster_wait.timeout = '1m'")
 	}
 

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -32,9 +32,8 @@ type SkippableTest interface {
 // WithIssue skips this test, logging the given issue ID as the reason.
 func WithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
 	t.Helper()
-	maybeSkip(t, append([]interface{}{
-		fmt.Sprintf("https://github.com/cockroachdb/cockroach/issues/%d", githubIssueID)},
-		args...))
+	maybeSkip(t, fmt.Sprintf("https://github.com/cockroachdb/cockroach/issues/%d", githubIssueID),
+		args...)
 }
 
 // Unimplemented skips this test case, loggint the given issue ID. It
@@ -43,20 +42,22 @@ func WithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
 // because of an unimplemented feature.
 func Unimplemented(t SkippableTest, githubIssueID int, args ...interface{}) {
 	t.Helper()
-	maybeSkip(t, append([]interface{}{
-		fmt.Sprintf("https://github.com/cockroachdb/cockroach/issues/%d", githubIssueID)},
-		args...))
+	maybeSkip(t, withIssue("unimplemented", githubIssueID), args...)
 }
 
 // IgnoreLint skips this test, explicitly marking it as not a test that
 // should be tracked as a "skipped test" by external tools. You should use this
 // if, for example, your test should only be run in Race mode.
+//
+// Does not respect COCKROACH_FORCE_RUN_SKIPPED_TESTS.
 func IgnoreLint(t SkippableTest, args ...interface{}) {
 	t.Helper()
-	maybeSkip(t, args...)
+	t.Skip(args...)
 }
 
 // IgnoreLintf is like IgnoreLint, and it also takes a format string.
+//
+// Does not respect COCKROACH_FORCE_RUN_SKIPPED_TESTS.
 func IgnoreLintf(t SkippableTest, format string, args ...interface{}) {
 	t.Helper()
 	t.Skipf(format, args...)
@@ -66,7 +67,7 @@ func IgnoreLintf(t SkippableTest, format string, args ...interface{}) {
 func UnderDeadlock(t SkippableTest, args ...interface{}) {
 	t.Helper()
 	if syncutil.DeadlockEnabled {
-		maybeSkip(t, append([]interface{}{"disabled under deadlock detector"}, args...))
+		maybeSkip(t, "disabled under deadlock detector", args...)
 	}
 }
 
@@ -75,10 +76,7 @@ func UnderDeadlock(t SkippableTest, args ...interface{}) {
 func UnderDeadlockWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
 	t.Helper()
 	if syncutil.DeadlockEnabled {
-		maybeSkip(t, append([]interface{}{fmt.Sprintf(
-			"disabled under deadlock detector. issue: https://github.com/cockroachdb/cockroach/issues/%d",
-			githubIssueID,
-		)}, args...))
+		maybeSkip(t, withIssue("disabled under deadlock detector", githubIssueID), args...)
 	}
 }
 
@@ -86,7 +84,7 @@ func UnderDeadlockWithIssue(t SkippableTest, githubIssueID int, args ...interfac
 func UnderRace(t SkippableTest, args ...interface{}) {
 	t.Helper()
 	if util.RaceEnabled {
-		maybeSkip(t, append([]interface{}{"disabled under race"}, args...))
+		maybeSkip(t, "disabled under race", args...)
 	}
 }
 
@@ -95,9 +93,7 @@ func UnderRace(t SkippableTest, args ...interface{}) {
 func UnderRaceWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
 	t.Helper()
 	if util.RaceEnabled {
-		maybeSkip(t, append([]interface{}{fmt.Sprintf(
-			"disabled under race. issue: https://github.com/cockroachdb/cockroach/issues/%d", githubIssueID,
-		)}, args...))
+		maybeSkip(t, withIssue("disabled under race", githubIssueID), args...)
 	}
 }
 
@@ -106,9 +102,7 @@ func UnderRaceWithIssue(t SkippableTest, githubIssueID int, args ...interface{})
 func UnderBazelWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
 	t.Helper()
 	if bazel.BuiltWithBazel() {
-		maybeSkip(t, append([]interface{}{fmt.Sprintf(
-			"disabled under bazel. issue: https://github.com/cockroachdb/cockroach/issues/%d", githubIssueID,
-		)}, args...))
+		maybeSkip(t, withIssue("disabled under bazel", githubIssueID), args...)
 	}
 }
 
@@ -119,7 +113,7 @@ var _ = UnderBazelWithIssue
 func UnderShort(t SkippableTest, args ...interface{}) {
 	t.Helper()
 	if testing.Short() {
-		maybeSkip(t, append([]interface{}{"disabled under -short"}, args...))
+		maybeSkip(t, "disabled under -short", args...)
 	}
 }
 
@@ -127,7 +121,7 @@ func UnderShort(t SkippableTest, args ...interface{}) {
 func UnderStress(t SkippableTest, args ...interface{}) {
 	t.Helper()
 	if Stress() {
-		maybeSkip(t, append([]interface{}{"disabled under stress"}, args...))
+		maybeSkip(t, "disabled under stress", args...)
 	}
 }
 
@@ -136,9 +130,7 @@ func UnderStress(t SkippableTest, args ...interface{}) {
 func UnderStressWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
 	t.Helper()
 	if Stress() {
-		maybeSkip(t, append([]interface{}{fmt.Sprintf(
-			"disabled under stress. issue: https://github.com/cockroachdb/cockroach/issues/%d", githubIssueID,
-		)}, args...))
+		maybeSkip(t, withIssue("disabled under stress", githubIssueID), args...)
 	}
 }
 
@@ -147,7 +139,7 @@ func UnderStressWithIssue(t SkippableTest, githubIssueID int, args ...interface{
 func UnderStressRace(t SkippableTest, args ...interface{}) {
 	t.Helper()
 	if Stress() && util.RaceEnabled {
-		maybeSkip(t, append([]interface{}{"disabled under stressrace"}, args...))
+		maybeSkip(t, "disabled under stressrace", args...)
 	}
 }
 
@@ -156,7 +148,7 @@ func UnderStressRace(t SkippableTest, args ...interface{}) {
 func UnderMetamorphic(t SkippableTest, args ...interface{}) {
 	t.Helper()
 	if util.IsMetamorphicBuild() {
-		maybeSkip(t, append([]interface{}{"disabled under metamorphic"}, args...))
+		maybeSkip(t, "disabled under metamorphic", args...)
 	}
 }
 
@@ -166,9 +158,7 @@ func UnderMetamorphic(t SkippableTest, args ...interface{}) {
 func UnderMetamorphicWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
 	t.Helper()
 	if util.IsMetamorphicBuild() {
-		maybeSkip(t, append([]interface{}{fmt.Sprintf(
-			"disabled under metamorphic. issue: https://github.com/cockroachdb/cockroach/issues/%d", githubIssueID,
-		)}, args...))
+		maybeSkip(t, withIssue("disabled under metamorphic", githubIssueID), args...)
 	}
 }
 
@@ -191,12 +181,20 @@ func UnderBench() bool {
 	return f != nil && f.Value.String() != ""
 }
 
+func withIssue(reason string, githubIssueID int) string {
+	return fmt.Sprintf(
+		"%s. issue: https://github.com/cockroachdb/cockroach/issues/%d",
+		reason,
+		githubIssueID,
+	)
+}
+
 var forceRunSkippedTests = envutil.EnvOrDefaultBool("COCKROACH_FORCE_RUN_SKIPPED_TESTS", false)
 
-func maybeSkip(t SkippableTest, args ...interface{}) {
+func maybeSkip(t SkippableTest, reason string, args ...interface{}) {
 	if forceRunSkippedTests {
 		return
 	}
 
-	t.Skip(args...)
+	t.Skip(append([]interface{}{reason}, args...)...)
 }


### PR DESCRIPTION
This test has a timeout that is too low. It fails in CI, where tests
are slow. It fails under deadlock and when stressed; but not on my
mac, which must be blessed. So to avoid a bigger mess, we bump the
timeout under duress.

Fixes #113949

Release note: None