### PR TITLE
release-23.1: kv: eliminate broken txn retry logic in replication reports

### DIFF
--- a/pkg/kv/kvserver/reports/BUILD.bazel
+++ b/pkg/kv/kvserver/reports/BUILD.bazel
@@ -58,7 +58,6 @@ go_test(
         "//pkg/config",
         "//pkg/config/zonepb",
         "//pkg/keys",
-        "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/roachpb",
         "//pkg/security/securityassets",

--- a/pkg/kv/kvserver/reports/constraint_stats_report.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report.go
@@ -367,8 +367,9 @@ func makeConstraintConformanceVisitor(
 	v := constraintConformanceVisitor{
 		cfg:           cfg,
 		storeResolver: storeResolver,
+		report:        make(ConstraintReport),
 	}
-	v.reset(ctx)
+	v.init(ctx)
 	return v
 }
 
@@ -383,14 +384,7 @@ func (v *constraintConformanceVisitor) Report() ConstraintReport {
 	return v.report
 }
 
-// reset is part of the rangeVisitor interface.
-func (v *constraintConformanceVisitor) reset(ctx context.Context) {
-	*v = constraintConformanceVisitor{
-		cfg:           v.cfg,
-		storeResolver: v.storeResolver,
-		report:        make(ConstraintReport, len(v.report)),
-	}
-
+func (v *constraintConformanceVisitor) init(ctx context.Context) {
 	// Iterate through all the zone configs to create report entries for all the
 	// zones that have constraints. Otherwise, just iterating through the ranges
 	// wouldn't create entries for constraints that aren't violated, and

--- a/pkg/kv/kvserver/reports/critical_localities_report.go
+++ b/pkg/kv/kvserver/reports/critical_localities_report.go
@@ -272,14 +272,13 @@ func makeCriticalLocalitiesVisitor(
 	nodeChecker nodeChecker,
 ) criticalLocalitiesVisitor {
 	allLocalities := expandLocalities(nodeLocalities)
-	v := criticalLocalitiesVisitor{
+	return criticalLocalitiesVisitor{
 		allLocalities: allLocalities,
 		cfg:           cfg,
 		storeResolver: storeResolver,
 		nodeChecker:   nodeChecker,
+		report:        make(LocalityReport),
 	}
-	v.reset(ctx)
-	return v
 }
 
 // expandLocalities expands each locality in its input into multiple localities,
@@ -316,17 +315,6 @@ func (v *criticalLocalitiesVisitor) failed() bool {
 // calls.
 func (v *criticalLocalitiesVisitor) Report() LocalityReport {
 	return v.report
-}
-
-// reset is part of the rangeVisitor interface.
-func (v *criticalLocalitiesVisitor) reset(ctx context.Context) {
-	*v = criticalLocalitiesVisitor{
-		allLocalities: v.allLocalities,
-		cfg:           v.cfg,
-		storeResolver: v.storeResolver,
-		nodeChecker:   v.nodeChecker,
-		report:        make(LocalityReport, len(v.report)),
-	}
 }
 
 // visitNewZone is part of the rangeVisitor interface.

--- a/pkg/kv/kvserver/reports/replication_stats_report.go
+++ b/pkg/kv/kvserver/reports/replication_stats_report.go
@@ -264,11 +264,12 @@ func makeReplicationStatsVisitor(
 	ctx context.Context, cfg *config.SystemConfig, nodeChecker nodeChecker,
 ) replicationStatsVisitor {
 	v := replicationStatsVisitor{
-		cfg:         cfg,
-		nodeChecker: nodeChecker,
-		report:      make(RangeReport),
+		cfg:           cfg,
+		nodeChecker:   nodeChecker,
+		report:        make(RangeReport),
+		prevNumVoters: -1,
 	}
-	v.reset(ctx)
+	v.init(ctx)
 	return v
 }
 
@@ -282,15 +283,7 @@ func (v *replicationStatsVisitor) Report() RangeReport {
 	return v.report
 }
 
-// reset is part of the rangeVisitor interface.
-func (v *replicationStatsVisitor) reset(ctx context.Context) {
-	*v = replicationStatsVisitor{
-		cfg:           v.cfg,
-		nodeChecker:   v.nodeChecker,
-		prevNumVoters: -1,
-		report:        make(RangeReport, len(v.report)),
-	}
-
+func (v *replicationStatsVisitor) init(ctx context.Context) {
 	// Iterate through all the zone configs to create report entries for all the
 	// zones that have constraints. Otherwise, just iterating through the ranges
 	// wouldn't create entries for zones that don't apply to any ranges.

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -537,10 +537,6 @@ type rangeVisitor interface {
 	// The idea is that, if failed() returns true, the report that the visitor
 	// produces will be considered incomplete and not persisted.
 	failed() bool
-
-	// reset resets the visitor's state, preparing it for visit() calls starting
-	// at the first range. This is called on retriable errors during range iteration.
-	reset(ctx context.Context)
 }
 
 // visitorError is returned by visitRanges when one or more visitors failed.

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -576,6 +576,12 @@ func visitRanges(
 
 	// Iterate over all the ranges.
 	for {
+		// Check for context cancellation.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		// Grab the next range.
 		rd, err := rangeStore.Next(ctx)
 		if err != nil {
 			return err
@@ -583,11 +589,6 @@ func visitRanges(
 		if rd.RangeID == 0 {
 			// We're done.
 			break
-		}
-
-		// Check for context cancellation.
-		if err := ctx.Err(); err != nil {
-			return err
 		}
 
 		newKey, err := resolver.resolveRange(ctx, &rd, cfg)

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -578,16 +578,7 @@ func visitRanges(
 	for {
 		rd, err := rangeStore.Next(ctx)
 		if err != nil {
-			if errIsRetriable(err) {
-				visitors = origVisitors
-				for _, v := range visitors {
-					v.reset(ctx)
-				}
-				// The iterator has been positioned to the beginning.
-				continue
-			} else {
-				return err
-			}
+			return err
 		}
 		if rd.RangeID == 0 {
 			// We're done.
@@ -640,17 +631,13 @@ type RangeIterator interface {
 	// Returns an empty RangeDescriptor when all the ranges have been exhausted. In that case,
 	// the iterator is not to be used any more (except for calling Close(), which will be a no-op).
 	//
-	// The returned error can be a retriable one (i.e.
-	// *kvpb.TransactionRetryWithProtoRefreshError, possibly wrapped). In that case, the iterator
-	// is reset automatically; the next Next() call ( should there be one) will
-	// return the first descriptor.
-	// In case of any other error, the iterator is automatically closed.
+	// In case of an error, the iterator is automatically closed.
 	// It can't be used any more (except for calling Close(), which will be a noop).
 	Next(context.Context) (roachpb.RangeDescriptor, error)
 
 	// Close destroys the iterator, releasing resources. It does not need to be
 	// called after Next() indicates exhaustion by returning an empty descriptor,
-	// or after Next() returns non-retriable errors.
+	// or after Next() returns an error.
 	Close(context.Context)
 }
 
@@ -731,6 +718,15 @@ func (r *meta2RangeIter) readBatch(ctx context.Context) (retErr error) {
 	}
 	if r.txn == nil {
 		r.txn = r.db.NewTxn(ctx, "rangeStoreImpl")
+		// Set a fixed timestamp to disable uncertainty intervals. This forgoes
+		// linearizability (which isn't at all important for this use case) for the
+		// guarantee that no retryable errors will be returned, so we don't need to
+		// worry about handling them in order to maintain a consistent view across
+		// batches. Uncertainty errors are the only form of retryable error that can
+		// be returned for read-only transactions.
+		if err := r.txn.SetFixedTimestamp(ctx, r.txn.ReadTimestamp()); err != nil {
+			return err
+		}
 	}
 
 	b := r.txn.NewBatch()
@@ -756,14 +752,8 @@ func (r *meta2RangeIter) readBatch(ctx context.Context) (retErr error) {
 	return nil
 }
 
-func errIsRetriable(err error) bool {
-	return errors.HasType(err, (*kvpb.TransactionRetryWithProtoRefreshError)(nil))
-}
-
 // handleErr manipulates the iterator's state in response to an error.
-// In case of retriable error, the iterator is reset such that the next Next()
-// call returns the first range. In case of any other error, resources are
-// released and the iterator shouldn't be used any more.
+// Resources are released and the iterator shouldn't be used any more.
 // A nil error may be passed, in which case handleErr is a no-op.
 //
 // handleErr is idempotent.
@@ -771,20 +761,18 @@ func (r *meta2RangeIter) handleErr(ctx context.Context, err error) {
 	if err == nil {
 		return
 	}
-	if !errIsRetriable(err) {
-		if r.txn != nil {
-			log.Eventf(ctx, "non-retriable error: %s", err)
-			// On any non-retriable error, rollback.
-			if rollbackErr := r.txn.Rollback(ctx); rollbackErr != nil {
-				log.Eventf(ctx, "rollback failed: %s", rollbackErr)
-			}
-			r.txn = nil
-		}
-		r.reset()
-		r.readingDone = true
-	} else {
-		r.reset()
+	if errors.HasType(err, (*kvpb.TransactionRetryWithProtoRefreshError)(nil)) {
+		log.Warningf(ctx, "unexpected retryable error from "+
+			"read-only transaction with fixed read timestamp: %s", err)
 	}
+	if r.txn != nil {
+		if rollbackErr := r.txn.Rollback(ctx); rollbackErr != nil {
+			log.Eventf(ctx, "rollback failed: %s", rollbackErr)
+		}
+		r.txn = nil
+	}
+	r.reset()
+	r.readingDone = true
 }
 
 // reset the iterator. The next Next() call will return the first range.

--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -20,10 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/keysutils"
@@ -33,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -416,66 +413,6 @@ func TestMeta2RangeIter(t *testing.T) {
 		numRangesPaginated++
 	}
 	require.Equal(t, numRanges, numRangesPaginated)
-}
-
-// Test that a retriable error returned from the range iterator is properly
-// handled by resetting the report.
-func TestRetriableErrorWhenGenerationReport(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	ctx := context.Background()
-	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
-
-	cfg := s.ExecutorConfig().(sql.ExecutorConfig).SystemConfig.GetSystemConfig()
-	dummyNodeChecker := func(id roachpb.NodeID) bool { return true }
-
-	v := makeReplicationStatsVisitor(ctx, cfg, dummyNodeChecker)
-	realIter := makeMeta2RangeIter(db, 10000 /* batchSize */)
-	require.NoError(t, visitRanges(ctx, &realIter, cfg, &v))
-	expReport := v.Report()
-	require.Greater(t, len(expReport), 0, "unexpected empty report")
-
-	realIter = makeMeta2RangeIter(db, 10000 /* batchSize */)
-	errorIter := erroryRangeIterator{
-		iter:           realIter,
-		injectErrAfter: 3,
-	}
-	v = makeReplicationStatsVisitor(ctx, cfg, func(id roachpb.NodeID) bool { return true })
-	require.NoError(t, visitRanges(ctx, &errorIter, cfg, &v))
-	require.Greater(t, len(v.report), 0, "unexpected empty report")
-	require.Equal(t, expReport, v.report)
-}
-
-type erroryRangeIterator struct {
-	iter           meta2RangeIter
-	rangesReturned int
-	injectErrAfter int
-}
-
-var _ RangeIterator = &erroryRangeIterator{}
-
-func (it *erroryRangeIterator) Next(ctx context.Context) (roachpb.RangeDescriptor, error) {
-	if it.rangesReturned == it.injectErrAfter {
-		// Don't inject any more errors.
-		it.injectErrAfter = -1
-
-		var err error
-		err = kvpb.NewTransactionRetryWithProtoRefreshError(
-			"injected err", uuid.Nil, roachpb.Transaction{})
-		// Let's wrap the error to check the unwrapping.
-		err = errors.Wrap(err, "dummy wrapper")
-		// Feed the error to the underlying iterator to reset it.
-		it.iter.handleErr(ctx, err)
-		return roachpb.RangeDescriptor{}, err
-	}
-	it.rangesReturned++
-	rd, err := it.iter.Next(ctx)
-	return rd, err
-}
-
-func (it *erroryRangeIterator) Close(ctx context.Context) {
-	it.iter.Close(ctx)
 }
 
 func TestZoneChecker(t *testing.T) {

--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -620,10 +620,6 @@ func (r *recordingRangeVisitor) failed() bool {
 	return false
 }
 
-func (r *recordingRangeVisitor) reset(ctx context.Context) {
-	r.rngs = nil
-}
-
 type visitorEntry struct {
 	newZone bool
 	rng     roachpb.RangeDescriptor
@@ -645,8 +641,4 @@ func (e *errorRangeVisitor) visitSameZone(context.Context, *roachpb.RangeDescrip
 
 func (e *errorRangeVisitor) failed() bool {
 	return e.errorReturned
-}
-
-func (e *errorRangeVisitor) reset(context.Context) {
-	e.errorReturned = false
 }


### PR DESCRIPTION
Backport 3/3 commits from #114113.

/cc @cockroachdb/release

---

Fixes #113669.

In #113669 and in other cases, we have seen that a replication report update can get stuck in a retry loop. This was because the transaction retry logic was not correctly preparing the transaction for retry by calling `Txn.PrepareForRetry` to "unpoison" the transaction. As a result, once a transaction hit a retry error, it would keep throwing the same error each time it was used.

The infinite loop had two negative consequences:
1. it wasted CPU resources
2. it prevented the node from shutting down cleanly

The second consequence is related to #87913. The fix for that issue added a context cancellation check, but the check was below the transaction retry loop, so it was ineffective at breaking out of the loop and completing the shut down.

This commit resolves this bug by eliminating the broken transaction retry logic. To do so, we now set a fixed timestamp on the read-only transaction, which disables its uncertainty interval. This trades off some theoretical guarantee of linearizability (which was unnecessary in a background loop that ran on a timer) for simplicity (no need to handle retry errors). We now just log if that assumption is incorrect and we somehow see a retry error, but otherwise start the loop over again.

Release note (bug fix): An active replication report update could get stuck in a retry loop on clusters with over 10000 ranges, which would prevent a node from shutting down cleanly. This has been fixed.

----

Release justification: fixes cases where drain can get stuck.
