### PR TITLE
opt: try to reduce key in FuncDepSet.AddFrom

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -10,6 +10,10 @@ exec-ddl
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 ----
 
+exec-ddl
+CREATE TABLE mn (m INT, n INT, PRIMARY KEY (m, n))
+----
+
 build
 SELECT * FROM xy UNION SELECT * FROM uv
 ----
@@ -639,3 +643,29 @@ except-all
       ├── prune: (2)
       └── tuple [type=tuple{int}]
            └── const: 1 [type=int]
+
+# Regression test for #113817. The key from the LHS of the intersection should
+# be reduced after adding the FDs from the RHS.
+norm
+SELECT m, n FROM mn
+INTERSECT
+SELECT x, y FROM xy
+----
+intersect-all
+ ├── columns: m:1(int!null) n:2(int)
+ ├── left columns: m:1(int!null) n:2(int)
+ ├── right columns: x:5(int) y:6(int)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── interesting orderings: (+1,+2)
+ ├── scan mn
+ │    ├── columns: m:1(int!null) n:2(int!null)
+ │    ├── key: (1,2)
+ │    ├── prune: (1,2)
+ │    └── interesting orderings: (+1,+2)
+ └── scan xy
+      ├── columns: x:5(int!null) y:6(int)
+      ├── key: (5)
+      ├── fd: (5)-->(6)
+      ├── prune: (5,6)
+      └── interesting orderings: (+5)

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -1152,6 +1152,7 @@ func (f *FuncDepSet) AddFrom(fdset *FuncDepSet) {
 		fd := &fdset.deps[i]
 		f.addDependency(fd.from, fd.to, fd.strict, fd.equiv)
 	}
+	f.tryToReduceKey(opt.ColSet{} /* notNullCols */)
 }
 
 // AddEquivFrom is similar to AddFrom, except that it only adds equivalence

--- a/pkg/sql/opt/props/func_dep_test.go
+++ b/pkg/sql/opt/props/func_dep_test.go
@@ -795,6 +795,17 @@ func TestFuncDeps_AddFrom(t *testing.T) {
 	abcde.AddStrictKey(c(2, 3), c(1, 2, 3, 4, 5))
 	verifyFD(t, abcde, "key(2,3); (1)-->(2-5), (2,3)-->(1,4,5)")
 	testColsAreStrictKey(t, abcde, c(1), true)
+
+	// Add a single-column strict dependency to a multi-column strict
+	// dependency.
+	m := &props.FuncDepSet{}
+	m.AddStrictKey(c(1, 2), c(1, 2))
+	verifyFD(t, m, "key(1,2)")
+	s := &props.FuncDepSet{}
+	s.AddStrictKey(c(1), c(1, 2))
+	verifyFD(t, s, "key(1); (1)-->(2)")
+	m.AddFrom(s)
+	verifyFD(t, m, "key(1); (1)-->(2)")
 }
 
 func TestFuncDeps_AddEquivFrom(t *testing.T) {
@@ -815,6 +826,16 @@ func TestFuncDeps_AddEquivFrom(t *testing.T) {
 	equiv.ProjectCols(opt.ColSet{})
 	equiv.AddEquivFrom(product)
 	verifyFD(t, &equiv, "(1)==(10), (10)==(1), (2)==(11), (11)==(2)")
+
+	// Add an equivalency to a multi-column strict dependency.
+	m := &props.FuncDepSet{}
+	m.AddStrictKey(c(1, 2), c(1, 2))
+	verifyFD(t, m, "key(1,2)")
+	s := &props.FuncDepSet{}
+	s.AddEquivalency(1, 2)
+	verifyFD(t, s, "(1)==(2), (2)==(1)")
+	m.AddEquivFrom(s)
+	verifyFD(t, m, "key(2); (1)==(2), (2)==(1)")
 }
 
 func TestFuncDeps_MakeProduct(t *testing.T) {


### PR DESCRIPTION
Previously, `FuncDepSet.AddFrom` could add dependencies to an FD without
reducing the key afterward. This could produce FDs with extra key
columns. For example, consider the two FDs below:

    fd1: key(1,2)
    fd2: key(1); (1)-->(2)

Adding `fd2` to `fd1` without reducing the key would produce
`key(1,2); (1)-->(2)` instead of `key(1); (1)-->(2)`. The unreduced key
is not incorrect, but it could prevent some possible optimizations from
triggering. In test builds the unreduced key causes an assertion
failure.

This commit fixes the issue by calling `FuncDepSet.tryToReduceKey` after
dependencies have been added within `FuncDepSet.AddFrom`. This fixes an
assertion failure in test builds when optimizing some queries with
`INTERSECT` expressions.

A test has also been added for a similar case with
`FuncDepSet.AddEquivFrom`, but no code changes are required because this
function calls `FuncDepSet.addEquivalency` which already reduces the
FD's key.

Fixes #113817

There is no release note because the assertion failure is only present
in test builds and the issue does not cause correctness bugs in release
builds.

Release note: None
