### PR TITLE
execinfrapb: truncate ChangeAggregator spans in diagram

### DIFF
--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -609,9 +609,23 @@ func (w *WindowerSpec) summary() (string, []string) {
 
 // summary implements the diagramCellType interface.
 func (s *ChangeAggregatorSpec) summary() (string, []string) {
-	var details []string
-	for _, watch := range s.Watches {
-		details = append(details, watch.Span.String())
+	var spanStr strings.Builder
+	if len(s.Watches) > 0 {
+		spanStr.WriteString(fmt.Sprintf("Watches [%d]: ", len(s.Watches)))
+		const limit = 3
+		for i := 0; i < len(s.Watches) && i < limit; i++ {
+			if i > 0 {
+				spanStr.WriteString(", ")
+			}
+			spanStr.WriteString(s.Watches[i].Span.String())
+		}
+		if len(s.Watches) > limit {
+			spanStr.WriteString("...")
+		}
+	}
+
+	details := []string{
+		spanStr.String(),
 	}
 	return "ChangeAggregator", details
 }

--- a/pkg/sql/execinfrapb/flow_diagram_test.go
+++ b/pkg/sql/execinfrapb/flow_diagram_test.go
@@ -939,3 +939,63 @@ func TestProcessorsImplementDiagramCellType(t *testing.T) {
 		require.Implements(t, (*diagramCellType)(nil), pcu.Field(i).Interface())
 	}
 }
+
+func TestChangeAggregatorSpec(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testData := []struct {
+		name            string
+		aggregatorSpec  ChangeAggregatorSpec
+		expectedWatches []string
+	}{
+		{
+			name:            "no watches",
+			aggregatorSpec:  ChangeAggregatorSpec{},
+			expectedWatches: []string{""},
+		},
+		{
+			name: "limit",
+			aggregatorSpec: ChangeAggregatorSpec{
+				Watches: []ChangeAggregatorSpec_Watch{
+					{
+						Span: roachpb.Span{Key: roachpb.Key("a")},
+					},
+					{
+						Span: roachpb.Span{Key: roachpb.Key("b")},
+					},
+					{
+						Span: roachpb.Span{Key: roachpb.Key("c")},
+					},
+				},
+			},
+			expectedWatches: []string{"Watches [3]: a, b, c"},
+		},
+		{
+			name: "overlimit",
+			aggregatorSpec: ChangeAggregatorSpec{
+				Watches: []ChangeAggregatorSpec_Watch{
+					{
+						Span: roachpb.Span{Key: roachpb.Key("a")},
+					},
+					{
+						Span: roachpb.Span{Key: roachpb.Key("b")},
+					},
+					{
+						Span: roachpb.Span{Key: roachpb.Key("c")},
+					},
+					{
+						Span: roachpb.Span{Key: roachpb.Key("d")},
+					},
+				},
+			},
+			expectedWatches: []string{"Watches [4]: a, b, c..."},
+		},
+	}
+
+	for _, td := range testData {
+		t.Run(td.name, func(t *testing.T) {
+			_, details := td.aggregatorSpec.summary()
+			require.Equal(t, td.expectedWatches, details)
+		})
+	}
+}


### PR DESCRIPTION
This change truncates the spans printined in the DistSQL diagram of a ChangeAggregator. This ensures that the encoded diagrams don't grow linearly with the number of spans that are being watched by a changefeed.

Fixes: #114248
Release note: None