### PR TITLE
regionliveness: minor nits for initial prober implementation

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlinstance/instancestorage",
         "//pkg/sql/sqlliveness",
+        "//pkg/sql/sqlliveness/slinstance",
         "//pkg/sql/sqlliveness/slstorage",
         "//pkg/sql/sqltestutils",
         "//pkg/testutils",

--- a/pkg/sql/regionliveness/BUILD.bazel
+++ b/pkg/sql/regionliveness/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
         "//pkg/sql/sqlliveness/slinstance",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/regionliveness/prober.go
+++ b/pkg/sql/regionliveness/prober.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -61,6 +62,16 @@ type livenessProber struct {
 	settings              *clustersettings.Settings
 }
 
+var probeLivenessTimeout = 15 * time.Second
+
+func TestingSetProbeLivenessTimeout(newTimeout time.Duration) func() {
+	oldTimeout := probeLivenessTimeout
+	probeLivenessTimeout = newTimeout
+	return func() {
+		probeLivenessTimeout = oldTimeout
+	}
+}
+
 // NewLivenessProber creates a new region liveness prober.
 func NewLivenessProber(
 	db isql.DB, regionProviderFactory RegionProviderFactory, settings *clustersettings.Settings,
@@ -79,19 +90,24 @@ func (l *livenessProber) ProbeLiveness(ctx context.Context, region string) error
 		return nil
 	}
 	const probeQuery = `
-SELECT * FROM system.sql_instances WHERE crdb_region=$1::system.crdb_internal_region
+SELECT count(*) FROM system.sql_instances WHERE crdb_region = $1::system.crdb_internal_region
 `
-	err := timeutil.RunWithTimeout(ctx, "probe-liveness", time.Second*15,
+	err := timeutil.RunWithTimeout(ctx, "probe-liveness", probeLivenessTimeout,
 		func(ctx context.Context) error {
 			return l.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-				_, err := txn.Exec(ctx, "probe-sql-instance", txn.KV(), probeQuery, region)
-				return err
+				_, err := txn.QueryRowEx(
+					ctx, "probe-sql-instance", txn.KV(), sessiondata.NodeUserSessionDataOverride,
+					probeQuery, region,
+				)
+				if err != nil {
+					return err
+				}
+				return nil
 			})
 		})
 
 	// Region is alive or we hit some other error.
-	if err == nil ||
-		!IsQueryTimeoutErr(err) {
+	if err == nil || !IsQueryTimeoutErr(err) {
 		return err
 	}
 
@@ -137,17 +153,19 @@ func (l *livenessProber) QueryLiveness(ctx context.Context, txn *kv.Txn) (LiveRe
 		return regionStatus, nil
 	}
 	// Detect and down regions and remove them.
-	rows, err := executor.QueryBuffered(ctx, "query-region-liveness", txn,
-		"SELECT * FROM system.region_liveness")
+	rows, err := executor.QueryBufferedEx(
+		ctx, "query-region-liveness", txn, sessiondata.NodeUserSessionDataOverride,
+		"SELECT crdb_region, unavailable_at FROM system.region_liveness",
+	)
 	if err != nil {
 		return nil, err
 	}
 	for _, row := range rows {
 		enum, _ := tree.AsDEnum(row[0])
-		timestamp := tree.MustBeDTimestamp(row[1])
+		unavailableAt := tree.MustBeDTimestamp(row[1])
 		// Region is now officially unavailable, so lets remove
 		// it.
-		if txn.ReadTimestamp().GoTime().After(timestamp.Time) {
+		if txn.ReadTimestamp().GoTime().After(unavailableAt.Time) {
 			delete(regionStatus, enum.LogicalRep)
 		}
 	}
@@ -158,5 +176,5 @@ func (l *livenessProber) QueryLiveness(ctx context.Context, txn *kv.Txn) (LiveRe
 // when checking for region liveness.
 func IsQueryTimeoutErr(err error) bool {
 	return pgerror.GetPGCode(err) == pgcode.QueryCanceled ||
-		errors.Is(err, &timeutil.TimeoutError{})
+		errors.HasType(err, (*timeutil.TimeoutError)(nil))
 }


### PR DESCRIPTION
- Use QueryRowEx so that the prober always runs as a privilged node user.
- Avoid using SELECT *, since that can break if the columns change, and it makes the code harder to understand.
- Fix broken errors.Is usage and use HasType instead. Also changed the check to avoid an allocation.

Epic: CRDB-28158
informs: #113231
fixes: https://github.com/cockroachdb/cockroach/issues/114245
Release note: None