### PR TITLE
nightlies: use remote execution for nightly stress

### DIFF
--- a/pkg/cmd/bazci/process-bep-file/main.go
+++ b/pkg/cmd/bazci/process-bep-file/main.go
@@ -106,7 +106,6 @@ func failurePoster(res *testResultWithXml, opts *issues.Options) githubpost.Fail
 		if res.attempt != 0 {
 			req.ExtraParams["attempt"] = fmt.Sprintf("%d", res.attempt)
 		}
-		req.ExtraLabels = append(req.ExtraLabels, "O-remote-execution")
 		return fmter, req
 	}
 	return func(ctx context.Context, failure githubpost.Failure) error {

--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -180,7 +180,6 @@ func runTC(queueBuild func(string, map[string]string)) {
 
 		opts["env.STRESSFLAGS"] = fmt.Sprintf("-maxruns %d -maxtime %s -maxfails %d -p %d",
 			maxRuns, maxTime, maxFails, parallelism)
-		queueBuildThenWait(buildID, opts)
 
 		// Run non-race build with deadlock detection.
 		opts["env.TAGS"] = "deadlock"


### PR DESCRIPTION
We keep the deadlock and race builds because these aren't ready to run in RBE yet.

Epic: CRDB-8308
Release note: None