### PR TITLE
backupccl: add TestOnlineRestoreS3 and TestOnlineRestoreBasic tests

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -181,6 +181,7 @@ go_test(
         "generative_split_and_scatter_processor_test.go",
         "key_rewriter_test.go",
         "main_test.go",
+        "online_restore_test.go",
         "partitioned_backup_test.go",
         "restore_data_processor_test.go",
         "restore_entry_cover_generated_test.go",  # keep

--- a/pkg/ccl/backupccl/backup_cloud_test.go
+++ b/pkg/ccl/backupccl/backup_cloud_test.go
@@ -113,10 +113,6 @@ func TestOnlineRestoreS3(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if os.Getenv("COCKROACH_UNSAFE_RESTORE") != "true" {
-		skip.IgnoreLint(t, "set COCKROACH_UNSAFE_RESTORE env var to true")
-	}
-
 	const numAccounts = 1000
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()

--- a/pkg/ccl/backupccl/backup_cloud_test.go
+++ b/pkg/ccl/backupccl/backup_cloud_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/amazon"
 	"github.com/cockroachdb/cockroach/pkg/cloud/azure"
@@ -106,6 +107,32 @@ func setupS3URI(
 	}
 	uri.RawQuery = values.Encode()
 	return uri
+}
+
+func TestOnlineRestoreS3(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	if os.Getenv("COCKROACH_UNSAFE_RESTORE") != "true" {
+		skip.IgnoreLint(t, "set COCKROACH_UNSAFE_RESTORE env var to true")
+	}
+
+	const numAccounts = 1000
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+
+	creds, bucket := requiredS3CredsAndBucket(t)
+	prefix := fmt.Sprintf("TestOnlineRestoreS3-%d", timeutil.Now().UnixNano())
+	uri := setupS3URI(t, sqlDB, bucket, prefix, creds)
+	externalStorage := uri.String()
+
+	sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s'", externalStorage))
+
+	params := base.TestClusterArgs{}
+	_, rSQLDB, cleanupFnRestored := backupRestoreTestSetupEmpty(t, 1, "", InitManualReplication, params)
+	defer cleanupFnRestored()
+
+	bankOnlineRestore(t, rSQLDB, numAccounts, externalStorage)
 }
 
 // TestBackupRestoreGoogleCloudStorage hits the real GCS and so could

--- a/pkg/ccl/backupccl/online_restore_test.go
+++ b/pkg/ccl/backupccl/online_restore_test.go
@@ -10,11 +10,9 @@ package backupccl
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -24,10 +22,6 @@ import (
 func TestOnlineRestoreBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	if os.Getenv("COCKROACH_UNSAFE_RESTORE") != "true" {
-		skip.IgnoreLint(t, "set COCKROACH_UNSAFE_RESTORE env var to true")
-	}
 
 	const numAccounts = 1000
 	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)

--- a/pkg/ccl/backupccl/online_restore_test.go
+++ b/pkg/ccl/backupccl/online_restore_test.go
@@ -1,0 +1,54 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnlineRestoreBasic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	if os.Getenv("COCKROACH_UNSAFE_RESTORE") != "true" {
+		skip.IgnoreLint(t, "set COCKROACH_UNSAFE_RESTORE env var to true")
+	}
+
+	const numAccounts = 1000
+	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
+	defer cleanupFn()
+	externalStorage := "nodelocal://1/backup"
+
+	sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s'", externalStorage))
+
+	params := base.TestClusterArgs{}
+	_, rSQLDB, cleanupFnRestored := backupRestoreTestSetupEmpty(t, 1, dir, InitManualReplication, params)
+	defer cleanupFnRestored()
+	bankOnlineRestore(t, rSQLDB, numAccounts, externalStorage)
+}
+
+func bankOnlineRestore(
+	t *testing.T, sqlDB *sqlutils.SQLRunner, numAccounts int, externalStorage string,
+) {
+	sqlDB.Exec(t, "CREATE DATABASE data")
+	sqlDB.Exec(t, fmt.Sprintf("RESTORE TABLE data.bank FROM LATEST IN '%s' WITH EXPERIMENTAL DEFERRED COPY", externalStorage))
+
+	var restoreRowCount int
+	sqlDB.QueryRow(t, "SELECT count(*) FROM data.bank").Scan(&restoreRowCount)
+	require.Equal(t, numAccounts, restoreRowCount)
+}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -65,7 +65,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	bulkutil "github.com/cockroachdb/cockroach/pkg/util/bulk"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
@@ -3210,8 +3209,6 @@ func (r *restoreResumer) cleanupTempSystemTables(ctx context.Context) error {
 	return nil
 }
 
-var onlineRestoreGate = envutil.EnvOrDefaultBool("COCKROACH_UNSAFE_RESTORE", false)
-
 // sendAddRemoteSSTs is a stubbed out, very simplisitic version of restore used
 // to test out ingesting "remote" SSTs. It will be replaced with a real distsql
 // plan and processors in the future.
@@ -3229,10 +3226,6 @@ func sendAddRemoteSSTs(
 ) error {
 	defer close(progCh)
 	defer close(tracingAggCh)
-
-	if !onlineRestoreGate {
-		return errors.AssertionFailedf("experimental restore mode not supported")
-	}
 
 	if encryption != nil {
 		return errors.AssertionFailedf("encryption not supported with online restore")

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -431,6 +431,7 @@ func restore(
 				details.URIs,
 				backupLocalityInfo,
 				progCh,
+				tracingAggCh,
 				genSpan,
 			)
 		}
@@ -3223,9 +3224,11 @@ func sendAddRemoteSSTs(
 	uris []string,
 	backupLocalityInfo []jobspb.RestoreDetails_BackupLocalityInfo,
 	progCh chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
+	tracingAggCh chan *execinfrapb.TracingAggregatorEvents,
 	genSpan func(ctx context.Context, spanCh chan execinfrapb.RestoreSpanEntry) error,
 ) error {
 	defer close(progCh)
+	defer close(tracingAggCh)
 
 	if !onlineRestoreGate {
 		return errors.AssertionFailedf("experimental restore mode not supported")

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -655,6 +655,10 @@ func addSSTablePreApply(
 			Size:            sst.BackingFileSize,
 			SmallestUserKey: start.Encode(),
 			LargestUserKey:  end.Encode(),
+
+			// TODO(msbutler): I guess we need to figure out if the backing external
+			// file has point or range keys in the target span.
+			HasPointKey: true,
 		}
 		tBegin := timeutil.Now()
 		defer func() {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -802,6 +802,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 			}
 			addCfgOpt(storage.MaxSize(sizeInBytes))
 			addCfgOpt(storage.CacheSize(cfg.CacheSize))
+			addCfgOpt(storage.RemoteStorageFactory(cfg.ExternalStorageAccessor))
 
 			detail(redact.Sprintf("store %d: in-memory, size %s", i, humanizeutil.IBytes(sizeInBytes)))
 		} else {


### PR DESCRIPTION
This patch adds TestOnlineRestoreS3 to our cloud unit test suite. To run locally, run:
```
./dev test pkg/ccl/backupccl -f TestOnlineRestoreS3 -- --test_env=AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID --test_env=AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY --test_env=AWS_S3_BUCKET=cockroachdb-backup-cloud-nightly --test_env=COCKROACH_UNSAFE_RESTORE=true
```

This patch also adds TestOnlineRestoreBasic which runs online restore through
nodelocal. To run locally, run:
```
./dev test pkg/ccl/backupccl -f TestOnlineRestoreBasic -- --test_env=COCKROACH_UNSAFE_RESTORE=true
```

Both tests will be skipped in the nightlies until we pass
COCKROACH_UNSAFE_RESTORE to their setup.

Epic: none

Release note: none