### PR TITLE
mixedversion: refactor test context

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -43,7 +43,7 @@ var (
 // provides convenient utility function to pretty print versions and
 // check whether this is the current version being tested.
 type Version struct {
-	*version.Version
+	version.Version
 }
 
 // String returns the string representation of this version. For
@@ -65,17 +65,17 @@ func (v *Version) String() string {
 // IsCurrent returns whether this version corresponds to the current
 // version being tested.
 func (v *Version) IsCurrent() bool {
-	return v.Version.Compare(CurrentVersion().Version) == 0
+	return v.Version.Compare(&CurrentVersion().Version) == 0
 }
 
 // CurrentVersion returns the version associated with the current
 // build.
 func CurrentVersion() *Version {
 	if TestBuildVersion != nil {
-		return &Version{TestBuildVersion} // test-only
+		return &Version{*TestBuildVersion} // test-only
 	}
 
-	return &Version{version.MustParse(build.BinaryVersion())}
+	return &Version{*version.MustParse(build.BinaryVersion())}
 }
 
 // MustParseVersion parses the version string given (with or without
@@ -86,7 +86,7 @@ func MustParseVersion(v string) *Version {
 		versionStr = "v" + v
 	}
 
-	return &Version{version.MustParse(versionStr)}
+	return &Version{*version.MustParse(versionStr)}
 }
 
 // BinaryVersion returns the binary version running on the node

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "mixedversion",
     srcs = [
+        "context.go",
         "helper.go",
         "mixedversion.go",
         "planner.go",
@@ -22,6 +23,7 @@ go_library(
         "//pkg/roachprod/vm",
         "//pkg/testutils/release",
         "//pkg/util/ctxgroup",
+        "//pkg/util/intsets",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
@@ -33,6 +35,7 @@ go_library(
 go_test(
     name = "mixedversion_test",
     srcs = [
+        "context_test.go",
         "helper_test.go",
         "mixedversion_test.go",
         "planner_test.go",
@@ -47,6 +50,7 @@ go_test(
         "//pkg/roachpb",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
+        "//pkg/util/intsets",
         "//pkg/util/version",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/context.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/context.go
@@ -1,0 +1,163 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package mixedversion
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/util/intsets"
+)
+
+type (
+	// Context wraps the context passed to predicate functions that
+	// dictate when a mixed-version hook will run during a test
+	Context struct {
+		// CockroachNodes is the set of cockroach nodes in the cluster
+		// that are being part of the upgrade being performed.
+		CockroachNodes option.NodeListOption
+		// FromVersion is the version the nodes are migrating from.
+		FromVersion *clusterupgrade.Version
+		// ToVersion is the version the nodes are migrating to.
+		ToVersion *clusterupgrade.Version
+		// Finalizing indicates whether the cluster version is in the
+		// process of upgrading (i.e., all nodes in the cluster have been
+		// upgraded to a certain version, and the migrations are being
+		// executed).
+		Finalizing bool
+
+		// nodesByVersion maps released versions to which nodes are
+		// currently running that version.
+		nodesByVersion map[clusterupgrade.Version]*intsets.Fast
+	}
+)
+
+func newInitialContext(
+	initialRelease *clusterupgrade.Version, crdbNodes option.NodeListOption,
+) *Context {
+	return &Context{
+		CockroachNodes: crdbNodes,
+		FromVersion:    initialRelease,
+		ToVersion:      initialRelease,
+		nodesByVersion: map[clusterupgrade.Version]*intsets.Fast{
+			*initialRelease: intSetP(crdbNodes...),
+		},
+	}
+}
+
+// newLongRunningContext is the test context passed to long running
+// tasks (background functions and the like). In these scenarios,
+// `FromVersion` and `ToVersion` correspond to, respectively, the
+// initial version the cluster is started at, and the final version
+// once the test finishes. Background functions should *not* rely on
+// context functions since the context is not dynamically updated as
+// the test makes progress during the background function's execution.
+func newLongRunningContext(
+	from, to *clusterupgrade.Version, crdbNodes option.NodeListOption,
+) *Context {
+	return &Context{
+		CockroachNodes: crdbNodes,
+		FromVersion:    from,
+		ToVersion:      to,
+		nodesByVersion: map[clusterupgrade.Version]*intsets.Fast{
+			*from: intSetP(crdbNodes...),
+		},
+	}
+}
+
+// clone copies the caller Context and returns the copy.
+func (c *Context) clone() Context {
+	nodesByVersion := make(map[clusterupgrade.Version]*intsets.Fast)
+	for v, nodes := range c.nodesByVersion {
+		newSet := nodes.Copy()
+		nodesByVersion[v] = &newSet
+	}
+
+	fromVersion := c.FromVersion.Version
+	toVersion := c.ToVersion.Version
+
+	return Context{
+		CockroachNodes: append(option.NodeListOption{}, c.CockroachNodes...),
+		FromVersion:    &clusterupgrade.Version{Version: fromVersion},
+		ToVersion:      &clusterupgrade.Version{Version: toVersion},
+		Finalizing:     c.Finalizing,
+		nodesByVersion: nodesByVersion,
+	}
+}
+
+// startUpgrade is called when the test is starting the upgrade to the
+// given version. This should be called once every node is already
+// running that version and the cluster version has finished reaching
+// the logical version corresponding to that release.
+func (c *Context) startUpgrade(nextRelease *clusterupgrade.Version) {
+	c.FromVersion = c.ToVersion
+	c.ToVersion = nextRelease
+}
+
+// changeVersion is used to indicate that the given `node` is now
+// running release version `v`.
+func (c *Context) changeVersion(node int, v *clusterupgrade.Version) {
+	currentVersion := c.NodeVersion(node)
+	c.nodesByVersion[*currentVersion].Remove(node)
+	if _, exists := c.nodesByVersion[*v]; !exists {
+		c.nodesByVersion[*v] = intSetP()
+	}
+
+	c.nodesByVersion[*v].Add(node)
+}
+
+// nodesInVersion returns a list of all nodes running the version
+// passed, if any.
+func (c *Context) nodesInVersion(v *clusterupgrade.Version) option.NodeListOption {
+	set, ok := c.nodesByVersion[*v]
+	if !ok {
+		return nil
+	}
+
+	return set.Ordered()
+}
+
+// NodeVersion returns the release version the given `node` is
+// currently running. Panics if the node is not valid.
+func (c *Context) NodeVersion(node int) *clusterupgrade.Version {
+	for version, nodes := range c.nodesByVersion {
+		if nodes.Contains(node) {
+			return &version
+		}
+	}
+
+	panic(fmt.Errorf("NodeVersion error: invalid node %d, cockroach nodes: %v", node, c.CockroachNodes))
+}
+
+// NodesInPreviousVersion returns a list of nodes running the version
+// we are upgrading from.
+func (c *Context) NodesInPreviousVersion() option.NodeListOption {
+	return c.nodesInVersion(c.FromVersion)
+}
+
+// NodesInNextVersion returns the list of nodes running the version we
+// are upgrading to.
+func (c *Context) NodesInNextVersion() option.NodeListOption {
+	return c.nodesInVersion(c.ToVersion)
+}
+
+// MixedBinary indicates if the cluster is currently in mixed-binary
+// mode, i.e., not all nodes in the cluster are running the same
+// released binary version.
+func (c *Context) MixedBinary() bool {
+	return len(c.NodesInPreviousVersion()) > 0 && len(c.NodesInNextVersion()) > 0
+}
+
+func intSetP(ns ...int) *intsets.Fast {
+	set := intsets.MakeFast(ns...)
+	return &set
+}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/context_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/context_test.go
@@ -1,0 +1,116 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package mixedversion
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/util/intsets"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContext_startUpgrade(t *testing.T) {
+	initialVersion := clusterupgrade.MustParseVersion("v22.2.10")
+	upgradeVersion := clusterupgrade.MustParseVersion("v23.1.2")
+
+	c := newInitialContext(initialVersion, option.NodeListOption{1, 2, 3})
+	c.startUpgrade(upgradeVersion)
+
+	require.Equal(t, &Context{
+		CockroachNodes: option.NodeListOption{1, 2, 3},
+		FromVersion:    initialVersion,
+		ToVersion:      upgradeVersion,
+		nodesByVersion: map[clusterupgrade.Version]*intsets.Fast{
+			*initialVersion: intSetP(1, 2, 3),
+		},
+	}, c)
+}
+
+// TestContextOperations runs a series of operations on a context and
+// checks that functions called on that context (that could be called
+// in user-provided hooks) behave as expected.
+func TestContextOperations(t *testing.T) {
+	initialVersion := clusterupgrade.MustParseVersion("v22.2.10")
+	upgradeVersion := clusterupgrade.MustParseVersion("v23.1.2")
+
+	c := newInitialContext(initialVersion, option.NodeListOption{1, 2, 3})
+	c.startUpgrade(upgradeVersion)
+
+	ops := []struct {
+		name                           string
+		changeVersionNode              int
+		changeVersion                  *clusterupgrade.Version
+		expectedNodesInPreviousVersion option.NodeListOption
+		expectedNodesInNextVersion     option.NodeListOption
+		expectedMixedBinary            bool
+	}{
+		{
+			name:                           "upgrade n1",
+			changeVersionNode:              1,
+			changeVersion:                  upgradeVersion,
+			expectedNodesInPreviousVersion: option.NodeListOption{2, 3},
+			expectedNodesInNextVersion:     option.NodeListOption{1},
+			expectedMixedBinary:            true,
+		},
+		{
+			name:                           "upgrade n3",
+			changeVersionNode:              3,
+			changeVersion:                  upgradeVersion,
+			expectedNodesInPreviousVersion: option.NodeListOption{2},
+			expectedNodesInNextVersion:     option.NodeListOption{1, 3},
+			expectedMixedBinary:            true,
+		},
+		{
+			name:                           "upgrade n2",
+			changeVersionNode:              2,
+			changeVersion:                  upgradeVersion,
+			expectedNodesInPreviousVersion: nil,
+			expectedNodesInNextVersion:     option.NodeListOption{1, 2, 3},
+			expectedMixedBinary:            false,
+		},
+		{
+			name:                           "downgrade n3",
+			changeVersionNode:              3,
+			changeVersion:                  initialVersion,
+			expectedNodesInPreviousVersion: option.NodeListOption{3},
+			expectedNodesInNextVersion:     option.NodeListOption{1, 2},
+			expectedMixedBinary:            true,
+		},
+		{
+			name:                           "downgrade n1",
+			changeVersionNode:              1,
+			changeVersion:                  initialVersion,
+			expectedNodesInPreviousVersion: option.NodeListOption{1, 3},
+			expectedNodesInNextVersion:     option.NodeListOption{2},
+			expectedMixedBinary:            true,
+		},
+		{
+			name:                           "downgrade n2",
+			changeVersionNode:              2,
+			changeVersion:                  initialVersion,
+			expectedNodesInPreviousVersion: option.NodeListOption{1, 2, 3},
+			expectedNodesInNextVersion:     nil,
+			expectedMixedBinary:            false,
+		},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			c.changeVersion(op.changeVersionNode, op.changeVersion)
+			require.Equal(t, op.expectedNodesInPreviousVersion, c.NodesInPreviousVersion())
+			require.Equal(t, op.expectedNodesInNextVersion, c.NodesInNextVersion())
+			require.Equal(t, op.expectedMixedBinary, c.MixedBinary())
+			require.Equal(t, op.changeVersion, c.NodeVersion(op.changeVersionNode))
+		})
+	}
+}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
@@ -103,7 +103,7 @@ func (h *Helper) Background(
 			}
 
 			desc := fmt.Sprintf("error in background function %s: %s", name, err)
-			return h.runner.testFailure(desc, bgLogger)
+			return h.runner.testFailure(desc, bgLogger, nil)
 		}
 
 		return nil

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
@@ -77,8 +77,7 @@ func TestClusterVersionAtLeast(t *testing.T) {
 			runner := testTestRunner()
 			runner.clusterVersions = clusterVersions
 
-			h := runner.newHelper(ctx, nilLogger)
-			h.testContext = &Context{Finalizing: false} // do not attempt to query cluster version
+			h := runner.newHelper(ctx, nilLogger, Context{Finalizing: false})
 
 			supportedFeature, err := h.ClusterVersionAtLeast(rng, tc.minVersion)
 			if tc.expectedErr == "" {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -36,19 +36,6 @@ import (
 )
 
 type (
-	// Helper is the struct passed to user-functions providing helper
-	// functions that mixed-version tests can use.
-	Helper struct {
-		ctx         context.Context
-		testContext *Context
-		// bgCount keeps track of the number of background tasks started
-		// with `helper.Background()`. The counter is used to generate
-		// unique log file names.
-		bgCount    int64
-		runner     *testRunner
-		stepLogger *logger.Logger
-	}
-
 	// backgroundEvent is the struct sent by background steps when they
 	// finish (successfully or not).
 	backgroundEvent struct {
@@ -488,10 +475,10 @@ func (tr *testRunner) newHelper(
 	ctx context.Context, l *logger.Logger, testContext Context,
 ) *Helper {
 	return &Helper{
-		ctx:         ctx,
-		runner:      tr,
-		stepLogger:  l,
-		testContext: &testContext,
+		Context:    &testContext,
+		ctx:        ctx,
+		runner:     tr,
+		stepLogger: l,
 	}
 }
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
@@ -81,5 +81,6 @@ func (tss testSingleStep) Run(
 }
 
 func newTestStep(f func() error) singleStep {
-	return testSingleStep{runFunc: f}
+	initialVersion := parseVersions([]string{predecessorVersion})[0]
+	return newSingleStep(newInitialContext(initialVersion, nodes), testSingleStep{runFunc: f})
 }

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -1537,7 +1537,7 @@ func (mvb *mixedVersionBackup) maybeTakePreviousVersionBackup(
 		return nil
 	}
 
-	previousVersion := h.Context().FromVersion
+	previousVersion := h.Context.FromVersion
 	label := fmt.Sprintf("before upgrade in %s", sanitizeVersionForBackup(previousVersion))
 	allPrevVersionNodes := labeledNodes{Nodes: mvb.roachNodes, Version: previousVersion.String()}
 	executeOnAllNodesSpec := backupSpec{PauseProbability: neverPause, Plan: allPrevVersionNodes, Execute: allPrevVersionNodes}
@@ -1564,14 +1564,13 @@ func (d *BackupRestoreTestDriver) nextRestoreID() int64 {
 // depending on the state of the test we are in. The given label is also used to
 // provide more context. Example: '22.2.4-to-current_final'
 func (mvb *mixedVersionBackup) backupNamePrefix(h *mixedversion.Helper, label string) string {
-	testContext := h.Context()
 	var finalizing string
-	if testContext.Finalizing {
+	if h.Context.Finalizing {
 		finalizing = finalizingLabel
 	}
 
-	fromVersion := sanitizeVersionForBackup(testContext.FromVersion)
-	toVersion := sanitizeVersionForBackup(testContext.ToVersion)
+	fromVersion := sanitizeVersionForBackup(h.Context.FromVersion)
+	toVersion := sanitizeVersionForBackup(h.Context.ToVersion)
 	sanitizedLabel := strings.ReplaceAll(label, " ", "-")
 
 	return fmt.Sprintf(
@@ -2079,14 +2078,11 @@ func (mvb *mixedVersionBackup) planAndRunBackups(
 		return nil
 	}
 
-	tc := h.Context() // test context
-	l.Printf("current context: %#v", tc)
-
 	onPrevious := labeledNodes{
-		Nodes: tc.NodesInPreviousVersion(), Version: sanitizeVersionForBackup(tc.FromVersion),
+		Nodes: h.Context.NodesInPreviousVersion(), Version: sanitizeVersionForBackup(h.Context.FromVersion),
 	}
 	onNext := labeledNodes{
-		Nodes: tc.NodesInNextVersion(), Version: sanitizeVersionForBackup(tc.ToVersion),
+		Nodes: h.Context.NodesInNextVersion(), Version: sanitizeVersionForBackup(h.Context.ToVersion),
 	}
 	onRandom := labeledNodes{Nodes: mvb.roachNodes, Version: "random node"}
 	defaultPauseProbability := 0.2
@@ -2124,7 +2120,7 @@ func (mvb *mixedVersionBackup) planAndRunBackups(
 		},
 	}
 
-	if tc.MixedBinary() {
+	if h.Context.MixedBinary() {
 		const numCollections = 2
 		rng.Shuffle(len(collectionSpecs), func(i, j int) {
 			collectionSpecs[i], collectionSpecs[j] = collectionSpecs[j], collectionSpecs[i]
@@ -2419,8 +2415,8 @@ func (mvb *mixedVersionBackup) verifyAllBackups(
 		}
 	}
 
-	verify(h.Context().FromVersion)
-	verify(h.Context().ToVersion)
+	verify(h.Context.FromVersion)
+	verify(h.Context.ToVersion)
 
 	// If the context was canceled (most likely due to a test timeout),
 	// return early. In these cases, it's likely that `restoreErrors`

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2083,10 +2083,10 @@ func (mvb *mixedVersionBackup) planAndRunBackups(
 	l.Printf("current context: %#v", tc)
 
 	onPrevious := labeledNodes{
-		Nodes: tc.FromVersionNodes, Version: sanitizeVersionForBackup(tc.FromVersion),
+		Nodes: tc.NodesInPreviousVersion(), Version: sanitizeVersionForBackup(tc.FromVersion),
 	}
 	onNext := labeledNodes{
-		Nodes: tc.ToVersionNodes, Version: sanitizeVersionForBackup(tc.ToVersion),
+		Nodes: tc.NodesInNextVersion(), Version: sanitizeVersionForBackup(tc.ToVersion),
 	}
 	onRandom := labeledNodes{Nodes: mvb.roachNodes, Version: "random node"}
 	defaultPauseProbability := 0.2
@@ -2124,7 +2124,7 @@ func (mvb *mixedVersionBackup) planAndRunBackups(
 		},
 	}
 
-	if len(tc.FromVersionNodes) > 0 {
+	if tc.MixedBinary() {
 		const numCollections = 2
 		rng.Shuffle(len(collectionSpecs), func(i, j int) {
 			collectionSpecs[i], collectionSpecs[j] = collectionSpecs[j], collectionSpecs[i]

--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -131,7 +131,7 @@ func validateCorpusFile(
 //     a version bump).
 func runDeclSchemaChangeCompatMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
 	currentVersion := clusterupgrade.CurrentVersion()
-	predecessorVersionStr, err := release.LatestPredecessor(currentVersion.Version)
+	predecessorVersionStr, err := release.LatestPredecessor(&currentVersion.Version)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -64,16 +64,20 @@ INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12);
 	mvt.InMixedVersion(
 		"modify and verify index data while in a mixed version state",
 		func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
-			node, db := h.RandomDB(r, h.Context().ToVersionNodes)
-			l.Printf("connecting to n%d", node)
+			// Run the following statements in a node running the next
+			// version, if any; otherwise, pick a random node.
+			nodes := c.All()
+			if h.Context().MixedBinary() {
+				nodes = h.Context().NodesInNextVersion()
+			}
 
-			if _, err := db.Exec(`DELETE FROM t WHERE x = 13 OR x = 20`); err != nil {
+			if err := h.ExecWithGateway(r, nodes, `DELETE FROM t WHERE x = 13 OR x = 20`); err != nil {
 				return err
 			}
-			if _, err := db.Exec(`INSERT INTO t VALUES (13, 14, 15, 16)`); err != nil {
+			if err := h.ExecWithGateway(r, nodes, `INSERT INTO t VALUES (13, 14, 15, 16)`); err != nil {
 				return err
 			}
-			if _, err := db.Exec(`UPDATE t SET w = 17 WHERE y = 14`); err != nil {
+			if err := h.ExecWithGateway(r, nodes, `UPDATE t SET w = 17 WHERE y = 14`); err != nil {
 				return err
 			}
 			if err := verifyTableData(ctx, c, l, 1, firstExpected); err != nil {

--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -67,8 +67,8 @@ INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12);
 			// Run the following statements in a node running the next
 			// version, if any; otherwise, pick a random node.
 			nodes := c.All()
-			if h.Context().MixedBinary() {
-				nodes = h.Context().NodesInNextVersion()
+			if h.Context.MixedBinary() {
+				nodes = h.Context.NodesInNextVersion()
 			}
 
 			if err := h.ExecWithGateway(r, nodes, `DELETE FROM t WHERE x = 13 OR x = 20`); err != nil {

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -410,9 +410,9 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 		// If migrations are running we want to ramp up the workload faster in order
 		// to expose them to more concurrent load. In a similar goal, we also let the
 		// TPCC workload run longer.
-		if h.Context().Finalizing && !c.IsLocal() {
+		if h.Context.Finalizing && !c.IsLocal() {
 			rampDur = 1 * time.Minute
-			if h.Context().ToVersion.IsCurrent() {
+			if h.Context.ToVersion.IsCurrent() {
 				workloadDur = 100 * time.Minute
 			}
 		}

--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -80,7 +80,7 @@ func runValidateSystemSchemaAfterVersionUpgrade(
 	mvt.AfterUpgradeFinalized(
 		"obtain system schema from the upgraded cluster",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			if !h.Context().ToVersion.IsCurrent() {
+			if !h.Context.ToVersion.IsCurrent() {
 				// Only validate the system schema if we're upgrading to the version
 				// under test.
 				return nil

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -152,7 +152,7 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// TODO(renato): stage different workload binaries for the
 			// releases being used in the test and use the appropriate
 			// binary in this step.
-			if !tc.FromVersion.IsCurrent() && !tc.ToVersion.IsCurrent() {
+			if !tc.ToVersion.IsCurrent() {
 				l.Printf("skipping this step -- only supported when current version is involved")
 				return nil
 			}

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -144,7 +144,6 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 	mvt.InMixedVersion(
 		"test schema change step",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			tc := h.Context()
 			// We currently only stage the `workload` binary built off the
 			// SHA being tested; therefore, we skip testing the schemachange
 			// workload if this is not an upgrade or downgrade involving the
@@ -152,7 +151,7 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// TODO(renato): stage different workload binaries for the
 			// releases being used in the test and use the appropriate
 			// binary in this step.
-			if !tc.ToVersion.IsCurrent() {
+			if !h.Context.ToVersion.IsCurrent() {
 				l.Printf("skipping this step -- only supported when current version is involved")
 				return nil
 			}


### PR DESCRIPTION
This PR refactors the maintenance of mixed-version test contexts and the methods available on `mixedversion.Context`. Specifically (one bullet point per commit):

* A `Context` is now associated with every `singleStep`, instead of just `runHookStep`. In other words, even internal steps now have a context associated with them.
* With this change, it becomes trivial to display the current released binary versions for each node before we start executing each step, and also when an error occurs.
* Make `Context` a struct field instead of function call. This is mostly to indicate to the caller that the context is static and no computation happens. In fact, the test context is derived during planning time. This is specially important for background functions, where node restarts are happening concurrently.
* Improve formatting of logical and cluster versions on test failure and at the beginning of every step by displaying it in a tabular format.

The `Context` type and related functions were also moved to their own file, `context.go`, to make it easier for people to be able to see all public functions available when using the framework.

These changes pave the way for a higher level internal API that will allow us to change or insert steps in upgrade plans in mixedversion tests.