### PR TITLE
colfetcher,roachtest: re-enable direct scans metamorphization

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -100,7 +100,10 @@ func importBankDataSplit(
 
 	// NB: starting the cluster creates the logs dir as a side effect,
 	// needed below.
-	c.Start(ctx, t.L(), maybeUseMemoryBudget(t, 50), install.MakeClusterSettings())
+	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings())
+	// See #113816 for why this is needed for now (probably until #94850 is
+	// resolved).
+	c.Run(ctx, c.Node(1), "./cockroach sql --insecure -e 'SET CLUSTER SETTING sql.distsql.direct_columnar_scans.enabled = false;'")
 	runImportBankDataSplit(ctx, rows, ranges, t, c)
 	return dest
 }
@@ -744,7 +747,7 @@ func runBackupMVCCRangeTombstones(
 ) {
 	if !config.skipClusterSetup {
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload") // required for tpch
-		c.Start(ctx, t.L(), maybeUseMemoryBudget(t, 50), install.MakeClusterSettings())
+		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings())
 	}
 	t.Status("starting csv servers")
 	c.Run(ctx, c.All(), `./cockroach workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)

--- a/pkg/sql/colfetcher/cfetcher_wrapper.go
+++ b/pkg/sql/colfetcher/cfetcher_wrapper.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
@@ -40,7 +41,11 @@ var DirectScansEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"sql.distsql.direct_columnar_scans.enabled",
 	"set to true to enable the 'direct' columnar scans in the KV layer",
-	// TODO(yuzefovich): make this metamorphic constant once #113816 is fixed.
+	directScansEnabledDefault,
+)
+
+var directScansEnabledDefault = util.ConstantWithMetamorphicTestBool(
+	"direct-scans-enabled",
 	false,
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/show_fingerprints
+++ b/pkg/sql/logictest/testdata/logic_test/show_fingerprints
@@ -125,7 +125,7 @@ INSERT INTO blocks VALUES (1, b'\x01')
 query TT
 SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE blocks
 ----
-blocks_pkey  590700560494856555
+blocks_pkey  -9087023432987872405
 
 # Verify that we can show fingerprints from a read-only transaction (#39204).
 statement ok


### PR DESCRIPTION
**sql: optimize EXPERIMENTAL_FINGERPRINTS**

This commit makes the internal query powering EXPERIMENTAL_FINGERPRINTS
more efficient. In particular, previously we always performed a cast of
non-BYTES types to BYTES; however, `fnv64` supports variadic input types
of both BYTES and STRING, so this commit counts the number of BYTES and
non-BYTES columns and casts the less frequent type to the other one (in
most cases this should eliminate redundant casts from STRING to BYTES).

Epic: None

Release note: None

**colfetcher,roachtest: re-enable direct scans metamorphization**

This commit makes a couple of tweaks to the backup roachtests which
allows us to make the default value of `sql.distsql.direct_columnar_scans.enabled`
a metamorphic variable again. In particular, we need to disable this
setting for backups on `bank` data set due to pathological case as
described in #113816. This also allows us to reduce `--max-sql-memory`
since we don't expect memory usage to be as high without direct scans.

Fixes: #113816.

Release note: None