### PR TITLE
CRDB-31650 : SpotVM Support in roachtest

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2720,3 +2720,38 @@ func archForTest(ctx context.Context, l *logger.Logger, testSpec registry.TestSp
 
 	return arch
 }
+
+// GetPreemptedVMs gets any VMs that were part of the cluster but preempted by cloud vendor.
+func (c *clusterImpl) GetPreemptedVMs(
+	ctx context.Context, l *logger.Logger,
+) ([]vm.PreemptedVM, error) {
+	pattern := "^" + regexp.QuoteMeta(c.name) + "$" // exact match of the cluster name
+	cloudClusters, err := roachprod.List(l, false, pattern, vm.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	cDetails, ok := cloudClusters.Clusters[c.name]
+	if !ok {
+		return nil, errors.Wrapf(errClusterNotFound, "%q", c.name)
+	}
+	// Bucket cDetails.vms by provider
+	providerToVMs := make(map[string][]vm.VM)
+	for _, vm := range cDetails.VMs {
+		providerToVMs[vm.Provider] = append(providerToVMs[vm.Provider], vm)
+	}
+
+	// Iterate through providerToVMs and call preemptedVMs for each provider
+	var allPreemptedVMs []vm.PreemptedVM
+	for provider, vms := range providerToVMs {
+		p := vm.Providers[provider]
+		if p.SupportsSpotVMs() {
+			preemptedVMS, err := p.GetPreemptedSpotVMs(l, vms, cDetails.CreatedAt)
+			if err != nil {
+				l.Errorf("failed to get preempted VMs for provider %s: %s", provider, err)
+				continue
+			}
+			allPreemptedVMs = append(allPreemptedVMs, preemptedVMS...)
+		}
+	}
+	return allPreemptedVMs, nil
+}

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -175,4 +175,7 @@ type Cluster interface {
 	// per-node, but this could be changed. Another assumption is that all
 	// volumes are created identically.
 	ApplySnapshots(ctx context.Context, snapshots []vm.VolumeSnapshot) error
+
+	// GetPreemptedVMs gets any VMs that were part of the cluster but preempted by cloud vendor.
+	GetPreemptedVMs(ctx context.Context, l *logger.Logger) ([]vm.PreemptedVM, error)
 }

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -95,7 +95,7 @@ type ClusterSpec struct {
 	TerminateOnMigration bool
 	UbuntuVersion        vm.UbuntuVersion
 	// Use a spot instance or equivalent of a cloud provider.
-	UseSpot bool
+	UseSpotVMs bool
 	// FileSystem determines the underlying FileSystem
 	// to be used. The default is ext4.
 	FileSystem fileSystemType
@@ -429,7 +429,7 @@ func (s *ClusterSpec) RoachprodOpts(
 	case GCE:
 		providerOpts = getGCEOpts(machineType, zones, s.VolumeSize, ssdCount,
 			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.TerminateOnMigration,
-			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType, s.UseSpot,
+			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType, s.UseSpotVMs,
 		)
 	case Azure:
 		providerOpts = getAzureOpts(machineType, zones)

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -178,16 +178,16 @@ func TerminateOnMigration() Option {
 	}
 }
 
-// UseSpotInstances creates a spot instance or equivalent of a cloud provider.
+// UseSpotVMs creates a spot vm or equivalent of a cloud provider.
 // Using this option creates SpotVMs instead of on demand VMS. SpotVMS are
 // cheaper but can be terminated at any time by the cloud provider.
 // This option is only supported by GCE for now.
 // See https://cloud.google.com/compute/docs/instances/spot,
 // https://azure.microsoft.com/en-in/products/virtual-machines/spot
 // and https://aws.amazon.com/ec2/spot/ for more details.
-func UseSpotInstances() Option {
+func UseSpotVMs() Option {
 	return func(spec *ClusterSpec) {
-		spec.UseSpot = true
+		spec.UseSpotVMs = true
 	}
 }
 

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1003,7 +1003,12 @@ func (r *testRunner) runTest(
 
 			durationStr := fmt.Sprintf("%.2fs", t.duration().Seconds())
 			if t.Failed() {
-				output := fmt.Sprintf("%s\ntest artifacts and logs in: %s", t.failureMsg(), t.ArtifactsDir())
+				failureMsg := t.failureMsg()
+				preemptedVMNames := getPreemptedVMNames(ctx, c, l)
+				if preemptedVMNames != "" {
+					failureMsg = "VMs preempted during the test run :" + preemptedVMNames + "\n" + failureMsg
+				}
+				output := fmt.Sprintf("%s\ntest artifacts and logs in: %s", failureMsg, t.ArtifactsDir())
 
 				if roachtestflags.TeamCity {
 					// If `##teamcity[testFailed ...]` is not present before `##teamCity[testFinished ...]`,
@@ -1177,6 +1182,24 @@ func (r *testRunner) runTest(
 		l.Printf("error during test teardown: %v; see test-teardown.log for details", err)
 	}
 	return nil
+}
+
+// getPreemptedVMNames returns a comma separated list of preempted VM names - if any.
+func getPreemptedVMNames(ctx context.Context, c *clusterImpl, l *logger.Logger) string {
+	preemptedVMs, err := c.GetPreemptedVMs(ctx, l)
+	var preemptedVMNames string
+	if err != nil {
+		l.Printf("failed to check preempted VMs: %s", err)
+	} else if len(preemptedVMs) > 0 {
+		for _, item := range preemptedVMs {
+			if preemptedVMNames != "" {
+				preemptedVMNames += ", " + item.Name
+			} else {
+				preemptedVMNames = item.Name
+			}
+		}
+	}
+	return preemptedVMNames
 }
 
 // The assertions here are executed after each test, and may result in a test failure. Test authors

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -257,6 +257,16 @@ type Provider struct {
 	IAMProfile string
 }
 
+func (p *Provider) SupportsSpotVMs() bool {
+	return false
+}
+
+func (p *Provider) GetPreemptedSpotVMs(
+	l *logger.Logger, vms vm.List, since time.Time,
+) ([]vm.PreemptedVM, error) {
+	return nil, nil
+}
+
 const (
 	defaultSSDMachineType = "m6id.xlarge"
 	defaultMachineType    = "m6i.xlarge"

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -94,6 +94,16 @@ type Provider struct {
 	}
 }
 
+func (p *Provider) SupportsSpotVMs() bool {
+	return false
+}
+
+func (p *Provider) GetPreemptedSpotVMs(
+	l *logger.Logger, vms vm.List, since time.Time,
+) ([]vm.PreemptedVM, error) {
+	return nil, nil
+}
+
 func (p *Provider) CreateVolumeSnapshot(
 	l *logger.Logger, volume vm.Volume, vsco vm.VolumeSnapshotCreateOpts,
 ) (vm.VolumeSnapshot, error) {

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -32,6 +32,16 @@ type provider struct {
 	unimplemented string
 }
 
+func (p *provider) SupportsSpotVMs() bool {
+	return false
+}
+
+func (p *provider) GetPreemptedSpotVMs(
+	l *logger.Logger, vms vm.List, since time.Time,
+) ([]vm.PreemptedVM, error) {
+	return nil, nil
+}
+
 func (p *provider) CreateVolumeSnapshot(
 	l *logger.Logger, volume vm.Volume, vsco vm.VolumeSnapshotCreateOpts,
 ) (vm.VolumeSnapshot, error) {

--- a/pkg/roachprod/vm/gce/BUILD.bazel
+++ b/pkg/roachprod/vm/gce/BUILD.bazel
@@ -29,5 +29,10 @@ go_test(
     size = "small",
     srcs = ["gcloud_test.go"],
     embed = [":gce"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "//pkg/roachprod/vm",
+        "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//assert",
+    ],
 )

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -315,6 +315,91 @@ type Provider struct {
 	ServiceAccount string
 }
 
+// LogEntry represents a single log entry from the gcloud logging(stack driver)
+type LogEntry struct {
+	LogName  string `json:"logName"`
+	Resource struct {
+		Labels struct {
+			InstanceID string `json:"instance_id"`
+		} `json:"labels"`
+	} `json:"resource"`
+	Timestamp    string `json:"timestamp"`
+	ProtoPayload struct {
+		ResourceName string `json:"resourceName"`
+	} `json:"protoPayload"`
+}
+
+func (p *Provider) SupportsSpotVMs() bool {
+	return true
+}
+
+// GetPreemptedSpotVMs checks the preemption status of the given VMs, by querying the GCP logging service.
+func (p *Provider) GetPreemptedSpotVMs(
+	l *logger.Logger, vms vm.List, since time.Time,
+) ([]vm.PreemptedVM, error) {
+	args, err := buildFilterPreemptionCliArgs(vms, p.GetProject(), since)
+	if err != nil {
+		l.Printf("Error building gcloud cli command: %v\n", err)
+		return nil, err
+	}
+	l.Printf("gcloud cli for preemption : " + strings.Join(append([]string{"gcloud"}, args...), " "))
+	var logEntries []LogEntry
+	if err := runJSONCommand(args, &logEntries); err != nil {
+		l.Printf("Error running gcloud cli command: %v\n", err)
+		return nil, err
+	}
+	// Extract the VM name and the time of preemption from logs.
+	var preemptedVMs []vm.PreemptedVM
+	for _, logEntry := range logEntries {
+		timestamp, err := time.Parse(time.RFC3339, logEntry.Timestamp)
+		if err != nil {
+			l.Printf("Error parsing gcp log timestamp, Preemption time not available: %v", err)
+			preemptedVMs = append(preemptedVMs, vm.PreemptedVM{Name: logEntry.ProtoPayload.ResourceName})
+			continue
+		}
+		preemptedVMs = append(preemptedVMs, vm.PreemptedVM{Name: logEntry.ProtoPayload.ResourceName, PreemptedAt: timestamp})
+	}
+	return preemptedVMs, nil
+}
+
+// buildFilterPreemptionCliArgs returns the arguments to be passed to gcloud cli to query the logs for preemption events.
+func buildFilterPreemptionCliArgs(
+	vms vm.List, projectName string, since time.Time,
+) ([]string, error) {
+	vmFullResourceNames := make([]string, len(vms))
+	if projectName == "" {
+		return nil, errors.New("project name cannot be empty")
+	}
+	if since.After(timeutil.Now()) {
+		return nil, errors.New("since cannot be in the future")
+	}
+	if vms == nil {
+		return nil, errors.New("vms cannot be nil")
+	}
+	// construct full resource names
+	for i, vmNode := range vms {
+		// example format : projects/cockroach-ephemeral/zones/us-east1-b/instances/test-name
+		vmFullResourceNames[i] = "projects/" + projectName + "/zones/" + vmNode.Zone + "/instances/" + vmNode.Name
+	}
+	// Prepend vmFullResourceNames with "protoPayload.resourceName=" to help with filter construction.
+	vmIDFilter := make([]string, len(vms))
+	for i, vmID := range vmFullResourceNames {
+		vmIDFilter[i] = fmt.Sprintf("protoPayload.resourceName=%s", vmID)
+	}
+	// Create a filter to match preemption events for the specified VM IDs
+	filter := fmt.Sprintf(`resource.type=gce_instance AND (protoPayload.methodName=compute.instances.preempted) AND (%s)`,
+		strings.Join(vmIDFilter, " OR "))
+	args := []string{
+		"logging",
+		"read",
+		"--project=" + projectName,
+		"--format=json",
+		fmt.Sprintf("--freshness=%dh", int(timeutil.Since(since).Hours()+1)), // only look at logs from the "since" specified
+		filter,
+	}
+	return args, nil
+}
+
 type snapshotJson struct {
 	CreationSizeBytes  string    `json:"creationSizeBytes"`
 	CreationTimestamp  time.Time `json:"creationTimestamp"`
@@ -998,7 +1083,7 @@ func (p *Provider) Create(
 			providerOpts.MinCPUPlatform = ""
 		}
 	}
-	//TODO(srosenberg): remove this once we have a better way to detect ARM64 machines
+	// TODO(srosenberg): remove this once we have a better way to detect ARM64 machines
 	if useArmAMI {
 		image = ARM64Image
 		l.Printf("Using ARM64 AMI: %s for machine type: %s", image, providerOpts.MachineType)

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -125,6 +125,16 @@ type Provider struct {
 	vm.DNSProvider
 }
 
+func (p *Provider) SupportsSpotVMs() bool {
+	return false
+}
+
+func (p *Provider) GetPreemptedSpotVMs(
+	l *logger.Logger, vms vm.List, since time.Time,
+) ([]vm.PreemptedVM, error) {
+	return nil, nil
+}
+
 func (p *Provider) CreateVolumeSnapshot(
 	l *logger.Logger, volume vm.Volume, vsco vm.VolumeSnapshotCreateOpts,
 ) (vm.VolumeSnapshot, error) {

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -420,6 +420,11 @@ type ListOptions struct {
 	ComputeEstimatedCost bool
 }
 
+type PreemptedVM struct {
+	Name        string
+	PreemptedAt time.Time
+}
+
 // A Provider is a source of virtual machines running on some hosting platform.
 type Provider interface {
 	CreateProviderOpts() ProviderOpts
@@ -471,6 +476,14 @@ type Provider interface {
 	ListVolumeSnapshots(l *logger.Logger, vslo VolumeSnapshotListOpts) ([]VolumeSnapshot, error)
 	// DeleteVolumeSnapshots permanently deletes the given snapshots.
 	DeleteVolumeSnapshots(l *logger.Logger, snapshot ...VolumeSnapshot) error
+
+	// SpotVM related APIs.
+
+	// SupportsSpotVMs returns if the provider supports spot VMs.
+	SupportsSpotVMs() bool
+	// GetPreemptedSpotVMs returns a list of Spot VMs that were preempted since the time specified.
+	// Returns nil, nil when SupportsSpotVMs() is false.
+	GetPreemptedSpotVMs(l *logger.Logger, vms List, since time.Time) ([]PreemptedVM, error)
 }
 
 // DeleteCluster is an optional capability for a Provider which can


### PR DESCRIPTION
Fixes CRDB-31650
Add Cluster and Provider interface methods to Support SpotVMs. 
GCP Implementation of the interface methods.
Check for preempted VMs on a test failure and surface the error in TeamCity's UI