### PR TITLE
sql: remove pre-23.1 version gates

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -191,10 +191,6 @@ const (
 	// This is a permanent migration which should exist forever.
 	Permanent_V22_2SQLSchemaTelemetryScheduledJobs
 
-	// TODO_Delete_V23_1Start demarcates the start of cluster versions stepped
-	// through during the process of upgrading from 22.2 to 23.1.
-	TODO_Delete_V23_1Start
-
 	// TODO_Delete_V23_1TenantNamesStateAndServiceMode adds columns to
 	// system.tenants.
 	TODO_Delete_V23_1TenantNamesStateAndServiceMode
@@ -204,21 +200,12 @@ const (
 	// for the system tenant.
 	TODO_Delete_V23_1DescIDSequenceForSystemTenant
 
-	// TODO_Delete_V23_1AddPartialStatisticsColumns adds two columns: one to store
-	// the predicate for a partial statistics collection, and another to refer to
-	// the full statistic it was collected from.
-	TODO_Delete_V23_1AddPartialStatisticsColumns
-
 	// TODO_Delete_V23_1CreateSystemJobInfoTable creates the system.job_info table.
 	TODO_Delete_V23_1CreateSystemJobInfoTable
 
 	// TODO_Delete_V23_1RoleMembersTableHasIDColumns is the version where the
 	// role_members system table has columns for ids.
 	TODO_Delete_V23_1RoleMembersTableHasIDColumns
-
-	// TODO_Delete_V23_1RoleMembersIDColumnsBackfilled is the version where the
-	// columns for ids in the role_members system table have been backfilled.
-	TODO_Delete_V23_1RoleMembersIDColumnsBackfilled
 
 	// TODO_Delete_V23_1ScheduledChangefeeds is the version where scheduled changefeeds are
 	// supported through `CREATE SCHEDULE FOR CHANGEFEED` statement.
@@ -232,15 +219,6 @@ const (
 	// column in the system.jobs table.
 	TODO_Delete_V23_1BackfillTypeColumnInJobsTable
 
-	// TODO_Delete_V23_1_AlterSystemStatementStatisticsAddIndexesUsage creates
-	// indexes usage virtual column based on (statistics->>'indexes') with
-	// inverted index on table system.statement_statistics.
-	TODO_Delete_V23_1_AlterSystemStatementStatisticsAddIndexesUsage
-
-	// TODO_Delete_V23_1AlterSystemSQLInstancesAddSQLAddr adds a sql_addr column
-	// to the system.sql_instances table.
-	TODO_Delete_V23_1AlterSystemSQLInstancesAddSQLAddr
-
 	// TODO_Delete_V23_1_ChangefeedExpressionProductionReady marks changefeed
 	// expressions (transformation) as production ready. This gate functions as a
 	// signal to attempt to upgrade chagnefeeds created prior to this version.
@@ -249,12 +227,6 @@ const (
 	// Permanent_V23_1KeyVisualizerTablesAndJobs adds the system tables that
 	// support the key visualizer.
 	Permanent_V23_1KeyVisualizerTablesAndJobs
-
-	// TODO_Delete_V23_1_KVDirectColumnarScans introduces the support of the "direct"
-	// columnar scans in the KV layer.
-	TODO_Delete_V23_1_KVDirectColumnarScans
-
-	TODO_Delete_V23_1_DeleteDroppedFunctionDescriptors
 
 	// Permanent_V23_1_CreateJobsMetricsPollingJob creates the permanent job
 	// responsible for polling the jobs table for metrics.
@@ -270,39 +242,14 @@ const (
 	// user_id column has been added to the system.privileges table.
 	TODO_Delete_V23_1SystemPrivilegesTableHasUserIDColumn
 
-	// TODO_Delete_V23_1SystemPrivilegesTableUserIDColumnBackfilled is the version
-	// where the user_id column in the system.privileges table has been
-	// backfilled.
-	TODO_Delete_V23_1SystemPrivilegesTableUserIDColumnBackfilled
-
 	// TODO_Delete_V23_1WebSessionsTableHasUserIDColumn is the version where the
 	// user_id column has been added to the system.web_sessions table.
 	TODO_Delete_V23_1WebSessionsTableHasUserIDColumn
-
-	// TODO_Delete_V23_1WebSessionsTableUserIDColumnBackfilled is the version
-	// where the user_id column in the system.web_sessions table has been
-	// backfilled.
-	TODO_Delete_V23_1WebSessionsTableUserIDColumnBackfilled
-
-	// TODO_Delete_V23_1_SchemaChangerDeprecatedIndexPredicates is the version
-	// where the declarative schema changer no longer produces
-	// scpb.SecondaryIndexPartial elements.
-	TODO_Delete_V23_1_SchemaChangerDeprecatedIndexPredicates
-
-	// TODO_Delete_V23_1AlterSystemPrivilegesAddIndexOnPathAndUsername adds a
-	// covering secondary index to system.privileges, on the path and username
-	// columns.
-	TODO_Delete_V23_1AlterSystemPrivilegesAddIndexOnPathAndUsername
 
 	// TODO_Delete_V23_1DatabaseRoleSettingsHasRoleIDColumn is the version where
 	// the role_id column has been added to the system.database_role_settings
 	// table.
 	TODO_Delete_V23_1DatabaseRoleSettingsHasRoleIDColumn
-
-	// TODO_Delete_V23_1DatabaseRoleSettingsRoleIDColumnBackfilled is the version
-	// where the role_id column in the system.database_role_settings table has
-	// been backfilled.
-	TODO_Delete_V23_1DatabaseRoleSettingsRoleIDColumnBackfilled
 
 	// TODO_Delete_V23_1TenantCapabilities is the version where tenant
 	// capabilities can be set.
@@ -312,65 +259,15 @@ const (
 	// longer write cluster version keys to engines.
 	TODO_Delete_V23_1DeprecateClusterVersionKey
 
-	// TODO_Delete_V23_1_SystemRbrDualWrite indicates regional by row compatible
-	// system tables should write to the old and new indexes. See
-	// system_rbr_indexes.go for more details.
-	TODO_Delete_V23_1_SystemRbrDualWrite
-
-	// TODO_Delete_V23_1_SystemRbrReadNew indicates regional by row compatible
-	// system tables should read from the new index. See system_rbr_indexes.go for
-	// more details.
-	TODO_Delete_V23_1_SystemRbrReadNew
-
-	// TODO_Delete_V23_1_SystemRbrSingleWrite indicates regional by row compatible
-	// system tables no longer need to write to the old index. See
-	// system_rbr_indexes.go for more details.
-	TODO_Delete_V23_1_SystemRbrSingleWrite
-
-	// TODO_Delete_V23_1_SystemRbrCleanup is used to gate an upgrade job that
-	// cleans up old keys that are not regional by row compatible.
-	TODO_Delete_V23_1_SystemRbrCleanup
-
 	// TODO_Delete_V23_1ExternalConnectionsTableHasOwnerIDColumn is the version
 	// where the owner_id column has been added to the system.external_connections
 	// table.
 	TODO_Delete_V23_1ExternalConnectionsTableHasOwnerIDColumn
 
-	// TODO_Delete_V23_1ExternalConnectionsTableOwnerIDColumnBackfilled is the
-	// version where the owner_id column in the system.external_connections table
-	// has been backfilled.
-	TODO_Delete_V23_1ExternalConnectionsTableOwnerIDColumnBackfilled
-
-	// TODO_Delete_V23_1AllowNewSystemPrivileges is the version at which we allow
-	// the new MODIFYSQLCLUSTERSETTING abd VIEWJOB system privileges to be used.
-	// Note: After v23.1 is released, we won't need to version gate these anymore,
-	// since we've made mixed-version clusters tolerate new privileges.
-	TODO_Delete_V23_1AllowNewSystemPrivileges
-
 	// TODO_Delete_V23_1JobInfoTableIsBackfilled is a version gate after which the
 	// system.job_info table has been backfilled with rows for the payload and
 	// progress of each job in the system.jobs table.
 	TODO_Delete_V23_1JobInfoTableIsBackfilled
-
-	// TODO_Delete_V23_1EnableFlushableIngest upgrades the Pebble format major
-	// version to FormatFlushableIngest, which enables use of flushable ingestion.
-	TODO_Delete_V23_1EnableFlushableIngest
-
-	// TODO_Delete_V23_1_UseDelRangeInGCJob enables the use of the DelRange
-	// operation in the GC job. Before it is enabled, the GC job uses ClearRange
-	// operations after the job waits out the GC TTL. After it has been enabled,
-	// the job instead issues DelRange operations at the beginning of the job and
-	// then waits for the data to be removed automatically before removing the
-	// descriptor and zone configurations.
-	TODO_Delete_V23_1_UseDelRangeInGCJob
-
-	// TODO_Delete_V23_1WaitedForDelRangeInGCJob corresponds to the migration
-	// which waits for the GC jobs to adopt the use of DelRange with tombstones.
-	TODO_Delete_V23_1WaitedForDelRangeInGCJob
-
-	// TODO_Delete_V23_1_TaskSystemTables is the version where the system tables
-	// task_payloads and tenant_tasks have been created.
-	TODO_Delete_V23_1_TaskSystemTables
 
 	// Permanent_V23_1_CreateAutoConfigRunnerJob is the version where the auto
 	// config runner persistent job has been created.
@@ -396,10 +293,6 @@ const (
 	// Permanent_V23_1ChangeSQLStatsTTL is the version where the gc TTL was
 	// updated to all SQL Stats tables.
 	Permanent_V23_1ChangeSQLStatsTTL
-
-	// TODO_Delete_V23_1_TenantIDSequence is the version where
-	// system.tenant_id_seq was introduced.
-	TODO_Delete_V23_1_TenantIDSequence
 
 	// Permanent_V23_1CreateSystemActivityUpdateJob is the version at which
 	// Cockroach adds a job that periodically updates the statement_activity and
@@ -529,53 +422,30 @@ var versionTable = [numKeys]roachpb.Version{
 	Permanent_V22_2SQLSchemaTelemetryScheduledJobs: {Major: 22, Minor: 1, Internal: 42},
 
 	// v23.1 versions. Internal versions must be even.
-	TODO_Delete_V23_1Start:                                           {Major: 22, Minor: 2, Internal: 2},
-	TODO_Delete_V23_1TenantNamesStateAndServiceMode:                  {Major: 22, Minor: 2, Internal: 4},
-	TODO_Delete_V23_1DescIDSequenceForSystemTenant:                   {Major: 22, Minor: 2, Internal: 6},
-	TODO_Delete_V23_1AddPartialStatisticsColumns:                     {Major: 22, Minor: 2, Internal: 8},
-	TODO_Delete_V23_1CreateSystemJobInfoTable:                        {Major: 22, Minor: 2, Internal: 10},
-	TODO_Delete_V23_1RoleMembersTableHasIDColumns:                    {Major: 22, Minor: 2, Internal: 12},
-	TODO_Delete_V23_1RoleMembersIDColumnsBackfilled:                  {Major: 22, Minor: 2, Internal: 14},
-	TODO_Delete_V23_1ScheduledChangefeeds:                            {Major: 22, Minor: 2, Internal: 16},
-	TODO_Delete_V23_1AddTypeColumnToJobsTable:                        {Major: 22, Minor: 2, Internal: 18},
-	TODO_Delete_V23_1BackfillTypeColumnInJobsTable:                   {Major: 22, Minor: 2, Internal: 20},
-	TODO_Delete_V23_1_AlterSystemStatementStatisticsAddIndexesUsage:  {Major: 22, Minor: 2, Internal: 22},
-	TODO_Delete_V23_1AlterSystemSQLInstancesAddSQLAddr:               {Major: 22, Minor: 2, Internal: 28},
-	TODO_Delete_V23_1_ChangefeedExpressionProductionReady:            {Major: 22, Minor: 2, Internal: 30},
-	Permanent_V23_1KeyVisualizerTablesAndJobs:                        {Major: 22, Minor: 2, Internal: 32},
-	TODO_Delete_V23_1_KVDirectColumnarScans:                          {Major: 22, Minor: 2, Internal: 34},
-	TODO_Delete_V23_1_DeleteDroppedFunctionDescriptors:               {Major: 22, Minor: 2, Internal: 36},
-	Permanent_V23_1_CreateJobsMetricsPollingJob:                      {Major: 22, Minor: 2, Internal: 38},
-	TODO_Delete_V23_1AllocatorCPUBalancing:                           {Major: 22, Minor: 2, Internal: 40},
-	TODO_Delete_V23_1SystemPrivilegesTableHasUserIDColumn:            {Major: 22, Minor: 2, Internal: 42},
-	TODO_Delete_V23_1SystemPrivilegesTableUserIDColumnBackfilled:     {Major: 22, Minor: 2, Internal: 44},
-	TODO_Delete_V23_1WebSessionsTableHasUserIDColumn:                 {Major: 22, Minor: 2, Internal: 46},
-	TODO_Delete_V23_1WebSessionsTableUserIDColumnBackfilled:          {Major: 22, Minor: 2, Internal: 48},
-	TODO_Delete_V23_1_SchemaChangerDeprecatedIndexPredicates:         {Major: 22, Minor: 2, Internal: 50},
-	TODO_Delete_V23_1AlterSystemPrivilegesAddIndexOnPathAndUsername:  {Major: 22, Minor: 2, Internal: 52},
-	TODO_Delete_V23_1DatabaseRoleSettingsHasRoleIDColumn:             {Major: 22, Minor: 2, Internal: 54},
-	TODO_Delete_V23_1DatabaseRoleSettingsRoleIDColumnBackfilled:      {Major: 22, Minor: 2, Internal: 56},
-	TODO_Delete_V23_1TenantCapabilities:                              {Major: 22, Minor: 2, Internal: 60},
-	TODO_Delete_V23_1DeprecateClusterVersionKey:                      {Major: 22, Minor: 2, Internal: 62},
-	TODO_Delete_V23_1_SystemRbrDualWrite:                             {Major: 22, Minor: 2, Internal: 66},
-	TODO_Delete_V23_1_SystemRbrReadNew:                               {Major: 22, Minor: 2, Internal: 68},
-	TODO_Delete_V23_1_SystemRbrSingleWrite:                           {Major: 22, Minor: 2, Internal: 70},
-	TODO_Delete_V23_1_SystemRbrCleanup:                               {Major: 22, Minor: 2, Internal: 72},
-	TODO_Delete_V23_1ExternalConnectionsTableHasOwnerIDColumn:        {Major: 22, Minor: 2, Internal: 74},
-	TODO_Delete_V23_1ExternalConnectionsTableOwnerIDColumnBackfilled: {Major: 22, Minor: 2, Internal: 76},
-	TODO_Delete_V23_1AllowNewSystemPrivileges:                        {Major: 22, Minor: 2, Internal: 78},
-	TODO_Delete_V23_1JobInfoTableIsBackfilled:                        {Major: 22, Minor: 2, Internal: 80},
-	TODO_Delete_V23_1EnableFlushableIngest:                           {Major: 22, Minor: 2, Internal: 82},
-	TODO_Delete_V23_1_UseDelRangeInGCJob:                             {Major: 22, Minor: 2, Internal: 84},
-	TODO_Delete_V23_1WaitedForDelRangeInGCJob:                        {Major: 22, Minor: 2, Internal: 86},
-	TODO_Delete_V23_1_TaskSystemTables:                               {Major: 22, Minor: 2, Internal: 88},
-	Permanent_V23_1_CreateAutoConfigRunnerJob:                        {Major: 22, Minor: 2, Internal: 90},
-	TODO_Delete_V23_1AddSQLStatsComputedIndexes:                      {Major: 22, Minor: 2, Internal: 92},
-	TODO_Delete_V23_1AddSystemActivityTables:                         {Major: 22, Minor: 2, Internal: 94},
-	TODO_Delete_V23_1StopWritingPayloadAndProgressToSystemJobs:       {Major: 22, Minor: 2, Internal: 96},
-	Permanent_V23_1ChangeSQLStatsTTL:                                 {Major: 22, Minor: 2, Internal: 98},
-	TODO_Delete_V23_1_TenantIDSequence:                               {Major: 22, Minor: 2, Internal: 100},
-	Permanent_V23_1CreateSystemActivityUpdateJob:                     {Major: 22, Minor: 2, Internal: 102},
+	TODO_Delete_V23_1TenantNamesStateAndServiceMode:            {Major: 22, Minor: 2, Internal: 4},
+	TODO_Delete_V23_1DescIDSequenceForSystemTenant:             {Major: 22, Minor: 2, Internal: 6},
+	TODO_Delete_V23_1CreateSystemJobInfoTable:                  {Major: 22, Minor: 2, Internal: 10},
+	TODO_Delete_V23_1RoleMembersTableHasIDColumns:              {Major: 22, Minor: 2, Internal: 12},
+	TODO_Delete_V23_1ScheduledChangefeeds:                      {Major: 22, Minor: 2, Internal: 16},
+	TODO_Delete_V23_1AddTypeColumnToJobsTable:                  {Major: 22, Minor: 2, Internal: 18},
+	TODO_Delete_V23_1BackfillTypeColumnInJobsTable:             {Major: 22, Minor: 2, Internal: 20},
+	TODO_Delete_V23_1_ChangefeedExpressionProductionReady:      {Major: 22, Minor: 2, Internal: 30},
+	Permanent_V23_1KeyVisualizerTablesAndJobs:                  {Major: 22, Minor: 2, Internal: 32},
+	Permanent_V23_1_CreateJobsMetricsPollingJob:                {Major: 22, Minor: 2, Internal: 38},
+	TODO_Delete_V23_1AllocatorCPUBalancing:                     {Major: 22, Minor: 2, Internal: 40},
+	TODO_Delete_V23_1SystemPrivilegesTableHasUserIDColumn:      {Major: 22, Minor: 2, Internal: 42},
+	TODO_Delete_V23_1WebSessionsTableHasUserIDColumn:           {Major: 22, Minor: 2, Internal: 46},
+	TODO_Delete_V23_1DatabaseRoleSettingsHasRoleIDColumn:       {Major: 22, Minor: 2, Internal: 54},
+	TODO_Delete_V23_1TenantCapabilities:                        {Major: 22, Minor: 2, Internal: 60},
+	TODO_Delete_V23_1DeprecateClusterVersionKey:                {Major: 22, Minor: 2, Internal: 62},
+	TODO_Delete_V23_1ExternalConnectionsTableHasOwnerIDColumn:  {Major: 22, Minor: 2, Internal: 74},
+	TODO_Delete_V23_1JobInfoTableIsBackfilled:                  {Major: 22, Minor: 2, Internal: 80},
+	Permanent_V23_1_CreateAutoConfigRunnerJob:                  {Major: 22, Minor: 2, Internal: 90},
+	TODO_Delete_V23_1AddSQLStatsComputedIndexes:                {Major: 22, Minor: 2, Internal: 92},
+	TODO_Delete_V23_1AddSystemActivityTables:                   {Major: 22, Minor: 2, Internal: 94},
+	TODO_Delete_V23_1StopWritingPayloadAndProgressToSystemJobs: {Major: 22, Minor: 2, Internal: 96},
+	Permanent_V23_1ChangeSQLStatsTTL:                           {Major: 22, Minor: 2, Internal: 98},
+	Permanent_V23_1CreateSystemActivityUpdateJob:               {Major: 22, Minor: 2, Internal: 102},
 
 	V23_1: {Major: 23, Minor: 1, Internal: 0},
 

--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -145,6 +145,7 @@ go_test(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlliveness",
+        "//pkg/sql/sqlliveness/slstorage",
         "//pkg/testutils",
         "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",

--- a/pkg/server/settingswatcher/version_guard_test.go
+++ b/pkg/server/settingswatcher/version_guard_test.go
@@ -109,9 +109,9 @@ func TestVersionGuard(t *testing.T) {
 			storageVersion:  &initialVersion,
 			settingsVersion: maxVersion,
 			checkVersions: map[clusterversion.Key]bool{
-				initialVersion:                        true,
-				maxVersion:                            true,
-				clusterversion.TODO_Delete_V23_1Start: true,
+				initialVersion: true,
+				startVersion:   true,
+				maxVersion:     true,
 			},
 		},
 	}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1341,47 +1341,13 @@ func insertJSONStatistic(
 	histogram interface{},
 ) error {
 	var (
-		ctx      = params.ctx
-		txn      = params.p.InternalSQLTxn()
-		settings = params.ExecCfg().Settings
+		ctx = params.ctx
+		txn = params.p.InternalSQLTxn()
 	)
 
 	var name interface{}
 	if s.Name != "" {
 		name = s.Name
-	}
-
-	if !settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1AddPartialStatisticsColumns) {
-
-		if s.PartialPredicate != "" {
-			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState, "statistic for columns %v with collection time %s to insert is partial but cluster version is below 23.1", s.Columns, s.CreatedAt)
-		}
-
-		_ /* rows */, err := txn.Exec(
-			ctx,
-			"insert-stats",
-			txn.KV(),
-			`INSERT INTO system.table_statistics (
-					"tableID",
-					"name",
-					"columnIDs",
-					"createdAt",
-					"rowCount",
-					"distinctCount",
-					"nullCount",
-					"avgSize",
-					histogram
-				) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-			tableID,
-			name,
-			columnIDs,
-			s.CreatedAt,
-			s.RowCount,
-			s.DistinctCount,
-			s.NullCount,
-			s.AvgSize,
-			histogram)
-		return err
 	}
 
 	var predicateValue interface{}

--- a/pkg/sql/catalog/descidgen/BUILD.bazel
+++ b/pkg/sql/catalog/descidgen/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descidgen",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/roachpb",

--- a/pkg/sql/catalog/descidgen/generate_id.go
+++ b/pkg/sql/catalog/descidgen/generate_id.go
@@ -13,7 +13,6 @@ package descidgen
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -65,15 +64,6 @@ func (g *generator) run(ctx context.Context, inc int64) (catid.DescID, error) {
 	return catid.DescID(nextID), err
 }
 
-// ErrDescIDSequenceMigrationInProgress is the error returned when the
-// descriptor ID generator is unavailable due to migrating the system tenant
-// counter from keys.LegacyDescIDGenerator to system.descriptor_id_seq.
-//
-// TODO(postamar): remove along with clusterversion.TODO_Delete_V23_1DescIDSequenceForSystemTenant
-var ErrDescIDSequenceMigrationInProgress = errors.New(
-	"descriptor ID generator unavailable, migration in progress, retry later",
-)
-
 // NewGenerator constructs a non-transactional eval.DescIDGenerator.
 //
 // In this implementation the value returned by PeekNextUniqueDescID is _not_
@@ -108,16 +98,6 @@ func key(
 	ctx context.Context, codec keys.SQLCodec, settings *cluster.Settings,
 ) (roachpb.Key, error) {
 	key := codec.SequenceKey(keys.DescIDSequenceID)
-	if cv := settings.Version; codec.ForSystemTenant() &&
-		!cv.IsActive(ctx, clusterversion.TODO_Delete_V23_1DescIDSequenceForSystemTenant) {
-		// At this point, the system tenant may still be using a legacy non-SQL key,
-		// or may be in the process of undergoing the migration away from it, in
-		// which case descriptor ID generation is made unavailable.
-		if cv.IsActive(ctx, clusterversion.TODO_Delete_V23_1DescIDSequenceForSystemTenant-1) {
-			return nil, ErrDescIDSequenceMigrationInProgress
-		}
-		key = keys.LegacyDescIDGenerator
-	}
 	return key, nil
 }
 

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/rangefeed",

--- a/pkg/sql/catalog/lease/kv_writer.go
+++ b/pkg/sql/catalog/lease/kv_writer.go
@@ -13,7 +13,6 @@ package lease
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/server/settingswatcher"
@@ -58,63 +57,35 @@ func leaseTableWithID(id descpb.ID) catalog.TableDescriptor {
 	return mut.ImmutableCopy().(catalog.TableDescriptor)
 }
 
-func (w *kvWriter) versionGuard(
-	ctx context.Context, txn *kv.Txn,
-) (settingswatcher.VersionGuard, error) {
-	return w.settingsWatcher.MakeVersionGuard(ctx, txn, clusterversion.TODO_Delete_V23_1_SystemRbrCleanup)
-}
-
 func (w *kvWriter) insertLease(ctx context.Context, txn *kv.Txn, l leaseFields) error {
-	return w.do(ctx, txn, l, func(guard settingswatcher.VersionGuard, b *kv.Batch) error {
-		if guard.IsActive(clusterversion.TODO_Delete_V23_1_SystemRbrDualWrite) {
-			err := w.newWriter.Insert(ctx, b, false /*kvTrace */, leaseAsRbrDatum(l)...)
-			if err != nil {
-				return err
-			}
-		}
-		if !guard.IsActive(clusterversion.TODO_Delete_V23_1_SystemRbrSingleWrite) {
-			err := w.oldWriter.Insert(ctx, b, false /*kvTrace */, leaseAsRbtDatum(l)...)
-			if err != nil {
-				return err
-			}
+	return w.do(ctx, txn, l, func(b *kv.Batch) error {
+		err := w.newWriter.Insert(ctx, b, false /*kvTrace */, leaseAsRbrDatum(l)...)
+		if err != nil {
+			return err
 		}
 		return nil
 	})
 }
 
 func (w *kvWriter) deleteLease(ctx context.Context, txn *kv.Txn, l leaseFields) error {
-	return w.do(ctx, txn, l, func(guard settingswatcher.VersionGuard, b *kv.Batch) error {
-		if guard.IsActive(clusterversion.TODO_Delete_V23_1_SystemRbrDualWrite) {
-			err := w.newWriter.Delete(ctx, b, false /*kvTrace */, leaseAsRbrDatum(l)...)
-			if err != nil {
-				return err
-			}
-		}
-		if !guard.IsActive(clusterversion.TODO_Delete_V23_1_SystemRbrSingleWrite) {
-			err := w.oldWriter.Delete(ctx, b, false /*kvTrace */, leaseAsRbtDatum(l)...)
-			if err != nil {
-				return err
-			}
+	return w.do(ctx, txn, l, func(b *kv.Batch) error {
+		err := w.newWriter.Delete(ctx, b, false /*kvTrace */, leaseAsRbrDatum(l)...)
+		if err != nil {
+			return err
 		}
 		return nil
 	})
 }
 
-type addToBatchFunc = func(settingswatcher.VersionGuard, *kv.Batch) error
+type addToBatchFunc = func(*kv.Batch) error
 
 func (w *kvWriter) do(
 	ctx context.Context, txn *kv.Txn, lease leaseFields, addToBatch addToBatchFunc,
 ) error {
 	run := (*kv.Txn).Run
 	do := func(ctx context.Context, txn *kv.Txn) error {
-		guard, err := w.versionGuard(ctx, txn)
-		if err != nil {
-			return err
-		}
-
 		b := txn.NewBatch()
-		err = addToBatch(guard, b)
-		if err != nil {
+		if err := addToBatch(b); err != nil {
 			return errors.NewAssertionErrorWithWrappedErrf(err, "failed to encode lease entry")
 		}
 		return run(txn, ctx, b)
@@ -135,13 +106,4 @@ func leaseAsRbrDatum(l leaseFields) []tree.Datum {
 		tree.NewDBytes(tree.DBytes(l.regionPrefix)),
 	}
 
-}
-
-func leaseAsRbtDatum(l leaseFields) []tree.Datum {
-	return []tree.Datum{
-		tree.NewDInt(tree.DInt(l.descID)),
-		tree.NewDInt(tree.DInt(l.version)),
-		tree.NewDInt(tree.DInt(l.instanceID)),
-		&l.expiration,
-	}
 }

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
@@ -1400,18 +1399,9 @@ func (m *Manager) DeleteOrphanedLeases(ctx context.Context, timeThreshold int64)
 		// doesn't implement AS OF SYSTEM TIME.
 
 		// Read orphaned leases.
-		const (
-			queryWithRegion = `
+		query := `
 SELECT "descID", version, expiration, crdb_region FROM system.public.lease AS OF SYSTEM TIME %d WHERE "nodeID" = %d
 `
-			queryWithoutRegion = `
-SELECT "descID", version, expiration FROM system.public.lease AS OF SYSTEM TIME %d WHERE "nodeID" = %d
-`
-		)
-		query := queryWithRegion
-		if !m.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1_SystemRbrReadNew) {
-			query = queryWithoutRegion
-		}
 		sqlQuery := fmt.Sprintf(query, timeThreshold, instanceID)
 		var rows []tree.Datums
 		retryOptions := base.DefaultRetryOptions()

--- a/pkg/sql/colexec/colbuilder/BUILD.bazel
+++ b/pkg/sql/colexec/colbuilder/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/colexec/colbuilder",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/col/coldata",
         "//pkg/col/coldataext",
         "//pkg/col/typeconv",

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -15,7 +15,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
@@ -835,9 +834,6 @@ func NewColOperator(
 			var resultTypes []*types.T
 			if flowCtx.EvalCtx.SessionData().DirectColumnarScansEnabled {
 				canUseDirectScan := func() bool {
-					if !flowCtx.EvalCtx.Settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1_KVDirectColumnarScans) {
-						return false
-					}
 					// We currently don't use the direct scans if TraceKV is
 					// enabled (due to not being able to tell the KV server
 					// about it). One idea would be to include this boolean into

--- a/pkg/sql/delegate/BUILD.bazel
+++ b/pkg/sql/delegate/BUILD.bazel
@@ -40,7 +40,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/delegate",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/security/username",

--- a/pkg/sql/gcjob/gcjobnotifier/BUILD.bazel
+++ b/pkg/sql/gcjob/gcjobnotifier/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/gcjob/gcjobnotifier",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/config",
         "//pkg/gossip",
         "//pkg/keys",

--- a/pkg/sql/grant_revoke_system.go
+++ b/pkg/sql/grant_revoke_system.go
@@ -15,14 +15,11 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
@@ -38,27 +35,6 @@ import (
 func (n *changeNonDescriptorBackedPrivilegesNode) ReadingOwnWrites() {}
 
 func (n *changeNonDescriptorBackedPrivilegesNode) startExec(params runParams) error {
-	privilegesTableHasUserIDCol := params.p.ExecCfg().Settings.Version.IsActive(params.ctx,
-		clusterversion.TODO_Delete_V23_1SystemPrivilegesTableHasUserIDColumn)
-	if !params.p.ExecCfg().Settings.Version.IsActive(
-		params.ctx,
-		clusterversion.TODO_Delete_V23_1AllowNewSystemPrivileges,
-	) {
-		if n.desiredprivs.Contains(privilege.MODIFYSQLCLUSTERSETTING) {
-			return pgerror.New(pgcode.FeatureNotSupported, "upgrade must be finalized before using MODIFYSQLCLUSTERSETTING system privilege")
-		}
-		if n.desiredprivs.Contains(privilege.VIEWJOB) {
-			return pgerror.New(pgcode.FeatureNotSupported, "upgrade must be finalized before using VIEWJOB system privilege")
-		}
-		if n.desiredprivs.Contains(privilege.REPLICATION) {
-			return pgerror.New(pgcode.FeatureNotSupported, "upgrade must be finalized before using REPLICATION system privilege")
-		}
-		if n.desiredprivs.Contains(privilege.MANAGEVIRTUALCLUSTER) {
-			return pgerror.New(pgcode.FeatureNotSupported, "upgrade must be finalized before using MANAGEVIRTUALCLUSTER system privilege")
-		}
-
-	}
-
 	if err := params.p.preChangePrivilegesValidation(params.ctx, n.grantees, n.withGrantOption, n.isGrant); err != nil {
 		return err
 	}
@@ -84,11 +60,7 @@ func (n *changeNonDescriptorBackedPrivilegesNode) startExec(params runParams) er
 
 		deleteStmt := fmt.Sprintf(
 			`DELETE FROM system.%s VALUES WHERE username = $1 AND path = $2`, catconstants.SystemPrivilegeTableName)
-		upsertStmt := fmt.Sprintf(
-			`UPSERT INTO system.%s (username, path, privileges, grant_options) VALUES ($1, $2, $3, $4)`,
-			catconstants.SystemPrivilegeTableName)
-		if privilegesTableHasUserIDCol {
-			upsertStmt = fmt.Sprintf(`
+		upsertStmt := fmt.Sprintf(`
 UPSERT INTO system.%s (username, path, privileges, grant_options, user_id)
 VALUES ($1, $2, $3, $4, (
 	SELECT CASE $1
@@ -96,8 +68,7 @@ VALUES ($1, $2, $3, $4, (
 		ELSE (SELECT user_id FROM system.users WHERE username = $1)
 	END
 ))`,
-				catconstants.SystemPrivilegeTableName, username.PublicRole, username.PublicRoleID)
-		}
+			catconstants.SystemPrivilegeTableName, username.PublicRole, username.PublicRoleID)
 
 		if n.isGrant {
 			// Privileges are valid, write them to the system.privileges table.

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -1369,7 +1368,7 @@ func (sc *SchemaChanger) createIndexGCJobWithDropTime(
 
 	gcJobRecord := CreateGCJobRecord(
 		jobDesc, sc.job.Payload().UsernameProto.Decode(), indexGCDetails,
-		!sc.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1_UseDelRangeInGCJob),
+		false, /* useLegacyGCJob */
 	)
 	jobID := sc.jobRegistry.MakeJobID()
 	if _, err := sc.jobRegistry.CreateJobWithTxn(ctx, gcJobRecord, jobID, txn); err != nil {

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -641,15 +641,7 @@ func (w *walkCtx) walkIndex(tbl catalog.TableDescriptor, idx catalog.Index) {
 			if idx.IsPartial() {
 				pp, err := w.newExpression(idx.GetPredicate())
 				onErrPanic(err)
-				if w.clusterVersion.IsActive(clusterversion.TODO_Delete_V23_1_SchemaChangerDeprecatedIndexPredicates) {
-					sec.EmbeddedExpr = pp
-				} else {
-					w.ev(scpb.Status_PUBLIC, &scpb.SecondaryIndexPartial{
-						TableID:    index.TableID,
-						IndexID:    index.IndexID,
-						Expression: *pp,
-					})
-				}
+				sec.EmbeddedExpr = pp
 			}
 			w.ev(idxStatus, sec)
 		}

--- a/pkg/sql/schemachanger/scexec/gc_jobs.go
+++ b/pkg/sql/schemachanger/scexec/gc_jobs.go
@@ -214,6 +214,8 @@ func (gj gcJobs) sort() {
 
 // createGCJobRecord creates the job record for a GC job, setting some
 // properties which are common for all GC jobs.
+//
+// TODO(radu): we should remove useLegacyJob, it is no longer used.
 func createGCJobRecord(
 	id jobspb.JobID,
 	description string,

--- a/pkg/sql/schemachanger/scpb/migration.go
+++ b/pkg/sql/schemachanger/scpb/migration.go
@@ -20,11 +20,7 @@ import (
 // HasDeprecatedElements returns if the target contains any element marked
 // for deprecation.
 func HasDeprecatedElements(version clusterversion.ClusterVersion, target Target) bool {
-	if version.IsActive(clusterversion.TODO_Delete_V23_1_SchemaChangerDeprecatedIndexPredicates) &&
-		target.GetSecondaryIndexPartial() != nil {
-		return true
-	}
-	return false
+	return target.GetSecondaryIndexPartial() != nil
 }
 
 // migrateTargetElement migrates an individual target at a given index.

--- a/pkg/sql/schemachanger/screl/scalars.go
+++ b/pkg/sql/schemachanger/screl/scalars.go
@@ -142,9 +142,5 @@ func VersionSupportsElementUse(el scpb.Element, version clusterversion.ClusterVe
 // MaxElementVersion returns the maximum cluster version at which an element
 // may be used.
 func MaxElementVersion(el scpb.Element) (version clusterversion.Key, exists bool) {
-	switch el.(type) {
-	case *scpb.SecondaryIndexPartial:
-		return clusterversion.TODO_Delete_V23_1_SchemaChangerDeprecatedIndexPredicates, true /* exists */
-	}
-	return version, false /* exists */
+	return 0, false /* exists */
 }

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -13,11 +13,9 @@ package sql
 import (
 	"context"
 	encjson "encoding/json"
-	"fmt"
 	"sort"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -34,17 +32,6 @@ import (
 )
 
 var showTableStatsColumns = colinfo.ResultColumns{
-	{Name: "statistics_name", Typ: types.String},
-	{Name: "column_names", Typ: types.StringArray},
-	{Name: "created", Typ: types.TimestampTZ},
-	{Name: "row_count", Typ: types.Int},
-	{Name: "distinct_count", Typ: types.Int},
-	{Name: "null_count", Typ: types.Int},
-	{Name: "avg_size", Typ: types.Int},
-	{Name: "histogram_id", Typ: types.Int},
-}
-
-var showTableStatsColumnsPartialStatisticsVer = colinfo.ResultColumns{
 	{Name: "statistics_name", Typ: types.String},
 	{Name: "column_names", Typ: types.StringArray},
 	{Name: "created", Typ: types.TimestampTZ},
@@ -99,11 +86,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 	if err := p.CheckAnyPrivilege(ctx, desc); err != nil {
 		return nil, err
 	}
-	partialStatsVerActive := p.ExtendedEvalContext().ExecCfg.Settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1AddPartialStatisticsColumns)
-	columns := showTableStatsColumnsPartialStatisticsVer
-	if !partialStatsVerActive {
-		columns = showTableStatsColumns
-	}
+	columns := showTableStatsColumns
 	if n.UsingJSON {
 		columns = showTableStatsJSONColumns
 	}
@@ -118,16 +101,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 			//    "handle" which can be used with SHOW HISTOGRAM.
 			// TODO(yuzefovich): refactor the code to use the iterator API
 			// (currently it is not possible due to a panic-catcher below).
-			var partialPredicateCol string
-			var fullStatisticIDCol string
-			if partialStatsVerActive {
-				partialPredicateCol = `
-"partialPredicate",`
-				fullStatisticIDCol = `
-,"fullStatisticID"
-`
-			}
-			stmt := fmt.Sprintf(`SELECT
+			stmt := `SELECT
 							"tableID",
 							"statisticID",
 							name,
@@ -137,12 +111,12 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 							"distinctCount",
 							"nullCount",
 							"avgSize",
-							%s
-							histogram
-							%s
+							"partialPredicate",
+							histogram,
+							"fullStatisticID"
 						FROM system.table_statistics
 						WHERE "tableID" = $1
-						ORDER BY "createdAt", "columnIDs", "statisticID"`, partialPredicateCol, fullStatisticIDCol)
+						ORDER BY "createdAt", "columnIDs", "statisticID"`
 
 			// There is a privilege check above to make sure the user has any
 			// privilege on the table being inspected. We use the node user to execute
@@ -178,10 +152,6 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 
 			histIdx := histogramIdx
 			nCols := numCols
-			if !partialStatsVerActive {
-				histIdx = histogramIdx - 1
-				nCols = numCols - 2
-			}
 
 			// Guard against crashes in the code below (e.g. #56356).
 			defer func() {
@@ -211,7 +181,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 					if ignoreStatsRowWithDroppedColumn {
 						continue
 					}
-					stat, err := stats.NewTableStatisticProto(row, partialStatsVerActive)
+					stat, err := stats.NewTableStatisticProto(row)
 					if err != nil {
 						return nil, err
 					}
@@ -235,7 +205,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 					statsList = append(merged, statsList...)
 					// Iterate in reverse order to match the ORDER BY "columnIDs".
 					for i := len(merged) - 1; i >= 0; i-- {
-						mergedRow, err := tableStatisticProtoToRow(&merged[i].TableStatisticProto, partialStatsVerActive)
+						mergedRow, err := tableStatisticProtoToRow(&merged[i].TableStatisticProto)
 						if err != nil {
 							return nil, err
 						}
@@ -248,7 +218,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 					forecastRows := make([]tree.Datums, 0, len(forecasts))
 					// Iterate in reverse order to match the ORDER BY "columnIDs".
 					for i := len(forecasts) - 1; i >= 0; i-- {
-						forecastRow, err := tableStatisticProtoToRow(&forecasts[i].TableStatisticProto, partialStatsVerActive)
+						forecastRow, err := tableStatisticProtoToRow(&forecasts[i].TableStatisticProto)
 						if err != nil {
 							return nil, err
 						}
@@ -296,7 +266,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 					if r[nameIdx] != tree.DNull {
 						statsRow.Name = string(*r[nameIdx].(*tree.DString))
 					}
-					if partialStatsVerActive && r[partialPredicateIdx] != tree.DNull && r[fullStatisticIDIdx] != tree.DNull {
+					if r[partialPredicateIdx] != tree.DNull && r[fullStatisticIDIdx] != tree.DNull {
 						statsRow.PartialPredicate = string(*r[partialPredicateIdx].(*tree.DString))
 						statsRow.FullStatisticID = (uint64)(*r[fullStatisticIDIdx].(*tree.DInt))
 					}
@@ -358,31 +328,17 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 					histogramID = r[statIDIdx]
 				}
 
-				var res tree.Datums
-				if partialStatsVerActive {
-					res = tree.Datums{
-						r[nameIdx],
-						colNames,
-						createdAtTZ,
-						r[rowCountIdx],
-						r[distinctCountIdx],
-						r[nullCountIdx],
-						r[avgSizeIdx],
-						r[partialPredicateIdx],
-						histogramID,
-						r[fullStatisticIDIdx],
-					}
-				} else {
-					res = tree.Datums{
-						r[nameIdx],
-						colNames,
-						createdAtTZ,
-						r[rowCountIdx],
-						r[distinctCountIdx],
-						r[nullCountIdx],
-						r[avgSizeIdx],
-						histogramID,
-					}
+				res := tree.Datums{
+					r[nameIdx],
+					colNames,
+					createdAtTZ,
+					r[rowCountIdx],
+					r[distinctCountIdx],
+					r[nullCountIdx],
+					r[avgSizeIdx],
+					r[partialPredicateIdx],
+					histogramID,
+					r[fullStatisticIDIdx],
 				}
 
 				if _, err := v.rows.AddRow(ctx, res); err != nil {
@@ -405,9 +361,7 @@ func statColumnString(desc catalog.TableDescriptor, colID tree.Datum) (colName s
 	return colDesc.GetName(), nil
 }
 
-func tableStatisticProtoToRow(
-	stat *stats.TableStatisticProto, partialStatsVerActive bool,
-) (tree.Datums, error) {
+func tableStatisticProtoToRow(stat *stats.TableStatisticProto) (tree.Datums, error) {
 	name := tree.DNull
 	if stat.Name != "" {
 		name = tree.NewDString(stat.Name)
@@ -436,10 +390,7 @@ func tableStatisticProtoToRow(
 		tree.NewDInt(tree.DInt(stat.DistinctCount)),
 		tree.NewDInt(tree.DInt(stat.NullCount)),
 		tree.NewDInt(tree.DInt(stat.AvgSize)),
-	}
-
-	if partialStatsVerActive {
-		row = append(row, partialPredicate)
+		partialPredicate,
 	}
 
 	if stat.HistogramData == nil {
@@ -451,8 +402,6 @@ func tableStatisticProtoToRow(
 		}
 		row = append(row, tree.NewDBytes(tree.DBytes(histogram)))
 	}
-	if partialStatsVerActive {
-		row = append(row, FullStatisticID)
-	}
+	row = append(row, FullStatisticID)
 	return row, nil
 }

--- a/pkg/sql/sqlinstance/instancestorage/BUILD.bazel
+++ b/pkg/sql/sqlinstance/instancestorage/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/rangefeed",
@@ -45,7 +44,6 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_logtags//:logtags",
     ],
 )
 

--- a/pkg/sql/sqlinstance/instancestorage/instancecache.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancecache.go
@@ -13,20 +13,15 @@ package instancestorage
 import (
 	"context"
 	"strings"
-	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/logtags"
 )
 
 // instanceCache represents a cache over the contents of sql_instances table.
@@ -215,118 +210,6 @@ type migrationCache struct {
 		syncutil.Mutex
 		cache instanceCache
 	}
-}
-
-// onVersionReached installs a callback that runs once the version is reached.
-// If the version was reached before installing the callback, the callback is run
-// synchronously.
-func onVersionReached(
-	ctx context.Context, settings *cluster.Settings, expect clusterversion.Key, do func(),
-) {
-	var once sync.Once
-
-	onVersionChanged := func(rpcContext context.Context, version clusterversion.ClusterVersion) {
-		if !version.IsActive(expect) {
-			return
-		}
-		once.Do(do)
-	}
-
-	settings.Version.SetOnChange(onVersionChanged)
-
-	onVersionChanged(ctx, settings.Version.ActiveVersion(ctx))
-}
-
-// newMigrationCache uses the oldCache and newCache functions to construct
-// instanceCaches. The cache registers a hook with the setting and switches
-// from the old implementation to the new implementation when the version
-// changes to TODO_Delete_V23_1_SystemRbrReadNew.
-func newMigrationCache(
-	ctx context.Context,
-	stopper *stop.Stopper,
-	settings *cluster.Settings,
-	oldCache, newCache func(ctx context.Context) (instanceCache, error),
-) (instanceCache, error) {
-	c := &migrationCache{}
-
-	// oldReady is signaled when the old cache finishes starting.
-	oldReady := make(chan error, 1)
-	err := stopper.RunAsyncTask(ctx, "start-old-cache-implementation", func(ctx context.Context) {
-		cache, err := oldCache(ctx)
-		if err != nil {
-			oldReady <- err
-		}
-
-		onVersionReached(ctx, settings, clusterversion.TODO_Delete_V23_1_SystemRbrReadNew, func() {
-			// Once the read new version gate is reached, close the original
-			// cache in order to clean up resources and prevent reading updates
-			// when the original index is deleted.
-			cache.Close()
-		})
-
-		// If the old cache is already stale, do not return it.
-		if settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1_SystemRbrReadNew) {
-			return
-		}
-
-		c.mu.Lock()
-		defer c.mu.Unlock()
-
-		// In the case of a race condition, if the new cache initialized first,
-		// do not ovewrwrite it.
-		if c.mu.cache != nil {
-			return
-		}
-
-		c.mu.cache = cache
-		oldReady <- nil
-	})
-	if err != nil {
-		oldReady <- err
-	}
-
-	// newReady is signaled when the new cache finishes starting.
-	newReady := make(chan error, 1)
-	newCacheCtx := logtags.AddTags(context.Background(), logtags.FromContext(ctx))
-	onVersionReached(ctx, settings, clusterversion.TODO_Delete_V23_1_SystemRbrReadNew, func() {
-		err := stopper.RunAsyncTask(newCacheCtx, "start-new-cache-implementation", func(ctx context.Context) {
-			// Rebuild the cancel signal since the goroutine has a  background
-			// context.
-			ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
-			defer cancel()
-
-			log.Ops.Info(ctx, "starting new system.sql_instance cache")
-
-			cache, err := newCache(ctx)
-			if err != nil {
-				log.Ops.Errorf(ctx, "error starting the new system.sql_instance cache: %s", err)
-				newReady <- err
-				return
-			}
-
-			log.Ops.Info(ctx, "new system.sql_instance cache is ready")
-
-			c.mu.Lock()
-			defer c.mu.Unlock()
-
-			c.mu.cache = cache
-			newReady <- nil
-		})
-		if err != nil {
-			log.Ops.Errorf(ctx, "unable to start new system.sql_instance cache: %s", err)
-			newReady <- err
-		}
-	})
-
-	// Wait for one of the caches to be ready or fail to start.
-	select {
-	case err = <-newReady:
-	case err = <-oldReady:
-	}
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
 }
 
 func (c *migrationCache) Close() {

--- a/pkg/sql/sqlinstance/instancestorage/instancecache_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancecache_test.go
@@ -91,7 +91,7 @@ func TestRangeFeed(t *testing.T) {
 
 		require.NoError(t, storage.generateAvailableInstanceRows(ctx, [][]byte{enum.One}, tenant.Clock().Now().Add(int64(time.Minute), 0)))
 
-		feed, err := storage.newInstanceCache(ctx, tenant.AppStopper())
+		feed, err := storage.newInstanceCache(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, feed)
 		defer feed.Close()
@@ -104,7 +104,7 @@ func TestRangeFeed(t *testing.T) {
 
 	t.Run("auth_error", func(t *testing.T) {
 		storage := newStorage(t, keys.SystemSQLCodec)
-		_, err := storage.newInstanceCache(ctx, tenant.AppStopper())
+		_, err := storage.newInstanceCache(ctx)
 		require.True(t, grpcutil.IsAuthError(err), "expected %+v to be an auth error", err)
 	})
 
@@ -114,7 +114,7 @@ func TestRangeFeed(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		_, err := storage.newInstanceCache(ctx, tenant.AppStopper())
+		_, err := storage.newInstanceCache(ctx)
 		require.Error(t, err)
 		require.ErrorIs(t, err, ctx.Err())
 	})

--- a/pkg/sql/sqlinstance/instancestorage/instancereader.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancereader.go
@@ -85,7 +85,7 @@ func (r *Reader) Start(ctx context.Context, self sqlinstance.InstanceInfo) {
 	// Make sure that the reader shuts down gracefully.
 	ctx, cancel := r.stopper.WithCancelOnQuiesce(ctx)
 	err := r.stopper.RunAsyncTask(ctx, "start-instance-reader", func(ctx context.Context) {
-		cache, err := r.storage.newInstanceCache(ctx, r.stopper)
+		cache, err := r.storage.newInstanceCache(ctx)
 		if err != nil {
 			r.setInitialScanDone(err)
 			return

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage_internal_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage_internal_test.go
@@ -56,12 +56,8 @@ func TestGetAvailableInstanceIDForRegion(t *testing.T) {
 
 	getAvailableInstanceID := func(storage *Storage, region []byte) (id base.SQLInstanceID, err error) {
 		err = storage.db.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
-			version, err := storage.versionGuard(ctx, txn)
-			if err != nil {
-				return err
-			}
-
-			id, err = storage.getAvailableInstanceIDForRegion(ctx, region, txn, &version)
+			var err error
+			id, err = storage.getAvailableInstanceIDForRegion(ctx, region, txn)
 			return err
 		})
 		return

--- a/pkg/sql/sqlliveness/slstorage/BUILD.bazel
+++ b/pkg/sql/sqlliveness/slstorage/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slstorage",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvpb",
@@ -23,7 +22,6 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/systemschema",
-        "//pkg/sql/enum",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sqlliveness",
         "//pkg/util/admission/admissionpb",

--- a/pkg/sql/sqlliveness/slstorage/key_encoder.go
+++ b/pkg/sql/sqlliveness/slstorage/key_encoder.go
@@ -76,33 +76,3 @@ func (e *rbrEncoder) decode(key roachpb.Key) (sqlliveness.SessionID, error) {
 func (e *rbrEncoder) indexPrefix() roachpb.Key {
 	return e.rbrIndex.Clone()
 }
-
-type rbtEncoder struct {
-	rbtIndex roachpb.Key
-}
-
-func (e *rbtEncoder) encode(id sqlliveness.SessionID) (roachpb.Key, error) {
-	const columnFamilyID = 0
-
-	key := e.indexPrefix()
-	key = encoding.EncodeBytesAscending(key, id.UnsafeBytes())
-	return keys.MakeFamilyKey(key, columnFamilyID), nil
-}
-
-func (e *rbtEncoder) decode(key roachpb.Key) (sqlliveness.SessionID, error) {
-	if !bytes.HasPrefix(key, e.rbtIndex) {
-		return "", errors.Newf("sqlliveness table key has an invalid prefix: %v", key)
-	}
-	rem := key[len(e.rbtIndex):]
-
-	rem, session, err := encoding.DecodeBytesAscending(rem, nil)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to decode region from session key")
-	}
-
-	return sqlliveness.SessionID(session), nil
-}
-
-func (e *rbtEncoder) indexPrefix() roachpb.Key {
-	return e.rbtIndex.Clone()
-}

--- a/pkg/sql/sqlliveness/slstorage/key_encoder_test.go
+++ b/pkg/sql/sqlliveness/slstorage/key_encoder_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/enum"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -54,16 +53,6 @@ func TestKeyEncoder(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, bytes.HasPrefix(key, codec.indexPrefix()))
 
-		decodedID, err := codec.decode(key)
-		require.NoError(t, err)
-		require.Equal(t, id, decodedID)
-	})
-
-	t.Run("EncodeLegacySession", func(t *testing.T) {
-		id := sqlliveness.SessionID(uuid.MakeV4().GetBytes())
-
-		key, err := codec.encode(id)
-		require.NoError(t, err)
 		decodedID, err := codec.decode(key)
 		require.NoError(t, err)
 		require.Equal(t, id, decodedID)

--- a/pkg/sql/sqlliveness/slstorage/sessionid.go
+++ b/pkg/sql/sqlliveness/slstorage/sessionid.go
@@ -11,8 +11,6 @@
 package slstorage
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/sql/enum"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -70,15 +68,7 @@ func MakeSessionID(region []byte, id uuid.UUID) (sqlliveness.SessionID, error) {
 func UnsafeDecodeSessionID(session sqlliveness.SessionID) (region, id []byte, err error) {
 	b := session.UnsafeBytes()
 	if len(b) == legacyLen {
-		// TODO(jeffswenson): once the TODO_Delete_V23_1_SystemRbrCleanup version gate is
-		// deleted, replace this branch with a validation error.
-		_ = clusterversion.TODO_Delete_V23_1_SystemRbrCleanup
-
-		// Legacy format of SessionID. Treat the session as if it belongs to
-		// region enum.One. This may crop up briefly if a session was created
-		// with an old binary right before the server is upgraded and the
-		// upgrade is kicked off while the session is still 'live'.
-		return enum.One, b, nil
+		return nil, nil, errors.Newf("unexpected legacy SessionID format")
 	}
 	if len(b) < minimumNonLegacyLen {
 		// The smallest valid v1 session id is a [version, 1, single_byte_region, uuid...],

--- a/pkg/sql/sqlliveness/slstorage/sessionid_test.go
+++ b/pkg/sql/sqlliveness/slstorage/sessionid_test.go
@@ -88,12 +88,6 @@ func TestSessionIDEncoding(t *testing.T) {
 			err:     "session id is too short",
 		},
 		{
-			name:    "legacy_session",
-			session: sqlliveness.SessionID(id1.GetBytes()),
-			region:  enum.One,
-			id:      id1,
-		},
-		{
 			name:    "session_v1",
 			session: must(slstorage.MakeSessionID(enum.One, id1)),
 			region:  enum.One,

--- a/pkg/sql/sqlliveness/slstorage/slstorage_internal_test.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage_internal_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/server/settingswatcher"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -30,7 +29,6 @@ func TestGetEncoder(t *testing.T) {
 	const (
 		isNil codecType = iota
 		isRbr
-		isRbt
 	)
 
 	checkCodec := func(t *testing.T, typ codecType, codec keyCodec) {
@@ -42,10 +40,6 @@ func TestGetEncoder(t *testing.T) {
 			require.NotNil(t, codec)
 			_, ok := codec.(*rbrEncoder)
 			require.True(t, ok, "expected %v to be an rbr encoder", codec)
-		case isRbt:
-			require.NotNil(t, codec)
-			_, ok := codec.(*rbtEncoder)
-			require.True(t, ok, "expected %v to be an rbt encoder", codec)
 		}
 	}
 
@@ -68,11 +62,7 @@ func TestGetEncoder(t *testing.T) {
 			storage := NewTestingStorage(
 				log.AmbientContext{}, nil, nil, nil, keys.SystemSQLCodec, nil, nil, systemschema.SqllivenessTable(), nil)
 
-			version := clusterversion.ClusterVersion{Version: clusterversion.ByKey(tc.version)}
-			guard := settingswatcher.TestMakeVersionGuard(version)
-
-			checkCodec(t, tc.readCodec, storage.getReadCodec(&guard))
-			checkCodec(t, tc.dualCodec, storage.getDualWriteCodec(&guard))
+			checkCodec(t, tc.readCodec, storage.keyCodec)
 		})
 	}
 }

--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/stats",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv/kvclient/rangefeed",

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -17,7 +17,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
@@ -522,19 +521,13 @@ const (
 // NewTableStatisticProto converts a row of datums from system.table_statistics
 // into a TableStatisticsProto. Note that any user-defined types in the
 // HistogramData will be unresolved.
-func NewTableStatisticProto(
-	datums tree.Datums, partialStatisticsColumnsVerActive bool,
-) (*TableStatisticProto, error) {
+func NewTableStatisticProto(datums tree.Datums) (*TableStatisticProto, error) {
 	if datums == nil || datums.Len() == 0 {
 		return nil, nil
 	}
 
 	hgIndex := histogramIndex
 	numStats := statsLen
-	if !partialStatisticsColumnsVerActive {
-		hgIndex = histogramIndex - 1
-		numStats = statsLen - 2
-	}
 	// Validate the input length.
 	if datums.Len() != numStats {
 		return nil, errors.Errorf("%d values returned from table statistics lookup. Expected %d", datums.Len(), numStats)
@@ -556,28 +549,9 @@ func NewTableStatisticProto(
 		{"distinctCount", distinctCountIndex, types.Int, false},
 		{"nullCount", nullCountIndex, types.Int, false},
 		{"avgSize", avgSizeIndex, types.Int, false},
+		{"partialPredicate", partialPredicateIndex, types.String, true},
 		{"histogram", hgIndex, types.Bytes, true},
-	}
-
-	// It's ok for expectedTypes to be in a different order than the input datums
-	// since we don't rely on a precise order of expectedTypes when we check them
-	// below.
-	if partialStatisticsColumnsVerActive {
-		expectedTypes = append(expectedTypes,
-			[]struct {
-				fieldName    string
-				fieldIndex   int
-				expectedType *types.T
-				nullable     bool
-			}{
-				{
-					"partialPredicate", partialPredicateIndex, types.String, true,
-				},
-				{
-					"fullStatisticID", fullStatisticsIdIndex, types.Int, true,
-				},
-			}...,
-		)
+		{"fullStatisticID", fullStatisticsIdIndex, types.Int, true},
 	}
 
 	for _, v := range expectedTypes {
@@ -606,13 +580,11 @@ func NewTableStatisticProto(
 	if datums[nameIndex] != tree.DNull {
 		res.Name = string(*datums[nameIndex].(*tree.DString))
 	}
-	if partialStatisticsColumnsVerActive {
-		if datums[partialPredicateIndex] != tree.DNull {
-			res.PartialPredicate = string(*datums[partialPredicateIndex].(*tree.DString))
-		}
-		if datums[fullStatisticsIdIndex] != tree.DNull {
-			res.FullStatisticID = uint64(*datums[fullStatisticsIdIndex].(*tree.DInt))
-		}
+	if datums[partialPredicateIndex] != tree.DNull {
+		res.PartialPredicate = string(*datums[partialPredicateIndex].(*tree.DString))
+	}
+	if datums[fullStatisticsIdIndex] != tree.DNull {
+		res.FullStatisticID = uint64(*datums[fullStatisticsIdIndex].(*tree.DInt))
 	}
 	if datums[hgIndex] != tree.DNull {
 		res.HistogramData = &HistogramData{}
@@ -629,11 +601,11 @@ func NewTableStatisticProto(
 // parseStats converts the given datums to a TableStatistic object. It might
 // need to run a query to get user defined type metadata.
 func (sc *TableStatisticsCache) parseStats(
-	ctx context.Context, datums tree.Datums, partialStatisticsColumnsVerActive bool,
+	ctx context.Context, datums tree.Datums,
 ) (*TableStatistic, error) {
 	var tsp *TableStatisticProto
 	var err error
-	tsp, err = NewTableStatisticProto(datums, partialStatisticsColumnsVerActive)
+	tsp, err = NewTableStatisticProto(datums)
 	if err != nil {
 		return nil, err
 	}
@@ -779,17 +751,7 @@ func (tsp *TableStatisticProto) IsAuto() bool {
 func (sc *TableStatisticsCache) getTableStatsFromDB(
 	ctx context.Context, tableID descpb.ID, forecast bool,
 ) ([]*TableStatistic, error) {
-	partialStatisticsColumnsVerActive := sc.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1AddPartialStatisticsColumns)
-	var partialPredicateCol string
-	var fullStatisticIDCol string
-	if partialStatisticsColumnsVerActive {
-		partialPredicateCol = `
-"partialPredicate",`
-		fullStatisticIDCol = `
-,"fullStatisticID"
-`
-	}
-	getTableStatisticsStmt := fmt.Sprintf(`
+	getTableStatisticsStmt := `
 SELECT
 	"tableID",
 	"statisticID",
@@ -800,13 +762,13 @@ SELECT
 	"distinctCount",
 	"nullCount",
 	"avgSize",
-	%s
-	histogram
-	%s
+	"partialPredicate",
+	histogram,
+	"fullStatisticID"
 FROM system.table_statistics
 WHERE "tableID" = $1
 ORDER BY "createdAt" DESC, "columnIDs" DESC, "statisticID" DESC
-`, partialPredicateCol, fullStatisticIDCol)
+`
 	// TODO(michae2): Add an index on system.table_statistics (tableID, createdAt,
 	// columnIDs, statisticID).
 
@@ -820,7 +782,7 @@ ORDER BY "createdAt" DESC, "columnIDs" DESC, "statisticID" DESC
 	var statsList []*TableStatistic
 	var ok bool
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
-		stats, err := sc.parseStats(ctx, it.Cur(), partialStatisticsColumnsVerActive)
+		stats, err := sc.parseStats(ctx, it.Cur())
 		if err != nil {
 			log.Warningf(ctx, "could not decode statistic for table %d: %v", tableID, err)
 			continue

--- a/pkg/sql/tenant_capability.go
+++ b/pkg/sql/tenant_capability.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigbounds"
@@ -45,9 +44,6 @@ func (p *planner) AlterTenantCapability(
 ) (planNode, error) {
 	if err := rejectIfCantCoordinateMultiTenancy(p.execCfg.Codec, "grant/revoke capabilities to", p.execCfg.Settings); err != nil {
 		return nil, err
-	}
-	if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1TenantCapabilities) {
-		return nil, pgerror.Newf(pgcode.ObjectNotInPrerequisiteState, "cannot alter tenant capabilities until version is finalized")
 	}
 
 	tSpec, err := p.planTenantSpec(ctx, n.TenantSpec, alterTenantCapabilityOp)

--- a/pkg/sql/tenant_deletion.go
+++ b/pkg/sql/tenant_deletion.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
@@ -86,21 +85,19 @@ func dropTenantInternal(
 		return err
 	}
 
-	if settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1TenantNamesStateAndServiceMode) {
-		if ignoreServiceMode {
-			// Compatibility with CC serverless use of
-			// crdb_internal.destroy_tenant(): we want to disable the check
-			// immediately below, as well as the additional check performed
-			// inside UpdateTenantRecord() (via validateTenantInfo).
-			info.ServiceMode = mtinfopb.ServiceModeNone
-		}
-		// We can only check the service mode after upgrading to a version
-		// that supports the service mode column.
-		if info.ServiceMode != mtinfopb.ServiceModeNone {
-			return errors.WithHint(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
-				"cannot drop tenant %q (%d) in service mode %v", info.Name, tenID, info.ServiceMode),
-				"Use ALTER VIRTUAL CLUSTER STOP SERVICE before DROP VIRTUAL CLUSTER.")
-		}
+	if ignoreServiceMode {
+		// Compatibility with CC serverless use of
+		// crdb_internal.destroy_tenant(): we want to disable the check
+		// immediately below, as well as the additional check performed
+		// inside UpdateTenantRecord() (via validateTenantInfo).
+		info.ServiceMode = mtinfopb.ServiceModeNone
+	}
+	// We can only check the service mode after upgrading to a version
+	// that supports the service mode column.
+	if info.ServiceMode != mtinfopb.ServiceModeNone {
+		return errors.WithHint(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+			"cannot drop tenant %q (%d) in service mode %v", info.Name, tenID, info.ServiceMode),
+			"Use ALTER VIRTUAL CLUSTER STOP SERVICE before DROP VIRTUAL CLUSTER.")
 	}
 
 	if info.DataState == mtinfopb.DataStateDrop {


### PR DESCRIPTION
This PR is only for the top commit (it is on top of #114306).

This change removes pre-23.1 version gates in SQL code.
    
Informs: #112501
Release note: None