### PR TITLE
roachprod-microbench: read-only sheet permissions

### DIFF
--- a/pkg/cmd/roachprod-microbench/google/service.go
+++ b/pkg/cmd/roachprod-microbench/google/service.go
@@ -364,7 +364,7 @@ func (srv *Service) updatePerms(ctx context.Context, spreadsheetID string) error
 	// with the link.
 	perm := &drive.Permission{
 		Type: "anyone",
-		Role: "writer",
+		Role: "reader",
 	}
 	_, err := srv.drive.Permissions.Create(spreadsheetID, perm).Context(ctx).Do()
 	return errors.Wrap(err, "update Spreadsheet permissions")


### PR DESCRIPTION
Previously sheets were open to editing for anyone with the link. But since sheets may be publicly shared it should be set to read-only. And since sheets are not the source of truth or record it should not be used as a discussion area.

This change updates the permissions of sheets to be read-only (view only).

Epic: None
Release Note: None