### PR TITLE
multiregion: fix flake in TestRegionLivenessProber

### DIFF
--- a/pkg/ccl/multiregionccl/regionliveness_test.go
+++ b/pkg/ccl/multiregionccl/regionliveness_test.go
@@ -42,7 +42,6 @@ func TestRegionLivenessProber(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderStressRace(t)
-	skip.UnderStress(t)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Previously, the TestRegionLivenessProber had too narrow of a timing window to detect region failure since the default timeout to declare a region dead was around ~40 seconds. As a result, SucceedsSoon could timeout before the failure was fully detected, leading to intermittent failures. This patch addresses this by extending the timeout for detecting the region failure.

Fixes: #114245

Release note: None