### PR TITLE
roachtest: bump tpcc/mixed-headroom/n5cpu16 timeout to 6 hours

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -477,7 +477,7 @@ func registerTPCC(r registry.Registry) {
 		// migrations while TPCC runs. It simulates a real production
 		// deployment in the middle of the migration into a new cluster version.
 		Name:    "tpcc/mixed-headroom/" + mixedHeadroomSpec.String(),
-		Timeout: 5 * time.Hour,
+		Timeout: 6 * time.Hour,
 		Owner:   registry.OwnerTestEng,
 		// TODO(tbg): add release_qualification tag once we know the test isn't
 		// buggy.


### PR DESCRIPTION
The new testing framework used randomizes the amount of times the TPCC workload is run. Bumping the timeout accounts for the worst case with 3 upgrades and running TPCC during all finalizations.

Epic: none
Fixes: #114330
Release note: none