### PR TITLE
sqlproxyccl: disable shared process test virtual cluster

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -293,6 +293,16 @@ var (
 	// TODO(#76378): Review existing tests and use the proper value instead.
 	TODOTestTenantDisabled = DefaultTestTenantOptions{testBehavior: ttDisabled, allowAdditionalTenants: true}
 
+	// TestRequiresExplicitSQLConnection is used when the test is unable to pass
+	// the cluster as an option in the connection URL. The test could still
+	// probabilistically use an external process test virtual cluster, but
+	// disables the selection of a shared process test virtual cluster.
+	TestRequiresExplicitSQLConnection = DefaultTestTenantOptions{
+		testBehavior:             ttExternalProcess,
+		allowAdditionalTenants:   true,
+		noWarnImplicitInterfaces: true,
+	}
+
 	// TestControlsTenantsExplicitly is used when the test wants to
 	// manage its own secondary tenants and tenant servers.
 	TestControlsTenantsExplicitly = DefaultTestTenantOptions{

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -136,9 +136,7 @@ func TestProxyProtocol(t *testing.T) {
 	defer te.Close()
 
 	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
-			base.TestTenantProbabilistic, 112867,
-		),
+		DefaultTestTenant: base.TestRequiresExplicitSQLConnection,
 	})
 
 	ts := sql.ApplicationLayer()
@@ -249,9 +247,7 @@ func TestPrivateEndpointsACL(t *testing.T) {
 	defer te.Close()
 
 	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
-			base.TestTenantProbabilistic, 112867,
-		),
+		DefaultTestTenant: base.TestRequiresExplicitSQLConnection,
 	})
 	defer sql.Stopper().Stop(ctx)
 
@@ -421,9 +417,7 @@ func TestAllowedCIDRRangesACL(t *testing.T) {
 	defer te.Close()
 
 	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
-			base.TestTenantProbabilistic, 112867,
-		),
+		DefaultTestTenant: base.TestRequiresExplicitSQLConnection,
 	})
 	defer sql.Stopper().Stop(ctx)
 
@@ -689,9 +683,7 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 	defer te.Close()
 
 	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
-			base.TestTenantProbabilisticOnly, 112867,
-		),
+		DefaultTestTenant: base.TestRequiresExplicitSQLConnection,
 	})
 	defer sql.Stopper().Stop(ctx)
 
@@ -890,9 +882,7 @@ func TestProxyTLSClose(t *testing.T) {
 	defer te.Close()
 
 	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
-			base.TestTenantProbabilistic, 112867,
-		),
+		DefaultTestTenant: base.TestRequiresExplicitSQLConnection,
 	})
 	defer sql.Stopper().Stop(ctx)
 
@@ -945,9 +935,7 @@ func TestProxyModifyRequestParams(t *testing.T) {
 	defer te.Close()
 
 	sql, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
-			base.TestTenantProbabilistic, 112867,
-		),
+		DefaultTestTenant: base.TestRequiresExplicitSQLConnection,
 	})
 	defer sql.Stopper().Stop(ctx)
 
@@ -1007,9 +995,7 @@ func TestInsecureProxy(t *testing.T) {
 	defer te.Close()
 
 	sql, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
-			base.TestTenantProbabilistic, 112867,
-		),
+		DefaultTestTenant: base.TestRequiresExplicitSQLConnection,
 	})
 	defer sql.Stopper().Stop(ctx)
 
@@ -1194,9 +1180,7 @@ func TestDenylistUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	sql, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
-			base.TestTenantProbabilistic, 112867,
-		),
+		DefaultTestTenant: base.TestRequiresExplicitSQLConnection,
 	})
 	defer sql.Stopper().Stop(ctx)
 


### PR DESCRIPTION
SQL proxy needs to disable shared process test virtual clusters as it already uses the cluster option in PG URLs to perform its own logic.

This change adds a test arg configuration that allows only external process test virtual clusters to be probabilistically selected, if a test requires this configuration.

Fixes: #112867

Epic: None
Release Note: None