### PR TITLE
sql/tests: avoid dropping database in RSG tests

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -297,7 +297,7 @@ func TestRandomSyntaxGeneration(t *testing.T) {
 		if strings.HasPrefix(s, "SET SESSION CHARACTERISTICS AS TRANSACTION") {
 			return errors.New("setting session characteristics is unsupported")
 		}
-		if strings.HasPrefix(s, "DROP DATABASE ident") {
+		if strings.HasPrefix(s, "DROP DATABASE") {
 			return errors.New("dropping the database is likely to timeout since it needs to drop a lot of dependent objects")
 		}
 		if strings.Contains(s, "READ ONLY") || strings.Contains(s, "read_only") {


### PR DESCRIPTION
The previous check did not cover DROP DATABASE IF EXISTS.

fixes https://github.com/cockroachdb/cockroach/issues/114294
Release note: None