### PR TITLE
 backup: plumb original URI to online restore AddSST

### DIFF
--- a/pkg/ccl/backupccl/backupdest/backup_destination.go
+++ b/pkg/ccl/backupccl/backupdest/backup_destination.go
@@ -540,7 +540,7 @@ func ResolveBackupManifests(
 			mem.Shrink(ctx, ownedMemSize)
 		}
 	}()
-	baseManifest, memSize, err := backupinfo.ReadBackupManifestFromStore(ctx, mem, baseStores[0],
+	baseManifest, memSize, err := backupinfo.ReadBackupManifestFromStore(ctx, mem, baseStores[0], fullyResolvedBaseDirectory[0],
 		encryption, kmsEnv)
 	if err != nil {
 		return nil, nil, nil, 0, err
@@ -692,7 +692,7 @@ func DeprecatedResolveBackupManifestsExplicitIncrementals(
 
 		var memSize int64
 		mainBackupManifests[i], memSize, err = backupinfo.ReadBackupManifestFromStore(ctx, mem,
-			stores[0], encryption, kmsEnv)
+			stores[0], uris[0], encryption, kmsEnv)
 		if err != nil {
 			return nil, nil, nil, 0, err
 		}

--- a/pkg/ccl/backupccl/backupinfo/manifest_handling.go
+++ b/pkg/ccl/backupccl/backupinfo/manifest_handling.go
@@ -152,7 +152,7 @@ func ReadBackupManifestFromURI(
 		return backuppb.BackupManifest{}, 0, err
 	}
 	defer exportStore.Close()
-	return ReadBackupManifestFromStore(ctx, mem, exportStore, encryption, kmsEnv)
+	return ReadBackupManifestFromStore(ctx, mem, exportStore, uri, encryption, kmsEnv)
 }
 
 // ReadBackupManifestFromStore reads and unmarshalls a BackupManifest from the
@@ -161,6 +161,7 @@ func ReadBackupManifestFromStore(
 	ctx context.Context,
 	mem *mon.BoundAccount,
 	exportStore cloud.ExternalStorage,
+	storeURI string,
 	encryption *jobspb.BackupEncryptionOptions,
 	kmsEnv cloud.KMSEnv,
 ) (backuppb.BackupManifest, int64, error) {
@@ -213,6 +214,7 @@ func ReadBackupManifestFromStore(
 		}
 	}
 	manifest.Dir = exportStore.Conf()
+	manifest.Dir.URI = storeURI
 	return manifest, memSize, nil
 }
 

--- a/pkg/cloud/cloudpb/external_storage.proto
+++ b/pkg/cloud/cloudpb/external_storage.proto
@@ -175,5 +175,12 @@ message ExternalStorage {
   reserved 7;
   FileTable FileTableConfig = 8 [(gogoproto.nullable) = false];
   ExternalConnectionConfig external_connection_config = 9 [(gogoproto.nullable) = false];
+
+  // URI is the string URI from which this encoded external storage config was
+  // derived, if known. May be empty in most cases unless set explicitly by the
+  // caller who created the config from a URI.
+  // TODO(dt): It would be nice if this were always set but we would need every
+  // implementation of ExternalStorage to do so in its Conf() method.
+  string URI = 10;
 }
 


### PR DESCRIPTION
This replaces the hacky map.

Release note: none.
Epic: none.