### PR TITLE
roachtest: bump timeout for hibernate tests

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -252,6 +253,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly, registry.ORM),
 		Tags:             registry.Tags(`default`, `orm`),
+		Timeout:          4 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runHibernate(ctx, t, c)
 		},


### PR DESCRIPTION
The hibernate tests are massive (11519 tests), and are slow. We are hitting against the default timeout of 3 hours, so this commit increases that to 4.

fixes https://github.com/cockroachdb/cockroach/issues/114301
fixes https://github.com/cockroachdb/cockroach/issues/114136
Release note: None