### PR TITLE
release-23.1: kvstreamer: adjust recently added test

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -652,7 +652,12 @@ func TestStreamerVaryingResponseSizes(t *testing.T) {
 	skip.UnderStress(t, "the test is too memory intensive")
 	skip.UnderRace(t, "the test is too memory intensive")
 
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	// Start a cluster with large --max-sql-memory parameter since we're
+	// inserting relatively large amount of data.
+	const rootPoolSize = 1 << 30 /* 1GiB */
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		SQLMemoryPoolSize: rootPoolSize,
+	})
 	defer s.Stopper().Stop(context.Background())
 
 	runner := sqlutils.MakeSQLRunner(db)


### PR DESCRIPTION
This commit gives larger --max-sql-memory budget to the server in a recently added test (which inserts large amount of data). On 23.2 and master we bumped the default --max-sql-memory from 128MiB to 256MiB, so we didn't need to do this there.

Fixes: #114373.

Release note: None

Release justification: test-only change.