### PR TITLE
upgrades: use Version()

### DIFF
--- a/pkg/upgrade/upgrades/upgrades.go
+++ b/pkg/upgrade/upgrades/upgrades.go
@@ -55,7 +55,7 @@ var registry = make(map[roachpb.Version]upgradebase.Upgrade)
 var upgrades = []upgradebase.Upgrade{
 	upgrade.NewPermanentTenantUpgrade(
 		"add users and roles",
-		toCV(clusterversion.VPrimordial1),
+		clusterversion.VPrimordial1.Version(),
 		addRootUser,
 		// v22_2StartupMigrationName - this upgrade corresponds to 3 old
 		// startupmigrations, out of which "make root a member..." is the last one.
@@ -64,118 +64,118 @@ var upgrades = []upgradebase.Upgrade{
 	),
 	upgrade.NewPermanentTenantUpgrade(
 		"enable diagnostics reporting",
-		toCV(clusterversion.VPrimordial2),
+		clusterversion.VPrimordial2.Version(),
 		optInToDiagnosticsStatReporting,
 		"enable diagnostics reporting", // v22_2StartupMigrationName
 		upgrade.RestoreActionNotRequired("TODO explain why this migration does not need to consider restore"),
 	),
 	upgrade.NewPermanentSystemUpgrade(
 		"populate initial version cluster setting table entry",
-		toCV(clusterversion.VPrimordial3),
+		clusterversion.VPrimordial3.Version(),
 		populateVersionSetting,
 		"populate initial version cluster setting table entry", // v22_2StartupMigrationName
 		upgrade.RestoreActionNotRequired("TODO explain why this migration does not need to consider restore"),
 	),
 	upgrade.NewPermanentTenantUpgrade(
 		"initialize the cluster.secret setting",
-		toCV(clusterversion.VPrimordial4),
+		clusterversion.VPrimordial4.Version(),
 		initializeClusterSecret,
 		"initialize cluster.secret", // v22_2StartupMigrationName
 		upgrade.RestoreActionNotRequired("TODO explain why this migration does not need to consider restore"),
 	),
 	upgrade.NewPermanentTenantUpgrade(
 		"update system.locations with default location data",
-		toCV(clusterversion.VPrimordial5),
+		clusterversion.VPrimordial5.Version(),
 		updateSystemLocationData,
 		"update system.locations with default location data", // v22_2StartupMigrationName
 		upgrade.RestoreActionNotRequired("TODO explain why this migration does not need to consider restore"),
 	),
 	upgrade.NewPermanentTenantUpgrade(
 		"create default databases",
-		toCV(clusterversion.VPrimordial6),
+		clusterversion.VPrimordial6.Version(),
 		createDefaultDbs,
 		"create default databases", // v22_2StartupMigrationName
 		upgrade.RestoreActionNotRequired("TODO explain why this migration does not need to consider restore"),
 	),
 	upgrade.NewPermanentTenantUpgrade(
 		"add default SQL schema telemetry schedule",
-		toCV(clusterversion.Permanent_V22_2SQLSchemaTelemetryScheduledJobs),
+		clusterversion.Permanent_V22_2SQLSchemaTelemetryScheduledJobs.Version(),
 		ensureSQLSchemaTelemetrySchedule,
 		"add default SQL schema telemetry schedule",
 		upgrade.RestoreActionNotRequired("TODO explain why this migration does not need to consider restore"),
 	),
 	upgrade.NewPermanentSystemUpgrade("add tables and jobs to support persisting key visualizer samples",
-		toCV(clusterversion.Permanent_V23_1KeyVisualizerTablesAndJobs),
+		clusterversion.Permanent_V23_1KeyVisualizerTablesAndJobs.Version(),
 		keyVisualizerTablesMigration,
 		"initialize key visualizer tables and jobs",
 		upgrade.RestoreActionNotRequired("TODO explain why this migration does not need to consider restore"),
 	),
 	upgrade.NewPermanentTenantUpgrade("create jobs metrics polling job",
-		toCV(clusterversion.Permanent_V23_1_CreateJobsMetricsPollingJob),
+		clusterversion.Permanent_V23_1_CreateJobsMetricsPollingJob.Version(),
 		createJobsMetricsPollingJob,
 		"create jobs metrics polling job",
 		upgrade.RestoreActionNotRequired("jobs are not restored"),
 	),
 	upgrade.NewPermanentTenantUpgrade("create auto config runner job",
-		toCV(clusterversion.Permanent_V23_1_CreateAutoConfigRunnerJob),
+		clusterversion.Permanent_V23_1_CreateAutoConfigRunnerJob.Version(),
 		createAutoConfigRunnerJob,
 		"create auto config runner job",
 		upgrade.RestoreActionNotRequired("TODO explain why this migration does not need to consider restore"),
 	),
 	upgrade.NewPermanentSystemUpgrade(
 		"change TTL for SQL Stats system tables",
-		toCV(clusterversion.Permanent_V23_1ChangeSQLStatsTTL),
+		clusterversion.Permanent_V23_1ChangeSQLStatsTTL.Version(),
 		sqlStatsTTLChange,
 		"change TTL for SQL Stats system tables",
 		upgrade.RestoreActionNotRequired("TODO explain why this migration does not need to consider restore"),
 	),
 	upgrade.NewPermanentTenantUpgrade(
 		"create sql activity updater job",
-		toCV(clusterversion.Permanent_V23_1CreateSystemActivityUpdateJob),
+		clusterversion.Permanent_V23_1CreateSystemActivityUpdateJob.Version(),
 		createActivityUpdateJobMigration,
 		"create statement_activity and transaction_activity job",
 		upgrade.RestoreActionNotRequired("TODO explain why this migration does not need to consider restore"),
 	),
 
-	newFirstUpgrade(toCV(clusterversion.V23_2Start)),
+	newFirstUpgrade(clusterversion.V23_2Start.Version()),
 
 	upgrade.NewTenantUpgrade(
 		"update system.statement_diagnostics_requests to support plan gist matching",
-		toCV(clusterversion.V23_2_StmtDiagForPlanGist),
+		clusterversion.V23_2_StmtDiagForPlanGist.Version(),
 		upgrade.NoPrecondition,
 		stmtDiagForPlanGistMigration,
 		upgrade.RestoreActionNotRequired("diagnostics requests are unique to the cluster on which they were requested"),
 	),
 	upgrade.NewTenantUpgrade(
 		"create system.region_liveness table",
-		toCV(clusterversion.V23_2_RegionaLivenessTable),
+		clusterversion.V23_2_RegionaLivenessTable.Version(),
 		upgrade.NoPrecondition,
 		createRegionLivenessTables,
 		upgrade.RestoreActionNotRequired("ephemeral table that is not backed up or restored"),
 	),
 	upgrade.NewTenantUpgrade(
 		"grant EXECUTE on all functions to the public role",
-		toCV(clusterversion.V23_2_GrantExecuteToPublic),
+		clusterversion.V23_2_GrantExecuteToPublic.Version(),
 		upgrade.NoPrecondition,
 		grantExecuteToPublicOnAllFunctions,
 		upgrade.RestoreActionNotRequired("TODO explain why this migration does not need to consider restore"),
 	),
 	upgrade.NewPermanentTenantUpgrade(
 		"create system.mvcc_statistics table and job",
-		toCV(clusterversion.Permanent_V23_2_MVCCStatisticsTable),
+		clusterversion.Permanent_V23_2_MVCCStatisticsTable.Version(),
 		createMVCCStatisticsTableAndJobMigration,
 		"create system.mvcc_statistics table and job",
 		upgrade.RestoreActionNotRequired("table is relevant to the storage cluster and is not restored"),
 	),
 	upgrade.NewTenantUpgrade(
 		"create transaction_execution_insights and statement_execution_insights tables",
-		toCV(clusterversion.V23_2_AddSystemExecInsightsTable),
+		clusterversion.V23_2_AddSystemExecInsightsTable.Version(),
 		upgrade.NoPrecondition,
 		systemExecInsightsTableMigration,
 		upgrade.RestoreActionNotRequired("execution insights are specific to the cluster that executed some query and are not restored"),
 	),
 
-	newFirstUpgrade(toCV(clusterversion.V24_1Start)),
+	newFirstUpgrade(clusterversion.V24_1Start.Version()),
 
 	// Note: when starting a new release version, the first upgrade (for
 	// Vxy_zStart) must be a newFirstUpgrade. Keep this comment at the bottom.
@@ -185,8 +185,4 @@ func init() {
 	for _, m := range upgrades {
 		registry[m.Version()] = m
 	}
-}
-
-func toCV(key clusterversion.Key) roachpb.Version {
-	return clusterversion.ByKey(key)
 }


### PR DESCRIPTION
Minor cleanup of the upgrades code - we now use `.Version()` instead
of a helper.

Epic: none
Release note: None