### PR TITLE
execbuilder: elide redundant locking lookup join in some simple cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
@@ -205,3 +205,120 @@ awaitquery q07
 awaitquery q08
 
 awaitquery q09
+
+subtest multi_lock
+
+statement ok
+INSERT INTO abc VALUES (5, 1, 7), (6, 1, 7)
+
+statement ok
+INSERT INTO bcd VALUES (6, 1, 5), (7, 1, 5)
+
+# Check that we can acquire the same lock multiple times.
+
+user testuser
+
+statement ok
+BEGIN ISOLATION LEVEL READ COMMITTED
+
+# Try locking the same row twice from a single statement.
+query IIIIII rowsort
+SELECT * FROM bcd JOIN abc ON a = d WHERE bcd.b IN (6, 7) FOR UPDATE OF abc
+----
+6  1  5  5  1  7
+7  1  5  5  1  7
+
+# Try locking the same row twice from the same transaction, with another waiter
+# in between the two.
+
+query III rowsort
+SELECT * FROM bcd WHERE b = 7 FOR UPDATE
+----
+7  1  5
+
+user root
+
+query III rowsort
+BEGIN ISOLATION LEVEL READ COMMITTED;
+SELECT * FROM abc WHERE a > 4 FOR UPDATE SKIP LOCKED;
+COMMIT;
+----
+6  1  7
+
+query III rowsort
+BEGIN ISOLATION LEVEL READ COMMITTED;
+SELECT * FROM bcd WHERE b < 8 FOR UPDATE SKIP LOCKED;
+COMMIT;
+----
+6  1  5
+
+query III async,rowsort q10
+BEGIN ISOLATION LEVEL READ COMMITTED;
+SELECT * FROM abc WHERE a > 4 FOR UPDATE;
+COMMIT;
+----
+5  2  7
+6  1  7
+
+query III async,rowsort q11
+BEGIN ISOLATION LEVEL READ COMMITTED;
+SELECT * FROM bcd WHERE b < 8 FOR UPDATE;
+COMMIT;
+----
+6  1  5
+7  2  5
+
+query III async,rowsort q12
+BEGIN ISOLATION LEVEL READ COMMITTED;
+UPDATE abc SET b = b + 1 WHERE a > 4 RETURNING *;
+COMMIT;
+----
+5  3  7
+6  2  7
+
+query III async,rowsort q13
+BEGIN ISOLATION LEVEL READ COMMITTED;
+UPDATE bcd SET c = c + 1 WHERE b < 8 RETURNING *;
+COMMIT;
+----
+6  2  5
+7  3  5
+
+user testuser
+
+query IIIIII rowsort
+SELECT * FROM abc JOIN bcd ON bcd.b = abc.c WHERE a IN (5, 6) FOR UPDATE OF bcd
+----
+5  1  7  7  1  5
+6  1  7  7  1  5
+
+statement ok
+UPDATE abc SET b = b + 1 WHERE a = 5
+
+statement ok
+UPDATE bcd SET c = c + 1 WHERE b = 7
+
+query III rowsort
+SELECT * FROM abc WHERE a > 4
+----
+5  2  7
+6  1  7
+
+query III rowsort
+SELECT * FROM bcd WHERE b < 8
+----
+6  1  5
+7  2  5
+
+statement ok
+COMMIT
+
+user root
+
+awaitquery q10
+
+awaitquery q11
+
+awaitquery q12
+
+awaitquery q13

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -420,7 +420,7 @@ vectorized: true
 
 # ------------------------------------------------------------------------------
 # Tests with subqueries.
-# 
+#
 # Row-level locking clauses only apply to subqueries in the FROM clause of a
 # SELECT statement. They don't apply to subqueries in the projection or in
 # the filter.
@@ -2667,3 +2667,263 @@ project
 
 statement ok
 RESET enable_durable_locking_for_serializable
+
+subtest lock_op_optimizations
+
+statement ok
+SET optimizer_use_lock_op_for_serializable = true
+
+# Push the locking down into the scan.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a = 5 FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 1 (missing stats)
+  table: t@t_pkey
+  spans: /5/0
+  locking strength: for update
+
+# Push the locking down into the scan.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a > 2 AND a < 7 FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• scan
+  columns: (a, b)
+  estimated row count: 4 (missing stats)
+  table: t@t_pkey
+  spans: /3-/7
+  parallel
+  locking strength: for update
+
+# Same as above but we can't push the locking down due to the filter.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE a > 2 AND a < 7 AND b % 2 = 0 FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• lookup join (semi)
+│ columns: (a, b)
+│ estimated row count: 1 (missing stats)
+│ table: t@t_pkey
+│ equality: (a) = (a)
+│ equality cols are key
+│ locking strength: for update
+│
+└── • filter
+    │ columns: (a, b)
+    │ estimated row count: 1 (missing stats)
+    │ filter: (b % 2) = 0
+    │
+    └── • scan
+          columns: (a, b)
+          estimated row count: 4 (missing stats)
+          table: t@t_pkey
+          spans: /3-/7
+          parallel
+
+# Scan on a secondary index. In this case we can't push the locking down.
+query T
+EXPLAIN (VERBOSE) SELECT b, a FROM u WHERE b = 5 FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• lookup join (semi)
+│ columns: (b, a)
+│ estimated row count: 10 (missing stats)
+│ table: u@u_pkey
+│ equality: (a) = (a)
+│ equality cols are key
+│ locking strength: for update
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 10 (missing stats)
+      table: u@u_b_idx
+      spans: /5-/6
+
+# Push the locking down into the index join.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM u WHERE b = 5 FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ columns: (a, b, c)
+│ estimated row count: 10 (missing stats)
+│ table: u@u_pkey
+│ key columns: a
+│ locking strength: for update
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 10 (missing stats)
+      table: u@u_b_idx
+      spans: /5-/6
+
+# Push the locking down into the lookup join.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t JOIN u ON u.a = t.b WHERE t.a = 5 FOR UPDATE OF u
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, a, b, c)
+│ estimated row count: 1 (missing stats)
+│ table: u@u_pkey
+│ equality: (b) = (a)
+│ equality cols are key
+│ locking strength: for update
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1 (missing stats)
+      table: t@t_pkey
+      spans: /5/0
+
+# Same as above but with another predicate in the join. In this case we can't
+# push the locking down.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t JOIN u ON u.a = t.b AND u.c < t.b WHERE t.a = 5 FOR UPDATE OF u
+----
+distribution: local
+vectorized: true
+·
+• lookup join (semi)
+│ columns: (a, b, a, b, c)
+│ estimated row count: 1 (missing stats)
+│ table: u@u_pkey
+│ equality: (a) = (a)
+│ equality cols are key
+│ locking strength: for update
+│
+└── • lookup join (inner)
+    │ columns: (a, b, a, b, c)
+    │ estimated row count: 1 (missing stats)
+    │ table: u@u_pkey
+    │ equality: (b) = (a)
+    │ equality cols are key
+    │ pred: c < a
+    │
+    └── • scan
+          columns: (a, b)
+          estimated row count: 1 (missing stats)
+          table: t@t_pkey
+          spans: /5/0
+
+# Lookup join on a secondary index. In this case we can't push the locking down.
+query T
+EXPLAIN (VERBOSE) SELECT t.*, u.b, u.a FROM t JOIN u ON u.b = t.b WHERE t.a = 5 FOR UPDATE OF u
+----
+distribution: local
+vectorized: true
+·
+• lookup join (semi)
+│ columns: (a, b, b, a)
+│ estimated row count: 10 (missing stats)
+│ table: u@u_pkey
+│ equality: (a) = (a)
+│ equality cols are key
+│ locking strength: for update
+│
+└── • lookup join (inner)
+    │ columns: (a, b, a, b)
+    │ estimated row count: 10 (missing stats)
+    │ table: u@u_b_idx
+    │ equality: (b) = (b)
+    │
+    └── • scan
+          columns: (a, b)
+          estimated row count: 1 (missing stats)
+          table: t@t_pkey
+          spans: /5/0
+
+# Lookup join on a different table. In this case we can't push the locking down.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t JOIN u ON u.a = t.b WHERE t.a = 5 FOR UPDATE OF t
+----
+distribution: local
+vectorized: true
+·
+• lookup join (semi)
+│ columns: (a, b, a, b, c)
+│ estimated row count: 1 (missing stats)
+│ table: t@t_pkey
+│ equality: (a) = (a)
+│ equality cols are key
+│ locking strength: for update
+│
+└── • lookup join (inner)
+    │ columns: (a, b, a, b, c)
+    │ estimated row count: 1 (missing stats)
+    │ table: u@u_pkey
+    │ equality: (b) = (a)
+    │ equality cols are key
+    │
+    └── • scan
+          columns: (a, b)
+          estimated row count: 1 (missing stats)
+          table: t@t_pkey
+          spans: /5/0
+
+# Self-lookup join, locking the left side. Cannot push down locking.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t t1 INNER LOOKUP JOIN t t2 ON t2.a = t1.b WHERE t1.a = 5 FOR UPDATE OF t1
+----
+distribution: local
+vectorized: true
+·
+• lookup join (semi)
+│ columns: (a, b, a, b)
+│ estimated row count: 1 (missing stats)
+│ table: t@t_pkey
+│ equality: (a) = (a)
+│ equality cols are key
+│ locking strength: for update
+│
+└── • lookup join (inner)
+    │ columns: (a, b, a, b)
+    │ estimated row count: 1 (missing stats)
+    │ table: t@t_pkey
+    │ equality: (b) = (a)
+    │ equality cols are key
+    │
+    └── • scan
+          columns: (a, b)
+          estimated row count: 1 (missing stats)
+          table: t@t_pkey
+          spans: /5/0
+
+# Self-lookup join, locking the right side. Can push down locking.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t t1 INNER LOOKUP JOIN t t2 ON t2.a = t1.b WHERE t1.a = 5 FOR UPDATE OF t2
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, a, b)
+│ estimated row count: 1 (missing stats)
+│ table: t@t_pkey
+│ equality: (b) = (a)
+│ equality cols are key
+│ locking strength: for update
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1 (missing stats)
+      table: t@t_pkey
+      spans: /5/0
+
+statement ok
+RESET optimizer_use_lock_op_for_serializable

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
@@ -38,20 +38,13 @@ vectorized: true
 • project
 │ columns: (aisle)
 │
-└── • lookup join (semi)
-    │ columns: (person, aisle)
-    │ estimated row count: 1 (missing stats)
-    │ table: supermarket@supermarket_pkey
-    │ equality: (person) = (person)
-    │ equality cols are key
-    │ locking strength: for update
-    │ locking durability: guaranteed
-    │
-    └── • scan
-          columns: (person, aisle)
-          estimated row count: 1 (missing stats)
-          table: supermarket@supermarket_pkey
-          spans: /"matilda"/0
+└── • scan
+      columns: (person, aisle)
+      estimated row count: 1 (missing stats)
+      table: supermarket@supermarket_pkey
+      spans: /"matilda"/0
+      locking strength: for update
+      locking durability: guaranteed
 
 query T
 EXPLAIN (OPT)
@@ -112,21 +105,13 @@ vectorized: true
     └── • project
         │ columns: (aisle)
         │
-        └── • lookup join (semi)
-            │ columns: (person, aisle)
-            │ estimated row count: 1 (missing stats)
-            │ table: supermarket@supermarket_pkey
-            │ equality: (person) = (person)
-            │ equality cols are key
-            │ locking strength: for update
-            │ locking durability: guaranteed
-            │
-            └── • scan
-                  columns: (person, aisle)
-                  estimated row count: 1 (missing stats)
-                  table: supermarket@supermarket_pkey
-                  spans: /"matilda"/0
-                  locking strength: for update
+        └── • scan
+              columns: (person, aisle)
+              estimated row count: 1 (missing stats)
+              table: supermarket@supermarket_pkey
+              spans: /"matilda"/0
+              locking strength: for update
+              locking durability: guaranteed
 
 query T
 EXPLAIN (OPT)
@@ -178,20 +163,13 @@ vectorized: true
         └── • project
             │ columns: (aisle)
             │
-            └── • lookup join (semi)
-                │ columns: (person, aisle)
-                │ estimated row count: 1 (missing stats)
-                │ table: supermarket@supermarket_pkey
-                │ equality: (person) = (person)
-                │ equality cols are key
-                │ locking strength: for update
-                │ locking durability: guaranteed
-                │
-                └── • scan
-                      columns: (person, aisle)
-                      estimated row count: 1 (missing stats)
-                      table: supermarket@supermarket_pkey
-                      spans: /"matilda"/0
+            └── • scan
+                  columns: (person, aisle)
+                  estimated row count: 1 (missing stats)
+                  table: supermarket@supermarket_pkey
+                  spans: /"matilda"/0
+                  locking strength: for update
+                  locking durability: guaranteed
 
 query T
 EXPLAIN (OPT)

--- a/pkg/sql/opt/testutils/opttester/BUILD.bazel
+++ b/pkg/sql/opt/testutils/opttester/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/settings/cluster",

--- a/pkg/sql/opt/xform/testdata/external/tpcc-read-committed
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-read-committed
@@ -1,0 +1,1496 @@
+import file=tpcc_schema
+----
+
+import file=tpcc_stats_w100
+----
+
+
+
+# --------------------------------------------------
+# 2.4 The New Order Transaction
+#
+# The New-Order business transaction consists of entering a complete order
+# through a single database transaction. It represents a mid-weight, read-write
+# transaction with a high frequency of execution and stringent response time
+# requirements to satisfy on-line users. This transaction is the backbone of
+# the workload. It is designed to place a variable load on the system to
+# reflect on-line database activity as typically found in production
+# environments.
+# --------------------------------------------------
+opt format=hide-qual isolation=ReadCommitted
+UPDATE district
+SET d_next_o_id = d_next_o_id + 1
+WHERE d_w_id = 10 AND d_id = 5
+RETURNING d_tax, d_next_o_id
+----
+project
+ ├── columns: d_tax:9 d_next_o_id:11
+ ├── cardinality: [0 - 1]
+ ├── volatile, mutations
+ ├── key: ()
+ ├── fd: ()-->(9,11)
+ └── update district
+      ├── columns: d_id:1!null d_w_id:2!null d_tax:9 d_next_o_id:11
+      ├── fetch columns: d_id:14 d_w_id:15 d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
+      ├── update-mapping:
+      │    └── d_next_o_id_new:27 => d_next_o_id:11
+      ├── return-mapping:
+      │    ├── d_id:14 => d_id:1
+      │    ├── d_w_id:15 => d_w_id:2
+      │    ├── d_tax:22 => d_tax:9
+      │    └── d_next_o_id_new:27 => d_next_o_id:11
+      ├── cardinality: [0 - 1]
+      ├── volatile, mutations
+      ├── key: ()
+      ├── fd: ()-->(1,2,9,11)
+      └── project
+           ├── columns: d_next_o_id_new:27 d_id:14!null d_w_id:15!null d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
+           ├── cardinality: [0 - 1]
+           ├── immutable
+           ├── key: ()
+           ├── fd: ()-->(14-24,27)
+           ├── scan district
+           │    ├── columns: d_id:14!null d_w_id:15!null d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
+           │    ├── constraint: /15/14: [/10/5 - /10/5]
+           │    ├── cardinality: [0 - 1]
+           │    ├── key: ()
+           │    └── fd: ()-->(14-24)
+           └── projections
+                └── d_next_o_id:24 + 1 [as=d_next_o_id_new:27, outer=(24), immutable]
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT w_tax FROM warehouse WHERE w_id = 10
+----
+project
+ ├── columns: w_tax:8
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(8)
+ └── scan warehouse
+      ├── columns: w_id:1!null w_tax:8
+      ├── constraint: /1: [/10 - /10]
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      └── fd: ()-->(1,8)
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT c_discount, c_last, c_credit
+FROM customer
+WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
+----
+project
+ ├── columns: c_discount:16 c_last:6 c_credit:14
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6,14,16)
+ └── scan customer
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_last:6 c_credit:14 c_discount:16
+      ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      └── fd: ()-->(1-3,6,14,16)
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT i_price, i_name, i_data
+FROM item
+WHERE i_id IN (125, 150, 175, 200, 25, 50, 75, 100, 225, 250, 275, 300)
+ORDER BY i_id
+----
+scan item
+ ├── columns: i_price:4 i_name:3 i_data:5  [hidden: i_id:1!null]
+ ├── constraint: /1
+ │    ├── [/25 - /25]
+ │    ├── [/50 - /50]
+ │    ├── [/75 - /75]
+ │    ├── [/100 - /100]
+ │    ├── [/125 - /125]
+ │    ├── [/150 - /150]
+ │    ├── [/175 - /175]
+ │    ├── [/200 - /200]
+ │    ├── [/225 - /225]
+ │    ├── [/250 - /250]
+ │    ├── [/275 - /275]
+ │    └── [/300 - /300]
+ ├── cardinality: [0 - 12]
+ ├── key: (1)
+ ├── fd: (1)-->(3-5)
+ └── ordering: +1
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_05
+FROM stock
+WHERE (s_i_id, s_w_id) IN ((1000, 4), (900, 4), (1100, 4), (1500, 4), (1400, 4))
+ORDER BY s_i_id
+FOR UPDATE
+----
+lock stock
+ ├── columns: s_quantity:3 s_ytd:14 s_order_cnt:15 s_remote_cnt:16 s_data:17 s_dist_05:8  [hidden: s_i_id:1!null s_w_id:2!null]
+ ├── locking: for-update,durability-guaranteed
+ ├── cardinality: [0 - 5]
+ ├── volatile, mutations
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3,8,14-17)
+ ├── ordering: +1 opt(2) [actual: +1]
+ └── scan stock
+      ├── columns: s_i_id:1!null s_w_id:2!null s_quantity:3 s_dist_05:8 s_ytd:14 s_order_cnt:15 s_remote_cnt:16 s_data:17
+      ├── constraint: /2/1
+      │    ├── [/4/900 - /4/900]
+      │    ├── [/4/1000 - /4/1000]
+      │    ├── [/4/1100 - /4/1100]
+      │    ├── [/4/1400 - /4/1400]
+      │    └── [/4/1500 - /4/1500]
+      ├── cardinality: [0 - 5]
+      ├── key: (1)
+      ├── fd: ()-->(2), (1)-->(3,8,14-17)
+      └── ordering: +1 opt(2) [actual: +1]
+
+opt format=hide-qual isolation=ReadCommitted
+INSERT INTO "order" (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local)
+VALUES (100, 5, 10, 50, '2019-08-26 16:50:41', 10, 1)
+----
+insert order
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:11 => o_id:1
+ │    ├── column2:12 => "order".o_d_id:2
+ │    ├── column3:13 => "order".o_w_id:3
+ │    ├── column4:14 => "order".o_c_id:4
+ │    ├── column5:15 => o_entry_d:5
+ │    ├── o_carrier_id_default:18 => o_carrier_id:6
+ │    ├── column6:16 => o_ol_cnt:7
+ │    └── column7:17 => o_all_local:8
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── values
+ │    ├── columns: column1:11!null column2:12!null column3:13!null column4:14!null column5:15!null column6:16!null column7:17!null o_carrier_id_default:18
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(11-18)
+ │    └── (100, 5, 10, 50, '2019-08-26 16:50:41', 10, 1, NULL)
+ └── f-k-checks
+      └── f-k-checks-item: order(o_w_id,o_d_id,o_c_id) -> customer(c_w_id,c_d_id,c_id)
+           └── anti-join (lookup customer)
+                ├── columns: o_w_id:19!null o_d_id:20!null o_c_id:21!null
+                ├── key columns: [19 20 21] = [24 23 22]
+                ├── lookup columns are key
+                ├── locking: for-share,durability-guaranteed
+                ├── cardinality: [0 - 1]
+                ├── volatile
+                ├── key: ()
+                ├── fd: ()-->(19-21)
+                ├── with-scan &1
+                │    ├── columns: o_w_id:19!null o_d_id:20!null o_c_id:21!null
+                │    ├── mapping:
+                │    │    ├──  column3:13 => o_w_id:19
+                │    │    ├──  column2:12 => o_d_id:20
+                │    │    └──  column4:14 => o_c_id:21
+                │    ├── cardinality: [1 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(19-21)
+                └── filters (true)
+
+opt format=hide-qual isolation=ReadCommitted
+INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES (2000, 100, 10)
+----
+insert new_order
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => new_order.no_o_id:1
+ │    ├── column2:7 => new_order.no_d_id:2
+ │    └── column3:8 => new_order.no_w_id:3
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── values
+ │    ├── columns: column1:6!null column2:7!null column3:8!null
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(6-8)
+ │    └── (2000, 100, 10)
+ └── f-k-checks
+      └── f-k-checks-item: new_order(no_w_id,no_d_id,no_o_id) -> order(o_w_id,o_d_id,o_id)
+           └── anti-join (lookup order)
+                ├── columns: no_w_id:9!null no_d_id:10!null no_o_id:11!null
+                ├── key columns: [9 10 11] = [14 13 12]
+                ├── lookup columns are key
+                ├── locking: for-share,durability-guaranteed
+                ├── cardinality: [0 - 1]
+                ├── volatile
+                ├── key: ()
+                ├── fd: ()-->(9-11)
+                ├── with-scan &1
+                │    ├── columns: no_w_id:9!null no_d_id:10!null no_o_id:11!null
+                │    ├── mapping:
+                │    │    ├──  column3:8 => no_w_id:9
+                │    │    ├──  column2:7 => no_d_id:10
+                │    │    └──  column1:6 => no_o_id:11
+                │    ├── cardinality: [1 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(9-11)
+                └── filters (true)
+
+opt format=hide-qual isolation=ReadCommitted
+UPDATE
+  stock
+SET
+  s_quantity
+    = CASE (s_i_id, s_w_id)
+    WHEN (6823, 0) THEN 26
+    WHEN (7853, 0) THEN 10
+    WHEN (8497, 0) THEN 62
+    WHEN (10904, 0) THEN 54
+    WHEN (16152, 0) THEN 80
+    WHEN (41382, 0) THEN 18
+    WHEN (55952, 0) THEN 56
+    WHEN (64817, 0) THEN 26
+    WHEN (66335, 0) THEN 30
+    WHEN (76567, 0) THEN 71
+    WHEN (81680, 0) THEN 51
+    WHEN (89641, 0) THEN 51
+    WHEN (89905, 0) THEN 77
+    ELSE crdb_internal.force_error('', 'unknown case')
+    END,
+  s_ytd
+    = CASE (s_i_id, s_w_id)
+    WHEN (6823, 0) THEN 6
+    WHEN (7853, 0) THEN 9
+    WHEN (8497, 0) THEN 13
+    WHEN (10904, 0) THEN 1
+    WHEN (16152, 0) THEN 2
+    WHEN (41382, 0) THEN 3
+    WHEN (55952, 0) THEN 10
+    WHEN (64817, 0) THEN 31
+    WHEN (66335, 0) THEN 9
+    WHEN (76567, 0) THEN 7
+    WHEN (81680, 0) THEN 4
+    WHEN (89641, 0) THEN 13
+    WHEN (89905, 0) THEN 20
+    END,
+  s_order_cnt
+    = CASE (s_i_id, s_w_id)
+    WHEN (6823, 0) THEN 1
+    WHEN (7853, 0) THEN 1
+    WHEN (8497, 0) THEN 2
+    WHEN (10904, 0) THEN 1
+    WHEN (16152, 0) THEN 1
+    WHEN (41382, 0) THEN 1
+    WHEN (55952, 0) THEN 1
+    WHEN (64817, 0) THEN 4
+    WHEN (66335, 0) THEN 2
+    WHEN (76567, 0) THEN 1
+    WHEN (81680, 0) THEN 1
+    WHEN (89641, 0) THEN 2
+    WHEN (89905, 0) THEN 4
+    END,
+  s_remote_cnt
+    = CASE (s_i_id, s_w_id)
+    WHEN (6823, 0) THEN 0
+    WHEN (7853, 0) THEN 0
+    WHEN (8497, 0) THEN 0
+    WHEN (10904, 0) THEN 0
+    WHEN (16152, 0) THEN 0
+    WHEN (41382, 0) THEN 0
+    WHEN (55952, 0) THEN 0
+    WHEN (64817, 0) THEN 0
+    WHEN (66335, 0) THEN 0
+    WHEN (76567, 0) THEN 0
+    WHEN (81680, 0) THEN 0
+    WHEN (89641, 0) THEN 0
+    WHEN (89905, 0) THEN 0
+    END
+WHERE
+  (s_i_id, s_w_id)
+  IN (
+      (6823, 0),
+      (7853, 0),
+      (8497, 0),
+      (10904, 0),
+      (16152, 0),
+      (41382, 0),
+      (55952, 0),
+      (64817, 0),
+      (66335, 0),
+      (76567, 0),
+      (81680, 0),
+      (89641, 0),
+      (89905, 0)
+    )
+----
+update stock
+ ├── columns: <none>
+ ├── fetch columns: s_i_id:20 s_w_id:21 s_quantity:22 s_dist_01:23 s_dist_02:24 s_dist_03:25 s_dist_04:26 s_dist_05:27 s_dist_06:28 s_dist_07:29 s_dist_08:30 s_dist_09:31 s_dist_10:32 s_ytd:33 s_order_cnt:34 s_remote_cnt:35 s_data:36
+ ├── update-mapping:
+ │    ├── s_quantity_new:39 => s_quantity:3
+ │    ├── s_ytd_new:40 => s_ytd:14
+ │    ├── s_order_cnt_new:41 => s_order_cnt:15
+ │    └── s_remote_cnt_new:42 => s_remote_cnt:16
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: s_quantity_new:39 s_ytd_new:40 s_order_cnt_new:41 s_remote_cnt_new:42 s_i_id:20!null s_w_id:21!null s_quantity:22 s_dist_01:23 s_dist_02:24 s_dist_03:25 s_dist_04:26 s_dist_05:27 s_dist_06:28 s_dist_07:29 s_dist_08:30 s_dist_09:31 s_dist_10:32 s_ytd:33 s_order_cnt:34 s_remote_cnt:35 s_data:36
+      ├── cardinality: [0 - 13]
+      ├── volatile
+      ├── key: (20)
+      ├── fd: ()-->(21), (20)-->(22-36,39-42)
+      ├── scan stock
+      │    ├── columns: s_i_id:20!null s_w_id:21!null s_quantity:22 s_dist_01:23 s_dist_02:24 s_dist_03:25 s_dist_04:26 s_dist_05:27 s_dist_06:28 s_dist_07:29 s_dist_08:30 s_dist_09:31 s_dist_10:32 s_ytd:33 s_order_cnt:34 s_remote_cnt:35 s_data:36
+      │    ├── constraint: /21/20
+      │    │    ├── [/0/6823 - /0/6823]
+      │    │    ├── [/0/7853 - /0/7853]
+      │    │    ├── [/0/8497 - /0/8497]
+      │    │    ├── [/0/10904 - /0/10904]
+      │    │    ├── [/0/16152 - /0/16152]
+      │    │    ├── [/0/41382 - /0/41382]
+      │    │    ├── [/0/55952 - /0/55952]
+      │    │    ├── [/0/64817 - /0/64817]
+      │    │    ├── [/0/66335 - /0/66335]
+      │    │    ├── [/0/76567 - /0/76567]
+      │    │    ├── [/0/81680 - /0/81680]
+      │    │    ├── [/0/89641 - /0/89641]
+      │    │    └── [/0/89905 - /0/89905]
+      │    ├── cardinality: [0 - 13]
+      │    ├── key: (20)
+      │    └── fd: ()-->(21), (20)-->(22-36)
+      └── projections
+           ├── CASE (s_i_id:20, s_w_id:21) WHEN (6823, 0) THEN 26 WHEN (7853, 0) THEN 10 WHEN (8497, 0) THEN 62 WHEN (10904, 0) THEN 54 WHEN (16152, 0) THEN 80 WHEN (41382, 0) THEN 18 WHEN (55952, 0) THEN 56 WHEN (64817, 0) THEN 26 WHEN (66335, 0) THEN 30 WHEN (76567, 0) THEN 71 WHEN (81680, 0) THEN 51 WHEN (89641, 0) THEN 51 WHEN (89905, 0) THEN 77 ELSE crdb_internal.force_error('', 'unknown case') END [as=s_quantity_new:39, outer=(20,21), volatile]
+           ├── CASE (s_i_id:20, s_w_id:21) WHEN (6823, 0) THEN 6 WHEN (7853, 0) THEN 9 WHEN (8497, 0) THEN 13 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 2 WHEN (41382, 0) THEN 3 WHEN (55952, 0) THEN 10 WHEN (64817, 0) THEN 31 WHEN (66335, 0) THEN 9 WHEN (76567, 0) THEN 7 WHEN (81680, 0) THEN 4 WHEN (89641, 0) THEN 13 WHEN (89905, 0) THEN 20 ELSE CAST(NULL AS INT8) END [as=s_ytd_new:40, outer=(20,21)]
+           ├── CASE (s_i_id:20, s_w_id:21) WHEN (6823, 0) THEN 1 WHEN (7853, 0) THEN 1 WHEN (8497, 0) THEN 2 WHEN (10904, 0) THEN 1 WHEN (16152, 0) THEN 1 WHEN (41382, 0) THEN 1 WHEN (55952, 0) THEN 1 WHEN (64817, 0) THEN 4 WHEN (66335, 0) THEN 2 WHEN (76567, 0) THEN 1 WHEN (81680, 0) THEN 1 WHEN (89641, 0) THEN 2 WHEN (89905, 0) THEN 4 ELSE CAST(NULL AS INT8) END [as=s_order_cnt_new:41, outer=(20,21)]
+           └── CASE (s_i_id:20, s_w_id:21) WHEN (6823, 0) THEN 0 WHEN (7853, 0) THEN 0 WHEN (8497, 0) THEN 0 WHEN (10904, 0) THEN 0 WHEN (16152, 0) THEN 0 WHEN (41382, 0) THEN 0 WHEN (55952, 0) THEN 0 WHEN (64817, 0) THEN 0 WHEN (66335, 0) THEN 0 WHEN (76567, 0) THEN 0 WHEN (81680, 0) THEN 0 WHEN (89641, 0) THEN 0 WHEN (89905, 0) THEN 0 ELSE CAST(NULL AS INT8) END [as=s_remote_cnt_new:42, outer=(20,21)]
+
+opt format=hide-qual isolation=ReadCommitted
+INSERT INTO order_line
+  (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity,  ol_amount,  ol_dist_info)
+VALUES
+  (3045,    2,       10,      3,         648,     0,              9,            394.470000, 'YhgLRrwsmd68P2bElAgrnp8u'),
+  (3045,    2,       10,      5,       25393,     0,             10,            830.600000, 'dLXe0YhgLRrwsmd68P2bElAg'),
+  (3045,    2,       10,      1,       47887,     0,              9,            204.390000, 'Xe0YhgLRrwsmd68P2bElAgrn'),
+  (3045,    2,       10,      2,       52000,     0,              6,            561.660000, 'ElAgrnp8ueWNXJpBB0ObpVWo'),
+  (3045,    2,       10,      4,       56624,     0,              6,            273.360000, 'RsaCXoEzmssaF9m9cdLXe0Yh'),
+  (3045,    2,       10,      6,       92966,     0,              4,            366.760000, 'saCXoEzmssaF9m9cdLXe0Yhg')
+----
+insert order_line
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:13 => order_line.ol_o_id:1
+ │    ├── column2:14 => order_line.ol_d_id:2
+ │    ├── column3:15 => order_line.ol_w_id:3
+ │    ├── column4:16 => ol_number:4
+ │    ├── column5:17 => order_line.ol_i_id:5
+ │    ├── column6:18 => order_line.ol_supply_w_id:6
+ │    ├── ol_delivery_d_default:24 => ol_delivery_d:7
+ │    ├── column7:19 => ol_quantity:8
+ │    ├── ol_amount_cast:22 => ol_amount:9
+ │    └── ol_dist_info_cast:23 => ol_dist_info:10
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── project
+ │    ├── columns: ol_delivery_d_default:24 column1:13!null column2:14!null column3:15!null column4:16!null column5:17!null column6:18!null column7:19!null ol_amount_cast:22!null ol_dist_info_cast:23!null
+ │    ├── cardinality: [6 - 6]
+ │    ├── fd: ()-->(24)
+ │    ├── values
+ │    │    ├── columns: column1:13!null column2:14!null column3:15!null column4:16!null column5:17!null column6:18!null column7:19!null ol_amount_cast:22!null ol_dist_info_cast:23!null
+ │    │    ├── cardinality: [6 - 6]
+ │    │    ├── (3045, 2, 10, 3, 648, 0, 9, 394.47, 'YhgLRrwsmd68P2bElAgrnp8u')
+ │    │    ├── (3045, 2, 10, 5, 25393, 0, 10, 830.60, 'dLXe0YhgLRrwsmd68P2bElAg')
+ │    │    ├── (3045, 2, 10, 1, 47887, 0, 9, 204.39, 'Xe0YhgLRrwsmd68P2bElAgrn')
+ │    │    ├── (3045, 2, 10, 2, 52000, 0, 6, 561.66, 'ElAgrnp8ueWNXJpBB0ObpVWo')
+ │    │    ├── (3045, 2, 10, 4, 56624, 0, 6, 273.36, 'RsaCXoEzmssaF9m9cdLXe0Yh')
+ │    │    └── (3045, 2, 10, 6, 92966, 0, 4, 366.76, 'saCXoEzmssaF9m9cdLXe0Yhg')
+ │    └── projections
+ │         └── CAST(NULL AS TIMESTAMP) [as=ol_delivery_d_default:24]
+ └── f-k-checks
+      ├── f-k-checks-item: order_line(ol_w_id,ol_d_id,ol_o_id) -> order(o_w_id,o_d_id,o_id)
+      │    └── anti-join (lookup order)
+      │         ├── columns: ol_w_id:25!null ol_d_id:26!null ol_o_id:27!null
+      │         ├── key columns: [25 26 27] = [30 29 28]
+      │         ├── lookup columns are key
+      │         ├── locking: for-share,durability-guaranteed
+      │         ├── cardinality: [0 - 6]
+      │         ├── volatile
+      │         ├── with-scan &1
+      │         │    ├── columns: ol_w_id:25!null ol_d_id:26!null ol_o_id:27!null
+      │         │    ├── mapping:
+      │         │    │    ├──  column3:15 => ol_w_id:25
+      │         │    │    ├──  column2:14 => ol_d_id:26
+      │         │    │    └──  column1:13 => ol_o_id:27
+      │         │    └── cardinality: [6 - 6]
+      │         └── filters (true)
+      └── f-k-checks-item: order_line(ol_supply_w_id,ol_i_id) -> stock(s_w_id,s_i_id)
+           └── anti-join (lookup stock)
+                ├── columns: ol_supply_w_id:38!null ol_i_id:39!null
+                ├── key columns: [38 39] = [41 40]
+                ├── lookup columns are key
+                ├── locking: for-share,durability-guaranteed
+                ├── cardinality: [0 - 6]
+                ├── volatile
+                ├── with-scan &1
+                │    ├── columns: ol_supply_w_id:38!null ol_i_id:39!null
+                │    ├── mapping:
+                │    │    ├──  column6:18 => ol_supply_w_id:38
+                │    │    └──  column5:17 => ol_i_id:39
+                │    └── cardinality: [6 - 6]
+                └── filters (true)
+
+# --------------------------------------------------
+# 2.5 The Payment Transaction
+#
+# The Payment business transaction updates the customer's balance and reflects
+# the payment on the district and warehouse sales statistics. It represents a
+# light-weight, read-write transaction with a high frequency of execution and
+# stringent response time requirements to satisfy on-line users. In addition,
+# this transaction includes non-primary key access to the CUSTOMER table.
+# --------------------------------------------------
+opt format=hide-qual isolation=ReadCommitted
+UPDATE warehouse SET w_ytd = w_ytd + 3860.61 WHERE w_id = 10
+RETURNING w_name, w_street_1, w_street_2, w_city, w_state, w_zip
+----
+project
+ ├── columns: w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
+ ├── cardinality: [0 - 1]
+ ├── volatile, mutations
+ ├── key: ()
+ ├── fd: ()-->(2-7)
+ └── update warehouse
+      ├── columns: w_id:1!null w_name:2 w_street_1:3 w_street_2:4 w_city:5 w_state:6 w_zip:7
+      ├── fetch columns: w_id:12 w_name:13 w_street_1:14 w_street_2:15 w_city:16 w_state:17 w_zip:18 w_tax:19 w_ytd:20
+      ├── update-mapping:
+      │    └── w_ytd_cast:24 => w_ytd:9
+      ├── return-mapping:
+      │    ├── w_id:12 => w_id:1
+      │    ├── w_name:13 => w_name:2
+      │    ├── w_street_1:14 => w_street_1:3
+      │    ├── w_street_2:15 => w_street_2:4
+      │    ├── w_city:16 => w_city:5
+      │    ├── w_state:17 => w_state:6
+      │    └── w_zip:18 => w_zip:7
+      ├── cardinality: [0 - 1]
+      ├── volatile, mutations
+      ├── key: ()
+      ├── fd: ()-->(1-7)
+      └── project
+           ├── columns: w_ytd_cast:24 w_id:12!null w_name:13 w_street_1:14 w_street_2:15 w_city:16 w_state:17 w_zip:18 w_tax:19 w_ytd:20
+           ├── cardinality: [0 - 1]
+           ├── immutable
+           ├── key: ()
+           ├── fd: ()-->(12-20,24)
+           ├── scan warehouse
+           │    ├── columns: w_id:12!null w_name:13 w_street_1:14 w_street_2:15 w_city:16 w_state:17 w_zip:18 w_tax:19 w_ytd:20
+           │    ├── constraint: /12: [/10 - /10]
+           │    ├── cardinality: [0 - 1]
+           │    ├── key: ()
+           │    └── fd: ()-->(12-20)
+           └── projections
+                └── assignment-cast: DECIMAL(12,2) [as=w_ytd_cast:24, outer=(20), immutable]
+                     └── w_ytd:20 + 3860.61
+
+opt format=hide-qual isolation=ReadCommitted
+UPDATE district SET d_ytd = d_ytd + 3860.61 WHERE (d_w_id = 10) AND (d_id = 5)
+RETURNING d_name, d_street_1, d_street_2, d_city, d_state, d_zip
+----
+project
+ ├── columns: d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
+ ├── cardinality: [0 - 1]
+ ├── volatile, mutations
+ ├── key: ()
+ ├── fd: ()-->(3-8)
+ └── update district
+      ├── columns: d_id:1!null d_w_id:2!null d_name:3 d_street_1:4 d_street_2:5 d_city:6 d_state:7 d_zip:8
+      ├── fetch columns: d_id:14 d_w_id:15 d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
+      ├── update-mapping:
+      │    └── d_ytd_cast:28 => d_ytd:10
+      ├── return-mapping:
+      │    ├── d_id:14 => d_id:1
+      │    ├── d_w_id:15 => d_w_id:2
+      │    ├── d_name:16 => d_name:3
+      │    ├── d_street_1:17 => d_street_1:4
+      │    ├── d_street_2:18 => d_street_2:5
+      │    ├── d_city:19 => d_city:6
+      │    ├── d_state:20 => d_state:7
+      │    └── d_zip:21 => d_zip:8
+      ├── cardinality: [0 - 1]
+      ├── volatile, mutations
+      ├── key: ()
+      ├── fd: ()-->(1-8)
+      └── project
+           ├── columns: d_ytd_cast:28 d_id:14!null d_w_id:15!null d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
+           ├── cardinality: [0 - 1]
+           ├── immutable
+           ├── key: ()
+           ├── fd: ()-->(14-24,28)
+           ├── scan district
+           │    ├── columns: d_id:14!null d_w_id:15!null d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
+           │    ├── constraint: /15/14: [/10/5 - /10/5]
+           │    ├── cardinality: [0 - 1]
+           │    ├── key: ()
+           │    └── fd: ()-->(14-24)
+           └── projections
+                └── assignment-cast: DECIMAL(12,2) [as=d_ytd_cast:28, outer=(23), immutable]
+                     └── d_ytd:23 + 3860.61
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT c_id
+FROM customer
+WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
+ORDER BY c_first ASC
+----
+project
+ ├── columns: c_id:1!null  [hidden: c_first:4]
+ ├── key: (1)
+ ├── fd: (1)-->(4)
+ ├── ordering: +4
+ └── scan customer@customer_idx
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_last:6!null
+      ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
+      ├── key: (1)
+      ├── fd: ()-->(2,3,6), (1)-->(4)
+      └── ordering: +4 opt(2,3,6) [actual: +4]
+
+opt format=hide-qual isolation=ReadCommitted
+UPDATE customer
+SET (c_balance, c_ytd_payment, c_payment_cnt, c_data)
+  = (
+    c_balance - (3860.61:::FLOAT8)::DECIMAL,
+    c_ytd_payment + (3860.61:::FLOAT8)::DECIMAL,
+    c_payment_cnt + 1,
+    CASE c_credit
+    WHEN 'BC'
+    THEN "left"(
+      c_id::STRING
+      || c_d_id::STRING
+      || c_w_id::STRING
+      || (5:::INT8)::STRING
+      || (10:::INT8)::STRING
+      || (3860.61:::FLOAT8)::STRING
+      || c_data,
+      500
+    )
+    ELSE c_data
+    END
+  )
+WHERE
+  (c_w_id = 10 AND c_d_id = 5) AND c_id = 1343
+RETURNING
+  c_first,
+  c_middle,
+  c_last,
+  c_street_1,
+  c_street_2,
+  c_city,
+  c_state,
+  c_zip,
+  c_phone,
+  c_since,
+  c_credit,
+  c_credit_lim,
+  c_discount,
+  c_balance,
+  CASE c_credit WHEN 'BC' THEN "left"(c_data, 200) ELSE '' END
+----
+project
+ ├── columns: c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 case:53
+ ├── cardinality: [0 - 1]
+ ├── volatile, mutations
+ ├── key: ()
+ ├── fd: ()-->(4-17,53)
+ ├── update customer
+ │    ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_street_1:7 c_street_2:8 c_city:9 c_state:10 c_zip:11 c_phone:12 c_since:13 c_credit:14 c_credit_lim:15 c_discount:16 c_balance:17 c_data:21
+ │    ├── fetch columns: c_id:24 c_d_id:25 c_w_id:26 c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
+ │    ├── update-mapping:
+ │    │    ├── c_balance_cast:51 => c_balance:17
+ │    │    ├── c_ytd_payment_cast:52 => c_ytd_payment:18
+ │    │    ├── c_payment_cnt_new:49 => c_payment_cnt:19
+ │    │    └── c_data_new:50 => c_data:21
+ │    ├── return-mapping:
+ │    │    ├── c_id:24 => c_id:1
+ │    │    ├── c_d_id:25 => c_d_id:2
+ │    │    ├── c_w_id:26 => c_w_id:3
+ │    │    ├── c_first:27 => c_first:4
+ │    │    ├── c_middle:28 => c_middle:5
+ │    │    ├── c_last:29 => c_last:6
+ │    │    ├── c_street_1:30 => c_street_1:7
+ │    │    ├── c_street_2:31 => c_street_2:8
+ │    │    ├── c_city:32 => c_city:9
+ │    │    ├── c_state:33 => c_state:10
+ │    │    ├── c_zip:34 => c_zip:11
+ │    │    ├── c_phone:35 => c_phone:12
+ │    │    ├── c_since:36 => c_since:13
+ │    │    ├── c_credit:37 => c_credit:14
+ │    │    ├── c_credit_lim:38 => c_credit_lim:15
+ │    │    ├── c_discount:39 => c_discount:16
+ │    │    ├── c_balance_cast:51 => c_balance:17
+ │    │    └── c_data_new:50 => c_data:21
+ │    ├── cardinality: [0 - 1]
+ │    ├── volatile, mutations
+ │    ├── key: ()
+ │    ├── fd: ()-->(1-17,21)
+ │    └── project
+ │         ├── columns: c_balance_cast:51 c_ytd_payment_cast:52 c_payment_cnt_new:49 c_data_new:50 c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(24-44,49-52)
+ │         ├── scan customer
+ │         │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
+ │         │    ├── constraint: /26/25/24: [/10/5/1343 - /10/5/1343]
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── key: ()
+ │         │    └── fd: ()-->(24-44)
+ │         └── projections
+ │              ├── assignment-cast: DECIMAL(12,2) [as=c_balance_cast:51, outer=(40), immutable]
+ │              │    └── c_balance:40 - 3860.61
+ │              ├── assignment-cast: DECIMAL(12,2) [as=c_ytd_payment_cast:52, outer=(41), immutable]
+ │              │    └── c_ytd_payment:41 + 3860.61
+ │              ├── c_payment_cnt:42 + 1 [as=c_payment_cnt_new:49, outer=(42), immutable]
+ │              └── CASE c_credit:37 WHEN 'BC' THEN left((((((c_id:24::STRING || c_d_id:25::STRING) || c_w_id:26::STRING) || '5') || '10') || '3860.61') || c_data:44, 500)::VARCHAR(500) ELSE c_data:44 END [as=c_data_new:50, outer=(24-26,37,44), immutable]
+ └── projections
+      └── CASE c_credit:14 WHEN 'BC' THEN left(c_data:21, 200) ELSE '' END [as=case:53, outer=(14,21), immutable]
+
+opt format=hide-qual isolation=ReadCommitted
+INSERT INTO history
+  (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_amount, h_date,                h_data)
+VALUES
+  (1343,   5,        10,       5,          10, 3860.61,  '2019-08-26 16:50:41', '8    Kdcgphy3')
+----
+insert history
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── rowid_default:22 => rowid:1
+ │    ├── column1:12 => history.h_c_id:2
+ │    ├── column2:13 => history.h_c_d_id:3
+ │    ├── column3:14 => history.h_c_w_id:4
+ │    ├── column4:15 => history.h_d_id:5
+ │    ├── column5:16 => history.h_w_id:6
+ │    ├── column7:18 => h_date:7
+ │    ├── h_amount_cast:20 => h_amount:8
+ │    └── h_data_cast:21 => h_data:9
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── values
+ │    ├── columns: column1:12!null column2:13!null column3:14!null column4:15!null column5:16!null column7:18!null h_amount_cast:20!null h_data_cast:21!null rowid_default:22
+ │    ├── cardinality: [1 - 1]
+ │    ├── volatile
+ │    ├── key: ()
+ │    ├── fd: ()-->(12-16,18,20-22)
+ │    └── (1343, 5, 10, 5, 10, '2019-08-26 16:50:41', 3860.61, '8    Kdcgphy3', gen_random_uuid())
+ └── f-k-checks
+      ├── f-k-checks-item: history(h_c_w_id,h_c_d_id,h_c_id) -> customer(c_w_id,c_d_id,c_id)
+      │    └── anti-join (lookup customer)
+      │         ├── columns: h_c_w_id:23!null h_c_d_id:24!null h_c_id:25!null
+      │         ├── key columns: [23 24 25] = [28 27 26]
+      │         ├── lookup columns are key
+      │         ├── locking: for-share,durability-guaranteed
+      │         ├── cardinality: [0 - 1]
+      │         ├── volatile
+      │         ├── key: ()
+      │         ├── fd: ()-->(23-25)
+      │         ├── with-scan &1
+      │         │    ├── columns: h_c_w_id:23!null h_c_d_id:24!null h_c_id:25!null
+      │         │    ├── mapping:
+      │         │    │    ├──  column3:14 => h_c_w_id:23
+      │         │    │    ├──  column2:13 => h_c_d_id:24
+      │         │    │    └──  column1:12 => h_c_id:25
+      │         │    ├── cardinality: [1 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(23-25)
+      │         └── filters (true)
+      └── f-k-checks-item: history(h_w_id,h_d_id) -> district(d_w_id,d_id)
+           └── anti-join (lookup district)
+                ├── columns: h_w_id:49!null h_d_id:50!null
+                ├── key columns: [49 50] = [52 51]
+                ├── lookup columns are key
+                ├── locking: for-share,durability-guaranteed
+                ├── cardinality: [0 - 1]
+                ├── volatile
+                ├── key: ()
+                ├── fd: ()-->(49,50)
+                ├── with-scan &1
+                │    ├── columns: h_w_id:49!null h_d_id:50!null
+                │    ├── mapping:
+                │    │    ├──  column5:16 => h_w_id:49
+                │    │    └──  column4:15 => h_d_id:50
+                │    ├── cardinality: [1 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(49,50)
+                └── filters (true)
+
+# --------------------------------------------------
+# 2.6 The Order Status Transaction
+#
+# The Order-Status business transaction queries the status of a customer's last
+# order. It represents a mid-weight read-only database transaction with a low
+# frequency of execution and response time requirement to satisfy on-line
+# users. In addition, this table includes non-primary key access to the
+# CUSTOMER table.
+# --------------------------------------------------
+opt format=hide-qual isolation=ReadCommitted
+SELECT c_balance, c_first, c_middle, c_last
+FROM customer
+WHERE c_w_id = 10 AND c_d_id = 100 AND c_id = 50
+----
+project
+ ├── columns: c_balance:17 c_first:4 c_middle:5 c_last:6
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(4-6,17)
+ └── scan customer
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6 c_balance:17
+      ├── constraint: /3/2/1: [/10/100/50 - /10/100/50]
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      └── fd: ()-->(1-6,17)
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT c_id, c_balance, c_first, c_middle
+FROM customer
+WHERE c_w_id = 10 AND c_d_id = 100 AND c_last = 'Smith'
+ORDER BY c_first ASC
+----
+project
+ ├── columns: c_id:1!null c_balance:17 c_first:4 c_middle:5
+ ├── key: (1)
+ ├── fd: (1)-->(4,5,17)
+ ├── ordering: +4
+ └── index-join customer
+      ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_middle:5 c_last:6!null c_balance:17
+      ├── key: (1)
+      ├── fd: ()-->(2,3,6), (1)-->(4,5,17)
+      ├── ordering: +4 opt(2,3,6) [actual: +4]
+      └── scan customer@customer_idx
+           ├── columns: c_id:1!null c_d_id:2!null c_w_id:3!null c_first:4 c_last:6!null
+           ├── constraint: /3/2/6/4/1: [/10/100/'Smith' - /10/100/'Smith']
+           ├── key: (1)
+           ├── fd: ()-->(2,3,6), (1)-->(4)
+           └── ordering: +4 opt(2,3,6) [actual: +4]
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT o_id, o_entry_d, o_carrier_id
+FROM "order"
+WHERE o_w_id = 10 AND o_d_id = 100 AND o_c_id = 50
+ORDER BY o_id DESC
+LIMIT 1
+----
+project
+ ├── columns: o_id:1!null o_entry_d:5 o_carrier_id:6
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1,5,6)
+ └── scan order@order_idx
+      ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_c_id:4!null o_entry_d:5 o_carrier_id:6
+      ├── constraint: /3/2/4/-1: [/10/100/50 - /10/100/50]
+      ├── limit: 1
+      ├── key: ()
+      └── fd: ()-->(1-6)
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
+FROM order_line
+WHERE ol_w_id = 10 AND ol_d_id = 100 AND ol_o_id = 1000
+----
+project
+ ├── columns: ol_i_id:5!null ol_supply_w_id:6 ol_quantity:8 ol_amount:9 ol_delivery_d:7
+ └── scan order_line
+      ├── columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null ol_i_id:5!null ol_supply_w_id:6 ol_delivery_d:7 ol_quantity:8 ol_amount:9
+      ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
+      └── fd: ()-->(1-3)
+
+# --------------------------------------------------
+# 2.7 The Delivery Transaction
+#
+# The Delivery business transaction consists of processing a batch of 10 new
+# (not yet delivered) orders. Each order is processed (delivered) in full
+# within the scope of a read-write database transaction. The number of orders
+# delivered as a group (or batched) within the same database transaction is
+# implementation specific. The business transaction, comprised of one or more
+# (up to 10) database transactions, has a low frequency of execution and must
+# complete within a relaxed response time requirement.
+#
+# The Delivery transaction is intended to be executed in deferred mode through
+# a queuing mechanism, rather than interactively, with terminal response
+# indicating transaction completion. The result of the deferred execution is
+# recorded into a result file.
+# --------------------------------------------------
+opt format=hide-qual isolation=ReadCommitted
+SELECT no_o_id
+FROM new_order
+WHERE no_w_id = 10 AND no_d_id = 100
+ORDER BY no_o_id ASC
+LIMIT 1
+FOR UPDATE
+----
+lock new_order
+ ├── columns: no_o_id:1!null  [hidden: no_d_id:2!null no_w_id:3!null]
+ ├── locking: for-update,durability-guaranteed
+ ├── cardinality: [0 - 1]
+ ├── volatile, mutations
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ └── scan new_order
+      ├── columns: no_o_id:1!null no_d_id:2!null no_w_id:3!null
+      ├── constraint: /3/2/1: [/10/100 - /10/100]
+      ├── limit: 1
+      ├── key: ()
+      └── fd: ()-->(1-3)
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT sum(ol_amount)
+FROM order_line
+WHERE ol_w_id = 10 AND ol_d_id = 100 AND ol_o_id = 1000
+----
+scalar-group-by
+ ├── columns: sum:13
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(13)
+ ├── scan order_line
+ │    ├── columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null ol_amount:9
+ │    ├── constraint: /3/2/-1/4: [/10/100/1000 - /10/100/1000]
+ │    └── fd: ()-->(1-3)
+ └── aggregations
+      └── sum [as=sum:13, outer=(9)]
+           └── ol_amount:9
+
+opt format=hide-qual isolation=ReadCommitted
+UPDATE "order"
+SET o_carrier_id = 10
+WHERE o_w_id = 10
+  AND (o_d_id, o_id) IN (
+      (10, 2167),
+      (5, 2167),
+      (6, 2167),
+      (9, 2167),
+      (4, 2167),
+      (7, 2167),
+      (8, 2167),
+      (1, 2167),
+      (2, 2167),
+      (3, 2167)
+    )
+RETURNING
+  o_d_id, o_c_id
+----
+project
+ ├── columns: o_d_id:2!null o_c_id:4
+ ├── cardinality: [0 - 10]
+ ├── volatile, mutations
+ ├── key: (2)
+ ├── fd: (2)-->(4)
+ └── update order
+      ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_c_id:4
+      ├── fetch columns: o_id:11 o_d_id:12 o_w_id:13 o_c_id:14 o_entry_d:15 o_carrier_id:16 o_ol_cnt:17 o_all_local:18
+      ├── update-mapping:
+      │    └── o_carrier_id_new:21 => o_carrier_id:6
+      ├── return-mapping:
+      │    ├── o_id:11 => o_id:1
+      │    ├── o_d_id:12 => o_d_id:2
+      │    ├── o_w_id:13 => o_w_id:3
+      │    └── o_c_id:14 => o_c_id:4
+      ├── cardinality: [0 - 10]
+      ├── volatile, mutations
+      ├── key: (2)
+      ├── fd: ()-->(1,3), (2)-->(4)
+      └── project
+           ├── columns: o_carrier_id_new:21!null o_id:11!null o_d_id:12!null o_w_id:13!null o_c_id:14 o_entry_d:15 o_carrier_id:16 o_ol_cnt:17 o_all_local:18
+           ├── cardinality: [0 - 10]
+           ├── key: (12)
+           ├── fd: ()-->(11,13,21), (12)-->(14-18)
+           ├── scan order
+           │    ├── columns: o_id:11!null o_d_id:12!null o_w_id:13!null o_c_id:14 o_entry_d:15 o_carrier_id:16 o_ol_cnt:17 o_all_local:18
+           │    ├── constraint: /13/12/-11
+           │    │    ├── [/10/1/2167 - /10/1/2167]
+           │    │    ├── [/10/2/2167 - /10/2/2167]
+           │    │    ├── [/10/3/2167 - /10/3/2167]
+           │    │    ├── [/10/4/2167 - /10/4/2167]
+           │    │    ├── [/10/5/2167 - /10/5/2167]
+           │    │    ├── [/10/6/2167 - /10/6/2167]
+           │    │    ├── [/10/7/2167 - /10/7/2167]
+           │    │    ├── [/10/8/2167 - /10/8/2167]
+           │    │    ├── [/10/9/2167 - /10/9/2167]
+           │    │    └── [/10/10/2167 - /10/10/2167]
+           │    ├── cardinality: [0 - 10]
+           │    ├── key: (12)
+           │    └── fd: ()-->(11,13), (12)-->(14-18)
+           └── projections
+                └── 10 [as=o_carrier_id_new:21]
+
+opt format=hide-qual isolation=ReadCommitted
+UPDATE customer
+SET c_delivery_cnt = c_delivery_cnt + 1,
+    c_balance = c_balance + CASE c_d_id
+      WHEN 6 THEN 57214.780000
+      WHEN 8 THEN 67755.430000
+      WHEN 1 THEN 51177.840000
+      WHEN 2 THEN 73840.700000
+      WHEN 4 THEN 45906.990000
+      WHEN 9 THEN 32523.760000
+      WHEN 10 THEN 20240.200000
+      WHEN 3 THEN 75299.790000
+      WHEN 5 THEN 56543.340000
+      WHEN 7 THEN 67157.940000
+    END
+WHERE c_w_id = 10 AND (c_d_id, c_id) IN (
+    (1, 1405),
+    (2, 137),
+    (3, 309),
+    (7, 2377),
+    (8, 2106),
+    (10, 417),
+    (4, 98),
+    (5, 1683),
+    (6, 2807),
+    (9, 1412)
+  )
+----
+update customer
+ ├── columns: <none>
+ ├── fetch columns: c_id:24 c_d_id:25 c_w_id:26 c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
+ ├── update-mapping:
+ │    ├── c_balance_cast:49 => c_balance:17
+ │    └── c_delivery_cnt_new:47 => c_delivery_cnt:20
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: c_balance_cast:49 c_delivery_cnt_new:47 c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
+      ├── cardinality: [0 - 10]
+      ├── immutable
+      ├── key: (24,25)
+      ├── fd: ()-->(26), (24,25)-->(27-44,49), (43)-->(47)
+      ├── scan customer
+      │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
+      │    ├── constraint: /26/25/24
+      │    │    ├── [/10/1/1405 - /10/1/1405]
+      │    │    ├── [/10/2/137 - /10/2/137]
+      │    │    ├── [/10/3/309 - /10/3/309]
+      │    │    ├── [/10/4/98 - /10/4/98]
+      │    │    ├── [/10/5/1683 - /10/5/1683]
+      │    │    ├── [/10/6/2807 - /10/6/2807]
+      │    │    ├── [/10/7/2377 - /10/7/2377]
+      │    │    ├── [/10/8/2106 - /10/8/2106]
+      │    │    ├── [/10/9/1412 - /10/9/1412]
+      │    │    └── [/10/10/417 - /10/10/417]
+      │    ├── cardinality: [0 - 10]
+      │    ├── key: (24,25)
+      │    └── fd: ()-->(26), (24,25)-->(27-44)
+      └── projections
+           ├── assignment-cast: DECIMAL(12,2) [as=c_balance_cast:49, outer=(25,40), immutable]
+           │    └── c_balance:40 + CASE c_d_id:25 WHEN 6 THEN 57214.780000 WHEN 8 THEN 67755.430000 WHEN 1 THEN 51177.840000 WHEN 2 THEN 73840.700000 WHEN 4 THEN 45906.990000 WHEN 9 THEN 32523.760000 WHEN 10 THEN 20240.200000 WHEN 3 THEN 75299.790000 WHEN 5 THEN 56543.340000 WHEN 7 THEN 67157.940000 ELSE CAST(NULL AS DECIMAL) END
+           └── c_delivery_cnt:43 + 1 [as=c_delivery_cnt_new:47, outer=(43), immutable]
+
+opt format=hide-qual isolation=ReadCommitted
+DELETE FROM new_order
+WHERE no_w_id = 10 AND (no_d_id, no_o_id) IN (
+    (10, 2167),
+    (5, 2167),
+    (6, 2167),
+    (9, 2167),
+    (4, 2167),
+    (7, 2167),
+    (8, 2167),
+    (1, 2167),
+    (2, 2167),
+    (3, 2167)
+  )
+----
+delete new_order
+ ├── columns: <none>
+ ├── fetch columns: no_o_id:6 no_d_id:7 no_w_id:8
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── scan new_order
+      ├── columns: no_o_id:6!null no_d_id:7!null no_w_id:8!null
+      ├── constraint: /8/7/6
+      │    ├── [/10/1/2167 - /10/1/2167]
+      │    ├── [/10/2/2167 - /10/2/2167]
+      │    ├── [/10/3/2167 - /10/3/2167]
+      │    ├── [/10/4/2167 - /10/4/2167]
+      │    ├── [/10/5/2167 - /10/5/2167]
+      │    ├── [/10/6/2167 - /10/6/2167]
+      │    ├── [/10/7/2167 - /10/7/2167]
+      │    ├── [/10/8/2167 - /10/8/2167]
+      │    ├── [/10/9/2167 - /10/9/2167]
+      │    └── [/10/10/2167 - /10/10/2167]
+      ├── cardinality: [0 - 10]
+      ├── key: (7)
+      └── fd: ()-->(6,8)
+
+
+opt format=hide-qual isolation=ReadCommitted
+UPDATE order_line
+SET ol_delivery_d = '2019-08-26 16:50:41'
+WHERE ol_w_id = 10 AND (ol_d_id, ol_o_id) IN (
+    (10, 2167),
+    (5, 2167),
+    (6, 2167),
+    (9, 2167),
+    (4, 2167),
+    (7, 2167),
+    (8, 2167),
+    (1, 2167),
+    (2, 2167),
+    (3, 2167)
+  )
+----
+update order_line
+ ├── columns: <none>
+ ├── fetch columns: ol_o_id:13 ol_d_id:14 ol_w_id:15 ol_number:16 ol_i_id:17 ol_supply_w_id:18 ol_delivery_d:19 ol_quantity:20 ol_amount:21 ol_dist_info:22
+ ├── update-mapping:
+ │    └── ol_delivery_d_new:25 => ol_delivery_d:7
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: ol_delivery_d_new:25!null ol_o_id:13!null ol_d_id:14!null ol_w_id:15!null ol_number:16!null ol_i_id:17!null ol_supply_w_id:18 ol_delivery_d:19 ol_quantity:20 ol_amount:21 ol_dist_info:22
+      ├── key: (14,16)
+      ├── fd: ()-->(13,15,25), (14,16)-->(17-22)
+      ├── scan order_line
+      │    ├── columns: ol_o_id:13!null ol_d_id:14!null ol_w_id:15!null ol_number:16!null ol_i_id:17!null ol_supply_w_id:18 ol_delivery_d:19 ol_quantity:20 ol_amount:21 ol_dist_info:22
+      │    ├── constraint: /15/14/-13/16
+      │    │    ├── [/10/1/2167 - /10/1/2167]
+      │    │    ├── [/10/2/2167 - /10/2/2167]
+      │    │    ├── [/10/3/2167 - /10/3/2167]
+      │    │    ├── [/10/4/2167 - /10/4/2167]
+      │    │    ├── [/10/5/2167 - /10/5/2167]
+      │    │    ├── [/10/6/2167 - /10/6/2167]
+      │    │    ├── [/10/7/2167 - /10/7/2167]
+      │    │    ├── [/10/8/2167 - /10/8/2167]
+      │    │    ├── [/10/9/2167 - /10/9/2167]
+      │    │    └── [/10/10/2167 - /10/10/2167]
+      │    ├── key: (14,16)
+      │    └── fd: ()-->(13,15), (14,16)-->(17-22)
+      └── projections
+           └── '2019-08-26 16:50:41' [as=ol_delivery_d_new:25]
+
+# --------------------------------------------------
+# 2.8 The Stock-Level Transaction
+#
+# The Stock-Level business transaction determines the number of recently sold
+# items that have a stock level below a specified threshold. It represents a
+# heavy read-only database transaction with a low frequency of execution, a
+# relaxed response time requirement, and relaxed consistency requirements.
+# --------------------------------------------------
+opt format=hide-qual isolation=ReadCommitted
+SELECT d_next_o_id
+FROM district
+WHERE d_w_id = 10 AND d_id = 100
+----
+project
+ ├── columns: d_next_o_id:11
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(11)
+ └── scan district
+      ├── columns: d_id:1!null d_w_id:2!null d_next_o_id:11
+      ├── constraint: /2/1: [/10/100 - /10/100]
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      └── fd: ()-->(1,2,11)
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT count(DISTINCT s_i_id)
+FROM order_line
+JOIN stock
+ON s_i_id=ol_i_id AND s_w_id=ol_w_id
+WHERE ol_w_id = 10
+    AND ol_d_id = 100
+    AND ol_o_id BETWEEN 1000 - 20 AND 1000 - 1
+    AND s_quantity < 15
+----
+scalar-group-by
+ ├── columns: count:32!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(32)
+ ├── distinct-on
+ │    ├── columns: s_i_id:13!null
+ │    ├── grouping columns: s_i_id:13!null
+ │    ├── key: (13)
+ │    └── inner-join (lookup stock)
+ │         ├── columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null ol_i_id:5!null s_i_id:13!null s_w_id:14!null s_quantity:15!null
+ │         ├── key columns: [3 5] = [14 13]
+ │         ├── lookup columns are key
+ │         ├── fd: ()-->(2,3,14), (13)-->(15), (5)==(13), (13)==(5), (3)==(14), (14)==(3)
+ │         ├── scan order_line
+ │         │    ├── columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null ol_i_id:5!null
+ │         │    ├── constraint: /3/2/-1/4: [/10/100/999 - /10/100/980]
+ │         │    └── fd: ()-->(2,3)
+ │         └── filters
+ │              ├── s_w_id:14 = 10 [outer=(14), constraints=(/14: [/10 - /10]; tight), fd=()-->(14)]
+ │              └── s_quantity:15 < 15 [outer=(15), constraints=(/15: (/NULL - /14]; tight)]
+ └── aggregations
+      └── count-rows [as=count:32]
+
+# --------------------------------------------------
+# Consistency Queries
+#
+# These queries run after TPCC in order to check database consistency.
+# They are not part of the benchmark itself.
+# --------------------------------------------------
+opt format=hide-qual isolation=ReadCommitted
+SELECT count(*)
+FROM warehouse
+FULL OUTER JOIN
+(
+    SELECT d_w_id, sum(d_ytd) as sum_d_ytd
+    FROM district
+    GROUP BY d_w_id
+)
+ON (w_id = d_w_id)
+WHERE w_ytd != sum_d_ytd
+----
+scalar-group-by
+ ├── columns: count:26!null
+ ├── cardinality: [1 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(26)
+ ├── inner-join (merge)
+ │    ├── columns: w_id:1!null w_ytd:9!null d_w_id:13!null sum:25!null
+ │    ├── left ordering: +1
+ │    ├── right ordering: +13
+ │    ├── immutable
+ │    ├── key: (13)
+ │    ├── fd: (1)-->(9), (13)-->(25), (1)==(13), (13)==(1)
+ │    ├── scan warehouse
+ │    │    ├── columns: w_id:1!null w_ytd:9
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(9)
+ │    │    └── ordering: +1
+ │    ├── group-by (streaming)
+ │    │    ├── columns: d_w_id:13!null sum:25
+ │    │    ├── grouping columns: d_w_id:13!null
+ │    │    ├── key: (13)
+ │    │    ├── fd: (13)-->(25)
+ │    │    ├── ordering: +13
+ │    │    ├── scan district
+ │    │    │    ├── columns: d_w_id:13!null d_ytd:21
+ │    │    │    └── ordering: +13
+ │    │    └── aggregations
+ │    │         └── sum [as=sum:25, outer=(21)]
+ │    │              └── d_ytd:21
+ │    └── filters
+ │         └── w_ytd:9 != sum:25 [outer=(9,25), immutable, constraints=(/9: (/NULL - ]; /25: (/NULL - ])]
+ └── aggregations
+      └── count-rows [as=count_rows:26]
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT d_next_o_id
+FROM district
+ORDER BY d_w_id, d_id
+----
+scan district
+ ├── columns: d_next_o_id:11  [hidden: d_id:1!null d_w_id:2!null]
+ ├── key: (1,2)
+ ├── fd: (1,2)-->(11)
+ └── ordering: +2,+1
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT max(no_o_id)
+FROM new_order
+GROUP BY no_d_id, no_w_id
+ORDER BY no_w_id, no_d_id
+----
+group-by (streaming)
+ ├── columns: max:6!null  [hidden: no_d_id:2!null no_w_id:3!null]
+ ├── grouping columns: no_d_id:2!null no_w_id:3!null
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(6)
+ ├── ordering: +3,+2
+ ├── scan new_order
+ │    ├── columns: no_o_id:1!null no_d_id:2!null no_w_id:3!null
+ │    ├── key: (1-3)
+ │    └── ordering: +3,+2
+ └── aggregations
+      └── max [as=max:6, outer=(1)]
+           └── no_o_id:1
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT max(o_id)
+FROM "order"
+GROUP BY o_d_id, o_w_id
+ORDER BY o_w_id, o_d_id
+----
+group-by (streaming)
+ ├── columns: max:11!null  [hidden: o_d_id:2!null o_w_id:3!null]
+ ├── grouping columns: o_d_id:2!null o_w_id:3!null
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(11)
+ ├── ordering: +3,+2
+ ├── scan order@order_idx
+ │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null
+ │    ├── key: (1-3)
+ │    └── ordering: +3,+2
+ └── aggregations
+      └── max [as=max:11, outer=(1)]
+           └── o_id:1
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT count(*)
+FROM
+(
+    SELECT max(no_o_id) - min(no_o_id) - count(*) AS nod
+    FROM new_order
+    GROUP BY no_w_id, no_d_id
+)
+WHERE nod != -1
+----
+scalar-group-by
+ ├── columns: count:10!null
+ ├── cardinality: [1 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(10)
+ ├── select
+ │    ├── columns: no_d_id:2!null no_w_id:3!null max:6!null min:7!null count_rows:8!null
+ │    ├── immutable
+ │    ├── key: (2,3)
+ │    ├── fd: (2,3)-->(6-8)
+ │    ├── group-by (streaming)
+ │    │    ├── columns: no_d_id:2!null no_w_id:3!null max:6!null min:7!null count_rows:8!null
+ │    │    ├── grouping columns: no_d_id:2!null no_w_id:3!null
+ │    │    ├── internal-ordering: +3,+2
+ │    │    ├── key: (2,3)
+ │    │    ├── fd: (2,3)-->(6-8)
+ │    │    ├── scan new_order
+ │    │    │    ├── columns: no_o_id:1!null no_d_id:2!null no_w_id:3!null
+ │    │    │    ├── key: (1-3)
+ │    │    │    └── ordering: +3,+2
+ │    │    └── aggregations
+ │    │         ├── max [as=max:6, outer=(1)]
+ │    │         │    └── no_o_id:1
+ │    │         ├── min [as=min:7, outer=(1)]
+ │    │         │    └── no_o_id:1
+ │    │         └── count-rows [as=count_rows:8]
+ │    └── filters
+ │         └── ((max:6 - min:7) - count_rows:8) != -1 [outer=(6-8), immutable]
+ └── aggregations
+      └── count-rows [as=count_rows:10]
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT sum(o_ol_cnt)
+FROM "order"
+GROUP BY o_w_id, o_d_id
+ORDER BY o_w_id, o_d_id
+----
+group-by (streaming)
+ ├── columns: sum:11  [hidden: o_d_id:2!null o_w_id:3!null]
+ ├── grouping columns: o_d_id:2!null o_w_id:3!null
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(11)
+ ├── ordering: +3,+2
+ ├── scan order
+ │    ├── columns: o_d_id:2!null o_w_id:3!null o_ol_cnt:7
+ │    └── ordering: +3,+2
+ └── aggregations
+      └── sum [as=sum:11, outer=(7)]
+           └── o_ol_cnt:7
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT count(*)
+FROM order_line
+GROUP BY ol_w_id, ol_d_id
+ORDER BY ol_w_id, ol_d_id
+----
+group-by (streaming)
+ ├── columns: count:13!null  [hidden: ol_d_id:2!null ol_w_id:3!null]
+ ├── grouping columns: ol_d_id:2!null ol_w_id:3!null
+ ├── key: (2,3)
+ ├── fd: (2,3)-->(13)
+ ├── ordering: +3,+2
+ ├── scan order_line
+ │    ├── columns: ol_d_id:2!null ol_w_id:3!null
+ │    └── ordering: +3,+2
+ └── aggregations
+      └── count-rows [as=count_rows:13]
+
+opt format=hide-qual isolation=ReadCommitted
+(SELECT no_w_id, no_d_id, no_o_id FROM new_order)
+EXCEPT ALL
+(SELECT o_w_id, o_d_id, o_id FROM "order" WHERE o_carrier_id IS NULL)
+----
+except-all
+ ├── columns: no_w_id:3!null no_d_id:2!null no_o_id:1!null
+ ├── left columns: no_w_id:3!null no_d_id:2!null no_o_id:1!null
+ ├── right columns: o_w_id:8 o_d_id:7 o_id:6
+ ├── key: (1-3)
+ ├── scan new_order
+ │    ├── columns: no_o_id:1!null no_d_id:2!null no_w_id:3!null
+ │    └── key: (1-3)
+ └── project
+      ├── columns: o_id:6!null o_d_id:7!null o_w_id:8!null
+      ├── key: (6-8)
+      └── select
+           ├── columns: o_id:6!null o_d_id:7!null o_w_id:8!null o_carrier_id:11
+           ├── key: (6-8)
+           ├── fd: ()-->(11)
+           ├── scan order@order_idx
+           │    ├── columns: o_id:6!null o_d_id:7!null o_w_id:8!null o_carrier_id:11
+           │    ├── key: (6-8)
+           │    └── fd: (6-8)-->(11)
+           └── filters
+                └── o_carrier_id:11 IS NULL [outer=(11), constraints=(/11: [/NULL - /NULL]; tight), fd=()-->(11)]
+
+opt format=hide-qual isolation=ReadCommitted
+(SELECT o_w_id, o_d_id, o_id FROM "order" WHERE o_carrier_id IS NULL)
+EXCEPT ALL
+(SELECT no_w_id, no_d_id, no_o_id FROM new_order)
+----
+except-all
+ ├── columns: o_w_id:3!null o_d_id:2!null o_id:1!null
+ ├── left columns: o_w_id:3!null o_d_id:2!null o_id:1!null
+ ├── right columns: no_w_id:13 no_d_id:12 no_o_id:11
+ ├── key: (1-3)
+ ├── project
+ │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null
+ │    ├── key: (1-3)
+ │    └── select
+ │         ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
+ │         ├── key: (1-3)
+ │         ├── fd: ()-->(6)
+ │         ├── scan order@order_idx
+ │         │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
+ │         │    ├── key: (1-3)
+ │         │    └── fd: (1-3)-->(6)
+ │         └── filters
+ │              └── o_carrier_id:6 IS NULL [outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
+ └── scan new_order
+      ├── columns: no_o_id:11!null no_d_id:12!null no_w_id:13!null
+      └── key: (11-13)
+
+opt format=hide-qual isolation=ReadCommitted
+(
+    SELECT o_w_id, o_d_id, o_id, o_ol_cnt
+    FROM "order"
+    ORDER BY o_w_id, o_d_id, o_id DESC
+)
+EXCEPT ALL
+(
+    SELECT ol_w_id, ol_d_id, ol_o_id, count(*)
+    FROM order_line
+    GROUP BY (ol_w_id, ol_d_id, ol_o_id)
+    ORDER BY ol_w_id, ol_d_id, ol_o_id DESC
+)
+----
+except-all
+ ├── columns: o_w_id:3!null o_d_id:2!null o_id:1!null o_ol_cnt:7
+ ├── left columns: o_w_id:3!null o_d_id:2!null o_id:1!null o_ol_cnt:7
+ ├── right columns: ol_w_id:13 ol_d_id:12 ol_o_id:11 count_rows:23
+ ├── internal-ordering: +3,+2,-1,+7
+ ├── key: (1-3)
+ ├── fd: (1-3)-->(7)
+ ├── scan order
+ │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_ol_cnt:7
+ │    ├── key: (1-3)
+ │    ├── fd: (1-3)-->(7)
+ │    └── ordering: +3,+2,-1
+ └── group-by (streaming)
+      ├── columns: ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null count_rows:23!null
+      ├── grouping columns: ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null
+      ├── key: (11-13)
+      ├── fd: (11-13)-->(23)
+      ├── ordering: +13,+12,-11
+      ├── scan order_line
+      │    ├── columns: ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null
+      │    └── ordering: +13,+12,-11
+      └── aggregations
+           └── count-rows [as=count_rows:23]
+
+opt format=hide-qual isolation=ReadCommitted
+(
+    SELECT ol_w_id, ol_d_id, ol_o_id, count(*)
+    FROM order_line
+    GROUP BY (ol_w_id, ol_d_id, ol_o_id)
+    ORDER BY ol_w_id, ol_d_id, ol_o_id DESC
+)
+EXCEPT ALL
+(
+    SELECT o_w_id, o_d_id, o_id, o_ol_cnt
+    FROM "order"
+    ORDER BY o_w_id, o_d_id, o_id DESC
+)
+----
+except-all
+ ├── columns: ol_w_id:3!null ol_d_id:2!null ol_o_id:1!null count:13
+ ├── left columns: ol_w_id:3!null ol_d_id:2!null ol_o_id:1!null count_rows:13
+ ├── right columns: o_w_id:16 o_d_id:15 o_id:14 o_ol_cnt:20
+ ├── internal-ordering: +3,+2,-1,+13
+ ├── key: (1-3)
+ ├── fd: (1-3)-->(13)
+ ├── group-by (streaming)
+ │    ├── columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null count_rows:13!null
+ │    ├── grouping columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null
+ │    ├── key: (1-3)
+ │    ├── fd: (1-3)-->(13)
+ │    ├── ordering: +3,+2,-1
+ │    ├── scan order_line
+ │    │    ├── columns: ol_o_id:1!null ol_d_id:2!null ol_w_id:3!null
+ │    │    └── ordering: +3,+2,-1
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:13]
+ └── scan order
+      ├── columns: o_id:14!null o_d_id:15!null o_w_id:16!null o_ol_cnt:20
+      ├── key: (14-16)
+      ├── fd: (14-16)-->(20)
+      └── ordering: +16,+15,-14
+
+opt format=hide-qual isolation=ReadCommitted
+SELECT count(*)
+FROM
+(
+    SELECT o_w_id, o_d_id, o_id
+    FROM "order"
+    WHERE o_carrier_id IS NULL
+)
+FULL OUTER JOIN
+(
+    SELECT ol_w_id, ol_d_id, ol_o_id
+    FROM order_line
+    WHERE ol_delivery_d IS NULL
+)
+ON (ol_w_id = o_w_id AND ol_d_id = o_d_id AND ol_o_id = o_id)
+WHERE ol_o_id IS NULL OR o_id IS NULL
+----
+scalar-group-by
+ ├── columns: count:23!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(23)
+ ├── select
+ │    ├── columns: o_id:1 o_d_id:2 o_w_id:3 ol_o_id:11 ol_d_id:12 ol_w_id:13
+ │    ├── full-join (merge)
+ │    │    ├── columns: o_id:1 o_d_id:2 o_w_id:3 ol_o_id:11 ol_d_id:12 ol_w_id:13
+ │    │    ├── left ordering: +13,+12,-11
+ │    │    ├── right ordering: +3,+2,-1
+ │    │    ├── project
+ │    │    │    ├── columns: ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null
+ │    │    │    ├── ordering: +13,+12,-11
+ │    │    │    └── select
+ │    │    │         ├── columns: ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null ol_delivery_d:17
+ │    │    │         ├── fd: ()-->(17)
+ │    │    │         ├── ordering: +13,+12,-11 opt(17) [actual: +13,+12,-11]
+ │    │    │         ├── scan order_line
+ │    │    │         │    ├── columns: ol_o_id:11!null ol_d_id:12!null ol_w_id:13!null ol_delivery_d:17
+ │    │    │         │    └── ordering: +13,+12,-11
+ │    │    │         └── filters
+ │    │    │              └── ol_delivery_d:17 IS NULL [outer=(17), constraints=(/17: [/NULL - /NULL]; tight), fd=()-->(17)]
+ │    │    ├── project
+ │    │    │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null
+ │    │    │    ├── key: (1-3)
+ │    │    │    ├── ordering: +3,+2,-1
+ │    │    │    └── select
+ │    │    │         ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
+ │    │    │         ├── key: (1-3)
+ │    │    │         ├── fd: ()-->(6)
+ │    │    │         ├── ordering: +3,+2,-1 opt(6) [actual: +3,+2,-1]
+ │    │    │         ├── scan order
+ │    │    │         │    ├── columns: o_id:1!null o_d_id:2!null o_w_id:3!null o_carrier_id:6
+ │    │    │         │    ├── key: (1-3)
+ │    │    │         │    ├── fd: (1-3)-->(6)
+ │    │    │         │    └── ordering: +3,+2,-1
+ │    │    │         └── filters
+ │    │    │              └── o_carrier_id:6 IS NULL [outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
+ │    │    └── filters (true)
+ │    └── filters
+ │         └── (ol_o_id:11 IS NULL) OR (o_id:1 IS NULL) [outer=(1,11)]
+ └── aggregations
+      └── count-rows [as=count_rows:23]


### PR DESCRIPTION
**execbuilder: elide redundant locking lookup join in some simple cases**

In some simple cases of SELECT FOR UPDATE using the new Lock operator, we can elide the locking lookup join and instead push the locking down into the input.

To optimize more complex cases we'll need to turn locking into a physical property which is required by the new Lock operator, similar to ordering.

Fixes: #114566

Release note: None

---

**opt: add read committed variant of tpcc opttest**

Add a copy of the tpcc opttest, but with read committed isolation. This shows the locking differences between plans built for serializable and plans built for read committed.

This doesn't show the optimization in the previous commit, because it applies during execbuilder.

Release note: None