### PR TITLE
rangefeed: unconditionally use mux rangefeeds

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
@@ -45,8 +44,6 @@ import (
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
 )
-
-var useMux = util.ConstantWithMetamorphicTestBool("changefeed.mux_rangefeed.enabled", true)
 
 type changeAggregator struct {
 	execinfra.ProcessorBase
@@ -494,7 +491,6 @@ func (ca *changeAggregator) makeKVFeedCfg(
 		SchemaChangePolicy:  schemaChange.Policy,
 		SchemaFeed:          sf,
 		Knobs:               ca.knobs.FeedKnobs,
-		UseMux:              useMux,
 		MonitoringCfg:       monitoringCfg,
 	}, nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
@@ -44,6 +45,8 @@ import (
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
 )
+
+var useMux = util.ConstantWithMetamorphicTestBool("changefeed.mux_rangefeed.enabled", true)
 
 type changeAggregator struct {
 	execinfra.ProcessorBase
@@ -491,7 +494,7 @@ func (ca *changeAggregator) makeKVFeedCfg(
 		SchemaChangePolicy:  schemaChange.Policy,
 		SchemaFeed:          sf,
 		Knobs:               ca.knobs.FeedKnobs,
-		UseMux:              changefeedbase.UseMuxRangeFeed.Get(&cfg.Settings.SV),
+		UseMux:              useMux,
 		MonitoringCfg:       monitoringCfg,
 	}, nil
 }

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -226,7 +226,7 @@ var UseMuxRangeFeed = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"changefeed.mux_rangefeed.enabled",
 	"if true, changefeed uses multiplexing rangefeed RPC",
-	util.ConstantWithMetamorphicTestBool("changefeed.mux_rangefeed.enabled", false),
+	util.ConstantWithMetamorphicTestBool("changefeed.mux_rangefeed.enabled", true),
 )
 
 // EventConsumerWorkers specifies the maximum number of workers to use when

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -221,14 +221,6 @@ var BatchReductionRetryEnabled = settings.RegisterBoolSetting(
 	settings.WithName("changefeed.batch_reduction_retry.enabled"),
 	settings.WithPublic)
 
-// UseMuxRangeFeed enables the use of MuxRangeFeed RPC.
-var UseMuxRangeFeed = settings.RegisterBoolSetting(
-	settings.ApplicationLevel,
-	"changefeed.mux_rangefeed.enabled",
-	"if true, changefeed uses multiplexing rangefeed RPC",
-	util.ConstantWithMetamorphicTestBool("changefeed.mux_rangefeed.enabled", true),
-)
-
 // EventConsumerWorkers specifies the maximum number of workers to use when
 // processing  events.
 var EventConsumerWorkers = settings.RegisterIntSetting(

--- a/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
@@ -73,7 +73,6 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
-        "//pkg/util",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -88,9 +88,6 @@ type Config struct {
 
 	// Knobs are kvfeed testing knobs.
 	Knobs TestingKnobs
-
-	// UseMux enables MuxRangeFeed rpc
-	UseMux bool
 }
 
 // Run will run the kvfeed. The feed runs synchronously and returns an
@@ -131,7 +128,7 @@ func Run(ctx context.Context, cfg Config) error {
 		cfg.InitialHighWater, cfg.EndTime,
 		cfg.Codec,
 		cfg.SchemaFeed,
-		sc, pff, bf, cfg.UseMux, cfg.Targets, cfg.Knobs)
+		sc, pff, bf, cfg.Targets, cfg.Knobs)
 	f.onBackfillCallback = cfg.MonitoringCfg.OnBackfillCallback
 	f.rangeObserver = startLaggingRangesObserver(g, cfg.MonitoringCfg.LaggingRangesCallback,
 		cfg.MonitoringCfg.LaggingRangesPollingInterval, cfg.MonitoringCfg.LaggingRangesThreshold)
@@ -260,8 +257,6 @@ type kvFeed struct {
 	schemaChangeEvents changefeedbase.SchemaChangeEventClass
 	schemaChangePolicy changefeedbase.SchemaChangePolicy
 
-	useMux bool
-
 	targets changefeedbase.Targets
 
 	// These dependencies are made available for test injection.
@@ -288,7 +283,6 @@ func newKVFeed(
 	sc kvScanner,
 	pff physicalFeedFactory,
 	bf func() kvevent.Buffer,
-	useMux bool,
 	targets changefeedbase.Targets,
 	knobs TestingKnobs,
 ) *kvFeed {
@@ -309,7 +303,6 @@ func newKVFeed(
 		scanner:             sc,
 		physicalFeed:        pff,
 		bufferFactory:       bf,
-		useMux:              useMux,
 		targets:             targets,
 		knobs:               knobs,
 	}
@@ -573,7 +566,6 @@ func (f *kvFeed) runUntilTableEvent(ctx context.Context, resumeFrontier span.Fro
 		WithDiff:      f.withDiff,
 		WithFiltering: f.withFiltering,
 		Knobs:         f.knobs,
-		UseMux:        f.useMux,
 		RangeObserver: f.rangeObserver,
 	}
 

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -144,7 +143,6 @@ func TestKVFeed(t *testing.T) {
 			tc.initialHighWater, tc.endTime,
 			codec,
 			tf, sf, rangefeedFactory(ref.run), bufferFactory,
-			util.ConstantWithMetamorphicTestBool("use_mux", true),
 			changefeedbase.Targets{},
 			TestingKnobs{})
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
@@ -33,7 +33,6 @@ type rangeFeedConfig struct {
 	WithFiltering bool
 	RangeObserver func(fn kvcoord.ForEachRangeFn)
 	Knobs         TestingKnobs
-	UseMux        bool
 }
 
 type rangefeedFactory func(
@@ -77,9 +76,6 @@ func (p rangefeedFactory) Run(ctx context.Context, sink kvevent.Writer, cfg rang
 	g := ctxgroup.WithContext(ctx)
 	g.GoCtx(feed.addEventsToBuffer)
 	var rfOpts []kvcoord.RangeFeedOption
-	if cfg.UseMux {
-		rfOpts = append(rfOpts, kvcoord.WithMuxRangeFeed())
-	}
 	if cfg.WithDiff {
 		rfOpts = append(rfOpts, kvcoord.WithDiff())
 	}

--- a/pkg/ccl/streamingccl/settings.go
+++ b/pkg/ccl/streamingccl/settings.go
@@ -57,14 +57,6 @@ var StreamReplicationMinCheckpointFrequency = settings.RegisterDurationSetting(
 	settings.WithName("physical_replication.producer.min_checkpoint_frequency"),
 )
 
-// StreamProducerMuxRangefeeds controls whether we start event streams using the mux rangefeeds.
-var StreamProducerMuxRangefeeds = settings.RegisterBoolSetting(
-	settings.SystemOnly,
-	"physical_replication.producer.mux_rangefeeds.enabled",
-	"controls whether rangefeeds used for physical replication use mux rangefeeds",
-	true,
-)
-
 // StreamReplicationConsumerHeartbeatFrequency controls frequency the stream replication
 // destination cluster sends heartbeat to the source cluster to keep the stream alive.
 var StreamReplicationConsumerHeartbeatFrequency = settings.RegisterDurationSetting(

--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -120,7 +120,6 @@ func (s *eventStream) Start(ctx context.Context, txn *kv.Txn) (retErr error) {
 		rangefeed.WithMemoryMonitor(s.mon),
 
 		rangefeed.WithOnSSTable(s.onSSTable),
-		rangefeed.WithMuxRangefeed(true),
 		rangefeed.WithOnDeleteRange(s.onDeleteRange),
 	}
 

--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -14,7 +14,6 @@ import (
 	"runtime/pprof"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/replicationutils"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -109,8 +108,6 @@ func (s *eventStream) Start(ctx context.Context, txn *kv.Txn) (retErr error) {
 
 	s.doneChan = make(chan struct{})
 
-	useMux := streamingccl.StreamProducerMuxRangefeeds.Get(&s.execCfg.Settings.SV)
-
 	// Common rangefeed options.
 	opts := []rangefeed.Option{
 		rangefeed.WithPProfLabel("job", fmt.Sprintf("id=%d", s.streamID)),
@@ -123,7 +120,7 @@ func (s *eventStream) Start(ctx context.Context, txn *kv.Txn) (retErr error) {
 		rangefeed.WithMemoryMonitor(s.mon),
 
 		rangefeed.WithOnSSTable(s.onSSTable),
-		rangefeed.WithMuxRangefeed(useMux),
+		rangefeed.WithMuxRangefeed(true),
 		rangefeed.WithOnDeleteRange(s.onDeleteRange),
 	}
 

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -404,10 +404,6 @@ var (
 	featureEnabled  featureState = 2
 )
 
-func (s featureState) bool() bool {
-	return s == featureEnabled
-}
-
 type enthropy struct {
 	*rand.Rand
 }
@@ -465,7 +461,6 @@ func (f *enumFeatureFlag) enabled(r enthropy, choose func(enthropy) string) (str
 // cdcFeatureFlags describes various cdc feature flags.
 // zero value cdcFeatureFlags uses metamorphic settings for features.
 type cdcFeatureFlags struct {
-	MuxRangefeed         featureFlag
 	RangeFeedScheduler   featureFlag
 	SchemaLockTables     featureFlag
 	DistributionStrategy enumFeatureFlag
@@ -2637,16 +2632,6 @@ func (cfc *changefeedCreator) applySettings() error {
 	// kv.rangefeed.enabled is required for changefeeds to run
 	if _, err := cfc.db.Exec("SET CLUSTER SETTING kv.rangefeed.enabled = true"); err != nil {
 		return err
-	}
-
-	muxEnabled := cfc.flags.MuxRangefeed.enabled(cfc.rng)
-	if muxEnabled != featureUnset {
-		cfc.logger.Printf("Setting changefeed.mux_rangefeed.enabled to %t", muxEnabled.bool())
-		if _, err := cfc.db.Exec(
-			"SET CLUSTER SETTING changefeed.mux_rangefeed.enabled = $1", muxEnabled.bool(),
-		); err != nil {
-			return err
-		}
 	}
 
 	rangeDistribution, rangeDistributionEnabled := cfc.flags.DistributionStrategy.enabled(cfc.rng,

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
@@ -154,9 +153,6 @@ func WithRangeObserver(observer func(ForEachRangeFn)) RangeFeedOption {
 	})
 }
 
-// A "kill switch" to disable multiplexing rangefeed if severe issues discovered with new implementation.
-var enableMuxRangeFeed = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_MULTIPLEXING_RANGEFEED", true)
-
 // RangeFeed divides a RangeFeed request on range boundaries and establishes a
 // RangeFeed to each of the individual ranges. It streams back results on the
 // provided channel.
@@ -232,7 +228,7 @@ func (ds *DistSender) RangeFeedSpans(
 
 	rl := newCatchupScanRateLimiter(&ds.st.SV)
 
-	if enableMuxRangeFeed && cfg.useMuxRangeFeed {
+	if cfg.useMuxRangeFeed {
 		return muxRangeFeed(ctx, cfg, spans, ds, rr, rl, eventCh)
 	}
 

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
@@ -158,8 +158,8 @@ func TestDistSenderRangeFeedRetryOnTransportErrors(t *testing.T) {
 					})
 
 					var opts []RangeFeedOption
-					if useMuxRangeFeed {
-						opts = append(opts, WithMuxRangeFeed())
+					if !useMuxRangeFeed {
+						opts = append(opts, WithoutMuxRangeFeed())
 					}
 					err := ds.RangeFeed(ctx, []roachpb.Span{{Key: keys.MinKey, EndKey: keys.MaxKey}}, hlc.Timestamp{}, nil, opts...)
 					require.Error(t, err)

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
@@ -35,16 +35,6 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 )
 
-// TestingSetEnableMuxRangeFeed adjusts enable rangefeed env variable
-// for testing.
-func TestingSetEnableMuxRangeFeed(enabled bool) func() {
-	old := enableMuxRangeFeed
-	enableMuxRangeFeed = enabled
-	return func() {
-		enableMuxRangeFeed = old
-	}
-}
-
 // Tests that the range feed handles transport errors appropriately. In
 // particular, that when encountering other decommissioned nodes it will refresh
 // its range descriptor and retry, but if this node is decommissioned it will

--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -28,7 +28,6 @@ type Option interface {
 type config struct {
 	scanConfig
 	retryOptions       retry.Options
-	useMuxRangefeed    bool
 	onInitialScanDone  OnInitialScanDone
 	withInitialScan    bool
 	onInitialScanError OnInitialScanError
@@ -225,7 +224,6 @@ func WithOnFrontierAdvance(f OnFrontierAdvance) Option {
 
 func initConfig(c *config, options []Option) {
 	*c = config{} // the default config is its zero value
-	c.useMuxRangefeed = useMuxRangeFeed
 	for _, o := range options {
 		o.set(c)
 	}
@@ -303,11 +301,5 @@ func WithPProfLabel(key, value string) Option {
 func WithSystemTablePriority() Option {
 	return optionFunc(func(c *config) {
 		c.overSystemTable = true
-	})
-}
-
-func WithMuxRangefeed(enabled bool) Option {
-	return optionFunc(func(c *config) {
-		c.useMuxRangefeed = enabled
 	})
 }

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -266,7 +266,7 @@ func (f *RangeFeed) Close() {
 // will be reset.
 const resetThreshold = 30 * time.Second
 
-var useMuxRangeFeed = util.ConstantWithMetamorphicTestBool("use-mux-rangefeed", false)
+var useMuxRangeFeed = util.ConstantWithMetamorphicTestBool("use-mux-rangefeed", true)
 
 // run will run the RangeFeed until the context is canceled or if the client
 // indicates that an initial scan error is non-recoverable.

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -294,8 +294,8 @@ func (f *RangeFeed) run(ctx context.Context, frontier span.Frontier) {
 	if f.scanConfig.overSystemTable {
 		rangefeedOpts = append(rangefeedOpts, kvcoord.WithSystemTablePriority())
 	}
-	if useMuxRangeFeed {
-		rangefeedOpts = append(rangefeedOpts, kvcoord.WithMuxRangeFeed())
+	if !useMuxRangeFeed {
+		rangefeedOpts = append(rangefeedOpts, kvcoord.WithoutMuxRangeFeed())
 	}
 	if f.withDiff {
 		rangefeedOpts = append(rangefeedOpts, kvcoord.WithDiff())

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -294,7 +294,7 @@ func (f *RangeFeed) run(ctx context.Context, frontier span.Frontier) {
 	if f.scanConfig.overSystemTable {
 		rangefeedOpts = append(rangefeedOpts, kvcoord.WithSystemTablePriority())
 	}
-	if f.useMuxRangefeed {
+	if useMuxRangeFeed {
 		rangefeedOpts = append(rangefeedOpts, kvcoord.WithMuxRangeFeed())
 	}
 	if f.withDiff {

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -56,123 +56,99 @@ var (
 
 type kvs = storageutils.KVs
 
-type rangefeedType struct {
-	useMuxRangefeed bool
-}
-
-func (t rangefeedType) String() string {
-	if t.useMuxRangefeed {
-		return "mux"
-	} else {
-		return "single"
-	}
-}
-
-var rangefeedTypes = []rangefeedType{
-	{
-		useMuxRangefeed: false,
-	},
-	{
-		useMuxRangefeed: true,
-	},
-}
-
 // TestRangeFeedIntegration is a basic integration test demonstrating all of
 // the pieces working together.
 func TestRangeFeedIntegration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testutils.RunValues(t, "rangefeed_type", rangefeedTypes, func(t *testing.T, s rangefeedType) {
-		ctx := context.Background()
-		settings := cluster.MakeClusterSettings()
-		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
-			Settings: settings,
-		})
-		defer srv.Stopper().Stop(ctx)
-		ts := srv.ApplicationLayer()
-
-		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-		_, _, err := srv.SplitRange(scratchKey)
-		require.NoError(t, err)
-		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-		mkKey := func(k string) roachpb.Key {
-			return encoding.EncodeStringAscending(scratchKey, k)
-		}
-		// Split the range a bunch of times.
-		const splits = 10
-		for i := 0; i < splits; i++ {
-			_, _, err := srv.SplitRange(mkKey(string([]byte{'a' + byte(i)})))
-			require.NoError(t, err)
-		}
-
-		require.NoError(t, db.Put(ctx, mkKey("a"), 1))
-		require.NoError(t, db.Put(ctx, mkKey("b"), 2))
-		afterB := db.Clock().Now()
-		require.NoError(t, db.Put(ctx, mkKey("c"), 3))
-
-		sp := roachpb.Span{
-			Key:    scratchKey,
-			EndKey: scratchKey.PrefixEnd(),
-		}
-
-		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-			// Whether rangefeeds are enabled is a property of both the
-			// storage layer and the application layer.
-			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-		}
-
-		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-		require.NoError(t, err)
-		rows := make(chan *kvpb.RangeFeedValue)
-		initialScanDone := make(chan struct{})
-		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, afterB,
-			func(ctx context.Context, value *kvpb.RangeFeedValue) {
-				select {
-				case rows <- value:
-				case <-ctx.Done():
-				}
-			},
-			rangefeed.WithDiff(true),
-			rangefeed.WithInitialScan(func(ctx context.Context) {
-				close(initialScanDone)
-			}),
-			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
-		)
-		require.NoError(t, err)
-		defer r.Close()
-		{
-			v1 := <-rows
-			require.Equal(t, mkKey("a"), v1.Key)
-			// Ensure the initial scan contract is fulfilled when WithDiff is specified.
-			require.Equal(t, v1.Value.RawBytes, v1.PrevValue.RawBytes)
-			require.Equal(t, v1.Value.Timestamp, afterB)
-			require.True(t, v1.PrevValue.Timestamp.IsEmpty())
-		}
-		{
-			v2 := <-rows
-			require.Equal(t, mkKey("b"), v2.Key)
-		}
-		<-initialScanDone
-		{
-			v3 := <-rows
-			require.Equal(t, mkKey("c"), v3.Key)
-		}
-
-		// Write a new value for "a" and make sure it is seen.
-		require.NoError(t, db.Put(ctx, mkKey("a"), 4))
-		{
-			v4 := <-rows
-			require.Equal(t, mkKey("a"), v4.Key)
-			prev, err := v4.PrevValue.GetInt()
-			require.NoError(t, err)
-			require.Equal(t, int64(1), prev)
-			updated, err := v4.Value.GetInt()
-			require.NoError(t, err)
-			require.Equal(t, int64(4), updated)
-		}
+	ctx := context.Background()
+	settings := cluster.MakeClusterSettings()
+	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: settings,
 	})
+	defer srv.Stopper().Stop(ctx)
+	ts := srv.ApplicationLayer()
+
+	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+	_, _, err := srv.SplitRange(scratchKey)
+	require.NoError(t, err)
+	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+	mkKey := func(k string) roachpb.Key {
+		return encoding.EncodeStringAscending(scratchKey, k)
+	}
+	// Split the range a bunch of times.
+	const splits = 10
+	for i := 0; i < splits; i++ {
+		_, _, err := srv.SplitRange(mkKey(string([]byte{'a' + byte(i)})))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, db.Put(ctx, mkKey("a"), 1))
+	require.NoError(t, db.Put(ctx, mkKey("b"), 2))
+	afterB := db.Clock().Now()
+	require.NoError(t, db.Put(ctx, mkKey("c"), 3))
+
+	sp := roachpb.Span{
+		Key:    scratchKey,
+		EndKey: scratchKey.PrefixEnd(),
+	}
+
+	// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+		// Whether rangefeeds are enabled is a property of both the
+		// storage layer and the application layer.
+		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+	}
+
+	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
+	require.NoError(t, err)
+	rows := make(chan *kvpb.RangeFeedValue)
+	initialScanDone := make(chan struct{})
+	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, afterB,
+		func(ctx context.Context, value *kvpb.RangeFeedValue) {
+			select {
+			case rows <- value:
+			case <-ctx.Done():
+			}
+		},
+		rangefeed.WithDiff(true),
+		rangefeed.WithInitialScan(func(ctx context.Context) {
+			close(initialScanDone)
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+	{
+		v1 := <-rows
+		require.Equal(t, mkKey("a"), v1.Key)
+		// Ensure the initial scan contract is fulfilled when WithDiff is specified.
+		require.Equal(t, v1.Value.RawBytes, v1.PrevValue.RawBytes)
+		require.Equal(t, v1.Value.Timestamp, afterB)
+		require.True(t, v1.PrevValue.Timestamp.IsEmpty())
+	}
+	{
+		v2 := <-rows
+		require.Equal(t, mkKey("b"), v2.Key)
+	}
+	<-initialScanDone
+	{
+		v3 := <-rows
+		require.Equal(t, mkKey("c"), v3.Key)
+	}
+
+	// Write a new value for "a" and make sure it is seen.
+	require.NoError(t, db.Put(ctx, mkKey("a"), 4))
+	{
+		v4 := <-rows
+		require.Equal(t, mkKey("a"), v4.Key)
+		prev, err := v4.PrevValue.GetInt()
+		require.NoError(t, err)
+		require.Equal(t, int64(1), prev)
+		updated, err := v4.Value.GetInt()
+		require.NoError(t, err)
+		require.Equal(t, int64(4), updated)
+	}
 }
 
 // TestWithOnFrontierAdvance sets up a rangefeed on a span that has more than
@@ -182,125 +158,122 @@ func TestWithOnFrontierAdvance(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testutils.RunValues(t, "rangefeed_type", rangefeedTypes, func(t *testing.T, s rangefeedType) {
-		ctx := context.Background()
-		settings := cluster.MakeClusterSettings()
-		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
-			ReplicationMode: base.ReplicationManual,
-			ServerArgs:      base.TestServerArgs{Settings: settings},
-		})
-		defer tc.Stopper().Stop(ctx)
+	ctx := context.Background()
+	settings := cluster.MakeClusterSettings()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs:      base.TestServerArgs{Settings: settings},
+	})
+	defer tc.Stopper().Stop(ctx)
 
-		srv := tc.Server(0)
-		ts := srv.ApplicationLayer()
-		db := ts.DB()
-		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-		_, _, err := srv.SplitRange(scratchKey)
-		require.NoError(t, err)
-		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-		mkKey := func(k string) roachpb.Key {
-			return encoding.EncodeStringAscending(scratchKey, k)
+	srv := tc.Server(0)
+	ts := srv.ApplicationLayer()
+	db := ts.DB()
+	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+	_, _, err := srv.SplitRange(scratchKey)
+	require.NoError(t, err)
+	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+	mkKey := func(k string) roachpb.Key {
+		return encoding.EncodeStringAscending(scratchKey, k)
+	}
+
+	sp := roachpb.Span{
+		Key:    scratchKey,
+		EndKey: scratchKey.PrefixEnd(),
+	}
+
+	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+		// Lower the closed timestamp target duration to speed up the test.
+		closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
+	}
+
+	// Split the range into two so we know the frontier has more than one span to
+	// track for certain. We later write to both these ranges.
+	_, _, err = srv.SplitRange(mkKey("b"))
+	require.NoError(t, err)
+
+	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
+	require.NoError(t, err)
+
+	// mu protects secondWriteTS.
+	var mu syncutil.Mutex
+	secondWriteFinished := false
+	frontierAdvancedAfterSecondWrite := false
+
+	// Track the checkpoint TS for spans belonging to both the ranges we split
+	// above. This can then be used to compute the minimum timestamp for both
+	// these spans. We use the key we write to for the ranges below as keys for
+	// this map.
+	spanCheckpointTimestamps := make(map[string]hlc.Timestamp)
+	forwardCheckpointForKey := func(key string, checkpoint *kvpb.RangeFeedCheckpoint) {
+		ts := hlc.MinTimestamp
+		if prevTS, found := spanCheckpointTimestamps[key]; found {
+			ts = prevTS
 		}
-
-		sp := roachpb.Span{
-			Key:    scratchKey,
-			EndKey: scratchKey.PrefixEnd(),
-		}
-
-		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-			// Lower the closed timestamp target duration to speed up the test.
-			closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
-		}
-
-		// Split the range into two so we know the frontier has more than one span to
-		// track for certain. We later write to both these ranges.
-		_, _, err = srv.SplitRange(mkKey("b"))
-		require.NoError(t, err)
-
-		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-		require.NoError(t, err)
-
-		// mu protects secondWriteTS.
-		var mu syncutil.Mutex
-		secondWriteFinished := false
-		frontierAdvancedAfterSecondWrite := false
-
-		// Track the checkpoint TS for spans belonging to both the ranges we split
-		// above. This can then be used to compute the minimum timestamp for both
-		// these spans. We use the key we write to for the ranges below as keys for
-		// this map.
-		spanCheckpointTimestamps := make(map[string]hlc.Timestamp)
-		forwardCheckpointForKey := func(key string, checkpoint *kvpb.RangeFeedCheckpoint) {
-			ts := hlc.MinTimestamp
-			if prevTS, found := spanCheckpointTimestamps[key]; found {
-				ts = prevTS
+		ts.Forward(checkpoint.ResolvedTS)
+		spanCheckpointTimestamps[key] = ts
+	}
+	rows := make(chan *kvpb.RangeFeedValue)
+	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, db.Clock().Now(),
+		func(ctx context.Context, value *kvpb.RangeFeedValue) {
+			select {
+			case rows <- value:
+			case <-ctx.Done():
 			}
-			ts.Forward(checkpoint.ResolvedTS)
-			spanCheckpointTimestamps[key] = ts
-		}
-		rows := make(chan *kvpb.RangeFeedValue)
-		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, db.Clock().Now(),
-			func(ctx context.Context, value *kvpb.RangeFeedValue) {
-				select {
-				case rows <- value:
-				case <-ctx.Done():
-				}
-			},
-			rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-				if checkpoint.Span.ContainsKey(mkKey("a")) {
-					forwardCheckpointForKey("a", checkpoint)
-				}
-				if checkpoint.Span.ContainsKey(mkKey("c")) {
-					forwardCheckpointForKey("c", checkpoint)
-				}
-			}),
-			rangefeed.WithOnFrontierAdvance(func(ctx context.Context, frontierTS hlc.Timestamp) {
-				minTS := hlc.MaxTimestamp
-				for _, ts := range spanCheckpointTimestamps {
-					minTS.Backward(ts)
-				}
-				assert.Truef(
-					t,
-					frontierTS.Equal(minTS),
-					"expected frontier timestamp to be equal to minimum timestamp across spans %s, found %s",
-					minTS,
-					frontierTS,
-				)
-				mu.Lock()
-				defer mu.Unlock()
-				if secondWriteFinished {
-					frontierAdvancedAfterSecondWrite = true
-				}
-			}),
-			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
-		)
-		require.NoError(t, err)
-		defer r.Close()
-
-		// Write to a key on both the ranges.
-		require.NoError(t, db.Put(ctx, mkKey("a"), 1))
-
-		v := <-rows
-		require.Equal(t, mkKey("a"), v.Key)
-
-		require.NoError(t, db.Put(ctx, mkKey("c"), 1))
-		mu.Lock()
-		secondWriteFinished = true
-		mu.Unlock()
-
-		v = <-rows
-		require.Equal(t, mkKey("c"), v.Key)
-
-		testutils.SucceedsSoon(t, func() error {
+		},
+		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
+			if checkpoint.Span.ContainsKey(mkKey("a")) {
+				forwardCheckpointForKey("a", checkpoint)
+			}
+			if checkpoint.Span.ContainsKey(mkKey("c")) {
+				forwardCheckpointForKey("c", checkpoint)
+			}
+		}),
+		rangefeed.WithOnFrontierAdvance(func(ctx context.Context, frontierTS hlc.Timestamp) {
+			minTS := hlc.MaxTimestamp
+			for _, ts := range spanCheckpointTimestamps {
+				minTS.Backward(ts)
+			}
+			assert.Truef(
+				t,
+				frontierTS.Equal(minTS),
+				"expected frontier timestamp to be equal to minimum timestamp across spans %s, found %s",
+				minTS,
+				frontierTS,
+			)
 			mu.Lock()
 			defer mu.Unlock()
-			if frontierAdvancedAfterSecondWrite {
-				return nil
+			if secondWriteFinished {
+				frontierAdvancedAfterSecondWrite = true
 			}
-			return errors.New("expected frontier to advance after second write")
-		})
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Write to a key on both the ranges.
+	require.NoError(t, db.Put(ctx, mkKey("a"), 1))
+
+	v := <-rows
+	require.Equal(t, mkKey("a"), v.Key)
+
+	require.NoError(t, db.Put(ctx, mkKey("c"), 1))
+	mu.Lock()
+	secondWriteFinished = true
+	mu.Unlock()
+
+	v = <-rows
+	require.Equal(t, mkKey("c"), v.Key)
+
+	testutils.SucceedsSoon(t, func() error {
+		mu.Lock()
+		defer mu.Unlock()
+		if frontierAdvancedAfterSecondWrite {
+			return nil
+		}
+		return errors.New("expected frontier to advance after second write")
 	})
 }
 
@@ -310,100 +283,97 @@ func TestWithOnCheckpoint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testutils.RunValues(t, "rangefeed_type", rangefeedTypes, func(t *testing.T, s rangefeedType) {
-		ctx := context.Background()
-		settings := cluster.MakeClusterSettings()
-		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
-			Settings: settings,
-		})
-		defer srv.Stopper().Stop(ctx)
-		ts := srv.ApplicationLayer()
-
-		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-		_, _, err := srv.SplitRange(scratchKey)
-		require.NoError(t, err)
-		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-		mkKey := func(k string) roachpb.Key {
-			return encoding.EncodeStringAscending(scratchKey, k)
-		}
-
-		sp := roachpb.Span{
-			Key:    scratchKey,
-			EndKey: scratchKey.PrefixEnd(),
-		}
-		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-			// Lower the closed timestamp target duration to speed up the test.
-			closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
-		}
-
-		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-		require.NoError(t, err)
-
-		var mu syncutil.RWMutex
-		var afterWriteTS hlc.Timestamp
-		checkpoints := make(chan *kvpb.RangeFeedCheckpoint)
-
-		// We need to start a goroutine that reads of the checkpoints channel, so to
-		// not block the rangefeed itself.
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			// We should expect a checkpoint event covering the key we just wrote, at a
-			// timestamp greater than when we wrote it.
-			testutils.SucceedsSoon(t, func() error {
-				for {
-					select {
-					case c := <-checkpoints:
-						mu.RLock()
-						writeTSUnset := afterWriteTS.IsEmpty()
-						mu.RUnlock()
-						if writeTSUnset {
-							return errors.New("write to key hasn't gone through yet")
-						}
-
-						if afterWriteTS.LessEq(c.ResolvedTS) && c.Span.ContainsKey(mkKey("a")) {
-							return nil
-						}
-					default:
-						return errors.New("no valid checkpoints found")
-					}
-				}
-			})
-		}()
-
-		rows := make(chan *kvpb.RangeFeedValue)
-		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, db.Clock().Now(),
-			func(ctx context.Context, value *kvpb.RangeFeedValue) {
-				select {
-				case rows <- value:
-				case <-ctx.Done():
-				}
-			},
-			rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-				select {
-				case checkpoints <- checkpoint:
-				case <-ctx.Done():
-				}
-			}),
-			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
-		)
-		require.NoError(t, err)
-		defer r.Close()
-
-		require.NoError(t, db.Put(ctx, mkKey("a"), 1))
-		mu.Lock()
-		afterWriteTS = db.Clock().Now()
-		mu.Unlock()
-		{
-			v := <-rows
-			require.Equal(t, mkKey("a"), v.Key)
-		}
-
-		wg.Wait()
+	ctx := context.Background()
+	settings := cluster.MakeClusterSettings()
+	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: settings,
 	})
+	defer srv.Stopper().Stop(ctx)
+	ts := srv.ApplicationLayer()
+
+	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+	_, _, err := srv.SplitRange(scratchKey)
+	require.NoError(t, err)
+	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+	mkKey := func(k string) roachpb.Key {
+		return encoding.EncodeStringAscending(scratchKey, k)
+	}
+
+	sp := roachpb.Span{
+		Key:    scratchKey,
+		EndKey: scratchKey.PrefixEnd(),
+	}
+	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+		// Lower the closed timestamp target duration to speed up the test.
+		closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
+	}
+
+	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
+	require.NoError(t, err)
+
+	var mu syncutil.RWMutex
+	var afterWriteTS hlc.Timestamp
+	checkpoints := make(chan *kvpb.RangeFeedCheckpoint)
+
+	// We need to start a goroutine that reads of the checkpoints channel, so to
+	// not block the rangefeed itself.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// We should expect a checkpoint event covering the key we just wrote, at a
+		// timestamp greater than when we wrote it.
+		testutils.SucceedsSoon(t, func() error {
+			for {
+				select {
+				case c := <-checkpoints:
+					mu.RLock()
+					writeTSUnset := afterWriteTS.IsEmpty()
+					mu.RUnlock()
+					if writeTSUnset {
+						return errors.New("write to key hasn't gone through yet")
+					}
+
+					if afterWriteTS.LessEq(c.ResolvedTS) && c.Span.ContainsKey(mkKey("a")) {
+						return nil
+					}
+				default:
+					return errors.New("no valid checkpoints found")
+				}
+			}
+		})
+	}()
+
+	rows := make(chan *kvpb.RangeFeedValue)
+	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, db.Clock().Now(),
+		func(ctx context.Context, value *kvpb.RangeFeedValue) {
+			select {
+			case rows <- value:
+			case <-ctx.Done():
+			}
+		},
+		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
+			select {
+			case checkpoints <- checkpoint:
+			case <-ctx.Done():
+			}
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	require.NoError(t, db.Put(ctx, mkKey("a"), 1))
+	mu.Lock()
+	afterWriteTS = db.Clock().Now()
+	mu.Unlock()
+	{
+		v := <-rows
+		require.Equal(t, mkKey("a"), v.Key)
+	}
+
+	wg.Wait()
 }
 
 // TestRangefeedValueTimestamps tests that the rangefeed values (and previous
@@ -413,116 +383,113 @@ func TestRangefeedValueTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testutils.RunValues(t, "rangefeed_type", rangefeedTypes, func(t *testing.T, s rangefeedType) {
-		ctx := context.Background()
-		settings := cluster.MakeClusterSettings()
-		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
-			Settings: settings,
-		})
-		defer srv.Stopper().Stop(ctx)
-		ts := srv.ApplicationLayer()
-
-		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-		_, _, err := srv.SplitRange(scratchKey)
-		require.NoError(t, err)
-		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-		mkKey := func(k string) roachpb.Key {
-			return encoding.EncodeStringAscending(scratchKey, k)
-		}
-
-		sp := roachpb.Span{
-			Key:    scratchKey,
-			EndKey: scratchKey.PrefixEnd(),
-		}
-		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-			// Lower the closed timestamp target duration to speed up the test.
-			closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
-		}
-
-		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-		require.NoError(t, err)
-
-		rows := make(chan *kvpb.RangeFeedValue)
-		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, db.Clock().Now(),
-			func(ctx context.Context, value *kvpb.RangeFeedValue) {
-				select {
-				case rows <- value:
-				case <-ctx.Done():
-				}
-			},
-			rangefeed.WithDiff(true),
-			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
-		)
-		require.NoError(t, err)
-		defer r.Close()
-
-		mustGetInt := func(value roachpb.Value) int {
-			val, err := value.GetInt()
-			require.NoError(t, err)
-			return int(val)
-		}
-
-		{
-			beforeWriteTS := db.Clock().Now()
-			require.NoError(t, db.Put(ctx, mkKey("a"), 1))
-			afterWriteTS := db.Clock().Now()
-
-			v := <-rows
-			require.Equal(t, mustGetInt(v.Value), 1)
-			require.True(t, beforeWriteTS.Less(v.Value.Timestamp))
-			require.True(t, v.Value.Timestamp.Less(afterWriteTS))
-
-			require.False(t, v.PrevValue.IsPresent())
-		}
-
-		{
-			beforeOverwriteTS := db.Clock().Now()
-			require.NoError(t, db.Put(ctx, mkKey("a"), 2))
-			afterOverwriteTS := db.Clock().Now()
-
-			v := <-rows
-			require.Equal(t, mustGetInt(v.Value), 2)
-			require.True(t, beforeOverwriteTS.Less(v.Value.Timestamp))
-			require.True(t, v.Value.Timestamp.Less(afterOverwriteTS))
-
-			require.True(t, v.PrevValue.IsPresent())
-			require.Equal(t, mustGetInt(v.PrevValue), 1)
-			require.True(t, v.PrevValue.Timestamp.IsEmpty())
-		}
-
-		{
-			beforeDelTS := db.Clock().Now()
-			_, err = db.Del(ctx, mkKey("a"))
-			require.NoError(t, err)
-			afterDelTS := db.Clock().Now()
-
-			v := <-rows
-			require.False(t, v.Value.IsPresent())
-			require.True(t, beforeDelTS.Less(v.Value.Timestamp))
-			require.True(t, v.Value.Timestamp.Less(afterDelTS))
-
-			require.True(t, v.PrevValue.IsPresent())
-			require.Equal(t, mustGetInt(v.PrevValue), 2)
-			require.True(t, v.PrevValue.Timestamp.IsEmpty())
-		}
-
-		{
-			beforeDelTS := db.Clock().Now()
-			_, err = db.Del(ctx, mkKey("a"))
-			require.NoError(t, err)
-			afterDelTS := db.Clock().Now()
-
-			v := <-rows
-			require.False(t, v.Value.IsPresent())
-			require.True(t, beforeDelTS.Less(v.Value.Timestamp))
-			require.True(t, v.Value.Timestamp.Less(afterDelTS))
-
-			require.False(t, v.PrevValue.IsPresent())
-			require.True(t, v.PrevValue.Timestamp.IsEmpty())
-		}
+	ctx := context.Background()
+	settings := cluster.MakeClusterSettings()
+	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: settings,
 	})
+	defer srv.Stopper().Stop(ctx)
+	ts := srv.ApplicationLayer()
+
+	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+	_, _, err := srv.SplitRange(scratchKey)
+	require.NoError(t, err)
+	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+	mkKey := func(k string) roachpb.Key {
+		return encoding.EncodeStringAscending(scratchKey, k)
+	}
+
+	sp := roachpb.Span{
+		Key:    scratchKey,
+		EndKey: scratchKey.PrefixEnd(),
+	}
+	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+		// Lower the closed timestamp target duration to speed up the test.
+		closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
+	}
+
+	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
+	require.NoError(t, err)
+
+	rows := make(chan *kvpb.RangeFeedValue)
+	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, db.Clock().Now(),
+		func(ctx context.Context, value *kvpb.RangeFeedValue) {
+			select {
+			case rows <- value:
+			case <-ctx.Done():
+			}
+		},
+		rangefeed.WithDiff(true),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	mustGetInt := func(value roachpb.Value) int {
+		val, err := value.GetInt()
+		require.NoError(t, err)
+		return int(val)
+	}
+
+	{
+		beforeWriteTS := db.Clock().Now()
+		require.NoError(t, db.Put(ctx, mkKey("a"), 1))
+		afterWriteTS := db.Clock().Now()
+
+		v := <-rows
+		require.Equal(t, mustGetInt(v.Value), 1)
+		require.True(t, beforeWriteTS.Less(v.Value.Timestamp))
+		require.True(t, v.Value.Timestamp.Less(afterWriteTS))
+
+		require.False(t, v.PrevValue.IsPresent())
+	}
+
+	{
+		beforeOverwriteTS := db.Clock().Now()
+		require.NoError(t, db.Put(ctx, mkKey("a"), 2))
+		afterOverwriteTS := db.Clock().Now()
+
+		v := <-rows
+		require.Equal(t, mustGetInt(v.Value), 2)
+		require.True(t, beforeOverwriteTS.Less(v.Value.Timestamp))
+		require.True(t, v.Value.Timestamp.Less(afterOverwriteTS))
+
+		require.True(t, v.PrevValue.IsPresent())
+		require.Equal(t, mustGetInt(v.PrevValue), 1)
+		require.True(t, v.PrevValue.Timestamp.IsEmpty())
+	}
+
+	{
+		beforeDelTS := db.Clock().Now()
+		_, err = db.Del(ctx, mkKey("a"))
+		require.NoError(t, err)
+		afterDelTS := db.Clock().Now()
+
+		v := <-rows
+		require.False(t, v.Value.IsPresent())
+		require.True(t, beforeDelTS.Less(v.Value.Timestamp))
+		require.True(t, v.Value.Timestamp.Less(afterDelTS))
+
+		require.True(t, v.PrevValue.IsPresent())
+		require.Equal(t, mustGetInt(v.PrevValue), 2)
+		require.True(t, v.PrevValue.Timestamp.IsEmpty())
+	}
+
+	{
+		beforeDelTS := db.Clock().Now()
+		_, err = db.Del(ctx, mkKey("a"))
+		require.NoError(t, err)
+		afterDelTS := db.Clock().Now()
+
+		v := <-rows
+		require.False(t, v.Value.IsPresent())
+		require.True(t, beforeDelTS.Less(v.Value.Timestamp))
+		require.True(t, v.Value.Timestamp.Less(afterDelTS))
+
+		require.False(t, v.PrevValue.IsPresent())
+		require.True(t, v.PrevValue.Timestamp.IsEmpty())
+	}
 }
 
 // TestWithOnSSTable tests that the rangefeed emits SST ingestions correctly.
@@ -530,96 +497,93 @@ func TestWithOnSSTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testutils.RunValues(t, "rangefeed_type", rangefeedTypes, func(t *testing.T, s rangefeedType) {
-		ctx := context.Background()
-		settings := cluster.MakeClusterSettings()
-		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
-			Settings:          settings,
-			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109473),
-		})
-		defer srv.Stopper().Stop(ctx)
-		tsrv := srv.ApplicationLayer()
-
-		_, _, err := srv.SplitRange(roachpb.Key("a"))
-		require.NoError(t, err)
-
-		for _, l := range []serverutils.ApplicationLayerInterface{tsrv, srv.SystemLayer()} {
-			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-		}
-
-		f, err := rangefeed.NewFactory(tsrv.AppStopper(), db, tsrv.ClusterSettings(), nil)
-		require.NoError(t, err)
-
-		// We start the rangefeed over a narrower span than the AddSSTable (c-e vs
-		// a-f), to ensure the entire SST is emitted even if the registration is
-		// narrower.
-		var once sync.Once
-		checkpointC := make(chan struct{})
-		sstC := make(chan kvcoord.RangeFeedMessage)
-		spans := []roachpb.Span{{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}}
-		r, err := f.RangeFeed(ctx, "test", spans, db.Clock().Now(),
-			func(ctx context.Context, value *kvpb.RangeFeedValue) {},
-			rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-				once.Do(func() {
-					close(checkpointC)
-				})
-			}),
-			rangefeed.WithOnSSTable(func(
-				ctx context.Context, sst *kvpb.RangeFeedSSTable, registeredSpan roachpb.Span,
-			) {
-				select {
-				case sstC <- kvcoord.RangeFeedMessage{
-					RangeFeedEvent: &kvpb.RangeFeedEvent{
-						SST: sst,
-					},
-					RegisteredSpan: registeredSpan,
-				}:
-				case <-ctx.Done():
-				}
-			}),
-			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
-		)
-		require.NoError(t, err)
-		defer r.Close()
-
-		// Wait for initial checkpoint.
-		select {
-		case <-checkpointC:
-		case <-time.After(3 * time.Second):
-			require.Fail(t, "timed out waiting for checkpoint")
-		}
-
-		// Ingest an SST.
-		now := db.Clock().Now()
-		now.Logical = 0
-		ts := int(now.WallTime)
-		sstKVs := kvs{
-			pointKV("a", ts, "1"),
-			pointKV("b", ts, "2"),
-			pointKV("c", ts, "3"),
-			rangeKV("d", "e", ts, ""),
-		}
-		sst, sstStart, sstEnd := storageutils.MakeSST(t, tsrv.ClusterSettings(), sstKVs)
-		_, _, _, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
-			false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{},
-			nil, /* stats */
-			false /* ingestAsWrites */, now)
-		require.Nil(t, pErr)
-
-		// Wait for the SST event and check its contents.
-		var sstMessage kvcoord.RangeFeedMessage
-		select {
-		case sstMessage = <-sstC:
-		case <-time.After(3 * time.Second):
-			require.Fail(t, "timed out waiting for SST event")
-		}
-
-		require.Equal(t, roachpb.Span{Key: sstStart, EndKey: sstEnd}, sstMessage.SST.Span)
-		require.Equal(t, now, sstMessage.SST.WriteTS)
-		require.Equal(t, sstKVs, storageutils.ScanSST(t, sstMessage.SST.Data))
-		require.Equal(t, spans[0], sstMessage.RegisteredSpan)
+	ctx := context.Background()
+	settings := cluster.MakeClusterSettings()
+	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
+		Settings:          settings,
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109473),
 	})
+	defer srv.Stopper().Stop(ctx)
+	tsrv := srv.ApplicationLayer()
+
+	_, _, err := srv.SplitRange(roachpb.Key("a"))
+	require.NoError(t, err)
+
+	for _, l := range []serverutils.ApplicationLayerInterface{tsrv, srv.SystemLayer()} {
+		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+	}
+
+	f, err := rangefeed.NewFactory(tsrv.AppStopper(), db, tsrv.ClusterSettings(), nil)
+	require.NoError(t, err)
+
+	// We start the rangefeed over a narrower span than the AddSSTable (c-e vs
+	// a-f), to ensure the entire SST is emitted even if the registration is
+	// narrower.
+	var once sync.Once
+	checkpointC := make(chan struct{})
+	sstC := make(chan kvcoord.RangeFeedMessage)
+	spans := []roachpb.Span{{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}}
+	r, err := f.RangeFeed(ctx, "test", spans, db.Clock().Now(),
+		func(ctx context.Context, value *kvpb.RangeFeedValue) {},
+		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
+			once.Do(func() {
+				close(checkpointC)
+			})
+		}),
+		rangefeed.WithOnSSTable(func(
+			ctx context.Context, sst *kvpb.RangeFeedSSTable, registeredSpan roachpb.Span,
+		) {
+			select {
+			case sstC <- kvcoord.RangeFeedMessage{
+				RangeFeedEvent: &kvpb.RangeFeedEvent{
+					SST: sst,
+				},
+				RegisteredSpan: registeredSpan,
+			}:
+			case <-ctx.Done():
+			}
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Wait for initial checkpoint.
+	select {
+	case <-checkpointC:
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for checkpoint")
+	}
+
+	// Ingest an SST.
+	now := db.Clock().Now()
+	now.Logical = 0
+	ts := int(now.WallTime)
+	sstKVs := kvs{
+		pointKV("a", ts, "1"),
+		pointKV("b", ts, "2"),
+		pointKV("c", ts, "3"),
+		rangeKV("d", "e", ts, ""),
+	}
+	sst, sstStart, sstEnd := storageutils.MakeSST(t, tsrv.ClusterSettings(), sstKVs)
+	_, _, _, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
+		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{},
+		nil, /* stats */
+		false /* ingestAsWrites */, now)
+	require.Nil(t, pErr)
+
+	// Wait for the SST event and check its contents.
+	var sstMessage kvcoord.RangeFeedMessage
+	select {
+	case sstMessage = <-sstC:
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for SST event")
+	}
+
+	require.Equal(t, roachpb.Span{Key: sstStart, EndKey: sstEnd}, sstMessage.SST.Span)
+	require.Equal(t, now, sstMessage.SST.WriteTS)
+	require.Equal(t, sstKVs, storageutils.ScanSST(t, sstMessage.SST.Data))
+	require.Equal(t, spans[0], sstMessage.RegisteredSpan)
 }
 
 // TestWithOnSSTableCatchesUpIfNotSet tests that the rangefeed runs a catchup
@@ -630,107 +594,104 @@ func TestWithOnSSTableCatchesUpIfNotSet(t *testing.T) {
 
 	storage.DisableMetamorphicSimpleValueEncoding(t)
 
-	testutils.RunValues(t, "rangefeed_type", rangefeedTypes, func(t *testing.T, s rangefeedType) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-		settings := cluster.MakeClusterSettings()
-		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
-			ServerArgs: base.TestServerArgs{
-				DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109473),
-				Knobs: base.TestingKnobs{
-					Store: &kvserver.StoreTestingKnobs{
-						SmallEngineBlocks: smallEngineBlocks,
-					},
+	settings := cluster.MakeClusterSettings()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109473),
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					SmallEngineBlocks: smallEngineBlocks,
 				},
-				Settings: settings,
 			},
-		})
-		defer tc.Stopper().Stop(ctx)
-		tsrv := tc.Server(0)
-		srv := tsrv.ApplicationLayer()
-		db := srv.DB()
-
-		_, _, err := tc.SplitRange(roachpb.Key("a"))
-		require.NoError(t, err)
-		require.NoError(t, tc.WaitForFullReplication())
-
-		for _, l := range []serverutils.ApplicationLayerInterface{srv, tsrv.SystemLayer()} {
-			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-		}
-
-		f, err := rangefeed.NewFactory(srv.AppStopper(), db, srv.ClusterSettings(), nil)
-		require.NoError(t, err)
-
-		// We start the rangefeed over a narrower span than the AddSSTable (c-e vs
-		// a-f), to ensure only the restricted span is emitted by the catchup scan.
-		var once sync.Once
-		checkpointC := make(chan struct{})
-		rowC := make(chan *kvpb.RangeFeedValue)
-		spans := []roachpb.Span{{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}}
-		r, err := f.RangeFeed(ctx, "test", spans, db.Clock().Now(),
-			func(ctx context.Context, value *kvpb.RangeFeedValue) {
-				select {
-				case rowC <- value:
-				case <-ctx.Done():
-				}
-			},
-			rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-				once.Do(func() {
-					close(checkpointC)
-				})
-			}),
-			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
-		)
-		require.NoError(t, err)
-		defer r.Close()
-
-		// Wait for initial checkpoint.
-		select {
-		case <-checkpointC:
-		case <-time.After(3 * time.Second):
-			require.Fail(t, "timed out waiting for checkpoint")
-		}
-
-		// Ingest an SST.
-		now := db.Clock().Now()
-		now.Logical = 0
-		ts := int(now.WallTime)
-		sstKVs := kvs{
-			pointKV("a", ts, "1"),
-			pointKV("b", ts, "2"),
-			pointKV("c", ts, "3"),
-			pointKV("d", ts, "4"),
-			pointKV("e", ts, "5"),
-		}
-		expectKVs := kvs{pointKV("c", ts, "3"), pointKV("d", ts, "4")}
-		sst, sstStart, sstEnd := storageutils.MakeSST(t, srv.ClusterSettings(), sstKVs)
-		_, _, _, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
-			false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{},
-			nil, /* stats */
-			false /* ingestAsWrites */, now)
-		require.Nil(t, pErr)
-
-		// Assert that we receive the KV pairs within the rangefeed span.
-		timer := time.NewTimer(3 * time.Second)
-		var seenKVs kvs
-		for len(seenKVs) < len(expectKVs) {
-			select {
-			case row := <-rowC:
-				seenKVs = append(seenKVs, storage.MVCCKeyValue{
-					Key: storage.MVCCKey{
-						Key:       row.Key,
-						Timestamp: row.Value.Timestamp,
-					},
-					Value: row.Value.RawBytes,
-				})
-			case <-timer.C:
-				require.Fail(t, "timed out waiting for catchup scan", "saw entries: %v", seenKVs)
-			}
-		}
-		require.Equal(t, expectKVs, seenKVs)
+			Settings: settings,
+		},
 	})
+	defer tc.Stopper().Stop(ctx)
+	tsrv := tc.Server(0)
+	srv := tsrv.ApplicationLayer()
+	db := srv.DB()
+
+	_, _, err := tc.SplitRange(roachpb.Key("a"))
+	require.NoError(t, err)
+	require.NoError(t, tc.WaitForFullReplication())
+
+	for _, l := range []serverutils.ApplicationLayerInterface{srv, tsrv.SystemLayer()} {
+		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+	}
+
+	f, err := rangefeed.NewFactory(srv.AppStopper(), db, srv.ClusterSettings(), nil)
+	require.NoError(t, err)
+
+	// We start the rangefeed over a narrower span than the AddSSTable (c-e vs
+	// a-f), to ensure only the restricted span is emitted by the catchup scan.
+	var once sync.Once
+	checkpointC := make(chan struct{})
+	rowC := make(chan *kvpb.RangeFeedValue)
+	spans := []roachpb.Span{{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}}
+	r, err := f.RangeFeed(ctx, "test", spans, db.Clock().Now(),
+		func(ctx context.Context, value *kvpb.RangeFeedValue) {
+			select {
+			case rowC <- value:
+			case <-ctx.Done():
+			}
+		},
+		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
+			once.Do(func() {
+				close(checkpointC)
+			})
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Wait for initial checkpoint.
+	select {
+	case <-checkpointC:
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for checkpoint")
+	}
+
+	// Ingest an SST.
+	now := db.Clock().Now()
+	now.Logical = 0
+	ts := int(now.WallTime)
+	sstKVs := kvs{
+		pointKV("a", ts, "1"),
+		pointKV("b", ts, "2"),
+		pointKV("c", ts, "3"),
+		pointKV("d", ts, "4"),
+		pointKV("e", ts, "5"),
+	}
+	expectKVs := kvs{pointKV("c", ts, "3"), pointKV("d", ts, "4")}
+	sst, sstStart, sstEnd := storageutils.MakeSST(t, srv.ClusterSettings(), sstKVs)
+	_, _, _, pErr := db.AddSSTableAtBatchTimestamp(ctx, sstStart, sstEnd, sst,
+		false /* disallowConflicts */, false /* disallowShadowing */, hlc.Timestamp{},
+		nil, /* stats */
+		false /* ingestAsWrites */, now)
+	require.Nil(t, pErr)
+
+	// Assert that we receive the KV pairs within the rangefeed span.
+	timer := time.NewTimer(3 * time.Second)
+	var seenKVs kvs
+	for len(seenKVs) < len(expectKVs) {
+		select {
+		case row := <-rowC:
+			seenKVs = append(seenKVs, storage.MVCCKeyValue{
+				Key: storage.MVCCKey{
+					Key:       row.Key,
+					Timestamp: row.Value.Timestamp,
+				},
+				Value: row.Value.RawBytes,
+			})
+		case <-timer.C:
+			require.Fail(t, "timed out waiting for catchup scan", "saw entries: %v", seenKVs)
+		}
+	}
+	require.Equal(t, expectKVs, seenKVs)
 }
 
 // TestWithOnDeleteRange tests that the rangefeed emits MVCC range tombstones.
@@ -741,182 +702,179 @@ func TestWithOnDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testutils.RunValues(t, "rangefeed_type", rangefeedTypes, func(t *testing.T, s rangefeedType) {
-		ctx := context.Background()
-		settings := cluster.MakeClusterSettings()
-		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
-			ServerArgs: base.TestServerArgs{
-				Settings: settings,
-				Knobs: base.TestingKnobs{
-					Store: &kvserver.StoreTestingKnobs{
-						SmallEngineBlocks: smallEngineBlocks,
-					},
+	ctx := context.Background()
+	settings := cluster.MakeClusterSettings()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Settings: settings,
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					SmallEngineBlocks: smallEngineBlocks,
 				},
 			},
-		})
-		defer tc.Stopper().Stop(ctx)
-		tsrv := tc.Server(0)
-		srv := tsrv.ApplicationLayer()
-		db := srv.DB()
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+	tsrv := tc.Server(0)
+	srv := tsrv.ApplicationLayer()
+	db := srv.DB()
 
-		_, _, err := tc.SplitRange(roachpb.Key("a"))
+	_, _, err := tc.SplitRange(roachpb.Key("a"))
+	require.NoError(t, err)
+	require.NoError(t, tc.WaitForFullReplication())
+
+	for _, l := range []serverutils.ApplicationLayerInterface{srv, tsrv.SystemLayer()} {
+		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+	}
+
+	f, err := rangefeed.NewFactory(srv.AppStopper(), db, srv.ClusterSettings(), nil)
+	require.NoError(t, err)
+
+	mkKey := func(s string) string {
+		return string(append(srv.Codec().TenantPrefix(), roachpb.Key(s)...))
+	}
+	// We lay down a few MVCC range tombstones and points. The first range
+	// tombstone should not be visible, because initial scans do not emit
+	// tombstones, nor should the points covered by it. The second range tombstone
+	// should be visible, because catchup scans do emit tombstones. The range
+	// tombstone should be ordered after the initial point, but before the foo
+	// catchup point, and the previous values should respect the range tombstones.
+	require.NoError(t, db.Put(ctx, mkKey("covered"), "covered"))
+	require.NoError(t, db.Put(ctx, mkKey("foo"), "covered"))
+	require.NoError(t, db.DelRangeUsingTombstone(ctx, mkKey("a"), mkKey("z")))
+	require.NoError(t, db.Put(ctx, mkKey("foo"), "initial"))
+	rangeFeedTS := db.Clock().Now()
+	require.NoError(t, db.Put(ctx, mkKey("covered"), "catchup"))
+	require.NoError(t, db.DelRangeUsingTombstone(ctx, mkKey("a"), mkKey("z")))
+	require.NoError(t, db.Put(ctx, mkKey("foo"), "catchup"))
+
+	// We start the rangefeed over a narrower span than the DeleteRanges (c-g),
+	// to ensure the DeleteRange event is truncated to the registration span.
+	var checkpointOnce sync.Once
+	checkpointC := make(chan struct{})
+	deleteRangeC := make(chan *kvpb.RangeFeedDeleteRange)
+	rowC := make(chan *kvpb.RangeFeedValue)
+
+	spans := []roachpb.Span{{
+		Key:    append(srv.Codec().TenantPrefix(), roachpb.Key("c")...),
+		EndKey: append(srv.Codec().TenantPrefix(), roachpb.Key("g")...),
+	}}
+	r, err := f.RangeFeed(ctx, "test", spans, rangeFeedTS,
+		func(ctx context.Context, e *kvpb.RangeFeedValue) {
+			select {
+			case rowC <- e:
+			case <-ctx.Done():
+			}
+		},
+		rangefeed.WithDiff(true),
+		rangefeed.WithInitialScan(nil),
+		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
+			checkpointOnce.Do(func() {
+				close(checkpointC)
+			})
+		}),
+		rangefeed.WithOnDeleteRange(func(ctx context.Context, e *kvpb.RangeFeedDeleteRange) {
+			select {
+			case deleteRangeC <- e:
+			case <-ctx.Done():
+			}
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Wait for initial scan. We should see the foo=initial point, but not the
+	// range tombstone nor the covered points.
+	select {
+	case e := <-rowC:
+		require.Equal(t, roachpb.Key(mkKey("foo")), e.Key)
+		value, err := e.Value.GetBytes()
 		require.NoError(t, err)
-		require.NoError(t, tc.WaitForFullReplication())
-
-		for _, l := range []serverutils.ApplicationLayerInterface{srv, tsrv.SystemLayer()} {
-			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-		}
-
-		f, err := rangefeed.NewFactory(srv.AppStopper(), db, srv.ClusterSettings(), nil)
+		require.Equal(t, "initial", string(value))
+		prevValue, err := e.PrevValue.GetBytes()
 		require.NoError(t, err)
+		require.Equal(t, "initial", string(prevValue)) // initial scans supply current as prev
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for initial scan event")
+	}
 
-		mkKey := func(s string) string {
-			return string(append(srv.Codec().TenantPrefix(), roachpb.Key(s)...))
-		}
-		// We lay down a few MVCC range tombstones and points. The first range
-		// tombstone should not be visible, because initial scans do not emit
-		// tombstones, nor should the points covered by it. The second range tombstone
-		// should be visible, because catchup scans do emit tombstones. The range
-		// tombstone should be ordered after the initial point, but before the foo
-		// catchup point, and the previous values should respect the range tombstones.
-		require.NoError(t, db.Put(ctx, mkKey("covered"), "covered"))
-		require.NoError(t, db.Put(ctx, mkKey("foo"), "covered"))
-		require.NoError(t, db.DelRangeUsingTombstone(ctx, mkKey("a"), mkKey("z")))
-		require.NoError(t, db.Put(ctx, mkKey("foo"), "initial"))
-		rangeFeedTS := db.Clock().Now()
-		require.NoError(t, db.Put(ctx, mkKey("covered"), "catchup"))
-		require.NoError(t, db.DelRangeUsingTombstone(ctx, mkKey("a"), mkKey("z")))
-		require.NoError(t, db.Put(ctx, mkKey("foo"), "catchup"))
-
-		// We start the rangefeed over a narrower span than the DeleteRanges (c-g),
-		// to ensure the DeleteRange event is truncated to the registration span.
-		var checkpointOnce sync.Once
-		checkpointC := make(chan struct{})
-		deleteRangeC := make(chan *kvpb.RangeFeedDeleteRange)
-		rowC := make(chan *kvpb.RangeFeedValue)
-
-		spans := []roachpb.Span{{
+	// Wait for catchup scan. We should see the second range tombstone, truncated
+	// to the rangefeed bounds (c-g), and it should be ordered before the points
+	// covered=catchup and foo=catchup. both points should have a tombstone as the
+	// previous value.
+	select {
+	case e := <-deleteRangeC:
+		require.Equal(t, roachpb.Span{
 			Key:    append(srv.Codec().TenantPrefix(), roachpb.Key("c")...),
 			EndKey: append(srv.Codec().TenantPrefix(), roachpb.Key("g")...),
-		}}
-		r, err := f.RangeFeed(ctx, "test", spans, rangeFeedTS,
-			func(ctx context.Context, e *kvpb.RangeFeedValue) {
-				select {
-				case rowC <- e:
-				case <-ctx.Done():
-				}
-			},
-			rangefeed.WithDiff(true),
-			rangefeed.WithInitialScan(nil),
-			rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-				checkpointOnce.Do(func() {
-					close(checkpointC)
-				})
-			}),
-			rangefeed.WithOnDeleteRange(func(ctx context.Context, e *kvpb.RangeFeedDeleteRange) {
-				select {
-				case deleteRangeC <- e:
-				case <-ctx.Done():
-				}
-			}),
-			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
-		)
+		}, e.Span)
+		require.NotEmpty(t, e.Timestamp)
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for DeleteRange event")
+	}
+
+	select {
+	case e := <-rowC:
+		require.Equal(t, roachpb.Key(mkKey("covered")), e.Key)
+		value, err := e.Value.GetBytes()
 		require.NoError(t, err)
-		defer r.Close()
+		require.Equal(t, "catchup", string(value))
+		prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
+		require.NoError(t, err)
+		require.True(t, prevValue.IsTombstone())
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for foo=catchup event")
+	}
 
-		// Wait for initial scan. We should see the foo=initial point, but not the
-		// range tombstone nor the covered points.
-		select {
-		case e := <-rowC:
-			require.Equal(t, roachpb.Key(mkKey("foo")), e.Key)
-			value, err := e.Value.GetBytes()
-			require.NoError(t, err)
-			require.Equal(t, "initial", string(value))
-			prevValue, err := e.PrevValue.GetBytes()
-			require.NoError(t, err)
-			require.Equal(t, "initial", string(prevValue)) // initial scans supply current as prev
-		case <-time.After(3 * time.Second):
-			require.Fail(t, "timed out waiting for initial scan event")
-		}
+	select {
+	case e := <-rowC:
+		require.Equal(t, roachpb.Key(mkKey("foo")), e.Key)
+		value, err := e.Value.GetBytes()
+		require.NoError(t, err)
+		require.Equal(t, "catchup", string(value))
+		prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
+		require.NoError(t, err)
+		require.True(t, prevValue.IsTombstone())
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for foo=catchup event")
+	}
 
-		// Wait for catchup scan. We should see the second range tombstone, truncated
-		// to the rangefeed bounds (c-g), and it should be ordered before the points
-		// covered=catchup and foo=catchup. both points should have a tombstone as the
-		// previous value.
-		select {
-		case e := <-deleteRangeC:
-			require.Equal(t, roachpb.Span{
-				Key:    append(srv.Codec().TenantPrefix(), roachpb.Key("c")...),
-				EndKey: append(srv.Codec().TenantPrefix(), roachpb.Key("g")...),
-			}, e.Span)
-			require.NotEmpty(t, e.Timestamp)
-		case <-time.After(3 * time.Second):
-			require.Fail(t, "timed out waiting for DeleteRange event")
-		}
+	// Wait for checkpoint after catchup scan.
+	select {
+	case <-checkpointC:
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for checkpoint")
+	}
 
-		select {
-		case e := <-rowC:
-			require.Equal(t, roachpb.Key(mkKey("covered")), e.Key)
-			value, err := e.Value.GetBytes()
-			require.NoError(t, err)
-			require.Equal(t, "catchup", string(value))
-			prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
-			require.NoError(t, err)
-			require.True(t, prevValue.IsTombstone())
-		case <-time.After(3 * time.Second):
-			require.Fail(t, "timed out waiting for foo=catchup event")
-		}
+	// Send another DeleteRange, and wait for the rangefeed event. This should
+	// be truncated to the rangefeed bounds (c-g).
+	require.NoError(t, db.DelRangeUsingTombstone(ctx, mkKey("a"), mkKey("z")))
+	select {
+	case e := <-deleteRangeC:
+		require.Equal(t, roachpb.Span{
+			Key:    append(srv.Codec().TenantPrefix(), roachpb.Key("c")...),
+			EndKey: append(srv.Codec().TenantPrefix(), roachpb.Key("g")...),
+		}, e.Span)
+		require.NotEmpty(t, e.Timestamp)
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for DeleteRange event")
+	}
 
-		select {
-		case e := <-rowC:
-			require.Equal(t, roachpb.Key(mkKey("foo")), e.Key)
-			value, err := e.Value.GetBytes()
-			require.NoError(t, err)
-			require.Equal(t, "catchup", string(value))
-			prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
-			require.NoError(t, err)
-			require.True(t, prevValue.IsTombstone())
-		case <-time.After(3 * time.Second):
-			require.Fail(t, "timed out waiting for foo=catchup event")
-		}
-
-		// Wait for checkpoint after catchup scan.
-		select {
-		case <-checkpointC:
-		case <-time.After(3 * time.Second):
-			require.Fail(t, "timed out waiting for checkpoint")
-		}
-
-		// Send another DeleteRange, and wait for the rangefeed event. This should
-		// be truncated to the rangefeed bounds (c-g).
-		require.NoError(t, db.DelRangeUsingTombstone(ctx, mkKey("a"), mkKey("z")))
-		select {
-		case e := <-deleteRangeC:
-			require.Equal(t, roachpb.Span{
-				Key:    append(srv.Codec().TenantPrefix(), roachpb.Key("c")...),
-				EndKey: append(srv.Codec().TenantPrefix(), roachpb.Key("g")...),
-			}, e.Span)
-			require.NotEmpty(t, e.Timestamp)
-		case <-time.After(3 * time.Second):
-			require.Fail(t, "timed out waiting for DeleteRange event")
-		}
-
-		// A final point write should be emitted with a tombstone as the previous value.
-		require.NoError(t, db.Put(ctx, mkKey("foo"), "final"))
-		select {
-		case e := <-rowC:
-			require.Equal(t, roachpb.Key(mkKey("foo")), e.Key)
-			value, err := e.Value.GetBytes()
-			require.NoError(t, err)
-			require.Equal(t, "final", string(value))
-			prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
-			require.NoError(t, err)
-			require.True(t, prevValue.IsTombstone())
-		case <-time.After(3 * time.Second):
-			require.Fail(t, "timed out waiting for foo=final event")
-		}
-	})
+	// A final point write should be emitted with a tombstone as the previous value.
+	require.NoError(t, db.Put(ctx, mkKey("foo"), "final"))
+	select {
+	case e := <-rowC:
+		require.Equal(t, roachpb.Key(mkKey("foo")), e.Key)
+		value, err := e.Value.GetBytes()
+		require.NoError(t, err)
+		require.Equal(t, "final", string(value))
+		prevValue, err := storage.DecodeMVCCValue(e.PrevValue.RawBytes)
+		require.NoError(t, err)
+		require.True(t, prevValue.IsTombstone())
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for foo=final event")
+	}
 }
 
 // TestUnrecoverableErrors verifies that unrecoverable internal errors are surfaced
@@ -925,94 +883,91 @@ func TestUnrecoverableErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testutils.RunValues(t, "rangefeed_type", rangefeedTypes, func(t *testing.T, s rangefeedType) {
-		ctx := context.Background()
-		settings := cluster.MakeClusterSettings()
-		srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
-			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109472),
-			Knobs: base.TestingKnobs{
-				SpanConfig: &spanconfig.TestingKnobs{
-					ConfigureScratchRange: true,
-				},
+	ctx := context.Background()
+	settings := cluster.MakeClusterSettings()
+	srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(109472),
+		Knobs: base.TestingKnobs{
+			SpanConfig: &spanconfig.TestingKnobs{
+				ConfigureScratchRange: true,
 			},
-			Settings: settings,
-		})
+		},
+		Settings: settings,
+	})
 
-		defer srv.Stopper().Stop(ctx)
-		ts := srv.ApplicationLayer()
+	defer srv.Stopper().Stop(ctx)
+	ts := srv.ApplicationLayer()
 
-		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-		_, _, err := srv.SplitRange(scratchKey)
+	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+	_, _, err := srv.SplitRange(scratchKey)
+	require.NoError(t, err)
+	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+
+	sp := roachpb.Span{
+		Key:    scratchKey,
+		EndKey: scratchKey.PrefixEnd(),
+	}
+	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+		// Lower the closed timestamp target duration to speed up the test.
+		closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
+	}
+
+	store, err := srv.GetStores().(*kvserver.Stores).GetStore(srv.GetFirstStoreID())
+	require.NoError(t, err)
+
+	{
+		// Lower the protectedts Cache refresh interval, so that the
+		// `preGCThresholdTS` defined below is less than the protectedts
+		// `readAt - GCTTL` window, resulting in a BatchTimestampBelowGCError.
+		_, err = sqlDB.Exec("SET CLUSTER SETTING kv.protectedts.poll_interval = '10ms'")
 		require.NoError(t, err)
-		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
 
-		sp := roachpb.Span{
-			Key:    scratchKey,
-			EndKey: scratchKey.PrefixEnd(),
+		ptsReader := store.GetStoreConfig().ProtectedTimestampReader
+		require.NoError(t,
+			spanconfigptsreader.TestingRefreshPTSState(ctx, t, ptsReader, srv.SystemLayer().Clock().Now()))
+	}
+
+	f, err := rangefeed.NewFactory(ts.AppStopper(), kvDB, ts.ClusterSettings(), nil)
+	require.NoError(t, err)
+
+	preGCThresholdTS := hlc.Timestamp{WallTime: 1}
+	mu := struct {
+		syncutil.Mutex
+		internalErr error
+	}{}
+
+	testutils.SucceedsSoon(t, func() error {
+		repl := store.LookupReplica(roachpb.RKey(scratchKey))
+		if conf, err := repl.LoadSpanConfig(ctx); err != nil || conf.GCPolicy.IgnoreStrictEnforcement {
+			return errors.New("waiting for span config to apply")
 		}
-		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-			// Lower the closed timestamp target duration to speed up the test.
-			closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
-		}
+		require.NoError(t, repl.ReadProtectedTimestampsForTesting(ctx))
+		return nil
+	})
 
-		store, err := srv.GetStores().(*kvserver.Stores).GetStore(srv.GetFirstStoreID())
-		require.NoError(t, err)
-
-		{
-			// Lower the protectedts Cache refresh interval, so that the
-			// `preGCThresholdTS` defined below is less than the protectedts
-			// `readAt - GCTTL` window, resulting in a BatchTimestampBelowGCError.
-			_, err = sqlDB.Exec("SET CLUSTER SETTING kv.protectedts.poll_interval = '10ms'")
-			require.NoError(t, err)
-
-			ptsReader := store.GetStoreConfig().ProtectedTimestampReader
-			require.NoError(t,
-				spanconfigptsreader.TestingRefreshPTSState(ctx, t, ptsReader, srv.SystemLayer().Clock().Now()))
-		}
-
-		f, err := rangefeed.NewFactory(ts.AppStopper(), kvDB, ts.ClusterSettings(), nil)
-		require.NoError(t, err)
-
-		preGCThresholdTS := hlc.Timestamp{WallTime: 1}
-		mu := struct {
-			syncutil.Mutex
-			internalErr error
-		}{}
-
-		testutils.SucceedsSoon(t, func() error {
-			repl := store.LookupReplica(roachpb.RKey(scratchKey))
-			if conf, err := repl.LoadSpanConfig(ctx); err != nil || conf.GCPolicy.IgnoreStrictEnforcement {
-				return errors.New("waiting for span config to apply")
-			}
-			require.NoError(t, repl.ReadProtectedTimestampsForTesting(ctx))
-			return nil
-		})
-
-		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, preGCThresholdTS,
-			func(context.Context, *kvpb.RangeFeedValue) {},
-			rangefeed.WithDiff(true),
-			rangefeed.WithOnInternalError(func(ctx context.Context, err error) {
-				mu.Lock()
-				defer mu.Unlock()
-
-				mu.internalErr = err
-			}),
-			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
-		)
-		require.NoError(t, err)
-		defer r.Close()
-
-		testutils.SucceedsSoon(t, func() error {
+	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, preGCThresholdTS,
+		func(context.Context, *kvpb.RangeFeedValue) {},
+		rangefeed.WithDiff(true),
+		rangefeed.WithOnInternalError(func(ctx context.Context, err error) {
 			mu.Lock()
 			defer mu.Unlock()
 
-			if !errors.HasType(mu.internalErr, &kvpb.BatchTimestampBeforeGCError{}) {
-				return errors.New("expected internal error")
-			}
-			return nil
-		})
+			mu.internalErr = err
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	testutils.SucceedsSoon(t, func() error {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if !errors.HasType(mu.internalErr, &kvpb.BatchTimestampBeforeGCError{}) {
+			return errors.New("expected internal error")
+		}
+		return nil
 	})
 }
 
@@ -1022,85 +977,82 @@ func TestMVCCHistoryMutationError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testutils.RunValues(t, "rangefeed_type", rangefeedTypes, func(t *testing.T, s rangefeedType) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-		settings := cluster.MakeClusterSettings()
-		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
-			Settings: settings,
-		})
-		defer srv.Stopper().Stop(ctx)
-		ts := srv.ApplicationLayer()
-
-		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-		_, _, err := srv.SplitRange(scratchKey)
-		require.NoError(t, err)
-		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-		sp := roachpb.Span{
-			Key:    scratchKey,
-			EndKey: scratchKey.PrefixEnd(),
-		}
-		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-			// Lower the closed timestamp target duration to speed up the test.
-			closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
-		}
-
-		// Set up a rangefeed.
-		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-		require.NoError(t, err)
-
-		var once sync.Once
-		checkpointC := make(chan struct{})
-		errC := make(chan error)
-		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, ts.Clock().Now(),
-			func(context.Context, *kvpb.RangeFeedValue) {},
-			rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
-				once.Do(func() {
-					close(checkpointC)
-				})
-			}),
-			rangefeed.WithOnInternalError(func(ctx context.Context, err error) {
-				select {
-				case errC <- err:
-				case <-ctx.Done():
-				}
-			}),
-			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
-		)
-		require.NoError(t, err)
-		defer r.Close()
-
-		// Wait for initial checkpoint.
-		select {
-		case <-checkpointC:
-		case err := <-errC:
-			require.NoError(t, err)
-		case <-time.After(3 * time.Second):
-			require.Fail(t, "timed out waiting for checkpoint")
-		}
-
-		// Send a ClearRange request that mutates MVCC history.
-		_, pErr := kv.SendWrapped(ctx, db.NonTransactionalSender(), &kvpb.ClearRangeRequest{
-			RequestHeader: kvpb.RequestHeader{
-				Key:    sp.Key,
-				EndKey: sp.EndKey,
-			},
-		})
-		require.Nil(t, pErr)
-
-		// Wait for the MVCCHistoryMutationError.
-		select {
-		case err := <-errC:
-			var mvccErr *kvpb.MVCCHistoryMutationError
-			require.ErrorAs(t, err, &mvccErr)
-			require.Equal(t, &kvpb.MVCCHistoryMutationError{Span: sp}, err)
-		case <-time.After(3 * time.Second):
-			require.Fail(t, "timed out waiting for error")
-		}
+	settings := cluster.MakeClusterSettings()
+	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: settings,
 	})
+	defer srv.Stopper().Stop(ctx)
+	ts := srv.ApplicationLayer()
+
+	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+	_, _, err := srv.SplitRange(scratchKey)
+	require.NoError(t, err)
+	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+	sp := roachpb.Span{
+		Key:    scratchKey,
+		EndKey: scratchKey.PrefixEnd(),
+	}
+	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+		// Lower the closed timestamp target duration to speed up the test.
+		closedts.TargetDuration.Override(ctx, &l.ClusterSettings().SV, 100*time.Millisecond)
+	}
+
+	// Set up a rangefeed.
+	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
+	require.NoError(t, err)
+
+	var once sync.Once
+	checkpointC := make(chan struct{})
+	errC := make(chan error)
+	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, ts.Clock().Now(),
+		func(context.Context, *kvpb.RangeFeedValue) {},
+		rangefeed.WithOnCheckpoint(func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
+			once.Do(func() {
+				close(checkpointC)
+			})
+		}),
+		rangefeed.WithOnInternalError(func(ctx context.Context, err error) {
+			select {
+			case errC <- err:
+			case <-ctx.Done():
+			}
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	// Wait for initial checkpoint.
+	select {
+	case <-checkpointC:
+	case err := <-errC:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for checkpoint")
+	}
+
+	// Send a ClearRange request that mutates MVCC history.
+	_, pErr := kv.SendWrapped(ctx, db.NonTransactionalSender(), &kvpb.ClearRangeRequest{
+		RequestHeader: kvpb.RequestHeader{
+			Key:    sp.Key,
+			EndKey: sp.EndKey,
+		},
+	})
+	require.Nil(t, pErr)
+
+	// Wait for the MVCCHistoryMutationError.
+	select {
+	case err := <-errC:
+		var mvccErr *kvpb.MVCCHistoryMutationError
+		require.ErrorAs(t, err, &mvccErr)
+		require.Equal(t, &kvpb.MVCCHistoryMutationError{Span: sp}, err)
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "timed out waiting for error")
+	}
 }
 
 // TestRangefeedWithLabelsOption verifies go routines started by rangefeed are
@@ -1109,114 +1061,111 @@ func TestRangefeedWithLabelsOption(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testutils.RunValues(t, "rangefeed_type", rangefeedTypes, func(t *testing.T, s rangefeedType) {
-		ctx := context.Background()
-		settings := cluster.MakeClusterSettings()
-		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
-			Settings: settings,
-		})
-		defer srv.Stopper().Stop(ctx)
-		ts := srv.ApplicationLayer()
+	ctx := context.Background()
+	settings := cluster.MakeClusterSettings()
+	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: settings,
+	})
+	defer srv.Stopper().Stop(ctx)
+	ts := srv.ApplicationLayer()
 
-		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-		_, _, err := srv.SplitRange(scratchKey)
+	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+	_, _, err := srv.SplitRange(scratchKey)
+	require.NoError(t, err)
+	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+	mkKey := func(k string) roachpb.Key {
+		return encoding.EncodeStringAscending(scratchKey, k)
+	}
+	// Split the range a bunch of times.
+	const splits = 10
+	for i := 0; i < splits; i++ {
+		_, _, err := srv.SplitRange(mkKey(string([]byte{'a' + byte(i)})))
 		require.NoError(t, err)
-		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-		mkKey := func(k string) roachpb.Key {
-			return encoding.EncodeStringAscending(scratchKey, k)
-		}
-		// Split the range a bunch of times.
-		const splits = 10
-		for i := 0; i < splits; i++ {
-			_, _, err := srv.SplitRange(mkKey(string([]byte{'a' + byte(i)})))
-			require.NoError(t, err)
-		}
+	}
 
-		require.NoError(t, db.Put(ctx, mkKey("a"), 1))
-		require.NoError(t, db.Put(ctx, mkKey("b"), 2))
-		afterB := db.Clock().Now()
-		require.NoError(t, db.Put(ctx, mkKey("c"), 3))
+	require.NoError(t, db.Put(ctx, mkKey("a"), 1))
+	require.NoError(t, db.Put(ctx, mkKey("b"), 2))
+	afterB := db.Clock().Now()
+	require.NoError(t, db.Put(ctx, mkKey("c"), 3))
 
-		sp := roachpb.Span{
-			Key:    scratchKey,
-			EndKey: scratchKey.PrefixEnd(),
-		}
-		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-		}
+	sp := roachpb.Span{
+		Key:    scratchKey,
+		EndKey: scratchKey.PrefixEnd(),
+	}
+	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+	}
 
-		const rangefeedName = "test-feed"
-		type label struct {
-			k, v string
-		}
-		defaultLabel := label{k: "rangefeed", v: rangefeedName}
-		label1 := label{k: "caller-label", v: "foo"}
-		label2 := label{k: "another-label", v: "bar"}
+	const rangefeedName = "test-feed"
+	type label struct {
+		k, v string
+	}
+	defaultLabel := label{k: "rangefeed", v: rangefeedName}
+	label1 := label{k: "caller-label", v: "foo"}
+	label2 := label{k: "another-label", v: "bar"}
 
-		allLabelsCorrect := struct {
-			syncutil.Mutex
-			correct bool
-		}{correct: true}
+	allLabelsCorrect := struct {
+		syncutil.Mutex
+		correct bool
+	}{correct: true}
 
-		verifyLabels := func(ctx context.Context) {
-			allLabelsCorrect.Lock()
-			defer allLabelsCorrect.Unlock()
-			if !allLabelsCorrect.correct {
-				return
-			}
-
-			m := make(map[string]string)
-			pprof.ForLabels(ctx, func(k, v string) bool {
-				m[k] = v
-				return true
-			})
-
-			allLabelsCorrect.correct =
-				m[defaultLabel.k] == defaultLabel.v && m[label1.k] == label1.v && m[label2.k] == label2.v
-		}
-
-		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-		require.NoError(t, err)
-		initialScanDone := make(chan struct{})
-
-		// We'll emit keyD a bit later, once initial scan completes.
-		keyD := mkKey("d")
-		var keyDSeen sync.Once
-		keyDSeenCh := make(chan struct{})
-
-		r, err := f.RangeFeed(ctx, rangefeedName, []roachpb.Span{sp}, afterB,
-			func(ctx context.Context, value *kvpb.RangeFeedValue) {
-				verifyLabels(ctx)
-				if value.Key.Equal(keyD) {
-					keyDSeen.Do(func() { close(keyDSeenCh) })
-				}
-			},
-			rangefeed.WithPProfLabel(label1.k, label1.v),
-			rangefeed.WithPProfLabel(label2.k, label2.v),
-			rangefeed.WithInitialScanParallelismFn(func() int { return 3 }),
-			rangefeed.WithOnScanCompleted(func(ctx context.Context, sp roachpb.Span) error {
-				verifyLabels(ctx)
-				return nil
-			}),
-			rangefeed.WithInitialScan(func(ctx context.Context) {
-				verifyLabels(ctx)
-				close(initialScanDone)
-			}),
-			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
-		)
-		require.NoError(t, err)
-		defer r.Close()
-
-		<-initialScanDone
-
-		// Write a new value for "a" and make sure it is seen.
-		require.NoError(t, db.Put(ctx, keyD, 5))
-		<-keyDSeenCh
+	verifyLabels := func(ctx context.Context) {
 		allLabelsCorrect.Lock()
 		defer allLabelsCorrect.Unlock()
-		require.True(t, allLabelsCorrect.correct)
-	})
+		if !allLabelsCorrect.correct {
+			return
+		}
+
+		m := make(map[string]string)
+		pprof.ForLabels(ctx, func(k, v string) bool {
+			m[k] = v
+			return true
+		})
+
+		allLabelsCorrect.correct =
+			m[defaultLabel.k] == defaultLabel.v && m[label1.k] == label1.v && m[label2.k] == label2.v
+	}
+
+	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
+	require.NoError(t, err)
+	initialScanDone := make(chan struct{})
+
+	// We'll emit keyD a bit later, once initial scan completes.
+	keyD := mkKey("d")
+	var keyDSeen sync.Once
+	keyDSeenCh := make(chan struct{})
+
+	r, err := f.RangeFeed(ctx, rangefeedName, []roachpb.Span{sp}, afterB,
+		func(ctx context.Context, value *kvpb.RangeFeedValue) {
+			verifyLabels(ctx)
+			if value.Key.Equal(keyD) {
+				keyDSeen.Do(func() { close(keyDSeenCh) })
+			}
+		},
+		rangefeed.WithPProfLabel(label1.k, label1.v),
+		rangefeed.WithPProfLabel(label2.k, label2.v),
+		rangefeed.WithInitialScanParallelismFn(func() int { return 3 }),
+		rangefeed.WithOnScanCompleted(func(ctx context.Context, sp roachpb.Span) error {
+			verifyLabels(ctx)
+			return nil
+		}),
+		rangefeed.WithInitialScan(func(ctx context.Context) {
+			verifyLabels(ctx)
+			close(initialScanDone)
+		}),
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	<-initialScanDone
+
+	// Write a new value for "a" and make sure it is seen.
+	require.NoError(t, db.Put(ctx, keyD, 5))
+	<-keyDSeenCh
+	allLabelsCorrect.Lock()
+	defer allLabelsCorrect.Unlock()
+	require.True(t, allLabelsCorrect.correct)
 }
 
 // TestRangeFeedStartTimeExclusive tests that the start timestamp of the
@@ -1225,61 +1174,58 @@ func TestRangeFeedStartTimeExclusive(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testutils.RunValues(t, "rangefeed_type", rangefeedTypes, func(t *testing.T, s rangefeedType) {
-		ctx := context.Background()
-		settings := cluster.MakeClusterSettings()
-		srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
-			Settings: settings,
-		})
-		defer srv.Stopper().Stop(ctx)
-		ts := srv.ApplicationLayer()
-
-		scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
-		_, _, err := srv.SplitRange(scratchKey)
-		require.NoError(t, err)
-		scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
-		mkKey := func(k string) roachpb.Key {
-			return encoding.EncodeStringAscending(scratchKey, k)
-		}
-		span := roachpb.Span{Key: scratchKey, EndKey: scratchKey.PrefixEnd()}
-
-		// Write three versions of "foo". Get the timestamp of the second version.
-		require.NoError(t, db.Put(ctx, mkKey("foo"), 1))
-		require.NoError(t, db.Put(ctx, mkKey("foo"), 2))
-		kv, err := db.Get(ctx, mkKey("foo"))
-		require.NoError(t, err)
-		ts2 := kv.Value.Timestamp
-		require.NoError(t, db.Put(ctx, mkKey("foo"), 3))
-
-		for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
-			// Enable rangefeeds, otherwise the thing will retry until they are enabled.
-			kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
-		}
-
-		f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
-		require.NoError(t, err)
-		rows := make(chan *kvpb.RangeFeedValue)
-		r, err := f.RangeFeed(ctx, "test", []roachpb.Span{span}, ts2,
-			func(ctx context.Context, value *kvpb.RangeFeedValue) {
-				select {
-				case rows <- value:
-				case <-ctx.Done():
-				}
-			},
-			rangefeed.WithMuxRangefeed(s.useMuxRangefeed),
-		)
-		require.NoError(t, err)
-		defer r.Close()
-
-		// The first emitted version should be 3.
-		select {
-		case row := <-rows:
-			require.Equal(t, mkKey("foo"), row.Key)
-			v, err := row.Value.GetInt()
-			require.NoError(t, err)
-			require.EqualValues(t, 3, v)
-		case <-time.After(3 * time.Second):
-			t.Fatal("timed out waiting for event")
-		}
+	ctx := context.Background()
+	settings := cluster.MakeClusterSettings()
+	srv, _, db := serverutils.StartServer(t, base.TestServerArgs{
+		Settings: settings,
 	})
+	defer srv.Stopper().Stop(ctx)
+	ts := srv.ApplicationLayer()
+
+	scratchKey := append(ts.Codec().TenantPrefix(), keys.ScratchRangeMin...)
+	_, _, err := srv.SplitRange(scratchKey)
+	require.NoError(t, err)
+	scratchKey = scratchKey[:len(scratchKey):len(scratchKey)]
+	mkKey := func(k string) roachpb.Key {
+		return encoding.EncodeStringAscending(scratchKey, k)
+	}
+	span := roachpb.Span{Key: scratchKey, EndKey: scratchKey.PrefixEnd()}
+
+	// Write three versions of "foo". Get the timestamp of the second version.
+	require.NoError(t, db.Put(ctx, mkKey("foo"), 1))
+	require.NoError(t, db.Put(ctx, mkKey("foo"), 2))
+	kv, err := db.Get(ctx, mkKey("foo"))
+	require.NoError(t, err)
+	ts2 := kv.Value.Timestamp
+	require.NoError(t, db.Put(ctx, mkKey("foo"), 3))
+
+	for _, l := range []serverutils.ApplicationLayerInterface{ts, srv.SystemLayer()} {
+		// Enable rangefeeds, otherwise the thing will retry until they are enabled.
+		kvserver.RangefeedEnabled.Override(ctx, &l.ClusterSettings().SV, true)
+	}
+
+	f, err := rangefeed.NewFactory(ts.AppStopper(), db, ts.ClusterSettings(), nil)
+	require.NoError(t, err)
+	rows := make(chan *kvpb.RangeFeedValue)
+	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{span}, ts2,
+		func(ctx context.Context, value *kvpb.RangeFeedValue) {
+			select {
+			case rows <- value:
+			case <-ctx.Done():
+			}
+		},
+	)
+	require.NoError(t, err)
+	defer r.Close()
+
+	// The first emitted version should be 3.
+	select {
+	case row := <-rows:
+		require.Equal(t, mkKey("foo"), row.Key)
+		v, err := row.Value.GetInt()
+		require.NoError(t, err)
+		require.EqualValues(t, 3, v)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
 }

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3506,8 +3506,9 @@ message JoinNodeResponse {
 service Internal {
   rpc Batch              (BatchRequest)              returns (BatchResponse)                  {}
   rpc RangeLookup        (RangeLookupRequest)        returns (RangeLookupResponse)            {}
-  // RangeFeed RPC is deprecated.  Use MuxRangeFeed instead.
-  // To be removed at version 23.1
+  // RangeFeed RPC is deprecated. Use MuxRangeFeed instead.
+  // This should be removed when support is no longer needed in
+  // mixed-version clusters, possibly in 24.2.
   rpc RangeFeed          (RangeFeedRequest)          returns (stream RangeFeedEvent)          {}
   rpc MuxRangeFeed       (stream RangeFeedRequest)   returns (stream MuxRangeFeedEvent) {}
   rpc GossipSubscription (GossipSubscriptionRequest) returns (stream GossipSubscriptionEvent) {}

--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -275,7 +275,7 @@ func TestRangefeedIsRoutedToNonVoter(t *testing.T) {
 	}
 	rangefeedCancel()
 	require.Regexp(t, "context canceled", <-rangefeedErrChan)
-	require.Regexp(t, `attempting to create a RangeFeed over replica .n2,s2.:\dNON_VOTER`,
+	require.Regexp(t, `MuxRangeFeed starting for span .* replica .n2,s2.:\dNON_VOTER`,
 		getRecAndFinish().String())
 }
 

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -231,6 +231,7 @@ var retiredSettings = map[InternalKey]struct{}{
 	// removed as of 24.1
 	"storage.mvcc.range_tombstones.enabled":        {},
 	"changefeed.balance_range_distribution.enable": {},
+	"kv.rangefeed.catchup_scan_concurrency":        {},
 	"kv.rangefeed.scheduler.enabled":               {},
 }
 

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -231,6 +231,7 @@ var retiredSettings = map[InternalKey]struct{}{
 	// removed as of 24.1
 	"storage.mvcc.range_tombstones.enabled":                {},
 	"changefeed.balance_range_distribution.enable":         {},
+	"changefeed.mux_rangefeed.enabled":                     {},
 	"kv.rangefeed.catchup_scan_concurrency":                {},
 	"kv.rangefeed.scheduler.enabled":                       {},
 	"physical_replication.producer.mux_rangefeeds.enabled": {},

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -229,10 +229,11 @@ var retiredSettings = map[InternalKey]struct{}{
 	"bulkio.restore.remove_regions.enabled":                    {},
 
 	// removed as of 24.1
-	"storage.mvcc.range_tombstones.enabled":        {},
-	"changefeed.balance_range_distribution.enable": {},
-	"kv.rangefeed.catchup_scan_concurrency":        {},
-	"kv.rangefeed.scheduler.enabled":               {},
+	"storage.mvcc.range_tombstones.enabled":                {},
+	"changefeed.balance_range_distribution.enable":         {},
+	"kv.rangefeed.catchup_scan_concurrency":                {},
+	"kv.rangefeed.scheduler.enabled":                       {},
+	"physical_replication.producer.mux_rangefeeds.enabled": {},
 }
 
 // sqlDefaultSettings is the list of "grandfathered" existing sql.defaults


### PR DESCRIPTION
**rangefeed: use mux rangefeeds by default**

Touches #113029.
Release note (performance improvement): rangefeeds, the infrastructure for changefeeds, now use a more efficient multiplexing protocol.

**kvclient: remove `kv.rangefeed.catchup_scan_concurrency`**

This is only used for non-mux rangefeeds, which will be disabled shortly.

Release note (ops change): the setting `kv.rangefeed.catchup_scan_concurrency` has been removed. Catchup scans are throttled via `kv.rangefeed.concurrent_catchup_iterators` on a per-node basis.

**streamingccl: remove `physical_replication.producer.mux_rangefeeds.enabled`**

The mux rangefeed protocol will be enabled unconditionally shortly.

**kvclient: remove `COCKROACH_ENABLE_MULTIPLEXING_RANGEFEED`**

Mux rangefeeds will be enabled unconditionally.

**changefeedccl: remove `changefeed.mux_rangefeed.enabled`**

Mux rangefeeds are now used unconditionally in changefeeds. The code options are left in place to retain test coverage in mixed-version clusters with old non-mux clients.

Release note (ops change): the cluster setting `changefeed.mux_rangefeed.enabled` has been removed, and is in effect always enabled.

**kvfeed: remove mux rangefeed config options**

This patch always uses mux rangefeeds in kvfeed, via the default rangefeed config. The legacy protocol may be used in metamorphic tests.

**rangefeed: remove `WithMuxRangefeed` option**

Mux rangefeeds are now always enabled, except when disabled in metamorphic tests. The corresponding DistSender option `kvcoord.WithMuxRangeFeed()` is retained for test coverage.

**kvcoord: invert `WithMuxRangeFeed` to `Without`**

This patch inverts the DistSender option `WithMuxRangeFeed` as `WithoutMuxRangeFeed`, to ensure callers always use mux rangefeeds unless they explicitly opt out (only in tests).

**kvpb: update `RangeFeed` method deprecation notice**