### PR TITLE
storage: skip counting used bytes during EvalAddSStable

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -145,7 +145,7 @@ func EvalAddSSTable(
 	log.Eventf(ctx, "evaluating AddSSTable [%s,%s)", start.Key, end.Key)
 
 	if min := addSSTableCapacityRemainingLimit.Get(&cArgs.EvalCtx.ClusterSettings().SV); min > 0 {
-		cap, err := cArgs.EvalCtx.GetEngineCapacity()
+		cap, err := cArgs.EvalCtx.GetEngineCapacity(true)
 		if err != nil {
 			return result.Result{}, err
 		}

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -134,7 +134,7 @@ type EvalContext interface {
 
 	// GetEngineCapacity returns the store's underlying engine capacity; other
 	// StoreCapacity fields not related to engine capacity are not populated.
-	GetEngineCapacity() (roachpb.StoreCapacity, error)
+	GetEngineCapacity(skipCountingUsed bool) (roachpb.StoreCapacity, error)
 
 	// GetApproximateDiskBytes returns an approximate measure of bytes in the store
 	// in the specified key range.
@@ -311,7 +311,7 @@ func (m *mockEvalCtxImpl) GetMaxBytes(context.Context) int64 {
 	}
 	return math.MaxInt64
 }
-func (m *mockEvalCtxImpl) GetEngineCapacity() (roachpb.StoreCapacity, error) {
+func (m *mockEvalCtxImpl) GetEngineCapacity(skipCountingUsed bool) (roachpb.StoreCapacity, error) {
 	return roachpb.StoreCapacity{Available: 1, Capacity: 1}, nil
 }
 func (m *mockEvalCtxImpl) GetApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2363,9 +2363,9 @@ func (r *Replica) GetResponseMemoryAccount() *mon.BoundAccount {
 
 // GetEngineCapacity returns the store's underlying engine capacity; other
 // StoreCapacity fields not related to engine capacity are not populated.
-func (r *Replica) GetEngineCapacity() (roachpb.StoreCapacity, error) {
+func (r *Replica) GetEngineCapacity(skipCountingUsed bool) (roachpb.StoreCapacity, error) {
 	// TODO(sep-raft-log): need to expose log engine capacity.
-	return r.store.TODOEngine().Capacity()
+	return r.store.TODOEngine().Capacity(skipCountingUsed)
 }
 
 // GetApproximateDiskBytes returns an approximate measure of bytes in the store

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -266,8 +266,10 @@ func (rec *SpanSetReplicaEvalContext) GetMaxBytes(ctx context.Context) int64 {
 }
 
 // GetEngineCapacity implements the batcheval.EvalContext interface.
-func (rec *SpanSetReplicaEvalContext) GetEngineCapacity() (roachpb.StoreCapacity, error) {
-	return rec.i.GetEngineCapacity()
+func (rec *SpanSetReplicaEvalContext) GetEngineCapacity(
+	skipCountingUsed bool,
+) (roachpb.StoreCapacity, error) {
+	return rec.i.GetEngineCapacity(skipCountingUsed)
 }
 
 // GetApproximateDiskBytes implements the batcheval.EvalContext interface.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2839,7 +2839,7 @@ func (s *Store) Capacity(ctx context.Context, useCached bool) (roachpb.StoreCapa
 		}
 	}
 
-	capacity, err := s.TODOEngine().Capacity()
+	capacity, err := s.TODOEngine().Capacity(false)
 	if err != nil {
 		return roachpb.StoreCapacity{}, err
 	}

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -924,7 +924,7 @@ type Engine interface {
 	// Attrs returns the engine/store attributes.
 	Attrs() roachpb.Attributes
 	// Capacity returns capacity details for the engine's available storage.
-	Capacity() (roachpb.StoreCapacity, error)
+	Capacity(skipCountingUsed bool) (roachpb.StoreCapacity, error)
 	// Properties returns the low-level properties for the engine's underlying storage.
 	Properties() roachpb.StoreProperties
 	// Compact forces compaction over the entire database.

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1829,7 +1829,7 @@ func (p *Pebble) Properties() roachpb.StoreProperties {
 }
 
 // Capacity implements the Engine interface.
-func (p *Pebble) Capacity() (roachpb.StoreCapacity, error) {
+func (p *Pebble) Capacity(skipCountingUsed bool) (roachpb.StoreCapacity, error) {
 	dir := p.path
 	if dir != "" {
 		var err error
@@ -1862,6 +1862,14 @@ func (p *Pebble) Capacity() (roachpb.StoreCapacity, error) {
 	}
 	fsuTotal := int64(du.TotalBytes)
 	fsuAvail := int64(du.AvailBytes)
+
+	if skipCountingUsed {
+		return roachpb.StoreCapacity{
+			Capacity:  fsuTotal,
+			Available: fsuAvail,
+			Used:      0,
+		}, nil
+	}
 
 	// If the emergency ballast isn't appropriately sized, try to resize it.
 	// This is a no-op if the ballast is already sized or if there's not


### PR DESCRIPTION
During EvalAddSSTable we check if the device is close to full to prevent overfilling it via bulk operations. We do this by calling engine.Capacity().

At some point however engine.Capacity started not retrieving the device bytes available and used -- in a quick o(1) sys call -- but started also traversing the store directories to count the actual size of each file. This shows up in the profile of a tight loop of adding virtual sstables, where this filepath.Walk is the majority of the cost of these calls.

The AddSStable call does not actually care how much of the device used space is in-use by the files in the store dir vs other files, as it is only checking if the device is full or not, so it never uses the 'Used' field returned by Capacity() so it can pass an option to simply skip counting these files up and return a summary with only the two device numbers populated.

Release note: none.
Epic: none.