### PR TITLE
roachtest: disable direct columnar scans in one more backup config

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -720,8 +720,11 @@ func runBackupMVCCRangeTombstones(
 	t.Status("configuring cluster")
 	_, err := conn.Exec(`SET CLUSTER SETTING kv.bulk_ingest.max_index_buffer_size = '2gb'`)
 	require.NoError(t, err)
-	_, err = conn.Exec(`SET CLUSTER SETTING server.debug.default_vmodule = 'txn=2,sst_batcher=4,
-revert=2'`)
+	_, err = conn.Exec(`SET CLUSTER SETTING server.debug.default_vmodule = 'txn=2,sst_batcher=4,revert=2'`)
+	require.NoError(t, err)
+	// See #113816 for why this is needed for now (probably until #94850 is
+	// resolved).
+	_, err = conn.Exec(`SET CLUSTER SETTING sql.distsql.direct_columnar_scans.enabled = false;`)
 	require.NoError(t, err)
 	// Wait for ranges to upreplicate.
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))


### PR DESCRIPTION
Fixes: #114409.

Release note: None