### PR TITLE
sql: avoid cast between strings for EXPERIMENTAL_FINGERPRINT

### DIFF
--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -301,6 +301,8 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 		case types.BytesFamily:
 			cols = append(cols, fmt.Sprintf("%s:::bytes", colNameOrExpr))
 			numBytesCols++
+		case types.StringFamily:
+			cols = append(cols, fmt.Sprintf("%s:::string", colNameOrExpr))
 		default:
 			cols = append(cols, fmt.Sprintf("%s::string", colNameOrExpr))
 		}


### PR DESCRIPTION
This removes the need for casting between strings with different OIDs.

Informs: #114409.

Release note: None