### PR TITLE
upgrades: skip upgrade tests when MinSupported is bumped

### DIFF
--- a/pkg/clusterversion/BUILD.bazel
+++ b/pkg/clusterversion/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/build",
         "//pkg/roachpb",
         "//pkg/settings",
+        "//pkg/testutils/skip",
         "//pkg/util/envutil",
         "//pkg/util/log",
         "//pkg/util/metric",

--- a/pkg/clusterversion/testutils.go
+++ b/pkg/clusterversion/testutils.go
@@ -10,8 +10,27 @@
 
 package clusterversion
 
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+)
+
 // TestingClusterVersion is a ClusterVersion that tests can use when they don't
 // want to go through a Settings object.
 var TestingClusterVersion = ClusterVersion{
 	Version: Latest.Version(),
+}
+
+// SkipWhenMinSupportedVersionIsAtLeast skips this test if MinSupported is >=
+// the given version.
+//
+// Used for upgrade tests that require support for a previous version; it allows
+// experimenting with bumping MinSupported and limiting how many things must be
+// fixed in the same PR that bumps it.
+func SkipWhenMinSupportedVersionIsAtLeast(t skip.SkippableTest, major, minor int) {
+	t.Helper()
+	v := roachpb.Version{Major: int32(major), Minor: int32(minor)}
+	if MinSupported.Version().AtLeast(v) {
+		skip.IgnoreLint(t, "test disabled when MinVersion >= %d.%d", major, minor)
+	}
 }

--- a/pkg/upgrade/upgrades/v23_2_create_region_liveness_test.go
+++ b/pkg/upgrade/upgrades/v23_2_create_region_liveness_test.go
@@ -26,6 +26,8 @@ import (
 
 func TestRegionLivenessTableMigration(t *testing.T) {
 	skip.UnderStressRace(t)
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 23, 2)
+
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 

--- a/pkg/upgrade/upgrades/v23_2_grant_execute_to_public_test.go
+++ b/pkg/upgrade/upgrades/v23_2_grant_execute_to_public_test.go
@@ -37,10 +37,11 @@ import (
 )
 
 func TestGrantExecuteToPublicOnAllFunctions(t *testing.T) {
+	skip.UnderRace(t)
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 23, 2)
+
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	skip.UnderRace(t)
 
 	var (
 		v0 = clusterversion.MinSupported.Version()
@@ -118,6 +119,8 @@ func TestGrantExecuteToPublicOnAllFunctions(t *testing.T) {
 }
 
 func BenchmarkGrantExecuteToPublicOnAllFunctions(b *testing.B) {
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(b, 23, 2)
+
 	defer leaktest.AfterTest(b)()
 	defer log.Scope(b).Close(b)
 

--- a/pkg/upgrade/upgrades/v23_2_plan_gist_stmt_diagnostics_requests_test.go
+++ b/pkg/upgrade/upgrades/v23_2_plan_gist_stmt_diagnostics_requests_test.go
@@ -33,6 +33,8 @@ import (
 )
 
 func TestStmtDiagForPlanGistMigration(t *testing.T) {
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 23, 2)
+
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 

--- a/pkg/upgrade/upgrades/v23_2_system_exec_insights_test.go
+++ b/pkg/upgrade/upgrades/v23_2_system_exec_insights_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestExecSystemInsights(t *testing.T) {
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 23, 2)
+
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 


### PR DESCRIPTION
This commit adds a `SkipWhenMinSupportedVersionIsAtLeast` primitive
and applies it to tests for 23.1->23.2 upgrades. This will allow
bumping `MinSupported` (e.g. in a special build) without having to
remove these tests at the same time.

Epic: none
Release note: None