### PR TITLE
sql: log stmt when session migration fails

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -277,7 +277,10 @@ func (ex *connExecutor) prepare(
 		if origin != PreparedStatementOriginSessionMigration {
 			return nil, err
 		} else {
-			log.Warningf(ctx, "could not prepare statement during session migration: %v", err)
+			f := tree.NewFmtCtx(tree.FmtMarkRedactionNode | tree.FmtSimple)
+			f.FormatNode(stmt.AST)
+			redactableStmt := f.CloseAndGetString()
+			log.Warningf(ctx, "could not prepare statement during session migration (%s): %v", redactableStmt, err)
 		}
 	}
 


### PR DESCRIPTION
We have seen this log message saying that session migration fails due to an issue with the AOST clause, but have not been able to repro this. Adding the statement to the log should help us learn more.

fixes https://github.com/cockroachdb/cockroach/issues/111592
Release note: None