### PR TITLE
lease: add nil check for the descriptor state

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -581,6 +581,9 @@ func acquireNodeLease(
 				return nil, err
 			}
 			t := m.findDescriptorState(id, false /* create */)
+			if t == nil {
+				return nil, errors.AssertionFailedf("could not find descriptor state for id %d", id)
+			}
 			t.mu.Lock()
 			t.mu.takenOffline = false
 			defer t.mu.Unlock()


### PR DESCRIPTION
We have seen a randomized test failure caused by a nil result from looking up the descriptor state. This should never happen, since the state is always created before trying to acquire it. Evidently, there is a concurrency bug here. We have not been able to reproduce it, so for now we will log the error with the problematic ID, rather than panicking and crashing the node.

fixes https://github.com/cockroachdb/cockroach/issues/114216

Release note: None