### PR TITLE
opt: fix minor bug in optsteps[web] and exploretrace

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -1021,8 +1021,34 @@ GenerateLookupJoins (no changes)
 GenerateStreamingGroupBy (no changes)
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
-ReorderJoins (no changes)
+ReorderJoins (higher cost)
 --------------------------------------------------------------------------------
+   project
+    ├── columns: k:1!null i:2 f:3 s:4 j:5
+    ├── key: (1)
+    ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
+    └── inner-join (hash)
+         ├── columns: k:1!null i:2!null f:3 s:4 j:5 y:9!null
+  -      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+  +      ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+         ├── key: (1)
+         ├── fd: (1)-->(2-5), (3,4)~~>(1,2,5), (2)==(9), (9)==(2)
+  -      ├── scan a
+  -      │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+  -      │    ├── key: (1)
+  -      │    └── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
+         ├── distinct-on
+         │    ├── columns: y:9
+         │    ├── grouping columns: y:9
+         │    ├── key: (9)
+         │    └── scan xy
+         │         └── columns: y:9
+  +      ├── scan a
+  +      │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+  +      │    ├── key: (1)
+  +      │    └── fd: (1)-->(2-5), (3,4)~~>(1,2,5)
+         └── filters
+              └── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
 --------------------------------------------------------------------------------
 GenerateMergeJoins (no changes)
 --------------------------------------------------------------------------------

--- a/pkg/sql/opt/testutils/opttester/forcing_opt.go
+++ b/pkg/sql/opt/testutils/opttester/forcing_opt.go
@@ -180,14 +180,25 @@ func (fc *forcingCoster) RestrictGroupToMember(loc memoLoc) {
 
 // ComputeCost is part of the xform.Coster interface.
 func (fc *forcingCoster) ComputeCost(e memo.RelExpr, required *physical.Required) memo.Cost {
+	// Always compute the cost even in the case that memo.MaxCost is returned
+	// below. This ensures that Memoize[Expr] functions in the statistics
+	// builder are still invoked even when a particular expression path is
+	// required via fc.restricted. Because groupIDs are assigned in
+	// Memoize[Expr] functions, invoking these functions in the same order and
+	// number is critical for expressions to be assigned the same groupID for
+	// each step of the forcing optimizer, and thus, allowing the restricted
+	// path mechanism to function properly. If some Memoize[Expr] functions are
+	// not called, then the groupIDs in the restricted path will not match the
+	// groupIDs of the expressions in the memo to restrict to.
+	cost := fc.inner.ComputeCost(e, required)
 	if fc.restricted != nil {
 		loc := fc.groups.MemoLoc(e)
 		if mIdx, ok := fc.restricted[loc.group]; ok && loc.member != mIdx {
-			return memo.MaxCost
+			cost = memo.MaxCost
 		}
 	}
 
-	return fc.inner.ComputeCost(e, required)
+	return cost
 }
 
 // MaybeGetBestCostRelation is part of the xform.Coster interface.


### PR DESCRIPTION
This commit fixes a minor bug in the `optsteps`, `optstepsweb`, and
`exploretrace` commands that prevented some transformations from being
displayed. For example, the bug hid the problematic transformation that
was fixed by #114394. See the code comment for more details.

Epic: None

Release note: None
