### PR TITLE
roachtest: spruce up online restore roachtests

### DIFF
--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -12,25 +12,32 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/require"
 )
 
 func registerOnlineRestore(r registry.Registry) {
-	durationGauge := r.PromFactory().NewGaugeVec(prometheus.GaugeOpts{Namespace: registry.
-		PrometheusNameSpace, Subsystem: "online_restore", Name: "duration"}, []string{"test_name"})
-
+	// This driver creates a variety of roachtests to benchmark online restore
+	// performance with the prefix
+	// restore/{online,offline}/workload={true,false}/<workload/scale>). For each
+	// online restore roachtest (prefix restore/online/*), the driver creates a
+	// corresponding roachtest that runs a conventional restore over the same
+	// cluster topology and workload in order to measure post restore query
+	// latency relative to online restore (prefix restore/control/*). Further, the
+	// driver creates an additional roachtest variant where
+	// `/workload={true,false}` determines if the driver will run a foreground
+	// workload after the restore completes.
 	for _, sp := range []restoreSpecs{
 		{
-			namePrefix:             "online",
+			// 400GB tpce Online Restore
 			hardware:               makeHardwareSpecs(hardwareSpecs{ebsThroughput: 250 /* MB/s */, workloadNode: true}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{nonRevisionHistory: true, version: "v23.1.11"}),
 			timeout:                5 * time.Hour,
@@ -40,102 +47,154 @@ func registerOnlineRestore(r registry.Registry) {
 			restoreUptoIncremental: 1,
 			skip:                   "used for ad hoc experiments",
 		},
+		{
+			// 8TB tpce Online Restore
+			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 10, volumeSize: 2000,
+				ebsThroughput: 250 /* MB/s */}),
+			backup: makeRestoringBackupSpecs(backupSpecs{
+				nonRevisionHistory: true,
+				version:            "v23.1.11",
+				workload:           tpceRestore{customers: 500000}}),
+			timeout:                5 * time.Hour,
+			clouds:                 registry.AllClouds,
+			suites:                 registry.Suites(registry.Nightly),
+			tags:                   registry.Tags("aws"),
+			restoreUptoIncremental: 1,
+			skip:                   "used for ad hoc experiments",
+		},
 	} {
-		sp := sp
-		sp.initTestName()
-		r.Add(registry.TestSpec{
-			Name:      sp.testName,
-			Owner:     registry.OwnerDisasterRecovery,
-			Benchmark: true,
-			Cluster:   sp.hardware.makeClusterSpecs(r, sp.backup.cloud),
-			Timeout:   sp.timeout,
-			// These tests measure performance. To ensure consistent perf,
-			// disable metamorphic encryption.
-			EncryptionSupport: registry.EncryptionAlwaysDisabled,
-			CompatibleClouds:  sp.clouds,
-			Suites:            sp.suites,
-			Tags:              sp.tags,
-			Skip:              sp.skip,
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+		for _, runOnline := range []bool{true, false} {
+			for _, runWorkload := range []bool{true, false} {
+				sp := sp
+				runOnline := runOnline
+				runWorkload := runWorkload
 
-				rd := makeRestoreDriver(t, c, sp)
-				rd.prepareCluster(ctx)
+				if runOnline {
+					sp.namePrefix = "online/"
+				} else {
+					sp.namePrefix = "offline/"
+					sp.skip = "used for ad hoc experiments"
+				}
+				sp.namePrefix = sp.namePrefix + fmt.Sprintf("workload=%t", runWorkload)
 
-				m := c.NewMonitor(ctx)
-				dul := roachtestutil.NewDiskUsageLogger(t, c)
-				m.Go(dul.Runner)
-				m.Go(func(ctx context.Context) error {
-					defer dul.Done()
-					t.Status(`running setup statements`)
-					db, err := rd.c.ConnE(ctx, rd.t.L(), rd.c.Node(1)[0])
-					if err != nil {
-						return errors.Wrapf(err, "failure to run setup statements")
-					}
-					defer db.Close()
+				sp.initTestName()
+				r.Add(registry.TestSpec{
+					Name:      sp.testName,
+					Owner:     registry.OwnerDisasterRecovery,
+					Benchmark: true,
+					Cluster:   sp.hardware.makeClusterSpecs(r, sp.backup.cloud),
+					Timeout:   sp.timeout,
+					// These tests measure performance. To ensure consistent perf,
+					// disable metamorphic encryption.
+					EncryptionSupport: registry.EncryptionAlwaysDisabled,
+					CompatibleClouds:  sp.clouds,
+					Suites:            sp.suites,
+					Tags:              sp.tags,
+					Skip:              sp.skip,
+					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 
-					t.Status(`Running online restore: linking phase`)
-					metricCollector := rd.initRestorePerfMetrics(ctx, durationGauge)
-					restoreCmd := rd.restoreCmd("DATABASE tpce", "WITH EXPERIMENTAL DEFERRED COPY")
-					t.L().Printf("Running %s", restoreCmd)
-					if _, err = db.ExecContext(ctx, restoreCmd); err != nil {
-						return err
-					}
-					metricCollector()
-					return nil
-				})
-				m.Wait()
+						testStartTime := timeutil.Now()
 
-				t.Status(`Running online restore: download phase`)
-				workloadCtx, workloadCancel := context.WithCancel(ctx)
-				mDownload := c.NewMonitor(workloadCtx)
-				defer func() {
-					workloadCancel()
-					mDownload.Wait()
-				}()
-				// TODO(msbutler): add foreground query latency tracker
+						rd := makeRestoreDriver(t, c, sp)
+						rd.prepareCluster(ctx)
 
-				mDownload.Go(func(ctx context.Context) error {
-					err := sp.backup.workload.run(ctx, t, c, sp.hardware)
-					// We expect the workload to return a context cancelled error because
-					// the roachtest driver cancels the monitor's context after the download job completes
-					if err != nil && ctx.Err() == nil {
-						// Implies the workload context was not cancelled and the workload cmd returned a
-						// different error.
-						return errors.Wrapf(err, `Workload context was not cancelled. Error returned by workload cmd`)
-					}
-					rd.t.L().Printf("workload successfully finished")
-					return nil
-				})
-				mDownload.Go(func(ctx context.Context) error {
-					defer workloadCancel()
-					// Wait for the job to succeed.
-					succeededJobTick := time.NewTicker(time.Minute * 1)
-					defer succeededJobTick.Stop()
-					done := ctx.Done()
-					conn, err := c.ConnE(ctx, t.L(), c.Node(1)[0])
-					require.NoError(t, err)
-					defer conn.Close()
-					for {
-						select {
-						case <-done:
-							return ctx.Err()
-						case <-succeededJobTick.C:
-							var status string
-							if err := conn.QueryRow(`SELECT status FROM [SHOW JOBS] WHERE job_type = 'RESTORE' ORDER BY created DESC LIMIT 1`).Scan(&status); err != nil {
+						m := c.NewMonitor(ctx, sp.hardware.getCRDBNodes())
+						m.Go(func(ctx context.Context) error {
+							db, err := rd.c.ConnE(ctx, rd.t.L(), rd.c.Node(1)[0])
+							if err != nil {
 								return err
 							}
-							if status == string(jobs.StatusSucceeded) {
-								return nil
-							} else if status == string(jobs.StatusRunning) {
-								rd.t.L().Printf("Download job still running")
-							} else {
-								return errors.Newf("job unexpectedly found in %s state", status)
+							defer db.Close()
+							if _, err := db.Exec("SET CLUSTER SETTING kv.queue.process.guaranteed_time_budget='1h'"); err != nil {
+								return err
 							}
-						}
-					}
+							opts := ""
+							if runOnline {
+								opts = "WITH EXPERIMENTAL DEFERRED COPY"
+							}
+							restoreCmd := rd.restoreCmd("DATABASE tpce", opts)
+							t.L().Printf("Running %s", restoreCmd)
+							if _, err = db.ExecContext(ctx, restoreCmd); err != nil {
+								return err
+							}
+							return nil
+						})
+						m.Wait()
+
+						workloadCtx, workloadCancel := context.WithCancel(ctx)
+						mDownload := c.NewMonitor(workloadCtx, sp.hardware.getCRDBNodes())
+						// TODO(msbutler): add foreground query latency tracker
+
+						mDownload.Go(func(ctx context.Context) error {
+							if !runWorkload {
+								fmt.Printf("roachtest configured to skip running the foreground workload")
+								return nil
+							}
+							err := sp.backup.workload.run(ctx, t, c, sp.hardware)
+							// We expect the workload to return a context cancelled error because
+							// the roachtest driver cancels the monitor's context after the download job completes
+							if err != nil && ctx.Err() == nil {
+								// Implies the workload context was not cancelled and the workload cmd returned a
+								// different error.
+								return errors.Wrapf(err, `Workload context was not cancelled. Error returned by workload cmd`)
+							}
+							rd.t.L().Printf("workload successfully finished")
+							return nil
+						})
+						mDownload.Go(func(ctx context.Context) error {
+							defer workloadCancel()
+							if runOnline {
+								return waitForDownloadJob(ctx, c, t.L())
+							}
+							if runWorkload {
+								// If we just completed an offline restore and are running the
+								// workload, run the workload until we're at most 15 minutes
+								// away from timing out.
+								testRuntime := timeutil.Since(testStartTime)
+								workloadDuration := sp.timeout - testRuntime
+								if workloadDuration > time.Minute*15 {
+									workloadDuration = workloadDuration - time.Minute*15
+								}
+								fmt.Printf("let workload run for %.2f minutes", workloadDuration.Minutes())
+								time.Sleep(workloadDuration)
+							}
+							return nil
+						})
+						mDownload.Wait()
+					},
 				})
-				mDownload.Wait()
-			},
-		})
+			}
+		}
+	}
+}
+
+func waitForDownloadJob(ctx context.Context, c cluster.Cluster, l *logger.Logger) error {
+	l.Printf(`Begin tracking online restore download phase completion`)
+	// Wait for the job to succeed.
+	succeededJobTick := time.NewTicker(time.Minute * 1)
+	defer succeededJobTick.Stop()
+	done := ctx.Done()
+	conn, err := c.ConnE(ctx, l, c.Node(1)[0])
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	for {
+		select {
+		case <-done:
+			return ctx.Err()
+		case <-succeededJobTick.C:
+			var status string
+			if err := conn.QueryRow(`SELECT status FROM [SHOW JOBS] WHERE job_type = 'RESTORE' ORDER BY created DESC LIMIT 1`).Scan(&status); err != nil {
+				return err
+			}
+			if status == string(jobs.StatusSucceeded) {
+				return nil
+			} else if status == string(jobs.StatusRunning) {
+				l.Printf("Download job still running")
+			} else {
+				return errors.Newf("job unexpectedly found in %s state", status)
+			}
+		}
 	}
 }

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -910,7 +910,7 @@ func (rd *restoreDriver) prepareCluster(ctx context.Context) {
 		// For now, only run the test on the cloud provider that also stores the backup.
 		rd.t.Skipf("test configured to run on %s", rd.sp.backup.cloud)
 	}
-	rd.c.Start(ctx, rd.t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings())
+	rd.c.Start(ctx, rd.t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), rd.sp.hardware.getCRDBNodes())
 	rd.getAOST(ctx)
 }
 


### PR DESCRIPTION
This patch modifies the OR roachtest driver in the following ways:
- it stops the cockroach process from running on the workload node
- it removes some copy pasta from the conventional restore roachtest that
  currently does not play nice with a roachprod cluster with a workload node.
- it adds an 8tb roachtest
- it changes the naming convention of the roachtests to
  `restore/{online,offline}/workload={true,false}/<workload/scale>`
- For each online restore roachtest `(prefix restore/online/*)`, the driver now
  creates a corresponding roachtest that runs a conventional restore over the
same cluster topology and workload in order to measure post restore query
latency relative to online restore `(prefix restore/control/*)`. Further, the
driver creates an additional roachtest variant where `/workload={true,false}`
determines if the driver will run a foreground workload after the restore
completes.

Epic: none

Release note: none