### PR TITLE
server: prevent test args race in shared-process multi-node cluster

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -261,9 +261,6 @@ func TestBackupRestoreJobTagAndLabel(t *testing.T) {
 	tc, _, _, cleanupFn := backupRestoreTestSetupWithParams(t, numNodes, numAccounts, InitManualReplication,
 		base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
-				DefaultTestTenant: base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
-					base.TestTenantProbabilistic, 113857, /* issueNumber */
-				),
 				Knobs: base.TestingKnobs{
 					DistSQL: &execinfra.TestingKnobs{
 						SetupFlowCb: func(ctx context.Context, _ base.SQLInstanceID, _ *execinfrapb.SetupFlowRequest) error {

--- a/pkg/server/application_api/stats_test.go
+++ b/pkg/server/application_api/stats_test.go
@@ -330,9 +330,6 @@ func TestClusterResetSQLStats(t *testing.T) {
 		t.Run(fmt.Sprintf("flushed=%t", flushed), func(t *testing.T) {
 			testCluster := serverutils.StartCluster(t, 3 /* numNodes */, base.TestClusterArgs{
 				ServerArgs: base.TestServerArgs{
-					DefaultTestTenant: base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
-						base.TestTenantProbabilistic, 113856, /* issueNumber */
-					),
 					Insecure: true,
 					Knobs: base.TestingKnobs{
 						SQLStatsKnobs: sqlstats.CreateTestingKnobs(),

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -646,27 +646,29 @@ func (ts *testServer) startDefaultTestTenant(
 	return ts.StartTenant(ctx, params)
 }
 
-func (ts *testServer) startSharedProcessDefaultTestTenant(
-	ctx context.Context,
-) (serverutils.ApplicationLayerInterface, error) {
-	params := base.TestSharedProcessTenantArgs{
+func (ts *testServer) getSharedProcessDefaultTenantArgs() base.TestSharedProcessTenantArgs {
+	args := base.TestSharedProcessTenantArgs{
 		TenantName:  "test-tenant",
 		TenantID:    serverutils.TestTenantID(),
 		Knobs:       ts.params.Knobs,
 		UseDatabase: ts.params.UseDatabase,
 	}
 	// See comment above on separate process tenant regarding the testing knobs.
-	params.Knobs.Server = &TestingKnobs{}
+	args.Knobs.Server = &TestingKnobs{}
 	if ts.params.Knobs.Server != nil {
-		params.Knobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs = ts.params.Knobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs
+		args.Knobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs = ts.params.Knobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs
 	}
+	return args
+}
 
-	tenant, _, err := ts.StartSharedProcessTenant(ctx, params)
+func (ts *testServer) startSharedProcessDefaultTestTenant(
+	ctx context.Context,
+) (serverutils.ApplicationLayerInterface, error) {
+	tenant, _, err := ts.StartSharedProcessTenant(ctx, ts.getSharedProcessDefaultTenantArgs())
 	if err != nil {
 		return nil, err
 	}
-
-	return tenant, err
+	return tenant, nil
 }
 
 // maybeStartDefaultTestTenant might start a test tenant. This can then be used
@@ -790,6 +792,18 @@ func (ts *testServer) grantDefaultTenantCapabilities(
 // The caller is responsible for calling .Stopper().Stop() even
 // when PreStart() returns an error.
 func (ts *testServer) PreStart(ctx context.Context) error {
+	// In case we'll need to start the shared-process default test tenant later
+	// down the line, make sure that we set the correct arguments. This matters
+	// in multi-node clusters where we need this to happen before the first call
+	// to Activate in order to prevent the race between testServer.Activate
+	// explicitly starting the shared-process tenant with the correct args and
+	// the server controller realizing that it's missing a tenant and starting
+	// one with no test args.
+	func(args base.TestSharedProcessTenantArgs) {
+		ts.topLevelServer.serverController.mu.Lock()
+		defer ts.topLevelServer.serverController.mu.Unlock()
+		ts.topLevelServer.serverController.mu.testArgs[args.TenantName] = args
+	}(ts.getSharedProcessDefaultTenantArgs())
 	return ts.topLevelServer.PreStart(ctx)
 }
 

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -57,9 +57,6 @@ func TestTraceAnalyzer(t *testing.T) {
 	tc := serverutils.StartCluster(t, numNodes, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual,
 		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
-				base.TestTenantProbabilistic, 113598,
-			),
 			UseDatabase: "test",
 			Knobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{

--- a/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
@@ -75,9 +75,6 @@ func TestSQLStatsDataDriven(t *testing.T) {
 
 	ctx := context.Background()
 	var params base.TestServerArgs
-	params.DefaultTestTenant = base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
-		base.TestTenantProbabilistic, 113854, /* issueNumber */
-	)
 	knobs := sqlstats.CreateTestingKnobs()
 	knobs.StubTimeNow = stubTime.Now
 	knobs.OnStmtStatsFlushFinished = injector.invokePostStmtStatsFlushCallback

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -74,9 +74,6 @@ func TestSQLStatsFlush(t *testing.T) {
 
 	testCluster := serverutils.StartCluster(t, 3 /* numNodes */, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
-				base.TestTenantProbabilistic, 113855, /* issueNumber */
-			),
 			Knobs: base.TestingKnobs{
 				SQLStatsKnobs: &sqlstats.TestingKnobs{
 					StubTimeNow: fakeTime.Now,


### PR DESCRIPTION
This commit prevents a possible race that could previously occur between the shared-process tenant being started explicitly with the correct args (via `Activate` call) and server controller realizing that a tenant is missing and starting it with no test args. It is achieved by setting the correct test args into the controller for the default shared-process tenant in server's `PreStart` method. All servers are pre-started before any is activated, so now even if the default tenant is started via the server controller on one of the nodes, it'll have the correct test args set.

Fixes: #113598.
Fixes: #113854.
Fixes: #113855.
Fixes: #113856.
Fixes: #113857.
Fixes: #113641.
Fixes: #113700.
Fixes: #113582.

Release note: None