### PR TITLE
backupccl: allow online restore to assume exclusive end keys

### DIFF
--- a/pkg/ccl/backupccl/bench_covering_test.go
+++ b/pkg/ccl/backupccl/bench_covering_test.go
@@ -111,6 +111,7 @@ func BenchmarkRestoreEntryCover(b *testing.B) {
 													layerToBackupManifestFileIterFactory,
 													nil,
 													filter,
+													&inclusiveEndKeyComparator{},
 													spanCh)
 											})
 

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
@@ -476,6 +476,12 @@ func runGenerativeSplitAndScatter(
 			return errors.Wrap(err, "failed to make span covering filter")
 		}
 		defer filter.close()
+
+		var fsc fileSpanComparator = &inclusiveEndKeyComparator{}
+		if spec.ExclusiveFileSpanComparison {
+			fsc = &exclusiveEndKeyComparator{}
+		}
+
 		return errors.Wrap(generateAndSendImportSpans(
 			ctx,
 			spec.Spans,
@@ -483,6 +489,7 @@ func runGenerativeSplitAndScatter(
 			layerToFileIterFactory,
 			backupLocalityMap,
 			filter,
+			fsc,
 			restoreSpanEntriesCh,
 		), "generating and sending import spans")
 	})

--- a/pkg/ccl/backupccl/restore_online.go
+++ b/pkg/ccl/backupccl/restore_online.go
@@ -173,14 +173,16 @@ func sendAddRemoteSSTWorker(
 			firstSplitDone := false
 			for _, file := range entry.Files {
 				restoringSubspan := file.BackupFileEntrySpan.Intersect(entry.Span)
-				log.Infof(ctx, "Experimental restore: sending span %s of file (path: %s, span: %s), with intersecting subspan %s",
-					file.BackupFileEntrySpan, file.Path, file.BackupFileEntrySpan, restoringSubspan)
-
 				if !restoringSubspan.Valid() {
-					log.Warningf(ctx, "backup file does not intersect with the restoring span")
-					continue
+					return errors.AssertionFailedf("file %s with span %s has no overlap with restore span %s",
+						file.Path,
+						file.BackupFileEntrySpan,
+						entry.Span,
+					)
 				}
 
+				log.Infof(ctx, "experimental restore: sending span %s of file %s (file span: %s) as part of restore span %s",
+					restoringSubspan, file.Path, file.BackupFileEntrySpan, entry.Span)
 				file.BackupFileEntrySpan = restoringSubspan
 				if !firstSplitDone {
 					expiration := execCtx.ExecCfg().Clock.Now().AddDuration(time.Hour)

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -301,6 +301,7 @@ func makeImportSpans(
 		layerToIterFactory,
 		nil,
 		filter,
+		&inclusiveEndKeyComparator{},
 		spanCh)
 	close(spanCh)
 

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -323,7 +323,7 @@ message RestoreFileSpec {
   optional roachpb.RowCount backup_file_entry_counts = 6 [(gogoproto.nullable) = false];
   optional uint64 backing_file_size = 7 [(gogoproto.nullable) = false];
   optional uint64 approximate_physical_size = 8 [(gogoproto.nullable) = false];
-  
+
   // NEXT ID: 9.
 }
 
@@ -447,6 +447,9 @@ message GenerativeSplitAndScatterSpec {
   optional int64 job_id = 18 [(gogoproto.nullable) = false, (gogoproto.customname) = "JobID"];
   optional bool use_frontier_checkpointing = 20 [(gogoproto.nullable) = false];
   repeated jobs.jobspb.RestoreProgress.FrontierEntry checkpointed_spans = 21 [(gogoproto.nullable) = false];
+  // ExclusiveFileSpanComparison is true if the backup can safely use
+  // exclusive file span comparison.
+  optional bool exclusive_file_span_comparison = 22 [(gogoproto.nullable) = false];
 
   reserved 19;
 }


### PR DESCRIPTION
Currently, we only support non-revision-history restores for online restore. As a result, we can assume file span end keys are exclusive. We were implicitly assuming this and throwing away files that didn't overlap with the restore span entry.

Epic: none

Release note: None