### PR TITLE
*: remove unused pre-23.1 gates

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -1558,26 +1558,20 @@ func checkForNewTables(
 }
 
 func getTenantInfo(
-	ctx context.Context,
-	settings *cluster.Settings,
-	codec keys.SQLCodec,
-	txn isql.Txn,
-	jobDetails jobspb.BackupDetails,
+	ctx context.Context, codec keys.SQLCodec, txn isql.Txn, jobDetails jobspb.BackupDetails,
 ) ([]roachpb.Span, []mtinfopb.TenantInfoWithUsage, error) {
 	var spans []roachpb.Span
 	var tenants []mtinfopb.TenantInfoWithUsage
 	var err error
 	if jobDetails.FullCluster && codec.ForSystemTenant() && jobDetails.IncludeAllSecondaryTenants {
 		// Include all tenants.
-		tenants, err = retrieveAllTenantsMetadata(
-			ctx, txn, settings,
-		)
+		tenants, err = retrieveAllTenantsMetadata(ctx, txn)
 		if err != nil {
 			return nil, nil, err
 		}
 	} else if len(jobDetails.SpecificTenantIds) > 0 {
 		for _, id := range jobDetails.SpecificTenantIds {
-			tenantInfo, err := retrieveSingleTenantMetadata(ctx, txn, id, settings)
+			tenantInfo, err := retrieveSingleTenantMetadata(ctx, txn, id)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1684,9 +1678,7 @@ func createBackupManifest(
 
 	var spans []roachpb.Span
 	var tenants []mtinfopb.TenantInfoWithUsage
-	tenantSpans, tenantInfos, err := getTenantInfo(
-		ctx, execCfg.Settings, execCfg.Codec, txn, jobDetails,
-	)
+	tenantSpans, tenantInfos, err := getTenantInfo(ctx, execCfg.Codec, txn, jobDetails)
 	if err != nil {
 		return backuppb.BackupManifest{}, err
 	}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -3033,13 +3033,9 @@ func (r *restoreResumer) restoreSystemUsers(
 				return err
 			}
 
-			roleMembersHasIDColumns := r.execCfg.Settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1RoleMembersTableHasIDColumns)
 			insertRoleMember := `
 INSERT INTO system.role_members ("role", "member", "isAdmin", role_id, member_id)
 VALUES ($1, $2, $3, (SELECT user_id FROM system.users WHERE username = $1), (SELECT user_id FROM system.users WHERE username = $2))`
-			if !roleMembersHasIDColumns {
-				insertRoleMember = `INSERT INTO system.role_members ("role", "member", "isAdmin") VALUES ($1, $2, $3)`
-			}
 
 			for _, roleMember := range roleMembers {
 				member := tree.MustBeDString(roleMember[1])

--- a/pkg/ccl/backupccl/system_schema.go
+++ b/pkg/ccl/backupccl/system_schema.go
@@ -15,7 +15,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -243,10 +242,6 @@ func roleMembersRestoreFunc(
 	txn isql.Txn,
 	systemTableName, tempTableName string,
 ) error {
-	if !deps.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1RoleMembersTableHasIDColumns) {
-		return defaultSystemTableRestoreFunc(ctx, deps, txn, systemTableName, tempTableName)
-	}
-
 	// It's enough to just check if role_id exists since member_id was added at
 	// the same time.
 	hasIDColumns, err := tableHasNotNullColumn(ctx, txn, tempTableName, "role_id")
@@ -370,10 +365,6 @@ func systemPrivilegesRestoreFunc(
 	txn isql.Txn,
 	systemTableName, tempTableName string,
 ) error {
-	if !deps.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1SystemPrivilegesTableHasUserIDColumn) {
-		return defaultSystemTableRestoreFunc(ctx, deps, txn, systemTableName, tempTableName)
-	}
-
 	hasUserIDColumn, err := tableHasNotNullColumn(ctx, txn, tempTableName, "user_id")
 	if err != nil {
 		return err
@@ -425,10 +416,6 @@ func systemDatabaseRoleSettingsRestoreFunc(
 	txn isql.Txn,
 	systemTableName, tempTableName string,
 ) error {
-	if !deps.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1DatabaseRoleSettingsHasRoleIDColumn) {
-		return defaultSystemTableRestoreFunc(ctx, deps, txn, systemTableName, tempTableName)
-	}
-
 	hasRoleIDColumn, err := tableHasNotNullColumn(ctx, txn, tempTableName, "role_id")
 	if err != nil {
 		return err
@@ -480,10 +467,6 @@ func systemExternalConnectionsRestoreFunc(
 	txn isql.Txn,
 	systemTableName, tempTableName string,
 ) error {
-	if !deps.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1ExternalConnectionsTableHasOwnerIDColumn) {
-		return defaultSystemTableRestoreFunc(ctx, deps, txn, systemTableName, tempTableName)
-	}
-
 	hasOwnerIDColumn, err := tableHasNotNullColumn(ctx, txn, tempTableName, "owner_id")
 	if err != nil {
 		return err

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -275,8 +274,7 @@ func newEvaluator(
 
 	sd := sql.NewInternalSessionData(ctx, cfg.Settings, "changefeed-evaluator")
 	if spec.Feed.SessionData == nil {
-		// This changefeed was created prior to
-		// clusterversion.TODO_Delete_V23_1_ChangefeedExpressionProductionReady; thus we must
+		// This changefeed was created prior to 23.1; thus we must
 		// rewrite expression to comply with current cluster version.
 		newExpr, err := cdceval.RewritePreviewExpression(sc)
 		if err != nil {
@@ -286,9 +284,8 @@ func newEvaluator(
 		}
 		if newExpr != sc {
 			log.Warningf(ctx,
-				"changefeed expression %s (job %d) created prior to %s rewritten as %s",
+				"changefeed expression %s (job %d) created prior to 22.2-30 rewritten as %s",
 				tree.AsString(sc), spec.JobID,
-				clusterversion.TODO_Delete_V23_1_ChangefeedExpressionProductionReady.String(),
 				tree.AsString(newExpr))
 			sc = newExpr
 		}

--- a/pkg/ccl/changefeedccl/scheduled_changefeed.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed.go
@@ -686,15 +686,6 @@ func createChangefeedScheduleTypeCheck(
 		return false, nil, nil
 	}
 
-	if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1ScheduledChangefeeds) {
-		return false, nil,
-			pgerror.Newf(
-				pgcode.FeatureNotSupported,
-				"cannot use scheduled changefeeds until cluster is upgraded to %s",
-				clusterversion.TODO_Delete_V23_1ScheduledChangefeeds.String,
-			)
-	}
-
 	changefeedStmt := schedule.CreateChangefeed
 	if changefeedStmt == nil {
 		return false, nil, nil

--- a/pkg/cli/auth.go
+++ b/pkg/cli/auth.go
@@ -127,7 +127,7 @@ func createAuthSessionToken(
 	err = sqlConn.ExecTxn(ctx, func(ctx context.Context, conn clisqlclient.TxBoundConn) error {
 		rows, err := conn.Query(ctx,
 			"SELECT crdb_internal.is_at_least_version($1)",
-			clusterversion.ByKey(clusterversion.TODO_Delete_V23_1WebSessionsTableHasUserIDColumn))
+			clusterversion.MinSupported.Version())
 		if err != nil {
 			return err
 		}

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -191,39 +191,6 @@ const (
 	// This is a permanent migration which should exist forever.
 	Permanent_V22_2SQLSchemaTelemetryScheduledJobs
 
-	// TODO_Delete_V23_1TenantNamesStateAndServiceMode adds columns to
-	// system.tenants.
-	TODO_Delete_V23_1TenantNamesStateAndServiceMode
-
-	// TODO_Delete_V23_1DescIDSequenceForSystemTenant migrates the descriptor ID
-	// generator counter from a meta key to the system.descriptor_id_seq sequence
-	// for the system tenant.
-	TODO_Delete_V23_1DescIDSequenceForSystemTenant
-
-	// TODO_Delete_V23_1CreateSystemJobInfoTable creates the system.job_info table.
-	TODO_Delete_V23_1CreateSystemJobInfoTable
-
-	// TODO_Delete_V23_1RoleMembersTableHasIDColumns is the version where the
-	// role_members system table has columns for ids.
-	TODO_Delete_V23_1RoleMembersTableHasIDColumns
-
-	// TODO_Delete_V23_1ScheduledChangefeeds is the version where scheduled changefeeds are
-	// supported through `CREATE SCHEDULE FOR CHANGEFEED` statement.
-	TODO_Delete_V23_1ScheduledChangefeeds
-
-	// TODO_Delete_V23_1AddTypeColumnToJobsTable adds the nullable job_type
-	// column to the system.jobs table.
-	TODO_Delete_V23_1AddTypeColumnToJobsTable
-
-	// TODO_Delete_V23_1BackfillTypeColumnInJobsTable backfills the job_type
-	// column in the system.jobs table.
-	TODO_Delete_V23_1BackfillTypeColumnInJobsTable
-
-	// TODO_Delete_V23_1_ChangefeedExpressionProductionReady marks changefeed
-	// expressions (transformation) as production ready. This gate functions as a
-	// signal to attempt to upgrade chagnefeeds created prior to this version.
-	TODO_Delete_V23_1_ChangefeedExpressionProductionReady
-
 	// Permanent_V23_1KeyVisualizerTablesAndJobs adds the system tables that
 	// support the key visualizer.
 	Permanent_V23_1KeyVisualizerTablesAndJobs
@@ -232,63 +199,9 @@ const (
 	// responsible for polling the jobs table for metrics.
 	Permanent_V23_1_CreateJobsMetricsPollingJob
 
-	// TODO_Delete_V23_1AllocatorCPUBalancing adds balancing CPU usage among
-	// stores using the allocator and store rebalancer. It assumes that at this
-	// version, stores now include their CPU in the StoreCapacity proto when
-	// gossiping.
-	TODO_Delete_V23_1AllocatorCPUBalancing
-
-	// TODO_Delete_V23_1SystemPrivilegesTableHasUserIDColumn is the version where the
-	// user_id column has been added to the system.privileges table.
-	TODO_Delete_V23_1SystemPrivilegesTableHasUserIDColumn
-
-	// TODO_Delete_V23_1WebSessionsTableHasUserIDColumn is the version where the
-	// user_id column has been added to the system.web_sessions table.
-	TODO_Delete_V23_1WebSessionsTableHasUserIDColumn
-
-	// TODO_Delete_V23_1DatabaseRoleSettingsHasRoleIDColumn is the version where
-	// the role_id column has been added to the system.database_role_settings
-	// table.
-	TODO_Delete_V23_1DatabaseRoleSettingsHasRoleIDColumn
-
-	// TODO_Delete_V23_1TenantCapabilities is the version where tenant
-	// capabilities can be set.
-	TODO_Delete_V23_1TenantCapabilities
-
-	// TODO_Delete_V23_1DeprecateClusterVersionKey is the version where we no
-	// longer write cluster version keys to engines.
-	TODO_Delete_V23_1DeprecateClusterVersionKey
-
-	// TODO_Delete_V23_1ExternalConnectionsTableHasOwnerIDColumn is the version
-	// where the owner_id column has been added to the system.external_connections
-	// table.
-	TODO_Delete_V23_1ExternalConnectionsTableHasOwnerIDColumn
-
-	// TODO_Delete_V23_1JobInfoTableIsBackfilled is a version gate after which the
-	// system.job_info table has been backfilled with rows for the payload and
-	// progress of each job in the system.jobs table.
-	TODO_Delete_V23_1JobInfoTableIsBackfilled
-
 	// Permanent_V23_1_CreateAutoConfigRunnerJob is the version where the auto
 	// config runner persistent job has been created.
 	Permanent_V23_1_CreateAutoConfigRunnerJob
-
-	// TODO_Delete_V23_1AddSQLStatsComputedIndexes is the version at which
-	// Cockroach adds new computed columns and indexes to the statement_statistics
-	// and transaction_statistics system tables. These columns optimize persisted
-	// SQL statistics queries for observability.
-	TODO_Delete_V23_1AddSQLStatsComputedIndexes
-
-	// TODO_Delete_V23_1AddSystemActivityTables is the version at which Cockroach
-	// adds system tables statement_activity and transaction_activity. These
-	// tables will contain a subset of data from statement_statistics and
-	// transaction_statistics that are optimized for the console.
-	TODO_Delete_V23_1AddSystemActivityTables
-
-	// TODO_Delete_V23_1StopWritingPayloadAndProgressToSystemJobs is the version
-	// where the payload and progress columns are no longer written to
-	// system.jobs.
-	TODO_Delete_V23_1StopWritingPayloadAndProgressToSystemJobs
 
 	// Permanent_V23_1ChangeSQLStatsTTL is the version where the gc TTL was
 	// updated to all SQL Stats tables.
@@ -420,32 +333,11 @@ var versionTable = [numKeys]roachpb.Version{
 
 	// Permanent upgrades from previous versions.
 	Permanent_V22_2SQLSchemaTelemetryScheduledJobs: {Major: 22, Minor: 1, Internal: 42},
-
-	// v23.1 versions. Internal versions must be even.
-	TODO_Delete_V23_1TenantNamesStateAndServiceMode:            {Major: 22, Minor: 2, Internal: 4},
-	TODO_Delete_V23_1DescIDSequenceForSystemTenant:             {Major: 22, Minor: 2, Internal: 6},
-	TODO_Delete_V23_1CreateSystemJobInfoTable:                  {Major: 22, Minor: 2, Internal: 10},
-	TODO_Delete_V23_1RoleMembersTableHasIDColumns:              {Major: 22, Minor: 2, Internal: 12},
-	TODO_Delete_V23_1ScheduledChangefeeds:                      {Major: 22, Minor: 2, Internal: 16},
-	TODO_Delete_V23_1AddTypeColumnToJobsTable:                  {Major: 22, Minor: 2, Internal: 18},
-	TODO_Delete_V23_1BackfillTypeColumnInJobsTable:             {Major: 22, Minor: 2, Internal: 20},
-	TODO_Delete_V23_1_ChangefeedExpressionProductionReady:      {Major: 22, Minor: 2, Internal: 30},
-	Permanent_V23_1KeyVisualizerTablesAndJobs:                  {Major: 22, Minor: 2, Internal: 32},
-	Permanent_V23_1_CreateJobsMetricsPollingJob:                {Major: 22, Minor: 2, Internal: 38},
-	TODO_Delete_V23_1AllocatorCPUBalancing:                     {Major: 22, Minor: 2, Internal: 40},
-	TODO_Delete_V23_1SystemPrivilegesTableHasUserIDColumn:      {Major: 22, Minor: 2, Internal: 42},
-	TODO_Delete_V23_1WebSessionsTableHasUserIDColumn:           {Major: 22, Minor: 2, Internal: 46},
-	TODO_Delete_V23_1DatabaseRoleSettingsHasRoleIDColumn:       {Major: 22, Minor: 2, Internal: 54},
-	TODO_Delete_V23_1TenantCapabilities:                        {Major: 22, Minor: 2, Internal: 60},
-	TODO_Delete_V23_1DeprecateClusterVersionKey:                {Major: 22, Minor: 2, Internal: 62},
-	TODO_Delete_V23_1ExternalConnectionsTableHasOwnerIDColumn:  {Major: 22, Minor: 2, Internal: 74},
-	TODO_Delete_V23_1JobInfoTableIsBackfilled:                  {Major: 22, Minor: 2, Internal: 80},
-	Permanent_V23_1_CreateAutoConfigRunnerJob:                  {Major: 22, Minor: 2, Internal: 90},
-	TODO_Delete_V23_1AddSQLStatsComputedIndexes:                {Major: 22, Minor: 2, Internal: 92},
-	TODO_Delete_V23_1AddSystemActivityTables:                   {Major: 22, Minor: 2, Internal: 94},
-	TODO_Delete_V23_1StopWritingPayloadAndProgressToSystemJobs: {Major: 22, Minor: 2, Internal: 96},
-	Permanent_V23_1ChangeSQLStatsTTL:                           {Major: 22, Minor: 2, Internal: 98},
-	Permanent_V23_1CreateSystemActivityUpdateJob:               {Major: 22, Minor: 2, Internal: 102},
+	Permanent_V23_1KeyVisualizerTablesAndJobs:      {Major: 22, Minor: 2, Internal: 32},
+	Permanent_V23_1_CreateJobsMetricsPollingJob:    {Major: 22, Minor: 2, Internal: 38},
+	Permanent_V23_1_CreateAutoConfigRunnerJob:      {Major: 22, Minor: 2, Internal: 90},
+	Permanent_V23_1ChangeSQLStatsTTL:               {Major: 22, Minor: 2, Internal: 98},
+	Permanent_V23_1CreateSystemActivityUpdateJob:   {Major: 22, Minor: 2, Internal: 102},
 
 	V23_1: {Major: 23, Minor: 1, Internal: 0},
 

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -433,11 +432,9 @@ func createJobsInBatchWithTxn(
 	// associated cluster version is active.
 	//
 	// TODO(adityamaru): Stop writing the payload and details to the system.jobs
-	// table once we are outside the compatability window for 22.2.
-	if r.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1CreateSystemJobInfoTable) {
-		if err := batchJobWriteToJobInfo(ctx, txn, jobs, modifiedMicros); err != nil {
-			return nil, err
-		}
+	// table, now that we are outside the compatibility window for 22.2.
+	if err := batchJobWriteToJobInfo(ctx, txn, jobs, modifiedMicros); err != nil {
+		return nil, err
 	}
 
 	return jobIDs, nil
@@ -479,66 +476,23 @@ func batchJobInsertStmt(
 	jobs []*Job,
 	modifiedMicros int64,
 ) (string, []interface{}, []jobspb.JobID, error) {
-	marshalPanic := func(m protoutil.Message) []byte {
-		data, err := protoutil.Marshal(m)
-		if err != nil {
-			panic(err)
-		}
-		return data
-	}
-
 	created, err := tree.MakeDTimestamp(timeutil.FromUnixMicros(modifiedMicros), time.Microsecond)
 	if err != nil {
 		return "", nil, nil, errors.NewAssertionErrorWithWrappedErrf(err, "failed to make timestamp for creation of job")
 	}
 	instanceID := r.ID()
-	columns := []string{`id`, `created`, `status`, `payload`, `progress`, `claim_session_id`, `claim_instance_id`, `job_type`}
+	columns := []string{`id`, `created`, `status`, `claim_session_id`, `claim_instance_id`, `job_type`}
 	valueFns := map[string]func(*Job) (interface{}, error){
 		`id`:                func(job *Job) (interface{}, error) { return job.ID(), nil },
 		`created`:           func(job *Job) (interface{}, error) { return created, nil },
 		`status`:            func(job *Job) (interface{}, error) { return StatusRunning, nil },
 		`claim_session_id`:  func(job *Job) (interface{}, error) { return sessionID.UnsafeBytes(), nil },
 		`claim_instance_id`: func(job *Job) (interface{}, error) { return instanceID, nil },
-		`payload`: func(job *Job) (interface{}, error) {
-			payload := job.Payload()
-			return marshalPanic(&payload), nil
-		},
-		`progress`: func(job *Job) (interface{}, error) {
-			progress := job.Progress()
-			progress.ModifiedMicros = modifiedMicros
-			return marshalPanic(&progress), nil
-		},
 		`job_type`: func(job *Job) (interface{}, error) {
 			payload := job.Payload()
 			return payload.Type().String(), nil
 		},
 	}
-
-	// TODO(adityamaru: Remove this once we are outside the compatability
-	// window for 22.2.
-	if r.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1StopWritingPayloadAndProgressToSystemJobs) {
-		columns = []string{`id`, `created`, `status`, `claim_session_id`, `claim_instance_id`, `job_type`}
-		valueFns = map[string]func(*Job) (interface{}, error){
-			`id`:                func(job *Job) (interface{}, error) { return job.ID(), nil },
-			`created`:           func(job *Job) (interface{}, error) { return created, nil },
-			`status`:            func(job *Job) (interface{}, error) { return StatusRunning, nil },
-			`claim_session_id`:  func(job *Job) (interface{}, error) { return sessionID.UnsafeBytes(), nil },
-			`claim_instance_id`: func(job *Job) (interface{}, error) { return instanceID, nil },
-			`job_type`: func(job *Job) (interface{}, error) {
-				payload := job.Payload()
-				return payload.Type().String(), nil
-			},
-		}
-	}
-	numColumns := len(columns)
-
-	// TODO(jayant): remove this version gate in 24.1
-	// To run the upgrade below, migration and schema change jobs will need to be
-	// created using the old schema, which does not have the job_type column.
-	if !r.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1AddTypeColumnToJobsTable) {
-		numColumns -= 1
-	}
-
 	appendValues := func(job *Job, vals *[]interface{}) (err error) {
 		defer func() {
 			switch r := recover(); r.(type) {
@@ -549,7 +503,7 @@ func batchJobInsertStmt(
 				panic(r)
 			}
 		}()
-		for j := 0; j < numColumns; j++ {
+		for j := range columns {
 			c := columns[j]
 			val, err := valueFns[c](job)
 			if err != nil {
@@ -559,11 +513,11 @@ func batchJobInsertStmt(
 		}
 		return nil
 	}
-	args := make([]interface{}, 0, len(jobs)*numColumns)
+	args := make([]interface{}, 0, len(jobs)*len(columns))
 	jobIDs := make([]jobspb.JobID, 0, len(jobs))
 	var buf strings.Builder
 	buf.WriteString(`INSERT INTO system.jobs (`)
-	buf.WriteString(strings.Join(columns[:numColumns], ", "))
+	buf.WriteString(strings.Join(columns, ", "))
 	buf.WriteString(`) VALUES `)
 	argIdx := 1
 	for i, job := range jobs {
@@ -571,7 +525,7 @@ func batchJobInsertStmt(
 			buf.WriteString(", ")
 		}
 		buf.WriteString("(")
-		for j := 0; j < numColumns; j++ {
+		for j := range columns {
 			if j > 0 {
 				buf.WriteString(", ")
 			}
@@ -627,12 +581,8 @@ func (r *Registry) CreateJobWithTxn(
 			return errors.NewAssertionErrorWithWrappedErrf(err, "failed to construct job created timestamp")
 		}
 
-		cols := []string{"id", "created", "status", "payload", "progress", "claim_session_id", "claim_instance_id", "job_type"}
-		vals := []interface{}{jobID, created, StatusRunning, payloadBytes, progressBytes, s.ID().UnsafeBytes(), r.ID(), jobType.String()}
-		if r.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1StopWritingPayloadAndProgressToSystemJobs) {
-			cols = []string{"id", "created", "status", "claim_session_id", "claim_instance_id", "job_type"}
-			vals = []interface{}{jobID, created, StatusRunning, s.ID().UnsafeBytes(), r.ID(), jobType.String()}
-		}
+		cols := []string{"id", "created", "status", "claim_session_id", "claim_instance_id", "job_type"}
+		vals := []interface{}{jobID, created, StatusRunning, s.ID().UnsafeBytes(), r.ID(), jobType.String()}
 		totalNumCols := len(cols)
 		numCols := totalNumCols
 		placeholders := func() string {
@@ -650,10 +600,6 @@ func (r *Registry) CreateJobWithTxn(
 		// database in question is being dropped.
 		override := sessiondata.RootUserSessionDataOverride
 		override.Database = catconstants.SystemDatabaseName
-		hasJobTypeColumn := r.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1AddTypeColumnToJobsTable)
-		if !hasJobTypeColumn {
-			numCols -= 1
-		}
 		insertStmt := fmt.Sprintf(`INSERT INTO system.jobs (%s) VALUES (%s)`,
 			strings.Join(cols[:numCols], ","), placeholders())
 		_, err = txn.ExecEx(
@@ -669,15 +615,13 @@ func (r *Registry) CreateJobWithTxn(
 		// associated cluster version is active.
 		//
 		// TODO(adityamaru): Stop writing the payload and details to the system.jobs
-		// table once we are outside the compatability window for 22.2.
-		if r.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1CreateSystemJobInfoTable) {
-			infoStorage := j.InfoStorage(txn)
-			if err := infoStorage.WriteLegacyPayload(ctx, payloadBytes); err != nil {
-				return err
-			}
-			if err := infoStorage.WriteLegacyProgress(ctx, progressBytes); err != nil {
-				return err
-			}
+		// table, now that we are outside the compatibility window for 22.2.
+		infoStorage := j.InfoStorage(txn)
+		if err := infoStorage.WriteLegacyPayload(ctx, payloadBytes); err != nil {
+			return err
+		}
+		if err := infoStorage.WriteLegacyProgress(ctx, progressBytes); err != nil {
+			return err
 		}
 
 		return nil
@@ -772,19 +716,10 @@ func (r *Registry) CreateAdoptableJobWithTxn(
 		}
 		typ := j.mu.payload.Type().String()
 
-		nCols := 7
-		cols := []string{"id", "status", "payload", "progress", "created_by_type", "created_by_id", "job_type"}
-		placeholders := []string{"$1", "$2", "$3", "$4", "$5", "$6", "$7"}
-		values := []interface{}{jobID, StatusRunning, payloadBytes, progressBytes, createdByType, createdByID, typ}
-		if !r.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1AddTypeColumnToJobsTable) {
-			nCols -= 1
-		}
-		if r.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1StopWritingPayloadAndProgressToSystemJobs) {
-			cols = []string{"id", "status", "created_by_type", "created_by_id", "job_type"}
-			placeholders = []string{"$1", "$2", "$3", "$4", "$5"}
-			values = []interface{}{jobID, StatusRunning, createdByType, createdByID, typ}
-			nCols = 5
-		}
+		cols := []string{"id", "status", "created_by_type", "created_by_id", "job_type"}
+		placeholders := []string{"$1", "$2", "$3", "$4", "$5"}
+		values := []interface{}{jobID, StatusRunning, createdByType, createdByID, typ}
+		nCols := len(cols)
 		// Insert the job row, but do not set a `claim_session_id`. By not
 		// setting the claim, the job can be adopted by any node and will
 		// be adopted by the node which next runs the adoption loop.
@@ -804,15 +739,13 @@ func (r *Registry) CreateAdoptableJobWithTxn(
 		// associated cluster version is active.
 		//
 		// TODO(adityamaru): Stop writing the payload and details to the system.jobs
-		// table once we are outside the compatability window for 22.2.
-		if r.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1CreateSystemJobInfoTable) {
-			infoStorage := j.InfoStorage(txn)
-			if err := infoStorage.WriteLegacyPayload(ctx, payloadBytes); err != nil {
-				return err
-			}
-			if err := infoStorage.WriteLegacyProgress(ctx, progressBytes); err != nil {
-				return err
-			}
+		// table, now that we are outside the compatibility window for 22.2.
+		infoStorage := j.InfoStorage(txn)
+		if err := infoStorage.WriteLegacyPayload(ctx, payloadBytes); err != nil {
+			return err
+		}
+		if err := infoStorage.WriteLegacyProgress(ctx, progressBytes); err != nil {
+			return err
 		}
 
 		return nil
@@ -1243,12 +1176,6 @@ func (r *Registry) cleanupOldJobs(ctx context.Context, olderThan time.Time) erro
 }
 
 // The ordering is important as we keep track of the maximum ID we've seen.
-const expiredJobsQuery = `
-SELECT id, payload, status FROM "".crdb_internal.system_jobs
-WHERE (created < $1) AND (id > $2)
-ORDER BY id
-LIMIT $3`
-
 const expiredJobsQueryWithJobInfoTable = `
 WITH
 latestpayload AS (
@@ -1274,12 +1201,7 @@ INNER JOIN latestpayload ON j.id = latestpayload.job_id`
 func (r *Registry) cleanupOldJobsPage(
 	ctx context.Context, olderThan time.Time, minID jobspb.JobID, pageSize int,
 ) (done bool, maxID jobspb.JobID, retErr error) {
-	var query string
-	if r.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1JobInfoTableIsBackfilled) {
-		query = expiredJobsQueryWithJobInfoTable
-	} else {
-		query = expiredJobsQuery
-	}
+	query := expiredJobsQueryWithJobInfoTable
 
 	it, err := r.db.Executor().QueryIterator(ctx, "gc-jobs", nil, /* txn */
 		query, olderThan, minID, pageSize)

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -220,16 +220,6 @@ func (u Updater) update(ctx context.Context, useReadLock bool, updateFn UpdateFn
 		}
 	}
 
-	if !u.j.registry.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1StopWritingPayloadAndProgressToSystemJobs) {
-		if payloadBytes != nil {
-			addSetter("payload", payloadBytes)
-		}
-
-		if progressBytes != nil {
-			addSetter("progress", progressBytes)
-		}
-	}
-
 	if ju.md.RunStats != nil {
 		runStats = ju.md.RunStats
 		addSetter("last_run", ju.md.RunStats.LastRun)
@@ -260,18 +250,16 @@ func (u Updater) update(ctx context.Context, useReadLock bool, updateFn UpdateFn
 	// associated cluster version is active.
 	//
 	// TODO(adityamaru): Stop writing the payload and details to the system.jobs
-	// table once we are outside the compatability window for 22.2.
-	if u.j.registry.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1CreateSystemJobInfoTable) {
-		infoStorage := j.InfoStorage(u.txn)
-		if payloadBytes != nil {
-			if err := infoStorage.WriteLegacyPayload(ctx, payloadBytes); err != nil {
-				return err
-			}
+	// table, now that we are outside the compatibility window for 22.2.
+	infoStorage := j.InfoStorage(u.txn)
+	if payloadBytes != nil {
+		if err := infoStorage.WriteLegacyPayload(ctx, payloadBytes); err != nil {
+			return err
 		}
-		if progressBytes != nil {
-			if err := infoStorage.WriteLegacyProgress(ctx, progressBytes); err != nil {
-				return err
-			}
+	}
+	if progressBytes != nil {
+		if err := infoStorage.WriteLegacyProgress(ctx, progressBytes); err != nil {
+			return err
 		}
 	}
 
@@ -393,45 +381,29 @@ WITH
 	latestprogress AS (SELECT job_id, value FROM system.job_info AS progress WHERE info_key = 'legacy_progress' AND job_id = $1 ORDER BY written DESC LIMIT 1)
 	SELECT
 		status, payload.value AS payload, progress.value AS progress`
-		selectWithSession = selectWithoutSession + `, claim_session_id`
-		from              = `
+
+		sessionColumn = `, claim_session_id`
+
+		backoffColumns = ", COALESCE(last_run, created), COALESCE(num_runs, 0)"
+
+		from = `
 	FROM system.jobs AS j
 	INNER JOIN latestpayload AS payload ON j.id = payload.job_id
 	LEFT JOIN latestprogress AS progress ON j.id = progress.job_id
-	WHERE id = $1
-`
-		fromForUpdate = from + `FOR UPDATE`
+	WHERE id = $1`
 
-		// TODO(adityamaru): Delete deprecated queries once we are outside the 22.2
-		// compatibility window.
-		deprecatedSelectWithoutSession = `SELECT status, payload, progress`
-		deprecatedSelectWithSession    = deprecatedSelectWithoutSession + `, claim_session_id`
-		deprecatedFrom                 = ` FROM system.jobs WHERE id = $1`
-		deprecatedFromForUpdate        = deprecatedFrom + ` FOR UPDATE`
-		backoffColumns                 = ", COALESCE(last_run, created), COALESCE(num_runs, 0)"
+		forUpdate = `
+  FOR UPDATE`
 	)
 
-	var stmt string
-	if version.IsActive(ctx, clusterversion.TODO_Delete_V23_1JobInfoTableIsBackfilled) {
-		stmt = selectWithoutSession
-		if hasSession {
-			stmt = selectWithSession
-		}
-		stmt = stmt + backoffColumns
-		if useReadLock {
-			return stmt + fromForUpdate
-		}
-		stmt = stmt + from
-	} else {
-		stmt = deprecatedSelectWithoutSession
-		if hasSession {
-			stmt = deprecatedSelectWithSession
-		}
-		stmt = stmt + backoffColumns
-		if useReadLock {
-			return stmt + deprecatedFromForUpdate
-		}
-		stmt = stmt + deprecatedFrom
+	stmt := selectWithoutSession
+	if hasSession {
+		stmt += sessionColumn
+	}
+	stmt += backoffColumns
+	stmt += from
+	if useReadLock {
+		stmt += forUpdate
 	}
 
 	return stmt

--- a/pkg/kv/kvserver/kvstorage/cluster_version.go
+++ b/pkg/kv/kvserver/kvstorage/cluster_version.go
@@ -16,33 +16,16 @@ import (
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
-// WriteClusterVersion writes the given cluster version to the min version file
-// and to the store-local cluster version key.
+// WriteClusterVersion writes the given cluster version to the min version file.
 func WriteClusterVersion(
 	ctx context.Context, eng storage.Engine, cv clusterversion.ClusterVersion,
 ) error {
-	if cv.Less(clusterversion.ByKey(clusterversion.TODO_Delete_V23_1DeprecateClusterVersionKey)) {
-		// We no longer read this key, but older versions still do. Continue writing
-		// the key for interoperability.
-		if err := storage.MVCCPutProto(
-			ctx,
-			eng,
-			keys.DeprecatedStoreClusterVersionKey(),
-			hlc.Timestamp{},
-			&cv,
-			storage.MVCCWriteOptions{},
-		); err != nil {
-			return err
-		}
-	}
 	return eng.SetMinVersion(cv.Version)
 }
 

--- a/pkg/kv/kvserver/rebalance_objective.go
+++ b/pkg/kv/kvserver/rebalance_objective.go
@@ -266,14 +266,6 @@ func ResolveLBRebalancingObjective(
 	if set == int64(LBRebalancingQueries) {
 		return LBRebalancingQueries
 	}
-	// When the cluster version hasn't finalized to 23.1, some unupgraded
-	// stores will not be populating additional fields in their StoreCapacity,
-	// in such cases we cannot balance another objective since the data may not
-	// exist. Fall back to QPS balancing.
-	if !st.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1AllocatorCPUBalancing) {
-		log.Infof(ctx, "version doesn't support cpu objective, reverting to qps balance objective")
-		return LBRebalancingQueries
-	}
 	// When the cpu timekeeping utility is unsupported on this aarch, the cpu
 	// usage cannot be gathered. Fall back to QPS balancing.
 	if !grunning.Supported() {

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/BUILD.bazel
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/kv/kvpb",
         "//pkg/multitenant/tenantcapabilities",
         "//pkg/multitenant/tenantcapabilities/tenantcapabilitiespb",

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
@@ -13,7 +13,6 @@ package tenantcapabilitiesauthorizer
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb"
@@ -355,14 +354,6 @@ func (a *Authorizer) getMode(
 ) (cp *tenantcapabilitiespb.TenantCapabilities, selectedMode authorizerModeType) {
 	// We prioritize what the cluster setting tells us.
 	selectedMode = authorizerModeType(authorizerMode.Get(&a.settings.SV))
-	if selectedMode == authorizerModeOn {
-		if !a.settings.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1TenantCapabilities) {
-			// If the cluster hasn't been upgraded to v23.1 with
-			// capabilities yet, the capabilities won't be ready for use. In
-			// that case, fall back to the previous behavior.
-			selectedMode = authorizerModeV222
-		}
-	}
 
 	// If the mode is "on", we need to check the capabilities. Are they
 	// available?

--- a/pkg/server/authserver/BUILD.bazel
+++ b/pkg/server/authserver/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/clusterversion",
         "//pkg/multitenant",
         "//pkg/roachpb",
         "//pkg/security",

--- a/pkg/server/authserver/authentication.go
+++ b/pkg/server/authserver/authentication.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/password"
@@ -466,8 +465,6 @@ func (s *authenticationServer) NewAuthSession(
 	ctx context.Context, userName username.SQLUsername,
 ) (int64, []byte, error) {
 	st := s.sqlServer.ExecutorConfig().Settings
-	webSessionsTableHasUserIDCol := st.Version.IsActive(ctx,
-		clusterversion.TODO_Delete_V23_1WebSessionsTableHasUserIDColumn)
 
 	secret, hashedSecret, err := CreateAuthSecret()
 	if err != nil {
@@ -477,17 +474,10 @@ func (s *authenticationServer) NewAuthSession(
 	expiration := s.sqlServer.ExecutorConfig().Clock.PhysicalTime().Add(WebSessionTimeout.Get(&st.SV))
 
 	insertSessionStmt := `
-INSERT INTO system.web_sessions ("hashedSecret", username, "expiresAt")
-VALUES($1, $2, $3)
-RETURNING id
-`
-	if webSessionsTableHasUserIDCol {
-		insertSessionStmt = `
 INSERT INTO system.web_sessions ("hashedSecret", username, "expiresAt", user_id)
 VALUES($1, $2, $3, (SELECT user_id FROM system.users WHERE username = $2))
 RETURNING id
 `
-	}
 	var id int64
 
 	row, err := s.sqlServer.InternalExecutor().QueryRowEx(

--- a/pkg/server/server_controller_orchestration.go
+++ b/pkg/server/server_controller_orchestration.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -188,12 +187,6 @@ func (c *serverController) createServerEntryLocked(
 func (c *serverController) getExpectedRunningTenants(
 	ctx context.Context, ie isql.Executor,
 ) (tenantNames []roachpb.TenantName, resErr error) {
-	if !c.st.Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1TenantNamesStateAndServiceMode) {
-		// Cluster not yet upgraded - we know there is no secondary tenant
-		// with a name yet.
-		return []roachpb.TenantName{catconstants.SystemTenantName}, nil
-	}
-
 	rowIter, err := ie.QueryIterator(ctx, "list-tenants", nil, /* txn */
 		`SELECT name FROM system.tenants
 WHERE service_mode = $1

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/base/serverident"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -764,8 +763,7 @@ func (ts *testServer) grantDefaultTenantCapabilities(
 	// configured an ExternalIODir since nodelocal storage only works with that
 	// configured.
 	shouldGrantNodelocalCap := ts.params.ExternalIODir != ""
-	canGrantNodelocalCap := ts.ClusterSettings().Version.IsActive(ctx, clusterversion.TODO_Delete_V23_1TenantCapabilities)
-	if canGrantNodelocalCap && shouldGrantNodelocalCap {
+	if shouldGrantNodelocalCap {
 		_, err := ie.Exec(ctx, "testserver-alter-tenant-cap", nil,
 			"ALTER TENANT [$1] GRANT CAPABILITY can_use_nodelocal_storage", tenantID.ToUint64())
 		if err != nil {


### PR DESCRIPTION
Fixes #112501.  Note that gates inside `pkg/sql` were already removed in #114307.

#### kv: remove pre-23.1 gates

Epic: none
Release note: None

#### server: remove pre-23.1 gates

Epic: none
Release note: None

#### ccl: remove pre-23.1 gates

Epic: none
Release note: None

#### jobs: remove pre-23.1 gates

Note that there is some follow-up cleanup remaining, and it is not as
simple as the TODO comments suggest. The remaining work is tracked
in #112545.

Epic: none
Release note: None

#### *: remove last remaining pre-23.1 gates

Epic: none
Release note: None

#### clusterversion: remove unused pre-23.1 gates

Epic: none
Release note: None
