### PR TITLE
sql: clean up legacy GC job code

### DIFF
--- a/pkg/sql/gcjob/BUILD.bazel
+++ b/pkg/sql/gcjob/BUILD.bazel
@@ -39,7 +39,6 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sqlerrors",
-        "//pkg/storage",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -507,10 +506,7 @@ func shouldUseDelRange(
 	knobs *sql.GCJobTestingKnobs,
 ) bool {
 	// TODO(ajwerner): Adopt the DeleteRange protocol for tenant GC.
-	return details.Tenant == nil &&
-		(storage.CanUseMVCCRangeTombstones(ctx, s) ||
-			// Allow this testing knob to override the storage setting, for convenience.
-			knobs.SkipWaitingForMVCCGC)
+	return details.Tenant == nil
 }
 
 // waitForWork waits until there is work to do given the gossipUpDateC, the

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -96,7 +96,6 @@ go_library(
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/stats",
         "//pkg/sql/types",
-        "//pkg/storage",
         "//pkg/util",
         "//pkg/util/bitarray",
         "//pkg/util/bufalloc",

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -51,7 +51,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1494,8 +1493,6 @@ func (r *importResumer) dropTables(
 		return nil
 	}
 
-	useDeleteRange := storage.CanUseMVCCRangeTombstones(ctx, r.settings)
-
 	var tableWasEmpty bool
 	var intoTable catalog.TableDescriptor
 	for _, tbl := range details.Tables {
@@ -1532,46 +1529,22 @@ func (r *importResumer) dropTables(
 		// it was rolled back to its pre-IMPORT state, and instead provide a manual
 		// admin knob (e.g. ALTER TABLE REVERT TO SYSTEM TIME) if anything goes wrong.
 		ts := hlc.Timestamp{WallTime: details.Walltime}.Prev()
-		if useDeleteRange {
-			predicates := kvpb.DeleteRangePredicates{StartTime: ts}
-			if err := sql.DeleteTableWithPredicate(
-				ctx,
-				execCfg.DB,
-				execCfg.Codec,
-				&execCfg.Settings.SV,
-				execCfg.DistSender,
-				intoTable,
-				predicates, sql.RevertTableDefaultBatchSize); err != nil {
-				return errors.Wrap(err, "rolling back IMPORT INTO in non empty table via DeleteRange")
-			}
-		} else {
-			// disallowShadowingBelow=writeTS used to write means no existing keys could
-			// have been covered by a key imported and the table was offline to other
-			// writes, so even if GC has run it would not have GC'ed any keys to which
-			// we need to revert, so we can safely ignore the target-time GC check.
-			const ignoreGC = true
-			if err := sql.RevertTables(ctx, txn.KV().DB(), execCfg, []catalog.TableDescriptor{intoTable}, ts, ignoreGC,
-				sql.RevertTableDefaultBatchSize); err != nil {
-				return errors.Wrap(err, "rolling back partially completed IMPORT via RevertRange")
-			}
+		predicates := kvpb.DeleteRangePredicates{StartTime: ts}
+		if err := sql.DeleteTableWithPredicate(
+			ctx,
+			execCfg.DB,
+			execCfg.Codec,
+			&execCfg.Settings.SV,
+			execCfg.DistSender,
+			intoTable,
+			predicates, sql.RevertTableDefaultBatchSize); err != nil {
+			return errors.Wrap(err, "rolling back IMPORT INTO in non empty table via DeleteRange")
 		}
 	} else if tableWasEmpty {
-		if useDeleteRange {
-			if err := gcjob.DeleteAllTableData(
-				ctx, execCfg.DB, execCfg.DistSender, execCfg.Codec, intoTable,
-			); err != nil {
-				return errors.Wrap(err, "rolling back IMPORT INTO in empty table via DeleteRange")
-			}
-		} else {
-			// Set a DropTime on the table descriptor to differentiate it from an
-			// older-format (v1.1) descriptor. This enables ClearTableData to use a
-			// RangeClear for faster data removal, rather than removing by chunks.
-			intoTable.TableDesc().DropTime = int64(1)
-			if err := gcjob.ClearTableData(
-				ctx, execCfg.DB, execCfg.DistSender, execCfg.Codec, &execCfg.Settings.SV, intoTable,
-			); err != nil {
-				return errors.Wrapf(err, "rolling back IMPORT INTO in empty table via ClearRange")
-			}
+		if err := gcjob.DeleteAllTableData(
+			ctx, execCfg.DB, execCfg.DistSender, execCfg.Codec, intoTable,
+		); err != nil {
+			return errors.Wrap(err, "rolling back IMPORT INTO in empty table via DeleteRange")
 		}
 	}
 

--- a/pkg/sql/schemachanger/scdeps/BUILD.bazel
+++ b/pkg/sql/schemachanger/scdeps/BUILD.bazel
@@ -40,7 +40,6 @@ go_library(
         "//pkg/sql/sqlerrors",
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
-        "//pkg/storage",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",

--- a/pkg/sql/schemachanger/scdeps/exec_deps.go
+++ b/pkg/sql/schemachanger/scdeps/exec_deps.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/errors"
 )
 
@@ -277,10 +276,6 @@ func (d *txnDeps) MakeJobID() jobspb.JobID {
 
 func (d *txnDeps) CheckPausepoint(name string) error {
 	return d.jobRegistry.CheckPausepoint(name)
-}
-
-func (d *txnDeps) UseLegacyGCJob(ctx context.Context) bool {
-	return !storage.CanUseMVCCRangeTombstones(ctx, d.settings)
 }
 
 func (d *txnDeps) SchemaChangerJobID() jobspb.JobID {

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -951,11 +951,6 @@ func (s *TestState) CheckPausepoint(name string) error {
 	return nil
 }
 
-// UseLegacyGCJob is false.
-func (s *TestState) UseLegacyGCJob(ctx context.Context) bool {
-	return false
-}
-
 // UpdateSchemaChangeJob implements the scexec.TransactionalJobRegistry interface.
 func (s *TestState) UpdateSchemaChangeJob(
 	ctx context.Context, id jobspb.JobID, fn scexec.JobUpdateCallback,

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -139,10 +139,6 @@ type TransactionalJobRegistry interface {
 	// See (*jobs.Registry).CheckPausepoint
 	CheckPausepoint(name string) error
 
-	// UseLegacyGCJob indicate whether the legacy GC job should be used.
-	// This only matters for setting the initial RunningStatus.
-	UseLegacyGCJob(ctx context.Context) bool
-
 	// TODO(ajwerner): Deal with setting the running status to indicate
 	// validating, backfilling, or generally performing metadata changes
 	// and waiting for lease draining.

--- a/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
+++ b/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
@@ -171,7 +171,7 @@ func (s *deferredState) exec(
 	q StatsRefreshQueue,
 	iss IndexSpanSplitter,
 ) error {
-	dbZoneConfigsToDelete, gcJobRecords := s.gcJobs.makeRecords(tjr.MakeJobID, !tjr.UseLegacyGCJob(ctx))
+	dbZoneConfigsToDelete, gcJobRecords := s.gcJobs.makeRecords(tjr.MakeJobID)
 	// Any databases being GCed should have an entry even if none of its tables
 	// are being dropped. This entry will be used to generate the GC jobs below.
 	for _, id := range dbZoneConfigsToDelete.Ordered() {

--- a/pkg/sql/schemachanger/scexec/gc_jobs.go
+++ b/pkg/sql/schemachanger/scexec/gc_jobs.go
@@ -78,7 +78,7 @@ func (gj *gcJobs) AddNewGCJobForIndex(
 // tables, their IDs will be in dbZoneConfigsToRemove and will not be mentioned
 // in any of the returned job records.
 func (gj gcJobs) makeRecords(
-	mkJobID func() jobspb.JobID, useLegacyJob bool,
+	mkJobID func() jobspb.JobID,
 ) (dbZoneConfigsToRemove catalog.DescriptorIDSet, gcJobRecords []jobs.Record) {
 	type stmts struct {
 		s   []scop.StatementForDropJob
@@ -143,7 +143,7 @@ func (gj gcJobs) makeRecords(
 		}
 		gcJobRecords = append(gcJobRecords,
 			createGCJobRecord(
-				mkJobID(), formatStatements(&s), username.NodeUserName(), j, useLegacyJob,
+				mkJobID(), formatStatements(&s), username.NodeUserName(), j,
 			))
 	}
 	{
@@ -157,7 +157,7 @@ func (gj gcJobs) makeRecords(
 		}
 		if len(j.Tables) > 0 {
 			gcJobRecords = append(gcJobRecords, createGCJobRecord(
-				mkJobID(), formatStatements(&s), username.NodeUserName(), j, useLegacyJob,
+				mkJobID(), formatStatements(&s), username.NodeUserName(), j,
 			))
 		}
 	}
@@ -185,7 +185,7 @@ func (gj gcJobs) makeRecords(
 		}
 		if len(j.Indexes) > 0 {
 			gcJobRecords = append(gcJobRecords, createGCJobRecord(
-				mkJobID(), formatStatements(&s), username.NodeUserName(), j, useLegacyJob,
+				mkJobID(), formatStatements(&s), username.NodeUserName(), j,
 			))
 		}
 	}
@@ -214,14 +214,11 @@ func (gj gcJobs) sort() {
 
 // createGCJobRecord creates the job record for a GC job, setting some
 // properties which are common for all GC jobs.
-//
-// TODO(radu): we should remove useLegacyJob, it is no longer used.
 func createGCJobRecord(
 	id jobspb.JobID,
 	description string,
 	userName username.SQLUsername,
 	details jobspb.SchemaChangeGCDetails,
-	useLegacyJob bool,
 ) jobs.Record {
 	descriptorIDs := make([]descpb.ID, 0)
 	if len(details.Indexes) > 0 {
@@ -237,9 +234,6 @@ func createGCJobRecord(
 		}
 	}
 	runningStatus := jobs.RunningStatus("waiting for MVCC GC")
-	if useLegacyJob {
-		runningStatus = "waiting for GC TTL"
-	}
 	return jobs.Record{
 		JobID:         id,
 		Description:   "GC for " + description,

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -254,10 +253,7 @@ func (p *planner) truncateTable(ctx context.Context, id descpb.ID, jobDesc strin
 		Indexes:  droppedIndexes,
 		ParentID: tableDesc.ID,
 	}
-	record := CreateGCJobRecord(
-		jobDesc, p.User(), details,
-		!storage.CanUseMVCCRangeTombstones(ctx, p.execCfg.Settings),
-	)
+	record := CreateGCJobRecord(jobDesc, p.User(), details)
 	if _, err := p.ExecCfg().JobRegistry.CreateAdoptableJobWithTxn(
 		ctx, record, p.ExecCfg().JobRegistry.MakeJobID(), p.InternalSQLTxn(),
 	); err != nil {

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -76,14 +76,6 @@ var minWALSyncInterval = settings.RegisterDurationSetting(
 	settings.NonNegativeDurationWithMaximum(1*time.Second),
 )
 
-// CanUseMVCCRangeTombstones returns true if the caller can begin writing MVCC
-// range tombstones, by setting DeleteRangeRequest.UseRangeTombstone.
-func CanUseMVCCRangeTombstones(ctx context.Context, st *cluster.Settings) bool {
-	// All compatible Cockroach cluster versions support MVCC range tombstones
-	// now.
-	return true
-}
-
 // MaxConflictsPerLockConflictError sets maximum number of locks returned in
 // LockConflictError in operations that return multiple locks per error.
 var MaxConflictsPerLockConflictError = settings.RegisterIntSetting(


### PR DESCRIPTION
This commit cleans up legacy GC job code that is no longer used.

Informs: #112501
Release note: None