### PR TITLE
release-23.1: sql: do not require system table privileges to use SHOW STATISTICS

### DIFF
--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -348,16 +348,17 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 		defer r.Exec(t, "SET ROLE root")
 		r.Exec(t, "CREATE TABLE permissions (k PRIMARY KEY) AS SELECT 1")
 		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT * FROM permissions")
-		// Check that we see two errors about missing privileges as warnings
-		// (one for the cluster settings and another for the table statistics).
+		// Check that we see an error about missing privileges for the cluster
+		// settings as a warnings. (Since `test` is the table owner, it already
+		// has permissions on the table itself.)
 		var numErrors int
 		for _, row := range rows {
-			if strings.HasPrefix(row[0], "-- error") {
+			if strings.HasPrefix(row[0], "-- error getting cluster settings:") {
 				numErrors++
 			}
 		}
-		if numErrors != 2 {
-			t.Fatalf("didn't see 2 errors in %v", rows)
+		if numErrors != 1 {
+			t.Fatalf("didn't see 1 error in %v", rows)
 		}
 		checkBundle(
 			t, fmt.Sprint(rows), "permission" /* tableName */, nil /* contentCheck */, true, /* expectErrors */

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2409,3 +2409,33 @@ SHOW HISTOGRAM $hist_id_1
 upper_bound  range_rows  distinct_range_rows  equal_rows
 'hello'      0           0                    2
 'hi'         0           0                    1
+
+# Test that a non-admin can use SHOW STATISTICS.
+
+statement ok
+CREATE TABLE tab_test_privileges (a INT PRIMARY KEY);
+
+statement ok
+INSERT INTO tab_test_privileges VALUES (1);
+
+statement ok
+CREATE STATISTICS tab_test_privileges_stat ON a FROM tab_test_privileges;
+
+user testuser
+
+query error testuser has no privileges on relation tab_test_privileges
+SELECT statistics_name, created FROM [SHOW STATISTICS FOR TABLE tab_test_privileges]
+
+user root
+
+statement ok
+GRANT SELECT ON tab_test_privileges TO testuser
+
+user testuser
+
+query T
+SELECT statistics_name FROM [SHOW STATISTICS FOR TABLE tab_test_privileges]
+----
+tab_test_privileges_stat
+
+user root


### PR DESCRIPTION
Backport 1/1 commits from #114166.

/cc @cockroachdb/release

Release justification: serious bug fix 

---

See the docs at: https://www.cockroachlabs.com/docs/stable/show-statistics
They say that no special privileges are needed.

Epic: None

Release note (bug fix): The SHOW STATISTICS command previously incorrectly
required the user to have the admin role. It was intended to only
require the user to have any privilege on the table being inspected.
This is now fixed.
