### PR TITLE
release-23.2: server: populate `pgPreServer` on shared process `testTenant`

### DIFF
--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -415,11 +415,7 @@ func TestClientAddrOverride(t *testing.T) {
 	defer sc.Close(t)
 
 	// Start a server.
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
-			base.TestTenantProbabilistic, 112867,
-		),
-	})
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	ctx := context.Background()
 	defer s.Stopper().Stop(ctx)
 	ts := s.ApplicationLayer()

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1383,10 +1383,12 @@ func (ts *testServer) StartSharedProcessTenant(
 	hts.t.status = sqlServerWrapper.tenantStatus
 
 	tt := &testTenant{
-		sql:            sqlServer,
-		Cfg:            sqlServer.cfg,
-		SQLCfg:         sqlServerWrapper.sqlCfg,
-		pgPreServer:    sqlServerWrapper.pgPreServer,
+		sql:    sqlServer,
+		Cfg:    sqlServer.cfg,
+		SQLCfg: sqlServerWrapper.sqlCfg,
+		// Shared process tenants do not create their own SQL servers. Instead, we
+		// use the `pgPreServer` from the server this tenant is serviced from.
+		pgPreServer:    ts.pgPreServer,
 		pgL:            sqlServerWrapper.loopbackPgL,
 		httpTestServer: hts,
 		drain:          sqlServerWrapper.drainServer,

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -633,11 +633,7 @@ func TestClientAddrOverride(t *testing.T) {
 	defer sc.Close(t)
 
 	// Start a server.
-	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
-			base.TestTenantProbabilistic, 112867,
-		),
-	})
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	ctx := context.Background()
 	defer srv.Stopper().Stop(ctx)
 


### PR DESCRIPTION
Backport 1/1 commits from #114345.

/cc @cockroachdb/release

---

Previously `pgPreServer` was not populated on `testTenant` because shared process virtual clusters do not start a SQL Listener, and hence does not populate this field. Although some tests want to interact with `PGPreServer` when running with a shared process virtual cluster, we can effectively point it in the direction of the server the shared process tenant is running on.

Fixes: #112867

Epic: None
Release Note: None

Release justification: Test only change.
