### PR TITLE
release-23.2: roachtest: improvements to retry api

### DIFF
--- a/pkg/cmd/roachprod-microbench/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/cmd/roachprod-microbench/model",
         "//pkg/roachprod",
         "//pkg/roachprod/config",
+        "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/ssh",
         "//pkg/roachprod/vm",

--- a/pkg/cmd/roachprod-microbench/cluster/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/cluster/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/roachprod",
+        "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/cmd/roachprod-microbench/cluster/execute.go
+++ b/pkg/cmd/roachprod-microbench/cluster/execute.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -60,8 +61,10 @@ func remoteWorker(
 				break
 			}
 			start := timeutil.Now()
-			runResult, err := roachprod.RunWithDetails(context.Background(), log, clusterNode,
-				"", "", false, command.Args)
+			runResult, err := roachprod.RunWithDetails(
+				context.Background(), log, clusterNode, "" /* SSHOptions */, "", /* processTag */
+				false /* secure */, command.Args, install.RunOptions{},
+			)
 			duration := timeutil.Since(start)
 			var stdout, stderr string
 			var exitStatus int

--- a/pkg/cmd/roachprod-microbench/util.go
+++ b/pkg/cmd/roachprod-microbench/util.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/spf13/cobra"
@@ -83,7 +84,10 @@ func initRoachprod(l *logger.Logger) error {
 }
 
 func roachprodRun(clusterName string, l *logger.Logger, cmdArray []string) error {
-	return roachprod.Run(context.Background(), l, clusterName, "", "", false, os.Stdout, os.Stderr, cmdArray)
+	return roachprod.Run(
+		context.Background(), l, clusterName, "", "", false,
+		os.Stdout, os.Stderr, cmdArray, install.RunOptions{},
+	)
 }
 
 func initLogger(path string) *logger.Logger {

--- a/pkg/cmd/roachprod-stress/BUILD.bazel
+++ b/pkg/cmd/roachprod-stress/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/roachprod",
+        "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/ssh",
         "//pkg/roachprod/vm",

--- a/pkg/cmd/roachprod-stress/main.go
+++ b/pkg/cmd/roachprod-stress/main.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ssh"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
@@ -138,7 +139,10 @@ func roundToSeconds(d time.Duration) time.Duration {
 }
 
 func roachprodRun(clusterName string, cmdArray []string) error {
-	return roachprod.Run(context.Background(), l, clusterName, "", "", false, os.Stdout, os.Stderr, cmdArray)
+	return roachprod.Run(
+		context.Background(), l, clusterName, "", "", false,
+		os.Stdout, os.Stderr, cmdArray, install.RunOptions{},
+	)
 }
 
 func run() error {

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -797,7 +797,7 @@ var runCmd = &cobra.Command{
 	Args: cobra.MinimumNArgs(1),
 	Run: wrap(func(_ *cobra.Command, args []string) error {
 		return roachprod.Run(context.Background(), config.Logger, args[0], extraSSHOptions, tag,
-			secure, os.Stdout, os.Stderr, args[1:], install.WithWaitOnFail())
+			secure, os.Stdout, os.Stderr, args[1:], install.WithFailSlow(true))
 	}),
 }
 

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -797,7 +797,7 @@ var runCmd = &cobra.Command{
 	Args: cobra.MinimumNArgs(1),
 	Run: wrap(func(_ *cobra.Command, args []string) error {
 		return roachprod.Run(context.Background(), config.Logger, args[0], extraSSHOptions, tag,
-			secure, os.Stdout, os.Stderr, args[1:], install.WithFailSlow(true))
+			secure, os.Stdout, os.Stderr, args[1:], install.RunOptions{FailOption: install.FailSlow})
 	}),
 }
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2237,8 +2237,10 @@ func (c *clusterImpl) Run(ctx context.Context, node option.NodeListOption, args 
 }
 
 // Run a command on the specified nodes and call test.Fatal if there is an error.
-func (c *clusterImpl) RunExt(ctx context.Context, node option.NodeListOption, args []string) {
-	err := c.RunEExt(ctx, node, args)
+func (c *clusterImpl) RunExt(
+	ctx context.Context, node option.NodeListOption, args []string, opts ...install.RunOption,
+) {
+	err := c.RunEExt(ctx, node, args, opts...)
 	if err != nil {
 		c.t.Fatal(err)
 	}
@@ -2252,7 +2254,9 @@ func (c *clusterImpl) RunE(ctx context.Context, node option.NodeListOption, args
 // will be redirected to a file which is logged via the cluster-wide logger in
 // case of an error. Logs will sort chronologically. Failing invocations will
 // have an additional marker file with a `.failed` extension instead of `.log`.
-func (c *clusterImpl) RunEExt(ctx context.Context, nodes option.NodeListOption, args []string) error {
+func (c *clusterImpl) RunEExt(
+	ctx context.Context, nodes option.NodeListOption, args []string, opts ...install.RunOption,
+) error {
 	if len(args) == 0 {
 		return errors.New("No command passed")
 	}
@@ -2294,7 +2298,11 @@ func (c *clusterImpl) RunWithDetailsSingleNode(
 // you treat an error from the command. This makes error checking easier / friendlier
 // and helps us avoid code replication.
 func (c *clusterImpl) RunWithDetailsSingleNodeExt(
-	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string,
+	ctx context.Context,
+	testLogger *logger.Logger,
+	nodes option.NodeListOption,
+	args []string,
+	opts ...install.RunOption,
 ) (install.RunResultDetails, error) {
 	if len(nodes) != 1 {
 		return install.RunResultDetails{}, errors.Newf("RunWithDetailsSingleNode received %d nodes. Use RunWithDetails if you need to run on multiple nodes.", len(nodes))
@@ -2314,7 +2322,11 @@ func (c *clusterImpl) RunWithDetails(
 // via the cluster-wide logger in case of an error. Failing invocations will have
 // an additional marker file with a `.failed` extension instead of `.log`.
 func (c *clusterImpl) RunWithDetailsExt(
-	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string,
+	ctx context.Context,
+	testLogger *logger.Logger,
+	nodes option.NodeListOption,
+	args []string,
+	opts ...install.RunOption,
 ) ([]install.RunResultDetails, error) {
 	if len(args) == 0 {
 		return nil, errors.New("No command passed")
@@ -2333,7 +2345,7 @@ func (c *clusterImpl) RunWithDetailsExt(
 	}
 
 	l.Printf("> %s", cmd)
-	results, err := roachprod.RunWithDetails(ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "" /* processTag */, c.IsSecure(), args)
+	results, err := roachprod.RunWithDetails(ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "" /* processTag */, c.IsSecure(), args, opts...)
 
 	var logFileFull string
 	if l.File != nil {

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2232,34 +2232,23 @@ func (c *clusterImpl) Wipe(ctx context.Context, preserveCerts bool, nodes ...opt
 	}
 }
 
-func (c *clusterImpl) Run(ctx context.Context, node option.NodeListOption, args ...string) {
-	c.RunExt(ctx, node, args)
-}
-
 // Run a command on the specified nodes and call test.Fatal if there is an error.
-func (c *clusterImpl) RunExt(
-	ctx context.Context, node option.NodeListOption, args []string, opts ...install.RunOption,
-) {
-	err := c.RunEExt(ctx, node, args, opts...)
+func (c *clusterImpl) Run(ctx context.Context, nodes option.NodeListOption, args ...string) {
+	err := c.RunE(ctx, nodes, args...)
 	if err != nil {
 		c.t.Fatal(err)
 	}
-}
-
-func (c *clusterImpl) RunE(ctx context.Context, node option.NodeListOption, args ...string) error {
-	return c.RunEExt(ctx, node, args)
 }
 
 // RunE runs a command on the specified node, returning an error. The output
 // will be redirected to a file which is logged via the cluster-wide logger in
 // case of an error. Logs will sort chronologically. Failing invocations will
 // have an additional marker file with a `.failed` extension instead of `.log`.
-func (c *clusterImpl) RunEExt(
-	ctx context.Context, nodes option.NodeListOption, args []string, opts ...install.RunOption,
-) error {
+func (c *clusterImpl) RunE(ctx context.Context, nodes option.NodeListOption, args ...string) error {
 	if len(args) == 0 {
 		return errors.New("No command passed")
 	}
+
 	l, logFile, err := c.loggerForCmd(nodes, args...)
 	if err != nil {
 		return err
@@ -2269,7 +2258,10 @@ func (c *clusterImpl) RunEExt(
 	cmd := strings.Join(args, " ")
 	c.t.L().Printf("running cmd `%s` on nodes [%v]; details in %s.log", roachprod.TruncateString(cmd, 30), nodes, logFile)
 	l.Printf("> %s", cmd)
-	if err := roachprod.Run(ctx, l, c.MakeNodes(nodes), "", "", c.IsSecure(), l.Stdout, l.Stderr, args, opts...); err != nil {
+	if err := roachprod.Run(
+		ctx, l, c.MakeNodes(nodes), "", "", c.IsSecure(),
+		l.Stdout, l.Stderr, args, install.OnNodes(nodes.InstallNodes()),
+	); err != nil {
 		if err := ctx.Err(); err != nil {
 			l.Printf("(note: incoming context was canceled: %s)", err)
 			return err
@@ -2287,46 +2279,26 @@ func (c *clusterImpl) RunEExt(
 	return nil
 }
 
-func (c *clusterImpl) RunWithDetailsSingleNode(
-	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string,
-) (install.RunResultDetails, error) {
-	return c.RunWithDetailsSingleNodeExt(ctx, testLogger, nodes, args)
-}
-
 // RunWithDetailsSingleNode is just like RunWithDetails but used when 1) operating
 // on a single node AND 2) an error from roachprod itself would be treated the same way
 // you treat an error from the command. This makes error checking easier / friendlier
 // and helps us avoid code replication.
-func (c *clusterImpl) RunWithDetailsSingleNodeExt(
-	ctx context.Context,
-	testLogger *logger.Logger,
-	nodes option.NodeListOption,
-	args []string,
-	opts ...install.RunOption,
+func (c *clusterImpl) RunWithDetailsSingleNode(
+	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string,
 ) (install.RunResultDetails, error) {
 	if len(nodes) != 1 {
 		return install.RunResultDetails{}, errors.Newf("RunWithDetailsSingleNode received %d nodes. Use RunWithDetails if you need to run on multiple nodes.", len(nodes))
 	}
-	results, err := c.RunWithDetailsExt(ctx, testLogger, nodes, args, opts...)
+	results, err := c.RunWithDetails(ctx, testLogger, nodes, args...)
 	return results[0], errors.CombineErrors(err, results[0].Err)
-}
-
-func (c *clusterImpl) RunWithDetails(
-	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string,
-) ([]install.RunResultDetails, error) {
-	return c.RunWithDetailsExt(ctx, testLogger, nodes, args)
 }
 
 // RunWithDetails runs a command on the specified nodes, returning the results
 // details and a `roachprod` error. The output will be redirected to a file which is logged
 // via the cluster-wide logger in case of an error. Failing invocations will have
 // an additional marker file with a `.failed` extension instead of `.log`.
-func (c *clusterImpl) RunWithDetailsExt(
-	ctx context.Context,
-	testLogger *logger.Logger,
-	nodes option.NodeListOption,
-	args []string,
-	opts ...install.RunOption,
+func (c *clusterImpl) RunWithDetails(
+	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string,
 ) ([]install.RunResultDetails, error) {
 	if len(args) == 0 {
 		return nil, errors.New("No command passed")
@@ -2345,7 +2317,10 @@ func (c *clusterImpl) RunWithDetailsExt(
 	}
 
 	l.Printf("> %s", cmd)
-	results, err := roachprod.RunWithDetails(ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "" /* processTag */, c.IsSecure(), args, opts...)
+	results, err := roachprod.RunWithDetails(
+		ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "", /* processTag */
+		c.IsSecure(), args, install.OnNodes(nodes.InstallNodes()),
+	)
 
 	var logFileFull string
 	if l.File != nil {

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2269,7 +2269,7 @@ func (c *clusterImpl) RunEExt(
 	cmd := strings.Join(args, " ")
 	c.t.L().Printf("running cmd `%s` on nodes [%v]; details in %s.log", roachprod.TruncateString(cmd, 30), nodes, logFile)
 	l.Printf("> %s", cmd)
-	if err := roachprod.Run(ctx, l, c.MakeNodes(nodes), "", "", c.IsSecure(), l.Stdout, l.Stderr, args); err != nil {
+	if err := roachprod.Run(ctx, l, c.MakeNodes(nodes), "", "", c.IsSecure(), l.Stdout, l.Stderr, args, opts...); err != nil {
 		if err := ctx.Err(); err != nil {
 			l.Printf("(note: incoming context was canceled: %s)", err)
 			return err
@@ -2307,7 +2307,7 @@ func (c *clusterImpl) RunWithDetailsSingleNodeExt(
 	if len(nodes) != 1 {
 		return install.RunResultDetails{}, errors.Newf("RunWithDetailsSingleNode received %d nodes. Use RunWithDetails if you need to run on multiple nodes.", len(nodes))
 	}
-	results, err := c.RunWithDetails(ctx, testLogger, nodes, args...)
+	results, err := c.RunWithDetailsExt(ctx, testLogger, nodes, args, opts...)
 	return results[0], errors.CombineErrors(err, results[0].Err)
 }
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2232,19 +2232,27 @@ func (c *clusterImpl) Wipe(ctx context.Context, preserveCerts bool, nodes ...opt
 	}
 }
 
-// Run a command on the specified nodes and call test.Fatal if there is an error.
 func (c *clusterImpl) Run(ctx context.Context, node option.NodeListOption, args ...string) {
-	err := c.RunE(ctx, node, args...)
+	c.RunExt(ctx, node, args)
+}
+
+// Run a command on the specified nodes and call test.Fatal if there is an error.
+func (c *clusterImpl) RunExt(ctx context.Context, node option.NodeListOption, args []string) {
+	err := c.RunEExt(ctx, node, args)
 	if err != nil {
 		c.t.Fatal(err)
 	}
+}
+
+func (c *clusterImpl) RunE(ctx context.Context, node option.NodeListOption, args ...string) error {
+	return c.RunEExt(ctx, node, args)
 }
 
 // RunE runs a command on the specified node, returning an error. The output
 // will be redirected to a file which is logged via the cluster-wide logger in
 // case of an error. Logs will sort chronologically. Failing invocations will
 // have an additional marker file with a `.failed` extension instead of `.log`.
-func (c *clusterImpl) RunE(ctx context.Context, nodes option.NodeListOption, args ...string) error {
+func (c *clusterImpl) RunEExt(ctx context.Context, nodes option.NodeListOption, args []string) error {
 	if len(args) == 0 {
 		return errors.New("No command passed")
 	}
@@ -2275,12 +2283,18 @@ func (c *clusterImpl) RunE(ctx context.Context, nodes option.NodeListOption, arg
 	return nil
 }
 
+func (c *clusterImpl) RunWithDetailsSingleNode(
+	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string,
+) (install.RunResultDetails, error) {
+	return c.RunWithDetailsSingleNodeExt(ctx, testLogger, nodes, args)
+}
+
 // RunWithDetailsSingleNode is just like RunWithDetails but used when 1) operating
 // on a single node AND 2) an error from roachprod itself would be treated the same way
 // you treat an error from the command. This makes error checking easier / friendlier
 // and helps us avoid code replication.
-func (c *clusterImpl) RunWithDetailsSingleNode(
-	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string,
+func (c *clusterImpl) RunWithDetailsSingleNodeExt(
+	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string,
 ) (install.RunResultDetails, error) {
 	if len(nodes) != 1 {
 		return install.RunResultDetails{}, errors.Newf("RunWithDetailsSingleNode received %d nodes. Use RunWithDetails if you need to run on multiple nodes.", len(nodes))
@@ -2289,12 +2303,18 @@ func (c *clusterImpl) RunWithDetailsSingleNode(
 	return results[0], errors.CombineErrors(err, results[0].Err)
 }
 
+func (c *clusterImpl) RunWithDetails(
+	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string,
+) ([]install.RunResultDetails, error) {
+	return c.RunWithDetailsExt(ctx, testLogger, nodes, args)
+}
+
 // RunWithDetails runs a command on the specified nodes, returning the results
 // details and a `roachprod` error. The output will be redirected to a file which is logged
 // via the cluster-wide logger in case of an error. Failing invocations will have
 // an additional marker file with a `.failed` extension instead of `.log`.
-func (c *clusterImpl) RunWithDetails(
-	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string,
+func (c *clusterImpl) RunWithDetailsExt(
+	ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string,
 ) ([]install.RunResultDetails, error) {
 	if len(args) == 0 {
 		return nil, errors.New("No command passed")

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -94,27 +94,19 @@ type Cluster interface {
 	// Use it when you need output details such as stdout or stderr, or remote exit status.
 	RunWithDetails(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string) ([]install.RunResultDetails, error)
 
-	RunWithDetailsExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string, opts ...install.RunOption) ([]install.RunResultDetails, error)
-
 	// Run is fatal on errors.
 	// Use it when an error means the test should fail.
 	Run(ctx context.Context, node option.NodeListOption, args ...string)
 
-	RunExt(ctx context.Context, node option.NodeListOption, args []string, opts ...install.RunOption)
-
 	// RunE runs a command on the specified nodes and returns an error.
 	// Use it when you need to run a command and only care if it ran successfully or not.
 	RunE(ctx context.Context, node option.NodeListOption, args ...string) error
-
-	RunEExt(ctx context.Context, node option.NodeListOption, args []string, opts ...install.RunOption) error
 
 	// RunWithDetailsSingleNode is just like RunWithDetails but used when 1) operating
 	// on a single node AND 2) an error from roachprod itself would be treated the same way
 	// you treat an error from the command. This makes error checking easier / friendlier
 	// and helps us avoid code replication.
 	RunWithDetailsSingleNode(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string) (install.RunResultDetails, error)
-
-	RunWithDetailsSingleNodeExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string, opts ...install.RunOption) (install.RunResultDetails, error)
 
 	// Metadata about the provisioned nodes.
 

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -94,19 +94,27 @@ type Cluster interface {
 	// Use it when you need output details such as stdout or stderr, or remote exit status.
 	RunWithDetails(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string) ([]install.RunResultDetails, error)
 
+	RunWithDetailsExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string) ([]install.RunResultDetails, error)
+
 	// Run is fatal on errors.
 	// Use it when an error means the test should fail.
 	Run(ctx context.Context, node option.NodeListOption, args ...string)
 
+	RunExt(ctx context.Context, node option.NodeListOption, args []string)
+
 	// RunE runs a command on the specified nodes and returns an error.
 	// Use it when you need to run a command and only care if it ran successfully or not.
 	RunE(ctx context.Context, node option.NodeListOption, args ...string) error
+
+	RunEExt(ctx context.Context, node option.NodeListOption, args []string) error
 
 	// RunWithDetailsSingleNode is just like RunWithDetails but used when 1) operating
 	// on a single node AND 2) an error from roachprod itself would be treated the same way
 	// you treat an error from the command. This makes error checking easier / friendlier
 	// and helps us avoid code replication.
 	RunWithDetailsSingleNode(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string) (install.RunResultDetails, error)
+
+	RunWithDetailsSingleNodeExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string) (install.RunResultDetails, error)
 
 	// Metadata about the provisioned nodes.
 

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -94,19 +94,19 @@ type Cluster interface {
 	// Use it when you need output details such as stdout or stderr, or remote exit status.
 	RunWithDetails(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string) ([]install.RunResultDetails, error)
 
-	RunWithDetailsExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string) ([]install.RunResultDetails, error)
+	RunWithDetailsExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string, opts ...install.RunOption) ([]install.RunResultDetails, error)
 
 	// Run is fatal on errors.
 	// Use it when an error means the test should fail.
 	Run(ctx context.Context, node option.NodeListOption, args ...string)
 
-	RunExt(ctx context.Context, node option.NodeListOption, args []string)
+	RunExt(ctx context.Context, node option.NodeListOption, args []string, opts ...install.RunOption)
 
 	// RunE runs a command on the specified nodes and returns an error.
 	// Use it when you need to run a command and only care if it ran successfully or not.
 	RunE(ctx context.Context, node option.NodeListOption, args ...string) error
 
-	RunEExt(ctx context.Context, node option.NodeListOption, args []string) error
+	RunEExt(ctx context.Context, node option.NodeListOption, args []string, opts ...install.RunOption) error
 
 	// RunWithDetailsSingleNode is just like RunWithDetails but used when 1) operating
 	// on a single node AND 2) an error from roachprod itself would be treated the same way
@@ -114,7 +114,7 @@ type Cluster interface {
 	// and helps us avoid code replication.
 	RunWithDetailsSingleNode(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string) (install.RunResultDetails, error)
 
-	RunWithDetailsSingleNodeExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string) (install.RunResultDetails, error)
+	RunWithDetailsSingleNodeExt(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args []string, opts ...install.RunOption) (install.RunResultDetails, error)
 
 	// Metadata about the provisioned nodes.
 

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "install.go",
         "iterm2.go",
         "nodes.go",
+        "run_options.go",
         "services.go",
         "session.go",
         "staging.go",

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -358,7 +358,7 @@ func (c *SyncedCluster) validateHost(ctx context.Context, l *logger.Logger, node
 		return nil
 	}
 	cmd := c.validateHostnameCmd("", node)
-	return c.Run(ctx, l, l.Stdout, l.Stderr, Nodes{node}, "validate-ssh-host", cmd)
+	return c.Run(ctx, l, l.Stdout, l.Stderr, OnNodes(Nodes{node}), "validate-ssh-host", cmd)
 }
 
 // cmdDebugName is the suffix of the generated ssh debug file
@@ -483,10 +483,11 @@ func (c *SyncedCluster) kill(
 		// `kill -9` without wait is never what a caller wants. See #77334.
 		wait = true
 	}
-	return c.Parallel(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
-		var waitCmd string
-		if wait {
-			waitCmd = fmt.Sprintf(`
+	return c.Parallel(ctx, l, OnNodes(c.Nodes).WithDisplay(display).WithRetryDisabled(),
+		func(ctx context.Context, node Node) (*RunResultDetails, error) {
+			var waitCmd string
+			if wait {
+				waitCmd = fmt.Sprintf(`
   for pid in ${pids}; do
     echo "${pid}: checking" >> %[1]s/roachprod.log
     waitcnt=0
@@ -503,22 +504,22 @@ func (c *SyncedCluster) kill(
     done
     echo "${pid}: dead" >> %[1]s/roachprod.log
   done`,
-				c.LogDir(node, "", 0), // [1]
-				maxWait,               // [2]
-			)
-		}
+					c.LogDir(node, "", 0), // [1]
+					maxWait,               // [2]
+				)
+			}
 
-		var virtualClusterFilter string
-		if virtualClusterLabel != "" {
-			virtualClusterFilter = fmt.Sprintf(
-				"grep -E '%s' |",
-				envVarRegex("ROACHPROD_VIRTUAL_CLUSTER", virtualClusterLabel),
-			)
-		}
+			var virtualClusterFilter string
+			if virtualClusterLabel != "" {
+				virtualClusterFilter = fmt.Sprintf(
+					"grep -E '%s' |",
+					envVarRegex("ROACHPROD_VIRTUAL_CLUSTER", virtualClusterLabel),
+				)
+			}
 
-		// NB: the awkward-looking `awk` invocation serves to avoid having the
-		// awk process match its own output from `ps`.
-		cmd := fmt.Sprintf(`
+			// NB: the awkward-looking `awk` invocation serves to avoid having the
+			// awk process match its own output from `ps`.
+			cmd := fmt.Sprintf(`
 mkdir -p %[1]s
 mkdir -p %[2]s
 echo ">>> roachprod %[1]s: $(date)" >> %[2]s/roachprod.log
@@ -531,16 +532,16 @@ if [ -n "${pids}" ]; then
   kill -%[5]d ${pids}
 %[6]s
 fi`,
-			cmdName,                   // [1]
-			c.LogDir(node, "", 0),     // [2]
-			virtualClusterFilter,      // [3]
-			c.roachprodEnvRegex(node), // [4]
-			sig,                       // [5]
-			waitCmd,                   // [6]
-		)
+				cmdName,                   // [1]
+				c.LogDir(node, "", 0),     // [2]
+				virtualClusterFilter,      // [3]
+				c.roachprodEnvRegex(node), // [4]
+				sig,                       // [5]
+				waitCmd,                   // [6]
+			)
 
-		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("kill"))
-	}, WithDisplay(display), WithRetryDisabled()) // Disable SSH Retries
+			return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("kill"))
+		})
 }
 
 // Wipe TODO(peter): document
@@ -549,7 +550,7 @@ func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCert
 	if err := c.Stop(ctx, l, 9, true /* wait */, 0 /* maxWait */, ""); err != nil {
 		return err
 	}
-	return c.Parallel(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
+	return c.Parallel(ctx, l, OnNodes(c.Nodes).WithDisplay(display), func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		var cmd string
 		if c.IsLocal() {
 			// Not all shells like brace expansion, so we'll do it here
@@ -574,7 +575,7 @@ func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCert
 			cmd = strings.Join(rmCmds, " && ")
 		}
 		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("wipe"))
-	}, WithDisplay(display))
+	})
 }
 
 // NodeStatus contains details about the status of a node.
@@ -589,7 +590,7 @@ type NodeStatus struct {
 // Status TODO(peter): document
 func (c *SyncedCluster) Status(ctx context.Context, l *logger.Logger) ([]NodeStatus, error) {
 	display := fmt.Sprintf("%s: status", c.Name)
-	res, _, err := c.ParallelE(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
+	res, _, err := c.ParallelE(ctx, l, OnNodes(c.Nodes).WithDisplay(display), func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		binary := cockroachNodeBinary(c, node)
 		cmd := fmt.Sprintf(`out=$(ps axeww -o pid -o ucomm -o command | \
   sed 's/export ROACHPROD=//g' | \
@@ -606,7 +607,7 @@ else
 fi
 `
 		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("status"))
-	}, WithDisplay(display))
+	})
 
 	if err != nil {
 		return nil, err
@@ -1232,18 +1233,17 @@ func (c *SyncedCluster) Run(
 	ctx context.Context,
 	l *logger.Logger,
 	stdout, stderr io.Writer,
-	nodes Nodes,
+	options RunOptions,
 	title, cmd string,
-	opts ...RunOption,
 ) error {
 	// Stream output if we're running the command on only 1 node.
-	stream := len(nodes) == 1
-	var display string
-	if !stream {
-		display = fmt.Sprintf("%s:%v: %s", c.Name, nodes, title)
+	stream := len(options.Nodes) == 1
+	// If the user has not specified a display string, and we are not streaming,
+	// we set a default display string.
+	if !stream && options.Display == "" {
+		options = options.WithDisplay(fmt.Sprintf("%s:%v: %s", c.Name, options.Nodes, title))
 	}
-	defaultOpts := []RunOption{WithDisplay(display)}
-	results, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
+	results, _, err := c.ParallelE(ctx, l, options, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		opts := RunCmdOptions{
 			combinedOut:             !stream,
 			includeRoachprodEnvVars: true,
@@ -1252,7 +1252,7 @@ func (c *SyncedCluster) Run(
 		}
 		result, err := c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
 		return result, err
-	}, append(defaultOpts, opts...)...)
+	})
 
 	if err != nil {
 		return err
@@ -1310,16 +1310,24 @@ func processResults(results []*RunResultDetails, stream bool, stdout io.Writer) 
 	return nil
 }
 
-// RunWithDetails runs a command on the specified nodes and returns results details and an error.
-// By default, this will wait for all commands to complete before returning unless encountering a roachprod error.
+// RunWithDetails runs a command on the specified nodes and returns results
+// details and an error. By default, this will wait for all commands to complete
+// before returning unless encountering a roachprod error, unless one of the
+// FailOptions has been explicitly set in the RunOptions.
 func (c *SyncedCluster) RunWithDetails(
-	ctx context.Context, l *logger.Logger, nodes Nodes, title, cmd string, opts ...RunOption,
+	ctx context.Context, l *logger.Logger, options RunOptions, title, cmd string,
 ) ([]RunResultDetails, error) {
-	display := fmt.Sprintf("%s:%v: %s", c.Name, nodes, title)
-	defaultOpts := []RunOption{WithDisplay(display), WithFailSlow(true)}
+	// If the user has not specified a display string, and we are not streaming,
+	// we set a default display string.
+	if options.Display == "" {
+		options = options.WithDisplay(fmt.Sprintf("%s:%v: %s", c.Name, options.Nodes, title))
+	}
+	if options.FailOption == FailDefault {
+		options = options.WithFailSlow()
+	}
 
 	// Failing slow here allows us to capture the output of all nodes even if one fails with a command error.
-	resultPtrs, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
+	resultPtrs, _, err := c.ParallelE(ctx, l, options, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		opts := RunCmdOptions{
 			includeRoachprodEnvVars: true,
 			stdout:                  l.Stdout,
@@ -1327,14 +1335,14 @@ func (c *SyncedCluster) RunWithDetails(
 		}
 		result, err := c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
 		return result, err
-	}, append(defaultOpts, opts...)...)
+	})
 
 	if err != nil {
 		return nil, err
 	}
 
 	// Return values to preserve API
-	results := make([]RunResultDetails, len(nodes))
+	results := make([]RunResultDetails, len(options.Nodes))
 	for i, v := range resultPtrs {
 		if v != nil {
 			results[i] = *v
@@ -1362,7 +1370,7 @@ func (c *SyncedCluster) RepeatRun(
 		}
 		attempt++
 		l.Printf("attempt %d - %s", attempt, title)
-		lastError = c.Run(ctx, l, stdout, stderr, nodes, title, cmd)
+		lastError = c.Run(ctx, l, stdout, stderr, OnNodes(nodes), title, cmd)
 		if lastError != nil {
 			l.Printf("error - retrying: %s", lastError)
 			continue
@@ -1375,27 +1383,28 @@ func (c *SyncedCluster) RepeatRun(
 // Wait TODO(peter): document
 func (c *SyncedCluster) Wait(ctx context.Context, l *logger.Logger) error {
 	display := fmt.Sprintf("%s: waiting for nodes to start", c.Name)
-	_, hasError, err := c.ParallelE(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
-		res := &RunResultDetails{Node: node}
-		var err error
-		cmd := "test -e /mnt/data1/.roachprod-initialized"
-		opts := defaultCmdOpts("wait-init")
-		for j := 0; j < 600; j++ {
-			res, err = c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
-			if err != nil {
-				return nil, err
-			}
+	_, hasError, err := c.ParallelE(ctx, l, OnNodes(c.Nodes).WithDisplay(display).WithRetryDisabled(),
+		func(ctx context.Context, node Node) (*RunResultDetails, error) {
+			res := &RunResultDetails{Node: node}
+			var err error
+			cmd := "test -e /mnt/data1/.roachprod-initialized"
+			opts := defaultCmdOpts("wait-init")
+			for j := 0; j < 600; j++ {
+				res, err = c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
+				if err != nil {
+					return nil, err
+				}
 
-			if res.Err != nil {
-				time.Sleep(500 * time.Millisecond)
-				continue
+				if res.Err != nil {
+					time.Sleep(500 * time.Millisecond)
+					continue
+				}
+				return res, nil
 			}
+			res.Err = errors.New("timed out after 5m")
+			l.Printf("  %2d: %v", node, res.Err)
 			return res, nil
-		}
-		res.Err = errors.New("timed out after 5m")
-		l.Printf("  %2d: %v", node, res.Err)
-		return res, nil
-	}, WithDisplay(display), WithRetryDisabled())
+		})
 
 	if err != nil {
 		return err
@@ -1434,20 +1443,21 @@ func (c *SyncedCluster) SetupSSH(ctx context.Context, l *logger.Logger) error {
 
 	// Generate an ssh key that we'll distribute to all the nodes in the
 	// cluster in order to allow inter-node ssh.
-	results, _, err := c.ParallelE(ctx, l, c.Nodes[0:1], func(ctx context.Context, n Node) (*RunResultDetails, error) {
-		// Create the ssh key and then tar up the public, private and
-		// authorized_keys files and output them to stdout. We'll take this output
-		// and pipe it back into tar on the other nodes in the cluster.
-		cmd := `
+	results, _, err := c.ParallelE(ctx, l, OnNodes(c.Nodes[0:1]).WithDisplay("generating ssh key"),
+		func(ctx context.Context, n Node) (*RunResultDetails, error) {
+			// Create the ssh key and then tar up the public, private and
+			// authorized_keys files and output them to stdout. We'll take this output
+			// and pipe it back into tar on the other nodes in the cluster.
+			cmd := `
 test -f .ssh/id_rsa || \
   (ssh-keygen -q -f .ssh/id_rsa -t rsa -N '' && \
    cat .ssh/id_rsa.pub >> .ssh/authorized_keys);
 tar cf - .ssh/id_rsa .ssh/id_rsa.pub .ssh/authorized_keys
 `
-		runOpts := defaultCmdOpts("ssh-gen-key")
-		runOpts.combinedOut = false
-		return c.runCmdOnSingleNode(ctx, l, n, cmd, runOpts)
-	}, WithDisplay("generating ssh key"))
+			runOpts := defaultCmdOpts("ssh-gen-key")
+			runOpts.combinedOut = false
+			return c.runCmdOnSingleNode(ctx, l, n, cmd, runOpts)
+		})
 
 	if err != nil {
 		return err
@@ -1456,11 +1466,12 @@ tar cf - .ssh/id_rsa .ssh/id_rsa.pub .ssh/authorized_keys
 	sshTar := []byte(results[0].Stdout)
 	// Skip the first node which is where we generated the key.
 	nodes := c.Nodes[1:]
-	if err := c.Parallel(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
-		runOpts := defaultCmdOpts("ssh-dist-key")
-		runOpts.stdin = bytes.NewReader(sshTar)
-		return c.runCmdOnSingleNode(ctx, l, node, `tar xf -`, runOpts)
-	}, WithDisplay("distributing ssh key")); err != nil {
+	if err := c.Parallel(ctx, l, OnNodes(nodes).WithDisplay("distributing ssh key"),
+		func(ctx context.Context, node Node) (*RunResultDetails, error) {
+			runOpts := defaultCmdOpts("ssh-dist-key")
+			runOpts.stdin = bytes.NewReader(sshTar)
+			return c.runCmdOnSingleNode(ctx, l, node, `tar xf -`, runOpts)
+		}); err != nil {
 		return err
 	}
 
@@ -1493,20 +1504,21 @@ tar cf - .ssh/id_rsa .ssh/id_rsa.pub .ssh/authorized_keys
 	for i, provider := range providers {
 		firstNodes[i] = providerPrivateIPs[provider][0].node
 	}
-	if err := c.Parallel(ctx, l, firstNodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
-		// Scan a combination of all remote IPs and local IPs pertaining to this
-		// node's cloud provider.
-		scanIPs := append([]string{}, publicIPs...)
-		nodeProvider := c.VMs[node-1].Provider
-		for _, nodeInfo := range providerPrivateIPs[nodeProvider] {
-			scanIPs = append(scanIPs, nodeInfo.ip)
-		}
+	if err := c.Parallel(ctx, l, OnNodes(firstNodes).WithDisplay("scanning hosts"),
+		func(ctx context.Context, node Node) (*RunResultDetails, error) {
+			// Scan a combination of all remote IPs and local IPs pertaining to this
+			// node's cloud provider.
+			scanIPs := append([]string{}, publicIPs...)
+			nodeProvider := c.VMs[node-1].Provider
+			for _, nodeInfo := range providerPrivateIPs[nodeProvider] {
+				scanIPs = append(scanIPs, nodeInfo.ip)
+			}
 
-		// ssh-keyscan may return fewer than the desired number of entries if the
-		// remote nodes are not responding yet, so we loop until we have a scan that
-		// found host keys for all the public IPs. Merge the newly scanned keys
-		// with the existing list to make this process idempotent.
-		cmd := `
+			// ssh-keyscan may return fewer than the desired number of entries if the
+			// remote nodes are not responding yet, so we loop until we have a scan that
+			// found host keys for all the public IPs. Merge the newly scanned keys
+			// with the existing list to make this process idempotent.
+			cmd := `
 set -e
 tmp="$(tempfile -d ~/.ssh -p 'roachprod' )"
 on_exit() {
@@ -1524,27 +1536,28 @@ for i in {1..20}; do
 done
 exit 1
 `
-		runOpts := defaultCmdOpts("ssh-scan-hosts")
-		runOpts.combinedOut = false
-		res, err := c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)
-		if err != nil {
-			return nil, err
-		}
+			runOpts := defaultCmdOpts("ssh-scan-hosts")
+			runOpts.combinedOut = false
+			res, err := c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)
+			if err != nil {
+				return nil, err
+			}
 
-		if res.Err != nil {
+			if res.Err != nil {
+				return res, nil
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			providerKnownHostData[nodeProvider] = []byte(res.Stdout)
 			return res, nil
-		}
-		mu.Lock()
-		defer mu.Unlock()
-		providerKnownHostData[nodeProvider] = []byte(res.Stdout)
-		return res, nil
-	}, WithDisplay("scanning hosts")); err != nil {
+		}); err != nil {
 		return err
 	}
 
-	if err := c.Parallel(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
-		provider := c.VMs[node-1].Provider
-		const cmd = `
+	if err := c.Parallel(ctx, l, OnNodes(c.Nodes).WithDisplay("distributing known_hosts"),
+		func(ctx context.Context, node Node) (*RunResultDetails, error) {
+			provider := c.VMs[node-1].Provider
+			const cmd = `
 known_hosts_data="$(cat)"
 set -e
 tmp="$(tempfile -p 'roachprod' -m 0644 )"
@@ -1560,7 +1573,7 @@ cat "${tmp}" >> ~/.ssh/known_hosts
 if [[ "$(whoami)" != "` + config.SharedUser + `" ]]; then
     # Ensure that the shared user has a .ssh directory
     sudo -u ` + config.SharedUser +
-			` bash -c "mkdir -p ~` + config.SharedUser + `/.ssh"
+				` bash -c "mkdir -p ~` + config.SharedUser + `/.ssh"
     # This somewhat absurd incantation ensures that we properly shell quote
     # filenames so that they both aren't expanded and work even if the filenames
     # include spaces.
@@ -1571,10 +1584,10 @@ if [[ "$(whoami)" != "` + config.SharedUser + `" ]]; then
         '"'"'{}'"'"' ~` + config.SharedUser + `/.ssh' \;
 fi
 `
-		runOpts := defaultCmdOpts("ssh-dist-known-hosts")
-		runOpts.stdin = bytes.NewReader(providerKnownHostData[provider])
-		return c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)
-	}, WithDisplay("distributing known_hosts")); err != nil {
+			runOpts := defaultCmdOpts("ssh-dist-known-hosts")
+			runOpts.stdin = bytes.NewReader(providerKnownHostData[provider])
+			return c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)
+		}); err != nil {
 		return err
 	}
 
@@ -1584,8 +1597,9 @@ fi
 		// additional authorized_keys to both the current user (your username on
 		// gce and the shared user on aws) as well as to the shared user on both
 		// platforms.
-		if err := c.Parallel(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
-			const cmd = `
+		if err := c.Parallel(ctx, l, OnNodes(c.Nodes).WithDisplay("adding additional authorized keys"),
+			func(ctx context.Context, node Node) (*RunResultDetails, error) {
+				const cmd = `
 keys_data="$(cat)"
 set -e
 tmp1="$(tempfile -d ~/.ssh -p 'roachprod' )"
@@ -1608,10 +1622,10 @@ if [[ "$(whoami)" != "` + config.SharedUser + `" ]]; then
 fi
 `
 
-			runOpts := defaultCmdOpts("ssh-add-extra-keys")
-			runOpts.stdin = bytes.NewReader(c.AuthorizedKeys)
-			return c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)
-		}, WithDisplay("adding additional authorized keys")); err != nil {
+				runOpts := defaultCmdOpts("ssh-add-extra-keys")
+				runOpts.stdin = bytes.NewReader(c.AuthorizedKeys)
+				return c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)
+			}); err != nil {
 			return err
 		}
 	}
@@ -1637,15 +1651,16 @@ func (c *SyncedCluster) DistributeCerts(ctx context.Context, l *logger.Logger) e
 
 	// Generate the ca, client and node certificates on the first node.
 	display := fmt.Sprintf("%s: initializing certs", c.Name)
-	if err := c.Parallel(ctx, l, c.Nodes[0:1], func(ctx context.Context, node Node) (*RunResultDetails, error) {
-		var cmd string
-		if c.IsLocal() {
-			cmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(1))
-		}
-		// TODO(ssd): Pre-populating the certs for tenants 1
-		// through 4 helps facilitate UA testing. But we
-		// should do something better here.
-		cmd += fmt.Sprintf(`
+	if err := c.Parallel(ctx, l, OnNodes(c.Nodes[0:1]).WithDisplay(display),
+		func(ctx context.Context, node Node) (*RunResultDetails, error) {
+			var cmd string
+			if c.IsLocal() {
+				cmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(1))
+			}
+			// TODO(ssd): Pre-populating the certs for tenants 1
+			// through 4 helps facilitate UA testing. But we
+			// should do something better here.
+			cmd += fmt.Sprintf(`
 rm -fr certs
 mkdir -p certs
 VERSION=$(%[1]s version --build-tag)
@@ -1665,8 +1680,9 @@ fi
 tar cvf %[3]s certs
 `, cockroachNodeBinary(c, 1), strings.Join(nodeNames, " "), certsTarName)
 
-		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("init-certs"))
-	}, WithDisplay(display)); err != nil {
+			return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("init-certs"))
+		},
+	); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		exit.WithCode(exit.UnspecifiedError())
 	}
@@ -1726,12 +1742,13 @@ func (c *SyncedCluster) createTenantCertBundle(
 	nodeNames []string,
 ) error {
 	display := fmt.Sprintf("%s: initializing tenant certs", c.Name)
-	return c.Parallel(ctx, l, c.Nodes[0:1], func(ctx context.Context, node Node) (*RunResultDetails, error) {
-		cmd := "set -e;"
-		if c.IsLocal() {
-			cmd += fmt.Sprintf(`cd %s ; `, c.localVMDir(1))
-		}
-		cmd += fmt.Sprintf(`
+	return c.Parallel(ctx, l, OnNodes(c.Nodes[0:1]).WithDisplay(display),
+		func(ctx context.Context, node Node) (*RunResultDetails, error) {
+			cmd := "set -e;"
+			if c.IsLocal() {
+				cmd += fmt.Sprintf(`cd %s ; `, c.localVMDir(1))
+			}
+			cmd += fmt.Sprintf(`
 CERT_DIR=tenant-certs/certs
 CA_KEY=certs/ca.key
 
@@ -1751,14 +1768,14 @@ fi
 %[1]s cert create-client testuser $TENANT_SCOPE_OPT $SHARED_ARGS
 tar cvf %[4]s $CERT_DIR
 `,
-			cockroachNodeBinary(c, node),
-			strings.Join(nodeNames, " "),
-			virtualClusterID,
-			bundleName,
-		)
+				cockroachNodeBinary(c, node),
+				strings.Join(nodeNames, " "),
+				virtualClusterID,
+				bundleName,
+			)
 
-		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("create-tenant-cert-bundle"))
-	}, WithDisplay(display))
+			return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("create-tenant-cert-bundle"))
+		})
 }
 
 // getFile retrieves the given file from the first node in the cluster. The
@@ -1862,21 +1879,22 @@ func (c *SyncedCluster) distributeLocalCertsTar(
 	}
 
 	display := c.Name + ": distributing certs"
-	return c.Parallel(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
-		var cmd string
-		if c.IsLocal() {
-			cmd = fmt.Sprintf("cd %s ; ", c.localVMDir(node))
-		}
-		if stripComponents > 0 {
-			cmd += fmt.Sprintf("tar --strip-components=%d -xf -", stripComponents)
-		} else {
-			cmd += "tar xf -"
-		}
+	return c.Parallel(ctx, l, OnNodes(nodes).WithDisplay(display),
+		func(ctx context.Context, node Node) (*RunResultDetails, error) {
+			var cmd string
+			if c.IsLocal() {
+				cmd = fmt.Sprintf("cd %s ; ", c.localVMDir(node))
+			}
+			if stripComponents > 0 {
+				cmd += fmt.Sprintf("tar --strip-components=%d -xf -", stripComponents)
+			} else {
+				cmd += "tar xf -"
+			}
 
-		runOpts := defaultCmdOpts("dist-local-certs")
-		runOpts.stdin = bytes.NewReader(certsTar)
-		return c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)
-	}, WithDisplay(display))
+			runOpts := defaultCmdOpts("dist-local-certs")
+			runOpts.stdin = bytes.NewReader(certsTar)
+			return c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)
+		})
 }
 
 const progressDone = "=======================================>"
@@ -2730,11 +2748,10 @@ func scp(l *logger.Logger, src, dest string) (*RunResultDetails, error) {
 func (c *SyncedCluster) Parallel(
 	ctx context.Context,
 	l *logger.Logger,
-	nodes Nodes,
+	options RunOptions,
 	fn func(ctx context.Context, n Node) (*RunResultDetails, error),
-	opts ...RunOption,
 ) error {
-	results, hasError, err := c.ParallelE(ctx, l, nodes, fn, opts...)
+	results, hasError, err := c.ParallelE(ctx, l, options, fn)
 	// `err` is an unexpected roachprod error, which we return immediately.
 	if err != nil {
 		return err
@@ -2765,10 +2782,11 @@ type ParallelResult struct {
 
 // ParallelE runs the given function in parallel on the specified nodes.
 //
-// By default, this will fail fast if a command error occurs on any node, and return
-// a slice containing all results up to that point, along with a boolean indicating
-// that at least one error occurred. If `WithFailSlow(true)` is passed in, then the function
-// will wait for all invocations to complete before returning.
+// By default, this will fail fast, unless explicitly specified otherwise in the
+// RunOptions, if a command error occurs on any node, and return a slice
+// containing all results up to that point, along with a boolean indicating that
+// at least one error occurred. If `WithFailSlow(true)` is passed in, then the
+// function will wait for all invocations to complete before returning.
 //
 // ParallelE only returns an error for roachprod itself, not any command errors run
 // on the cluster.
@@ -2787,20 +2805,21 @@ type ParallelResult struct {
 func (c *SyncedCluster) ParallelE(
 	ctx context.Context,
 	l *logger.Logger,
-	nodes Nodes,
+	options RunOptions,
 	fn func(ctx context.Context, n Node) (*RunResultDetails, error),
-	opts ...RunOption,
 ) ([]*RunResultDetails, bool, error) {
-	// Default options, which can be overridden by those passed in
-	options := RunOptions{
-		RetryOptions:  DefaultRetryOpt,
-		ShouldRetryFn: DefaultShouldRetryFn,
+	// Defaults for RunOptions if not specified.
+	if options.RetryOptions == nil {
+		options.RetryOptions = DefaultRetryOpt
 	}
-	for _, opt := range opts {
-		opt(&options)
+	if options.ShouldRetryFn == nil {
+		options.ShouldRetryFn = DefaultShouldRetryFn
+	}
+	if options.FailOption == FailDefault {
+		options.FailOption = FailFast
 	}
 
-	count := len(nodes)
+	count := len(options.Nodes)
 	if options.Concurrency == 0 || options.Concurrency > count {
 		options.Concurrency = count
 	}
@@ -2826,7 +2845,10 @@ func (c *SyncedCluster) ParallelE(
 			defer wg.Done()
 			// This is rarely expected to return an error, but we fail fast in case.
 			// Command errors, which are far more common, will be contained within the result.
-			res, err := runWithMaybeRetry(groupCtx, l, options.RetryOptions, options.ShouldRetryFn, func(ctx context.Context) (*RunResultDetails, error) { return fn(ctx, nodes[i]) })
+			res, err := runWithMaybeRetry(
+				groupCtx, l, options.RetryOptions, options.ShouldRetryFn,
+				func(ctx context.Context) (*RunResultDetails, error) { return fn(ctx, options.Nodes[i]) },
+			)
 			if err != nil {
 				errorChannel <- err
 				return
@@ -2883,7 +2905,7 @@ func (c *SyncedCluster) ParallelE(
 				n++
 				if r.Err != nil { // Command error
 					hasError = true
-					if !options.FailSlow {
+					if options.FailOption != FailSlow {
 						groupCancel()
 						return results, true, nil
 					}

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -105,7 +105,7 @@ func NewSyncedCluster(
 var ErrAfterRetry = errors.New("error occurred after retries")
 
 // The first retry is after 5s, the second and final is after 25s
-var defaultRetryOpt = retry.Options{
+var DefaultRetryOpt = &retry.Options{
 	InitialBackoff: 5 * time.Second,
 	Multiplier:     5,
 	MaxBackoff:     1 * time.Minute,
@@ -113,29 +113,27 @@ var defaultRetryOpt = retry.Options{
 	MaxRetries: 2,
 }
 
-var DefaultSSHRetryOpts = NewRetryOpts(defaultRetryOpt, func(res *RunResultDetails) bool { return errors.Is(res.Err, rperrors.ErrSSH255) })
+var DefaultShouldRetryFn = func(res *RunResultDetails) bool { return errors.Is(res.Err, rperrors.ErrSSH255) }
 
 // defaultSCPRetry won't retry if the error output contains any of the following
 // substrings, in which cases retries are unlikely to help.
 var noScpRetrySubstrings = []string{"no such file or directory", "permission denied", "connection timed out"}
-var defaultSCPRetry = NewRetryOpts(defaultRetryOpt,
-	func(res *RunResultDetails) bool {
-		out := strings.ToLower(res.Output(false))
-		for _, s := range noScpRetrySubstrings {
-			if strings.Contains(out, s) {
-				return false
-			}
+var defaultSCPShouldRetryFn = func(res *RunResultDetails) bool {
+	out := strings.ToLower(res.Output(false))
+	for _, s := range noScpRetrySubstrings {
+		if strings.Contains(out, s) {
+			return false
 		}
-		return true
-	},
-)
+	}
+	return true
+}
 
 // runWithMaybeRetry will run the specified function `f` at least once, or only
 // once if `runRetryOpts` is nil
 //
-// Any RunResultDetails containing a non nil err from `f` is passed to `runRetryOpts.ShouldRetryFn` which,
-// if it returns true, will result in `f` being retried using the `retryOpts`
-// If the `ShouldRetryFn` is not specified (nil), then retries will be performed
+// Any RunResultDetails containing a non nil err from `f` is passed to `shouldRetryFn` which,
+// if it returns true, will result in `f` being retried using the `RetryOpts`
+// If the `shouldRetryFn` is not specified (nil), then retries will be performed
 // regardless of the previous result / error.
 //
 // If a non-nil error (as opposed to the result containing a non-nil error) is returned,
@@ -147,7 +145,8 @@ var defaultSCPRetry = NewRetryOpts(defaultRetryOpt,
 func runWithMaybeRetry(
 	ctx context.Context,
 	l *logger.Logger,
-	retryOpts *RetryOpts,
+	retryOpts *retry.Options,
+	shouldRetryFn func(*RunResultDetails) bool,
 	f func(ctx context.Context) (*RunResultDetails, error),
 ) (*RunResultDetails, error) {
 	if retryOpts == nil {
@@ -162,7 +161,7 @@ func runWithMaybeRetry(
 	var res = &RunResultDetails{}
 	var cmdErr, err error
 
-	for r := retry.StartWithCtx(ctx, retryOpts.Options); r.Next(); {
+	for r := retry.StartWithCtx(ctx, *retryOpts); r.Next(); {
 		res, err = f(ctx)
 		if err != nil {
 			// non retryable roachprod error
@@ -171,7 +170,7 @@ func runWithMaybeRetry(
 		res.Attempt = r.CurrentAttempt() + 1
 		if res.Err != nil {
 			cmdErr = errors.CombineErrors(cmdErr, res.Err)
-			if retryOpts.ShouldRetryFn == nil || retryOpts.ShouldRetryFn(res) {
+			if shouldRetryFn == nil || shouldRetryFn(res) {
 				l.Printf("encountered [%v] on attempt %v of %v", res.Err, r.CurrentAttempt()+1, retryOpts.MaxRetries+1)
 				continue
 			}
@@ -194,7 +193,8 @@ func runWithMaybeRetry(
 func scpWithRetry(
 	ctx context.Context, l *logger.Logger, src, dest string,
 ) (*RunResultDetails, error) {
-	return runWithMaybeRetry(ctx, l, defaultSCPRetry, func(ctx context.Context) (*RunResultDetails, error) { return scp(l, src, dest) })
+	return runWithMaybeRetry(ctx, l, DefaultRetryOpt, defaultSCPShouldRetryFn,
+		func(ctx context.Context) (*RunResultDetails, error) { return scp(l, src, dest) })
 }
 
 // Host returns the public IP of a node.
@@ -540,7 +540,7 @@ fi`,
 		)
 
 		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("kill"))
-	}, WithDisplay(display), WithRetryOpts(nil)) // Disable SSH Retries
+	}, WithDisplay(display), WithRetryDisabled()) // Disable SSH Retries
 }
 
 // Wipe TODO(peter): document
@@ -1242,7 +1242,7 @@ func (c *SyncedCluster) Run(
 	if !stream {
 		display = fmt.Sprintf("%s:%v: %s", c.Name, nodes, title)
 	}
-
+	defaultOpts := []RunOption{WithDisplay(display)}
 	results, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		opts := RunCmdOptions{
 			combinedOut:             !stream,
@@ -1252,7 +1252,7 @@ func (c *SyncedCluster) Run(
 		}
 		result, err := c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
 		return result, err
-	}, append(opts, WithDisplay(display))...)
+	}, append(defaultOpts, opts...)...)
 
 	if err != nil {
 		return err
@@ -1311,11 +1311,12 @@ func processResults(results []*RunResultDetails, stream bool, stdout io.Writer) 
 }
 
 // RunWithDetails runs a command on the specified nodes and returns results details and an error.
-// This will wait for all commands to complete before returning unless encountering a roachprod error.
+// By default, this will wait for all commands to complete before returning unless encountering a roachprod error.
 func (c *SyncedCluster) RunWithDetails(
-	ctx context.Context, l *logger.Logger, nodes Nodes, title, cmd string,
+	ctx context.Context, l *logger.Logger, nodes Nodes, title, cmd string, opts ...RunOption,
 ) ([]RunResultDetails, error) {
 	display := fmt.Sprintf("%s:%v: %s", c.Name, nodes, title)
+	defaultOpts := []RunOption{WithDisplay(display), WithFailSlow(true)}
 
 	// Failing slow here allows us to capture the output of all nodes even if one fails with a command error.
 	resultPtrs, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
@@ -1326,7 +1327,7 @@ func (c *SyncedCluster) RunWithDetails(
 		}
 		result, err := c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
 		return result, err
-	}, WithDisplay(display), WithWaitOnFail())
+	}, append(defaultOpts, opts...)...)
 
 	if err != nil {
 		return nil, err
@@ -1394,7 +1395,7 @@ func (c *SyncedCluster) Wait(ctx context.Context, l *logger.Logger) error {
 		res.Err = errors.New("timed out after 5m")
 		l.Printf("  %2d: %v", node, res.Err)
 		return res, nil
-	}, WithDisplay(display), WithRetryOpts(nil))
+	}, WithDisplay(display), WithRetryDisabled())
 
 	if err != nil {
 		return err
@@ -2766,7 +2767,7 @@ type ParallelResult struct {
 //
 // By default, this will fail fast if a command error occurs on any node, and return
 // a slice containing all results up to that point, along with a boolean indicating
-// that at least one error occurred. If `WithWaitOnFail()` is passed in, then the function
+// that at least one error occurred. If `WithFailSlow(true)` is passed in, then the function
 // will wait for all invocations to complete before returning.
 //
 // ParallelE only returns an error for roachprod itself, not any command errors run
@@ -2790,7 +2791,11 @@ func (c *SyncedCluster) ParallelE(
 	fn func(ctx context.Context, n Node) (*RunResultDetails, error),
 	opts ...RunOption,
 ) ([]*RunResultDetails, bool, error) {
-	options := RunOptions{RetryOpts: DefaultSSHRetryOpts}
+	// Default options, which can be overridden by those passed in
+	options := RunOptions{
+		RetryOptions:  DefaultRetryOpt,
+		ShouldRetryFn: DefaultShouldRetryFn,
+	}
 	for _, opt := range opts {
 		opt(&options)
 	}
@@ -2821,7 +2826,7 @@ func (c *SyncedCluster) ParallelE(
 			defer wg.Done()
 			// This is rarely expected to return an error, but we fail fast in case.
 			// Command errors, which are far more common, will be contained within the result.
-			res, err := runWithMaybeRetry(groupCtx, l, options.RetryOpts, func(ctx context.Context) (*RunResultDetails, error) { return fn(ctx, nodes[i]) })
+			res, err := runWithMaybeRetry(groupCtx, l, options.RetryOptions, options.ShouldRetryFn, func(ctx context.Context) (*RunResultDetails, error) { return fn(ctx, nodes[i]) })
 			if err != nil {
 				errorChannel <- err
 				return
@@ -2878,7 +2883,7 @@ func (c *SyncedCluster) ParallelE(
 				n++
 				if r.Err != nil { // Command error
 					hasError = true
-					if !options.WaitOnFail {
+					if !options.FailSlow {
 						groupCancel()
 						return results, true, nil
 					}

--- a/pkg/roachprod/install/cluster_synced_test.go
+++ b/pkg/roachprod/install/cluster_synced_test.go
@@ -97,58 +97,58 @@ func TestRunWithMaybeRetry(t *testing.T) {
 
 	attempt := 0
 	cases := []struct {
-		f                func(ctx context.Context) (*RunResultDetails, error)
-		shouldRetryFn    func(*RunResultDetails) bool
+		f                func(ctx context.Context) (*install.RunResultDetails, error)
+		shouldRetryFn    func(*install.RunResultDetails) bool
 		nilRetryOpts     bool
 		expectedAttempts int
 		shouldError      bool
 	}{
 		{ // 1. Happy path: no error, no retry required
-			f: func(ctx context.Context) (*RunResultDetails, error) {
+			f: func(ctx context.Context) (*install.RunResultDetails, error) {
 				return newResult(0), nil
 			},
 			expectedAttempts: 1,
 			shouldError:      false,
 		},
 		{ // 2. Error, but with no retries
-			f: func(ctx context.Context) (*RunResultDetails, error) {
+			f: func(ctx context.Context) (*install.RunResultDetails, error) {
 				return newResult(1), nil
 			},
-			shouldRetryFn: func(*RunResultDetails) bool {
+			shouldRetryFn: func(*install.RunResultDetails) bool {
 				return false
 			},
 			expectedAttempts: 1,
 			shouldError:      true,
 		},
 		{ // 3. Error, but no retry function specified
-			f: func(ctx context.Context) (*RunResultDetails, error) {
+			f: func(ctx context.Context) (*install.RunResultDetails, error) {
 				return newResult(1), nil
 			},
 			expectedAttempts: 3,
 			shouldError:      true,
 		},
 		{ // 4. Error, with retries exhausted
-			f: func(ctx context.Context) (*RunResultDetails, error) {
+			f: func(ctx context.Context) (*install.RunResultDetails, error) {
 				return newResult(255), nil
 			},
-			shouldRetryFn:    func(d *RunResultDetails) bool { return d.RemoteExitStatus == 255 },
+			shouldRetryFn:    func(d *install.RunResultDetails) bool { return d.RemoteExitStatus == 255 },
 			expectedAttempts: 3,
 			shouldError:      true,
 		},
 		{ // 5. Eventual success after retries
-			f: func(ctx context.Context) (*RunResultDetails, error) {
+			f: func(ctx context.Context) (*install.RunResultDetails, error) {
 				attempt++
 				if attempt == 3 {
 					return newResult(0), nil
 				}
 				return newResult(255), nil
 			},
-			shouldRetryFn:    func(d *RunResultDetails) bool { return d.RemoteExitStatus == 255 },
+			shouldRetryFn:    func(d *install.RunResultDetails) bool { return d.RemoteExitStatus == 255 },
 			expectedAttempts: 3,
 			shouldError:      false,
 		},
 		{ // 6. Error, runs once because nil retryOpts
-			f: func(ctx context.Context) (*RunResultDetails, error) {
+			f: func(ctx context.Context) (*install.RunResultDetails, error) {
 				return newResult(255), nil
 			},
 			nilRetryOpts:     true,
@@ -160,9 +160,9 @@ func TestRunWithMaybeRetry(t *testing.T) {
 	for idx, tc := range cases {
 		attempt = 0
 		t.Run(fmt.Sprintf("%d", idx+1), func(t *testing.T) {
-			var retryOpts *RunRetryOpts
+			var retryOpts *RetryOpts
 			if !tc.nilRetryOpts {
-				retryOpts = newRunRetryOpts(testRetryOpts, tc.shouldRetryFn)
+				retryOpts = NewRetryOpts(testRetryOpts, tc.shouldRetryFn)
 			}
 			res, _ := runWithMaybeRetry(context.Background(), l, retryOpts, tc.f)
 
@@ -176,12 +176,12 @@ func TestRunWithMaybeRetry(t *testing.T) {
 	}
 }
 
-func newResult(exitCode int) *RunResultDetails {
+func newResult(exitCode int) *install.RunResultDetails {
 	var err error
 	if exitCode != 0 {
 		err = errors.Newf("Error with exit code %v", exitCode)
 	}
-	return &RunResultDetails{RemoteExitStatus: exitCode, Err: err}
+	return &install.RunResultDetails{RemoteExitStatus: exitCode, Err: err}
 }
 
 func nilLogger() *logger.Logger {

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -573,7 +573,7 @@ func (c *SyncedCluster) ExecSQL(
 			ssh.Escape(args)
 
 		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("run-sql"))
-	}, WithDisplay(display), WithWaitOnFail())
+	}, WithDisplay(display), WithFailSlow(true))
 
 	return results, err
 }

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -270,7 +270,7 @@ func (c *SyncedCluster) servicesWithOpenPortSelection(
 ) (ServiceDescriptors, error) {
 	var mu syncutil.Mutex
 	var servicesToRegister ServiceDescriptors
-	err := c.Parallel(ctx, l, c.Nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
+	err := c.Parallel(ctx, l, OnNodes(c.Nodes), func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		services := make(ServiceDescriptors, 0)
 		res := &RunResultDetails{Node: node}
 		if _, ok := serviceMap[node][ServiceTypeSQL]; !ok {
@@ -559,21 +559,22 @@ func (c *SyncedCluster) ExecSQL(
 	args []string,
 ) ([]*RunResultDetails, error) {
 	display := fmt.Sprintf("%s: executing sql", c.Name)
-	results, _, err := c.ParallelE(ctx, l, nodes, func(ctx context.Context, node Node) (*RunResultDetails, error) {
-		desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
-		if err != nil {
-			return nil, err
-		}
-		var cmd string
-		if c.IsLocal() {
-			cmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(node))
-		}
-		cmd += cockroachNodeBinary(c, node) + " sql --url " +
-			c.NodeURL("localhost", desc.Port, virtualClusterName, desc.ServiceMode) + " " +
-			ssh.Escape(args)
+	results, _, err := c.ParallelE(ctx, l, OnNodes(nodes).WithDisplay(display).WithFailSlow(),
+		func(ctx context.Context, node Node) (*RunResultDetails, error) {
+			desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
+			if err != nil {
+				return nil, err
+			}
+			var cmd string
+			if c.IsLocal() {
+				cmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(node))
+			}
+			cmd += cockroachNodeBinary(c, node) + " sql --url " +
+				c.NodeURL("localhost", desc.Port, virtualClusterName, desc.ServiceMode) + " " +
+				ssh.Escape(args)
 
-		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("run-sql"))
-	}, WithDisplay(display), WithFailSlow(true))
+			return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("run-sql"))
+		})
 
 	return results, err
 }

--- a/pkg/roachprod/install/download.go
+++ b/pkg/roachprod/install/download.go
@@ -73,7 +73,7 @@ func Download(
 		dest,
 	)
 	if err := c.Run(ctx, l, l.Stdout, l.Stderr,
-		downloadNodes,
+		OnNodes(downloadNodes),
 		fmt.Sprintf("downloading %s", basename),
 		downloadCmd,
 	); err != nil {
@@ -85,7 +85,7 @@ func Download(
 	if c.IsLocal() && !filepath.IsAbs(dest) {
 		src := filepath.Join(c.localVMDir(downloadNodes[0]), dest)
 		cpCmd := fmt.Sprintf(`cp "%s" "%s"`, src, dest)
-		return c.Run(ctx, l, l.Stdout, l.Stderr, c.Nodes[1:], "copying to remaining nodes", cpCmd)
+		return c.Run(ctx, l, l.Stdout, l.Stderr, OnNodes(c.Nodes[1:]), "copying to remaining nodes", cpCmd)
 	}
 
 	return nil

--- a/pkg/roachprod/install/install.go
+++ b/pkg/roachprod/install/install.go
@@ -161,7 +161,7 @@ func SortedCmds() []string {
 func Install(ctx context.Context, l *logger.Logger, c *SyncedCluster, args []string) error {
 	do := func(title, cmd string) error {
 		var buf bytes.Buffer
-		err := c.Run(ctx, l, &buf, &buf, c.Nodes, "installing "+title, cmd)
+		err := c.Run(ctx, l, &buf, &buf, OnNodes(c.Nodes), "installing "+title, cmd)
 		if err != nil {
 			l.Printf(buf.String())
 		}

--- a/pkg/roachprod/install/run_options.go
+++ b/pkg/roachprod/install/run_options.go
@@ -1,0 +1,63 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package install
+
+import "github.com/cockroachdb/cockroach/pkg/util/retry"
+
+type RunOptions struct {
+	*RetryOpts
+	// WaitOnFail will cause the Parallel function to wait for all nodes to
+	// finish when encountering a command error on any node. The default
+	// behaviour is to exit immediately on the first error, in which case the
+	// slice of ParallelResults will only contain the one error result.
+	WaitOnFail bool
+	// These are private to roachprod
+	Concurrency int
+	Display     string
+}
+
+type RunOption func(runOpts *RunOptions)
+
+func WithRetryOpts(retryOpts *RetryOpts) RunOption {
+	return func(runOpts *RunOptions) {
+		runOpts.RetryOpts = retryOpts
+	}
+}
+
+func WithWaitOnFail() RunOption {
+	return func(runOpts *RunOptions) {
+		runOpts.WaitOnFail = true
+	}
+}
+
+func WithConcurrency(concurrency int) RunOption {
+	return func(runOpts *RunOptions) {
+		runOpts.Concurrency = concurrency
+	}
+}
+
+func WithDisplay(display string) RunOption {
+	return func(runOpts *RunOptions) {
+		runOpts.Display = display
+	}
+}
+
+type RetryOpts struct {
+	retry.Options
+	ShouldRetryFn func(*RunResultDetails) bool
+}
+
+func NewRetryOpts(retryOpts retry.Options, shouldRetryFn func(*RunResultDetails) bool) *RetryOpts {
+	return &RetryOpts{
+		Options:       retryOpts,
+		ShouldRetryFn: shouldRetryFn,
+	}
+}

--- a/pkg/roachprod/install/run_options.go
+++ b/pkg/roachprod/install/run_options.go
@@ -13,12 +13,20 @@ package install
 import "github.com/cockroachdb/cockroach/pkg/util/retry"
 
 type RunOptions struct {
-	*RetryOpts
-	// WaitOnFail will cause the Parallel function to wait for all nodes to
+	// RetryOptions are the retry options
+	RetryOptions *retry.Options
+	// ShouldRetryFn is only applicable when RetryOptions is not nil
+	// and specifies a function to be called in the case that a retry
+	// is about to be performed. A user can provide a function which, for
+	// example, inspects the previous result's output, and decides not to
+	// retry any further, by returning false.
+	ShouldRetryFn func(*RunResultDetails) bool
+	// FailSlow will cause the Parallel function to wait for all nodes to
 	// finish when encountering a command error on any node. The default
 	// behaviour is to exit immediately on the first error, in which case the
 	// slice of ParallelResults will only contain the one error result.
-	WaitOnFail bool
+	// Named as such to make clear that this is not enabled by default.
+	FailSlow bool
 	// These are private to roachprod
 	Concurrency int
 	Display     string
@@ -26,15 +34,31 @@ type RunOptions struct {
 
 type RunOption func(runOpts *RunOptions)
 
-func WithRetryOpts(retryOpts *RetryOpts) RunOption {
+// WithRetryOpts specifies retry behaviour
+func WithRetryOpts(retryOpts retry.Options) RunOption {
 	return func(runOpts *RunOptions) {
-		runOpts.RetryOpts = retryOpts
+		runOpts.RetryOptions = &retryOpts
 	}
 }
 
-func WithWaitOnFail() RunOption {
+// WithRetryDisabled disables retries for a command,
+// and is a friendly equivalent to `WithRetryOpts(nil)`
+func WithRetryDisabled() RunOption {
 	return func(runOpts *RunOptions) {
-		runOpts.WaitOnFail = true
+		runOpts.RetryOptions = nil
+	}
+}
+
+// WithRetryFn is only applicable when retryOpts is not nil
+func WithRetryFn(fn func(*RunResultDetails) bool) RunOption {
+	return func(runOpts *RunOptions) {
+		runOpts.ShouldRetryFn = fn
+	}
+}
+
+func WithFailSlow(failSlow bool) RunOption {
+	return func(runOpts *RunOptions) {
+		runOpts.FailSlow = failSlow
 	}
 }
 
@@ -47,17 +71,5 @@ func WithConcurrency(concurrency int) RunOption {
 func WithDisplay(display string) RunOption {
 	return func(runOpts *RunOptions) {
 		runOpts.Display = display
-	}
-}
-
-type RetryOpts struct {
-	retry.Options
-	ShouldRetryFn func(*RunResultDetails) bool
-}
-
-func NewRetryOpts(retryOpts retry.Options, shouldRetryFn func(*RunResultDetails) bool) *RetryOpts {
-	return &RetryOpts{
-		Options:       retryOpts,
-		ShouldRetryFn: shouldRetryFn,
 	}
 }

--- a/pkg/roachprod/install/staging.go
+++ b/pkg/roachprod/install/staging.go
@@ -303,7 +303,7 @@ func stageRemoteBinary(
 		`curl -sfSL -o "%s" "%s" && chmod 755 %s`, target, binURL, target,
 	)
 	return c.Run(
-		ctx, l, l.Stdout, l.Stderr, c.Nodes, fmt.Sprintf("staging binary (%s)", applicationName), cmdStr,
+		ctx, l, l.Stdout, l.Stderr, OnNodes(c.Nodes), fmt.Sprintf("staging binary (%s)", applicationName), cmdStr,
 	)
 }
 
@@ -333,7 +333,7 @@ curl -sfSL -o "%s" "%s" 2>/dev/null || echo 'optional library %s not found; cont
 		libraryName+ext,
 	)
 	return c.Run(
-		ctx, l, l.Stdout, l.Stderr, c.Nodes, fmt.Sprintf("staging library (%s)", libraryName), cmdStr,
+		ctx, l, l.Stdout, l.Stderr, OnNodes(c.Nodes), fmt.Sprintf("staging library (%s)", libraryName), cmdStr,
 	)
 }
 
@@ -372,6 +372,6 @@ if [ -d ${tmpdir}/lib ]; then mv ${tmpdir}/lib/* ${dir}/lib; fi && \
 chmod 755 ${dir}/cockroach
 `, dir, binURL)
 	return c.Run(
-		ctx, l, l.Stdout, l.Stderr, c.Nodes, "staging cockroach release binary", cmdStr,
+		ctx, l, l.Stdout, l.Stderr, OnNodes(c.Nodes), "staging cockroach release binary", cmdStr,
 	)
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -403,7 +403,7 @@ func RunWithDetails(
 	}
 
 	cmd := strings.TrimSpace(strings.Join(cmdArray, " "))
-	return c.RunWithDetails(ctx, l, c.Nodes, TruncateString(cmd, 30), cmd)
+	return c.RunWithDetails(ctx, l, c.Nodes, TruncateString(cmd, 30), cmd, opts...)
 }
 
 // SQL runs `cockroach sql` on a remote cluster. If a single node is passed,

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -359,7 +359,7 @@ func Run(
 	secure bool,
 	stdout, stderr io.Writer,
 	cmdArray []string,
-	opts ...install.RunOption,
+	options install.RunOptions,
 ) error {
 	if err := LoadClusters(); err != nil {
 		return err
@@ -374,9 +374,13 @@ func Run(
 	if len(cmdArray) == 0 {
 		return c.SSH(ctx, l, strings.Split(SSHOptions, " "), cmdArray)
 	}
+	// If no nodes were specified, run on nodes derived from the clusterName.
+	if len(options.Nodes) == 0 {
+		options.Nodes = c.TargetNodes()
+	}
 
 	cmd := strings.TrimSpace(strings.Join(cmdArray, " "))
-	return c.Run(ctx, l, stdout, stderr, c.Nodes, TruncateString(cmd, 30), cmd, opts...)
+	return c.Run(ctx, l, stdout, stderr, options, TruncateString(cmd, 30), cmd)
 }
 
 // RunWithDetails runs a command on the nodes in a cluster.
@@ -386,7 +390,7 @@ func RunWithDetails(
 	clusterName, SSHOptions, processTag string,
 	secure bool,
 	cmdArray []string,
-	opts ...install.RunOption,
+	options install.RunOptions,
 ) ([]install.RunResultDetails, error) {
 	if err := LoadClusters(); err != nil {
 		return nil, err
@@ -401,9 +405,12 @@ func RunWithDetails(
 	if len(cmdArray) == 0 {
 		return nil, c.SSH(ctx, l, strings.Split(SSHOptions, " "), cmdArray)
 	}
-
+	// If no nodes were specified, run on nodes derived from the clusterName.
+	if len(options.Nodes) == 0 {
+		options.Nodes = c.TargetNodes()
+	}
 	cmd := strings.TrimSpace(strings.Join(cmdArray, " "))
-	return c.RunWithDetails(ctx, l, c.Nodes, TruncateString(cmd, 30), cmd, opts...)
+	return c.RunWithDetails(ctx, l, options, TruncateString(cmd, 30), cmd)
 }
 
 // SQL runs `cockroach sql` on a remote cluster. If a single node is passed,
@@ -808,7 +815,7 @@ func Reformat(ctx context.Context, l *logger.Logger, clusterName string, fs stri
 		return fmt.Errorf("unknown filesystem %q", fs)
 	}
 
-	err = c.Run(ctx, l, os.Stdout, os.Stderr, c.Nodes, "reformatting", fmt.Sprintf(`
+	err = c.Run(ctx, l, os.Stdout, os.Stderr, install.OnNodes(c.Nodes), "reformatting", fmt.Sprintf(`
 set -euo pipefail
 if sudo zpool list -Ho name 2>/dev/null | grep ^data1$; then
 sudo zpool destroy -f data1
@@ -1107,71 +1114,72 @@ func Pprof(ctx context.Context, l *logger.Logger, clusterName string, opts Pprof
 
 	httpClient := httputil.NewClientWithTimeout(timeout)
 	startTime := timeutil.Now().Unix()
-	err = c.Parallel(ctx, l, c.TargetNodes(), func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
-		res := &install.RunResultDetails{Node: node}
-		host := c.Host(node)
-		port, err := c.NodeUIPort(ctx, node)
-		if err != nil {
-			return nil, err
-		}
-		scheme := "http"
-		if c.Secure {
-			scheme = "https"
-		}
-		outputFile := fmt.Sprintf("pprof-%s-%d-%s-%04d.out", profType, startTime, c.Name, node)
-		outputDir := filepath.Dir(outputFile)
-		file, err := os.CreateTemp(outputDir, ".pprof")
-		if err != nil {
-			res.Err = errors.Wrap(err, "create tmpfile for pprof download")
-			return res, res.Err
-		}
-
-		defer func() {
-			err := file.Close()
-			if err != nil && !errors.Is(err, oserror.ErrClosed) {
-				l.Errorf("warning: could not close temporary file")
+	err = c.Parallel(ctx, l, install.OnNodes(c.TargetNodes()).WithDisplay(description),
+		func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
+			res := &install.RunResultDetails{Node: node}
+			host := c.Host(node)
+			port, err := c.NodeUIPort(ctx, node)
+			if err != nil {
+				return nil, err
 			}
-			err = os.Remove(file.Name())
-			if err != nil && !oserror.IsNotExist(err) {
-				l.Errorf("warning: could not remove temporary file")
+			scheme := "http"
+			if c.Secure {
+				scheme = "https"
 			}
-		}()
+			outputFile := fmt.Sprintf("pprof-%s-%d-%s-%04d.out", profType, startTime, c.Name, node)
+			outputDir := filepath.Dir(outputFile)
+			file, err := os.CreateTemp(outputDir, ".pprof")
+			if err != nil {
+				res.Err = errors.Wrap(err, "create tmpfile for pprof download")
+				return res, res.Err
+			}
 
-		pprofURL := fmt.Sprintf("%s://%s:%d/%s", scheme, host, port, pprofPath)
-		resp, err := httpClient.Get(context.Background(), pprofURL)
-		if err != nil {
-			res.Err = err
-			return res, res.Err
-		}
-		defer resp.Body.Close()
+			defer func() {
+				err := file.Close()
+				if err != nil && !errors.Is(err, oserror.ErrClosed) {
+					l.Errorf("warning: could not close temporary file")
+				}
+				err = os.Remove(file.Name())
+				if err != nil && !oserror.IsNotExist(err) {
+					l.Errorf("warning: could not remove temporary file")
+				}
+			}()
 
-		if resp.StatusCode != http.StatusOK {
-			res.Err = errors.Newf("unexpected status from pprof endpoint: %s", resp.Status)
-			return res, res.Err
-		}
+			pprofURL := fmt.Sprintf("%s://%s:%d/%s", scheme, host, port, pprofPath)
+			resp, err := httpClient.Get(context.Background(), pprofURL)
+			if err != nil {
+				res.Err = err
+				return res, res.Err
+			}
+			defer resp.Body.Close()
 
-		if _, err := io.Copy(file, resp.Body); err != nil {
-			res.Err = err
-			return res, res.Err
-		}
-		if err := file.Sync(); err != nil {
-			res.Err = err
-			return res, res.Err
-		}
-		if err := file.Close(); err != nil {
-			res.Err = err
-			return res, res.Err
-		}
-		if err := os.Rename(file.Name(), outputFile); err != nil {
-			res.Err = err
-			return res, res.Err
-		}
+			if resp.StatusCode != http.StatusOK {
+				res.Err = errors.Newf("unexpected status from pprof endpoint: %s", resp.Status)
+				return res, res.Err
+			}
 
-		mu.Lock()
-		outputFiles = append(outputFiles, outputFile)
-		mu.Unlock()
-		return res, nil
-	}, install.WithDisplay(description))
+			if _, err := io.Copy(file, resp.Body); err != nil {
+				res.Err = err
+				return res, res.Err
+			}
+			if err := file.Sync(); err != nil {
+				res.Err = err
+				return res, res.Err
+			}
+			if err := file.Close(); err != nil {
+				res.Err = err
+				return res, res.Err
+			}
+			if err := os.Rename(file.Name(), outputFile); err != nil {
+				res.Err = err
+				return res, res.Err
+			}
+
+			mu.Lock()
+			outputFiles = append(outputFiles, outputFile)
+			mu.Unlock()
+			return res, nil
+		})
 
 	for _, s := range outputFiles {
 		l.Printf("Created %s", s)
@@ -1701,75 +1709,76 @@ func CreateSnapshot(
 		syncutil.Mutex
 		snapshots []vm.VolumeSnapshot
 	}{}
-	if err := c.Parallel(ctx, l, nodes, func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
-		res := &install.RunResultDetails{Node: node}
+	if err := c.Parallel(ctx, l, install.OnNodes(nodes),
+		func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
+			res := &install.RunResultDetails{Node: node}
 
-		cVM := c.VMs[node-1]
-		crdbVersion := statusByNodeID[int(node)].Version
-		if crdbVersion == "" {
-			crdbVersion = "unknown"
-		}
-		crdbVersion = strings.TrimPrefix(crdbVersion, "cockroach-")
-		// N.B. snapshot name cannot exceed 63 characters, so we use short sha for dev version.
-		if index := strings.Index(crdbVersion, "dev-"); index != -1 {
-			sha := crdbVersion[index+4:]
-			if len(sha) > 7 {
-				crdbVersion = crdbVersion[:index+4] + sha[:7]
+			cVM := c.VMs[node-1]
+			crdbVersion := statusByNodeID[int(node)].Version
+			if crdbVersion == "" {
+				crdbVersion = "unknown"
 			}
-		}
-
-		labels := map[string]string{
-			"roachprod-node-src-spec": cVM.MachineType,
-			"roachprod-cluster-node":  cVM.Name,
-			"roachprod-crdb-version":  crdbVersion,
-			vm.TagCluster:             clusterName,
-			vm.TagRoachprod:           "true",
-			vm.TagLifetime:            SnapshotTTL.String(),
-			vm.TagCreated: strings.ToLower(
-				strings.ReplaceAll(timeutil.Now().Format(time.RFC3339), ":", "_")), // format according to gce label naming requirements
-		}
-		for k, v := range vsco.Labels {
-			labels[k] = v
-		}
-
-		if err := vm.ForProvider(cVM.Provider, func(provider vm.Provider) error {
-			volumes, err := provider.ListVolumes(l, &cVM)
-			if err != nil {
-				return err
-			}
-
-			if len(volumes) == 0 {
-				return fmt.Errorf("node %d does not have any non-bootable persistent volumes attached", node)
-			}
-
-			for _, volume := range volumes {
-				snapshotFingerprintInfix := strings.ReplaceAll(
-					fmt.Sprintf("%s-n%d", crdbVersion, len(nodes)), ".", "-")
-				snapshotName := fmt.Sprintf("%s-%s-%04d", vsco.Name, snapshotFingerprintInfix, node)
-				if len(snapshotName) > 63 {
-					return fmt.Errorf("snapshot name %q exceeds 63 characters; shorten name prefix and use description arg. for more context", snapshotName)
+			crdbVersion = strings.TrimPrefix(crdbVersion, "cockroach-")
+			// N.B. snapshot name cannot exceed 63 characters, so we use short sha for dev version.
+			if index := strings.Index(crdbVersion, "dev-"); index != -1 {
+				sha := crdbVersion[index+4:]
+				if len(sha) > 7 {
+					crdbVersion = crdbVersion[:index+4] + sha[:7]
 				}
-				volumeSnapshot, err := provider.CreateVolumeSnapshot(l, volume,
-					vm.VolumeSnapshotCreateOpts{
-						Name:        snapshotName,
-						Labels:      labels,
-						Description: vsco.Description,
-					})
+			}
+
+			labels := map[string]string{
+				"roachprod-node-src-spec": cVM.MachineType,
+				"roachprod-cluster-node":  cVM.Name,
+				"roachprod-crdb-version":  crdbVersion,
+				vm.TagCluster:             clusterName,
+				vm.TagRoachprod:           "true",
+				vm.TagLifetime:            SnapshotTTL.String(),
+				vm.TagCreated: strings.ToLower(
+					strings.ReplaceAll(timeutil.Now().Format(time.RFC3339), ":", "_")), // format according to gce label naming requirements
+			}
+			for k, v := range vsco.Labels {
+				labels[k] = v
+			}
+
+			if err := vm.ForProvider(cVM.Provider, func(provider vm.Provider) error {
+				volumes, err := provider.ListVolumes(l, &cVM)
 				if err != nil {
 					return err
 				}
-				l.Printf("created volume snapshot %s (id=%s) for volume %s on %s/n%d\n",
-					volumeSnapshot.Name, volumeSnapshot.ID, volume.Name, volume.ProviderResourceID, node)
-				volumesSnapshotMu.Lock()
-				volumesSnapshotMu.snapshots = append(volumesSnapshotMu.snapshots, volumeSnapshot)
-				volumesSnapshotMu.Unlock()
+
+				if len(volumes) == 0 {
+					return fmt.Errorf("node %d does not have any non-bootable persistent volumes attached", node)
+				}
+
+				for _, volume := range volumes {
+					snapshotFingerprintInfix := strings.ReplaceAll(
+						fmt.Sprintf("%s-n%d", crdbVersion, len(nodes)), ".", "-")
+					snapshotName := fmt.Sprintf("%s-%s-%04d", vsco.Name, snapshotFingerprintInfix, node)
+					if len(snapshotName) > 63 {
+						return fmt.Errorf("snapshot name %q exceeds 63 characters; shorten name prefix and use description arg. for more context", snapshotName)
+					}
+					volumeSnapshot, err := provider.CreateVolumeSnapshot(l, volume,
+						vm.VolumeSnapshotCreateOpts{
+							Name:        snapshotName,
+							Labels:      labels,
+							Description: vsco.Description,
+						})
+					if err != nil {
+						return err
+					}
+					l.Printf("created volume snapshot %s (id=%s) for volume %s on %s/n%d\n",
+						volumeSnapshot.Name, volumeSnapshot.ID, volume.Name, volume.ProviderResourceID, node)
+					volumesSnapshotMu.Lock()
+					volumesSnapshotMu.snapshots = append(volumesSnapshotMu.snapshots, volumeSnapshot)
+					volumesSnapshotMu.Unlock()
+				}
+				return nil
+			}); err != nil {
+				res.Err = err
 			}
-			return nil
+			return res, nil
 		}); err != nil {
-			res.Err = err
-		}
-		return res, nil
-	}); err != nil {
 		return nil, err
 	}
 
@@ -1820,97 +1829,99 @@ func ApplySnapshots(
 	}
 
 	// Detach and delete existing volumes. This is destructive.
-	if err := c.Parallel(ctx, l, c.TargetNodes(), func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
-		res := &install.RunResultDetails{Node: node}
+	if err := c.Parallel(ctx, l, install.OnNodes(c.TargetNodes()),
+		func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
+			res := &install.RunResultDetails{Node: node}
 
-		cVM := &c.VMs[node-1]
-		if err := vm.ForProvider(cVM.Provider, func(provider vm.Provider) error {
-			volumes, err := provider.ListVolumes(l, cVM)
-			if err != nil {
-				return err
-			}
-			for _, volume := range volumes {
-				if err := provider.DeleteVolume(l, volume, cVM); err != nil {
+			cVM := &c.VMs[node-1]
+			if err := vm.ForProvider(cVM.Provider, func(provider vm.Provider) error {
+				volumes, err := provider.ListVolumes(l, cVM)
+				if err != nil {
 					return err
 				}
-				l.Printf("detached and deleted volume %s from %s", volume.ProviderResourceID, cVM.Name)
+				for _, volume := range volumes {
+					if err := provider.DeleteVolume(l, volume, cVM); err != nil {
+						return err
+					}
+					l.Printf("detached and deleted volume %s from %s", volume.ProviderResourceID, cVM.Name)
+				}
+				return nil
+			}); err != nil {
+				res.Err = err
 			}
-			return nil
+			return res, nil
 		}); err != nil {
-			res.Err = err
-		}
-		return res, nil
-	}); err != nil {
 		return err
 	}
 
-	return c.Parallel(ctx, l, c.TargetNodes(), func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
-		res := &install.RunResultDetails{Node: node}
+	return c.Parallel(ctx, l, install.OnNodes(c.TargetNodes()),
+		func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
+			res := &install.RunResultDetails{Node: node}
 
-		volumeOpts := opts // make a copy
-		volumeOpts.Labels = map[string]string{}
-		for k, v := range opts.Labels {
-			volumeOpts.Labels[k] = v
-		}
-
-		// TODO: same issue as above if the target nodes are not sequential starting from 1
-		cVM := &c.VMs[node-1]
-		if err := vm.ForProvider(cVM.Provider, func(provider vm.Provider) error {
-			volumeOpts.Zone = cVM.Zone
-			// NB: The "-1" signifies that it's the first attached non-boot volume.
-			// This is typical naming convention in GCE clusters.
-			volumeOpts.Name = fmt.Sprintf("%s-%04d-1", clusterName, node)
-			volumeOpts.SourceSnapshotID = snapshots[node-1].ID
-
-			volumes, err := provider.ListVolumes(l, cVM)
-			if err != nil {
-				return err
+			volumeOpts := opts // make a copy
+			volumeOpts.Labels = map[string]string{}
+			for k, v := range opts.Labels {
+				volumeOpts.Labels[k] = v
 			}
-			for _, vol := range volumes {
-				if vol.Name == volumeOpts.Name {
-					l.Printf(
-						"volume (%s) is already attached to node %d skipping volume creation", vol.ProviderResourceID, node)
-					return nil
+
+			// TODO: same issue as above if the target nodes are not sequential starting from 1
+			cVM := &c.VMs[node-1]
+			if err := vm.ForProvider(cVM.Provider, func(provider vm.Provider) error {
+				volumeOpts.Zone = cVM.Zone
+				// NB: The "-1" signifies that it's the first attached non-boot volume.
+				// This is typical naming convention in GCE clusters.
+				volumeOpts.Name = fmt.Sprintf("%s-%04d-1", clusterName, node)
+				volumeOpts.SourceSnapshotID = snapshots[node-1].ID
+
+				volumes, err := provider.ListVolumes(l, cVM)
+				if err != nil {
+					return err
 				}
+				for _, vol := range volumes {
+					if vol.Name == volumeOpts.Name {
+						l.Printf(
+							"volume (%s) is already attached to node %d skipping volume creation", vol.ProviderResourceID, node)
+						return nil
+					}
+				}
+
+				volumeOpts.Labels[vm.TagCluster] = clusterName
+				volumeOpts.Labels[vm.TagLifetime] = cVM.Lifetime.String()
+				volumeOpts.Labels[vm.TagRoachprod] = "true"
+				volumeOpts.Labels[vm.TagCreated] = strings.ToLower(
+					strings.ReplaceAll(timeutil.Now().Format(time.RFC3339), ":", "_")) // format according to gce label naming requirements
+
+				volume, err := provider.CreateVolume(l, volumeOpts)
+				if err != nil {
+					return err
+				}
+				l.Printf("created volume %s", volume.ProviderResourceID)
+
+				device, err := cVM.AttachVolume(l, volume)
+				if err != nil {
+					return err
+				}
+				l.Printf("attached volume %s to %s", volume.ProviderResourceID, cVM.ProviderID)
+
+				// Save the cluster to cache.
+				if err := saveCluster(l, &c.Cluster); err != nil {
+					return err
+				}
+
+				var buf bytes.Buffer
+				if err := c.Run(ctx, l, &buf, &buf, install.OnNodes([]install.Node{node}),
+					"mounting volume", genMountCommands(device, "/mnt/data1")); err != nil {
+					l.Printf(buf.String())
+					return err
+				}
+				l.Printf("mounted %s to %s", volume.ProviderResourceID, cVM.ProviderID)
+
+				return nil
+			}); err != nil {
+				res.Err = err
 			}
-
-			volumeOpts.Labels[vm.TagCluster] = clusterName
-			volumeOpts.Labels[vm.TagLifetime] = cVM.Lifetime.String()
-			volumeOpts.Labels[vm.TagRoachprod] = "true"
-			volumeOpts.Labels[vm.TagCreated] = strings.ToLower(
-				strings.ReplaceAll(timeutil.Now().Format(time.RFC3339), ":", "_")) // format according to gce label naming requirements
-
-			volume, err := provider.CreateVolume(l, volumeOpts)
-			if err != nil {
-				return err
-			}
-			l.Printf("created volume %s", volume.ProviderResourceID)
-
-			device, err := cVM.AttachVolume(l, volume)
-			if err != nil {
-				return err
-			}
-			l.Printf("attached volume %s to %s", volume.ProviderResourceID, cVM.ProviderID)
-
-			// Save the cluster to cache.
-			if err := saveCluster(l, &c.Cluster); err != nil {
-				return err
-			}
-
-			var buf bytes.Buffer
-			if err := c.Run(ctx, l, &buf, &buf, []install.Node{node},
-				"mounting volume", genMountCommands(device, "/mnt/data1")); err != nil {
-				l.Printf(buf.String())
-				return err
-			}
-			l.Printf("mounted %s to %s", volume.ProviderResourceID, cVM.ProviderID)
-
-			return nil
-		}); err != nil {
-			res.Err = err
-		}
-		return res, nil
-	})
+			return res, nil
+		})
 }
 
 func genMountCommands(devicePath, mountDir string) string {
@@ -1995,7 +2006,7 @@ func sendCaptureCommand(
 ) error {
 	nodes := c.TargetNodes()
 	httpClient := httputil.NewClientWithTimeout(0 /* timeout: None */)
-	_, _, err := c.ParallelE(ctx, l, nodes,
+	_, _, err := c.ParallelE(ctx, l, install.OnNodes(nodes).WithDisplay(fmt.Sprintf("Performing workload capture %s", action)),
 		func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
 			port, err := c.NodeUIPort(ctx, node)
 			if err != nil {
@@ -2062,7 +2073,7 @@ func sendCaptureCommand(
 				}
 			}
 			return res, res.Err
-		}, install.WithDisplay(fmt.Sprintf("Performing workload capture %s", action)))
+		})
 	return err
 }
 
@@ -2104,7 +2115,7 @@ func createAttachMountVolumes(
 				return err
 			}
 			l.Printf("Attached Volume %s to %s", volume.ProviderResourceID, cVM.ProviderID)
-			err = c.Run(ctx, l, l.Stdout, l.Stderr, curNode,
+			err = c.Run(ctx, l, l.Stdout, l.Stderr, install.OnNodes(curNode),
 				"Mounting volume", genMountCommands(device, mountDir))
 			return err
 		})

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -359,7 +359,7 @@ func Run(
 	secure bool,
 	stdout, stderr io.Writer,
 	cmdArray []string,
-	opts ...install.ParallelOption,
+	opts ...install.RunOption,
 ) error {
 	if err := LoadClusters(); err != nil {
 		return err
@@ -386,6 +386,7 @@ func RunWithDetails(
 	clusterName, SSHOptions, processTag string,
 	secure bool,
 	cmdArray []string,
+	opts ...install.RunOption,
 ) ([]install.RunResultDetails, error) {
 	if err := LoadClusters(); err != nil {
 		return nil, err


### PR DESCRIPTION
Backport 4/4 commits from #112411.

/cc @cockroachdb/release

---

SSH retries are implemented when executing commands via roachprod, transparent to the user. i.e. As a result, today, commands executed via `c.Run` retry automatically if the error has an exit code of `255` (ssh issue). 

In order to make this more configurable for the caller the following changes are introduced:

1. Implement an options struct to specify run options:
   * `install.RunOptions` can be constructed by specifying the nodes the operation intends to run on.
   * The options can be customised by calling the convenience `.With` methods.
2. Refactor existing options
   * Remove `install.RetryOpts` which contains `retry.Options` and `func(*RunResultDetails) bool` into separately specifiable options. This exposes the more familiar `retry.Options` directly to callers.
   * Expose `WithRetryOpts(...)` and `WithRetryFn(...)`
   * Set retry defaults in `c.Parallel` which are overridable by callers.

3. The existing API functions in `roachtest` have been left untouched for now, but will be updated to use the `RunOptions` struct in a follow-up PR.

The goal is to introduce the new API without changing any of the tests (via preserving the existing API). A future change will remove the old functions, and rename the new ones.

Follow up PRs to
- Remove custom retry logic in favour of roachprod retries
- Disable retries on certain long running tests such as `weekly/tpcc/headroom`
- Update the default roachprod ssh retry, which is enabled automatically
- Refactor `roachtest` calls to use the `RunOptions` struct in the `run` functions.

Epic: none
Release note: none
Fixes: #105753 

Release justification: Test only change.
