### PR TITLE
rangefeed: fix premature checkpoint due to intent resolution race

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -1685,6 +1685,9 @@ message LeaseInfoResponse{
   // still not evaluated by the node it was sent to if that node's replica is a
   // learner or the node doesn't have a replica at all.
   int32 evaluated_by = 4 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.StoreID"];
+  // LeaseAppliedIndex is the lease applied index of the last applied command at
+  // the time that the LeaseInfo request is executed.
+  uint64 lease_applied_index = 5 [(gogoproto.casttype) = "LeaseAppliedIndex"];
 }
 
 // A RequestLeaseResponse is the response to a RequestLease() or TransferLease()

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -109,6 +109,7 @@ go_test(
         "cmd_export_test.go",
         "cmd_get_test.go",
         "cmd_is_span_empty_test.go",
+        "cmd_lease_info_test.go",
         "cmd_lease_test.go",
         "cmd_query_intent_test.go",
         "cmd_query_resolved_timestamp_test.go",

--- a/pkg/kv/kvserver/batcheval/cmd_lease_info.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_info.go
@@ -54,5 +54,6 @@ func LeaseInfo(
 		reply.Lease = lease
 	}
 	reply.EvaluatedBy = cArgs.EvalCtx.StoreID()
+	reply.LeaseAppliedIndex = cArgs.EvalCtx.GetLeaseAppliedIndex()
 	return result.Result{}, nil
 }

--- a/pkg/kv/kvserver/batcheval/cmd_lease_info_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_info_test.go
@@ -1,0 +1,69 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package batcheval_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeaseInfo(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	lease := roachpb.Lease{Sequence: 1}
+	nextLease := roachpb.Lease{Sequence: 2}
+	storeID := roachpb.StoreID(7)
+	lai := kvpb.LeaseAppliedIndex(314)
+
+	// Test with and without pending lease transfer.
+	testutils.RunTrueAndFalse(t, "transfer", func(t *testing.T, transfer bool) {
+		evalCtx := batcheval.MockEvalCtx{
+			Lease:             lease,
+			StoreID:           storeID,
+			LeaseAppliedIndex: lai,
+		}
+		if transfer {
+			evalCtx.NextLease = nextLease
+		}
+
+		var resp kvpb.LeaseInfoResponse
+		_, err := batcheval.LeaseInfo(ctx, nil /* reader */, batcheval.CommandArgs{
+			EvalCtx: evalCtx.EvalContext(),
+			Args:    &kvpb.LeaseInfoRequest{},
+		}, &resp)
+		require.NoError(t, err)
+
+		if transfer {
+			require.Equal(t, kvpb.LeaseInfoResponse{
+				Lease:             nextLease,
+				CurrentLease:      &lease,
+				LeaseAppliedIndex: lai,
+				EvaluatedBy:       storeID,
+			}, resp)
+		} else {
+			require.Equal(t, kvpb.LeaseInfoResponse{
+				Lease:             lease,
+				LeaseAppliedIndex: lai,
+				EvaluatedBy:       storeID,
+			}, resp)
+		}
+	})
+}

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -180,6 +180,8 @@ type MockEvalCtx struct {
 	CanCreateTxnRecordFn func() (bool, kvpb.TransactionAbortedReason)
 	MinTxnCommitTSFn     func() hlc.Timestamp
 	Lease                roachpb.Lease
+	NextLease            roachpb.Lease
+	LeaseAppliedIndex    kvpb.LeaseAppliedIndex
 	CurrentReadSummary   rspb.ReadSummary
 	ClosedTimestamp      hlc.Timestamp
 	RevokedLeaseSeq      roachpb.LeaseSequence
@@ -240,7 +242,7 @@ func (m *mockEvalCtxImpl) GetTerm(kvpb.RaftIndex) (kvpb.RaftTerm, error) {
 	return m.Term, nil
 }
 func (m *mockEvalCtxImpl) GetLeaseAppliedIndex() kvpb.LeaseAppliedIndex {
-	panic("unimplemented")
+	return m.LeaseAppliedIndex
 }
 func (m *mockEvalCtxImpl) Desc() *roachpb.RangeDescriptor {
 	return m.MockEvalCtx.Desc
@@ -283,7 +285,7 @@ func (m *mockEvalCtxImpl) GetLastReplicaGCTimestamp(context.Context) (hlc.Timest
 	panic("unimplemented")
 }
 func (m *mockEvalCtxImpl) GetLease() (roachpb.Lease, roachpb.Lease) {
-	return m.Lease, roachpb.Lease{}
+	return m.Lease, m.NextLease
 }
 func (m *mockEvalCtxImpl) GetRangeInfo(ctx context.Context) roachpb.RangeInfo {
 	return roachpb.RangeInfo{Desc: *m.Desc(), Lease: m.Lease}

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -372,6 +373,14 @@ func (tp *testTxnPusher) PushTxns(
 
 func (tp *testTxnPusher) ResolveIntents(ctx context.Context, intents []roachpb.LockUpdate) error {
 	return tp.resolveIntentsFn(ctx, intents)
+}
+
+func (tp *testTxnPusher) GetLeaseholderLAI(ctx context.Context) (kvpb.LeaseAppliedIndex, error) {
+	return 0, nil
+}
+
+func (tp *testTxnPusher) GetReplicaLAI(ctx context.Context) kvpb.LeaseAppliedIndex {
+	return 0
 }
 
 func (tp *testTxnPusher) mockPushTxns(


### PR DESCRIPTION
Naïve proof of concept, needs additional testing and improvements. Does this seem reasonable to you @nvanbenschoten?

Given the severity of this, I'm inclined to backport it despite the protocol change.

cc @miretskiy 

---

**kvpb: add `LeaseInfoResponse.LeaseAppliedIndex`**

This returns the current lease applied index of the current leaseholder. This is useful e.g. if followers want to ensure they have applied all pending log entries that have currently been applied on the leaseholder.

**rangefeed: fix premature checkpoint due to intent resolution race**

`PushTxn` may return a false `ABORTED` status for a transaction that has in fact been committed, if the transaction record has been removed after resolving all intents. This is possible because the timestamp cache does not retain sufficient information to disambiguate a committed transaction from an aborted one for removed transaction records (see `Replica.CanCreateTxnRecord` and `batcheval.SynthesizeTxnFromMeta`).

However, the rangefeed txn pusher trusted this `ABORTED` status, and removed the txn's intents from the rangefeed's resolved timestamp intent queue. This can lead to the following sequence of events:

1. A rangefeed is established on a follower F.

2. A txn writes an intent at time t1, applied on the leaseholder L.

3. L emits a closed timestamp t2.

4. F applies the intent write and closed timestamp t2.

5. The txn commits with write timestamp t1.

6. The txn's intent and record is removed on L, but not yet on F.

7. F pushes the txn on L, receives `ABORTED` and discards the intents.

8. F emits a checkpoint at t2 across the rangefeed.

9. F applies the intent resolution, emits an event at t1 < checkpoint t2.

This violates the fundamental checkpoint guarantee. Furthermore, a changefeed will drop events below its frontier, so this write may not be emitted to clients at all.

This patch fixes the bug by waiting for the local replica to reach the leaseholder's current lease applied index before removing the intents from tracking, which will ensure that any intents that have been resolved on the leaseholder will also be applied on the local replica first.

Resolves #104309.
Replaces #111218.
Epic: none

Release note (bug fix): fixed a bug where a rangefeed could emit a checkpoint before emitting all committed writes below it. This could happen if the rangefeed runs on a follower replica that lags significantly behind the leaseholder (beyond the closed timestamp target duration), a transaction has been running for more than 10 seconds before committing, and the transaction is able to quickly resolve all intents and remove its transaction record. This may result in a changefeed omitting the write event entirely, logging an error like "cdc ux violation: detected timestamp ... that is less or equal to the local frontier".

**rangefeed: assert intent commits above resolved timestamp**