### PR TITLE
release: fix release qualification script

### DIFF
--- a/build/teamcity/internal/release/process/roachtest-release-qualification.sh
+++ b/build/teamcity/internal/release/process/roachtest-release-qualification.sh
@@ -39,6 +39,7 @@ chmod +x cockroach
 run_bazel <<'EOF'
 bazel build --config ci --config crosslinux //pkg/cmd/workload //pkg/cmd/roachtest //pkg/cmd/roachprod
 BAZEL_BIN=$(bazel info bazel-bin --config ci --config crosslinux)
+mkdir -p bin
 cp $BAZEL_BIN/pkg/cmd/roachprod/roachprod_/roachprod bin
 cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
 cp $BAZEL_BIN/pkg/cmd/workload/workload_/workload    bin


### PR DESCRIPTION
Previously, the script tried to copy files to the `bin` directory, but there was no guaranty that the directory existed.

This PR fixes the assumption by creating the `bin` directory.

Epic: none
Release note: None