### PR TITLE
roachtest: make tpce/c=100000/nodes=5 a benchmark test

### DIFF
--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -269,6 +269,7 @@ func registerTPCE(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("tpce/c=%d/nodes=%d", largeWeekly.customers, largeWeekly.nodes),
 		Owner:            registry.OwnerTestEng,
+		Benchmark:        true,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Weekly),
 		Tags:             registry.Tags("weekly"),


### PR DESCRIPTION
This test is essentially used as a benchmarking test, but was previously not opted in via TestSpec.Bencmark.

We now opt it in so we can fetch perf artifacts and opt it out of metamorphic builds.

Epic: none
Release note: none
Fixes: #114343