### PR TITLE
github-pull-request-make: pass timeout via -test.timeout

### DIFF
--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -358,7 +358,8 @@ func main() {
 				args = append(args, fmt.Sprintf("--test_timeout=%d", int((duration+1*time.Minute).Seconds())))
 				args = append(args, "--test_output", "streamed")
 
-				args = append(args, "--run_under", fmt.Sprintf("%s -bazel -shardable-artifacts 'XML_OUTPUT_FILE=%s merge-test-xmls' -stderr -maxfails 1 -maxtime %s -p %d -timeout %s", bazelStressTarget, bazciPath, duration, parallelism, timeout))
+				args = append(args, "--run_under", fmt.Sprintf("%s -bazel -shardable-artifacts 'XML_OUTPUT_FILE=%s merge-test-xmls' -stderr -maxfails 1 -maxtime %s -p %d", bazelStressTarget, bazciPath, duration, parallelism))
+				args = append(args, "--test_arg", "-test.timeout", "--test_arg", timeout.String())
 				cmd := exec.Command("bazci", args...)
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr


### PR DESCRIPTION
The `-timeout` flag causes the test to be unceremoniously killed.
Instead use `-test.timeout` via `--test_arg` which has better behavior
(produces stacktraces, etc.)

Epic: none
Release note: None