### PR TITLE
stress: use CI timeouts

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_engflow.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+export EXTRA_TEST_ARGS="--config use_ci_timeouts"
+
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 
 $THIS_DIR/stress_engflow_impl.sh


### PR DESCRIPTION
The default timeout is 60m for enormous tests which can delay things quite a bit. Opt in to using CI timeouts (15m for long-running tests).

Epic: CRDB-8308
Release note: None