### PR TITLE
backupccl: consider followers in backup proc planning

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -86,6 +86,12 @@ var BackupCheckpointInterval = settings.RegisterDurationSetting(
 	"the minimum time between writing progress checkpoints during a backup",
 	time.Minute)
 
+var backupUseFollowerReads = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"bulkio.backup.plan_on_followers.enabled",
+	"assume utilization of follower reads when planning backup worker placement",
+	true)
+
 var forceReadBackupManifest = util.ConstantWithMetamorphicTestBool("backup-read-manifest", false)
 
 func countRows(raw kvpb.BulkOpSummary, pkIDs map[uint64]bool) roachpb.RowCount {
@@ -199,10 +205,22 @@ func backup(
 	evalCtx := execCtx.ExtendedEvalContext()
 	dsp := execCtx.DistSQLPlanner()
 
+	// planningTimestamp is passed to dsp planning as a means of conveying the
+	// timestamp at which we will be reading so that it can determine if followers
+	// should be eligible. It is not used for anything other than its timestamps
+	// and thus is never committed or rolled back.
+	var planningTimestamp *kv.Txn
+	if backupUseFollowerReads.Get(evalCtx.ExecCfg.SV()) {
+		planningTimestamp = kv.NewTxn(ctx, execCtx.ExecCfg().DB, roachpb.NodeID(dsp.GatewayID()))
+		if err := planningTimestamp.SetFixedTimestamp(ctx, backupManifest.EndTime); err != nil {
+			return roachpb.RowCount{}, 0, err
+		}
+	}
+
 	// We don't return the compatible nodes here since PartitionSpans will
 	// filter out incompatible nodes.
-	planCtx, _, err := dsp.SetupAllNodesPlanningWithOracle(
-		ctx, evalCtx, execCtx.ExecCfg(), physicalplan.DefaultReplicaChooser, execLocality,
+	planCtx, _, err := dsp.SetupAllNodesPlanningWithOracleAndFollowers(
+		ctx, evalCtx, execCtx.ExecCfg(), physicalplan.DefaultReplicaChooser, execLocality, planningTimestamp,
 	)
 	if err != nil {
 		return roachpb.RowCount{}, 0, errors.Wrap(err, "failed to determine nodes on which to run")

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1651,6 +1651,7 @@ func TestBackupRestoreResume(t *testing.T) {
 					Files: []backuppb.BackupManifest_File{
 						{Path: "garbage-checkpoint", Span: backupCompletedSpan},
 					},
+					EndTime: srv.Clock().Now(),
 				})
 				if err != nil {
 					t.Fatal(err)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4732,11 +4732,11 @@ func (dsp *DistSQLPlanner) NewPlanningCtx(
 	ctx context.Context,
 	evalCtx *extendedEvalContext,
 	planner *planner,
-	txn *kv.Txn,
+	spanResolutionTS *kv.Txn,
 	distributionType DistributionType,
 ) *PlanningCtx {
 	return dsp.NewPlanningCtxWithOracle(
-		ctx, evalCtx, planner, txn, distributionType, physicalplan.DefaultReplicaChooser, roachpb.Locality{},
+		ctx, evalCtx, planner, spanResolutionTS, distributionType, physicalplan.DefaultReplicaChooser, roachpb.Locality{},
 	)
 }
 
@@ -4746,7 +4746,7 @@ func (dsp *DistSQLPlanner) NewPlanningCtxWithOracle(
 	ctx context.Context,
 	evalCtx *extendedEvalContext,
 	planner *planner,
-	txn *kv.Txn,
+	spanResolutionTS *kv.Txn,
 	distributionType DistributionType,
 	oracle replicaoracle.Oracle,
 	localityFiler roachpb.Locality,
@@ -4785,7 +4785,7 @@ func (dsp *DistSQLPlanner) NewPlanningCtxWithOracle(
 		// we still need to instantiate a full planning context.
 		planCtx.parallelizeScansIfLocal = true
 	}
-	planCtx.spanIter = dsp.spanResolver.NewSpanResolverIterator(txn, oracle)
+	planCtx.spanIter = dsp.spanResolver.NewSpanResolverIterator(spanResolutionTS, oracle)
 	planCtx.nodeStatuses = make(map[base.SQLInstanceID]NodeStatus)
 	planCtx.nodeStatuses[dsp.gatewaySQLInstanceID] = NodeOK
 	return planCtx


### PR DESCRIPTION
Followers are only considered when planning procesor placement if the txn passed to the replica oracle is non-nil, as the txn timestamp is what is used to determine if it is able to be served by a follower.

This changes backup to pass a non-nil txn that is used exclusively to carry this timestamp from the backup process to the planning oracle.

Release note (bug fix): backups will now plan where to execute taking follower replicas into account.
Epic: none.