### PR TITLE
kvstreamer: use large pool for remote execution

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/BUILD.bazel
+++ b/pkg/kv/kvclient/kvstreamer/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "streamer_test.go",
     ],
     embed = [":kvstreamer"],
+    exec_properties = {"Pool": "large"},
     deps = [
         "//pkg/base",
         "//pkg/keys",


### PR DESCRIPTION
See #114225

Epic: CRDB-8308
Release note: None