### PR TITLE
release-23.2: sql: use 'background' QoS for COPY by default

### DIFF
--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -1031,7 +1031,7 @@ func (p *planner) preparePlannerForCopy(
 
 			// Start the implicit txn for the next batch.
 			nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID()
-			txnOpt.txn = kv.NewTxnWithSteppingEnabled(ctx, p.execCfg.DB, nodeID, p.SessionData().DefaultTxnQualityOfService)
+			txnOpt.txn = kv.NewTxnWithSteppingEnabled(ctx, p.execCfg.DB, nodeID, p.SessionData().CopyTxnQualityOfService)
 			txnOpt.txnTimestamp = p.execCfg.Clock.PhysicalTime()
 			txnOpt.stmtTimestamp = txnOpt.txnTimestamp
 		}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3399,6 +3399,10 @@ func (m *sessionDataMutator) SetQualityOfService(val sessiondatapb.QoSLevel) {
 	m.data.DefaultTxnQualityOfService = val.Validate()
 }
 
+func (m *sessionDataMutator) SetCopyQualityOfService(val sessiondatapb.QoSLevel) {
+	m.data.CopyTxnQualityOfService = val.Validate()
+}
+
 func (m *sessionDataMutator) SetOptSplitScanLimit(val int32) {
 	m.data.OptSplitScanLimit = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5484,6 +5484,7 @@ client_encoding                                            UTF8
 client_min_messages                                        notice
 copy_from_atomic_enabled                                   on
 copy_from_retries_enabled                                  on
+copy_transaction_quality_of_service                        background
 cost_scans_with_default_col_size                           off
 database                                                   test
 datestyle                                                  ISO, MDY

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2801,6 +2801,7 @@ client_encoding                                            UTF8                N
 client_min_messages                                        notice              NULL      NULL        NULL        string
 copy_from_atomic_enabled                                   on                  NULL      NULL        NULL        string
 copy_from_retries_enabled                                  on                  NULL      NULL        NULL        string
+copy_transaction_quality_of_service                        background          NULL      NULL        NULL        string
 cost_scans_with_default_col_size                           off                 NULL      NULL        NULL        string
 database                                                   test                NULL      NULL        NULL        string
 datestyle                                                  ISO, MDY            NULL      NULL        NULL        string
@@ -2969,6 +2970,7 @@ client_encoding                                            UTF8                N
 client_min_messages                                        notice              NULL  user     NULL      notice              notice
 copy_from_atomic_enabled                                   on                  NULL  user     NULL      on                  on
 copy_from_retries_enabled                                  on                  NULL  user     NULL      on                  on
+copy_transaction_quality_of_service                        background          NULL  user     NULL      background          background
 cost_scans_with_default_col_size                           off                 NULL  user     NULL      off                 off
 database                                                   test                NULL  user     NULL      ·                   test
 datestyle                                                  ISO, MDY            NULL  user     NULL      ISO, MDY            ISO, MDY
@@ -3131,6 +3133,7 @@ client_min_messages                                        NULL    NULL     NULL
 copy_fast_path_enabled                                     NULL    NULL     NULL     NULL        NULL
 copy_from_atomic_enabled                                   NULL    NULL     NULL     NULL        NULL
 copy_from_retries_enabled                                  NULL    NULL     NULL     NULL        NULL
+copy_transaction_quality_of_service                        NULL    NULL     NULL     NULL        NULL
 cost_scans_with_default_col_size                           NULL    NULL     NULL     NULL        NULL
 crdb_version                                               NULL    NULL     NULL     NULL        NULL
 database                                                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -39,6 +39,7 @@ client_encoding                                            UTF8
 client_min_messages                                        notice
 copy_from_atomic_enabled                                   on
 copy_from_retries_enabled                                  on
+copy_transaction_quality_of_service                        background
 cost_scans_with_default_col_size                           off
 database                                                   test
 datestyle                                                  ISO, MDY

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -463,6 +463,9 @@ message LocalOnlySessionData {
   // internal errors due to incomplete functional dependencies, and also
   // fixes a bug that incorrectly truncated the provided ordering (see #113072).
   bool optimizer_use_provided_ordering_fix = 115;
+  // CopyTxnQualityOfService indicates the default QoSLevel/WorkPriority of the
+  // transactions used to evaluate COPY commands.
+  int32 copy_txn_quality_of_service = 117 [(gogoproto.casttype)="QoSLevel"];
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2216,6 +2216,8 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
 	`default_transaction_quality_of_service`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`default_transaction_quality_of_service`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {
@@ -2234,6 +2236,28 @@ var varGen = map[string]sessionVar{
 			return sessiondatapb.Normal.String()
 		},
 	},
+
+	// CockroachDB extension.
+	`copy_transaction_quality_of_service`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`copy_transaction_quality_of_service`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			qosLevel, ok := sessiondatapb.ParseQoSLevelFromString(s)
+			if !ok {
+				return newVarValueError(`copy_transaction_quality_of_service`, s,
+					sessiondatapb.UserLowName, sessiondatapb.NormalName, sessiondatapb.UserHighName)
+			}
+			m.SetCopyQualityOfService(qosLevel)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return evalCtx.SessionData().CopyTxnQualityOfService.String(), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return sessiondatapb.UserLow.String()
+		},
+	},
+
+	// CockroachDB extension.
 	`opt_split_scan_limit`: {
 		GetStringVal: makeIntGetStringValFn(`opt_split_scan_limit`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {


### PR DESCRIPTION
Backport 1/1 commits from #114452.

/cc @cockroachdb/release

---

This commit makes it so that COPY command evaluation uses the "background" quality-of-service level by default. Previously, it was using the same QoS level as other user commands (which is controlled by `default_transaction_quality_of_service` and is "regular" by default), and "regular" QoS is not subject to admission control. We've seen at least one case where COPY led to overloading the cluster, so this commit introduces a separate session variable `copy_transaction_quality_of_service` to control the QoS level for COPY, "background" by default.

Fixes: #113704.

Release note (sql change): COPY commands now use "background" quality-of-service level making it subject to admission control (previously, it used the same level as other commands, determined by `default_transaction_quality_of_service` which is "regular" by default, which is not subject to admission control). It can be changed via newly added `copy_transaction_quality_of_service` session variable.

Release justification: low-risk stability improvement.