### PR TITLE
ui: update `crl-email-subscription` styling

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/dashboard/emailSubscription.styl
+++ b/pkg/ui/workspaces/db-console/src/views/dashboard/emailSubscription.styl
@@ -22,6 +22,7 @@
   height 90px
   background-image url("../../../assets/dashboard/email_signup_bg.png")
   background-repeat round
+  background-color #171239
 
   &__text
     font-size $font-size--large


### PR DESCRIPTION
Previously, when the background image failed to load for the
`crl-email-subscription` CSS class it would render white text on
a white background, making it difficult to read the call to action.

This patch adds the `background-color` property to the
`crl-email-subscription` CSS class so that it is used when the
background image fails to load.

Fixes: #105740
Part of: CRDB-29170

Release note (ui change): The overview page now correctly renders the
background color for the email signup, fixing an issue where it was
difficult to read the text.