### PR TITLE
kvstreamer: resolve a deadlock in an edge case

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/results_buffer.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer.go
@@ -53,8 +53,8 @@ type resultsBuffer interface {
 	get(context.Context) (_ []Result, allComplete bool, _ error)
 
 	// wait blocks until there is at least one Result available to be returned
-	// to the client.
-	wait()
+	// to the client or the passed-in context is canceled.
+	wait(context.Context) error
 
 	// releaseOne decrements the number of unreleased Results by one.
 	releaseOne()
@@ -233,8 +233,19 @@ func (b *resultsBufferBase) signal() bool {
 	}
 }
 
-func (b *resultsBufferBase) wait() {
-	<-b.hasResults
+func (b *resultsBufferBase) wait(ctx context.Context) error {
+	if buildutil.CrdbTestBuild {
+		// Note that here we don't check the context cancellation in hopes of
+		// reproducing #101823.
+		<-b.hasResults
+		return nil
+	}
+	select {
+	case <-b.hasResults:
+		return b.error()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (b *resultsBufferBase) numUnreleased() int {


### PR DESCRIPTION
This commit reverts 655588aa2c373f1dc807080a71e8ef836af55982. From now on, in non-test builds the streamer should respect the context cancellation whereas in the test builds we kept the previous behavior in hopes of reproducing #101823.

Fixes: #108884.

Release note: None