### PR TITLE
row: reduce the size of spans string

### DIFF
--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -532,7 +532,7 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	// Note that spansToRequests below might modify spans, so we need to log the
 	// spans before that.
 	if log.ExpensiveLogEnabled(ctx, 2) {
-		log.VEventf(ctx, 2, "Scan %s", f.spans)
+		log.VEventf(ctx, 2, "Scan %s", f.spans.BoundedString(1024 /* bytesHint */))
 	}
 
 	ba := &kvpb.BatchRequest{}

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -87,7 +87,7 @@ func (f *txnKVStreamer) SetupNextFetch(
 	}
 	f.reset(ctx)
 	if log.ExpensiveLogEnabled(ctx, 2) {
-		log.VEventf(ctx, 2, "Scan %s", spans)
+		log.VEventf(ctx, 2, "Scan %s", spans.BoundedString(1024 /* bytesHint */))
 	}
 	// Make sure to nil out the requests past the length that will be used in
 	// spansToRequests so that we lose references to the underlying Get and Scan


### PR DESCRIPTION
Previously, in `txnKVFetcher` and `txnKVStreamer`, in verbose mode (including when collecting stmt bundles) we would include the whole string represenation of `roachpb.Spans` we're scanning. However, we could have thousands of them to scan at once, resulting in huge log messages that would take up inflexible tracing budget. This commit introduces a somewhat "smart" truncation logic to bounding the size of the returned string. In particular, at least 6 spans (3 from the front and 3 from the back) are always included, and we give 1024 bytes "hint" in these two places.

Found when working on #113729. Now the corresponding trace message looks like
```
    24.701ms     22.429ms                event:sql/row/kv_batch_streamer.go:90 [n1,client=127.0.0.1:65160,hostnossl,user=root] Scan /Table/104/1/1/0, /Table/104/1/2/0, /Table/104/1/3/0, /Table/104/1/4/0, /Table/104/1/5/0, /Table/104/1/6/0, /Table/104/1/7/0, /Table/104/1/8/0, /Table/104/1/9/0, /Table/104/1/10/0, /Table/104/1/11/0, /Table/104/1/12/0, /Table/104/1/13/0, /Table/104/1/14/0, /Table/104/1/15/0, /Table/104/1/16/0, /Table/104/1/17/0, /Table/104/1/18/0, /Table/104/1/19/0, /Table/104/1/20/0, /Table/104/1/21/0, /Table/104/1/22/0, /Table/104/1/23/0, /Table/104/1/24/0, /Table/104/1/25/0, /Table/104/1/26/0, /Table/104/1/27/0, /Table/104/1/28/0, /Table/104/1/29/0, /Table/104/1/30/0, /Table/104/1/31/0, /Table/104/1/32/0, /Table/104/1/33/0, /Table/104/1/34/0, /Table/104/1/35/0, /Table/104/1/36/0, /Table/104/1/37/0, /Table/104/1/38/0, /Table/104/1/39/0, /Table/104/1/40/0, /Table/104/1/41/0, /Table/104/1/42/0, /Table/104/1/43/0, /Table/104/1/44/0, /Table/104/1/45/0, /Table/104/1/46/0, /Table/104/1/47/0, /Table/104/1/48/0, /Table/104/1/49/0, /Table/104/1/50/0, /Table/104/1/51/0, /Table/104/1/52/0, /Table/104/1/53/0, /Table/104/1/54/0, /Table/104/1/55/0 ... /Table/104/1/30000/0, /Table/104/1/31000/0, /Table/104/1/32000/0
```

Epic: None

Release note: None