### PR TITLE
rpc: move heartbeat log message to level 2

### DIFF
--- a/pkg/rpc/heartbeat.go
+++ b/pkg/rpc/heartbeat.go
@@ -117,7 +117,7 @@ func checkVersion(
 // with the requester's address.
 func (hs *HeartbeatService) Ping(ctx context.Context, request *PingRequest) (*PingResponse, error) {
 	if log.ExpensiveLogEnabled(ctx, 2) {
-		log.Dev.Infof(ctx, "received heartbeat: %+v vs local cluster %+v node %+v", request, hs.clusterID, hs.nodeID)
+		log.Dev.VInfof(ctx, 2, "received heartbeat: %+v vs local cluster %+v node %+v", request, hs.clusterID, hs.nodeID)
 	}
 	// Check that cluster IDs match.
 	clusterID := hs.clusterID.Get()


### PR DESCRIPTION
Recently I've been running clusters with the open telemetry collector enabled. This turns on verbose tracing. This log message is one of the log messages that tends to make the logs rather chatty with tracing enabled.

Epic: none

Release note: None