### PR TITLE
server: fix TestStatusLocalLogs flaky test

### DIFF
--- a/pkg/server/storage_api/BUILD.bazel
+++ b/pkg/server/storage_api/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//pkg/util/stop",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_pkg_errors//:errors",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",


### PR DESCRIPTION
This patch uses log interceptor to track exact time when logged entry was submitted instead of suggestion that entry sinked right after it was logged.
Also the time between logs are increased just to make it more safe in case of stress testing.

Epic: None

Release note: None

Resolves: #112375