### PR TITLE
sql: use timestamp rather than txn for physical planning

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -334,7 +334,7 @@ func makePlan(
 	drainingNodes []roachpb.NodeID,
 ) func(context.Context, *sql.DistSQLPlanner) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
 	return func(ctx context.Context, dsp *sql.DistSQLPlanner) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
-		var blankTxn *kv.Txn
+		var blankTxn func() hlc.Timestamp
 
 		distMode := sql.DistributionTypeAlways
 		if details.SinkURI == `` {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -877,7 +877,7 @@ func NumRangesInSpans(
 	ctx context.Context, db *kv.DB, distSQLPlanner *DistSQLPlanner, spans []roachpb.Span,
 ) (int, error) {
 	txn := db.NewTxn(ctx, "num-ranges-in-spans")
-	spanResolver := distSQLPlanner.spanResolver.NewSpanResolverIterator(txn, physicalplan.DefaultReplicaChooser)
+	spanResolver := distSQLPlanner.spanResolver.NewSpanResolverIterator(txn.RequiredFrontier, physicalplan.DefaultReplicaChooser)
 	rangeIds := make(map[int64]struct{})
 	for _, span := range spans {
 		// For each span, iterate the spanResolver until it's exhausted, storing
@@ -911,7 +911,7 @@ func NumRangesInSpanContainedBy(
 	containedBy []roachpb.Span,
 ) (total, inContainedBy int, _ error) {
 	txn := db.NewTxn(ctx, "num-ranges-in-spans")
-	spanResolver := distSQLPlanner.spanResolver.NewSpanResolverIterator(txn, physicalplan.DefaultReplicaChooser)
+	spanResolver := distSQLPlanner.spanResolver.NewSpanResolverIterator(txn.RequiredFrontier, physicalplan.DefaultReplicaChooser)
 	// For each span, iterate the spanResolver until it's exhausted, storing
 	// the found range ids in the map to de-duplicate them.
 	spanResolver.Seek(ctx, outerSpan, kvcoord.Ascending)

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -579,7 +578,7 @@ type testSpanResolver struct {
 
 // NewSpanResolverIterator is part of the SpanResolver interface.
 func (tsr *testSpanResolver) NewSpanResolverIterator(
-	txn *kv.Txn, optionalOracle replicaoracle.Oracle,
+	_ func() hlc.Timestamp, _ replicaoracle.Oracle,
 ) physicalplan.SpanResolverIterator {
 	return &testSpanResolverIterator{tsr: tsr}
 }

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan/replicaoracle"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -46,9 +47,26 @@ func (dsp *DistSQLPlanner) SetupAllNodesPlanningWithOracle(
 	localityFilter roachpb.Locality,
 ) (*PlanningCtx, []base.SQLInstanceID, error) {
 	if dsp.codec.ForSystemTenant() {
-		return dsp.setupAllNodesPlanningSystem(ctx, evalCtx, execCfg, oracle, localityFilter)
+		return dsp.setupAllNodesPlanningSystem(ctx, evalCtx, execCfg, oracle, localityFilter, nil /*txn*/)
 	}
-	return dsp.setupAllNodesPlanningTenant(ctx, evalCtx, execCfg, oracle, localityFilter)
+	return dsp.setupAllNodesPlanningTenant(ctx, evalCtx, execCfg, oracle, localityFilter, nil /*txn*/)
+}
+
+// SetupAllNodesPlanningWithOracleAndFollowers is like
+// SetupAllNodesPlanningWithOracle but with a timestamp fn param that if non-nil
+// allows the flow to plan on followers.
+func (dsp *DistSQLPlanner) SetupAllNodesPlanningWithOracleAndFollowers(
+	ctx context.Context,
+	evalCtx *extendedEvalContext,
+	execCfg *ExecutorConfig,
+	oracle replicaoracle.Oracle,
+	localityFilter roachpb.Locality,
+	spanResolutionTS func() hlc.Timestamp,
+) (*PlanningCtx, []base.SQLInstanceID, error) {
+	if dsp.codec.ForSystemTenant() {
+		return dsp.setupAllNodesPlanningSystem(ctx, evalCtx, execCfg, oracle, localityFilter, spanResolutionTS)
+	}
+	return dsp.setupAllNodesPlanningTenant(ctx, evalCtx, execCfg, oracle, localityFilter, spanResolutionTS)
 }
 
 // setupAllNodesPlanningSystem creates a planCtx and returns all nodes available
@@ -60,8 +78,9 @@ func (dsp *DistSQLPlanner) setupAllNodesPlanningSystem(
 	execCfg *ExecutorConfig,
 	oracle replicaoracle.Oracle,
 	localityFilter roachpb.Locality,
+	spanResolutionTS func() hlc.Timestamp,
 ) (*PlanningCtx, []base.SQLInstanceID, error) {
-	planCtx := dsp.NewPlanningCtxWithOracle(ctx, evalCtx, nil /* planner */, nil, /* txn */
+	planCtx := dsp.NewPlanningCtxWithOracle(ctx, evalCtx, nil /* planner */, spanResolutionTS,
 		DistributionTypeAlways, oracle, localityFilter)
 
 	ss, err := execCfg.NodesStatusServer.OptionalNodesStatusServer()
@@ -98,8 +117,9 @@ func (dsp *DistSQLPlanner) setupAllNodesPlanningTenant(
 	execCfg *ExecutorConfig,
 	oracle replicaoracle.Oracle,
 	localityFilter roachpb.Locality,
+	txn func() hlc.Timestamp,
 ) (*PlanningCtx, []base.SQLInstanceID, error) {
-	planCtx := dsp.NewPlanningCtxWithOracle(ctx, evalCtx, nil /* planner */, nil, /* txn */
+	planCtx := dsp.NewPlanningCtxWithOracle(ctx, evalCtx, nil /* planner */, txn,
 		DistributionTypeAlways, oracle, localityFilter)
 	pods, err := dsp.sqlAddressResolver.GetAllInstances(ctx)
 	if err != nil {

--- a/pkg/sql/physicalplan/replicaoracle/oracle.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle.go
@@ -18,7 +18,6 @@ import (
 	"math/rand"
 	"sort"
 
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -83,7 +82,7 @@ type Oracle interface {
 	// about any of the nodes that might be tried.
 	ChoosePreferredReplica(
 		ctx context.Context,
-		txn *kv.Txn,
+		ts func() hlc.Timestamp,
 		rng *roachpb.RangeDescriptor,
 		leaseholder *roachpb.ReplicaDescriptor,
 		ctPolicy roachpb.RangeClosedTimestampPolicy,
@@ -150,7 +149,7 @@ func newRandomOracle(cfg Config) Oracle {
 
 func (o *randomOracle) ChoosePreferredReplica(
 	ctx context.Context,
-	_ *kv.Txn,
+	_ func() hlc.Timestamp,
 	desc *roachpb.RangeDescriptor,
 	_ *roachpb.ReplicaDescriptor,
 	_ roachpb.RangeClosedTimestampPolicy,
@@ -195,7 +194,7 @@ func newClosestOracle(cfg Config) Oracle {
 
 func (o *closestOracle) ChoosePreferredReplica(
 	ctx context.Context,
-	_ *kv.Txn,
+	_ func() hlc.Timestamp,
 	desc *roachpb.RangeDescriptor,
 	leaseholder *roachpb.ReplicaDescriptor,
 	_ roachpb.RangeClosedTimestampPolicy,
@@ -260,7 +259,7 @@ func newBinPackingOracle(cfg Config) Oracle {
 
 func (o *binPackingOracle) ChoosePreferredReplica(
 	ctx context.Context,
-	_ *kv.Txn,
+	_ func() hlc.Timestamp,
 	desc *roachpb.RangeDescriptor,
 	leaseholder *roachpb.ReplicaDescriptor,
 	_ roachpb.RangeClosedTimestampPolicy,
@@ -332,7 +331,7 @@ func newPreferFollowerOracle(cfg Config) Oracle {
 
 func (o preferFollowerOracle) ChoosePreferredReplica(
 	ctx context.Context,
-	_ *kv.Txn,
+	_ func() hlc.Timestamp,
 	desc *roachpb.RangeDescriptor,
 	leaseholder *roachpb.ReplicaDescriptor,
 	_ roachpb.RangeClosedTimestampPolicy,


### PR DESCRIPTION
The txn used in planning ctx was only used to convey the timestamp that would be used during execution to the replica oracle so that it could potentially determine which replicas could serve a request as of that timestamp; it was not used as an actual txn to interact with the database in any way, even though passing a full txn did not make this clear.

This changes the API to take a function to access the timestamp and only the timestamp, rather than a whole txn.

Release note: none.
Epic: none.