### PR TITLE
changefeedccl: Avoid logging when context may be canceled

### DIFF
--- a/pkg/ccl/changefeedccl/batching_sink.go
+++ b/pkg/ccl/changefeedccl/batching_sink.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -399,11 +398,12 @@ func (s *batchingSink) runBatchingWorker(ctx context.Context) {
 	for {
 		select {
 		case req := <-s.eventCh:
-			if err := s.pacer.Pace(ctx); err != nil {
-				if pacerLogEvery.ShouldLog() {
-					log.Errorf(ctx, "automatic sink batcher pacing: %v", err)
-				}
-			}
+			// Swallow pacer error -- it happens only if context is canceled,
+			// and that's handled below.
+			// TODO(yevgeniy): rework this function: this function should simply
+			// return an error, and not rely on "handleError".
+			// It's hard to reason about this functions correctness otherwise.
+			_ = s.pacer.Pace(ctx)
 
 			switch r := req.(type) {
 			case *rowEvent:

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -13,7 +13,6 @@ import (
 	"hash"
 	"hash/crc32"
 	"runtime"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
@@ -36,10 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
-
-// pacerLogEvery is used for logging errors instead of returning terminal
-// errors when pacer.Pace returns an error.
-var pacerLogEvery log.EveryN = log.Every(100 * time.Millisecond)
 
 // eventContext holds metadata pertaining to event.
 type eventContext struct {
@@ -328,9 +323,7 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 	// unavailable. If there is unused CPU time left from the last call to
 	// Pace, then use that time instead of blocking.
 	if err := c.pacer.Pace(ctx); err != nil {
-		if pacerLogEvery.ShouldLog() {
-			log.Errorf(ctx, "automatic pacing: %v", err)
-		}
+		return err
 	}
 
 	schemaTimestamp := ev.KV().Value.Timestamp


### PR DESCRIPTION
Calling log  methods on a context that's already canceled may produce "use of Span after Finish" under tests. Avoid doing that when pacing CPU usage.

Fixes #114130

Release note: None