### PR TITLE
roachtest: disable backups in kv/splits/* roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -693,7 +693,7 @@ func registerKVSplits(r registry.Registry) {
 
 				settings := install.MakeClusterSettings()
 				settings.Env = append(settings.Env, "COCKROACH_MEMPROF_INTERVAL=1m", "COCKROACH_DISABLE_QUIESCENCE="+strconv.FormatBool(!item.quiesce))
-				startOpts := option.DefaultStartOpts()
+				startOpts := option.DefaultStartOptsNoBackups()
 				startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--cache=256MiB")
 				c.Start(ctx, t.L(), startOpts, settings, c.Range(1, nodes))
 


### PR DESCRIPTION
`kv/splits/nodes=3/*` creates many splits and pushes the CPU of the cluster to the limit of resource exhaustion for the 300k split variety.

Disable backups from running against the cluster, which were enabled after the test was created. This should provide a small amount of additional headroom.

Informs: #114544
Release note: None