### PR TITLE
sql: use a session-bound internal executor for SQL cursors

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql.go
+++ b/pkg/cmd/roachtest/tests/npgsql.go
@@ -78,7 +78,7 @@ func registerNpgsql(r registry.Registry) {
 			c,
 			node,
 			"install dependencies",
-			`sudo snap install dotnet-sdk --classic && \
+			`sudo snap install dotnet-sdk --channel=7.0/stable --classic && \
 sudo snap alias dotnet-sdk.dotnet dotnet && \
 sudo ln -s /snap/dotnet-sdk/current/dotnet /usr/local/bin/dotnet`,
 		); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/read_committed
@@ -424,3 +424,45 @@ subtest end
 
 statement ok
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE
+
+subtest cursor
+
+# Verify that SQL and PL/pgSQL cursors run under READ COMMITTED correctly.
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+DECLARE curs CURSOR FOR SELECT * FROM (VALUES (1), (2), (3)) AS t;
+MOVE FORWARD 2 IN curs;
+
+query I
+FETCH 1 curs
+----
+3
+
+statement ok
+COMMIT
+
+statement ok
+CREATE FUNCTION f_cursor() RETURNS INT AS $$
+DECLARE
+  foo INT;
+  curs CURSOR FOR VALUES (1), (2);
+BEGIN
+  OPEN curs;
+  FETCH curs INTO foo;
+  CLOSE curs;
+  RETURN foo;
+END
+$$ LANGUAGE plpgsql
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+query I
+SELECT f_cursor()
+----
+1
+
+statement ok
+COMMIT
+
+subtest end


### PR DESCRIPTION
This fixes a bug where the internal executor used to execute a SQL
cursor statement was not correctly denoted as being delegated from an
outer transaction. This is fixed by using the internal executor factory
and passing in the extraTxnState.

No release note since this bug was not released.

---

roachtest: use dotnet v7 for npgsql test

The version wasn't pinned, so a recent release made it start using v8,
which doesn't work with this test.

---

fixes https://github.com/cockroachdb/cockroach/issues/114034
fixes https://github.com/cockroachdb/cockroach/issues/114298
fixes https://github.com/cockroachdb/cockroach/issues/114303


Release note: None