### PR TITLE
kvserver: skip repl queue rebalance under deadlock

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -68,6 +68,7 @@ func TestReplicateQueueRebalance(t *testing.T) {
 	// This test was seen taking north of 20m under race.
 	skip.UnderRace(t)
 	skip.UnderShort(t)
+	skip.UnderDeadlock(t)
 
 	const numNodes = 5
 


### PR DESCRIPTION
`TestReplicateQueueRebalance` occasionally times out under deadlock builds during setup. The test times out because of failed liveness heartbeats from overload/slowness, which later mark stores as suspect - delaying the rebalance part of the test.

Skip under deadlock.

Resolves: #114415
Release note: None