### PR TITLE
roachtest: segregate issues for coverage and metamorphic builds

### DIFF
--- a/pkg/cmd/internal/issues/testdata/issues
+++ b/pkg/cmd/internal/issues/testdata/issues
@@ -15,33 +15,33 @@ Existing issue query:
 Related issues query:
   repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure -label:branch-master
 
-# We must search only for issues that also have B-metamorphic set.
-build-issue-queries labels=(C-test-failure,B-metamorphic) label-match-set=(C-test-failure,B-metamorphic)
+# We must search only for issues that also have B-metamorphic-enabled set.
+build-issue-queries labels=(C-test-failure,B-metamorphic-enabled) label-match-set=(C-test-failure,B-metamorphic-enabled)
 ----
 Existing issue query:
-  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:C-test-failure label:B-metamorphic label:branch-master -label:X-noreuse
+  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:C-test-failure label:B-metamorphic-enabled label:branch-master -label:X-noreuse
 Related issues query:
-  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:C-test-failure label:B-metamorphic -label:branch-master
+  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:C-test-failure label:B-metamorphic-enabled -label:branch-master
 
-# We must search only for issues that do NOT have B-metamorphic set.
-build-issue-queries labels=(C-test-failure) label-match-set=(C-test-failure,B-metamorphic)
+# We must search only for issues that do NOT have B-metamorphic-enabled set.
+build-issue-queries labels=(C-test-failure) label-match-set=(C-test-failure,B-metamorphic-enabled)
 ----
 Existing issue query:
-  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:C-test-failure label:branch-master -label:B-metamorphic -label:X-noreuse
+  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:C-test-failure label:branch-master -label:B-metamorphic-enabled -label:X-noreuse
 Related issues query:
-  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:C-test-failure -label:B-metamorphic -label:branch-master
+  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:C-test-failure -label:B-metamorphic-enabled -label:branch-master
 
 # The extra label should not affect the search.
-build-issue-queries labels=(C-test-failure,B-metamorphic,extra-label) label-match-set=(C-test-failure,B-metamorphic)
+build-issue-queries labels=(C-test-failure,B-metamorphic-enabled,extra-label) label-match-set=(C-test-failure,B-metamorphic-enabled)
 ----
 Existing issue query:
-  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:C-test-failure label:B-metamorphic label:branch-master -label:X-noreuse
+  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:C-test-failure label:B-metamorphic-enabled label:branch-master -label:X-noreuse
 Related issues query:
-  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:C-test-failure label:B-metamorphic -label:branch-master
+  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:C-test-failure label:B-metamorphic-enabled -label:branch-master
 
-build-issue-queries labels=(extra-label) label-match-set=(C-test-failure,B-metamorphic)
+build-issue-queries labels=(extra-label) label-match-set=(C-test-failure,B-metamorphic-enabled)
 ----
 Existing issue query:
-  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:branch-master -label:C-test-failure -label:B-metamorphic -label:X-noreuse
+  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure label:branch-master -label:C-test-failure -label:B-metamorphic-enabled -label:X-noreuse
 Related issues query:
-  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure -label:C-test-failure -label:B-metamorphic -label:branch-master
+  repo:"repo" user:"org" is:issue is:open in:title sort:created-desc "foo: bar failed" label:O-robot label:C-test-failure -label:C-test-failure -label:B-metamorphic-enabled -label:branch-master

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -142,6 +142,7 @@ func (g *githubIssues) createPostRequest(
 	firstFailure failure,
 	message string,
 	metamorphicBuild bool,
+	coverageBuild bool,
 ) (issues.PostRequest, error) {
 	var mention []string
 	var projColID int
@@ -175,13 +176,25 @@ func (g *githubIssues) createPostRequest(
 
 	// Issues posted from roachtest are identifiable as such, and they are also release blockers
 	// (this label may be removed by a human upon closer investigation).
+	const infraFlakeLabel = "X-infra-flake"
+	const metamorphicLabel = "B-metamorphic-enabled"
+	const coverageLabel = "B-coverage-enabled"
 	labels := []string{"O-roachtest"}
 	if infraFlake {
-		labels = append(labels, "X-infra-flake")
+		labels = append(labels, infraFlakeLabel)
 	} else {
 		labels = append(labels, issues.TestFailureLabel)
 		if !spec.NonReleaseBlocker {
-			labels = append(labels, issues.ReleaseBlockerLabel)
+			// TODO(radu): remove this check once these build types are stabilized.
+			if !metamorphicBuild && !coverageBuild {
+				labels = append(labels, issues.ReleaseBlockerLabel)
+			}
+		}
+		if metamorphicBuild {
+			labels = append(labels, metamorphicLabel)
+		}
+		if coverageBuild {
+			labels = append(labels, coverageLabel)
 		}
 	}
 	labels = append(labels, spec.ExtraLabels...)
@@ -213,6 +226,7 @@ func (g *githubIssues) createPostRequest(
 		roachtestPrefix("cpu"):              fmt.Sprintf("%d", spec.Cluster.CPUs),
 		roachtestPrefix("ssd"):              fmt.Sprintf("%d", spec.Cluster.SSDs),
 		roachtestPrefix("metamorphicBuild"): fmt.Sprintf("%t", metamorphicBuild),
+		roachtestPrefix("coverageBuild"):    fmt.Sprintf("%t", coverageBuild),
 	}
 	// Emit CPU architecture only if it was specified; otherwise, it's captured below, assuming cluster was created.
 	if spec.Cluster.Arch != "" {
@@ -240,16 +254,33 @@ func (g *githubIssues) createPostRequest(
 		issueMessage = "The details about this test failure may contain sensitive information; " +
 			"consult the logs for details. WARNING: DO NOT COPY UNREDACTED ARTIFACTS TO THIS ISSUE."
 	}
+	var topLevelNotes []string
+	if coverageBuild {
+		topLevelNotes = append(topLevelNotes,
+			"This is a special code-coverage build. If the same failure was hit in a non-coverage run, "+
+				"there should be a similar issue without the "+coverageLabel+" label. If there isn't one, it is "+
+				"possible that this failure is related to the code coverage infrastructure or overhead.")
+	}
+	if metamorphicBuild {
+		topLevelNotes = append(topLevelNotes,
+			"This build has metamorphic test constants enabled. If the same failure was hit in a "+
+				"non-metamorphic run, there should be a similar issue without the "+metamorphicLabel+" label. If there "+
+				"isn't one, it is possible that this failure is caused by a metamorphic constant.")
+	}
+
 	return issues.PostRequest{
 		MentionOnCreate: mention,
 		ProjectColumnID: projColID,
 		PackageName:     "roachtest",
 		TestName:        issueName,
 		Labels:          labels,
-		Message:         issueMessage,
-		Artifacts:       artifacts,
-		ExtraParams:     clusterParams,
-		HelpCommand:     generateHelpCommand(testName, issueClusterName, roachtestflags.Cloud, start, end),
+		// Keep issues separate unless the if these labels don't match.
+		AdoptIssueLabelMatchSet: []string{infraFlakeLabel, coverageLabel, metamorphicLabel},
+		TopLevelNotes:           topLevelNotes,
+		Message:                 issueMessage,
+		Artifacts:               artifacts,
+		ExtraParams:             clusterParams,
+		HelpCommand:             generateHelpCommand(testName, issueClusterName, roachtestflags.Cloud, start, end),
 	}, nil
 }
 
@@ -269,7 +300,7 @@ func (g *githubIssues) MaybePost(t *testImpl, l *logger.Logger, message string) 
 	default:
 		metamorphicBuild = tests.UsingRuntimeAssertions(t)
 	}
-	postRequest, err := g.createPostRequest(t.Name(), t.start, t.end, t.spec, t.firstFailure(), message, metamorphicBuild)
+	postRequest, err := g.createPostRequest(t.Name(), t.start, t.end, t.spec, t.firstFailure(), message, metamorphicBuild, t.goCoverEnabled)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -128,12 +128,16 @@ func TestCreatePostRequest(t *testing.T) {
 		return failure{squashedErr: ref}
 	}
 
+	// TODO(radu): these tests should be converted to datadriven tests which
+	// output the full rendering of the github issue message along with the
+	// metadata.
 	testCases := []struct {
 		nonReleaseBlocker       bool
 		clusterCreationFailed   bool
 		loadTeamsFailed         bool
 		localSSD                bool
 		metamorphicBuild        bool
+		coverageBuild           bool
 		extraLabels             []string
 		arch                    vm.CPUArch
 		failure                 failure
@@ -143,6 +147,7 @@ func TestCreatePostRequest(t *testing.T) {
 		expectedSkipTestFailure bool
 		expectedParams          map[string]string
 	}{
+		// 1.
 		{
 			nonReleaseBlocker: true,
 			failure:           createFailure(errors.New("other")),
@@ -157,8 +162,10 @@ func TestCreatePostRequest(t *testing.T) {
 				"arch":             "amd64",
 				"localSSD":         "false",
 				"metamorphicBuild": "false",
+				"coverageBuild":    "false",
 			}),
 		},
+		// 2.
 		{
 			localSSD:         true,
 			metamorphicBuild: true,
@@ -175,9 +182,10 @@ func TestCreatePostRequest(t *testing.T) {
 				"arch":             "arm64",
 				"localSSD":         "true",
 				"metamorphicBuild": "true",
+				"coverageBuild":    "false",
 			}),
 		},
-		// Assert that release-blocker label doesn't exist when
+		// 3. Assert that release-blocker label doesn't exist when
 		// !nonReleaseBlocker and issue is an SSH flake. Also ensure that
 		// in the event of a failed cluster creation, nil `vmOptions` and
 		// `clusterImpl` are not dereferenced
@@ -191,29 +199,30 @@ func TestCreatePostRequest(t *testing.T) {
 				"ssd":              "0",
 				"cpu":              "4",
 				"metamorphicBuild": "false",
+				"coverageBuild":    "false",
 			}),
 		},
-		// Simulate failure loading TEAMS.yaml
+		// 4. Simulate failure loading TEAMS.yaml
 		{
 			nonReleaseBlocker: true,
 			loadTeamsFailed:   true,
 			failure:           createFailure(errors.New("other")),
 			expectedLabels:    []string{"C-test-failure"},
 		},
-		// Error during post test assertions
+		// 5. Error during post test assertions
 		{
 			nonReleaseBlocker: true,
 			failure:           createFailure(errDuringPostAssertions),
 			expectedLabels:    []string{"C-test-failure"},
 		},
-		// Error during dns operation.
+		// 6. Error during dns operation.
 		{
 			nonReleaseBlocker: true,
 			failure:           createFailure(gce.ErrDNSOperation),
 			expectedPost:      true,
 			expectedLabels:    []string{"T-testeng", "X-infra-flake"},
 		},
-		// Assert that extra labels in the test spec are added to the issue.
+		// 7. Assert that extra labels in the test spec are added to the issue.
 		{
 			extraLabels:    []string{"foo-label"},
 			failure:        createFailure(errors.New("other")),
@@ -228,13 +237,53 @@ func TestCreatePostRequest(t *testing.T) {
 				"arch":             "amd64",
 				"localSSD":         "false",
 				"metamorphicBuild": "false",
+				"coverageBuild":    "false",
+			}),
+		},
+		// 8. Verify that release-blocker label is not applied on metamorphic builds
+		// (for now).
+		{
+			metamorphicBuild: true,
+			failure:          createFailure(errors.New("other")),
+			expectedPost:     true,
+			expectedLabels:   []string{"C-test-failure", "B-metamorphic-enabled"},
+			expectedParams: prefixAll(map[string]string{
+				"cloud":            "gce",
+				"encrypted":        "false",
+				"fs":               "ext4",
+				"ssd":              "0",
+				"cpu":              "4",
+				"arch":             "amd64",
+				"localSSD":         "false",
+				"metamorphicBuild": "true",
+				"coverageBuild":    "false",
+			}),
+		},
+		// 9. Verify that release-blocker label is not applied on coverage builds (for
+		// now).
+		{
+			extraLabels:    []string{"foo-label"},
+			coverageBuild:  true,
+			failure:        createFailure(errors.New("other")),
+			expectedPost:   true,
+			expectedLabels: []string{"C-test-failure", "B-coverage-enabled", "foo-label"},
+			expectedParams: prefixAll(map[string]string{
+				"cloud":            "gce",
+				"encrypted":        "false",
+				"fs":               "ext4",
+				"ssd":              "0",
+				"cpu":              "4",
+				"arch":             "amd64",
+				"localSSD":         "false",
+				"metamorphicBuild": "false",
+				"coverageBuild":    "true",
 			}),
 		},
 	}
 
 	reg := makeTestRegistry()
 	for idx, c := range testCases {
-		t.Run("", func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d", idx+1), func(t *testing.T) {
 			clusterSpec := reg.MakeClusterSpec(1, spec.Arch(c.arch))
 
 			testSpec := &registry.TestSpec{
@@ -278,10 +327,10 @@ func TestCreatePostRequest(t *testing.T) {
 
 			if c.loadTeamsFailed {
 				// Assert that if TEAMS.yaml cannot be loaded then function errors.
-				_, err := github.createPostRequest("github_test", ti.start, ti.end, testSpec, c.failure, "message", c.metamorphicBuild)
+				_, err := github.createPostRequest("github_test", ti.start, ti.end, testSpec, c.failure, "message", c.metamorphicBuild, c.coverageBuild)
 				assert.Error(t, err, "Expected an error in createPostRequest when loading teams fails, but got nil")
 			} else {
-				req, err := github.createPostRequest("github_test", ti.start, ti.end, testSpec, c.failure, "message", c.metamorphicBuild)
+				req, err := github.createPostRequest("github_test", ti.start, ti.end, testSpec, c.failure, "message", c.metamorphicBuild, c.coverageBuild)
 				assert.NoError(t, err, "Expected no error in createPostRequest")
 
 				r := &issues.Renderer{}

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_8.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_8.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_9.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_9.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----


### PR DESCRIPTION
This PR is now just for the top commit. The rest is #115302.

#### roachtest: segregate issues for coverage and metamorphic builds

Issues posted for metamorphic/coverage builds now have
`B-metamorphic`/`B-coverage` labels and no `release-blocker` label.
We also include top-level notices in the issue description with
information about these builds.

We adopt an existing issue only when the metamorphic/coverage labels
match exactly.

Informs: #114615
Release note: None