### PR TITLE
cloud: early-boot storage providers

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -233,6 +233,7 @@ go_test(
         "//pkg/cloud/cloudpb",
         "//pkg/cloud/gcp",
         "//pkg/cloud/impl:cloudimpl",
+        "//pkg/cloud/nodelocal",
         "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",

--- a/pkg/ccl/backupccl/restore_online_test.go
+++ b/pkg/ccl/backupccl/restore_online_test.go
@@ -82,23 +82,33 @@ func TestOnlineRestoreErrors(t *testing.T) {
 	t.Run("incremental backups are unsupported", func(t *testing.T) {
 		sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s'", incrementalBackup))
 		sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO LATEST IN '%s'", incrementalBackup))
-		rSQLDB.ExpectErr(t, "incremental backup not supported", fmt.Sprintf("RESTORE TABLE data.bank FROM LATEST IN '%s' WITH EXPERIMENTAL DEFERRED COPY", incrementalBackup))
+		rSQLDB.ExpectErr(t, "incremental backup not supported",
+			fmt.Sprintf("RESTORE TABLE data.bank FROM LATEST IN '%s' WITH EXPERIMENTAL DEFERRED COPY", incrementalBackup))
 	})
 	t.Run("full backups with revision history are unsupported", func(t *testing.T) {
 		var systemTime string
 		sqlDB.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&systemTime)
 		sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s' AS OF SYSTEM TIME '%s' WITH revision_history", fullBackupWithRevs, systemTime))
-		rSQLDB.ExpectErr(t, "revision history backup not supported", fmt.Sprintf("RESTORE TABLE data.bank FROM LATEST IN '%s' WITH EXPERIMENTAL DEFERRED COPY", fullBackupWithRevs))
+		rSQLDB.ExpectErr(t, "revision history backup not supported",
+			fmt.Sprintf("RESTORE TABLE data.bank FROM LATEST IN '%s' WITH EXPERIMENTAL DEFERRED COPY", fullBackupWithRevs))
 	})
-	t.Run("icremental backups with revision history are unsupported", func(t *testing.T) {
+	t.Run("incremental backups with revision history are unsupported", func(t *testing.T) {
 		sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s' WITH revision_history", incrementalBackupWithRevs))
 		sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO LATEST IN '%s' WITH revision_history", incrementalBackupWithRevs))
-		rSQLDB.ExpectErr(t, "incremental backup not supported", fmt.Sprintf("RESTORE TABLE data.bank FROM LATEST IN '%s' WITH EXPERIMENTAL DEFERRED COPY", incrementalBackupWithRevs))
+		rSQLDB.ExpectErr(t, "incremental backup not supported",
+			fmt.Sprintf("RESTORE TABLE data.bank FROM LATEST IN '%s' WITH EXPERIMENTAL DEFERRED COPY", incrementalBackupWithRevs))
 	})
 	t.Run("descriptor rewrites are unsupported", func(t *testing.T) {
 		sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s'", fullBackup))
 		rSQLDB.Exec(t, "CREATE DATABASE new_data")
-		rSQLDB.ExpectErr(t, "descriptor rewrites not supported", fmt.Sprintf("RESTORE TABLE data.bank FROM LATEST IN '%s' WITH into_db=new_data,EXPERIMENTAL DEFERRED COPY", fullBackup))
+		rSQLDB.ExpectErr(t, "descriptor rewrites not supported",
+			fmt.Sprintf("RESTORE TABLE data.bank FROM LATEST IN '%s' WITH into_db=new_data,EXPERIMENTAL DEFERRED COPY", fullBackup))
+	})
+	t.Run("external storage locations that don't support early boot are unsupported", func(t *testing.T) {
+		rSQLDB.Exec(t, "CREATE DATABASE bank")
+		rSQLDB.Exec(t, "BACKUP INTO 'userfile:///my_backups'")
+		rSQLDB.ExpectErr(t, "scheme userfile is not accessible during node startup",
+			"RESTORE DATABASE bank FROM LATEST IN 'userfile:///my_backups' WITH EXPERIMENTAL DEFERRED COPY")
 	})
 
 }

--- a/pkg/ccl/backupccl/restore_online_test.go
+++ b/pkg/ccl/backupccl/restore_online_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cloud/nodelocal"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -24,6 +25,8 @@ import (
 func TestOnlineRestoreBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
 
 	const numAccounts = 1000
 	_, sqlDB, dir, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, base.TestClusterArgs{
@@ -56,12 +59,9 @@ func TestOnlineRestoreErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	_, sqlDB, dir, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, 1, InitManualReplication, base.TestClusterArgs{
-		// Online restore is not supported in a secondary tenant yet.
-		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
-		},
-	})
+	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
+
+	_, sqlDB, dir, cleanupFn := backupRestoreTestSetup(t, singleNode, 1, InitManualReplication)
 	defer cleanupFn()
 	params := base.TestClusterArgs{
 		// Online restore is not supported in a secondary tenant yet.

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1856,6 +1856,14 @@ func doRestorePlan(
 	if err != nil {
 		return err
 	}
+	if restoreStmt.Options.ExperimentalOnline {
+		for _, uri := range defaultURIs {
+			if err := cloud.SchemeSupportsEarlyBoot(uri); err != nil {
+				return errors.Wrap(err, "backup URI not supported for online restore")
+			}
+		}
+	}
+
 	defer func() {
 		mem.Shrink(ctx, memReserved)
 	}()

--- a/pkg/cloud/BUILD.bazel
+++ b/pkg/cloud/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
     ],
     embed = [":cloud"],
     deps = [
+        "//pkg/cloud/cloudpb",
         "//pkg/util/ioctx",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -395,7 +395,7 @@ func TestS3DisallowCustomEndpoints(t *testing.T) {
 
 	dest := cloudpb.ExternalStorage{S3Config: &cloudpb.ExternalStorage_S3{Endpoint: "http://do.not.go.there/"}}
 	s3, err := MakeS3Storage(context.Background(),
-		cloud.ExternalStorageContext{
+		cloud.EarlyBootExternalStorageContext{
 			IOConf: base.ExternalIODirConfig{DisableHTTP: true},
 		},
 		dest,
@@ -421,7 +421,7 @@ func TestS3DisallowImplicitCredentials(t *testing.T) {
 	testSettings := cluster.MakeTestingClusterSettings()
 
 	s3, err := MakeS3Storage(context.Background(),
-		cloud.ExternalStorageContext{
+		cloud.EarlyBootExternalStorageContext{
 			IOConf:   base.ExternalIODirConfig{DisableImplicitCredentials: true},
 			Settings: testSettings,
 		},
@@ -657,13 +657,11 @@ func TestReadFileAtReturnsSize(t *testing.T) {
 	gsURI := fmt.Sprintf("s3://%s/%s?AUTH=implicit", bucket, "read-file-at-returns-size")
 	conf, err := cloud.ExternalStorageConfFromURI(gsURI, user)
 	require.NoError(t, err)
-	args := cloud.ExternalStorageContext{
-		IOConf:          base.ExternalIODirConfig{},
-		Settings:        testSettings,
-		DB:              nil,
-		Options:         nil,
-		Limiters:        nil,
-		MetricsRecorder: cloud.NilMetrics,
+	args := cloud.EarlyBootExternalStorageContext{
+		IOConf:   base.ExternalIODirConfig{},
+		Settings: testSettings,
+		Options:  nil,
+		Limiters: nil,
 	}
 	s, err := MakeS3Storage(ctx, args, conf)
 	require.NoError(t, err)

--- a/pkg/cloud/azure/azure_storage_test.go
+++ b/pkg/cloud/azure/azure_storage_test.go
@@ -208,7 +208,7 @@ func TestParseAzureURL(t *testing.T) {
 		u, err := url.Parse("azure://container/path?AZURE_ACCOUNT_NAME=account&AZURE_ACCOUNT_KEY=key")
 		require.NoError(t, err)
 
-		sut, err := parseAzureURL(cloud.ExternalStorageURIContext{}, u)
+		sut, err := parseAzureURL(u)
 		require.NoError(t, err)
 
 		require.Equal(t, azure.PublicCloud.Name, sut.AzureConfig.Environment)
@@ -218,7 +218,7 @@ func TestParseAzureURL(t *testing.T) {
 		u, err := url.Parse("azure://container/path?AZURE_ACCOUNT_NAME=account&AZURE_CLIENT_ID=client&AZURE_CLIENT_SECRET=secret&AZURE_TENANT_ID=tenant")
 		require.NoError(t, err)
 
-		_, err = parseAzureURL(cloud.ExternalStorageURIContext{}, u)
+		_, err = parseAzureURL(u)
 		require.NoError(t, err)
 	})
 
@@ -226,7 +226,7 @@ func TestParseAzureURL(t *testing.T) {
 		u, err := url.Parse("azure://container/path?AZURE_ACCOUNT_NAME=account&AZURE_ACCOUNT_KEY=key&AZURE_CLIENT_ID=client&AZURE_CLIENT_SECRET=secret&AZURE_TENANT_ID=tenant")
 		require.NoError(t, err)
 
-		_, err = parseAzureURL(cloud.ExternalStorageURIContext{}, u)
+		_, err = parseAzureURL(u)
 		require.Error(t, err)
 
 	})
@@ -235,7 +235,7 @@ func TestParseAzureURL(t *testing.T) {
 		u, err := url.Parse("azure://container/path?AZURE_ACCOUNT_NAME=account&AUTH=implicit")
 		require.NoError(t, err)
 
-		_, err = parseAzureURL(cloud.ExternalStorageURIContext{}, u)
+		_, err = parseAzureURL(u)
 		require.NoError(t, err)
 	})
 
@@ -243,7 +243,7 @@ func TestParseAzureURL(t *testing.T) {
 		u, err := url.Parse("azure-storage://container/path?AZURE_ACCOUNT_NAME=account&AZURE_ACCOUNT_KEY=key&AZURE_ENVIRONMENT=AzureUSGovernmentCloud")
 		require.NoError(t, err)
 
-		sut, err := parseAzureURL(cloud.ExternalStorageURIContext{}, u)
+		sut, err := parseAzureURL(u)
 		require.NoError(t, err)
 
 		require.Equal(t, azure.USGovernmentCloud.Name, sut.AzureConfig.Environment)
@@ -259,7 +259,7 @@ func TestMakeAzureStorageURLFromEnvironment(t *testing.T) {
 		{environment: azure.USGovernmentCloud.Name, expected: "https://account.blob.core.usgovcloudapi.net/container"},
 	} {
 		t.Run(tt.environment, func(t *testing.T) {
-			sut, err := makeAzureStorage(context.Background(), cloud.ExternalStorageContext{}, cloudpb.ExternalStorage{
+			sut, err := makeAzureStorage(context.Background(), cloud.EarlyBootExternalStorageContext{}, cloudpb.ExternalStorage{
 				AzureConfig: &cloudpb.ExternalStorage_Azure{
 					Container:   "container",
 					Prefix:      "path",

--- a/pkg/cloud/externalconn/connection_storage.go
+++ b/pkg/cloud/externalconn/connection_storage.go
@@ -99,6 +99,11 @@ func makeExternalConnectionStorage(
 }
 
 func init() {
-	cloud.RegisterExternalStorageProvider(cloudpb.ExternalStorageProvider_external, parseExternalConnectionURL,
-		makeExternalConnectionStorage, cloud.RedactedParams(), scheme)
+	cloud.RegisterExternalStorageProvider(cloudpb.ExternalStorageProvider_external,
+		cloud.RegisteredProvider{
+			ParseFn:        parseExternalConnectionURL,
+			ConstructFn:    makeExternalConnectionStorage,
+			RedactedParams: cloud.RedactedParams(),
+			Schemes:        []string{scheme},
+		})
 }

--- a/pkg/cloud/gcp/gcs_storage_test.go
+++ b/pkg/cloud/gcp/gcs_storage_test.go
@@ -477,13 +477,11 @@ func TestReadFileAtReturnsSize(t *testing.T) {
 	gsURI := fmt.Sprintf("gs://%s/%s-%d?AUTH=implicit", bucket, "read-file-at-returns-size", testID)
 	conf, err := cloud.ExternalStorageConfFromURI(gsURI, user)
 	require.NoError(t, err)
-	args := cloud.ExternalStorageContext{
-		IOConf:          base.ExternalIODirConfig{},
-		Settings:        testSettings,
-		DB:              nil,
-		Options:         nil,
-		Limiters:        nil,
-		MetricsRecorder: cloud.NilMetrics,
+	args := cloud.EarlyBootExternalStorageContext{
+		IOConf:   base.ExternalIODirConfig{},
+		Settings: testSettings,
+		Options:  nil,
+		Limiters: nil,
 	}
 	s, err := makeGCSStorage(ctx, args, conf)
 	require.NoError(t, err)

--- a/pkg/cloud/httpsink/http_storage_test.go
+++ b/pkg/cloud/httpsink/http_storage_test.go
@@ -241,7 +241,7 @@ func TestHttpGet(t *testing.T) {
 			})
 
 			conf := cloudpb.ExternalStorage{HttpPath: cloudpb.ExternalStorage_Http{BaseUri: s.URL}}
-			store, err := MakeHTTPStorage(ctx, cloud.ExternalStorageContext{Settings: testSettings}, conf)
+			store, err := MakeHTTPStorage(ctx, cloud.EarlyBootExternalStorageContext{Settings: testSettings}, conf)
 			require.NoError(t, err)
 
 			var file ioctx.ReadCloserCtx
@@ -279,7 +279,7 @@ func TestHttpGetWithCancelledContext(t *testing.T) {
 
 	conf := cloudpb.ExternalStorage{HttpPath: cloudpb.ExternalStorage_Http{BaseUri: s.URL}}
 	store, err := MakeHTTPStorage(context.Background(),
-		cloud.ExternalStorageContext{Settings: testSettings}, conf)
+		cloud.EarlyBootExternalStorageContext{Settings: testSettings}, conf)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, store.Close())
@@ -408,8 +408,7 @@ func TestExhaustRetries(t *testing.T) {
 	cloud.HTTPRetryOptions.MaxRetries = 10
 
 	conf := cloudpb.ExternalStorage{HttpPath: cloudpb.ExternalStorage_Http{BaseUri: "http://does.not.matter"}}
-	store, err := MakeHTTPStorage(context.Background(), cloud.ExternalStorageContext{Settings: testSettings,
-		MetricsRecorder: cloud.NilMetrics}, conf)
+	store, err := MakeHTTPStorage(context.Background(), cloud.EarlyBootExternalStorageContext{Settings: testSettings}, conf)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, store.Close())
@@ -466,13 +465,11 @@ func TestReadFileAtReturnsSize(t *testing.T) {
 	defer server.Close()
 
 	conf := cloudpb.ExternalStorage{HttpPath: cloudpb.ExternalStorage_Http{BaseUri: server.URL}}
-	args := cloud.ExternalStorageContext{
-		IOConf:          base.ExternalIODirConfig{},
-		Settings:        testSettings,
-		DB:              nil,
-		Options:         nil,
-		Limiters:        nil,
-		MetricsRecorder: cloud.NilMetrics,
+	args := cloud.EarlyBootExternalStorageContext{
+		IOConf:   base.ExternalIODirConfig{},
+		Settings: testSettings,
+		Options:  nil,
+		Limiters: nil,
 	}
 	s, err := MakeHTTPStorage(ctx, args, conf)
 	require.NoError(t, err)

--- a/pkg/cloud/impl_registry.go
+++ b/pkg/cloud/impl_registry.go
@@ -41,10 +41,12 @@ var redactedQueryParams = map[string]struct{}{}
 
 // confParsers maps URI schemes to a ExternalStorageURIParser for that scheme.
 var confParsers = map[string]ExternalStorageURIParser{}
+var earlyBootConfParsers = map[string]EarlyBootExternalStorageURIParser{}
 
 // implementations maps an ExternalStorageProvider enum value to a constructor
 // of instances of that external storage.
 var implementations = map[cloudpb.ExternalStorageProvider]ExternalStorageConstructor{}
+var earlyBootImplementations = map[cloudpb.ExternalStorageProvider]EarlyBootExternalStorageConstructor{}
 
 // rateAndBurstSettings represents a pair of byteSizeSettings used to configure
 // the rate a burst properties of a quotapool.RateLimiter.
@@ -97,16 +99,37 @@ func registerLimiterSettings(providerType cloudpb.ExternalStorageProvider) {
 	}
 }
 
+type RegisteredProvider struct {
+	ParseFn     ExternalStorageURIParser
+	ConstructFn ExternalStorageConstructor
+
+	EarlyBootParseFn     EarlyBootExternalStorageURIParser
+	EarlyBootConstructFn EarlyBootExternalStorageConstructor
+
+	RedactedParams map[string]struct{}
+	Schemes        []string
+}
+
+// SchemeSupportsEarlyBoot returns an error if the scheme of the
+// provided URL has a provider that can't be used during early boot.
+func SchemeSupportsEarlyBoot(path string) error {
+	uri, err := url.Parse(path)
+	if err != nil {
+		return err
+	}
+	_, ok := earlyBootConfParsers[uri.Scheme]
+	if !ok {
+		return errors.Newf("scheme %s is not accessible during node startup", uri.Scheme)
+	}
+	return nil
+}
+
 // RegisterExternalStorageProvider registers an external storage provider for a
 // given URI scheme and provider type.
 func RegisterExternalStorageProvider(
-	providerType cloudpb.ExternalStorageProvider,
-	parseFn ExternalStorageURIParser,
-	constructFn ExternalStorageConstructor,
-	redactedParams map[string]struct{},
-	schemes ...string,
+	providerType cloudpb.ExternalStorageProvider, provider RegisteredProvider,
 ) {
-	registerExternalStorageProviderImpl(providerType, parseFn, constructFn, redactedParams, schemes...)
+	registerExternalStorageProviderImpls(providerType, provider)
 	// We do not register limiter settings for the `external` provider. An
 	// external connection object represents an underlying external resource that
 	// will have its own registered limiters.
@@ -115,26 +138,52 @@ func RegisterExternalStorageProvider(
 	}
 }
 
-func registerExternalStorageProviderImpl(
-	providerType cloudpb.ExternalStorageProvider,
-	parseFn ExternalStorageURIParser,
-	constructFn ExternalStorageConstructor,
-	redactedParams map[string]struct{},
-	schemes ...string,
+func registerExternalStorageProviderImpls(
+	providerType cloudpb.ExternalStorageProvider, provider RegisteredProvider,
 ) {
-	for _, scheme := range schemes {
+	for _, scheme := range provider.Schemes {
 		if _, ok := confParsers[scheme]; ok {
 			panic(fmt.Sprintf("external storage provider already registered for %s", scheme))
 		}
-		confParsers[scheme] = parseFn
-		for param := range redactedParams {
+
+		if provider.ParseFn != nil {
+			confParsers[scheme] = provider.ParseFn
+		} else if provider.EarlyBootParseFn != nil {
+			confParsers[scheme] = func(_ ExternalStorageURIContext, u *url.URL) (cloudpb.ExternalStorage, error) {
+				return provider.EarlyBootParseFn(u)
+			}
+		} else {
+			panic(fmt.Sprintf("ParseFn or EarlyBootParseFn must be set for %s", providerType))
+		}
+
+		if provider.EarlyBootParseFn != nil {
+			earlyBootConfParsers[scheme] = provider.EarlyBootParseFn
+		}
+
+		for param := range provider.RedactedParams {
 			redactedQueryParams[param] = struct{}{}
 		}
 	}
+
 	if _, ok := implementations[providerType]; ok {
 		panic(fmt.Sprintf("external storage provider already registered for %s", providerType.String()))
 	}
-	implementations[providerType] = constructFn
+
+	if provider.ConstructFn != nil {
+		implementations[providerType] = provider.ConstructFn
+	} else if provider.EarlyBootConstructFn != nil {
+		implementations[providerType] = func(
+			ctx context.Context, args ExternalStorageContext, es cloudpb.ExternalStorage,
+		) (ExternalStorage, error) {
+			return provider.EarlyBootConstructFn(ctx, args.EarlyBootExternalStorageContext, es)
+		}
+	} else {
+		panic(fmt.Sprintf("ConstructFn or EarlyBootConstructFn must be set for %s", providerType))
+	}
+
+	if provider.EarlyBootConstructFn != nil {
+		earlyBootImplementations[providerType] = provider.EarlyBootConstructFn
+	}
 }
 
 // ExternalStorageConfFromURI generates an ExternalStorage config from a URI string.
@@ -191,61 +240,85 @@ func MakeExternalStorage(
 	if cloudMetrics, ok = metrics.(*Metrics); !ok {
 		return nil, errors.Newf("invalid metrics type: %T", metrics)
 	}
+	getImpl := func(provider cloudpb.ExternalStorageProvider) (func(context.Context, ExternalStorageContext, cloudpb.ExternalStorage) (ExternalStorage, error), bool) {
+		fn, ok := implementations[provider]
+		return fn, ok
+	}
 	args := ExternalStorageContext{
-		IOConf:            conf,
-		Settings:          settings,
+		EarlyBootExternalStorageContext: EarlyBootExternalStorageContext{
+			IOConf:   conf,
+			Settings: settings,
+			Options:  opts,
+			Limiters: limiters,
+		},
 		BlobClientFactory: blobClientFactory,
 		DB:                db,
-		Options:           opts,
-		Limiters:          limiters,
 		MetricsRecorder:   cloudMetrics,
 	}
-	if conf.DisableOutbound && dest.Provider != cloudpb.ExternalStorageProvider_userfile {
-		return nil, errors.New("external network access is disabled")
+
+	return makeExternalStorage[ExternalStorageContext](ctx, dest, conf, limiters, metrics, settings, args, getImpl, opts...)
+}
+
+// EarlyBootExternalStorageConfFromURI generates an
+// cloudpb.ExternalStorage config from a URI string. The returned
+// cloudpb.ExternalStorage is guaranteed to be for an ExternalStorage
+// provider that is accessible without access to SQL or the underlying
+// store.
+func EarlyBootExternalStorageConfFromURI(path string) (cloudpb.ExternalStorage, error) {
+	uri, err := url.Parse(path)
+	if err != nil {
+		return cloudpb.ExternalStorage{}, err
 	}
-	options := ExternalStorageOptions{}
-	for _, o := range opts {
-		o(&options)
+	if fn, ok := earlyBootConfParsers[uri.Scheme]; ok {
+		return fn(uri)
 	}
-	if fn, ok := implementations[dest.Provider]; ok {
-		e, err := fn(ctx, args, dest)
-		if err != nil {
-			return nil, err
-		}
+	return cloudpb.ExternalStorage{}, errors.Errorf("unsupported storage scheme: %q - refer to docs to find supported storage schemes",
+		uri.Scheme)
+}
 
-		// We do not wrap the ExternalStorage for the `external` provider. An
-		// external connection object represents an underlying external resource
-		// that will have its own `esWrapper`.
-		if dest.Provider == cloudpb.ExternalStorageProvider_external {
-			return e, nil
-		}
+// EarlyBootExternalStorageFromURI returns an ExternalStorage for the
+// given URI. Returned ExternalStorage providers are guaranteed to be
+// accessible without access to SQL or the underlying store.
+func EarlyBootExternalStorageFromURI(
+	ctx context.Context,
+	uri string,
+	externalConfig base.ExternalIODirConfig,
+	settings *cluster.Settings,
+	limiters Limiters,
+	metrics metric.Struct,
+	opts ...ExternalStorageOption,
+) (ExternalStorage, error) {
+	conf, err := EarlyBootExternalStorageConfFromURI(uri)
+	if err != nil {
+		return nil, err
+	}
+	return MakeEarlyBootExternalStorage(ctx, conf, externalConfig, settings, limiters, metrics, opts...)
+}
 
-		var httpTracer *httptrace.ClientTrace
-		if cloudMetrics != nil && httpMetrics.Get(&settings.SV) {
-			httpTracer = &httptrace.ClientTrace{
-				GotConn: func(info httptrace.GotConnInfo) {
-					if info.Reused {
-						cloudMetrics.ConnsReused.Inc(1)
-					} else {
-						cloudMetrics.ConnsOpened.Inc(1)
-					}
-				},
-				TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
-					cloudMetrics.TLSHandhakes.Inc(1)
-				},
-			}
-		}
-
-		return &esWrapper{
-			ExternalStorage: e,
-			lim:             limiters[dest.Provider],
-			ioRecorder:      options.ioAccountingInterceptor,
-			metrics:         cloudMetrics,
-			httpTracer:      httpTracer,
-		}, nil
+// MakeEarlyBootExternalStorage creates an ExternalStorage from the
+// given config. The returned ExternalStorage is guaranteed to be
+// accessible without access to SQL or the underlying store.
+func MakeEarlyBootExternalStorage(
+	ctx context.Context,
+	dest cloudpb.ExternalStorage,
+	conf base.ExternalIODirConfig,
+	settings *cluster.Settings,
+	limiters Limiters,
+	metrics metric.Struct,
+	opts ...ExternalStorageOption,
+) (ExternalStorage, error) {
+	getImpl := func(provider cloudpb.ExternalStorageProvider) (func(context.Context, EarlyBootExternalStorageContext, cloudpb.ExternalStorage) (ExternalStorage, error), bool) {
+		fn, ok := earlyBootImplementations[provider]
+		return fn, ok
+	}
+	args := EarlyBootExternalStorageContext{
+		IOConf:   conf,
+		Settings: settings,
+		Options:  opts,
+		Limiters: limiters,
 	}
 
-	return nil, errors.Errorf("unsupported external destination type: %s", dest.Provider.String())
+	return makeExternalStorage[EarlyBootExternalStorageContext](ctx, dest, conf, limiters, metrics, settings, args, getImpl, opts...)
 }
 
 type rwLimiter struct {
@@ -256,11 +329,9 @@ type rwLimiter struct {
 // when interacting with the providers in the collection.
 type Limiters map[cloudpb.ExternalStorageProvider]rwLimiter
 
-func makeLimiter(
-	ctx context.Context, sv *settings.Values, s rateAndBurstSettings,
-) *quotapool.RateLimiter {
+func makeLimiter(sv *settings.Values, s rateAndBurstSettings) *quotapool.RateLimiter {
 	lim := quotapool.NewRateLimiter(string(s.rate.Name()), quotapool.Limit(0), 0)
-	fn := func(ctx context.Context) {
+	fn := func(_ context.Context) {
 		rate := quotapool.Limit(s.rate.Get(sv))
 		if rate == 0 {
 			rate = quotapool.Limit(math.Inf(1))
@@ -273,18 +344,18 @@ func makeLimiter(
 	}
 	s.rate.SetOnChange(sv, fn)
 	s.burst.SetOnChange(sv, fn)
-	fn(ctx)
+	fn(context.Background())
 	return lim
 }
 
 // MakeLimiters makes limiters for all registered ExternalStorageProviders and
 // sets them up to be updated when settings change. It should be called only
 // once per server at creation.
-func MakeLimiters(ctx context.Context, sv *settings.Values) Limiters {
+func MakeLimiters(sv *settings.Values) Limiters {
 	m := make(Limiters, len(limiterSettings))
 	for k := range limiterSettings {
 		l := limiterSettings[k]
-		m[k] = rwLimiter{read: makeLimiter(ctx, sv, l.read), write: makeLimiter(ctx, sv, l.write)}
+		m[k] = rwLimiter{read: makeLimiter(sv, l.read), write: makeLimiter(sv, l.write)}
 	}
 	return m
 }
@@ -433,32 +504,100 @@ type ReadWriterInterceptor interface {
 	Writer(context.Context, ExternalStorage, io.WriteCloser) io.WriteCloser
 }
 
+// makeExternalStorage creates an ExternalStorage from the given config.
+func makeExternalStorage[T interface {
+	ExternalStorageContext | EarlyBootExternalStorageContext
+}](
+	ctx context.Context,
+	dest cloudpb.ExternalStorage,
+	conf base.ExternalIODirConfig,
+	limiters Limiters,
+	metrics metric.Struct,
+	settings *cluster.Settings,
+	args T,
+	getImpl func(cloudpb.ExternalStorageProvider) (func(context.Context, T, cloudpb.ExternalStorage) (ExternalStorage, error), bool),
+	opts ...ExternalStorageOption,
+) (ExternalStorage, error) {
+	var cloudMetrics *Metrics
+	var ok bool
+	if cloudMetrics, ok = metrics.(*Metrics); !ok {
+		return nil, errors.Newf("invalid metrics type: %T", metrics)
+	}
+	if conf.DisableOutbound && dest.Provider != cloudpb.ExternalStorageProvider_userfile {
+		return nil, errors.New("external network access is disabled")
+	}
+	options := ExternalStorageOptions{}
+	for _, o := range opts {
+		o(&options)
+	}
+	if fn, ok := getImpl(dest.Provider); ok {
+		e, err := fn(ctx, args, dest)
+		if err != nil {
+			return nil, err
+		}
+
+		// We do not wrap the ExternalStorage for the `external` provider. An
+		// external connection object represents an underlying external resource
+		// that will have its own `esWrapper`.
+		if dest.Provider == cloudpb.ExternalStorageProvider_external {
+			return e, nil
+		}
+
+		var httpTracer *httptrace.ClientTrace
+		if cloudMetrics != nil && httpMetrics.Get(&settings.SV) {
+			httpTracer = &httptrace.ClientTrace{
+				GotConn: func(info httptrace.GotConnInfo) {
+					if info.Reused {
+						cloudMetrics.ConnsReused.Inc(1)
+					} else {
+						cloudMetrics.ConnsOpened.Inc(1)
+					}
+				},
+				TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
+					cloudMetrics.TLSHandhakes.Inc(1)
+				},
+			}
+		}
+
+		return &esWrapper{
+			ExternalStorage: e,
+			lim:             limiters[dest.Provider],
+			ioRecorder:      options.ioAccountingInterceptor,
+			metrics:         cloudMetrics,
+			httpTracer:      httpTracer,
+		}, nil
+	}
+
+	return nil, errors.Errorf("unsupported external destination type: %s", dest.Provider.String())
+}
+
 // ReplaceProviderForTesting replaces an existing registered provider
 // with the given alternate implementation.
 //
 // The returned func restores the prooduction implemenation.
 func ReplaceProviderForTesting(
-	providerType cloudpb.ExternalStorageProvider,
-	parseFn ExternalStorageURIParser,
-	constructFn ExternalStorageConstructor,
-	redactedParams map[string]struct{},
-	schemes ...string,
+	providerType cloudpb.ExternalStorageProvider, provider RegisteredProvider,
 ) func() {
-	if len(schemes) != 1 {
+	if len(provider.Schemes) != 1 {
 		panic("expected 1 scheme")
 	}
-	scheme := schemes[0]
+	scheme := provider.Schemes[0]
 
 	remove := func() {
 		delete(implementations, providerType)
+		delete(earlyBootImplementations, providerType)
+
 		delete(confParsers, scheme)
+		delete(earlyBootConfParsers, scheme)
 	}
 
 	oldImpl := implementations[providerType]
 	oldParser := confParsers[scheme]
+	oldEarlyImpl := earlyBootImplementations[providerType]
+	oldEaryParser := earlyBootConfParsers[scheme]
 
 	remove()
-	registerExternalStorageProviderImpl(providerType, parseFn, constructFn, redactedParams, schemes...)
+	registerExternalStorageProviderImpls(providerType, provider)
 
 	return func() {
 		remove()
@@ -467,6 +606,12 @@ func ReplaceProviderForTesting(
 		}
 		if oldParser != nil {
 			confParsers[scheme] = oldParser
+		}
+		if oldEarlyImpl != nil {
+			earlyBootImplementations[providerType] = oldEarlyImpl
+		}
+		if oldEaryParser != nil {
+			earlyBootConfParsers[scheme] = oldEaryParser
 		}
 	}
 }

--- a/pkg/cloud/nodelocal/BUILD.bazel
+++ b/pkg/cloud/nodelocal/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "nodelocal_connection.go",
         "nodelocal_storage.go",
+        "test_nodelocal_storage.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cloud/nodelocal",
     visibility = ["//visibility:public"],
@@ -19,6 +20,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/server/telemetry",
         "//pkg/settings/cluster",
+        "//pkg/util/buildutil",
         "//pkg/util/ioctx",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",

--- a/pkg/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage.go
@@ -226,5 +226,10 @@ func (*localFileStorage) Close() error {
 
 func init() {
 	cloud.RegisterExternalStorageProvider(cloudpb.ExternalStorageProvider_nodelocal,
-		parseLocalFileURI, makeLocalFileStorage, cloud.RedactedParams(), scheme)
+		cloud.RegisteredProvider{
+			ConstructFn:    makeLocalFileStorage,
+			ParseFn:        parseLocalFileURI,
+			RedactedParams: cloud.RedactedParams(),
+			Schemes:        []string{scheme},
+		})
 }

--- a/pkg/cloud/nodelocal/test_nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/test_nodelocal_storage.go
@@ -1,0 +1,61 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package nodelocal
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/blobs"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+)
+
+// ReplaceNodeLocalForTesting replaces the implementation of of
+// nodelocal with one reads and writes directly from the given
+// directory.
+//
+// The returned func restores the prooduction implemenation.
+func ReplaceNodeLocalForTesting(root string) func() {
+	makeFn := func(ctx context.Context, conf cloud.ExternalStorageContext, es cloudpb.ExternalStorage) (cloud.ExternalStorage, error) {
+		if !buildutil.CrdbTestBuild {
+			panic("nodelocal test implementation in non-test build")
+		}
+		c, err := blobs.NewLocalClient(root)
+		if err != nil {
+			return nil, err
+		}
+		lfs := &localFileStorage{
+			cfg:        es.LocalFileConfig,
+			ioConf:     base.ExternalIODirConfig{},
+			base:       es.LocalFileConfig.Path,
+			blobClient: c,
+			settings:   conf.Settings,
+		}
+		return lfs, nil
+	}
+
+	parserFn := func(_ cloud.ExternalStorageURIContext, uri *url.URL) (cloudpb.ExternalStorage, error) {
+		if !buildutil.CrdbTestBuild {
+			panic("nodelocal test implementation in non-test build")
+		}
+
+		return cloudpb.ExternalStorage{
+			Provider: cloudpb.ExternalStorageProvider_nodelocal,
+			LocalFileConfig: cloudpb.ExternalStorage_LocalFileConfig{
+				Path: uri.Path,
+			},
+		}, nil
+	}
+	return cloud.ReplaceProviderForTesting(cloudpb.ExternalStorageProvider_nodelocal, parserFn, makeFn, cloud.RedactedParams(), scheme)
+}

--- a/pkg/cloud/nullsink/nullsink_storage.go
+++ b/pkg/cloud/nullsink/nullsink_storage.go
@@ -100,5 +100,10 @@ var _ cloud.ExternalStorage = &nullSinkStorage{}
 
 func init() {
 	cloud.RegisterExternalStorageProvider(cloudpb.ExternalStorageProvider_null,
-		parseNullURL, makeNullSinkStorage, cloud.RedactedParams(), "null")
+		cloud.RegisteredProvider{
+			ConstructFn:    makeNullSinkStorage,
+			ParseFn:        parseNullURL,
+			RedactedParams: cloud.RedactedParams(),
+			Schemes:        []string{"null"},
+		})
 }

--- a/pkg/cloud/uris_test.go
+++ b/pkg/cloud/uris_test.go
@@ -11,18 +11,28 @@
 package cloud_test
 
 import (
+	"context"
+	"net/url"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSanitizeExternalStorageURI(t *testing.T) {
 	// Register a scheme to test scheme-specific redaction.
-	cloud.RegisterExternalStorageProvider(0, nil, nil,
-		cloud.RedactedParams("TEST_PARAM"),
-		"test-scheme",
-	)
+	cloud.RegisterExternalStorageProvider(0, cloud.RegisteredProvider{
+		ParseFn: func(cloud.ExternalStorageURIContext, *url.URL) (cloudpb.ExternalStorage, error) {
+			return cloudpb.ExternalStorage{}, errors.Newf("unimplemented")
+		},
+		ConstructFn: func(context.Context, cloud.ExternalStorageContext, cloudpb.ExternalStorage) (cloud.ExternalStorage, error) {
+			return nil, errors.Newf("unimplemented")
+		},
+		RedactedParams: cloud.RedactedParams("TEST_PARAM"),
+		Schemes:        []string{"test-scheme"},
+	})
 	testCases := []struct {
 		name             string
 		inputURI         string

--- a/pkg/cloud/userfile/file_table_storage.go
+++ b/pkg/cloud/userfile/file_table_storage.go
@@ -296,5 +296,10 @@ func (f *fileTableStorage) Size(ctx context.Context, basename string) (int64, er
 
 func init() {
 	cloud.RegisterExternalStorageProvider(cloudpb.ExternalStorageProvider_userfile,
-		parseUserfileURL, makeFileTableStorage, cloud.RedactedParams(), scheme)
+		cloud.RegisteredProvider{
+			ConstructFn:    makeFileTableStorage,
+			ParseFn:        parseUserfileURL,
+			RedactedParams: cloud.RedactedParams(),
+			Schemes:        []string{scheme},
+		})
 }

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -127,8 +127,8 @@ func TestReadEnvironmentVariables(t *testing.T) {
 	cfg.AmbientCtx.Tracer = nil
 	cfgExpected.Tracer = nil
 	cfgExpected.AmbientCtx.Tracer = nil
-	cfg.ExternalStorageAccessor = nil
-	cfgExpected.ExternalStorageAccessor = nil
+	cfg.EarlyBootExternalStorageAccessor = nil
+	cfgExpected.EarlyBootExternalStorageAccessor = nil
 	// Temp storage disk monitors will have slightly different names, so we
 	// override them to point to the same one.
 	cfgExpected.TempStorageConfig.Mon = cfg.TempStorageConfig.Mon

--- a/pkg/server/external_storage_builder.go
+++ b/pkg/server/external_storage_builder.go
@@ -44,7 +44,7 @@ type externalStorageBuilder struct {
 }
 
 func (e *externalStorageBuilder) init(
-	ctx context.Context,
+	esAccessor *cloud.EarlyBootExternalStorageAccessor,
 	conf base.ExternalIODirConfig,
 	settings *cluster.Settings,
 	nodeIDContainer *base.SQLIDContainer,
@@ -67,12 +67,12 @@ func (e *externalStorageBuilder) init(
 	e.blobClientFactory = blobClientFactory
 	e.initCalled = true
 	e.db = db
-	e.limiters = cloud.MakeLimiters(&settings.SV)
+	e.limiters = esAccessor.Limiters()
 	e.recorder = recorder
 
 	// Register the metrics that track interactions with external storage
 	// providers.
-	e.metrics = cloud.MakeMetrics()
+	e.metrics = esAccessor.Metrics()
 	registry.AddMetricStruct(e.metrics)
 }
 

--- a/pkg/server/external_storage_builder.go
+++ b/pkg/server/external_storage_builder.go
@@ -67,7 +67,7 @@ func (e *externalStorageBuilder) init(
 	e.blobClientFactory = blobClientFactory
 	e.initCalled = true
 	e.db = db
-	e.limiters = cloud.MakeLimiters(ctx, &settings.SV)
+	e.limiters = cloud.MakeLimiters(&settings.SV)
 	e.recorder = recorder
 
 	// Register the metrics that track interactions with external storage

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2065,7 +2065,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 	ieMon.StartNoReserved(ctx, s.PGServer().SQLServer.GetBytesMonitor())
 	s.stopper.AddCloser(stop.CloserFn(func() { ieMon.Stop(ctx) }))
 	s.externalStorageBuilder.init(
-		ctx,
+		s.cfg.EarlyBootExternalStorageAccessor,
 		s.cfg.ExternalIODirConfig,
 		s.st,
 		s.sqlServer.sqlIDContainer,
@@ -2076,11 +2076,6 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		nil, /* TenantExternalIORecorder */
 		s.appRegistry,
 	)
-	if err := s.cfg.ExternalStorageAccessor.Init(
-		s.externalStorageBuilder.makeExternalStorage, s.externalStorageBuilder.makeExternalStorageFromURI,
-	); err != nil {
-		return err
-	}
 
 	// Start the job scheduler now that the SQL Server and
 	// external storage is initialized.

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -336,7 +336,7 @@ func makeSharedProcessTenantServerConfig(
 
 	sqlCfg = MakeSQLConfig(tenantID, tempStorageCfg)
 	baseCfg.Settings.ExternalIODir = kvServerCfg.BaseConfig.Settings.ExternalIODir
-	sqlCfg.ExternalIODirConfig = kvServerCfg.SQLConfig.ExternalIODirConfig
+	baseCfg.ExternalIODirConfig = kvServerCfg.BaseConfig.ExternalIODirConfig
 
 	// Use the internal connector instead of the network.
 	// See: https://github.com/cockroachdb/cockroach/issues/84591

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -832,8 +832,8 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	ieMon.StartNoReserved(ctx, s.PGServer().SQLServer.GetBytesMonitor())
 	s.stopper.AddCloser(stop.CloserFn(func() { ieMon.Stop(ctx) }))
 	s.externalStorageBuilder.init(
-		ctx,
-		s.sqlCfg.ExternalIODirConfig,
+		s.cfg.EarlyBootExternalStorageAccessor,
+		s.cfg.ExternalIODirConfig,
 		s.sqlServer.cfg.Settings,
 		s.sqlServer.sqlIDContainer,
 		s.kvNodeDialer,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1092,10 +1092,6 @@ func (t *testTenant) DistSQLPlanningNodeID() roachpb.NodeID {
 	return 0
 }
 
-func (ts *testTenant) ExternalStorageAccessor() interface{} {
-	return ts.sql.cfg.ExternalStorageAccessor
-}
-
 // LeaseManager is part of the serverutils.ApplicationLayerInterface.
 func (t *testTenant) LeaseManager() interface{} {
 	return t.sql.leaseMgr
@@ -1657,7 +1653,6 @@ func (ts *testServer) StartTenant(
 	st.ExternalIODir = params.ExternalIODir
 	sqlCfg := makeTestSQLConfig(st, params.TenantID)
 	sqlCfg.TenantLoopbackAddr = ts.AdvRPCAddr()
-	sqlCfg.ExternalIODirConfig = params.ExternalIODirConfig
 	if params.MemoryPoolSize != 0 {
 		sqlCfg.MemoryPoolSize = params.MemoryPoolSize
 	}
@@ -1706,6 +1701,7 @@ func (ts *testServer) StartTenant(
 	baseCfg.DefaultZoneConfig = ts.Cfg.DefaultZoneConfig
 	baseCfg.HeapProfileDirName = ts.Cfg.BaseConfig.HeapProfileDirName
 	baseCfg.GoroutineDumpDirName = ts.Cfg.BaseConfig.GoroutineDumpDirName
+	baseCfg.ExternalIODirConfig = params.ExternalIODirConfig
 
 	// Grant the tenant the default capabilities.
 	if err := ts.grantDefaultTenantCapabilities(ctx, params.TenantID, params.SkipTenantCheck); err != nil {
@@ -1891,10 +1887,6 @@ func (ts *testServer) UpdateChecker() interface{} {
 // DiagnosticsReporter implements the serverutils.ApplicationLayerInterface.
 func (ts *testServer) DiagnosticsReporter() interface{} {
 	return ts.topLevelServer.sqlServer.diagnosticsReporter
-}
-
-func (ts *testServer) ExternalStorageAccessor() interface{} {
-	return ts.Cfg.ExternalStorageAccessor
 }
 
 type v2AuthDecorator struct {

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -57,7 +57,6 @@ go_library(
         "//pkg/kv/kvserver/diskmap",
         "//pkg/kv/kvserver/uncertainty",
         "//pkg/roachpb",
-        "//pkg/security/username",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/fetchpb",

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -184,7 +184,7 @@ func SecondaryCache(size int64) ConfigOption {
 }
 
 // RemoteStorageFactory enables use of remote storage (experimental).
-func RemoteStorageFactory(accessor *cloud.ExternalStorageAccessor) ConfigOption {
+func RemoteStorageFactory(accessor *cloud.EarlyBootExternalStorageAccessor) ConfigOption {
 	return func(cfg *engineConfig) error {
 		cfg.RemoteStorageFactory = accessor
 		return nil

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -793,7 +792,7 @@ type PebbleConfig struct {
 	SharedStorage cloud.ExternalStorage
 
 	// RemoteStorageFactory is used to pass the ExternalStorage factory.
-	RemoteStorageFactory *cloud.ExternalStorageAccessor
+	RemoteStorageFactory *cloud.EarlyBootExternalStorageAccessor
 
 	// onClose is a slice of functions to be invoked before the engine is closed.
 	onClose []func(*Pebble)
@@ -992,11 +991,11 @@ func (p *Pebble) Download(ctx context.Context, span roachpb.Span) error {
 type remoteStorageAdaptor struct {
 	p       *Pebble
 	ctx     context.Context
-	factory *cloud.ExternalStorageAccessor
+	factory *cloud.EarlyBootExternalStorageAccessor
 }
 
 func (r remoteStorageAdaptor) CreateStorage(locator remote.Locator) (remote.Storage, error) {
-	es, err := r.factory.OpenURL(r.ctx, string(locator), username.SQLUsername{})
+	es, err := r.factory.OpenURL(r.ctx, string(locator))
 	return &externalStorageWrapper{p: r.p, ctx: r.ctx, es: es}, err
 }
 


### PR DESCRIPTION
This adds the concept of "early boot" external storage providers. Such providers can be constructed and used without depending on a working SQL or storage layer.

We want such a distinction to support using external storage providers from pebble itself. When starting a node with external SSTs, we would like to be able to open the providers for those SSTs without regard to where the server startup is.

Previously, we attempted to simply block until the required dependencies were available. However, this quickly revealed a deadlock at startup.  While we could potentially fix the deadlock, we do not want to have to be constantly vigilant for minor changes to pebble that could re-introduce such a deadlock.

Epic: none
Release note: None