### PR TITLE
kv: store span by pointer in latch struct

### DIFF
--- a/pkg/kv/kvserver/spanlatch/manager_test.go
+++ b/pkg/kv/kvserver/spanlatch/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/poison"
@@ -679,6 +680,13 @@ func TestLatchManagerWaitFor(t *testing.T) {
 	lg3, err = m.WaitUntilAcquired(context.Background(), lg3)
 	require.NoError(t, err)
 	m.Release(lg3)
+}
+
+// TestSizeOfLatch tests the size of the latch struct.
+func TestSizeOfLatch(t *testing.T) {
+	var la latch
+	size := int(unsafe.Sizeof(la))
+	require.Equal(t, 56, size)
 }
 
 func BenchmarkLatchManagerReadOnlyMix(b *testing.B) {


### PR DESCRIPTION
kv: store span by pointer in latch struct

This pr changes latch struct to store a pointer to span that is preallocated
on the heap. The new struct will reduce memory footprint of span by 40 bytes. One
side effect would be increase the probably of running into nil pointer issue
especially when spans pointer are not initialized and accessed properly.

Fixes: https://github.com/cockroachdb/cockroach/issues/114603
Release note: None.