### PR TITLE
sql,server: remove crdb_internal.has_role_option

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/doc.go
+++ b/pkg/ccl/changefeedccl/cdceval/doc.go
@@ -134,7 +134,6 @@ functions along with the number of arguments and the return type of the overload
   crdb_internal.get_namespace_id                               |        2 | int8
   crdb_internal.get_namespace_id                               |        3 | int8
   crdb_internal.get_zone_config                                |        1 | bytea
-  crdb_internal.has_role_option                                |        1 | bool
   crdb_internal.is_admin                                       |        0 | bool
   crdb_internal.locality_value                                 |        1 | text
   crdb_internal.node_id                                        |        0 | int8

--- a/pkg/jobs/jobsauth/authorization.go
+++ b/pkg/jobs/jobsauth/authorization.go
@@ -61,6 +61,9 @@ type AuthorizationAccessor interface {
 	// HasPrivilege mirrors sql.AuthorizationAccessor.
 	HasPrivilege(ctx context.Context, privilegeObject privilege.Object, privilege privilege.Kind, user username.SQLUsername) (bool, error)
 
+	// UserHasRoleOption mirrors sql.AuthorizationAccessor.
+	UserHasRoleOption(ctx context.Context, user username.SQLUsername, roleOption roleoption.Option) (bool, error)
+
 	// HasRoleOption mirrors sql.AuthorizationAccessor.
 	HasRoleOption(ctx context.Context, roleOption roleoption.Option) (bool, error)
 

--- a/pkg/jobs/jobsauth/authorization_test.go
+++ b/pkg/jobs/jobsauth/authorization_test.go
@@ -96,6 +96,16 @@ func (a *testAuthAccessor) HasPrivilege(
 	return false, nil
 }
 
+func (a *testAuthAccessor) UserHasRoleOption(
+	_ context.Context, user username.SQLUsername, roleOption roleoption.Option,
+) (bool, error) {
+	if user != a.user {
+		panic(fmt.Sprintf("testAuthAccessor does not implement UserHasRoleOption for user %s", user))
+	}
+	_, ok := a.roleOptions[roleOption]
+	return ok, nil
+}
+
 func (a *testAuthAccessor) HasRoleOption(
 	_ context.Context, roleOption roleoption.Option,
 ) (bool, error) {

--- a/pkg/server/authserver/BUILD.bazel
+++ b/pkg/server/authserver/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/isql",
-        "//pkg/sql/roleoption",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/types",

--- a/pkg/server/authserver/api_v2.go
+++ b/pkg/server/authserver/api_v2.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
-	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 )
 
 type ServerV2 interface {
@@ -62,13 +61,10 @@ func NewV2Mux(s ServerV2, inner http.Handler, allowAnonymous bool) AuthV2Mux {
 }
 
 // NewRoleAuthzMux creates a new RoleAuthzMux.
-func NewRoleAuthzMux(
-	ie isql.Executor, role APIRole, option roleoption.Option, inner http.Handler,
-) RoleAuthzMux {
+func NewRoleAuthzMux(ie isql.Executor, role APIRole, inner http.Handler) RoleAuthzMux {
 	return &roleAuthorizationMux{
-		ie:     ie,
-		role:   role,
-		option: option,
-		inner:  inner,
+		ie:    ie,
+		role:  role,
+		inner: inner,
 	}
 }

--- a/pkg/server/privchecker/privchecker.go
+++ b/pkg/server/privchecker/privchecker.go
@@ -271,34 +271,15 @@ func (c *adminPrivilegeChecker) HasAdminRole(
 	return bool(dbDatum), nil
 }
 
-// HasRoleOptions is part of the SQLPrivilegeChecker interface.
+// HasRoleOption is part of the SQLPrivilegeChecker interface.
 // Note that the function returns plain errors, and it is the caller's
 // responsibility to convert them to serverErrors.
 func (c *adminPrivilegeChecker) HasRoleOption(
 	ctx context.Context, user username.SQLUsername, roleOption roleoption.Option,
 ) (bool, error) {
-	if user.IsRootUser() {
-		// Shortcut.
-		return true, nil
-	}
-	row, err := c.ie.QueryRowEx(
-		ctx, "check-role-option", nil, /* txn */
-		sessiondata.InternalExecutorOverride{User: user},
-		"SELECT crdb_internal.has_role_option($1)", roleOption.String())
-	if err != nil {
-		return false, err
-	}
-	if row == nil {
-		return false, errors.AssertionFailedf("hasRoleOption: expected 1 row, got 0")
-	}
-	if len(row) != 1 {
-		return false, errors.AssertionFailedf("hasRoleOption: expected 1 column, got %d", len(row))
-	}
-	dbDatum, ok := tree.AsDBool(row[0])
-	if !ok {
-		return false, errors.AssertionFailedf("hasRoleOption: expected bool, got %T", row[0])
-	}
-	return bool(dbDatum), nil
+	aa, cleanup := c.makeAuthzAccessor("check-role-option")
+	defer cleanup()
+	return aa.UserHasRoleOption(ctx, user, roleOption)
 }
 
 // HasPrivilegeOrRoleOption is a helper function which calls both HasGlobalPrivilege and HasRoleOption.

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -840,7 +840,6 @@ go_test(
         "//pkg/sql/privilege",
         "//pkg/sql/querycache",
         "//pkg/sql/randgen",
-        "//pkg/sql/roleoption",
         "//pkg/sql/row",
         "//pkg/sql/rowenc",
         "//pkg/sql/rowenc/keyside",

--- a/pkg/sql/logictest/testdata/logic_test/internal_executor
+++ b/pkg/sql/logictest/testdata/logic_test/internal_executor
@@ -14,4 +14,7 @@ statement ok
 SET avoid_buffering = true;
 
 statement ok
-SELECT crdb_internal.has_role_option('VIEWACTIVITY')
+CREATE TABLE t (i INT PRIMARY KEY);
+
+statement ok
+SELECT has_table_privilege('testuser', 't', 'SELECT');

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6310,38 +6310,6 @@ SELECT
 		},
 	),
 
-	// Returns true iff the current user has the specified role option.
-	// Note: it would be a privacy leak to extend this to check arbitrary usernames.
-	"crdb_internal.has_role_option": makeBuiltin(
-		tree.FunctionProperties{
-			Category:         builtinconstants.CategorySystemInfo,
-			DistsqlBlocklist: true,
-		},
-		tree.Overload{
-			Types: tree.ParamTypes{
-				{Name: "option", Typ: types.String},
-			},
-			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if evalCtx.SessionAccessor == nil {
-					return nil, errors.AssertionFailedf("session accessor not set")
-				}
-				optionStr := string(tree.MustBeDString(args[0]))
-				option, ok := roleoption.ByName[optionStr]
-				if !ok {
-					return nil, errors.Newf("unrecognized role option %s", optionStr)
-				}
-				ok, err := evalCtx.SessionAccessor.HasRoleOption(ctx, option)
-				if err != nil {
-					return nil, err
-				}
-				return tree.MakeDBool(tree.DBool(ok)), nil
-			},
-			Info:       "Returns whether the current user has the specified role option",
-			Volatility: volatility.Stable,
-		},
-	),
-
 	"crdb_internal.assignment_cast": makeBuiltin(
 		tree.FunctionProperties{
 			Category: builtinconstants.CategorySystemInfo,

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -1317,7 +1317,6 @@ var builtinOidsArray = []string{
 	1337: `crdb_internal.num_inverted_index_entries(val: string, version: int) -> int`,
 	1338: `crdb_internal.num_inverted_index_entries(val: anyelement[], version: int) -> int`,
 	1339: `crdb_internal.is_admin() -> bool`,
-	1340: `crdb_internal.has_role_option(option: string) -> bool`,
 	1341: `crdb_internal.assignment_cast(val: anyelement, type: anyelement) -> anyelement`,
 	1342: `crdb_internal.round_decimal_values(val: decimal, scale: int) -> decimal`,
 	1343: `crdb_internal.round_decimal_values(val: decimal[], scale: int) -> decimal[]`,


### PR DESCRIPTION
None of the endpoints require role options now, and in general we want to move away from using role options in favor of system privileges. As such, we should just remove this code.

Epic: None
Release note: None