### PR TITLE
release-23.1: roachtest: port tpcc/mixed-headroom to the new framework + refactor test context

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -43,7 +43,7 @@ var (
 // provides convenient utility function to pretty print versions and
 // check whether this is the current version being tested.
 type Version struct {
-	*version.Version
+	version.Version
 }
 
 // String returns the string representation of this version. For
@@ -65,17 +65,17 @@ func (v *Version) String() string {
 // IsCurrent returns whether this version corresponds to the current
 // version being tested.
 func (v *Version) IsCurrent() bool {
-	return v.Version.Compare(CurrentVersion().Version) == 0
+	return v.Version.Compare(&CurrentVersion().Version) == 0
 }
 
 // CurrentVersion returns the version associated with the current
 // build.
 func CurrentVersion() *Version {
 	if TestBuildVersion != nil {
-		return &Version{TestBuildVersion} // test-only
+		return &Version{*TestBuildVersion} // test-only
 	}
 
-	return &Version{version.MustParse(build.BinaryVersion())}
+	return &Version{*version.MustParse(build.BinaryVersion())}
 }
 
 // MustParseVersion parses the version string given (with or without
@@ -86,7 +86,7 @@ func MustParseVersion(v string) *Version {
 		versionStr = "v" + v
 	}
 
-	return &Version{version.MustParse(versionStr)}
+	return &Version{*version.MustParse(versionStr)}
 }
 
 // BinaryVersion returns the binary version running on the node

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "mixedversion",
     srcs = [
+        "context.go",
         "helper.go",
         "mixedversion.go",
         "planner.go",
@@ -22,6 +23,7 @@ go_library(
         "//pkg/roachprod/vm",
         "//pkg/testutils/release",
         "//pkg/util/ctxgroup",
+        "//pkg/util/intsets",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
@@ -33,6 +35,7 @@ go_library(
 go_test(
     name = "mixedversion_test",
     srcs = [
+        "context_test.go",
         "helper_test.go",
         "mixedversion_test.go",
         "planner_test.go",
@@ -48,6 +51,7 @@ go_test(
         "//pkg/roachpb",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
+        "//pkg/util/intsets",
         "//pkg/util/version",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/context.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/context.go
@@ -1,0 +1,163 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package mixedversion
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/util/intsets"
+)
+
+type (
+	// Context wraps the context passed to predicate functions that
+	// dictate when a mixed-version hook will run during a test
+	Context struct {
+		// CockroachNodes is the set of cockroach nodes in the cluster
+		// that are being part of the upgrade being performed.
+		CockroachNodes option.NodeListOption
+		// FromVersion is the version the nodes are migrating from.
+		FromVersion *clusterupgrade.Version
+		// ToVersion is the version the nodes are migrating to.
+		ToVersion *clusterupgrade.Version
+		// Finalizing indicates whether the cluster version is in the
+		// process of upgrading (i.e., all nodes in the cluster have been
+		// upgraded to a certain version, and the migrations are being
+		// executed).
+		Finalizing bool
+
+		// nodesByVersion maps released versions to which nodes are
+		// currently running that version.
+		nodesByVersion map[clusterupgrade.Version]*intsets.Fast
+	}
+)
+
+func newInitialContext(
+	initialRelease *clusterupgrade.Version, crdbNodes option.NodeListOption,
+) *Context {
+	return &Context{
+		CockroachNodes: crdbNodes,
+		FromVersion:    initialRelease,
+		ToVersion:      initialRelease,
+		nodesByVersion: map[clusterupgrade.Version]*intsets.Fast{
+			*initialRelease: intSetP(crdbNodes...),
+		},
+	}
+}
+
+// newLongRunningContext is the test context passed to long running
+// tasks (background functions and the like). In these scenarios,
+// `FromVersion` and `ToVersion` correspond to, respectively, the
+// initial version the cluster is started at, and the final version
+// once the test finishes. Background functions should *not* rely on
+// context functions since the context is not dynamically updated as
+// the test makes progress during the background function's execution.
+func newLongRunningContext(
+	from, to *clusterupgrade.Version, crdbNodes option.NodeListOption,
+) *Context {
+	return &Context{
+		CockroachNodes: crdbNodes,
+		FromVersion:    from,
+		ToVersion:      to,
+		nodesByVersion: map[clusterupgrade.Version]*intsets.Fast{
+			*from: intSetP(crdbNodes...),
+		},
+	}
+}
+
+// clone copies the caller Context and returns the copy.
+func (c *Context) clone() Context {
+	nodesByVersion := make(map[clusterupgrade.Version]*intsets.Fast)
+	for v, nodes := range c.nodesByVersion {
+		newSet := nodes.Copy()
+		nodesByVersion[v] = &newSet
+	}
+
+	fromVersion := c.FromVersion.Version
+	toVersion := c.ToVersion.Version
+
+	return Context{
+		CockroachNodes: append(option.NodeListOption{}, c.CockroachNodes...),
+		FromVersion:    &clusterupgrade.Version{Version: fromVersion},
+		ToVersion:      &clusterupgrade.Version{Version: toVersion},
+		Finalizing:     c.Finalizing,
+		nodesByVersion: nodesByVersion,
+	}
+}
+
+// startUpgrade is called when the test is starting the upgrade to the
+// given version. This should be called once every node is already
+// running that version and the cluster version has finished reaching
+// the logical version corresponding to that release.
+func (c *Context) startUpgrade(nextRelease *clusterupgrade.Version) {
+	c.FromVersion = c.ToVersion
+	c.ToVersion = nextRelease
+}
+
+// changeVersion is used to indicate that the given `node` is now
+// running release version `v`.
+func (c *Context) changeVersion(node int, v *clusterupgrade.Version) {
+	currentVersion := c.NodeVersion(node)
+	c.nodesByVersion[*currentVersion].Remove(node)
+	if _, exists := c.nodesByVersion[*v]; !exists {
+		c.nodesByVersion[*v] = intSetP()
+	}
+
+	c.nodesByVersion[*v].Add(node)
+}
+
+// nodesInVersion returns a list of all nodes running the version
+// passed, if any.
+func (c *Context) nodesInVersion(v *clusterupgrade.Version) option.NodeListOption {
+	set, ok := c.nodesByVersion[*v]
+	if !ok {
+		return nil
+	}
+
+	return set.Ordered()
+}
+
+// NodeVersion returns the release version the given `node` is
+// currently running. Panics if the node is not valid.
+func (c *Context) NodeVersion(node int) *clusterupgrade.Version {
+	for version, nodes := range c.nodesByVersion {
+		if nodes.Contains(node) {
+			return &version
+		}
+	}
+
+	panic(fmt.Errorf("NodeVersion error: invalid node %d, cockroach nodes: %v", node, c.CockroachNodes))
+}
+
+// NodesInPreviousVersion returns a list of nodes running the version
+// we are upgrading from.
+func (c *Context) NodesInPreviousVersion() option.NodeListOption {
+	return c.nodesInVersion(c.FromVersion)
+}
+
+// NodesInNextVersion returns the list of nodes running the version we
+// are upgrading to.
+func (c *Context) NodesInNextVersion() option.NodeListOption {
+	return c.nodesInVersion(c.ToVersion)
+}
+
+// MixedBinary indicates if the cluster is currently in mixed-binary
+// mode, i.e., not all nodes in the cluster are running the same
+// released binary version.
+func (c *Context) MixedBinary() bool {
+	return len(c.NodesInPreviousVersion()) > 0 && len(c.NodesInNextVersion()) > 0
+}
+
+func intSetP(ns ...int) *intsets.Fast {
+	set := intsets.MakeFast(ns...)
+	return &set
+}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/context_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/context_test.go
@@ -1,0 +1,116 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package mixedversion
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/util/intsets"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContext_startUpgrade(t *testing.T) {
+	initialVersion := clusterupgrade.MustParseVersion("v22.2.10")
+	upgradeVersion := clusterupgrade.MustParseVersion("v23.1.2")
+
+	c := newInitialContext(initialVersion, option.NodeListOption{1, 2, 3})
+	c.startUpgrade(upgradeVersion)
+
+	require.Equal(t, &Context{
+		CockroachNodes: option.NodeListOption{1, 2, 3},
+		FromVersion:    initialVersion,
+		ToVersion:      upgradeVersion,
+		nodesByVersion: map[clusterupgrade.Version]*intsets.Fast{
+			*initialVersion: intSetP(1, 2, 3),
+		},
+	}, c)
+}
+
+// TestContextOperations runs a series of operations on a context and
+// checks that functions called on that context (that could be called
+// in user-provided hooks) behave as expected.
+func TestContextOperations(t *testing.T) {
+	initialVersion := clusterupgrade.MustParseVersion("v22.2.10")
+	upgradeVersion := clusterupgrade.MustParseVersion("v23.1.2")
+
+	c := newInitialContext(initialVersion, option.NodeListOption{1, 2, 3})
+	c.startUpgrade(upgradeVersion)
+
+	ops := []struct {
+		name                           string
+		changeVersionNode              int
+		changeVersion                  *clusterupgrade.Version
+		expectedNodesInPreviousVersion option.NodeListOption
+		expectedNodesInNextVersion     option.NodeListOption
+		expectedMixedBinary            bool
+	}{
+		{
+			name:                           "upgrade n1",
+			changeVersionNode:              1,
+			changeVersion:                  upgradeVersion,
+			expectedNodesInPreviousVersion: option.NodeListOption{2, 3},
+			expectedNodesInNextVersion:     option.NodeListOption{1},
+			expectedMixedBinary:            true,
+		},
+		{
+			name:                           "upgrade n3",
+			changeVersionNode:              3,
+			changeVersion:                  upgradeVersion,
+			expectedNodesInPreviousVersion: option.NodeListOption{2},
+			expectedNodesInNextVersion:     option.NodeListOption{1, 3},
+			expectedMixedBinary:            true,
+		},
+		{
+			name:                           "upgrade n2",
+			changeVersionNode:              2,
+			changeVersion:                  upgradeVersion,
+			expectedNodesInPreviousVersion: nil,
+			expectedNodesInNextVersion:     option.NodeListOption{1, 2, 3},
+			expectedMixedBinary:            false,
+		},
+		{
+			name:                           "downgrade n3",
+			changeVersionNode:              3,
+			changeVersion:                  initialVersion,
+			expectedNodesInPreviousVersion: option.NodeListOption{3},
+			expectedNodesInNextVersion:     option.NodeListOption{1, 2},
+			expectedMixedBinary:            true,
+		},
+		{
+			name:                           "downgrade n1",
+			changeVersionNode:              1,
+			changeVersion:                  initialVersion,
+			expectedNodesInPreviousVersion: option.NodeListOption{1, 3},
+			expectedNodesInNextVersion:     option.NodeListOption{2},
+			expectedMixedBinary:            true,
+		},
+		{
+			name:                           "downgrade n2",
+			changeVersionNode:              2,
+			changeVersion:                  initialVersion,
+			expectedNodesInPreviousVersion: option.NodeListOption{1, 2, 3},
+			expectedNodesInNextVersion:     nil,
+			expectedMixedBinary:            false,
+		},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			c.changeVersion(op.changeVersionNode, op.changeVersion)
+			require.Equal(t, op.expectedNodesInPreviousVersion, c.NodesInPreviousVersion())
+			require.Equal(t, op.expectedNodesInNextVersion, c.NodesInNextVersion())
+			require.Equal(t, op.expectedMixedBinary, c.MixedBinary())
+			require.Equal(t, op.changeVersion, c.NodeVersion(op.changeVersionNode))
+		})
+	}
+}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
@@ -103,7 +103,7 @@ func (h *Helper) Background(
 			}
 
 			desc := fmt.Sprintf("error in background function %s: %s", name, err)
-			return h.runner.testFailure(desc, bgLogger)
+			return h.runner.testFailure(desc, bgLogger, nil)
 		}
 
 		return nil

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
@@ -77,8 +77,7 @@ func TestClusterVersionAtLeast(t *testing.T) {
 			runner := testTestRunner()
 			runner.clusterVersions = clusterVersions
 
-			h := runner.newHelper(ctx, nilLogger)
-			h.testContext = &Context{Finalizing: false} // do not attempt to query cluster version
+			h := runner.newHelper(ctx, nilLogger, Context{Finalizing: false})
 
 			supportedFeature, err := h.ClusterVersionAtLeast(rng, tc.minVersion)
 			if tc.expectedErr == "" {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -36,19 +36,6 @@ import (
 )
 
 type (
-	// Helper is the struct passed to user-functions providing helper
-	// functions that mixed-version tests can use.
-	Helper struct {
-		ctx         context.Context
-		testContext *Context
-		// bgCount keeps track of the number of background tasks started
-		// with `helper.Background()`. The counter is used to generate
-		// unique log file names.
-		bgCount    int64
-		runner     *testRunner
-		stepLogger *logger.Logger
-	}
-
 	// backgroundEvent is the struct sent by background steps when they
 	// finish (successfully or not).
 	backgroundEvent struct {
@@ -488,10 +475,10 @@ func (tr *testRunner) newHelper(
 	ctx context.Context, l *logger.Logger, testContext Context,
 ) *Helper {
 	return &Helper{
-		ctx:         ctx,
-		runner:      tr,
-		stepLogger:  l,
-		testContext: &testContext,
+		Context:    &testContext,
+		ctx:        ctx,
+		runner:     tr,
+		stepLogger: l,
 	}
 }
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
@@ -81,5 +81,6 @@ func (tss testSingleStep) Run(
 }
 
 func newTestStep(f func() error) singleStep {
-	return testSingleStep{runFunc: f}
+	initialVersion := parseVersions([]string{predecessorVersion})[0]
+	return newSingleStep(newInitialContext(initialVersion, nodes), testSingleStep{runFunc: f})
 }

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -1537,7 +1537,7 @@ func (mvb *mixedVersionBackup) maybeTakePreviousVersionBackup(
 		return nil
 	}
 
-	previousVersion := h.Context().FromVersion
+	previousVersion := h.Context.FromVersion
 	label := fmt.Sprintf("before upgrade in %s", sanitizeVersionForBackup(previousVersion))
 	allPrevVersionNodes := labeledNodes{Nodes: mvb.roachNodes, Version: previousVersion.String()}
 	executeOnAllNodesSpec := backupSpec{PauseProbability: neverPause, Plan: allPrevVersionNodes, Execute: allPrevVersionNodes}
@@ -1564,14 +1564,13 @@ func (d *BackupRestoreTestDriver) nextRestoreID() int64 {
 // depending on the state of the test we are in. The given label is also used to
 // provide more context. Example: '22.2.4-to-current_final'
 func (mvb *mixedVersionBackup) backupNamePrefix(h *mixedversion.Helper, label string) string {
-	testContext := h.Context()
 	var finalizing string
-	if testContext.Finalizing {
+	if h.Context.Finalizing {
 		finalizing = finalizingLabel
 	}
 
-	fromVersion := sanitizeVersionForBackup(testContext.FromVersion)
-	toVersion := sanitizeVersionForBackup(testContext.ToVersion)
+	fromVersion := sanitizeVersionForBackup(h.Context.FromVersion)
+	toVersion := sanitizeVersionForBackup(h.Context.ToVersion)
 	sanitizedLabel := strings.ReplaceAll(label, " ", "-")
 
 	return fmt.Sprintf(
@@ -2079,14 +2078,11 @@ func (mvb *mixedVersionBackup) planAndRunBackups(
 		return nil
 	}
 
-	tc := h.Context() // test context
-	l.Printf("current context: %#v", tc)
-
 	onPrevious := labeledNodes{
-		Nodes: tc.NodesInPreviousVersion(), Version: sanitizeVersionForBackup(tc.FromVersion),
+		Nodes: h.Context.NodesInPreviousVersion(), Version: sanitizeVersionForBackup(h.Context.FromVersion),
 	}
 	onNext := labeledNodes{
-		Nodes: tc.NodesInNextVersion(), Version: sanitizeVersionForBackup(tc.ToVersion),
+		Nodes: h.Context.NodesInNextVersion(), Version: sanitizeVersionForBackup(h.Context.ToVersion),
 	}
 	onRandom := labeledNodes{Nodes: mvb.roachNodes, Version: "random node"}
 	defaultPauseProbability := 0.2
@@ -2124,7 +2120,7 @@ func (mvb *mixedVersionBackup) planAndRunBackups(
 		},
 	}
 
-	if tc.MixedBinary() {
+	if h.Context.MixedBinary() {
 		const numCollections = 2
 		rng.Shuffle(len(collectionSpecs), func(i, j int) {
 			collectionSpecs[i], collectionSpecs[j] = collectionSpecs[j], collectionSpecs[i]
@@ -2419,8 +2415,8 @@ func (mvb *mixedVersionBackup) verifyAllBackups(
 		}
 	}
 
-	verify(h.Context().FromVersion)
-	verify(h.Context().ToVersion)
+	verify(h.Context.FromVersion)
+	verify(h.Context.ToVersion)
 
 	// If the context was canceled (most likely due to a test timeout),
 	// return early. In these cases, it's likely that `restoreErrors`

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2083,10 +2083,10 @@ func (mvb *mixedVersionBackup) planAndRunBackups(
 	l.Printf("current context: %#v", tc)
 
 	onPrevious := labeledNodes{
-		Nodes: tc.FromVersionNodes, Version: sanitizeVersionForBackup(tc.FromVersion),
+		Nodes: tc.NodesInPreviousVersion(), Version: sanitizeVersionForBackup(tc.FromVersion),
 	}
 	onNext := labeledNodes{
-		Nodes: tc.ToVersionNodes, Version: sanitizeVersionForBackup(tc.ToVersion),
+		Nodes: tc.NodesInNextVersion(), Version: sanitizeVersionForBackup(tc.ToVersion),
 	}
 	onRandom := labeledNodes{Nodes: mvb.roachNodes, Version: "random node"}
 	defaultPauseProbability := 0.2
@@ -2124,7 +2124,7 @@ func (mvb *mixedVersionBackup) planAndRunBackups(
 		},
 	}
 
-	if len(tc.FromVersionNodes) > 0 {
+	if tc.MixedBinary() {
 		const numCollections = 2
 		rng.Shuffle(len(collectionSpecs), func(i, j int) {
 			collectionSpecs[i], collectionSpecs[j] = collectionSpecs[j], collectionSpecs[i]

--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -252,8 +252,10 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 	}
 
 	// Set up and run test.
-	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All(), mixedversion.ClusterSettingOption(
-		install.EnvOption{"COCKROACH_SCAN_MAX_IDLE_TIME=10ms"})) // speed up queues
+	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All(),
+		mixedversion.ClusterSettingOption(install.EnvOption{"COCKROACH_SCAN_MAX_IDLE_TIME=10ms"}), // speed up queues
+		mixedversion.MaxUpgrades(2), // crdb_internal.kv_set_queue_active is only available on v22.1+
+	)
 
 	mvt.OnStartup("create test table", createTable)
 	mvt.InMixedVersion("move replicas", moveReplicas)

--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -131,7 +131,7 @@ func validateCorpusFile(
 //     a version bump).
 func runDeclSchemaChangeCompatMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
 	currentVersion := clusterupgrade.CurrentVersion()
-	predecessorVersionStr, err := release.LatestPredecessor(currentVersion.Version)
+	predecessorVersionStr, err := release.LatestPredecessor(&currentVersion.Version)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/tests/mixed_version_tenant_span_stats.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_tenant_span_stats.go
@@ -95,7 +95,7 @@ func registerTenantSpanStatsMixedVersion(r registry.Registry) {
 
 			mvt.InMixedVersion("fetch span stats - mixed", func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
 				// Skip finalizing state.
-				if h.Context().Finalizing {
+				if h.Context.Finalizing {
 					return nil
 				}
 

--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -64,16 +64,20 @@ INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12);
 	mvt.InMixedVersion(
 		"modify and verify index data while in a mixed version state",
 		func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
-			node, db := h.RandomDB(r, h.Context().ToVersionNodes)
-			l.Printf("connecting to n%d", node)
+			// Run the following statements in a node running the next
+			// version, if any; otherwise, pick a random node.
+			nodes := c.All()
+			if h.Context().MixedBinary() {
+				nodes = h.Context().NodesInNextVersion()
+			}
 
-			if _, err := db.Exec(`DELETE FROM t WHERE x = 13 OR x = 20`); err != nil {
+			if err := h.ExecWithGateway(r, nodes, `DELETE FROM t WHERE x = 13 OR x = 20`); err != nil {
 				return err
 			}
-			if _, err := db.Exec(`INSERT INTO t VALUES (13, 14, 15, 16)`); err != nil {
+			if err := h.ExecWithGateway(r, nodes, `INSERT INTO t VALUES (13, 14, 15, 16)`); err != nil {
 				return err
 			}
-			if _, err := db.Exec(`UPDATE t SET w = 17 WHERE y = 14`); err != nil {
+			if err := h.ExecWithGateway(r, nodes, `UPDATE t SET w = 17 WHERE y = 14`); err != nil {
 				return err
 			}
 			if err := verifyTableData(ctx, c, l, 1, firstExpected); err != nil {

--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -67,8 +67,8 @@ INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12);
 			// Run the following statements in a node running the next
 			// version, if any; otherwise, pick a random node.
 			nodes := c.All()
-			if h.Context().MixedBinary() {
-				nodes = h.Context().NodesInNextVersion()
+			if h.Context.MixedBinary() {
+				nodes = h.Context.NodesInNextVersion()
 			}
 
 			if err := h.ExecWithGateway(r, nodes, `DELETE FROM t WHERE x = 13 OR x = 20`); err != nil {

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -459,6 +459,7 @@ func registerTPCC(r registry.Registry) {
 		Suites:            registry.Suites(registry.Nightly, registry.ReleaseQualification),
 		Tags:              registry.Tags(`default`, `release_qualification`, `aws`),
 		Cluster:           headroomSpec,
+		Timeout:           4 * time.Hour,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -23,16 +23,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/testutils/release"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/search"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
@@ -354,12 +354,11 @@ func maxSupportedTPCCWarehouses(
 }
 
 // runTPCCMixedHeadroom runs a mixed-version test that imports a large
-// `bank` dataset, and runs one or multiple database upgrades while a
-// TPCC workload is running. The number of database upgrades is
-// controlled by the `versionsToUpgrade` parameter.
-func runTPCCMixedHeadroom(
-	ctx context.Context, t test.Test, c cluster.Cluster, versionsToUpgrade int,
-) {
+// `bank` dataset, and runs multiple database upgrades while a TPCC
+// workload is running. The number of database upgrades is randomized
+// by the mixed-version framework which chooses a random predecessor version
+// and upgrades until it reaches the current version.
+func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
 	workloadNode := c.Node(c.Spec().NodeCount)
 
@@ -368,26 +367,6 @@ func runTPCCMixedHeadroom(
 	if c.IsLocal() {
 		headroomWarehouses = 10
 	}
-
-	// We'll need this below.
-	tpccBackgroundStepper := func(duration time.Duration) backgroundStepper {
-		return backgroundStepper{
-			nodes: crdbNodes,
-			run: func(ctx context.Context, u *versionUpgradeTest) error {
-				t.L().Printf("running background TPCC workload for %s", duration)
-				runTPCC(ctx, t, c, tpccOptions{
-					Warehouses: headroomWarehouses,
-					Duration:   duration,
-					SetupType:  usingExistingData,
-					Start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-						// Noop - we don't let tpcc upload or start binaries in this test.
-					},
-				})
-				return nil
-			}}
-	}
-
-	randomCRDBNode := func() int { return crdbNodes.RandNode()[0] }
 
 	// NB: this results in ~100GB of (actual) disk usage per node once things
 	// have settled down, and ~7.5k ranges. The import takes ~40 minutes.
@@ -398,91 +377,74 @@ func runTPCCMixedHeadroom(
 		bankRows = 1000
 	}
 
-	rng, seed := randutil.NewLockedPseudoRand()
-	t.L().Printf("using random seed %d", seed)
-	history, err := release.RandomPredecessorHistory(rng, t.BuildVersion(), versionsToUpgrade)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sep := " -> "
-	t.L().Printf("testing upgrade: %s%scurrent", strings.Join(history, sep), sep)
-	releases := make([]*clusterupgrade.Version, 0, len(history))
-	for _, v := range history {
-		releases = append(releases, clusterupgrade.MustParseVersion(v))
-	}
-	releases = append(releases, clusterupgrade.CurrentVersion())
+	mvt := mixedversion.NewTest(ctx, t, t.L(), c, crdbNodes)
 
-	waitForWorkloadToRampUp := sleepStep(rampDuration(c.IsLocal()))
-	logStep := func(format string, args ...interface{}) versionStep {
-		return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
-			t.L().Printf(format, args...)
+	importTPCC := func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
+		randomNode := c.Node(h.RandomNode(rng, crdbNodes))
+		cmd := tpccImportCmdWithCockroachBinary(test.DefaultCockroachPath, headroomWarehouses, fmt.Sprintf("{pgurl%s}", randomNode))
+		return c.RunE(ctx, randomNode, cmd)
+	}
+
+	// Add a lot of cold data to this cluster. This further stresses the version
+	// upgrade machinery, in which a) all ranges are touched and b) work proportional
+	// to the amount data may be carried out.
+	importLargeBank := func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
+		randomNode := c.Node(h.RandomNode(rng, crdbNodes))
+		cmd := roachtestutil.NewCommand(fmt.Sprintf("%s workload fixtures import bank", test.DefaultCockroachPath)).
+			Arg("{pgurl%s}", randomNode).
+			Flag("payload-bytes", 10240).
+			Flag("rows", bankRows).
+			Flag("seed", 4).
+			Flag("db", "bigbank").
+			String()
+		return c.RunE(ctx, randomNode, cmd)
+	}
+
+	// We don't run this in the background using the Workload() wrapper. We want
+	// it to block and wait for the workload to ramp up before attempting to upgrade
+	// the cluster version. If we start the migrations immediately after launching
+	// the tpcc workload, they could finish "too quickly", before the workload had
+	// a chance to pick up the pace (starting all the workers, range merge/splits,
+	// compactions, etc). By waiting here, we increase the concurrency exposed to
+	// the upgrade migrations, and increase the chances of exposing bugs (such as #83079).
+	runTPCCWorkload := func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
+		workloadDur := 10 * time.Minute
+		rampDur := rampDuration(c.IsLocal())
+		// If migrations are running we want to ramp up the workload faster in order
+		// to expose them to more concurrent load. In a similar goal, we also let the
+		// TPCC workload run longer.
+		if h.Context().Finalizing && !c.IsLocal() {
+			rampDur = 1 * time.Minute
+			if h.Context().ToVersion.IsCurrent() {
+				workloadDur = 100 * time.Minute
+			}
 		}
+		cmd := roachtestutil.NewCommand("./cockroach workload run tpcc").
+			Arg("{pgurl%s}", crdbNodes).
+			Flag("duration", workloadDur).
+			Flag("warehouses", headroomWarehouses).
+			Flag("histograms", t.PerfArtifactsDir()+"/stats.json").
+			Flag("ramp", rampDur).
+			Flag("prometheus-port", 2112).
+			Flag("pprofport", workloadPProfStartPort).
+			String()
+		return c.RunE(ctx, workloadNode, cmd)
 	}
 
-	oldestVersion := releases[0]
-	setupSteps := []versionStep{
-		logStep("starting from fixture at version %s", oldestVersion),
-		uploadAndStartFromCheckpointFixture(crdbNodes, oldestVersion),
-		waitForUpgradeStep(crdbNodes),                                    // let oldest version settle (gossip etc)
-		uploadVersionStep(workloadNode, clusterupgrade.CurrentVersion()), // for tpccBackgroundStepper's workload
-
-		// Load TPCC dataset, don't run TPCC yet. We do this while in the
-		// version we are starting with to load some data and hopefully
-		// create some state that will need work by long-running
-		// migrations.
-		importTPCCStep(oldestVersion, headroomWarehouses, crdbNodes),
-		// Add a lot of cold data to this cluster. This further stresses the version
-		// upgrade machinery, in which a) all ranges are touched and b) work proportional
-		// to the amount data may be carried out.
-		importLargeBankStep(oldestVersion, bankRows, crdbNodes),
+	checkTPCCWorkload := func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
+		cmd := roachtestutil.NewCommand(fmt.Sprintf("%s workload check tpcc", test.DefaultCockroachPath)).
+			Arg("{pgurl:1}").
+			Flag("warehouses", headroomWarehouses).
+			String()
+		return c.RunE(ctx, workloadNode, cmd)
 	}
 
-	// upgradeToVersionSteps returns the list of steps to be performed
-	// when upgrading to the given version.
-	upgradeToVersionSteps := func(crdbVersion *clusterupgrade.Version) []versionStep {
-		duration := 10 * time.Minute
-		if crdbVersion.IsCurrent() {
-			duration = 100 * time.Minute
-		}
-		tpccWorkload := tpccBackgroundStepper(duration)
-
-		return []versionStep{
-			logStep("upgrading to version %q", crdbVersion.String()),
-			preventAutoUpgradeStep(randomCRDBNode()),
-			// Upload and restart cluster into the new
-			// binary (stays at previous cluster version).
-			binaryUpgradeStep(crdbNodes, crdbVersion),
-			// Now start running TPCC in the background.
-			tpccWorkload.launch,
-			// Wait for the workload to ramp up before attemping to
-			// upgrade the cluster version. If we start the migrations
-			// immediately after launching the tpcc workload above, they
-			// could finish "too quickly", before the workload had a
-			// chance to pick up the pace (starting all the workers, range
-			// merge/splits, compactions, etc). By waiting here, we
-			// increase the concurrency exposed to the upgrade migrations,
-			// and increase the chances of exposing bugs (such as #83079).
-			waitForWorkloadToRampUp,
-			// While tpcc is running in the background, bump the cluster
-			// version manually. We do this over allowing automatic upgrades
-			// to get a better idea of what errors come back here, if any.
-			// This will block until the long-running migrations have run.
-			allowAutoUpgradeStep(randomCRDBNode()),
-			waitForUpgradeStep(crdbNodes),
-			// Wait until TPCC background run terminates
-			// and fail if it reports an error.
-			tpccWorkload.wait,
-		}
-	}
-
-	// Test steps consist of the setup steps + the upgrade steps for
-	// each upgrade being carried out here.
-	testSteps := append([]versionStep{}, setupSteps...)
-	for _, nextVersion := range releases[1:] {
-		testSteps = append(testSteps, upgradeToVersionSteps(nextVersion)...)
-	}
-
-	newVersionUpgradeTest(c, testSteps...).run(ctx, t)
+	uploadVersion(ctx, t, c, workloadNode, clusterupgrade.CurrentVersion())
+	mvt.OnStartup("load TPCC dataset", importTPCC)
+	mvt.OnStartup("load bank dataset", importLargeBank)
+	mvt.InMixedVersion("TPCC workload", runTPCCWorkload)
+	mvt.AfterUpgradeFinalized("check TPCC workload", checkTPCCWorkload)
+	mvt.Run()
 }
 
 func registerTPCC(r registry.Registry) {
@@ -527,23 +489,10 @@ func registerTPCC(r registry.Registry) {
 		Cluster:           mixedHeadroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runTPCCMixedHeadroom(ctx, t, c, 1)
+			runTPCCMixedHeadroom(ctx, t, c)
 		},
 	})
 
-	r.Add(registry.TestSpec{
-		// run the same mixed-headroom test, but going back two versions
-		Name:              "tpcc/mixed-headroom/multiple-upgrades/" + mixedHeadroomSpec.String(),
-		Owner:             registry.OwnerTestEng,
-		CompatibleClouds:  registry.AllExceptAWS,
-		Suites:            registry.Suites(registry.Nightly),
-		Tags:              registry.Tags(`default`),
-		Cluster:           mixedHeadroomSpec,
-		EncryptionSupport: registry.EncryptionMetamorphic,
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runTPCCMixedHeadroom(ctx, t, c, 2)
-		},
-	})
 	r.Add(registry.TestSpec{
 		Name:              "tpcc-nowait/nodes=3/w=1",
 		Owner:             registry.OwnerTestEng,

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -413,9 +413,9 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 		// If migrations are running we want to ramp up the workload faster in order
 		// to expose them to more concurrent load. In a similar goal, we also let the
 		// TPCC workload run longer.
-		if h.Context().Finalizing && !c.IsLocal() {
+		if h.Context.Finalizing && !c.IsLocal() {
 			rampDur = 1 * time.Minute
-			if h.Context().ToVersion.IsCurrent() {
+			if h.Context.ToVersion.IsCurrent() {
 				workloadDur = 100 * time.Minute
 			}
 		}

--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -80,7 +80,7 @@ func runValidateSystemSchemaAfterVersionUpgrade(
 	mvt.AfterUpgradeFinalized(
 		"obtain system schema from the upgraded cluster",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			if !h.Context().ToVersion.IsCurrent() {
+			if !h.Context.ToVersion.IsCurrent() {
 				// Only validate the system schema if we're upgrading to the version
 				// under test.
 				return nil

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -153,7 +153,7 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// TODO(renato): stage different workload binaries for the
 			// releases being used in the test and use the appropriate
 			// binary in this step.
-			if !tc.FromVersion.IsCurrent() && !tc.ToVersion.IsCurrent() {
+			if !tc.ToVersion.IsCurrent() {
 				l.Printf("skipping this step -- only supported when current version is involved")
 				return nil
 			}

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -145,7 +145,6 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 	mvt.InMixedVersion(
 		"test schema change step",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			tc := h.Context()
 			// We currently only stage the `workload` binary built off the
 			// SHA being tested; therefore, we skip testing the schemachange
 			// workload if this is not an upgrade or downgrade involving the
@@ -153,7 +152,7 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// TODO(renato): stage different workload binaries for the
 			// releases being used in the test and use the appropriate
 			// binary in this step.
-			if !tc.ToVersion.IsCurrent() {
+			if !h.Context.ToVersion.IsCurrent() {
 				l.Printf("skipping this step -- only supported when current version is involved")
 				return nil
 			}

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -456,55 +456,6 @@ done
 		}).run(ctx, t)
 }
 
-// importTPCCStep runs a TPCC import import on the first crdbNode (monitoring them all for
-// crashes during the import). If oldV is nil, this runs the import using the specified
-// version (for example "19.2.1", as provided by LatestPredecessor()) using the location
-// used by c.Stage(). An empty oldV uses the main cockroach binary.
-func importTPCCStep(
-	oldV *clusterupgrade.Version, headroomWarehouses int, crdbNodes option.NodeListOption,
-) versionStep {
-	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
-		// We need to use the predecessor binary to load into the
-		// predecessor cluster to avoid random breakage. For example, you
-		// can't use 21.1 to import into 20.2 due to some flag changes.
-		//
-		// TODO(tbg): also import a large dataset (for example 2TB bank)
-		// that will provide cold data that may need to be migrated.
-		var cmd string
-		if oldV.IsCurrent() {
-			cmd = tpccImportCmd(headroomWarehouses)
-		} else {
-			cmd = tpccImportCmdWithCockroachBinary(clusterupgrade.BinaryPathForVersion(t, oldV), headroomWarehouses, "--checks=false")
-		}
-		// Use a monitor so that we fail cleanly if the cluster crashes
-		// during import.
-		m := u.c.NewMonitor(ctx, crdbNodes)
-		m.Go(func(ctx context.Context) error {
-			return u.c.RunE(ctx, u.c.Node(crdbNodes[0]), cmd)
-		})
-		m.Wait()
-	}
-}
-
-func importLargeBankStep(
-	oldV *clusterupgrade.Version, rows int, crdbNodes option.NodeListOption,
-) versionStep {
-	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
-		// Use the predecessor binary to load into the predecessor
-		// cluster to avoid random breakage due to flag changes, etc.
-		binary := clusterupgrade.BinaryPathForVersion(t, oldV)
-
-		// Use a monitor so that we fail cleanly if the cluster crashes
-		// during import.
-		m := u.c.NewMonitor(ctx, crdbNodes)
-		m.Go(func(ctx context.Context) error {
-			return u.c.RunE(ctx, u.c.Node(crdbNodes[0]), binary, "workload", "fixtures", "import", "bank",
-				"--payload-bytes=10240", "--rows="+fmt.Sprint(rows), "--seed=4", "--db=bigbank")
-		})
-		m.Wait()
-	}
-}
-
 func sleepStep(d time.Duration) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		time.Sleep(d)


### PR DESCRIPTION
Backport:
  * 1/1 commits from "roachtest: port tpcc/mixed-headroom to the new framework" (#113706)
  * 1/1 commits from " roachtest: bump timeout for tpcc/headroom/n4cpu16" (#114381) 
  * 4/4 commits from "mixedversion: refactor test context" (#114220 

Please see individual PRs for details.

Release justification: test-only changes.

/cc @cockroachdb/release
