### PR TITLE
release-23.1: roachtest: use dotnet v7 for npgsql test

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql.go
+++ b/pkg/cmd/roachtest/tests/npgsql.go
@@ -76,7 +76,7 @@ func registerNpgsql(r registry.Registry) {
 			c,
 			node,
 			"install dependencies",
-			`sudo snap install dotnet-sdk --classic && \
+			`sudo snap install dotnet-sdk --channel=7.0/stable --classic && \
 sudo snap alias dotnet-sdk.dotnet dotnet && \
 sudo ln -s /snap/dotnet-sdk/current/dotnet /usr/local/bin/dotnet`,
 		); err != nil {


### PR DESCRIPTION
Backport 1/2 commits from #114606.

/cc @cockroachdb/release

Release justification: test only change

---

roachtest: use dotnet v7 for npgsql test

The version wasn't pinned, so a recent release made it start using v8,
which doesn't work with this test.

---

fixes https://github.com/cockroachdb/cockroach/issues/114034
fixes https://github.com/cockroachdb/cockroach/issues/114298
fixes https://github.com/cockroachdb/cockroach/issues/114303


Release note: None
