### PR TITLE
roachprod: better error reporting for SyncedCluster Wait

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1401,7 +1401,7 @@ func (c *SyncedCluster) Wait(ctx context.Context, l *logger.Logger) error {
 				}
 				return res, nil
 			}
-			res.Err = errors.New("timed out after 5m")
+			res.Err = errors.Wrapf(res.Err, "timed out after 5m")
 			l.Printf("  %2d: %v", node, res.Err)
 			return res, nil
 		})


### PR DESCRIPTION
Previously, `Wait` swallowed an error and did not report the actual cause. This
change captures the original error as well.

Epic: None
Release Note: None