### PR TITLE
opt: reduce planning time for queries with many joins

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -3650,7 +3650,7 @@ project
       │    ├── key columns: [13 17 12 11] = [6 2 5 1]
       │    ├── lookup columns are key
       │    ├── immutable
-      │    ├── stats: [rows=0.01031997, distinct(1)=0.01032, null(1)=0, distinct(2)=0.01032, null(2)=0, distinct(5)=0.01032, null(5)=0, distinct(6)=0.01032, null(6)=0, distinct(10)=0.0102714, null(10)=0, distinct(11)=0.01032, null(11)=0, distinct(12)=0.01032, null(12)=0, distinct(13)=0.01032, null(13)=0, distinct(16)=0.0102638, null(16)=0, distinct(17)=0.01032, null(17)=0, distinct(18)=0.010244, null(18)=0, distinct(19)=0.010244, null(19)=0, distinct(20)=0.0102638, null(20)=0, distinct(21)=0.0102638, null(21)=0, distinct(2,5,6)=0.01032, null(2,5,6)=0]
+      │    ├── stats: [rows=0.01031997, distinct(1)=0.01032, null(1)=0, distinct(2)=0.01032, null(2)=0, distinct(5)=0.01032, null(5)=0, distinct(6)=0.01032, null(6)=0, distinct(11)=0.01032, null(11)=0, distinct(12)=0.01032, null(12)=0, distinct(13)=0.01032, null(13)=0, distinct(17)=0.01032, null(17)=0, distinct(2,5,6)=0.01032, null(2,5,6)=0]
       │    ├── cost: 112.088874
       │    ├── fd: ()-->(2,5,6,12,13,17,20,21), (16)-->(18,19), (11)==(1,16), (16)==(1,11), (12)==(5,20), (20)==(5,12), (13)==(6,21), (21)==(6,13), (6)==(13,21), (2)==(17), (17)==(2), (5)==(12,20), (1)==(11,16)
       │    ├── distribution: ap-southeast-2
@@ -3660,7 +3660,7 @@ project
       │    │    ├── key columns: [21 16] = [21 16]
       │    │    ├── lookup columns are key
       │    │    ├── immutable
-      │    │    ├── stats: [rows=1.101776, distinct(10)=1.08174, null(10)=0, distinct(11)=0.936667, null(11)=0, distinct(12)=0.936667, null(12)=0, distinct(13)=0.936667, null(13)=0, distinct(16)=0.936667, null(16)=0, distinct(17)=0.709904, null(17)=0, distinct(18)=0.693547, null(18)=0, distinct(19)=0.693547, null(19)=0, distinct(20)=0.936667, null(20)=0, distinct(21)=0.936667, null(21)=0]
+      │    │    ├── stats: [rows=1.101776, distinct(11)=0.936667, null(11)=0, distinct(12)=0.936667, null(12)=0, distinct(13)=0.936667, null(13)=0, distinct(16)=0.936667, null(16)=0, distinct(17)=0.709904, null(17)=0, distinct(20)=0.936667, null(20)=0, distinct(21)=0.936667, null(21)=0]
       │    │    ├── cost: 107.514948
       │    │    ├── fd: ()-->(12,13,17,20,21), (16)-->(18,19), (11)==(16), (16)==(11), (12)==(20), (20)==(12), (13)==(21), (21)==(13)
       │    │    ├── distribution: ap-southeast-2
@@ -3680,7 +3680,7 @@ project
       │    │    │    ├── project
       │    │    │    │    ├── columns: "lookup_join_const_col_@17":28 str:10 abc_id:11 x.id2:12 x.crdb_region:13
       │    │    │    │    ├── immutable
-      │    │    │    │    ├── stats: [rows=3.666667, distinct(10)=3.11719, null(10)=0, distinct(11)=3.11719, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=1, null(13)=0, distinct(28)=1, null(28)=0]
+      │    │    │    │    ├── stats: [rows=3.666667, distinct(11)=3.11719, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=1, null(13)=0, distinct(28)=1, null(28)=0]
       │    │    │    │    ├── cost: 73.3666668
       │    │    │    │    ├── fd: ()-->(12,13,28)
       │    │    │    │    ├── distribution: ap-southeast-2
@@ -3689,7 +3689,7 @@ project
       │    │    │    │    │    ├── columns: str:10 abc_id:11 x.id2:12 x.crdb_region:13
       │    │    │    │    │    ├── constraint: /13/12/10/11/9: [/'ap-southeast-2'/'68088706-02c6-47d1-b993-a421cd761f2b' - /'ap-southeast-2'/'68088706-02c6-47d1-b993-a421cd761f2b']
       │    │    │    │    │    ├── immutable
-      │    │    │    │    │    ├── stats: [rows=3.666667, distinct(10)=3.11719, null(10)=0, distinct(11)=3.11719, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=1, null(13)=0, distinct(12,13)=1, null(12,13)=0]
+      │    │    │    │    │    ├── stats: [rows=3.666667, distinct(11)=3.11719, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=1, null(13)=0, distinct(12,13)=1, null(12,13)=0]
       │    │    │    │    │    │   histogram(13)=  0       3.6667
       │    │    │    │    │    │                 <--- 'ap-southeast-2'
       │    │    │    │    │    ├── cost: 73.2733335

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -2308,7 +2308,7 @@ project
       ├── project
       │    ├── columns: c:2 b:1
       │    ├── immutable
-      │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=1000, null(2)=0]
+      │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
       │    ├── cost: 1088.44
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
@@ -2378,7 +2378,7 @@ project
       ├── project
       │    ├── columns: c:2(float!null) b:1(float!null)
       │    ├── immutable
-      │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=1000, null(2)=0]
+      │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
       │    ├── cost: 1088.44
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -3307,14 +3307,14 @@ inner-join (lookup geo_table)
  │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:11
  │    ├── inverted-expr
  │    │    └── st_intersects(geo_table2.geom:2, geo_table.geom:12)
- │    ├── stats: [rows=10000, distinct(1)=999.957, null(1)=0, distinct(11)=999.957, null(11)=0]
+ │    ├── stats: [rows=10000, distinct(11)=999.957, null(11)=0]
  │    ├── cost: 41812.84
  │    ├── key: (1,11)
  │    ├── fd: (1)-->(2)
  │    ├── distribution: test
  │    ├── scan geo_table2
  │    │    ├── columns: geo_table2.k:1 geo_table2.geom:2
- │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10]
+ │    │    ├── stats: [rows=1000, distinct(2)=100, null(2)=10]
  │    │    ├── cost: 1108.82
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)
@@ -3400,14 +3400,14 @@ left-join (lookup geo_table)
  │    ├── first join in paired joiner; continuation column: continuation:16
  │    ├── inverted-expr
  │    │    └── st_intersects(geo_table2.geom:2, geo_table.geom:12)
- │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(11)=999.957, null(11)=0]
+ │    ├── stats: [rows=10000, distinct(11)=999.957, null(11)=0]
  │    ├── cost: 41812.84
  │    ├── key: (1,11)
  │    ├── fd: (1)-->(2), (11)-->(16)
  │    ├── distribution: test
  │    ├── scan geo_table2
  │    │    ├── columns: geo_table2.k:1 geo_table2.geom:2
- │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+ │    │    ├── stats: [rows=1000]
  │    │    ├── cost: 1108.82
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)
@@ -3439,7 +3439,7 @@ semi-join (lookup geo_table)
  │    ├── first join in paired joiner; continuation column: continuation:16
  │    ├── inverted-expr
  │    │    └── st_intersects(geo_table2.geom:2, geo_table.geom:12)
- │    ├── stats: [rows=10000, distinct(1)=999.957, null(1)=0, distinct(11)=999.957, null(11)=0]
+ │    ├── stats: [rows=10000, distinct(11)=999.957, null(11)=0]
  │    ├── cost: 41812.84
  │    ├── key: (1,11)
  │    ├── fd: (1)-->(2), (11)-->(16)
@@ -3479,14 +3479,14 @@ anti-join (lookup geo_table)
  │    ├── first join in paired joiner; continuation column: continuation:16
  │    ├── inverted-expr
  │    │    └── st_intersects(geo_table2.geom:2, geo_table.geom:12)
- │    ├── stats: [rows=10000, distinct(1)=1000, null(1)=0, distinct(11)=999.957, null(11)=0]
+ │    ├── stats: [rows=10000, distinct(11)=999.957, null(11)=0]
  │    ├── cost: 41812.84
  │    ├── key: (1,11)
  │    ├── fd: (1)-->(2), (11)-->(16)
  │    ├── distribution: test
  │    ├── scan geo_table2
  │    │    ├── columns: geo_table2.k:1 geo_table2.geom:2
- │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+ │    │    ├── stats: [rows=1000]
  │    │    ├── cost: 1108.82
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2)

--- a/pkg/sql/opt/memo/testdata/stats/inverted-join
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-join
@@ -33,12 +33,12 @@ project
       │    ├── columns: ltable.k:1(int!null) ltable.geom:2(geometry) rtable.k:10(int!null)
       │    ├── inverted-expr
       │    │    └── st_intersects(ltable.geom:2, rtable.geom:11) [type=bool]
-      │    ├── stats: [rows=10000, distinct(1)=999.957, null(1)=0, distinct(10)=999.957, null(10)=0]
+      │    ├── stats: [rows=10000, distinct(10)=999.957, null(10)=0]
       │    ├── key: (1,10)
       │    ├── fd: (1)-->(2)
       │    ├── scan ltable
       │    │    ├── columns: ltable.k:1(int!null) ltable.geom:2(geometry)
-      │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10]
+      │    │    ├── stats: [rows=1000, distinct(2)=100, null(2)=10]
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2)
       │    └── filters (true)
@@ -65,12 +65,12 @@ project
       │    ├── columns: ltable.k:1(int!null) ltable.geom:2(geometry) rtable.k:10(int!null)
       │    ├── inverted-expr
       │    │    └── st_intersects(ltable.geom:2, rtable.geom:11) [type=bool]
-      │    ├── stats: [rows=10000, distinct(1)=999.957, null(1)=0, distinct(10)=999.957, null(10)=0]
+      │    ├── stats: [rows=10000, distinct(10)=999.957, null(10)=0]
       │    ├── key: (1,10)
       │    ├── fd: (1)-->(2)
       │    ├── scan ltable
       │    │    ├── columns: ltable.k:1(int!null) ltable.geom:2(geometry)
-      │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10]
+      │    │    ├── stats: [rows=1000, distinct(2)=100, null(2)=10]
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2)
       │    └── filters (true)
@@ -169,7 +169,7 @@ inner-join (lookup json_arr1 [as=t1])
  │    ├── columns: t2.k:8(int!null) t2.j:9(jsonb) t2.a:10(string[]) t1.k:13(int!null)
  │    ├── inverted-expr
  │    │    └── (t1.a:15 @> t2.a:10) AND (t1.a:15 @> ARRAY['foo']) [type=bool]
- │    ├── stats: [rows=33.33333, distinct(8)=3.33319, null(8)=0, distinct(13)=32.9462, null(13)=0]
+ │    ├── stats: [rows=33.33333, distinct(13)=32.9462, null(13)=0]
  │    ├── key: (8,13)
  │    ├── fd: (8)-->(9,10)
  │    ├── scan json_arr2 [as=t2]
@@ -204,7 +204,7 @@ project
       │    ├── columns: t2.k:8(int!null) t2.j:9(jsonb) t2.a:10(string[]) t1.k:13(int!null)
       │    ├── inverted-expr
       │    │    └── t1.j:14 @> t2.j:9 [type=bool]
-      │    ├── stats: [rows=33.33333, distinct(8)=3.33319, null(8)=0, distinct(13)=32.9462, null(13)=0]
+      │    ├── stats: [rows=33.33333, distinct(13)=32.9462, null(13)=0]
       │    ├── key: (8,13)
       │    ├── fd: (8)-->(9,10)
       │    ├── scan json_arr2 [as=t2]
@@ -265,7 +265,7 @@ inner-join (lookup json_arr1 [as=t1])
  │    ├── columns: t2.k:8(int!null) t2.j:9(jsonb) t2.a:10(string[]) t1.k:13(int!null)
  │    ├── inverted-expr
  │    │    └── (t1.a:15 <@ t2.a:10) AND (t1.a:15 <@ ARRAY['foo']) [type=bool]
- │    ├── stats: [rows=33.33333, distinct(8)=3.33319, null(8)=0, distinct(13)=32.9462, null(13)=0]
+ │    ├── stats: [rows=33.33333, distinct(13)=32.9462, null(13)=0]
  │    ├── key: (8,13)
  │    ├── fd: (8)-->(9,10)
  │    ├── scan json_arr2 [as=t2]
@@ -300,7 +300,7 @@ project
       │    ├── columns: t2.k:8(int!null) t2.j:9(jsonb) t2.a:10(string[]) t1.k:13(int!null)
       │    ├── inverted-expr
       │    │    └── t1.j:14 <@ t2.j:9 [type=bool]
-      │    ├── stats: [rows=33.33333, distinct(8)=3.33319, null(8)=0, distinct(13)=32.9462, null(13)=0]
+      │    ├── stats: [rows=33.33333, distinct(13)=32.9462, null(13)=0]
       │    ├── key: (8,13)
       │    ├── fd: (8)-->(9,10)
       │    ├── scan json_arr2 [as=t2]

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -110,12 +110,12 @@ project
       ├── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6), (9)-->(7,8,10,11), (1)==(7), (7)==(1)
       ├── scan xysd
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) xysd.crdb_internal_mvcc_timestamp:5(decimal) xysd.tableoid:6(oid)
-      │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=0, distinct(4)=500, null(4)=0]
+      │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=0]
       │    ├── key: (1)
       │    └── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6)
       ├── scan uv
       │    ├── columns: u:7(int) v:8(int!null) rowid:9(int!null) uv.crdb_internal_mvcc_timestamp:10(decimal) uv.tableoid:11(oid)
-      │    ├── stats: [rows=10000, distinct(7)=500, null(7)=0, distinct(8)=100, null(8)=0, distinct(9)=10000, null(9)=0]
+      │    ├── stats: [rows=10000, distinct(7)=500, null(7)=0]
       │    ├── key: (9)
       │    └── fd: (9)-->(7,8,10,11)
       └── filters
@@ -137,7 +137,7 @@ project
       ├── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6), (9)-->(7,8,10,11)
       ├── scan xysd
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) xysd.crdb_internal_mvcc_timestamp:5(decimal) xysd.tableoid:6(oid)
-      │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(4)=500, null(4)=0]
+      │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0]
       │    ├── key: (1)
       │    └── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6)
       ├── scan uv
@@ -168,7 +168,7 @@ project
       │    └── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6)
       ├── scan uv
       │    ├── columns: u:7(int) v:8(int!null) rowid:9(int!null) uv.crdb_internal_mvcc_timestamp:10(decimal) uv.tableoid:11(oid)
-      │    ├── stats: [rows=10000, distinct(7)=500, null(7)=0, distinct(8)=100, null(8)=0, distinct(9)=10000, null(9)=0]
+      │    ├── stats: [rows=10000, distinct(7)=500, null(7)=0]
       │    ├── key: (9)
       │    └── fd: (9)-->(7,8,10,11)
       └── filters
@@ -354,7 +354,7 @@ semi-join (hash)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(4)=500, null(4)=0]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan uv
@@ -374,7 +374,7 @@ anti-join (hash)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(4)=500, null(4)=0]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan uv
@@ -394,7 +394,7 @@ inner-join (hash)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (1)==(7), (7)==(1), (2)==(8), (8)==(2)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=0, distinct(4)=500, null(4)=0]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan uv
@@ -416,7 +416,7 @@ inner-join (hash)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (1)==(7), (7)==(1)
  ├── select
  │    ├── columns: x:1(int!null) y:2(int!null) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=3737.5, distinct(1)=3737.5, null(1)=0, distinct(2)=299, null(2)=0, distinct(4)=499.999, null(4)=0]
+ │    ├── stats: [rows=3737.5, distinct(1)=3737.5, null(1)=0, distinct(2)=299, null(2)=0]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── scan xysd
@@ -428,7 +428,7 @@ inner-join (hash)
  │         └── (y:2 > 0) AND (y:2 < 300) [type=bool, outer=(2), constraints=(/2: [/1 - /299]; tight)]
  ├── scan uv
  │    ├── columns: u:7(int) v:8(int!null)
- │    └── stats: [rows=10000, distinct(7)=500, null(7)=0, distinct(8)=100, null(8)=0]
+ │    └── stats: [rows=10000, distinct(7)=500, null(7)=0]
  └── filters
       ├── x:1 = u:7 [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
       └── (y:2 + v:8) = 5 [type=bool, outer=(2,8), immutable]
@@ -463,7 +463,7 @@ project
       │    │    └── fd: (1)-->(2)
       │    ├── scan uv
       │    │    ├── columns: u:7(int) v:8(int!null)
-      │    │    └── stats: [rows=10000, distinct(7)=500, null(7)=0, distinct(8)=100, null(8)=0]
+      │    │    └── stats: [rows=10000, distinct(7)=500, null(7)=0]
       │    └── filters
       │         ├── x:1 = u:7 [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
       │         └── (y:2 + v:8) = 5 [type=bool, outer=(2,8), immutable]
@@ -500,7 +500,7 @@ project
       │    │    └── fd: (1)-->(2)
       │    ├── scan uv
       │    │    ├── columns: u:7(int) v:8(int!null)
-      │    │    └── stats: [rows=10000, distinct(7)=500, null(7)=0, distinct(8)=100, null(8)=0]
+      │    │    └── stats: [rows=10000, distinct(7)=500, null(7)=0]
       │    └── filters
       │         ├── x:1 = u:7 [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
       │         └── (y:2 + v:8) = 5 [type=bool, outer=(2,8), immutable]
@@ -569,7 +569,7 @@ project
       │    ├── fd: (1)-->(2)
       │    ├── scan uv
       │    │    ├── columns: u:7(int) v:8(int!null)
-      │    │    └── stats: [rows=10000, distinct(7)=500, null(7)=0, distinct(8)=100, null(8)=0]
+      │    │    └── stats: [rows=10000, distinct(7)=500, null(7)=0]
       │    ├── scan xysd
       │    │    ├── columns: x:1(int!null) y:2(int)
       │    │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=0]
@@ -745,12 +745,12 @@ project
       ├── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6), (9)-->(7,8,10,11), (1)==(7), (7)==(1)
       ├── scan xysd
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) xysd.crdb_internal_mvcc_timestamp:5(decimal) xysd.tableoid:6(oid)
-      │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=5000, null(1,2)=0, distinct(2,3)=5000, null(2,3)=25]
+      │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(1,2)=5000, null(1,2)=0, distinct(2,3)=5000, null(2,3)=25]
       │    ├── key: (1)
       │    └── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6)
       ├── scan uv
       │    ├── columns: u:7(int) v:8(int!null) rowid:9(int!null) uv.crdb_internal_mvcc_timestamp:10(decimal) uv.tableoid:11(oid)
-      │    ├── stats: [rows=10000, distinct(7)=500, null(7)=5000, distinct(8)=100, null(8)=0, distinct(9)=10000, null(9)=0]
+      │    ├── stats: [rows=10000, distinct(7)=500, null(7)=5000, distinct(9)=10000, null(9)=0]
       │    ├── key: (9)
       │    └── fd: (9)-->(7,8,10,11)
       └── filters
@@ -772,7 +772,7 @@ project
       ├── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6), (9)-->(7,8,10,11)
       ├── scan xysd
       │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) xysd.crdb_internal_mvcc_timestamp:5(decimal) xysd.tableoid:6(oid)
-      │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=5000, null(1,2)=0, distinct(2,3)=5000, null(2,3)=25]
+      │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(1,2)=5000, null(1,2)=0, distinct(2,3)=5000, null(2,3)=25]
       │    ├── key: (1)
       │    └── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6)
       ├── scan uv
@@ -803,7 +803,7 @@ project
       │    └── fd: (1)-->(2-6), (3,4)~~>(1,2,5,6)
       ├── scan uv
       │    ├── columns: u:7(int) v:8(int!null) rowid:9(int!null) uv.crdb_internal_mvcc_timestamp:10(decimal) uv.tableoid:11(oid)
-      │    ├── stats: [rows=10000, distinct(7)=500, null(7)=5000, distinct(8)=100, null(8)=0, distinct(9)=10000, null(9)=0]
+      │    ├── stats: [rows=10000, distinct(7)=500, null(7)=5000, distinct(9)=10000, null(9)=0]
       │    ├── key: (9)
       │    └── fd: (9)-->(7,8,10,11)
       └── filters
@@ -933,7 +933,7 @@ semi-join (hash)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(4)=500, null(4)=0]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  ├── scan uv
@@ -950,7 +950,7 @@ semi-join (hash)
  ├── stats: [rows=10000, distinct(1)=500, null(1)=0]
  ├── scan uv
  │    ├── columns: u:1(int) v:2(int!null)
- │    └── stats: [rows=10000, distinct(1)=500, null(1)=5000, distinct(2)=100, null(2)=0]
+ │    └── stats: [rows=10000, distinct(1)=500, null(1)=5000]
  ├── scan xysd
  │    ├── columns: x:6(int!null)
  │    ├── stats: [rows=5000, distinct(6)=5000, null(6)=0]
@@ -982,19 +982,19 @@ inner-join (merge)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (9)-->(7,8), (1)==(7), (7)==(1)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=5000, null(1,2)=0, distinct(2,3)=5000, null(2,3)=25]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(1,2)=5000, null(1,2)=0, distinct(2,3)=5000, null(2,3)=25]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    └── ordering: +1
  ├── sort
  │    ├── columns: u:7(int) v:8(int!null) rowid:9(int!null)
- │    ├── stats: [rows=10000, distinct(7)=500, null(7)=5000, distinct(8)=100, null(8)=0, distinct(9)=10000, null(9)=0]
+ │    ├── stats: [rows=10000, distinct(7)=500, null(7)=5000, distinct(8)=100, null(8)=0]
  │    ├── key: (9)
  │    ├── fd: (9)-->(7,8)
  │    ├── ordering: +7
  │    └── scan uv
  │         ├── columns: u:7(int) v:8(int!null) rowid:9(int!null)
- │         ├── stats: [rows=10000, distinct(7)=500, null(7)=5000, distinct(8)=100, null(8)=0, distinct(9)=10000, null(9)=0]
+ │         ├── stats: [rows=10000, distinct(7)=500, null(7)=5000, distinct(8)=100, null(8)=0]
  │         ├── key: (9)
  │         └── fd: (9)-->(7,8)
  └── filters (true)
@@ -1023,7 +1023,7 @@ left-join (merge)
  ├── fd: (1)-->(2-4), (3,4)~~>(1,2), (9)-->(7,8)
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
- │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(4)=500, null(4)=0, distinct(1,2)=5000, null(1,2)=0, distinct(2,3)=5000, null(2,3)=25]
+ │    ├── stats: [rows=5000, distinct(1)=5000, null(1)=0, distinct(2)=400, null(2)=2500, distinct(3)=500, null(3)=50, distinct(1,2)=5000, null(1,2)=0, distinct(2,3)=5000, null(2,3)=25]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    └── ordering: +1
@@ -1760,7 +1760,7 @@ inner-join (cross)
  │    └── stats: [rows=1000, distinct(1)=100, null(1)=10]
  ├── scan classrequest
  │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
- │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, distinct(7)=100, null(7)=10, distinct(8)=100, null(8)=10]
+ │    ├── stats: [rows=1000, distinct(7)=100, null(7)=10, distinct(8)=100, null(8)=10]
  │    ├── key: (6)
  │    └── fd: (6)-->(7-9)
  └── filters
@@ -1780,7 +1780,7 @@ inner-join (cross)
  │    └── stats: [rows=1000, distinct(1)=100, null(1)=10]
  ├── scan classrequest
  │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
- │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, distinct(7)=100, null(7)=10, distinct(8)=100, null(8)=10, distinct(9)=100, null(9)=10]
+ │    ├── stats: [rows=1000, distinct(7)=100, null(7)=10, distinct(8)=100, null(8)=10, distinct(9)=100, null(9)=10]
  │    ├── key: (6)
  │    └── fd: (6)-->(7-9)
  └── filters
@@ -1949,7 +1949,7 @@ inner-join (cross)
  │    └── stats: [rows=5000, distinct(1)=5000, null(1)=0]
  ├── scan classrequest
  │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
- │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, distinct(7)=500, null(7)=0, distinct(8)=50, null(8)=0]
+ │    ├── stats: [rows=1000, distinct(7)=500, null(7)=0, distinct(8)=50, null(8)=0]
  │    ├── key: (6)
  │    └── fd: (6)-->(7-9)
  └── filters
@@ -1968,7 +1968,7 @@ inner-join (cross)
  │    └── stats: [rows=5000, distinct(1)=5000, null(1)=0]
  ├── scan classrequest
  │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
- │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, distinct(7)=500, null(7)=0, distinct(9)=10, null(9)=0]
+ │    ├── stats: [rows=1000, distinct(7)=500, null(7)=0, distinct(9)=10, null(9)=0]
  │    ├── key: (6)
  │    └── fd: (6)-->(7-9)
  └── filters
@@ -1988,7 +1988,7 @@ inner-join (cross)
  │    └── stats: [rows=5000, distinct(1)=5000, null(1)=0]
  ├── scan classrequest
  │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
- │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, distinct(7)=500, null(7)=0, distinct(8)=50, null(8)=0, distinct(9)=10, null(9)=0]
+ │    ├── stats: [rows=1000, distinct(7)=500, null(7)=0, distinct(8)=50, null(8)=0, distinct(9)=10, null(9)=0]
  │    ├── key: (6)
  │    └── fd: (6)-->(7-9)
  └── filters

--- a/pkg/sql/opt/memo/testdata/stats/lookup-join
+++ b/pkg/sql/opt/memo/testdata/stats/lookup-join
@@ -197,7 +197,7 @@ inner-join (lookup def)
  ├── fd: (1,3)-->(2), (7,8)-->(6), (1)==(8), (8)==(1)
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int) c:3(int!null)
- │    ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(3)=10, null(3)=0]
+ │    ├── stats: [rows=100, distinct(1)=100, null(1)=0]
  │    ├── key: (1,3)
  │    └── fd: (1,3)-->(2)
  └── filters (true)
@@ -215,13 +215,13 @@ inner-join (merge)
  ├── fd: (1,3)-->(2), (7,8)-->(6), (1)==(7), (7)==(1)
  ├── scan def@e_idx
  │    ├── columns: d:6(int) e:7(int!null) f:8(int!null)
- │    ├── stats: [rows=10000, distinct(7)=100, null(7)=0, distinct(8)=10000, null(8)=0]
+ │    ├── stats: [rows=10000, distinct(7)=100, null(7)=0]
  │    ├── key: (7,8)
  │    ├── fd: (7,8)-->(6)
  │    └── ordering: +7
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int) c:3(int!null)
- │    ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(3)=10, null(3)=0]
+ │    ├── stats: [rows=100, distinct(1)=100, null(1)=0]
  │    ├── key: (1,3)
  │    ├── fd: (1,3)-->(2)
  │    └── ordering: +1
@@ -263,7 +263,7 @@ left-join (lookup def)
  │    ├── fd: (1,3)-->(2), (7,8)-->(6)
  │    ├── scan abc
  │    │    ├── columns: a:1(int!null) b:2(int) c:3(int!null)
- │    │    ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=10, null(2)=1, distinct(3)=10, null(3)=0]
+ │    │    ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=10, null(2)=1]
  │    │    ├── key: (1,3)
  │    │    └── fd: (1,3)-->(2)
  │    └── filters
@@ -287,7 +287,7 @@ right-join (hash)
  │    └── fd: (7,8)-->(6,9)
  ├── scan abc
  │    ├── columns: a:1(int!null) b:2(int) c:3(int!null)
- │    ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=10, null(2)=1, distinct(3)=10, null(3)=0]
+ │    ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=10, null(2)=1]
  │    ├── key: (1,3)
  │    └── fd: (1,3)-->(2)
  └── filters

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -362,17 +362,17 @@ upsert mno
       │    │    │    ├── columns: m:6(int!null) n:7(int) o:8(int)
       │    │    │    ├── grouping columns: n:7(int) o:8(int)
       │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
-      │    │    │    ├── stats: [rows=2000, distinct(6)=1981, null(6)=0, distinct(7)=100, null(7)=10, distinct(8)=1900, null(8)=100]
+      │    │    │    ├── stats: [rows=2000, distinct(7)=100, null(7)=10, distinct(8)=1900, null(8)=100]
       │    │    │    ├── key: (6)
       │    │    │    ├── fd: (6)-->(7,8), (7,8)~~>(6)
       │    │    │    ├── project
       │    │    │    │    ├── columns: m:6(int!null) n:7(int) o:8(int)
-      │    │    │    │    ├── stats: [rows=2000, distinct(7)=100, null(7)=10, distinct(8)=1900, null(8)=100, distinct(7,8)=1981, null(7,8)=20]
+      │    │    │    │    ├── stats: [rows=2000, distinct(7)=100, null(7)=10, distinct(8)=1900, null(8)=100]
       │    │    │    │    ├── key: (6)
       │    │    │    │    ├── fd: (6)-->(7,8), (7,8)~~>(6)
       │    │    │    │    └── scan mno
       │    │    │    │         ├── columns: m:6(int!null) n:7(int) o:8(int) crdb_internal_mvcc_timestamp:9(decimal) tableoid:10(oid)
-      │    │    │    │         ├── stats: [rows=2000, distinct(7)=100, null(7)=10, distinct(8)=1900, null(8)=100, distinct(7,8)=1981, null(7,8)=20]
+      │    │    │    │         ├── stats: [rows=2000, distinct(7)=100, null(7)=10, distinct(8)=1900, null(8)=100]
       │    │    │    │         ├── key: (6)
       │    │    │    │         └── fd: (6)-->(7-10), (7,8)~~>(6,9,10)
       │    │    │    └── aggregations

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
@@ -1573,7 +1573,7 @@ root
            │    │    ├── scan t.public.child_diff_type
            │    │    │    ├── columns: t.public.child_diff_type.c:12(int!null) t.public.child_diff_type.p:13(int2)
            │    │    │    ├── flags: disabled not visible index feature
-           │    │    │    ├── stats: [rows=1000, distinct(12)=1000, null(12)=0, distinct(13)=100, null(13)=10]
+           │    │    │    ├── stats: [rows=1000, distinct(13)=100, null(13)=10]
            │    │    │    ├── key: (12)
            │    │    │    ├── fd: (12)-->(13)
            │    │    │    ├── prune: (12,13)

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -139,13 +139,13 @@ inner-join (lookup g [as=g2])
  │    ├── flags: force inverted join (into right side)
  │    ├── inverted-expr
  │    │    └── st_contains(g1.geom:2, g2.geom:12)
- │    ├── stats: [rows=10000, distinct(1)=999.957, null(1)=0, distinct(11)=999.957, null(11)=0]
+ │    ├── stats: [rows=10000, distinct(11)=999.957, null(11)=0]
  │    ├── cost: 41472.44
  │    ├── key: (1,11)
  │    ├── fd: (1)-->(2)
  │    ├── scan g [as=g1]
  │    │    ├── columns: g1.k:1!null g1.geom:2
- │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10]
+ │    │    ├── stats: [rows=1000, distinct(2)=100, null(2)=10]
  │    │    ├── cost: 1068.42
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2)
@@ -365,14 +365,14 @@ limit
  │    │    ├── columns: t.id:1!null sender_id:2!null receiver_id:3 amount:4!null t.creation_date:5!null last_update:6 schedule_date:7 status:8 comment:9 linked_trans_id:10 c1:11 c2:12 c3:13 s.id:16!null s.name:17!null s.gender:18 s.email:19 s.first_name:20 s.last_name:21 s.creation_date:22!null s.situation:23 s.balance:24!null s.is_blocked:25
  │    │    ├── key columns: [2] = [16]
  │    │    ├── lookup columns are key
- │    │    ├── stats: [rows=990, distinct(1)=628.605, null(1)=0, distinct(2)=99, null(2)=0, distinct(3)=99.995, null(3)=9.9, distinct(4)=99.995, null(4)=0, distinct(5)=99.995, null(5)=0, distinct(16)=99, null(16)=0, distinct(17)=99.995, null(17)=0, distinct(22)=99.995, null(22)=0, distinct(24)=99.995, null(24)=0]
+ │    │    ├── stats: [rows=990, distinct(2)=99, null(2)=0, distinct(3)=99.995, null(3)=9.9, distinct(16)=99, null(16)=0]
  │    │    ├── cost: 1511.62
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-13), (16)-->(17-25), (2)==(16), (16)==(2)
  │    │    ├── limit hint: 100.00
  │    │    ├── scan transaction [as=t]
  │    │    │    ├── columns: t.id:1!null sender_id:2 receiver_id:3 amount:4!null t.creation_date:5!null last_update:6 schedule_date:7 status:8 comment:9 linked_trans_id:10 c1:11 c2:12 c3:13
- │    │    │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(4)=100, null(4)=0, distinct(5)=100, null(5)=0]
+ │    │    │    ├── stats: [rows=1000, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10]
  │    │    │    ├── cost: 270.02
  │    │    │    ├── key: (1)
  │    │    │    ├── fd: (1)-->(2-13)
@@ -504,7 +504,7 @@ project
       ├── fd: ()-->(1,2,8,9), (1)==(8), (8)==(1), (2)==(9), (9)==(2), (3)==(10), (10)==(3)
       ├── select
       │    ├── columns: w:1!null x:2!null y:3!null z:4!null
-      │    ├── stats: [rows=100, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=25, null(3)=0, distinct(4)=10, null(4)=0]
+      │    ├── stats: [rows=100, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=25, null(3)=0]
       │    ├── cost: 138.96
       │    ├── fd: ()-->(1,2)
       │    ├── scan wxyz
@@ -614,7 +614,7 @@ project
       ├── fd: ()-->(1,2,5-10,14,15), (1)==(14), (14)==(1), (2)==(15), (15)==(2), (3)==(16), (16)==(3)
       ├── select
       │    ├── columns: w:1!null x:2!null y:3!null z:4!null i:5!null j:6!null k:7!null l:8!null m:9!null n:10!null
-      │    ├── stats: [rows=0.9000001, distinct(1)=0.9, null(1)=0, distinct(2)=0.9, null(2)=0, distinct(3)=0.884032, null(3)=0, distinct(4)=0.899636, null(4)=0, distinct(5)=0.9, null(5)=0, distinct(6)=0.9, null(6)=0, distinct(7)=0.9, null(7)=0, distinct(8)=0.9, null(8)=0, distinct(9)=0.9, null(9)=0, distinct(10)=0.9, null(10)=0, distinct(5-10)=0.9, null(5-10)=0]
+      │    ├── stats: [rows=0.9000001, distinct(1)=0.9, null(1)=0, distinct(2)=0.9, null(2)=0, distinct(3)=0.884032, null(3)=0, distinct(5)=0.9, null(5)=0, distinct(6)=0.9, null(6)=0, distinct(7)=0.9, null(7)=0, distinct(8)=0.9, null(8)=0, distinct(9)=0.9, null(9)=0, distinct(10)=0.9, null(10)=0, distinct(5-10)=0.9, null(5-10)=0]
       │    ├── cost: 12230.22
       │    ├── fd: ()-->(1,2,5-10)
       │    ├── scan wxyzijklmn
@@ -753,7 +753,7 @@ project
       │    ├── scan abcde@idx_abd
       │    │    ├── columns: a:7!null b:8!null c:9!null d:10!null
       │    │    ├── constraint: /7/8/10: [/'foo'/'2ab23800-06b1-4e19-a3bb-df3768b808d2' - /'foo'/'2ab23800-06b1-4e19-a3bb-df3768b808d2']
-      │    │    ├── stats: [rows=125000, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0, distinct(9)=24975.6, null(9)=0, distinct(10)=93750, null(10)=0]
+      │    │    ├── stats: [rows=125000, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0, distinct(9)=24975.6, null(9)=0]
       │    │    ├── cost: 126.02
       │    │    ├── key: (9)
       │    │    ├── fd: ()-->(7,8), (9)-->(10), (10)-->(9)

--- a/pkg/sql/opt/xform/testdata/coster/zone
+++ b/pkg/sql/opt/xform/testdata/coster/zone
@@ -447,7 +447,7 @@ inner-join (lookup t.public.xy@y2)
  ├── scan t.public.abc@bc2
  │    ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int!null) t.public.abc.c:3(string)
  │    ├── constraint: /2/3: [/1 - /1]
- │    ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=1, null(2)=0]
+ │    ├── stats: [rows=10, distinct(2)=1, null(2)=0]
  │    ├── cost: 24.6200001
  │    ├── key: (1)
  │    ├── fd: ()-->(2), (1)-->(3), (2,3)~~>(1)
@@ -487,7 +487,7 @@ inner-join (lookup t.public.xy@y1)
  ├── scan t.public.abc@bc2
  │    ├── columns: t.public.abc.a:1(int!null) t.public.abc.b:2(int!null) t.public.abc.c:3(string)
  │    ├── constraint: /2/3: [/1 - /1]
- │    ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=1, null(2)=0]
+ │    ├── stats: [rows=10, distinct(2)=1, null(2)=0]
  │    ├── cost: 24.6200001
  │    ├── key: (1)
  │    ├── fd: ()-->(2), (1)-->(3), (2,3)~~>(1)
@@ -861,7 +861,7 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │    │         ├── a2.r:7 = 'east' [outer=(7), constraints=(/7: [/'east' - /'east']; tight), fd=()-->(7)]
  │    │         └── a1.a:2 = a2.b:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
  │    ├── cardinality: [0 - 1]
- │    ├── stats: [rows=0.9009, distinct(1)=0.897389, null(1)=0, distinct(2)=0.9009, null(2)=0, distinct(3)=0.9009, null(3)=0, distinct(4)=0.9009, null(4)=0]
+ │    ├── stats: [rows=0.9009, distinct(2)=0.9009, null(2)=0]
  │    ├── cost: 13.0632823
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
@@ -871,7 +871,7 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │    │    ├── left columns: a1.r:13 a1.a:14 a1.b:15 a1.c:16
  │    │    ├── right columns: a1.r:19 a1.a:20 a1.b:21 a1.c:22
  │    │    ├── cardinality: [0 - 1]
- │    │    ├── stats: [rows=0.91, distinct(1)=0.906283, null(1)=0, distinct(2)=0.91, null(2)=0, distinct(3)=0.91, null(3)=0, distinct(4)=0.91, null(4)=0, distinct(3,4)=0.91, null(3,4)=0]
+ │    │    ├── stats: [rows=0.91, distinct(2)=0.91, null(2)=0, distinct(3)=0.91, null(3)=0, distinct(4)=0.91, null(4)=0, distinct(3,4)=0.91, null(3,4)=0]
  │    │    ├── cost: 5.6885176
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)

--- a/pkg/sql/opt/xform/testdata/external/planet-osm
+++ b/pkg/sql/opt/xform/testdata/external/planet-osm
@@ -1755,13 +1755,13 @@ sort
       │         │    ├── key columns: [218] = [143]
       │         │    ├── lookup columns are key
       │         │    ├── immutable
-      │         │    ├── stats: [rows=3926737, distinct(29)=1, null(29)=0, distinct(69)=2632.06, null(69)=0, distinct(100)=31, null(100)=1.52957e+06, distinct(142)=146376, null(142)=0]
+      │         │    ├── stats: [rows=3926737, distinct(69)=2632.06, null(69)=0, distinct(100)=31, null(100)=1.52957e+06]
       │         │    ├── fd: ()-->(29)
       │         │    ├── inner-join (inverted planet_osm_line@planet_osm_line_way_idx [as=l])
       │         │    │    ├── columns: p.highway:29!null p.way:69 l.rowid:218!null
       │         │    │    ├── inverted-expr
       │         │    │    │    └── st_dwithin(p.way:69, l.way:217, 100.0)
-      │         │    │    ├── stats: [rows=3926737, distinct(29)=1, null(29)=0, distinct(218)=148586, null(218)=0]
+      │         │    │    ├── stats: [rows=3926737, distinct(218)=148586, null(218)=0]
       │         │    │    ├── fd: ()-->(29)
       │         │    │    ├── select
       │         │    │    │    ├── columns: p.highway:29!null p.way:69
@@ -1778,7 +1778,7 @@ sort
       │         ├── values
       │         │    ├── columns: column1:147!null column2:148!null
       │         │    ├── cardinality: [5 - 5]
-      │         │    ├── stats: [rows=5, distinct(147)=5, null(147)=0, distinct(148)=5, null(148)=0]
+      │         │    ├── stats: [rows=5, distinct(147)=5, null(147)=0]
       │         │    ├── ('tertiary', 1)
       │         │    ├── ('unclassified', 2)
       │         │    ├── ('residential', 3)

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -564,7 +564,7 @@ project
       ├── index-join cardsinfo
       │    ├── columns: dealerid:9!null cardid:10!null buyprice:11!null sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null version:17!null
       │    ├── immutable
-      │    ├── stats: [rows=0.02016214, distinct(9)=0.0201621, null(9)=0, distinct(10)=0.0201621, null(10)=0, distinct(11)=0.0201621, null(11)=0, distinct(12)=0.0201621, null(12)=0, distinct(13)=0.0201621, null(13)=0, distinct(14)=0.0201621, null(14)=0, distinct(15)=0.0201621, null(15)=0, distinct(16)=0.0201621, null(16)=0, distinct(17)=0.0201621, null(17)=0, distinct(9,17)=0.0201621, null(9,17)=0]
+      │    ├── stats: [rows=0.02016214, distinct(9)=0.0201621, null(9)=0, distinct(10)=0.0201621, null(10)=0, distinct(17)=0.0201621, null(17)=0, distinct(9,17)=0.0201621, null(9,17)=0]
       │    │   histogram(17)=  0                0                 0.020162           0
       │    │                 <--- 1584421773604892000.0000000000 ---------- 1584421778604892000
       │    ├── key: (10)
@@ -718,7 +718,7 @@ project
       │    │    ├── limit hint: 100.00
       │    │    ├── index-join transactiondetails
       │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null
-      │    │    │    ├── stats: [rows=478.6466, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=478.647, null(3)=0, distinct(4)=1, null(4)=0, distinct(5)=478.641, null(5)=0, distinct(6)=478.641, null(6)=0, distinct(7)=478.641, null(7)=0, distinct(1,2,4)=1, null(1,2,4)=0]
+      │    │    │    ├── stats: [rows=478.6466, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=478.647, null(3)=0, distinct(4)=1, null(4)=0, distinct(1,2,4)=1, null(1,2,4)=0]
       │    │    │    ├── key: (3,5)
       │    │    │    ├── fd: ()-->(1,2,4), (3,5)-->(6,7)
       │    │    │    ├── ordering: -3 opt(1,2,4) [actual: -3]
@@ -726,7 +726,7 @@ project
       │    │    │    └── scan transactiondetails@detailscardidindex,rev
       │    │    │         ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
       │    │    │         ├── constraint: /1/2/4/3/5: [/1/false/21953 - /1/false/21953]
-      │    │    │         ├── stats: [rows=478.6466, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=478.647, null(3)=0, distinct(4)=1, null(4)=0, distinct(5)=478.641, null(5)=0, distinct(1,2,4)=1, null(1,2,4)=0]
+      │    │    │         ├── stats: [rows=478.6466, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=478.647, null(3)=0, distinct(4)=1, null(4)=0, distinct(1,2,4)=1, null(1,2,4)=0]
       │    │    │         ├── key: (3,5)
       │    │    │         ├── fd: ()-->(1,2,4)
       │    │    │         ├── ordering: -3 opt(1,2,4) [actual: -3]
@@ -848,7 +848,7 @@ project
  │    │    │    │    │    ├── key columns: [32 1] = [9 10]
  │    │    │    │    │    ├── lookup columns are key
  │    │    │    │    │    ├── immutable
- │    │    │    │    │    ├── stats: [rows=29618.46, distinct(1)=19000, null(1)=0, distinct(2)=11668.1, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5572.86, null(6)=0, distinct(9)=1, null(9)=0, distinct(10)=19000, null(10)=0, distinct(11)=21038, null(11)=0, distinct(12)=21038, null(12)=0, distinct(13)=21038, null(13)=0, distinct(14)=21038, null(14)=0, distinct(15)=21038, null(15)=0, distinct(16)=21038, null(16)=0, distinct(17)=23225.6, null(17)=0, distinct(2,4,5,10)=29618.5, null(2,4,5,10)=0]
+ │    │    │    │    │    ├── stats: [rows=29618.46, distinct(1)=19000, null(1)=0, distinct(10)=19000, null(10)=0, distinct(2,4,5,10)=29618.5, null(2,4,5,10)=0]
  │    │    │    │    │    ├── key: (10)
  │    │    │    │    │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
  │    │    │    │    │    ├── ordering: +2,+4,+5 opt(9) [actual: +2,+4,+5]
@@ -864,7 +864,7 @@ project
  │    │    │    │    │    │    ├── index-join cards
  │    │    │    │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
  │    │    │    │    │    │    │    ├── immutable
- │    │    │    │    │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5601.15, null(6)=0, distinct(2,4,5)=19000, null(2,4,5)=0]
+ │    │    │    │    │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(2,4,5)=19000, null(2,4,5)=0]
  │    │    │    │    │    │    │    ├── key: (1)
  │    │    │    │    │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
  │    │    │    │    │    │    │    ├── ordering: +2,+4,+5
@@ -872,7 +872,7 @@ project
  │    │    │    │    │    │    │    └── scan cards@cardsnamesetnumber
  │    │    │    │    │    │    │         ├── columns: id:1!null name:2!null setname:4 number:5!null
  │    │    │    │    │    │    │         ├── constraint: /2/4/5: [/'Shock'/'7E'/249 - ]
- │    │    │    │    │    │    │         ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0]
+ │    │    │    │    │    │    │         ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0]
  │    │    │    │    │    │    │         ├── key: (1)
  │    │    │    │    │    │    │         ├── fd: (1)-->(2,4,5), (2,4,5)~~>(1)
  │    │    │    │    │    │    │         ├── ordering: +2,+4,+5
@@ -973,13 +973,13 @@ sort
       │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:11!null transactions.isbuy:12!null date:13!null accountname:14!null customername:15!null
       │    │    │    ├── left ordering: +3
       │    │    │    ├── right ordering: +13
-      │    │    │    ├── stats: [rows=119679, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=119679, null(3)=0, distinct(4)=50017.4, null(4)=0, distinct(5)=114043, null(5)=0, distinct(6)=114043, null(6)=0, distinct(7)=114043, null(7)=0, distinct(11)=1, null(11)=0, distinct(12)=1, null(12)=0, distinct(13)=119679, null(13)=0, distinct(14)=75651.6, null(14)=0, distinct(15)=75651.6, null(15)=0]
+      │    │    │    ├── stats: [rows=119679, distinct(3)=119679, null(3)=0, distinct(4)=50017.4, null(4)=0, distinct(13)=119679, null(13)=0]
       │    │    │    ├── key: (4,5,13)
       │    │    │    ├── fd: ()-->(1,2,11,12), (3-5)-->(6,7), (13)-->(14,15), (3)==(13), (13)==(3)
       │    │    │    ├── scan transactiondetails
       │    │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null
       │    │    │    │    ├── constraint: /1/2/3/4/5: [/1/false/'2020-02-23 00:00:00+00' - /1/false/'2020-03-01 00:00:00+00']
-      │    │    │    │    ├── stats: [rows=1270000, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1.27e+06, null(3)=0, distinct(4)=57000, null(4)=0, distinct(5)=1.23043e+06, null(5)=0, distinct(6)=1.23043e+06, null(6)=0, distinct(7)=1.23043e+06, null(7)=0, distinct(1,2)=1, null(1,2)=0, distinct(1-3)=1.27e+06, null(1-3)=0]
+      │    │    │    │    ├── stats: [rows=1270000, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1.27e+06, null(3)=0, distinct(4)=57000, null(4)=0, distinct(1,2)=1, null(1,2)=0, distinct(1-3)=1.27e+06, null(1-3)=0]
       │    │    │    │    ├── key: (3-5)
       │    │    │    │    ├── fd: ()-->(1,2), (3-5)-->(6,7)
       │    │    │    │    └── ordering: +3 opt(1,2) [actual: +3]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -572,7 +572,7 @@ project
       ├── index-join cardsinfo
       │    ├── columns: dealerid:9!null cardid:10!null buyprice:11!null sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null version:17!null
       │    ├── immutable
-      │    ├── stats: [rows=0.00014, distinct(9)=0.00014, null(9)=0, distinct(10)=0.00014, null(10)=0, distinct(11)=0.00014, null(11)=0, distinct(12)=0.00014, null(12)=0, distinct(13)=0.00014, null(13)=0, distinct(14)=0.00014, null(14)=0, distinct(15)=0.00014, null(15)=0, distinct(16)=0.00014, null(16)=0, distinct(17)=0.00014, null(17)=0, distinct(9,17)=0.00014, null(9,17)=0]
+      │    ├── stats: [rows=0.00014, distinct(9)=0.00014, null(9)=0, distinct(10)=0.00014, null(10)=0, distinct(17)=0.00014, null(17)=0, distinct(9,17)=0.00014, null(9,17)=0]
       │    │   histogram(17)=
       │    ├── key: (10)
       │    ├── fd: ()-->(9), (10)-->(11-17), (17)-->(10-16)
@@ -722,7 +722,7 @@ project
       │    │    ├── limit hint: 100.00
       │    │    ├── index-join transactiondetails
       │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null sellprice:6!null buyprice:7!null
-      │    │    │    ├── stats: [rows=478.6466, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=478.647, null(3)=0, distinct(4)=1, null(4)=0, distinct(5)=478.641, null(5)=0, distinct(6)=478.641, null(6)=0, distinct(7)=478.641, null(7)=0, distinct(1,2,4)=1, null(1,2,4)=0]
+      │    │    │    ├── stats: [rows=478.6466, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=478.647, null(3)=0, distinct(4)=1, null(4)=0, distinct(1,2,4)=1, null(1,2,4)=0]
       │    │    │    ├── key: (3,5)
       │    │    │    ├── fd: ()-->(1,2,4), (3,5)-->(6,7)
       │    │    │    ├── ordering: -3 opt(1,2,4) [actual: -3]
@@ -730,7 +730,7 @@ project
       │    │    │    └── scan transactiondetails@detailscardidindex,rev
       │    │    │         ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null cardid:4!null quantity:5!null
       │    │    │         ├── constraint: /1/2/4/3/5: [/1/false/21953 - /1/false/21953]
-      │    │    │         ├── stats: [rows=478.6466, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=478.647, null(3)=0, distinct(4)=1, null(4)=0, distinct(5)=478.641, null(5)=0, distinct(1,2,4)=1, null(1,2,4)=0]
+      │    │    │         ├── stats: [rows=478.6466, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=478.647, null(3)=0, distinct(4)=1, null(4)=0, distinct(1,2,4)=1, null(1,2,4)=0]
       │    │    │         ├── key: (3,5)
       │    │    │         ├── fd: ()-->(1,2,4)
       │    │    │         ├── ordering: -3 opt(1,2,4) [actual: -3]
@@ -852,7 +852,7 @@ project
  │    │    │    │    │    ├── key columns: [38 1] = [9 10]
  │    │    │    │    │    ├── lookup columns are key
  │    │    │    │    │    ├── immutable
- │    │    │    │    │    ├── stats: [rows=29618.46, distinct(1)=19000, null(1)=0, distinct(2)=11668.1, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5572.86, null(6)=0, distinct(9)=1, null(9)=0, distinct(10)=19000, null(10)=0, distinct(11)=21038, null(11)=0, distinct(12)=21038, null(12)=0, distinct(13)=21038, null(13)=0, distinct(14)=21038, null(14)=0, distinct(15)=21038, null(15)=0, distinct(16)=21038, null(16)=0, distinct(17)=23225.6, null(17)=0, distinct(2,4,5,10)=29618.5, null(2,4,5,10)=0]
+ │    │    │    │    │    ├── stats: [rows=29618.46, distinct(1)=19000, null(1)=0, distinct(10)=19000, null(10)=0, distinct(2,4,5,10)=29618.5, null(2,4,5,10)=0]
  │    │    │    │    │    ├── key: (10)
  │    │    │    │    │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
  │    │    │    │    │    ├── ordering: +2,+4,+5 opt(9) [actual: +2,+4,+5]
@@ -868,7 +868,7 @@ project
  │    │    │    │    │    │    ├── index-join cards
  │    │    │    │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
  │    │    │    │    │    │    │    ├── immutable
- │    │    │    │    │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0, distinct(6)=5601.15, null(6)=0, distinct(2,4,5)=19000, null(2,4,5)=0]
+ │    │    │    │    │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(2,4,5)=19000, null(2,4,5)=0]
  │    │    │    │    │    │    │    ├── key: (1)
  │    │    │    │    │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
  │    │    │    │    │    │    │    ├── ordering: +2,+4,+5
@@ -876,7 +876,7 @@ project
  │    │    │    │    │    │    │    └── scan cards@cardsnamesetnumber
  │    │    │    │    │    │    │         ├── columns: id:1!null name:2!null setname:4 number:5!null
  │    │    │    │    │    │    │         ├── constraint: /2/4/5: [/'Shock'/'7E'/249 - ]
- │    │    │    │    │    │    │         ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(5)=829, null(5)=0]
+ │    │    │    │    │    │    │         ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0]
  │    │    │    │    │    │    │         ├── key: (1)
  │    │    │    │    │    │    │         ├── fd: (1)-->(2,4,5), (2,4,5)~~>(1)
  │    │    │    │    │    │    │         ├── ordering: +2,+4,+5
@@ -977,13 +977,13 @@ sort
       │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null transactions.dealerid:13!null transactions.isbuy:14!null date:15!null accountname:16!null customername:17!null
       │    │    │    ├── left ordering: +3
       │    │    │    ├── right ordering: +15
-      │    │    │    ├── stats: [rows=119679, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=119679, null(3)=0, distinct(4)=50017.4, null(4)=0, distinct(5)=114043, null(5)=0, distinct(6)=114043, null(6)=0, distinct(7)=114043, null(7)=0, distinct(13)=1, null(13)=0, distinct(14)=1, null(14)=0, distinct(15)=119679, null(15)=0, distinct(16)=75651.6, null(16)=0, distinct(17)=75651.6, null(17)=0]
+      │    │    │    ├── stats: [rows=119679, distinct(3)=119679, null(3)=0, distinct(4)=50017.4, null(4)=0, distinct(15)=119679, null(15)=0]
       │    │    │    ├── key: (4,5,15)
       │    │    │    ├── fd: ()-->(1,2,13,14), (3-5)-->(6,7), (15)-->(16,17), (3)==(15), (15)==(3)
       │    │    │    ├── scan transactiondetails
       │    │    │    │    ├── columns: transactiondetails.dealerid:1!null transactiondetails.isbuy:2!null transactiondate:3!null transactiondetails.cardid:4!null quantity:5!null transactiondetails.sellprice:6!null transactiondetails.buyprice:7!null
       │    │    │    │    ├── constraint: /1/2/3/4/5: [/1/false/'2020-02-23 00:00:00+00' - /1/false/'2020-03-01 00:00:00+00']
-      │    │    │    │    ├── stats: [rows=1270000, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1.27e+06, null(3)=0, distinct(4)=57000, null(4)=0, distinct(5)=1.23043e+06, null(5)=0, distinct(6)=1.23043e+06, null(6)=0, distinct(7)=1.23043e+06, null(7)=0, distinct(1,2)=1, null(1,2)=0, distinct(1-3)=1.27e+06, null(1-3)=0]
+      │    │    │    │    ├── stats: [rows=1270000, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1.27e+06, null(3)=0, distinct(4)=57000, null(4)=0, distinct(1,2)=1, null(1,2)=0, distinct(1-3)=1.27e+06, null(1-3)=0]
       │    │    │    │    ├── key: (3-5)
       │    │    │    │    ├── fd: ()-->(1,2), (3-5)-->(6,7)
       │    │    │    │    └── ordering: +3 opt(1,2) [actual: +3]


### PR DESCRIPTION
Prior to this commit, some queries with many joins would perform a large
number of allocations calculating the selectivity of null-rejecting join
filters. This was due to `statisticsBuiler.selectivityFromNullsRemoved`
allocating a single-column set for each not-null column, and allocating
column statistics for each set.

Many of those allocations and much unnecessary computations to traverse
the expression tree are now avoided. This is made possible by the
realization that the selectivity of a null-rejecting filter is always 1
if the column was already not-null in the input.

Epic: None

Release note: None
