### PR TITLE
pkg/obsservice: move default addresses from localhost to 0.0.0.0

### DIFF
--- a/pkg/obsservice/README.md
+++ b/pkg/obsservice/README.md
@@ -103,7 +103,7 @@ I231113 22:25:02.716505 1 main/main.go:112  [-] 1  Listening for OTLP connection
 
 You can use environment variables to control things like the OTLP listen address.
 ```shell
-$ docker run -e OTLP_ADDR=localhost:7171 -e HTTP_ADDR=localhost:8082 --platform=linux/amd64 obsservice:latest
+$ docker run -e OTLP_ADDR=0.0.0.0:7171 -e HTTP_ADDR=0.0.0.0:8082 --platform=linux/amd64 obsservice:latest
 I231113 22:25:02.716505 1 main/main.go:112  [-] 1  Listening for OTLP connections on localhost:7171.
 Listening for HTTP requests on http://localhost:8082.
 ```

--- a/pkg/obsservice/cmd/obsservice/Dockerfile
+++ b/pkg/obsservice/cmd/obsservice/Dockerfile
@@ -7,7 +7,7 @@
 
 FROM --platform=linux/amd64 debian:stable-slim
 WORKDIR /bin
-ENV OTLP_ADDR=localhost:4317
-ENV HTTP_ADDR=localhost:8081
+ENV OTLP_ADDR=0.0.0.0:4317
+ENV HTTP_ADDR=0.0.0.0:8081
 COPY ./artifact_obsservice /bin/
 CMD /bin/artifact_obsservice --otlp-addr=$OTLP_ADDR --http-addr=$HTTP_ADDR


### PR DESCRIPTION
The previous Dockerfile had the obsservice binary listening on `localhost` by default for OTLP/HTTP connections. This made the container application unreachable by outside traffic, even when exposing the expected port on the container. Instead, `0.0.0.0` must be used for the containerized application, so that it listens on every available network interface instead of just the loopback address.

This patch updates the Dockerfile and README to fix this.

Release note: none

Epic: CC-25978