### PR TITLE
concurrency: fix pagination for query locks 

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1864,20 +1864,19 @@ func (kl *keyLocks) safeFormat(sb *redact.StringBuilder, txnStatusCache *txnStat
 	}
 }
 
-// collectLockStateInfo converts receiver into exportable LockStateInfo metadata
-// and returns (true, valid LockStateInfo), or (false, empty LockStateInfo) if
-// it was filtered out due to being an empty lock or an uncontended lock (if
-// includeUncontended is false).
+// collectLockStateInfo exports all locks held on the receiver's key as a list
+// of roachpb.LockStateInfos. If no locks are held, or the lock is uncontended
+// and includeUncontended is false, nothing is returned.
 func (kl *keyLocks) collectLockStateInfo(
-	includeUncontended bool, now time.Time,
-) (bool, []roachpb.LockStateInfo) {
+	includeUncontended bool, now time.Time, rangeID roachpb.RangeID,
+) []roachpb.LockStateInfo {
 	kl.mu.Lock()
 	defer kl.mu.Unlock()
 
 	// Don't include locks that have neither lock holders, nor claims, nor
 	// waiting readers/locking requests.
 	if kl.isEmptyLock() {
-		return false, []roachpb.LockStateInfo{}
+		return nil
 	}
 
 	// Filter out locks without waiting readers/locking requests unless explicitly
@@ -1890,15 +1889,15 @@ func (kl *keyLocks) collectLockStateInfo(
 	if !includeUncontended && kl.waitingReaders.Len() == 0 &&
 		(kl.queuedLockingRequests.Len() == 0 ||
 			(kl.queuedLockingRequests.Len() == 1 && !kl.queuedLockingRequests.Front().Value.active)) {
-		return false, []roachpb.LockStateInfo{}
+		return nil
 	}
 
-	return true, kl.lockStateInfo(now)
+	return kl.lockStateInfo(now, rangeID)
 }
 
 // lockStateInfo converts receiver to the roachpb.LockStateInfo structure.
 // REQUIRES: kl.mu is locked.
-func (kl *keyLocks) lockStateInfo(now time.Time) []roachpb.LockStateInfo {
+func (kl *keyLocks) lockStateInfo(now time.Time, rangeID roachpb.RangeID) []roachpb.LockStateInfo {
 	waiterCount := kl.waitingReaders.Len() + kl.queuedLockingRequests.Len()
 	lockWaiters := make([]lock.Waiter, 0, waiterCount)
 
@@ -1932,6 +1931,7 @@ func (kl *keyLocks) lockStateInfo(now time.Time) []roachpb.LockStateInfo {
 	if !kl.isLocked() {
 		return []roachpb.LockStateInfo{
 			{
+				RangeID:      rangeID,
 				Key:          kl.key,
 				LockHolder:   nil,
 				Durability:   lock.Unreplicated,
@@ -1950,6 +1950,7 @@ func (kl *keyLocks) lockStateInfo(now time.Time) []roachpb.LockStateInfo {
 			durability = lock.Replicated
 		}
 		lsi := roachpb.LockStateInfo{
+			RangeID:      rangeID,
 			Key:          kl.key,
 			LockHolder:   tl.txn,
 			Durability:   durability,
@@ -4364,40 +4365,47 @@ func (t *lockTableImpl) QueryLockTableState(
 	var numLocks int64
 	var numBytes int64
 	var nextKey roachpb.Key
-	var nextByteSize int64
+	var nextNumBytes int64
 
 	// Iterate over locks and gather metadata.
 	iter := snap.MakeIter()
 	ltRange := &keyLocks{key: span.Key, endKey: span.EndKey}
 	for iter.FirstOverlap(ltRange); iter.Valid(); iter.NextOverlap(ltRange) {
 		l := iter.Cur()
+		nextKey = l.key
 
-		if ok, lInfos := l.collectLockStateInfo(opts.IncludeUncontended, now); ok {
-			for _, lInfo := range lInfos {
-				nextKey = l.key
-				nextByteSize = int64(lInfo.Size())
-				lInfo.RangeID = t.rID
+		lInfos := l.collectLockStateInfo(opts.IncludeUncontended, now, t.rID)
+		nextNumBytes = 0
+		nextNumLocks := int64(len(lInfos))
+		for _, lInfo := range lInfos {
+			nextNumBytes += int64(lInfo.Size())
+		}
 
-				// Check if adding the lock would exceed our byte or count limits,
-				// though we must ensure we return at least one lock.
-				if len(lockTableState) > 0 && opts.TargetBytes > 0 && (numBytes+nextByteSize) > opts.TargetBytes {
-					resumeState.ResumeReason = kvpb.RESUME_BYTE_LIMIT
-					break
-				} else if len(lockTableState) > 0 && opts.MaxLocks > 0 && numLocks >= opts.MaxLocks {
-					resumeState.ResumeReason = kvpb.RESUME_KEY_LIMIT
-					break
-				}
-
-				lockTableState = append(lockTableState, lInfo)
-				numLocks++
-				numBytes += nextByteSize
+		// We always return locks on at least one key, regardless of the byte or
+		// count limits.
+		if len(lockTableState) > 0 {
+			// Check if accumulating the result will cause byte limits to be exceeded.
+			if opts.TargetBytes > 0 && (numBytes+nextNumBytes) > opts.TargetBytes {
+				resumeState.ResumeReason = kvpb.RESUME_BYTE_LIMIT
+				break
+			}
+			// Check if accumulating the result will cause lock count limits to be
+			// exceeded.
+			if opts.MaxLocks > 0 && (numLocks+nextNumLocks) > opts.MaxLocks {
+				resumeState.ResumeReason = kvpb.RESUME_KEY_LIMIT
+				break
 			}
 		}
+
+		// Adding all locks on this key won't cause us to go over byte/count limits.
+		lockTableState = append(lockTableState, lInfos...)
+		numBytes += nextNumBytes
+		numLocks += nextNumLocks
 	}
 
 	// If we need to paginate results, set the continuation key in the ResumeSpan.
 	if resumeState.ResumeReason != 0 {
-		resumeState.ResumeNextBytes = nextByteSize
+		resumeState.ResumeNextBytes = nextNumBytes
 		resumeState.ResumeSpan = &roachpb.Span{Key: nextKey, EndKey: span.EndKey}
 	}
 	resumeState.TotalBytes = numBytes

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/query
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/query
@@ -170,3 +170,83 @@ num locks: 1, bytes returned: 91, resume reason: RESUME_UNKNOWN, resume span: <n
   range_id=3 key="e" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=200ms
    waiters:
     waiting_txn:00000000-0000-0000-0000-000000000003 active_waiter:true strength:Exclusive wait_duration:200ms
+
+clear
+----
+num=0
+
+new-request r=req5 txn=txn3 ts=10,1 spans=shared@a,e
+----
+
+scan r=req5
+----
+start-waiting: false
+
+acquire r=req5 k=a durability=u strength=shared
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+acquire r=req5 k=b durability=u strength=shared
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+acquire r=req5 k=c durability=u strength=shared
+----
+num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+acquire r=req5 k=d durability=u strength=shared
+----
+num=4
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+new-request r=req6 txn=txn2 ts=10,1 spans=shared@b
+----
+
+scan r=req6
+----
+start-waiting: false
+
+acquire r=req6 k=b durability=u strength=shared
+----
+num=4
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+ lock: "b"
+  holders: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+           txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
+
+query span=a,f uncontended max-bytes=50
+----
+num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span: {d-f}
+ locks:
+  range_id=3 key="a" holder=00000000-0000-0000-0000-000000000003 durability=Unreplicated duration=0s
+
+query span=a,f uncontended max-locks=2 uncontended
+----
+num locks: 2, bytes returned: 82, resume reason: RESUME_KEY_LIMIT, resume span: {d-f}
+ locks:
+  range_id=3 key="a" holder=00000000-0000-0000-0000-000000000003 durability=Unreplicated duration=0s
+  range_id=3 key="b" holder=00000000-0000-0000-0000-000000000003 durability=Unreplicated duration=0s

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/query
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/query
@@ -89,7 +89,7 @@ num locks: 2, bytes returned: 82, resume reason: RESUME_KEY_LIMIT, resume span: 
 
 query span=a,f max-bytes=50 uncontended
 ----
-num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span: {e-f}
+num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span: {c-f}
  locks:
   range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
 
@@ -97,7 +97,7 @@ num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span:
 
 query span=a,f max-bytes=10 uncontended
 ----
-num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span: {e-f}
+num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span: {c-f}
  locks:
   range_id=3 key="b" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
 
@@ -240,13 +240,40 @@ num=4
 
 query span=a,f uncontended max-bytes=50
 ----
-num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span: {d-f}
+num locks: 1, bytes returned: 41, resume reason: RESUME_BYTE_LIMIT, resume span: {b-f}
  locks:
   range_id=3 key="a" holder=00000000-0000-0000-0000-000000000003 durability=Unreplicated duration=0s
 
 query span=a,f uncontended max-locks=2 uncontended
 ----
-num locks: 2, bytes returned: 82, resume reason: RESUME_KEY_LIMIT, resume span: {d-f}
+num locks: 1, bytes returned: 41, resume reason: RESUME_KEY_LIMIT, resume span: {b-f}
+ locks:
+  range_id=3 key="a" holder=00000000-0000-0000-0000-000000000003 durability=Unreplicated duration=0s
+
+
+# Bumping max locks up to 3 should return all locks on key b.
+query span=a,f uncontended max-locks=3 uncontended
+----
+num locks: 3, bytes returned: 123, resume reason: RESUME_KEY_LIMIT, resume span: {c-f}
  locks:
   range_id=3 key="a" holder=00000000-0000-0000-0000-000000000003 durability=Unreplicated duration=0s
   range_id=3 key="b" holder=00000000-0000-0000-0000-000000000003 durability=Unreplicated duration=0s
+  range_id=3 key="b" holder=00000000-0000-0000-0000-000000000002 durability=Unreplicated duration=0s
+
+# Starting the scan from b with max-locks set to 1 (less than the number of
+# locks, which is 2) should return all locks even though it goes over the limit.
+query span=b,f uncontended max-locks=1 uncontended
+----
+num locks: 2, bytes returned: 82, resume reason: RESUME_KEY_LIMIT, resume span: {c-f}
+ locks:
+  range_id=3 key="b" holder=00000000-0000-0000-0000-000000000003 durability=Unreplicated duration=0s
+  range_id=3 key="b" holder=00000000-0000-0000-0000-000000000002 durability=Unreplicated duration=0s
+
+# Same idea as above, but this time with byte limit.
+
+query span=b,f uncontended max-bytes=50
+----
+num locks: 2, bytes returned: 82, resume reason: RESUME_BYTE_LIMIT, resume span: {c-f}
+ locks:
+  range_id=3 key="b" holder=00000000-0000-0000-0000-000000000003 durability=Unreplicated duration=0s
+  range_id=3 key="b" holder=00000000-0000-0000-0000-000000000002 durability=Unreplicated duration=0s


### PR DESCRIPTION
This patch fixes the issue demonstrated in the previous commit. It also
simplifies the handling of limits when dealing with multiple locks on a
single key and adds tests. In particular, we now either return all locks
on a single key or none at all when running against byte/lock number
limits -- if we can only return some of the locks without running into
limits, we decide to return none.

Epic: none

Closes https://github.com/cockroachdb/cockroach/issues/114741

Release note: None