### PR TITLE
stress: tweak args for `deadlock` and `race` nightlies

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -45,7 +45,7 @@ query --ui_event_filters=-DEBUG
 clean --ui_event_filters=-WARNING
 info --ui_event_filters=-WARNING
 
-build:race --@io_bazel_rules_go//go/config:race "--test_env=GORACE=halt_on_error=1 log_path=stdout" --test_sharding_strategy=disabled
+build:race --@io_bazel_rules_go//go/config:race "--test_env=GORACE=halt_on_error=1 log_path=stdout"
 test:test --test_env=TZ=
 # Note: these timeout values are used indirectly in `build/teamcity/cockroach/ci/tests/testrace_impl.sh`.
 # If those values are updated, the script should be updated accordingly.

--- a/.bazelrc
+++ b/.bazelrc
@@ -127,6 +127,7 @@ build:engflowbase --extra_execution_platforms=//build/toolchains:cross_linux
 build:engflowbase --remote_upload_local_results=false
 build:engflowbase --remote_download_toplevel
 test:engflowbase --test_env=REMOTE_EXEC=1
+test:engflowbase --test_env=GOTRACEBACK=all
 build:engflow --config=engflowbase
 build:engflow --remote_cache=grpcs://tanzanite.cluster.engflow.com
 build:engflow --remote_executor=grpcs://tanzanite.cluster.engflow.com

--- a/build/teamcity/cockroach/ci/tests/testrace_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/testrace_impl.sh
@@ -32,6 +32,7 @@ do
             $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=ci --config=race "$test" \
                                 --test_env=COCKROACH_LOGIC_TESTS_SKIP=true \
                                 --test_timeout $timeout \
+                                --test_sharding_strategy=disabled \
                                 --test_env=GOMAXPROCS=8
         done
     done

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
@@ -20,6 +20,7 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --formatter=pebble-metamorphic -- test --c
                                       @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test \
                                       --test_env TC_SERVER_URL=$TC_SERVER_URL \
                                       --test_timeout=14400 '--test_filter=TestMeta$' \
+                                      --test_sharding_strategy=disabled \
                                       --define gotags=bazel,invariants \
                                       --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 3h -maxfails 1 -timeout 30m -stderr -p 1" \
                                       --test_arg -dir --test_arg $ARTIFACTS_DIR \

--- a/build/teamcity/cockroach/nightlies/stress_engflow.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow.sh
@@ -6,4 +6,6 @@ export EXTRA_TEST_ARGS="--config use_ci_timeouts"
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 
+unset GITHUB_API_TOKEN
+
 $THIS_DIR/stress_engflow_impl.sh

--- a/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
@@ -2,8 +2,11 @@
 
 set -euo pipefail
 
-export EXTRA_TEST_ARGS="--define gotags=bazel,gss,deadlock"
+export RUNS_PER_TEST=3
+export EXTRA_TEST_ARGS="--define gotags=bazel,gss,deadlock --test_timeout=1800,3600,5395,5395"
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
+
+unset GITHUB_API_TOKEN
 
 $THIS_DIR/stress_engflow_impl.sh

--- a/build/teamcity/cockroach/nightlies/stress_engflow_race.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_race.sh
@@ -2,9 +2,11 @@
 
 set -euo pipefail
 
-export RUNS_PER_TEST=5
-export EXTRA_TEST_ARGS="--@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1"
+export RUNS_PER_TEST=3
+export EXTRA_TEST_ARGS="--config=race --test_timeout=1800,3600,5395,5395"
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
+
+unset GITHUB_API_TOKEN
 
 $THIS_DIR/stress_engflow_impl.sh

--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=89
+DEV_VERSION=90
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -233,7 +233,7 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
 	}
 	if race {
-		args = append(args, "--config=race")
+		args = append(args, "--config=race", "--test_sharding_strategy=disabled")
 	}
 	if deadlock {
 		goTags = append(goTags, "deadlock")

--- a/pkg/cmd/dev/testdata/recorderdriven/test
+++ b/pkg/cmd/dev/testdata/recorderdriven/test
@@ -47,7 +47,7 @@ bazel test //pkg/testutils:testutils_test //pkg/util/limit:limit_test //pkg/util
 dev test pkg/spanconfig --count 5 --race
 ----
 bazel query 'kind(.*_test, pkg/spanconfig:all)'
-bazel test --config=race //pkg/spanconfig:spanconfig_test --test_env=GOTRACEBACK=all --runs_per_test=5 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
+bazel test --config=race --test_sharding_strategy=disabled //pkg/spanconfig:spanconfig_test --test_env=GOTRACEBACK=all --runs_per_test=5 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
 
 dev test pkg/cmd/dev -f TestDataDriven/test --rewrite -v
 ----

--- a/pkg/cmd/dev/testdata/recorderdriven/test.rec
+++ b/pkg/cmd/dev/testdata/recorderdriven/test.rec
@@ -79,7 +79,7 @@ bazel query 'kind(.*_test, pkg/spanconfig:all)'
 ----
 //pkg/spanconfig:spanconfig_test
 
-bazel test --config=race //pkg/spanconfig:spanconfig_test --test_env=GOTRACEBACK=all --runs_per_test=5 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
+bazel test --config=race --test_sharding_strategy=disabled //pkg/spanconfig:spanconfig_test --test_env=GOTRACEBACK=all --runs_per_test=5 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
 ----
 
 bazel query 'kind(.*_test, pkg/cmd/dev:all)'

--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -345,9 +345,8 @@ func main() {
 				args = append(args, "--")
 				if target == "stressrace" {
 					args = append(args, "--config=race")
-				} else {
-					args = append(args, "--test_sharding_strategy=disabled")
 				}
+				args = append(args, "--test_sharding_strategy=disabled")
 				var filters []string
 				for test := range pkg.tests {
 					filters = append(filters, "^"+test+"$")


### PR DESCRIPTION
Increase timeouts, reduce the number of test runs, unset
GITHUB_API_TOKEN for nightlies that aren't working fully yet.

Also set `GOTRACEBACK=all` for all EngFlow tests.

Epic: [CRDB-8308](https://cockroachlabs.atlassian.net/browse/CRDB-8308)
Release note: None