### PR TITLE
scexec: don't set running_status on GC job during init

### DIFF
--- a/pkg/sql/schemachanger/scexec/gc_jobs.go
+++ b/pkg/sql/schemachanger/scexec/gc_jobs.go
@@ -233,7 +233,6 @@ func createGCJobRecord(
 			descriptorIDs = append(descriptorIDs, details.ParentID)
 		}
 	}
-	runningStatus := jobs.RunningStatus("waiting for MVCC GC")
 	return jobs.Record{
 		JobID:         id,
 		Description:   "GC for " + description,
@@ -241,7 +240,6 @@ func createGCJobRecord(
 		DescriptorIDs: descriptorIDs,
 		Details:       details,
 		Progress:      jobspb.SchemaChangeGCProgress{},
-		RunningStatus: runningStatus,
 		NonCancelable: true,
 	}
 }


### PR DESCRIPTION
The running_status is only supposed to be set while the job is running, so it was a mistake to set it when creating the job.

Not setting it also deflakes a test which relies on the running_status to know if the GC has begun (and deleting the data has completed).

fixes https://github.com/cockroachdb/cockroach/issues/114557
Release note: None