### PR TITLE
sql: add missing synchronization for accounting in closed session cache

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -969,7 +969,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	sessionRegistry := sql.NewSessionRegistry()
 
 	// Instantiate the cache of closed SQL sessions.
-	closedSessionCache := sql.NewClosedSessionCache(cfg.Settings, sqlMonitorAndMetrics.rootSQLMemoryMonitor, time.Now)
+	closedSessionCache := sql.NewClosedSessionCache(ctx, cfg.Settings, sqlMonitorAndMetrics.rootSQLMemoryMonitor, time.Now)
 
 	// Instantiate the distSQL remote flow runner.
 	remoteFlowRunnerAcc := sqlMonitorAndMetrics.rootSQLMemoryMonitor.MakeBoundAccount()

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -341,7 +341,8 @@ func newTenantServer(
 
 	// Instantiate the cache of closed SQL sessions.
 	closedSessionCache := sql.NewClosedSessionCache(
-		baseCfg.Settings, args.monitorAndMetrics.rootSQLMemoryMonitor, time.Now)
+		ctx, baseCfg.Settings, args.monitorAndMetrics.rootSQLMemoryMonitor, time.Now,
+	)
 	args.closedSessionCache = closedSessionCache
 
 	// Instantiate the serverIterator to provide fanout to SQL instances. The

--- a/pkg/sql/closed_session_cache_test.go
+++ b/pkg/sql/closed_session_cache_test.go
@@ -60,7 +60,7 @@ func TestSessionCacheBasic(t *testing.T) {
 					math.MaxInt64,
 					st,
 				)
-				cache = NewClosedSessionCache(st, monitor, time.Now)
+				cache = NewClosedSessionCache(ctx, st, monitor, time.Now)
 
 				ClosedSessionCacheCapacity.Override(ctx, &st.SV, int64(capacity))
 				ClosedSessionCacheTimeToLive.Override(ctx, &st.SV, int64(timeToLive))

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -308,7 +308,7 @@ func startConnExecutor(
 			config.NewSystemConfig(zonepb.DefaultZoneConfigRef()),
 		),
 		SessionRegistry:    NewSessionRegistry(),
-		ClosedSessionCache: NewClosedSessionCache(st, pool, time.Now),
+		ClosedSessionCache: NewClosedSessionCache(ctx, st, pool, time.Now),
 		NodeInfo: NodeInfo{
 			NodeID:           nodeID,
 			LogicalClusterID: func() uuid.UUID { return uuid.UUID{} },


### PR DESCRIPTION
Memory accounts are not thread safe, and we previously were missing synchronization when shrinking the account upon eviction from the closed sessions cache. This is now fixed. Additionally, this commit does some minor cleanup.

Fixes: #113994.

Release note: None