### PR TITLE
builtins: remove crdb_internal.gc_tenant

### DIFF
--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -657,11 +657,6 @@ func (c *DummyTenantOperator) DropTenantByID(
 	return errors.WithStack(errEvalTenant)
 }
 
-// GCTenant is part of the tree.TenantOperator interface.
-func (c *DummyTenantOperator) GCTenant(_ context.Context, _ uint64) error {
-	return errors.WithStack(errEvalTenant)
-}
-
 // UpdateTenantResourceLimits is part of the tree.TenantOperator interface.
 func (c *DummyTenantOperator) UpdateTenantResourceLimits(
 	_ context.Context,

--- a/pkg/sql/logictest/testdata/logic_test/tenant_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_builtins
@@ -112,11 +112,6 @@ id  active  name
 10  true    tenant-number-ten
 11  true    tenant-number-eleven
 
-# Garbage collect a non-drop tenant fails.
-
-query error tenant 5 is not in data state DROP
-SELECT crdb_internal.gc_tenant(5)
-
 # Note this just marks the tenant as dropped but does not call GC.
 
 statement ok
@@ -272,9 +267,6 @@ SELECT crdb_internal.create_tenant('not-allowed')
 
 statement error user testuser does not have MANAGEVIRTUALCLUSTER system privilege
 DROP TENANT [1]
-
-statement error crdb_internal.gc_tenant\(\): user testuser does not have REPAIRCLUSTERMETADATA system privilege
-SELECT crdb_internal.gc_tenant(314)
 
 user root
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6798,33 +6798,6 @@ Parameters:` + randgencfg.ConfigDoc,
 		},
 	),
 
-	"crdb_internal.gc_tenant": makeBuiltin(
-		// TODO(jeffswenson): Delete crdb_internal.gc_tenant after the DestroyTenant
-		// changes are deployed to all Cockroach Cloud serverless hosts.
-		tree.FunctionProperties{
-			Category:     builtinconstants.CategoryMultiTenancy,
-			Undocumented: true,
-		},
-		tree.Overload{
-			Types: tree.ParamTypes{
-				{Name: "id", Typ: types.Int},
-			},
-			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				sTenID, err := mustBeDIntInTenantRange(args[0])
-				if err != nil {
-					return nil, err
-				}
-				if err := evalCtx.Tenant.GCTenant(ctx, uint64(sTenID)); err != nil {
-					return nil, err
-				}
-				return args[0], nil
-			},
-			Info:       "Garbage collects a tenant with the provided ID. Must be run by the System tenant.",
-			Volatility: volatility.Volatile,
-		},
-	),
-
 	// Used to configure the tenant token bucket. See UpdateTenantResourceLimits.
 	"crdb_internal.update_tenant_resource_limits": makeBuiltin(
 		tree.FunctionProperties{

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -1328,7 +1328,6 @@ var builtinOidsArray = []string{
 	1351: `crdb_internal.unsafe_delete_namespace_entry(parent_id: int, parent_schema_id: int, name: string, desc_id: int) -> bool`,
 	1352: `crdb_internal.unsafe_delete_namespace_entry(parent_id: int, parent_schema_id: int, name: string, desc_id: int, force: bool) -> bool`,
 	1353: `crdb_internal.sql_liveness_is_alive(session_id: bytes) -> bool`,
-	1354: `crdb_internal.gc_tenant(id: int) -> int`,
 	1355: `crdb_internal.update_tenant_resource_limits(tenant_id: int, available_request_units: float, refill_rate: float, max_burst_request_units: float, as_of: timestamp, as_of_consumed_request_units: float) -> int`,
 	1356: `crdb_internal.compact_engine_span(node_id: int, store_id: int, start_key: bytes, end_key: bytes) -> bool`,
 	1357: `crdb_internal.increment_feature_counter(feature: string) -> bool`,

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -649,11 +649,6 @@ type TenantOperator interface {
 	// the gc job will not wait for a GC ttl.
 	DropTenantByID(ctx context.Context, tenantID uint64, synchronous, ignoreServiceMode bool) error
 
-	// GCTenant attempts to garbage collect a DROP tenant from the system. Upon
-	// success it also removes the tenant record.
-	// It returns an error if the tenant does not exist.
-	GCTenant(ctx context.Context, tenantID uint64) error
-
 	// LookupTenantID returns the ID for the given tenant name.o
 	LookupTenantID(ctx context.Context, tenantName roachpb.TenantName) (roachpb.TenantID, error)
 


### PR DESCRIPTION
This is an internal function that was deprecated a while ago. It's no longer used since DestroyTenant is used instead.

Epic: None
Release note: None