### PR TITLE
lexbase: fix double-escaping in json + sql display format

### DIFF
--- a/pkg/cli/clisqlexec/format_sql.go
+++ b/pkg/cli/clisqlexec/format_sql.go
@@ -48,7 +48,7 @@ func (p *sqlReporter) iter(w, _ io.Writer, _ int, row []string) error {
 	fmt.Fprint(w, "INSERT INTO results VALUES (")
 	for i, r := range row {
 		var buf bytes.Buffer
-		lexbase.EncodeSQLStringWithFlags(&buf, r, lexbase.EncNoFlags)
+		lexbase.EncodeSQLStringWithFlags(&buf, r, lexbase.EncNoDoubleEscapeQuotes)
 		fmt.Fprint(w, buf.String())
 		if i < len(row)-1 {
 			fmt.Fprint(w, ", ")


### PR DESCRIPTION
This fixes an issue #107518 .

Introduce a new flag, EncNoDoubleEscape, that prevents the escaping of backslashes when they are used as escape characters.

Release note: None