### PR TITLE
release-23.2: roachprod: garbage collect DNS records

### DIFF
--- a/pkg/roachprod/cloud/BUILD.bazel
+++ b/pkg/roachprod/cloud/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_slack_go_slack//:slack",
+        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/roachprod/cloud/gc.go
+++ b/pkg/roachprod/cloud/gc.go
@@ -11,6 +11,7 @@
 package cloud
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"hash/fnv"
@@ -28,6 +29,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/slack-go/slack"
+	"golang.org/x/exp/maps"
 )
 
 var errNoSlackClient = fmt.Errorf("no Slack client")
@@ -348,6 +350,56 @@ func GCClusters(l *logger.Logger, cloud *Cloud, dryrun bool) error {
 		for _, c := range s.destroy {
 			if err := DestroyCluster(l, c); err != nil {
 				postError(l, client, channel, err)
+			}
+		}
+	}
+	return nil
+}
+
+// GCDNS deletes dangling DNS records for clusters that have been destroyed.
+// This is inferred when a DNS record name contains a cluster name that is no
+// longer present. The cluster list is traversed and the DNS records for each
+// provider are listed. If a DNS record is found that does not have a
+// corresponding cluster, it is deleted.
+func GCDNS(l *logger.Logger, cloud *Cloud, dryrun bool) error {
+	// Gather cluster names.
+	clusterNames := make(map[string]struct{})
+	for _, cluster := range cloud.Clusters {
+		clusterNames[cluster.Name] = struct{}{}
+	}
+	// Ensure all DNS providers do not have records for clusters that are no
+	// longer present.
+	ctx := context.Background()
+	for _, provider := range vm.Providers {
+		p, ok := provider.(vm.DNSProvider)
+		if !ok {
+			continue
+		}
+		records, err := p.ListRecords(ctx)
+		if err != nil {
+			return err
+		}
+		danglingRecordNames := make(map[string]struct{})
+		for _, record := range records {
+			nameParts := strings.Split(record.Name, ".")
+			// Only consider DNS records that contain a cluster name.
+			if len(nameParts) < 3 {
+				continue
+			}
+			dnsClusterName := nameParts[2]
+			if _, exists := clusterNames[dnsClusterName]; !exists {
+				danglingRecordNames[record.Name] = struct{}{}
+			}
+		}
+		if !dryrun {
+			keys := maps.Keys(danglingRecordNames)
+			if err := p.DeleteRecordsByName(ctx, keys...); err != nil {
+				return err
+			}
+		} else {
+			// Log dangling DNS records that would be deleted in a non-dryrun.
+			for danglingRecordName := range danglingRecordNames {
+				l.Printf("deleting dangling DNS record %s", danglingRecordName)
 			}
 		}
 	}

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
@@ -1434,18 +1435,53 @@ func Create(
 	return SetupSSH(ctx, l, clusterName)
 }
 
-// GC garbage-collects expired clusters and unused SSH keypairs in AWS.
+// GC garbage-collects expired clusters, unused SSH key pairs in AWS, and unused
+// DNS records.
 func GC(l *logger.Logger, dryrun bool) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
-	cld, err := cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
-	if err == nil {
-		// GCClusters depends on ListCloud so only call it if ListCloud runs without errors
-		err = cloud.GCClusters(l, cld, dryrun)
+
+	// Use the `addOpFn` helper to run GC operations concurrently and collect
+	// errors.
+	errorsChan := make(chan error, 8)
+	var wg sync.WaitGroup
+	addOpFn := func(fn func() error) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errorsChan <- fn()
+		}()
 	}
-	otherErr := cloud.GCAWSKeyPairs(l, dryrun)
-	return errors.CombineErrors(err, otherErr)
+
+	// GCAwsKeyPairs has no dependencies and can start immediately.
+	addOpFn(func() error {
+		return cloud.GCAWSKeyPairs(l, dryrun)
+	})
+
+	// The operations below depend on ListCloud so only call it if ListCloud runs
+	// without errors.
+	cld, listErr := cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
+	errorsChan <- listErr
+	if listErr == nil {
+		addOpFn(func() error {
+			return cloud.GCClusters(l, cld, dryrun)
+		})
+		addOpFn(func() error {
+			return cloud.GCDNS(l, cld, dryrun)
+		})
+	}
+
+	// Wait for all operations to finish and combine all errors.
+	go func() {
+		wg.Wait()
+		close(errorsChan)
+	}()
+	var combinedErrors error
+	for err := range errorsChan {
+		combinedErrors = errors.CombineErrors(combinedErrors, err)
+	}
+	return combinedErrors
 }
 
 // LogsOpts TODO

--- a/pkg/roachprod/vm/dns.go
+++ b/pkg/roachprod/vm/dns.go
@@ -50,7 +50,9 @@ type DNSRecord struct {
 type DNSProvider interface {
 	CreateRecords(ctx context.Context, records ...DNSRecord) error
 	LookupSRVRecords(ctx context.Context, service, proto, subdomain string) ([]DNSRecord, error)
-	DeleteRecordsBySubdomain(subdomain string) error
+	ListRecords(ctx context.Context) ([]DNSRecord, error)
+	DeleteRecordsBySubdomain(ctx context.Context, subdomain string) error
+	DeleteRecordsByName(ctx context.Context, names ...string) error
 	Domain() string
 }
 

--- a/pkg/roachprod/vm/dns.go
+++ b/pkg/roachprod/vm/dns.go
@@ -48,11 +48,20 @@ type DNSRecord struct {
 // DNSProvider is an optional capability for a Provider that provides DNS
 // management services.
 type DNSProvider interface {
+	// CreateRecords creates DNS records.
 	CreateRecords(ctx context.Context, records ...DNSRecord) error
+	// LookupSRVRecords looks up SRV records for the given service, proto, and
+	// subdomain. The protocol is usually "tcp" and the subdomain is usually the
+	// cluster name. The service is a combination of the virtual cluster name and
+	// type of service.
 	LookupSRVRecords(ctx context.Context, service, proto, subdomain string) ([]DNSRecord, error)
+	// ListRecords lists all DNS records managed for the zone.
 	ListRecords(ctx context.Context) ([]DNSRecord, error)
+	// DeleteRecordsBySubdomain deletes all DNS records with the given subdomain.
 	DeleteRecordsBySubdomain(ctx context.Context, subdomain string) error
+	// DeleteRecordsByName deletes all DNS records with the given name.
 	DeleteRecordsByName(ctx context.Context, names ...string) error
+	// Domain returns the domain name (zone) of the DNS provider.
 	Domain() string
 }
 

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -11,6 +11,7 @@
 package local
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -97,7 +98,7 @@ func DeleteCluster(l *logger.Logger, name string) error {
 	// Local clusters are expected to specifically use the local DNS provider
 	// implementation, and should clean up any DNS records in the local file
 	// system cache.
-	return p.DeleteRecordsBySubdomain(c.Name)
+	return p.DeleteRecordsBySubdomain(context.Background(), c.Name)
 }
 
 // Clusters returns a list of all known local clusters.


### PR DESCRIPTION
Backport 4/4 commits from #111260.

/cc @cockroachdb/release

---

The commits in this PR pertain to deleting DNS records through garbage collection. The functionality has been removed from `DestroyCluster`. Moving the functionality the the garbage collection job ensures that all dangling DNS records will eventually be deleted.

Release Note: None
Epic: None

Release justification: Test only change.