### PR TITLE
tenantcapabilitieswatcher: make the watcher react faster

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/span_config_event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/span_config_event_stream.go
@@ -97,6 +97,7 @@ func (s *spanConfigEventStream) Start(ctx context.Context, txn *kv.Txn) error {
 		defaultBatchSize,
 		roachpb.Spans{s.spec.Span},
 		true, // withPrevValue
+		true, // withRowTSInInitialScan
 		spanconfigkvsubscriber.NewSpanConfigDecoder().TranslateEvent,
 		s.handleUpdate,
 		rangefeedCacheKnobs,

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/cache_impl_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/cache_impl_test.go
@@ -45,12 +45,14 @@ func NewCache(
 	// many rows.
 	const bufferSize = 1 << 20 // infinite?
 	const withPrevValue = false
+	const withRowTSInInitialScan = true
 	c := Cache{}
 	c.w = NewWatcher(
 		name, clock, f,
 		bufferSize,
 		spans,
 		withPrevValue,
+		withRowTSInInitialScan,
 		passThroughTranslation,
 		c.handleUpdate,
 		nil)

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher_test.go
@@ -54,7 +54,8 @@ func TestWatchAuthErr(t *testing.T) {
 		tenant.RangeFeedFactory().(*rangefeed.Factory),
 		1024,
 		[]roachpb.Span{hostScratchSpan},
-		false, /*=withPrevValue*/
+		false, /* withPrevValue */
+		true,  /* withRowTSInInitialScan */
 		func(ctx context.Context, kv *kvpb.RangeFeedValue) rangefeedbuffer.Event {
 			t.Fatalf("rangefeed should fail before producing results")
 			return nil

--- a/pkg/multitenant/tenantcapabilities/BUILD.bazel
+++ b/pkg/multitenant/tenantcapabilities/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/multitenant/tenantcapabilities/tenantcapabilitiespb",
         "//pkg/roachpb",
         "//pkg/spanconfig/spanconfigbounds",
+        "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_cockroachdb_redact//interfaces",

--- a/pkg/multitenant/tenantcapabilities/interfaces.go
+++ b/pkg/multitenant/tenantcapabilities/interfaces.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 // Reader provides access to the global tenant capability state. The global
@@ -94,7 +95,8 @@ func (e Entry) Ready() bool {
 // Update represents an update to the global tenant capability state.
 type Update struct {
 	Entry
-	Deleted bool // whether the entry was deleted or not
+	Deleted   bool // whether the entry was deleted or not
+	Timestamp hlc.Timestamp
 }
 
 func (u Update) String() string {

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/decoder_test.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/decoder_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/stretchr/testify/require"
 )
@@ -32,6 +33,7 @@ import (
 // TenantCapabilities stored in the system.tenants table.
 func TestDecodeCapabilities(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	ts, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/basic
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/basic
@@ -17,7 +17,6 @@ ok
 
 updates
 ----
-Incremental Update
 update: ten=10 name=foo state=add service=shared cap={can_admin_unsplit:true}
 update: ten=11 name=bar state=ready service=none cap={default}
 
@@ -32,7 +31,6 @@ ok
 
 updates
 ----
-Incremental Update
 update: ten=11 name= state=add service=none cap={can_admin_unsplit:true}
 
 get-capabilities ten=11
@@ -45,7 +43,6 @@ ok
 
 updates
 ----
-Incremental Update
 delete: ten=10
 
 get-capabilities ten=10
@@ -72,7 +69,6 @@ ok
 
 updates
 ----
-Incremental Update
 update: ten=15 name=bli state=add service=external cap={can_admin_unsplit:true}
 
 # Ensure only the last update is applied, even when there are multiple updates
@@ -91,7 +87,6 @@ ok
 
 updates
 ----
-Incremental Update
 delete: ten=11
 
 get-capabilities ten=11
@@ -117,7 +112,6 @@ ok
 
 updates
 ----
-Incremental Update
 update: ten=15 name=blax state=ready service=none cap={default}
 
 flush-state

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/initial_scan
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/initial_scan
@@ -37,7 +37,6 @@ ok
 
 updates
 ----
-Complete Update
 update: ten=11 name=bar state=add service=external cap={default}
 update: ten=15 name=woo state=add service=none cap={can_admin_unsplit:true}
 

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/rangefeed_errors
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/rangefeed_errors
@@ -24,7 +24,6 @@ ok
 
 updates
 ----
-Incremental Update
 update: ten=10 name=foo state=add service=shared cap={can_admin_unsplit:true}
 update: ten=11 name=bar state=add service=none cap={default}
 update: ten=12 name=baz state=ready service=none cap={default}
@@ -81,7 +80,6 @@ ok
 # it is able to restart.
 updates
 ----
-Complete Update
 update: ten=11 name=bar state=add service=none cap={default}
 update: ten=12 name=bli state=add service=none cap={can_admin_unsplit:true}
 update: ten=50 name=blax state=add service=none cap={default}

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testingknobs.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testingknobs.go
@@ -12,7 +12,6 @@ package tenantcapabilitieswatcher
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 )
 
@@ -24,9 +23,7 @@ type TestingKnobs struct {
 
 	// WatcherUpdatesInterceptor, if set, is called each time the Watcher
 	// receives a set of updates.
-	WatcherUpdatesInterceptor func(
-		updateType rangefeedcache.UpdateType, updates []tenantcapabilities.Update,
-	)
+	WatcherUpdatesInterceptor func(update tenantcapabilities.Update)
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher_test.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher_test.go
@@ -85,7 +85,11 @@ func TestDataDriven(t *testing.T) {
 
 		tdb := sqlutils.MakeSQLRunner(db)
 		tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-		tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
+		// Make test faster.
+		// TODO(knz): Remove this after #111753 is merged.
+		tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms'`)
+		tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms'`)
+		tdb.Exec(t, `SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '10ms'`)
 
 		const dummyTableName = "dummy_system_tenants"
 		tdb.Exec(t, fmt.Sprintf("CREATE TABLE %s (LIKE system.tenants INCLUDING ALL)", dummyTableName))

--- a/pkg/server/settingswatcher/settings_watcher.go
+++ b/pkg/server/settingswatcher/settings_watcher.go
@@ -248,6 +248,7 @@ func (s *SettingsWatcher) Start(ctx context.Context) error {
 		bufferSize,
 		[]roachpb.Span{settingsTableSpan},
 		false, // withPrevValue
+		true,  // withRowTSInInitialScan
 		func(ctx context.Context, kv *kvpb.RangeFeedValue) rangefeedbuffer.Event {
 			return s.handleKV(ctx, kv)
 		},

--- a/pkg/server/systemconfigwatcher/cache.go
+++ b/pkg/server/systemconfigwatcher/cache.go
@@ -82,6 +82,7 @@ func NewWithAdditionalProvider(
 	// many rows.
 	const bufferSize = 1 << 20 // infinite?
 	const withPrevValue = false
+	const withRowTSInInitialScan = true
 	c := Cache{
 		defaultZoneConfig: defaultZoneConfig,
 	}
@@ -103,6 +104,7 @@ func NewWithAdditionalProvider(
 		bufferSize,
 		spans,
 		withPrevValue,
+		withRowTSInInitialScan,
 		passThroughTranslation,
 		c.handleUpdate,
 		nil)

--- a/pkg/server/tenantsettingswatcher/watcher.go
+++ b/pkg/server/tenantsettingswatcher/watcher.go
@@ -194,6 +194,7 @@ func (w *Watcher) startRangeFeed(
 		0, /* bufferSize */
 		[]roachpb.Span{tenantSettingsTableSpan},
 		false, /* withPrevValue */
+		true,  /* withRowTSInInitialScan */
 		translateEvent,
 		onUpdate,
 		nil, /* knobs */

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -222,6 +222,7 @@ func New(
 		int(bufferMemLimit/spanConfigurationsTableRowSize),
 		[]roachpb.Span{spanConfigTableSpan},
 		true, // withPrevValue
+		true, // withRowTSInInitialScan
 		NewSpanConfigDecoder().TranslateEvent,
 		s.handleUpdate,
 		rfCacheKnobs,


### PR DESCRIPTION
Needed for #111637.
Epic: CRDB-26691

Superceeds #112094

Prior to this patch, the tenant info watcher would only react to
changes to `system.tenants` upon rangefeed cache flushes, which could
be (in default config) up to 3 seconds after the change is committed.

This commit accelerates the behavior by processing updates as soon as
the rangefeed observes the change.

This new behavior is similar to the way that cluster settings changes
are processed immediately in the settings
watcher (pkg/settingswatcher).

In order to handle deletions that occur during errors that aren't
automatically retried inside the rangefeed library (and are instead
retried by the watcher resulting in a new full scan), we emit any
scan-generated rangefeed events at their scan timestamp, allowing us a
means of clearing any stale data from the cache.

Release note: None