### PR TITLE
release-23.2: roachprod: use gcloud CLI instead of net.LookupSRV

### DIFF
--- a/pkg/roachprod/install/services.go
+++ b/pkg/roachprod/install/services.go
@@ -146,8 +146,7 @@ func (c *SyncedCluster) DiscoverServices(
 	mu := syncutil.Mutex{}
 	records := make([]vm.DNSRecord, 0)
 	err := vm.FanOutDNS(c.VMs, func(dnsProvider vm.DNSProvider, _ vm.List) error {
-		service := fmt.Sprintf("%s-%s", virtualClusterName, string(serviceType))
-		r, lookupErr := dnsProvider.LookupSRVRecords(ctx, service, "tcp", c.Name)
+		r, lookupErr := dnsProvider.LookupSRVRecords(ctx, serviceDNSName(dnsProvider, virtualClusterName, serviceType, c.Name))
 		if lookupErr != nil {
 			return lookupErr
 		}

--- a/pkg/roachprod/vm/dns.go
+++ b/pkg/roachprod/vm/dns.go
@@ -54,7 +54,7 @@ type DNSProvider interface {
 	// subdomain. The protocol is usually "tcp" and the subdomain is usually the
 	// cluster name. The service is a combination of the virtual cluster name and
 	// type of service.
-	LookupSRVRecords(ctx context.Context, service, proto, subdomain string) ([]DNSRecord, error)
+	LookupSRVRecords(ctx context.Context, name string) ([]DNSRecord, error)
 	// ListRecords lists all DNS records managed for the zone.
 	ListRecords(ctx context.Context) ([]DNSRecord, error)
 	// DeleteRecordsBySubdomain deletes all DNS records with the given subdomain.

--- a/pkg/roachprod/vm/gce/BUILD.bazel
+++ b/pkg/roachprod/vm/gce/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/flagstub",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",

--- a/pkg/roachprod/vm/gce/BUILD.bazel
+++ b/pkg/roachprod/vm/gce/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/flagstub",
-        "//pkg/util/retry",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",

--- a/pkg/roachprod/vm/gce/dns.go
+++ b/pkg/roachprod/vm/gce/dns.go
@@ -40,7 +40,7 @@ var _ vm.DNSProvider = &dnsProvider{}
 // dnsProvider implements the vm.DNSProvider interface.
 type dnsProvider struct {
 	recordsCache struct {
-		mu      syncutil.RWMutex
+		mu      syncutil.Mutex
 		records map[string][]vm.DNSRecord
 	}
 }
@@ -48,7 +48,7 @@ type dnsProvider struct {
 func NewDNSProvider() vm.DNSProvider {
 	return &dnsProvider{
 		recordsCache: struct {
-			mu      syncutil.RWMutex
+			mu      syncutil.Mutex
 			records map[string][]vm.DNSRecord
 		}{records: make(map[string][]vm.DNSRecord)},
 	}
@@ -252,8 +252,8 @@ func (n *dnsProvider) updateCache(name string, records []vm.DNSRecord) {
 }
 
 func (n *dnsProvider) getCache(name string) ([]vm.DNSRecord, bool) {
-	n.recordsCache.mu.RLock()
-	defer n.recordsCache.mu.RUnlock()
+	n.recordsCache.mu.Lock()
+	defer n.recordsCache.mu.Unlock()
 	records, ok := n.recordsCache.records[n.normaliseName(name)]
 	return records, ok
 }

--- a/pkg/roachprod/vm/local/dns.go
+++ b/pkg/roachprod/vm/local/dns.go
@@ -64,14 +64,11 @@ func (n *dnsProvider) CreateRecords(_ context.Context, records ...vm.DNSRecord) 
 }
 
 // LookupSRVRecords is part of the vm.DNSProvider interface.
-func (n *dnsProvider) LookupSRVRecords(
-	_ context.Context, service, proto, subdomain string,
-) ([]vm.DNSRecord, error) {
+func (n *dnsProvider) LookupSRVRecords(_ context.Context, name string) ([]vm.DNSRecord, error) {
 	records, err := n.loadRecords()
 	if err != nil {
 		return nil, err
 	}
-	name := fmt.Sprintf("_%s._%s.%s.%s", service, proto, subdomain, n.Domain())
 	var matchingRecords []vm.DNSRecord
 	for _, record := range records {
 		if record.Name == name && record.Type == vm.SRV {

--- a/pkg/roachprod/vm/local/dns_test.go
+++ b/pkg/roachprod/vm/local/dns_test.go
@@ -53,7 +53,7 @@ func TestLookupRecords(t *testing.T) {
 	}...)
 
 	t.Run("lookup system", func(t *testing.T) {
-		records, err := p.LookupSRVRecords(ctx, "system-sql", "tcp", "local")
+		records, err := p.LookupSRVRecords(ctx, "_system-sql._tcp.local.local-zone")
 		require.NoError(t, err)
 		require.Equal(t, 3, len(records))
 		for _, r := range records {
@@ -63,7 +63,7 @@ func TestLookupRecords(t *testing.T) {
 	})
 
 	t.Run("parse SRV data", func(t *testing.T) {
-		records, err := p.LookupSRVRecords(ctx, "tenant-1-sql", "tcp", "local")
+		records, err := p.LookupSRVRecords(ctx, "_tenant-1-sql._tcp.local.local-zone")
 		require.NoError(t, err)
 		require.Equal(t, 1, len(records))
 		data, err := records[0].ParseSRVRecord()


### PR DESCRIPTION
Backport 4/4 commits from #113934.

/cc @cockroachdb/release

---

Previously `net.LookupSRV` with a custom resolver was used to lookup DNS
records. This approach resulted in several flakes and required waiting on DNS
servers to have the records available. The CLI is more stable, but has a greater
call overhead.

This PR also introduces a cache to reduce the cost of the `LookupSRVRecords`
call which could be called frequently depending on the origin of use. The cache
is updated for any CRUD operations on the DNS entries, and a call to the CLI
will not occur if any entry exists for the name the lookup is attempting. The
names are also normalised to remove a trailing dot in order to make matching
against the cache work correctly.

There is a small risk that the cache could go out of sync if any other roachprod
process manipulates the records with a create, update or destroy operation,
while a continuous roachprod process is interacting with the entries. This risk
is relatively small and usually applies to roachtest rather than everyday use of
roachprod.

Fixes #111269

Epic: None
Release Note: None

Release justification: Test only change.