### PR TITLE
sql: check for schema change transactions in RC while preparing statements

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1411,6 +1411,10 @@ type connExecutor struct {
 		// transaction has been executed.
 		firstStmtExecuted bool
 
+		// upgradedToSerializable indicates that the transaction has been implicitly
+		// upgraded to the SERIALIZABLE isolation level.
+		upgradedToSerializable bool
+
 		// numDDL keeps track of how many DDL statements have been
 		// executed so far.
 		numDDL int
@@ -1970,6 +1974,7 @@ func (ns *prepStmtNamespace) resetTo(
 func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent, payloadErr error) {
 	ex.extraTxnState.numDDL = 0
 	ex.extraTxnState.firstStmtExecuted = false
+	ex.extraTxnState.upgradedToSerializable = false
 	ex.extraTxnState.hasAdminRoleCache = HasAdminRoleCache{}
 	ex.extraTxnState.createdSequences = nil
 
@@ -3766,7 +3771,6 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 
 		}
 	case txnStart:
-		ex.extraTxnState.firstStmtExecuted = false
 		ex.recordTransactionStart(advInfo.txnEvent.txnID)
 		// Start of the transaction, so no statements were executed earlier.
 		// Bump the txn counter for logging.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1040,7 +1040,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.autoCommit = canAutoCommit &&
 		!ex.server.cfg.TestingKnobs.DisableAutoCommitDuringExec && ex.extraTxnState.numDDL == 0
 	p.extendedEvalCtx.TxnIsSingleStmt = canAutoCommit && !ex.extraTxnState.firstStmtExecuted
-	ex.extraTxnState.firstStmtExecuted = true
+	defer func() { ex.extraTxnState.firstStmtExecuted = true }()
 
 	var stmtThresholdSpan *tracing.Span
 	alreadyRecording := ex.transitionCtx.sessionTracing.Enabled()
@@ -2185,22 +2185,41 @@ func (ex *connExecutor) handleTxnRowsWrittenReadLimits(ctx context.Context) erro
 	return errors.CombineErrors(writtenErr, readErr)
 }
 
-// makeExecPlan creates an execution plan and populates planner.curPlan using
-// the cost-based optimizer.
-func (ex *connExecutor) makeExecPlan(ctx context.Context, planner *planner) error {
-	if tree.CanModifySchema(planner.stmt.AST) {
-		if planner.Txn().IsoLevel().ToleratesWriteSkew() {
-			if planner.extendedEvalCtx.TxnIsSingleStmt && planner.extendedEvalCtx.TxnImplicit {
+// maybeUpgradeToSerializable checks if the statement is a schema change, and
+// upgrades the transaction to serializable isolation if it is. If the
+// transaction contains multiple statements, and an upgrade was attempted, an
+// error is returned.
+func (ex *connExecutor) maybeUpgradeToSerializable(ctx context.Context, stmt Statement) error {
+	p := &ex.planner
+	if ex.extraTxnState.upgradedToSerializable && ex.extraTxnState.firstStmtExecuted {
+		return pgerror.Newf(
+			pgcode.FeatureNotSupported, "multi-statement transaction involving a schema change needs to be SERIALIZABLE",
+		)
+	}
+	if tree.CanModifySchema(stmt.AST) {
+		if ex.state.mu.txn.IsoLevel().ToleratesWriteSkew() {
+			if !ex.extraTxnState.firstStmtExecuted {
 				if err := ex.state.setIsolationLevel(isolation.Serializable); err != nil {
 					return err
 				}
-				planner.BufferClientNotice(ctx, pgnotice.Newf("setting implicit transaction isolation level to SERIALIZABLE due to schema change"))
+				ex.extraTxnState.upgradedToSerializable = true
+				p.BufferClientNotice(ctx, pgnotice.Newf("setting transaction isolation level to SERIALIZABLE due to schema change"))
 			} else {
 				return pgerror.Newf(
-					pgcode.FeatureNotSupported, "explicit transaction involving a schema change needs to be SERIALIZABLE",
+					pgcode.FeatureNotSupported, "multi-statement transaction involving a schema change needs to be SERIALIZABLE",
 				)
 			}
 		}
+	}
+	return nil
+}
+
+// makeExecPlan creates an execution plan and populates planner.curPlan using
+// the cost-based optimizer. This is used to create the plan when executing a
+// query in the "simple" pgwire protocol.
+func (ex *connExecutor) makeExecPlan(ctx context.Context, planner *planner) error {
+	if err := ex.maybeUpgradeToSerializable(ctx, planner.stmt); err != nil {
+		return err
 	}
 
 	if err := planner.makeOptimizerPlan(ctx); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/read_committed
@@ -176,110 +176,122 @@ subtest schema_changes_implicit
 query T noticetrace
 ALTER TABLE supermarket ADD COLUMN age INT
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 CREATE TABLE foo(a INT)
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 DROP TABLE supermarket
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 DROP USER testuser
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 CREATE USER testuser
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 GRANT admin TO testuser
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 GRANT SELECT ON foo TO testuser
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 GRANT USAGE ON SCHEMA public TO testuser
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 CREATE INDEX foo_idx ON foo(a)
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 CREATE FUNCTION f (x INT) RETURNS INT LANGUAGE SQL AS $$
   SELECT x+1
 $$
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 ALTER FUNCTION f (x INT) RENAME TO g
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 GRANT EXECUTE ON FUNCTION g (x INT) TO testuser
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 CREATE TYPE typ AS ENUM('a', 'b')
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 ALTER TYPE typ ADD VALUE 'c'
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 GRANT USAGE ON TYPE typ TO testuser
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 CREATE DATABASE foo
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 GRANT CONNECT ON DATABASE foo TO testuser
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 ALTER DATABASE foo RENAME TO foo2
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 CREATE SCHEMA s
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query T noticetrace
 ALTER SCHEMA s RENAME TO foo
 ----
-NOTICE: setting implicit transaction isolation level to SERIALIZABLE due to schema change
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
-subtest schema_changes_explicit
-# Schema changes are prohibited under explicit transactions with weak isolation levels.
+subtest schema_changes_multi-stmt
+# Schema changes are prohibited under multi-statement transactions with weak isolation levels.
+# They are allowed in single-statement explicit transactions.
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+CREATE TABLE single_stmt_explicit (a INT PRIMARY KEY);
+COMMIT
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+ALTER TABLE single_stmt_explicit ADD COLUMN b TEXT;
+COMMIT
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 ALTER TABLE supermarket ADD COLUMN age INT
 
 statement ok
@@ -287,6 +299,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 CREATE TABLE foo(a INT)
 
 statement ok
@@ -294,6 +307,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 DROP TABLE supermarket
 
 statement ok
@@ -301,6 +315,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 CREATE USER foo
 
 statement ok
@@ -308,6 +323,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 DROP USER testuser
 
 statement ok
@@ -315,6 +331,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 GRANT admin TO testuser
 
 statement ok
@@ -322,6 +339,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 GRANT SELECT ON supermarket TO testuser
 
 statement ok
@@ -329,6 +347,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 GRANT USAGE ON SCHEMA public TO testuser
 
 statement ok
@@ -336,6 +355,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 GRANT CONNECT ON DATABASE postgres TO testuser
 
 statement ok
@@ -343,6 +363,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 CREATE INDEX foo ON supermarket(ends_with, starts_with)
 
 statement ok
@@ -350,6 +371,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 CREATE FUNCTION f (x INT) RETURNS INT LANGUAGE SQL AS $$
   SELECT x+1
 $$
@@ -359,6 +381,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 ALTER FUNCTION f (x INT) RENAME TO g
 
 statement ok
@@ -366,6 +389,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 GRANT EXECUTE ON FUNCTION f (x INT) TO testuser
 
 statement ok
@@ -373,6 +397,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 CREATE TYPE typ AS ENUM('a', 'b')
 
 statement ok
@@ -380,6 +405,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 ALTER TYPE typ ADD VALUE 'c'
 
 statement ok
@@ -387,6 +413,7 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT 1;
 GRANT USAGE ON TYPE typ TO testuser
 
 statement ok
@@ -394,28 +421,32 @@ ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
-CREATE DATABASE foo
+CREATE DATABASE foo;
+SELECT 1;
 
 statement ok
 ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
-ALTER DATABASE postgres RENAME TO foo
+ALTER DATABASE postgres RENAME TO foo;
+SELECT 1;
 
 statement ok
 ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
-CREATE SCHEMA s
+CREATE SCHEMA s;
+SELECT 1;
 
 statement ok
 ROLLBACK
 
 statement error transaction involving a schema change needs to be SERIALIZABLE
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
-ALTER SCHEMA s RENAME TO foo
+SELECT 1;
+ALTER SCHEMA s RENAME TO foo;
 
 statement ok
 ROLLBACK

--- a/pkg/sql/pgwire/testdata/pgtest/implicit_txn
+++ b/pkg/sql/pgwire/testdata/pgtest/implicit_txn
@@ -50,7 +50,7 @@ until noncrdb_only
 ReadyForQuery
 ----
 {"Type":"BindComplete"}
-{"Severity":"WARNING","SeverityUnlocalized":"WARNING","Code":"25001","Message":"there is already a transaction in progress","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"xact.c","Line":3689,"Routine":"BeginTransactionBlock","UnknownFields":null}
+{"Severity":"WARNING","SeverityUnlocalized":"WARNING","Code":"25001","Message":"there is already a transaction in progress","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"xact.c","Line":0,"Routine":"BeginTransactionBlock","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"BEGIN"}
 {"Type":"ReadyForQuery","TxStatus":"T"}
 

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":68,"Routine":"DropIndex","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":0,"Routine":"DropIndex","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/pgwire/testdata/pgtest/read_committed
+++ b/pkg/sql/pgwire/testdata/pgtest/read_committed
@@ -1,0 +1,77 @@
+only crdb
+----
+
+send
+Query {"String": "SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = 'true'"}
+Query {"String": "SET default_transaction_isolation = 'read committed'"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"SET CLUSTER SETTING"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CommandComplete","CommandTag":"SET"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE TABLE t1 (a int)"}
+----
+
+until
+ReadyForQuery
+----
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"setting transaction isolation level to SERIALIZABLE due to schema change","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"conn_executor_exec.go","Line":0,"Routine":"maybeUpgradeToSerializable","UnknownFields":null}
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "CREATE TABLE t2 (a int primary key)"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"setting transaction isolation level to SERIALIZABLE due to schema change","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"conn_executor_exec.go","Line":0,"Routine":"maybeUpgradeToSerializable","UnknownFields":null}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "CREATE TABLE t3 (a int); CREATE TABLE t4 (a int);"}
+----
+
+until keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"setting transaction isolation level to SERIALIZABLE due to schema change","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"conn_executor_exec.go","Line":0,"Routine":"maybeUpgradeToSerializable","UnknownFields":null}
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"multi-statement transaction involving a schema change needs to be SERIALIZABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "CREATE TABLE t3 (a int primary key)"}
+Bind
+Execute
+Parse {"Query": "CREATE TABLE t4 (a int primary key)"}
+Bind
+Execute
+Sync
+----
+
+until keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"setting transaction isolation level to SERIALIZABLE due to schema change","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"conn_executor_exec.go","Line":0,"Routine":"maybeUpgradeToSerializable","UnknownFields":null}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"multi-statement transaction involving a schema change needs to be SERIALIZABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/testutils/pgtest/pgtest.go
+++ b/pkg/testutils/pgtest/pgtest.go
@@ -243,6 +243,13 @@ func (p *PGTest) Until(
 			return nil, err
 		}
 		msg := x.Interface().(pgproto3.BackendMessage)
+		if notice, ok := msg.(*pgproto3.NoticeResponse); ok {
+			// The line number can change frequently, so to reduce churn, we always
+			// ignore it.
+			notice.Line = 0
+			msgs = append(msgs, notice)
+			continue
+		}
 		msgs = append(msgs, msg)
 	}
 	return msgs, nil


### PR DESCRIPTION
Certain schema change statements, e.g. CREATE TABLE, CREATE VIEW, and CREATE FUNCTION, use a different code path in order to be prepared. Most other schema change statements are planned opaquely, but these ones are planned in the optimizer.

That means the check we have to see if a READ COMMITTED transaction has a schema change needs to also happen in the optimizer.

Along with this, the check is relaxed slightly so it only checks if a transaction has a single statement, rather than also checking if it is implicit.

No release note since this bug was not released.

Informs: https://github.com/cockroachdb/cockroach/pull/108137
Epic: CRDB-26546

Release note: None