### PR TITLE
streamingccl: deflake TestStreamingMismatchedMRDatabase

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -1304,6 +1304,7 @@ func TestStreamingMismatchedMRDatabase(t *testing.T) {
 	c.SrcTenantSQL.Exec(t, "CREATE TABLE many.x (id INT PRIMARY KEY, n INT)")
 	c.SrcTenantSQL.Exec(t, "INSERT INTO many.x VALUES (1, 1)")
 
+	c.WaitUntilStartTimeReached(jobspb.JobID(ingestionJobID))
 	srcTime := c.SrcCluster.Server(0).Clock().Now()
 	c.Cutover(producerJobID, ingestionJobID, srcTime.GoTime(), false)
 


### PR DESCRIPTION
Previously, this test would flake because it would attempt set a cutover timestamp before the initial scan completed, causing an error due to #114734. To prevent this flake, the test now waits for the initial scan to complete before cutover.

Informs #114669

Epic: none