### PR TITLE
changefeedccl: memory opt in sarama metadata fetching

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -257,6 +257,12 @@ func (s *kafkaSink) Dial() error {
 		return err
 	}
 
+	if err = client.RefreshMetadata(s.Topics()...); err != nil {
+		// Now that we do not fetch metadata for all topics by default, we try
+		// RefreshMetadata manually to check for any connection error.
+		return errors.CombineErrors(err, client.Close())
+	}
+
 	producer, err := s.newAsyncProducer(client)
 	if err != nil {
 		return err
@@ -1072,6 +1078,8 @@ func buildKafkaConfig(
 	config.ClientID = `CockroachDB`
 	config.Producer.Return.Successes = true
 	config.Producer.Partitioner = newChangefeedPartitioner
+	// Do not fetch metadata for all topics but just for the necessary ones.
+	config.Metadata.Full = false
 
 	if dialConfig.tlsEnabled {
 		config.Net.TLS.Enable = true

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -276,7 +276,8 @@ func makeTestKafkaSink(
 				return p, nil
 			},
 			OverrideClientInit: func(config *sarama.Config) (kafkaClient, error) {
-				return nil, nil
+				client := &fakeKafkaClient{config}
+				return client, nil
 			},
 		},
 	}


### PR DESCRIPTION
Prior to this commit, sarama clients fetch metadata for all topics periodically.
This takes a substantial amount of memory when users create too many topics.
This patch changes sarama configuration so that we only fetch metadata for a
minimal set of topics that have been necessary.

Fixes: #113576
Release Note: none 