### PR TITLE
backupccl,server: add DownloadSpans client side API

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3408,6 +3408,65 @@ Support status: [reserved](#support-status)
 
 
 
+## DownloadSpan
+
+`GET /_status/downloadspans`
+
+
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.DownloadSpanRequest-string) |  |  | [reserved](#support-status) |
+| span | [cockroach.roachpb.Span](#cockroach.server.serverpb.DownloadSpanRequest-cockroach.roachpb.Span) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| errors_by_node_id | [DownloadSpanResponse.ErrorsByNodeIdEntry](#cockroach.server.serverpb.DownloadSpanResponse-cockroach.server.serverpb.DownloadSpanResponse.ErrorsByNodeIdEntry) | repeated | ErrorsByNodeID contains any errors that occurred during fan-out calls to other nodes. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.DownloadSpanResponse-cockroach.server.serverpb.DownloadSpanResponse.ErrorsByNodeIdEntry"></a>
+#### DownloadSpanResponse.ErrorsByNodeIdEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.DownloadSpanResponse-int32) |  |  |  |
+| value | [string](#cockroach.server.serverpb.DownloadSpanResponse-string) |  |  |  |
+
+
+
+
+
+
 ## HotRanges
 
 `GET /_status/hotranges`

--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -76,6 +76,7 @@ go_library(
         "//pkg/scheduledjobs",
         "//pkg/scheduledjobs/schedulebase",
         "//pkg/security/username",
+        "//pkg/server/serverpb",
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1602,6 +1602,9 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	}
 
 	if len(details.DownloadSpans) > 0 {
+		if err := p.ExecCfg().JobRegistry.CheckPausepoint("restore.before_do_download_files"); err != nil {
+			return err
+		}
 		return r.doDownloadFiles(ctx, p)
 	}
 
@@ -3223,87 +3226,6 @@ func init() {
 		},
 		jobs.UsesTenantCostControl,
 	)
-}
-
-func (r *restoreResumer) doDownloadFiles(ctx context.Context, execCtx sql.JobExecContext) error {
-	details := r.job.Details().(jobspb.RestoreDetails)
-	total := r.job.Progress().Details.(*jobspb.Progress_Restore).Restore.TotalDownloadRequired
-
-	// If this is the first resumption of this job, we need to find out the total
-	// amount we expect to download and persist it so that we can indiciate our
-	// progress as that number goes down later.
-	if total == 0 {
-		log.Infof(ctx, "calculating total download size (across all stores) to complete restore")
-		if err := r.job.NoTxn().RunningStatus(ctx, jobs.RunningStatus("Calculating total download size...")); err != nil {
-			return errors.Wrapf(err, "failed to update running status of job %d", errors.Safe(r.job.ID()))
-		}
-
-		for _, span := range details.DownloadSpans {
-			resp, err := execCtx.ExecCfg().TenantStatusServer.SpanStats(ctx, &roachpb.SpanStatsRequest{
-				Spans: []roachpb.Span{span},
-			})
-			if err != nil {
-				return err
-			}
-			for _, stats := range resp.SpanToStats {
-				total += stats.ExternalFileBytes
-			}
-		}
-
-		if total == 0 {
-			return nil
-		}
-
-		if err := r.job.NoTxn().FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
-			prog := details.(*jobspb.Progress_Restore).Restore
-			prog.TotalDownloadRequired = total
-			return 0.0
-		}); err != nil {
-			return err
-		}
-
-		status := jobs.RunningStatus(fmt.Sprintf("Downloading %s of restored data...", sz(total)))
-		if err := r.job.NoTxn().RunningStatus(ctx, status); err != nil {
-			return errors.Wrapf(err, "failed to update running status of job %d", errors.Safe(r.job.ID()))
-		}
-	}
-
-	var lastProgressUpdate time.Time
-	for rt := retry.StartWithCtx(
-		ctx, retry.Options{InitialBackoff: time.Second * 10, Multiplier: 1.2, MaxBackoff: time.Minute * 5},
-	); ; rt.Next() {
-
-		var remaining uint64
-		for _, span := range details.DownloadSpans {
-			resp, err := execCtx.ExecCfg().TenantStatusServer.SpanStats(ctx, &roachpb.SpanStatsRequest{
-				Spans: []roachpb.Span{span},
-			})
-			if err != nil {
-				return err
-			}
-			for _, stats := range resp.SpanToStats {
-				remaining += stats.ExternalFileBytes
-			}
-		}
-
-		fractionComplete := float32(total-remaining) / float32(total)
-		log.Infof(ctx, "restore download phase, %s downloaded, %s remaining of %s total (%.1f complete)",
-			sz(total-remaining), sz(remaining), sz(total), fractionComplete,
-		)
-
-		if remaining == 0 {
-			return nil
-		}
-
-		if timeutil.Since(lastProgressUpdate) > time.Minute {
-			if err := r.job.NoTxn().FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
-				return fractionComplete
-			}); err != nil {
-				return err
-			}
-			lastProgressUpdate = timeutil.Now()
-		}
-	}
 }
 
 type sz int64

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -880,6 +880,24 @@ func (c *connector) HotRangesV2(
 	return resp, nil
 }
 
+// DownloadSpan implements the serverpb.TenantStatusServer interface
+func (c *connector) DownloadSpan(
+	ctx context.Context, req *serverpb.DownloadSpanRequest,
+) (*serverpb.DownloadSpanResponse, error) {
+	if !roachpb.IsSystemTenantID(c.tenantID.InternalValue) {
+		return nil, status.Errorf(codes.PermissionDenied, "only the system tenant can issue download span requests")
+	}
+	var resp *serverpb.DownloadSpanResponse
+	if err := c.withClient(ctx, func(ctx context.Context, c *client) error {
+		var err error
+		resp, err = c.DownloadSpan(ctx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 // WithTxn implements the spanconfig.KVAccessor interface.
 func (c *connector) WithTxn(context.Context, *kv.Txn) spanconfig.KVAccessor {
 	panic("not applicable")

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "server_systemlog_gc.go",
         "session_writer.go",
         "settings_cache.go",
+        "span_download.go",
         "span_stats_server.go",
         "sql_stats.go",
         "start_listen.go",

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -87,6 +87,10 @@ type TenantStatusServer interface {
 	// SpanStats is used to access MVCC stats from KV
 	SpanStats(context.Context, *roachpb.SpanStatsRequest) (*roachpb.SpanStatsResponse, error)
 	Nodes(context.Context, *NodesRequest) (*NodesResponse, error)
+	// TODO(adityamaru): DownloadSpan has the side effect of telling the engine to
+	// download remote files. A method that mutates state should not be on the
+	// status server and so in the long run we should move it.
+	DownloadSpan(ctx context.Context, request *DownloadSpanRequest) (*DownloadSpanResponse, error)
 }
 
 // OptionalNodesStatusServer returns the wrapped NodesStatusServer, if it is

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -599,6 +599,20 @@ message EngineStatsResponse {
   repeated EngineStatsInfo stats = 1 [ (gogoproto.nullable) = false ];
 }
 
+message DownloadSpanRequest {
+  string node_id = 1 [(gogoproto.customname) = "NodeID"];
+  roachpb.Span span = 2 [(gogoproto.nullable) = false];
+}
+
+message DownloadSpanResponse {
+  // ErrorsByNodeID contains any errors that occurred during fan-out calls to other nodes.
+  map<int32, string> errors_by_node_id = 1 [
+    (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID",
+    (gogoproto.customname) = "ErrorsByNodeID",
+    (gogoproto.nullable) = false
+  ];
+}
+
 message TraceEvent {
   google.protobuf.Timestamp time = 1
       [ (gogoproto.nullable) = false, (gogoproto.stdtime) = true ];
@@ -2415,6 +2429,12 @@ service Status {
   rpc ProblemRanges(ProblemRangesRequest) returns (ProblemRangesResponse) {
     option (google.api.http) = {
       get : "/_status/problemranges"
+    };
+  }
+
+  rpc DownloadSpan(DownloadSpanRequest) returns (DownloadSpanResponse) {
+    option (google.api.http) = {
+      get : "/_status/downloadspans"
     };
   }
 

--- a/pkg/server/span_download.go
+++ b/pkg/server/span_download.go
@@ -1,0 +1,87 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/authserver"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (t *statusServer) DownloadSpan(
+	ctx context.Context, req *serverpb.DownloadSpanRequest,
+) (*serverpb.DownloadSpanResponse, error) {
+	ctx = t.AnnotateCtx(ctx)
+
+	// TODO(adityamaru): Figure out proper privileges, for now we restrict this
+	// call to system tenant only in the tenant connector.
+	return t.sqlServer.tenantConnect.DownloadSpan(ctx, req)
+}
+
+func (s *systemStatusServer) DownloadSpan(
+	ctx context.Context, req *serverpb.DownloadSpanRequest,
+) (*serverpb.DownloadSpanResponse, error) {
+	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
+	ctx = s.AnnotateCtx(ctx)
+
+	resp := &serverpb.DownloadSpanResponse{
+		ErrorsByNodeID: make(map[roachpb.NodeID]string),
+	}
+	if len(req.NodeID) > 0 {
+		_, local, err := s.parseNodeID(req.NodeID)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		}
+
+		if local {
+			return resp, s.localDownloadSpan(ctx, req)
+		}
+
+		return nil, errors.AssertionFailedf("requesting download on a specific node is not supported yet")
+	}
+
+	// Send DownloadSpan request to all stores on all nodes.
+	remoteRequest := serverpb.DownloadSpanRequest{NodeID: "local", Span: req.Span}
+	nodeFn := func(ctx context.Context, status serverpb.StatusClient, _ roachpb.NodeID) (*serverpb.DownloadSpanResponse, error) {
+		return status.DownloadSpan(ctx, &remoteRequest)
+	}
+	responseFn := func(nodeID roachpb.NodeID, downloadSpanResp *serverpb.DownloadSpanResponse) {}
+	errorFn := func(nodeID roachpb.NodeID, err error) {
+		resp.ErrorsByNodeID[nodeID] = err.Error()
+	}
+
+	if err := iterateNodes(ctx, s.serverIterator, s.stopper, "download spans",
+		noTimeout,
+		s.dialNode,
+		nodeFn,
+		responseFn,
+		errorFn,
+	); err != nil {
+		return nil, srverrors.ServerError(ctx, err)
+	}
+
+	return resp, nil
+}
+
+func (s *systemStatusServer) localDownloadSpan(
+	ctx context.Context, req *serverpb.DownloadSpanRequest,
+) error {
+	return s.stores.VisitStores(func(store *kvserver.Store) error {
+		return store.TODOEngine().Download(ctx, req.Span)
+	})
+}

--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/rangedesc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
 
@@ -199,6 +200,8 @@ func (s *systemStatusServer) getLocalStats(
 func (s *systemStatusServer) statsForSpan(
 	ctx context.Context, span roachpb.Span,
 ) (*roachpb.SpanStats, error) {
+	ctx, sp := tracing.ChildSpan(ctx, "systemStatusServer.statsForSpan")
+	defer sp.Finish()
 
 	var descriptors []roachpb.RangeDescriptor
 	scanner := rangedesc.NewScanner(s.db)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1092,6 +1092,10 @@ func (t *testTenant) DistSQLPlanningNodeID() roachpb.NodeID {
 	return 0
 }
 
+func (ts *testTenant) ExternalStorageAccessor() interface{} {
+	return ts.sql.cfg.ExternalStorageAccessor
+}
+
 // LeaseManager is part of the serverutils.ApplicationLayerInterface.
 func (t *testTenant) LeaseManager() interface{} {
 	return t.sql.leaseMgr
@@ -1887,6 +1891,10 @@ func (ts *testServer) UpdateChecker() interface{} {
 // DiagnosticsReporter implements the serverutils.ApplicationLayerInterface.
 func (ts *testServer) DiagnosticsReporter() interface{} {
 	return ts.topLevelServer.sqlServer.diagnosticsReporter
+}
+
+func (ts *testServer) ExternalStorageAccessor() interface{} {
+	return ts.Cfg.ExternalStorageAccessor
 }
 
 type v2AuthDecorator struct {

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1106,6 +1106,10 @@ type Engine interface {
 
 	// GetStoreID is used to retrieve the configured store ID.
 	GetStoreID() (int32, error)
+
+	// Download informs the engine to download remote files corresponding to the
+	// given span.
+	Download(ctx context.Context, span roachpb.Span) error
 }
 
 // Batch is the interface for batch specific operations.

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -6949,6 +6949,8 @@ func ComputeStatsWithVisitors(
 	nowNanos int64,
 	visitors ComputeStatsVisitors,
 ) (enginepb.MVCCStats, error) {
+	ctx, sp := tracing.ChildSpan(ctx, "ComputeStatsWithVisitors")
+	defer sp.Finish()
 	if isLockTableKey(start) {
 		return computeLockTableStatsWithVisitors(ctx, r, start, end, nowNanos, visitors.LockTableKey)
 	}


### PR DESCRIPTION
This change adds an endpoint to the status
server, tenant connector and system status
server to instruct pebble to download a span.

The endpoint fans out to all nodes in the cluster, and instructs every store on each node to download the external files that intersect with the span.

This change also wires up online restore to issue
these download requests once the linking phase is complete. Currently, we issue download requests for each index span in the backup but going forward we will want to define prioritization heuristics for what spans to send.

Epic: none
Release note: None