### PR TITLE
storage: correct terminology in log line for disk stalls

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1396,9 +1396,9 @@ func (p *Pebble) makeMetricEtcEventListener(ctx context.Context) pebble.EventLis
 					// up.
 					log.MakeProcessUnavailable()
 
-					log.Fatalf(ctx, "file write stall detected: %s", info)
+					log.Fatalf(ctx, "disk stall detected: %s", info)
 				} else {
-					p.async(func() { log.Errorf(ctx, "file write stall detected: %s", info) })
+					p.async(func() { log.Errorf(ctx, "disk stall detected: %s", info) })
 				}
 				return
 			}


### PR DESCRIPTION
Previously, we'd use the term "file write stall" in the log line for a disk stall, and not use the term "disk stall" which is what metrics and documentation refers to this event as. Furthermore, "write stalls" are a different, unrelated kind of stall in Pebble.

This change addresses this by changing the wording to refer to this event as a "disk stall" in the log.

Epic: none

Release note (ops change): Updates the error message in case of stalled disks to use the appropriate term for that event ("disk stall"), which is also what metrics/dashboards refer to that event as.