### PR TITLE
sql: some fixes around Annotations handling

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1729,6 +1729,13 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 			ppInfo.dispatchToExecutionEngine.cleanup.appendFunc(namedFunc{
 				fName: "log statement",
 				f: func() {
+					if planner.extendedEvalCtx.Annotations == nil {
+						// This is a safety check in case resetPlanner() was
+						// executed, but then we never set the annotations on
+						// the planner. Formatting the stmt for logging requires
+						// non-nil annotations.
+						planner.extendedEvalCtx.Annotations = &planner.semaCtx.Annotations
+					}
 					planner.maybeLogStatement(
 						ctx,
 						ex.executorType,

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -268,6 +268,7 @@ func (ex *connExecutor) prepare(
 
 		p.stmt = stmt
 		p.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
+		p.extendedEvalCtx.Annotations = &p.semaCtx.Annotations
 		flags, err = ex.populatePrepared(ctx, txn, placeholderHints, p, origin)
 		return err
 	}


### PR DESCRIPTION
**sql: update Annotations of EvalCtx to refer to new ones in prepare**

It looks like in most places where we override `SemaCtx.Annotations` we
also make the corresponding update to `EvalCtx.Annotations` too, but we
were missing such an update in the `prepare` code path. This commit
fixes that.

Release note: None

**sql: prevent nil pointer panic with pausable portals and logging**

Formatting a stmt for logging purposes requires non-nil `Annotations` to
be set on the eval ctx of the planner. However, in some code paths we
set those to `nil`, and usually it's not a problem (because we'll update
it afterwards), but with pausable portal cleanup it seems possible for
`Annotations` to remain `nil` (e.g. because we hit an error before we
could update the planner). This commit prevents this type of a panic
from occurring.

Fixes: #112821.

Release note: None