### PR TITLE
workload/schemachange: export OTLP traces to disk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -223,6 +223,7 @@ require (
 	go.opentelemetry.io/otel/exporters/zipkin v1.0.0-RC3
 	go.opentelemetry.io/otel/sdk v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0
+	go.opentelemetry.io/proto/otlp v0.11.0
 	golang.org/x/perf v0.0.0-20230113213139-801c7ef9e5c5
 	golang.org/x/term v0.10.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -392,7 +393,6 @@ require (
 	go.mongodb.org/mongo-driver v1.5.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.3.0 // indirect
-	go.opentelemetry.io/proto/otlp v0.11.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.0 // indirect
@@ -416,7 +416,7 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	// The indicated commit is required on top of v1.0.0-RC3 because
 	// it fixes an import comment that otherwise breaks our prereqs tool.
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.3.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.3.0
 	google.golang.org/grpc/examples v0.0.0-20210324172016-702608ffae4d // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1235,6 +1235,7 @@ func TestLint(t *testing.T) {
 			":!storage/enginepb/mvcc3_valueheader.go",
 			":!sql/types/types_jsonpb.go",
 			":!sql/schemachanger/scplan/scviz/maps.go",
+			":!workload/schemachange/tracing.go",
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -48,8 +48,11 @@ go_library(
         "@com_github_spf13_pflag//:pflag",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel//codes",
+        "@io_opentelemetry_go_otel_exporters_otlp_otlptrace//:otlptrace",
         "@io_opentelemetry_go_otel_sdk//trace",
         "@io_opentelemetry_go_otel_trace//:trace",
+        "@io_opentelemetry_go_proto_otlp//collector/trace/v1:trace",
+        "@io_opentelemetry_go_proto_otlp//trace/v1:trace",
         "@org_golang_x_exp//slices",
     ],
 )

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -35,6 +35,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/spf13/pflag"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -88,6 +89,7 @@ type schemaChange struct {
 	fkChildInvalidPct               int
 	declarativeSchemaChangerPct     int
 	declarativeSchemaMaxStmtsPerTxn int
+	traceFilePath                   string
 }
 
 var schemaChangeMeta = workload.Meta{
@@ -113,6 +115,8 @@ var schemaChangeMeta = workload.Meta{
 			`Percentage of times that a sequence is owned by column upon creation.`)
 		s.flags.StringVar(&s.logFilePath, `txn-log`, "",
 			`If provided, transactions will be written to this file in JSON form`)
+		s.flags.StringVar(&s.traceFilePath, `trace-file`, "",
+			`The file to write OTeL traces to. Defaults to schemachange-workload.{timestamp}.otlp.ndjson.gz`)
 		s.flags.IntVar(&s.fkParentInvalidPct, `fk-parent-invalid-pct`, defaultFkParentInvalidPct,
 			`Percentage of times to choose an invalid parent column in a fk constraint.`)
 		s.flags.IntVar(&s.fkChildInvalidPct, `fk-child-invalid-pct`, defaultFkChildInvalidPct,
@@ -155,10 +159,11 @@ func (s *schemaChange) Ops(
 	// Initialize tracing ahead of everything else. The Ops function is used for
 	// managing the life cycle of this workload so we keep tracing localized to
 	// this function.
-	// NB: a noopSpanProcessor is provided here as there appears to be a bug in
-	// the OTeL SDK that causes Shutdown to error if no processors have been
-	// registered.
-	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(noopSpanProcessor{}))
+	tracerProvider, err := s.initTracerProvider()
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
+
 	tracer := tracerProvider.Tracer("schemachange")
 
 	// NB: The schemaChange.Ops span ends when this function returns, NOT when
@@ -809,6 +814,24 @@ func (l *atomicLog) printLn(message string) {
 	defer l.mu.Unlock()
 
 	_, _ = l.mu.log.Write(append([]byte(message), '\n'))
+}
+
+func (s *schemaChange) initTracerProvider() (*sdktrace.TracerProvider, error) {
+	path := s.traceFilePath
+	if path == "" {
+		path = fmt.Sprintf("schemachange-workload.%s.otlp.ndjson.gz", timeutil.Now().Format("20060102150405"))
+	}
+
+	// NB: otlptrace is usually used to connect to an HTTP or gRPC server, hence
+	// the context. OTLPFileClient writes to a file, so there's no use in adding a timeout to this context.
+	exporter, err := otlptrace.New(context.Background(), &OTLPFileClient{Path: path})
+	if err != nil {
+		return nil, err
+	}
+
+	return sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+	), nil
 }
 
 // initJsonLogFile opens the file denoted by filePath and sets s.logFile on success.

--- a/pkg/workload/schemachange/tracing.go
+++ b/pkg/workload/schemachange/tracing.go
@@ -11,16 +11,22 @@
 package schemachange
 
 import (
+	"compress/gzip"
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v5"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/trace"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 // EndSpan is a helper for ending a span and annotating it with error
@@ -44,16 +50,6 @@ func EndSpan(span trace.Span, err error) {
 	}
 	span.End()
 }
-
-// noopSpanProcessor is an sdktrace.SpanProcessor that does nothing.
-type noopSpanProcessor struct{}
-
-var _ sdktrace.SpanProcessor = noopSpanProcessor{}
-
-func (noopSpanProcessor) ForceFlush(ctx context.Context) error                     { return nil }
-func (noopSpanProcessor) OnEnd(s sdktrace.ReadOnlySpan)                            {}
-func (noopSpanProcessor) OnStart(parent context.Context, s sdktrace.ReadWriteSpan) {}
-func (noopSpanProcessor) Shutdown(ctx context.Context) error                       { return nil }
 
 type PGXTracer struct {
 	tracer trace.Tracer
@@ -81,4 +77,86 @@ func (*PGXTracer) TraceQueryEnd(ctx context.Context, conn *pgx.Conn, data pgx.Tr
 		attribute.String("command_tag", data.CommandTag.String()),
 	)
 	EndSpan(span, data.Err)
+}
+
+// OTLPFileClient is a [otlptrace.Client] that "uploads" spans to a .ndjson.gz file
+// instead of sending them to a remote server.
+//
+// The output .ndjson.gz [1] conforms to the OTLP File Spec [2]. Unfortunately,
+// most tooling will fail to read this format as OTeL's proto files made an
+// backwards incompatible change [3]. This results in CockroachDB's OTeL SDK
+// JSON encoding messaging with differently named keys. At the time of writing,
+// no tooling exists to ingest this format nor any other format but plenty of
+// tooling (JQ, DuckDB, Python) exists to work with JSON.
+//
+// If necessary, the NDJSON can be post-processed to be loaded into protobufs
+// and then re-encoded as binary to be sent to an OTPL ingestor, like Jaeger.
+//
+// [1]: https://github.com/ndjson/ndjson-spec
+// [2]: https://opentelemetry.io/docs/specs/otel/protocol/file-exporter/
+// [3]: https://github.com/open-telemetry/opentelemetry-proto/blob/v0.15.0/opentelemetry/proto/trace/v1/trace.proto#L55-L82
+type OTLPFileClient struct {
+	// Path is the path to the tar.gz file that spans will be written to.
+	Path string
+
+	mu   syncutil.Mutex
+	file *os.File
+	gzip *gzip.Writer
+	json *json.Encoder
+}
+
+var _ otlptrace.Client = &OTLPFileClient{}
+
+// Start implements otlptrace.Client.
+func (c *OTLPFileClient) Start(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.file != nil {
+		return nil
+	}
+
+	var err error
+	c.file, err = os.Create(c.Path)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	c.gzip = gzip.NewWriter(c.file)
+	c.json = json.NewEncoder(c.gzip)
+
+	return nil
+}
+
+// Stop implements otlptrace.Client.
+func (c *OTLPFileClient) Stop(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.gzip.Close(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if err := c.file.Close(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+// UploadTraces implements otlptrace.Client.
+func (c *OTLPFileClient) UploadTraces(
+	ctx context.Context, protoSpans []*tracepb.ResourceSpans,
+) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.file == nil {
+		return errors.New(".Start not called")
+	}
+
+	// NB: .Encode automatically terminates JSON with a newline.
+	return c.json.Encode(&coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: protoSpans,
+	})
 }


### PR DESCRIPTION
#### aa052138f4399ecd6b7c95cc744385471a0ea36c workload/schemachange: export OTLP traces to disk

Previous commits instrumented the schemachange workload with OTeL but
did not provide a way to access the output spans.

This commit implements a OTLP client that exports to a gzipped JSON+nl
file. As noted in the client's documentation, tooling for this format is
sparse but JSON wrangling tools can provide extremely rich insights. Due
to versioning issues, loading traces into a tool like Jaeger will
require a small amount of post-processing.

Epic: none
Release note (cli change): workload schemachange now writes a
.otlp.ndjson.gz archive containing OTLP trace bundles for debugging
purposes.