### PR TITLE
workload/schemachange: re-enable add FKs

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1047,13 +1047,9 @@ SELECT COALESCE(
 func (og *operationGenerator) constraintExists(
 	ctx context.Context, tx pgx.Tx, constraintName string,
 ) (bool, error) {
-	return og.scanBool(ctx, tx, fmt.Sprintf(`
-	SELECT EXISTS(
-	        SELECT *
-	          FROM pg_catalog.pg_constraint
-	           WHERE conname = '%s'
-	       );
-	`, constraintName))
+	return og.scanBool(ctx, tx, `SELECT EXISTS(
+		SELECT * FROM pg_catalog.pg_constraint WHERE conname = $1
+	 )`, constraintName)
 }
 
 func (og *operationGenerator) rowsSatisfyFkConstraint(

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -252,7 +252,7 @@ var opWeights = []int{
 	// DDL Operations
 	alterTableAddColumn:               1,
 	alterTableDropConstraint:          0, // TODO(spaskob): unimplemented
-	alterTableAddConstraintForeignKey: 0, // Disabled and tracked with #91195
+	alterTableAddConstraintForeignKey: 1, // Tentatively re-enabled, see #91195.
 	alterDatabaseAddRegion:            1,
 	alterDatabaseAddSuperRegion:       0, // Disabled and tracked with #111299
 	alterDatabaseDropSuperRegion:      0, // Disabled and tracked with #111299


### PR DESCRIPTION
#### bb56e9c3b7f904e7cbcc22ef84d31954dc0ebe53 workload/schemachange: re-enable add FKs

Previously, `ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY` was disabled in
the RSW due to bugs in the legacy schemachanger.

The original issue in question (#91227) appears to be unresolved. However,
runs of the RSW have yet to fail due to foreign keys.

Optimistically, this commit fixes minor escaping issues with the
operation and re-enables it.

Epic: CRDB-19168
Fixes: #91195
Informs: #91227
Release note: None