### PR TITLE
storage: benchmark replicated lock acquisition

### DIFF
--- a/pkg/testutils/subtest.go
+++ b/pkg/testutils/subtest.go
@@ -10,25 +10,29 @@
 
 package testutils
 
-import (
-	"fmt"
-	"testing"
-)
+import "fmt"
 
 // RunTrueAndFalse calls the provided function in a subtest, first with the
 // boolean argument set to false and next with the boolean argument set to true.
-func RunTrueAndFalse(t *testing.T, name string, fn func(t *testing.T, b bool)) {
+func RunTrueAndFalse[T testingTB[T]](t T, name string, fn func(t T, b bool)) {
 	t.Helper()
 	RunValues(t, name, []bool{false, true}, fn)
 }
 
 // RunValues calls the provided function in a subtest for each of the
 // provided values.
-func RunValues[T any](t *testing.T, name string, values []T, fn func(*testing.T, T)) {
+func RunValues[T testingTB[T], V any](t T, name string, values []V, fn func(T, V)) {
 	t.Helper()
 	for _, v := range values {
-		t.Run(fmt.Sprintf("%s=%v", name, v), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s=%v", name, v), func(t T) {
 			fn(t, v)
 		})
 	}
+}
+
+// testingTB is an interface that matches *testing.T and *testing.B, without
+// incurring the package dependency.
+type testingTB[T any] interface {
+	Run(name string, f func(t T)) bool
+	Helper()
 }


### PR DESCRIPTION
Informs #100193.

This commit adds two new microbenchmarks:
- `BenchmarkMVCCCheckForAcquireLock_Pebble`
- `BenchmarkMVCCAcquireLock_Pebble`

These sit atop the `MVCCCheckForAcquireLock` and `MVCCAcquireLock` functions, which were introduced in #110323.

Initial results:
```
name                                                                                                   time/op
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=false/strength=Shared-10      1.02µs ± 0%
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=false/strength=Exclusive-10   1.02µs ± 1%
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=true/strength=Shared-10       2.41µs ± 2%
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=true/strength=Exclusive-10    2.47µs ±10%
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=true/heldSameTxn=false/strength=Shared-10       2.48µs ±10%
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=true/heldSameTxn=false/strength=Exclusive-10    2.60µs ± 1%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=false/strength=Shared-10        448ns ± 0%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=false/strength=Exclusive-10     456ns ± 2%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=true/strength=Shared-10        1.61µs ± 2%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=true/strength=Exclusive-10     1.57µs ± 2%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=true/heldSameTxn=false/strength=Shared-10        1.46µs ± 3%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=true/heldSameTxn=false/strength=Exclusive-10     1.95µs ±39%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=false/strength=Shared-10              4.75µs ± 8%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=false/strength=Exclusive-10           4.52µs ± 4%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=true/strength=Shared-10               4.01µs ± 3%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=true/strength=Exclusive-10            4.02µs ± 2%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=true/heldSameTxn=false/strength=Shared-10               2.31µs ± 2%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=true/heldSameTxn=false/strength=Exclusive-10            2.62µs ± 2%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=false/strength=Shared-10                880ns ± 2%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=false/strength=Exclusive-10             871ns ± 2%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=true/strength=Shared-10                2.92µs ± 3%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=true/strength=Exclusive-10             2.91µs ± 2%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=true/heldSameTxn=false/strength=Shared-10                1.46µs ± 3%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=true/heldSameTxn=false/strength=Exclusive-10             1.71µs ± 2%

name                                                                                                   alloc/op
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=false/strength=Shared-10       0.00B
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=false/strength=Exclusive-10    0.00B
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=true/strength=Shared-10         372B ± 0%
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=true/strength=Exclusive-10      372B ± 0%
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=true/heldSameTxn=false/strength=Shared-10         336B ±35%
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=true/heldSameTxn=false/strength=Exclusive-10      674B ± 0%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=false/strength=Shared-10        0.00B
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=false/strength=Exclusive-10     0.00B
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=true/strength=Shared-10          352B ± 0%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=true/strength=Exclusive-10       352B ± 0%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=true/heldSameTxn=false/strength=Shared-10          279B ± 0%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=true/heldSameTxn=false/strength=Exclusive-10       654B ± 0%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=false/strength=Shared-10                713B ± 1%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=false/strength=Exclusive-10             713B ± 2%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=true/strength=Shared-10                 834B ± 0%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=true/strength=Exclusive-10              834B ± 0%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=true/heldSameTxn=false/strength=Shared-10                 299B ± 0%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=true/heldSameTxn=false/strength=Exclusive-10              674B ± 0%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=false/strength=Shared-10                 251B ±27%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=false/strength=Exclusive-10              198B ± 1%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=true/strength=Shared-10                  811B ± 0%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=true/strength=Exclusive-10               810B ± 0%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=true/heldSameTxn=false/strength=Shared-10                  279B ± 0%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=true/heldSameTxn=false/strength=Exclusive-10               654B ± 0%

name                                                                                                   allocs/op
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=false/strength=Shared-10        0.00
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=false/strength=Exclusive-10     0.00
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=true/strength=Shared-10         8.00 ± 0%
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=true/strength=Exclusive-10      8.00 ± 0%
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=true/heldSameTxn=false/strength=Shared-10         7.30 ±10%
MVCCCheckForAcquireLock_Pebble/batch=false/heldOtherTxn=true/heldSameTxn=false/strength=Exclusive-10      12.0 ± 0%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=false/strength=Shared-10         0.00
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=false/strength=Exclusive-10      0.00
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=true/strength=Shared-10          7.00 ± 0%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=true/strength=Exclusive-10       7.00 ± 0%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=true/heldSameTxn=false/strength=Shared-10          6.00 ± 0%
MVCCCheckForAcquireLock_Pebble/batch=true/heldOtherTxn=true/heldSameTxn=false/strength=Exclusive-10       11.0 ± 0%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=false/strength=Shared-10                2.00 ± 0%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=false/strength=Exclusive-10             2.00 ± 0%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=true/strength=Shared-10                 23.0 ± 0%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=false/heldSameTxn=true/strength=Exclusive-10              23.0 ± 0%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=true/heldSameTxn=false/strength=Shared-10                 7.00 ± 0%
MVCCAcquireLock_Pebble/batch=false/heldOtherTxn=true/heldSameTxn=false/strength=Exclusive-10              12.0 ± 0%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=false/strength=Shared-10                 0.00
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=false/strength=Exclusive-10              0.00
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=true/strength=Shared-10                  22.0 ± 0%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=false/heldSameTxn=true/strength=Exclusive-10               22.0 ± 0%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=true/heldSameTxn=false/strength=Shared-10                  6.00 ± 0%
MVCCAcquireLock_Pebble/batch=true/heldOtherTxn=true/heldSameTxn=false/strength=Exclusive-10               11.0 ± 0%
```

Release note: None