### PR TITLE
deploy: update container build instructions

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,6 +1,6 @@
 # Docker Deploy
 
-Installing docker is a prerequisite. The instructions differ depending on the
+Installing Docker is a prerequisite. The instructions differ depending on the
 environment. Docker is comprised of two parts: the daemon server which runs on
 Linux and accepts commands, and the client which is a Go program capable of
 running on MacOS, all Unix variants and Windows.
@@ -33,11 +33,24 @@ running CockroachDB. It is based on RedHat's `ubi9/ubi-minimal` image and
 contains only the main CockroachDB binary, libgeos libraries, and licenses. To
 fetch this image, run `docker pull cockroachdb/cockroach` in the usual fashion.
 
-To build the image yourself, use the Dockerfile in the `deploy` directory after
-fetching a cross-built version of `cockroach` from CI, or by building yourself
-using `./dev build cockroach geos --cross{=linuxarm}`. Copy the `cockroach`,
-`libgeos.so`, and `libgeos_c.so` files into `build/deploy` then run
-`docker build` in that directory.
+To build the image yourself:
+
+1. Fetch a cross-built version of `cockroach` from CI, or build one yourself
+   using `./dev build cockroach geos --cross[=linuxarm]`.
+
+1. Copy the necessary files into the `build/deploy` directory.
+
+    ```sh
+    cp ./artifacts/{cockroach,libgeos.so,libgeos_c.so} ./build/deploy
+    cp -r ./licenses ./build/deploy
+    ```
+
+1. Build the CockroachDB Docker image.
+
+    ```sh
+    cd ./build/deploy
+    docker build -t localhost/cockroach:latest .
+    ```
 
 # Updating toolchains
 


### PR DESCRIPTION
The documentation for building a container image of CockroachDB locally
was missing a step to copy the `licenses` directory into `build/deploy`,
leading to the following error when attempting a `docker build`:

```
STEP 7/13: COPY licenses/* /licenses/
Error: building at STEP "COPY licenses/* /licenses/": checking on sources under "/var/tmp/libpod_builder2005735694/build": Rel: can't make  relative to /var/tmp/libpod_builder2005735694/build; copier: stat: ["/licenses/*"]: no such file or directory
```

This patch updates the build instructions with the steps needed to build
a local container image of CockroachDB.

Release note: None
