### PR TITLE
logictest: always use --max-sql-memory of at least 320MiB

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1424,9 +1424,16 @@ func (t *logicTest) newCluster(
 		defaultTestTenant = base.TestTenantProbabilisticOnly
 	}
 
+	// Ensure that the server has at least 320MiB of SQL memory budget. We've
+	// seen cases when the default of 256MiB is insufficient.
+	const maxSQLMemoryLimitLowerBound = 320 << 20 /* 320MiB */
+	maxSQLMemoryLimit := serverArgs.MaxSQLMemoryLimit
+	if maxSQLMemoryLimit <= maxSQLMemoryLimitLowerBound {
+		maxSQLMemoryLimit = maxSQLMemoryLimitLowerBound
+	}
 	params := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			SQLMemoryPoolSize: serverArgs.MaxSQLMemoryLimit,
+			SQLMemoryPoolSize: maxSQLMemoryLimit,
 			DefaultTestTenant: defaultTestTenant,
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
@@ -4011,8 +4018,8 @@ var logicTestsConfigFilter = envutil.EnvOrDefaultString("COCKROACH_LOGIC_TESTS_C
 // want to specify for the test clusters to be created with.
 type TestServerArgs struct {
 	// MaxSQLMemoryLimit determines the value of --max-sql-memory startup
-	// argument for the server. If unset, then the default limit of 256MiB will
-	// be used.
+	// argument for the server. This value will always be bumped to at least
+	// 320MiB (including when unset).
 	MaxSQLMemoryLimit int64
 	// If set, mutations.MaxBatchSize, row.getKVBatchSize, and other values
 	// randomized via the metamorphic testing will be overridden to use the

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1,9 +1,3 @@
-# Set the distsql_workmem to the default production value because metamorphic
-# values may be too low for the legacy schema changer.
-onlyif config local-legacy-schema-changer
-statement ok
-SET distsql_workmem = '64MiB'
-
 statement ok
 CREATE TABLE ab (
   a INT PRIMARY KEY,


### PR DESCRIPTION
**Revert "logictest: disable metamorphic distsql_workmem for UDF test"**

This reverts commit https://github.com/cockroachdb/cockroach/commit/420b8977fed481056d6cab8e4ff32a248cdf9035.

This change had no effect on the problem it was trying to fix. The
following commit will address that problem properly.

Release note: None

**logictest: always use --max-sql-memory of at least 320MiB**

Previously, if a logic test config didn't explicitly specify
`MaxSQLMemoryLimit` (only sqllite configs set that to 512MiB),
then the server would use the default value of 256MiB. However,
it seems to be insufficient in some edge cases (namely, during
the validation phase of `udf` test file), so this commit bumps
the limit to at least 320MiB.

`udf` file creates lots of objects, so it seems reasonable that some
internal queries would need to use more memory. I don't really see
downside to bumping this limit a bit. That said, we don't want to bump
it too high in case we start seeing root budget being exceeded in many
more places - that could indicate a real problem.

Fixes: #114440.

Release note: None