### PR TITLE
sql: replace single node test clusters with test servers

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -2632,30 +2632,28 @@ func TestHistoricalAcquireDroppedDescriptor(t *testing.T) {
 	seenDrop := make(chan error)
 	recvSeenDrop := seenDrop
 	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			Knobs: base.TestingKnobs{
-				SQLLeaseManager: &lease.ManagerTestingKnobs{
-					TestingDescriptorRefreshedEvent: func(descriptor *descpb.Descriptor) {
-						_, _, name, state, err := descpb.GetDescriptorMetadata(descriptor)
-						if err != nil {
-							t.Fatal(err)
-						}
-						if name != typeName || seenDrop == nil {
-							return
-						}
-						if state == descpb.DescriptorState_DROP {
-							close(seenDrop)
-							seenDrop = nil
-						}
-					},
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLLeaseManager: &lease.ManagerTestingKnobs{
+				TestingDescriptorRefreshedEvent: func(descriptor *descpb.Descriptor) {
+					_, _, name, state, err := descpb.GetDescriptorMetadata(descriptor)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if name != typeName || seenDrop == nil {
+						return
+					}
+					if state == descpb.DescriptorState_DROP {
+						close(seenDrop)
+						seenDrop = nil
+					}
 				},
 			},
 		},
 	})
-	defer tc.Stopper().Stop(ctx)
+	defer s.Stopper().Stop(ctx)
 
-	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	tdb := sqlutils.MakeSQLRunner(conn)
 	tdb.Exec(t, "CREATE TYPE "+typeName+" AS ENUM ('a')")
 	var now string
 	tdb.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&now)
@@ -2789,13 +2787,11 @@ func TestDropDescriptorRacesWithAcquisition(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			Knobs: testingKnobs,
-		},
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: testingKnobs,
 	})
-	defer tc.Stopper().Stop(ctx)
-	db := tc.ServerConn(0)
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
 
 	// Create our table. This will not acquire a lease.
 	{
@@ -2833,7 +2829,7 @@ func TestDropDescriptorRacesWithAcquisition(t *testing.T) {
 	require.NoError(t, <-readFromFooErr)
 	require.NoError(t, <-dropErrChan)
 
-	tc.Server(0).LeaseManager().(*lease.Manager).VisitLeases(func(
+	s.LeaseManager().(*lease.Manager).VisitLeases(func(
 		desc catalog.Descriptor, takenOffline bool, refCount int, expiration tree.DTimestamp,
 	) (wantMore bool) {
 		t.Log(desc, takenOffline, refCount, expiration)
@@ -2988,6 +2984,9 @@ func TestLeaseTxnDeadlineExtension(t *testing.T) {
 	// Set the lease duration such that the next lease acquisition will
 	// require the lease to be reacquired.
 	lease.LeaseDuration.Override(ctx, &params.Settings.SV, 0)
+	// Leasing setting used above conflicts with disabling replication when
+	// starting the single server, so skip those.
+	params.PartOfCluster = true
 	params.Knobs.Store = &kvserver.StoreTestingKnobs{
 		TestingRequestFilter: func(ctx context.Context, req *kvpb.BatchRequest) *kvpb.Error {
 			filterMu.Lock()
@@ -3009,20 +3008,19 @@ func TestLeaseTxnDeadlineExtension(t *testing.T) {
 		},
 	}
 
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ServerArgs: params})
-	defer tc.Stopper().Stop(ctx)
-	conn := tc.ServerConn(0)
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
 	// Setup tables for the test.
-	_, err := conn.Exec(`
+	_, err := sqlDB.Exec(`
 CREATE TABLE t1(val int);
 	`)
 	require.NoError(t, err)
 	// Validates that transaction deadlines can move forward into
 	// the future after lease expiry.
 	t.Run("validate-lease-txn-deadline-ext", func(t *testing.T) {
-		conn, err := tc.ServerConn(0).Conn(ctx)
+		conn, err := sqlDB.Conn(ctx)
 		require.NoError(t, err)
-		descModConn := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+		descModConn := sqlutils.MakeSQLRunner(sqlDB)
 		waitChan := make(chan error)
 		resumeChan := make(chan struct{})
 		go func() {
@@ -3082,9 +3080,9 @@ SELECT * FROM T1;`)
 	// if the lease can't be renewed, for example if the descriptor gets
 	// modified.
 	t.Run("validate-lease-txn-deadline-ext-blocked", func(t *testing.T) {
-		conn, err := tc.ServerConn(0).Conn(ctx)
+		conn, err := sqlDB.Conn(ctx)
 		require.NoError(t, err)
-		descModConn := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+		descModConn := sqlutils.MakeSQLRunner(sqlDB)
 		waitChan := make(chan error)
 		resumeChan := make(chan struct{})
 		go func() {

--- a/pkg/sql/colfetcher/bytes_read_test.go
+++ b/pkg/sql/colfetcher/bytes_read_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -29,12 +29,9 @@ func TestBytesRead(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	testClusterArgs := base.TestClusterArgs{ReplicationMode: base.ReplicationAuto}
-	tc := testcluster.StartTestCluster(t, 1, testClusterArgs)
 	ctx := context.Background()
-	defer tc.Stopper().Stop(ctx)
-
-	conn := tc.Conns[0]
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
 
 	// Create the table with disabled automatic table stats collection. The
 	// stats collection is disabled so that the ColBatchScan would read the

--- a/pkg/sql/colfetcher/vectorized_batch_size_test.go
+++ b/pkg/sql/colfetcher/vectorized_batch_size_test.go
@@ -20,9 +20,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/assert"
@@ -81,14 +81,10 @@ func TestScanBatchSize(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	skip.UnderMetamorphic(t, "This test doesn't work with metamorphic batch sizes.")
 
-	testClusterArgs := base.TestClusterArgs{
-		ReplicationMode: base.ReplicationAuto,
-	}
-	tc := testcluster.StartTestCluster(t, 1, testClusterArgs)
 	ctx := context.Background()
-	defer tc.Stopper().Stop(ctx)
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
 
-	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	// Until we propagate the estimated row count hint in the KV projection
@@ -157,10 +153,9 @@ func TestCFetcherLimitsOutputBatch(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	skip.UnderMetamorphic(t, "This test doesn't work with metamorphic batch sizes.")
 
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ReplicationMode: base.ReplicationAuto})
 	ctx := context.Background()
-	defer tc.Stopper().Stop(ctx)
-	conn := tc.Conns[0]
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
 
 	// Until we propagate the estimated row count hint in the KV projection
 	// pushdown case, this test is expected to fail if the direct scans are

--- a/pkg/sql/colflow/vectorized_flow_deadlock_test.go
+++ b/pkg/sql/colflow/vectorized_flow_deadlock_test.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -47,10 +47,9 @@ func TestVectorizedFlowDeadlocksWhenSpilling(t *testing.T) {
 			VecFDsToAcquire: vecFDsLimit,
 		}},
 	}
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ServerArgs: serverArgs})
 	ctx := context.Background()
-	defer tc.Stopper().Stop(ctx)
-	conn := tc.Conns[0]
+	s, conn, _ := serverutils.StartServer(t, serverArgs)
+	defer s.Stopper().Stop(ctx)
 
 	_, err := conn.ExecContext(ctx, "CREATE TABLE t (a, b) AS SELECT i, i FROM generate_series(1, 10000) AS g(i)")
 	require.NoError(t, err)

--- a/pkg/sql/colflow/vectorized_flow_planning_test.go
+++ b/pkg/sql/colflow/vectorized_flow_planning_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -28,10 +28,9 @@ func TestVectorizedPlanning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ReplicationMode: base.ReplicationAuto})
 	ctx := context.Background()
-	defer tc.Stopper().Stop(ctx)
-	conn := tc.Conns[0]
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
 
 	t.Run("no columnarizer-materializer", func(t *testing.T) {
 		if !buildutil.CrdbTestBuild {

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1053,28 +1052,27 @@ func TestDropIndexHandlesRetriableErrors(t *testing.T) {
 	ctx := context.Background()
 	rf := newDynamicRequestFilter()
 	dropIndexPlanningDoneCh := make(chan struct{})
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			Knobs: base.TestingKnobs{
-				Store: &kvserver.StoreTestingKnobs{
-					TestingRequestFilter: rf.filter,
-				},
-				SQLExecutor: &sql.ExecutorTestingKnobs{
-					BeforeExecute: func(ctx context.Context, stmt string, descriptors *descs.Collection) {
-						if strings.Contains(stmt, "DROP INDEX") {
-							// Force release all cached descriptors to force a kv fetch with
-							// the table ID so that we can guarantee the DynamicRequestFilter
-							// would see such relevant request and inject the error we want at
-							// the right time.
-							descriptors.ReleaseAll(ctx)
-							close(dropIndexPlanningDoneCh)
-						}
-					},
+	srv, conn, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				TestingRequestFilter: rf.filter,
+			},
+			SQLExecutor: &sql.ExecutorTestingKnobs{
+				BeforeExecute: func(ctx context.Context, stmt string, descriptors *descs.Collection) {
+					if strings.Contains(stmt, "DROP INDEX") {
+						// Force release all cached descriptors to force a kv
+						// fetch with the table ID so that we can guarantee the
+						// DynamicRequestFilter would see such relevant request
+						// and inject the error we want at the right time.
+						descriptors.ReleaseAll(ctx)
+						close(dropIndexPlanningDoneCh)
+					}
 				},
 			},
 		},
 	})
-	defer tc.Stopper().Stop(ctx)
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
 
 	// What we want to do is have a transaction which does the planning work to
 	// drop an index. Then we want to expose the execution of the DROP INDEX to
@@ -1082,7 +1080,7 @@ func TestDropIndexHandlesRetriableErrors(t *testing.T) {
 	// injecting a ReadWithinUncertainty error underneath the DROP INDEX
 	// after planning has concluded.
 
-	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	tdb := sqlutils.MakeSQLRunner(conn)
 	tdb.Exec(t, "CREATE TABLE foo (i INT PRIMARY KEY, j INT, INDEX j_idx (j))")
 
 	var tableID uint32
@@ -1095,8 +1093,8 @@ WHERE
     name = $1 AND database_name = current_database();`,
 		"foo").Scan(&tableID)
 
-	codec := tc.ApplicationLayer(0).Codec()
-	txn, err := tc.ServerConn(0).Begin()
+	codec := s.Codec()
+	txn, err := conn.Begin()
 	require.NoError(t, err)
 	// Let's find out our transaction ID for our transaction by running a query.
 	// We'll also use this query to install a refresh span over the table data.

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -237,11 +237,11 @@ func TestContentionTimeOnWrites(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
 	ctx := context.Background()
-	defer tc.Stopper().Stop(ctx)
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
 
-	runner := sqlutils.MakeSQLRunner(tc.Conns[0])
+	runner := sqlutils.MakeSQLRunner(conn)
 	runner.Exec(t, "CREATE TABLE t (k INT PRIMARY KEY, v INT)")
 
 	// The test involves three goroutines:
@@ -270,7 +270,7 @@ func TestContentionTimeOnWrites(t *testing.T) {
 				close(sem)
 			}
 		}()
-		txn, err := tc.Conns[0].Begin()
+		txn, err := conn.Begin()
 		if err != nil {
 			errCh <- err
 			return

--- a/pkg/sql/session_migration_test.go
+++ b/pkg/sql/session_migration_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -45,12 +45,12 @@ func TestSessionMigration(t *testing.T) {
 
 	ctx := context.Background()
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "session_migration"), func(t *testing.T, path string) {
-		tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
-		defer tc.Stopper().Stop(ctx)
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+		defer s.Stopper().Stop(ctx)
 
 		openConnFunc := func() *pgx.Conn {
 			pgURL, cleanupGoDB, err := sqlutils.PGUrlE(
-				tc.Server(0).AdvSQLAddr(),
+				s.AdvSQLAddr(),
 				"StartServer", /* prefix */
 				url.User(username.RootUser),
 			)
@@ -63,7 +63,7 @@ func TestSessionMigration(t *testing.T) {
 			conn, err := pgx.ConnectConfig(ctx, config)
 			require.NoError(t, err)
 
-			tc.Server(0).Stopper().AddCloser(
+			s.Stopper().AddCloser(
 				stop.CloserFn(func() {
 					cleanupGoDB()
 				}))
@@ -79,7 +79,7 @@ func TestSessionMigration(t *testing.T) {
 
 		openUserConnFunc := func(user string) *pgx.Conn {
 			pgURL, cleanupGoDB, err := sqlutils.PGUrlE(
-				tc.Server(0).AdvSQLAddr(),
+				s.AdvSQLAddr(),
 				"StartServer", /* prefix */
 				url.User(user),
 			)
@@ -92,7 +92,7 @@ func TestSessionMigration(t *testing.T) {
 			conn, err := pgx.ConnectConfig(ctx, config)
 			require.NoError(t, err)
 
-			tc.Server(0).Stopper().AddCloser(
+			s.Stopper().AddCloser(
 				stop.CloserFn(func() {
 					cleanupGoDB()
 				}))

--- a/pkg/sql/show_create_table_test.go
+++ b/pkg/sql/show_create_table_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -31,13 +31,12 @@ func TestShowCreateTableWithConstraintInvalidated(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
-	defer tc.Stopper().Stop(ctx)
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
 
-	s0 := tc.Server(0)
+	s0 := s.ApplicationLayer()
 
-	tdb := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	tdb := sqlutils.MakeSQLRunner(conn)
 	tdb.Exec(t, `CREATE DATABASE db`)
 	tdb.Exec(t, `USE db`)
 	tdb.Exec(t, `CREATE SCHEMA schema`)

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -301,9 +301,8 @@ func TestDeleteFailedJob(t *testing.T) {
 
 	ctx := context.Background()
 	serverArgs := base.TestServerArgs{Knobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()}}
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ServerArgs: serverArgs})
-	defer tc.Stopper().Stop(ctx)
-	conn := tc.ApplicationLayer(0).SQLConn(t)
+	s, conn, _ := serverutils.StartServer(t, serverArgs)
+	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	sqlDB.Exec(t, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`)
@@ -515,9 +514,9 @@ func TestCreateStatsAsOfTime(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
-	defer tc.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(tc.ApplicationLayer(0).SQLConn(t))
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(conn)
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE d.t (x INT PRIMARY KEY)`)
 

--- a/pkg/sql/tests/virtual_table_test.go
+++ b/pkg/sql/tests/virtual_table_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/assert"
@@ -32,17 +32,17 @@ func TestVirtualTableGenCancel(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
-	defer tc.Stopper().Stop(ctx)
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
 
 	const workers = 10
 	const iterations = 10
 	var wg sync.WaitGroup
 	wg.Add(workers)
 	for i := 0; i < workers; i++ {
-		conn, err := tc.ServerConn(0).Conn(ctx)
-		require.NoError(t, err)
-		_, err = conn.ExecContext(ctx, "SET statement_timeout='100us'")
+		conn := s.SQLConn(t)
+		_, err := conn.ExecContext(ctx, "SET statement_timeout='100us'")
 		require.NoError(t, err)
 		go func() {
 			defer wg.Done()

--- a/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/ttl/ttlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/ttl/ttljob"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -296,11 +296,10 @@ func TestSelectQueryBuilder(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := context.Background()
-			testCluster := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
-			defer testCluster.Stopper().Stop(ctx)
+			srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+			defer srv.Stopper().Stop(ctx)
 
-			testServer := testCluster.Server(0)
-			ie := testServer.InternalExecutor().(*sql.InternalExecutor)
+			ie := srv.ApplicationLayer().InternalExecutor().(*sql.InternalExecutor)
 
 			// Generate PKColNames.
 			pkColDirs := tc.pkColDirs
@@ -422,13 +421,12 @@ func TestDeleteQueryBuilder(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := context.Background()
+			srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+			defer srv.Stopper().Stop(ctx)
+			s := srv.ApplicationLayer()
 
-			testCluster := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
-			defer testCluster.Stopper().Stop(ctx)
-
-			testServer := testCluster.Server(0)
-			ie := testServer.InternalExecutor().(*sql.InternalExecutor)
-			db := testServer.InternalDB().(*sql.InternalDB)
+			ie := s.InternalExecutor().(*sql.InternalExecutor)
+			db := s.InternalDB().(*sql.InternalDB)
 
 			// Generate PKColNames.
 			numPKCols := tc.numPKCols


### PR DESCRIPTION
This commit audits test clusters that are initialized with a single server in `pkg/sql` and replaces many with just test servers directly. This is a minor cleanup. Additionally, this commit adjusts some tests to work under multi-tenancy once enabled.

One notable change that required an investigation was in `TestLeaseTxnDeadlineExtension`. In particular, there we set the lease duration to 0. Then, with the switch to single test server, we were no longer setting `PartOfCluster` knob which made it so that we'd disable the replication on the server. That, in turn, results in "set-zone" internal queries, and those queries would get retried indefinitely because the query wouldn't be able to commit - IIUC due to zero lease duration it would always set the txn deadline in such a way that it would pass by the time we attempt to commit (both of these things are done in `connExecutor.handleAutoCommit`). Thus, to go around this problem the test continues to set `PartOfCluster` explicitly (similar to what we did in a new test in 3b465209b1eca4d361e266ff0f8a8213113586ec).

Informs: #114769.

Epic: None

Release note: None