### PR TITLE
opt: eliminate trivial Select filters and constrained scans

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_foreign_key_lookup_join
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_foreign_key_lookup_join
@@ -167,7 +167,7 @@ vectorized: true
     └── • scan
           missing stats
           table: child_rbr@child_rbr_pkey
-          spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
+          spans: FULL SCAN
 
 query IIIIITI
 SELECT *
@@ -200,7 +200,7 @@ vectorized: true
         └── • scan
               missing stats
               table: child_rbr@child_rbr_pkey
-              spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
+              spans: FULL SCAN
 
 query IIIIITI rowsort
 SELECT *

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -1983,7 +1983,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES 
 │                   └── • scan
 │                         missing stats
 │                         table: regional_by_row_table_virt@regional_by_row_table_virt_pkey
-│                         spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
+│                         spans: FULL SCAN (SOFT LIMIT)
 │
 └── • constraint-check
     │
@@ -2162,7 +2162,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b)
 │                   └── • scan
 │                         missing stats
 │                         table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
-│                         spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
+│                         spans: FULL SCAN (SOFT LIMIT)
 │
 └── • constraint-check
     │
@@ -2182,7 +2182,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b)
                     └── • scan
                           missing stats
                           table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
-                          spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
+                          spans: FULL SCAN (SOFT LIMIT)
 
 query T retry
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b) VALUES (1, 1, 1)] OFFSET 2

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -853,7 +853,7 @@ func (c *CustomFuncs) ExtractUnboundConditions(
 // return filters for all constant computed columns, regardless of the order of
 // their dependencies.
 //
-// As with checkConstraintFilters, ComputedColFilters do not really filter any
+// As with CheckConstraintFilters, ComputedColFilters do not really filter any
 // rows, they are rather facts or guarantees about the data. Treating them as
 // filters may allow some indexes to be constrained and used. Consider the
 // following example:
@@ -1236,6 +1236,61 @@ func buildConjunctionOfEqualityPredsOnComputedAndNonComputedCols(
 		return nil, false
 	}
 	return computedColPlusOriginalColEqualityConjunction, true
+}
+
+// CheckConstraintFilters generates all filters that we can derive from the
+// check constraints. These are constraints that have been validated and are
+// non-nullable. We only use non-nullable check constraints because they
+// behave differently from filters on NULL. Check constraints are satisfied
+// when their expression evaluates to NULL, while filters are not.
+//
+// For example, the check constraint a > 1 is satisfied if a is NULL but the
+// equivalent filter a > 1 is not.
+//
+// These filters do not really filter any rows, they are rather facts or
+// guarantees about the data but treating them as filters may allow some
+// indexes to be constrained and used. Consider the following example:
+//
+// CREATE TABLE abc (
+//
+//	a INT PRIMARY KEY,
+//	b INT NOT NULL,
+//	c STRING NOT NULL,
+//	CHECK (a < 10 AND a > 1),
+//	CHECK (b < 10 AND b > 1),
+//	CHECK (c in ('first', 'second')),
+//	INDEX secondary (b, a),
+//	INDEX tertiary (c, b, a))
+//
+// Now consider the query: SELECT a, b WHERE a > 5
+//
+// Notice that the filter provided previously wouldn't let the optimizer use
+// the secondary or tertiary indexes. However, given that we can use the
+// constraints on a, b and c, we can actually use the secondary and tertiary
+// indexes. In fact, for the above query we can do the following:
+//
+// select
+//
+//	├── columns: a:1(int!null) b:2(int!null)
+//	├── scan abc@tertiary
+//	│		├── columns: a:1(int!null) b:2(int!null)
+//	│		└── constraint: /3/2/1: [/'first'/2/6 - /'first'/9/9] [/'second'/2/6 - /'second'/9/9]
+//	└── filters
+//	      └── gt [type=bool]
+//	          ├── variable: a [type=int]
+//	          └── const: 5 [type=int]
+//
+// Similarly, the secondary index could also be used. All such index scans
+// will be added to the memo group.
+func (c *CustomFuncs) CheckConstraintFilters(tabID opt.TableID) memo.FiltersExpr {
+	md := c.mem.Metadata()
+	tabMeta := md.TableMeta(tabID)
+	if tabMeta.Constraints == nil {
+		return memo.FiltersExpr{}
+	}
+	filters := *tabMeta.Constraints.(*memo.FiltersExpr)
+	// Limit slice capacity to allow the caller to append if necessary.
+	return filters[:len(filters):len(filters)]
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -448,3 +448,23 @@ $input
     )
     (RemoveFiltersItem $filter $item)
 )
+
+# EliminateFilterImpliedByCheckConstraints detects cases where a filter is
+# implied by the check constraints for the input table-scan, and removes the
+# filter. This is correct because check constraints are static guarantees about
+# the table's rows, rather than filters that are applied to them.
+[EliminateFilterImpliedByCheckConstraints, Normalize]
+(Select
+    $input:(Scan $scanPrivate:*)
+    $filters:[
+        ...
+        $item:* &
+            (IsFilterImpliedByCheckConstraints
+                $item
+                $scanPrivate
+            )
+        ...
+    ]
+)
+=>
+(Select $input (RemoveFiltersItem $filters $item))

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -25,6 +25,34 @@ CREATE TABLE e
 )
 ----
 
+exec-ddl
+CREATE TABLE checks (
+  a INT NOT NULL,
+  b INT NOT NULL,
+  c INT,
+  d INT NOT NULL,
+  e INT NOT NULL,
+  f INT NOT NULL,
+  g INT,
+  h INT NOT NULL,
+  CHECK (a = 5),
+  CHECK (b > 5),
+  CHECK (c = 5),
+  CHECK (d > 5 AND e = 5),
+  CHECK (f > 5 AND g = 5),
+  CHECK (h < 5 OR h > 5)
+)
+----
+
+exec-ddl
+CREATE TABLE singleton_check(
+  singleton BOOL DEFAULT TRUE,
+  count INT NOT NULL,
+  PRIMARY KEY (singleton),
+  CHECK (singleton)
+)
+----
+
 # --------------------------------------------------
 # SimplifySelectFilters
 # --------------------------------------------------
@@ -2489,3 +2517,209 @@ project
       │         └── row-number [as=row_num:25]
       └── filters
            └── row_num:25 <= 100 [outer=(25), constraints=(/25: (/NULL - /100]; tight)]
+
+# --------------------------------------------------
+# EliminateFilterImpliedByCheckConstraints
+# --------------------------------------------------
+
+norm expect=EliminateFilterImpliedByCheckConstraints
+SELECT * FROM checks WHERE a = 5;
+----
+scan checks
+ ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ ├── check constraint expressions
+ │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+ │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+ │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+ └── fd: ()-->(1,5)
+
+norm expect=EliminateFilterImpliedByCheckConstraints
+SELECT * FROM checks WHERE b > 5;
+----
+scan checks
+ ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ ├── check constraint expressions
+ │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+ │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+ │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+ └── fd: ()-->(1,5)
+
+# The filter isn't exactly the same as the check constraint, but is still
+# implied by it.
+norm expect=EliminateFilterImpliedByCheckConstraints
+SELECT * FROM checks WHERE b > 1;
+----
+scan checks
+ ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ ├── check constraint expressions
+ │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+ │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+ │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+ └── fd: ()-->(1,5)
+
+# Both filters are trivial and should be removed.
+norm expect=EliminateFilterImpliedByCheckConstraints
+SELECT * FROM checks WHERE a = 5 AND b > 5;
+----
+scan checks
+ ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ ├── check constraint expressions
+ │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+ │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+ │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+ └── fd: ()-->(1,5)
+
+# The "a" filter is trivial, but the "c" filter is not.
+norm expect=EliminateFilterImpliedByCheckConstraints
+SELECT * FROM checks WHERE a = 5 AND c = 100;
+----
+select
+ ├── columns: a:1!null b:2!null c:3!null d:4!null e:5!null f:6!null g:7 h:8!null
+ ├── fd: ()-->(1,3,5)
+ ├── scan checks
+ │    ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ │    ├── check constraint expressions
+ │    │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │    │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+ │    │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+ │    │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+ │    └── fd: ()-->(1,5)
+ └── filters
+      └── c:3 = 100 [outer=(3), constraints=(/3: [/100 - /100]; tight), fd=()-->(3)]
+
+# The "b > 5" filter is trivial, but the "b < 10" is more restrictive than the
+# check constraint and so must remain.
+norm expect=EliminateFilterImpliedByCheckConstraints
+SELECT * FROM checks WHERE b > 5 AND b < 10;
+----
+select
+ ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ ├── fd: ()-->(1,5)
+ ├── scan checks
+ │    ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ │    ├── check constraint expressions
+ │    │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │    │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+ │    │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+ │    │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+ │    └── fd: ()-->(1,5)
+ └── filters
+      └── b:2 < 10 [outer=(2), constraints=(/2: (/NULL - /9]; tight)]
+
+# Case with a filter that references multiple columns.
+norm expect=EliminateFilterImpliedByCheckConstraints
+SELECT * FROM checks WHERE d > 5 AND e = 5;
+----
+scan checks
+ ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ ├── check constraint expressions
+ │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+ │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+ │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+ └── fd: ()-->(1,5)
+
+# Case with a disjunction.
+norm expect=EliminateFilterImpliedByCheckConstraints
+SELECT * FROM checks WHERE h < 5 OR h > 5;
+----
+scan checks
+ ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ ├── check constraint expressions
+ │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+ │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+ │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+ └── fd: ()-->(1,5)
+
+# No-op equality with a different constant.
+norm expect-not=EliminateFilterImpliedByCheckConstraints
+SELECT * FROM checks WHERE a = 10;
+----
+select
+ ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ ├── fd: ()-->(1,5)
+ ├── scan checks
+ │    ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ │    ├── check constraint expressions
+ │    │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │    │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+ │    │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+ │    │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+ │    └── fd: ()-->(1,5)
+ └── filters
+      └── a:1 = 10 [outer=(1), constraints=(/1: [/10 - /10]; tight), fd=()-->(1)]
+
+# No-op because the explicit filter is more selective than the check constraint.
+norm expect-not=EliminateFilterImpliedByCheckConstraints
+SELECT * FROM checks WHERE b = 10;
+----
+select
+ ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ ├── fd: ()-->(1,2,5)
+ ├── scan checks
+ │    ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ │    ├── check constraint expressions
+ │    │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │    │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+ │    │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+ │    │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+ │    └── fd: ()-->(1,5)
+ └── filters
+      └── b:2 = 10 [outer=(2), constraints=(/2: [/10 - /10]; tight), fd=()-->(2)]
+
+# No-op because "c" is nullable, and check constraints pass when they evaluate
+# to NULL.
+norm expect-not=EliminateFilterImpliedByCheckConstraints
+SELECT * FROM checks WHERE c = 5;
+----
+select
+ ├── columns: a:1!null b:2!null c:3!null d:4!null e:5!null f:6!null g:7 h:8!null
+ ├── fd: ()-->(1,3,5)
+ ├── scan checks
+ │    ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ │    ├── check constraint expressions
+ │    │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │    │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+ │    │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+ │    │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+ │    └── fd: ()-->(1,5)
+ └── filters
+      └── c:3 = 5 [outer=(3), constraints=(/3: [/5 - /5]; tight), fd=()-->(3)]
+
+# No-op because "g" is nullable.
+norm expect-not=EliminateFilterImpliedByCheckConstraints
+SELECT * FROM checks WHERE f > 5 AND g = 5;
+----
+select
+ ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7!null h:8!null
+ ├── fd: ()-->(1,5,7)
+ ├── scan checks
+ │    ├── columns: a:1!null b:2!null c:3 d:4!null e:5!null f:6!null g:7 h:8!null
+ │    ├── check constraint expressions
+ │    │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │    │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+ │    │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+ │    │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+ │    └── fd: ()-->(1,5)
+ └── filters
+      ├── f:6 > 5 [outer=(6), constraints=(/6: [/6 - ]; tight)]
+      └── g:7 = 5 [outer=(7), constraints=(/7: [/5 - /5]; tight), fd=()-->(7)]
+
+# This is a simplified version of an internal query performed on the
+# system.span_count table, which is vulnerable to the small increase in latency
+# caused by an unnecessary Select operation.
+norm expect=EliminateFilterImpliedByCheckConstraints
+SELECT * FROM singleton_check WHERE singleton;
+----
+scan singleton_check
+ ├── columns: singleton:1!null count:2!null
+ ├── check constraint expressions
+ │    └── singleton:1 [outer=(1), constraints=(/1: [/true - /true]; tight), fd=()-->(1)]
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ └── fd: ()-->(1,2)

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -381,7 +381,7 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 
 	// Generate implicit filters from CHECK constraints and computed columns as
 	// optional filters to help generate lookup join keys.
-	optionalFilters := c.checkConstraintFilters(scanPrivate.Table)
+	optionalFilters := c.CheckConstraintFilters(scanPrivate.Table)
 	computedColFilters := c.ComputedColFilters(scanPrivate, on, optionalFilters)
 	optionalFilters = append(optionalFilters, computedColFilters...)
 
@@ -827,7 +827,7 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 				// latter may be reduced during partial index implication and
 				// using them here would result in a reduced set of optional
 				// filters.
-				optionalFilters = c.checkConstraintFilters(scanPrivate.Table)
+				optionalFilters = c.CheckConstraintFilters(scanPrivate.Table)
 				computedColFilters := c.ComputedColFilters(scanPrivate, on, optionalFilters)
 				optionalFilters = append(optionalFilters, computedColFilters...)
 

--- a/pkg/sql/opt/xform/rules/scan.opt
+++ b/pkg/sql/opt/xform/rules/scan.opt
@@ -76,3 +76,21 @@
 )
 =>
 (GenerateLocalityOptimizedScan $scanPrivate)
+
+# GeneratePseudoPartialIndexScans generates partial index scans using the
+# table's check constraints. This handles the case when the partial index
+# predicate applies to all rows of the table, and therefore a partial index
+# scan can always be used.
+[GeneratePseudoPartialIndexScans, Explore]
+(Scan
+    $scanPrivate:* &
+        (IsCanonicalScan $scanPrivate) &
+        (TableHasPartialIndex
+            $tableID:(TableIDFromScanPrivate $scanPrivate)
+        )
+)
+=>
+(GeneratePartialIndexScans
+    $scanPrivate
+    (CheckConstraintFilters $tableID)
+)

--- a/pkg/sql/opt/xform/scan_funcs.go
+++ b/pkg/sql/opt/xform/scan_funcs.go
@@ -560,3 +560,16 @@ func (c *CustomFuncs) IsSelectFromRemoteTableRowsOnly(input memo.RelExpr) bool {
 	}
 	return false
 }
+
+// TableHasPartialIndex returns true if the given table has at least one partial
+// index.
+func (c *CustomFuncs) TableHasPartialIndex(tableID opt.TableID) bool {
+	md := c.e.mem.Metadata()
+	tab := md.Table(tableID)
+	for i, n := 0, tab.IndexCount(); i < n; i++ {
+		if _, ok := tab.Index(i).Predicate(); ok {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -453,6 +453,12 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 			return
 		}
 
+		// Make a best-effort check to avoid generating trivial constrained scans
+		// that actually scan the entire table.
+		if c.IsConstraintImpliedByCheckConstraints(combinedConstraint, scanPrivate) {
+			return
+		}
+
 		// Construct new constrained ScanPrivate.
 		newScanPrivate := *scanPrivate
 		newScanPrivate.Distribution.Regions = nil

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -343,7 +343,7 @@ func (c *CustomFuncs) GetOptionalFiltersAndFilterColumns(
 	explicitFilters memo.FiltersExpr, scanPrivate *memo.ScanPrivate,
 ) (optionalFilters memo.FiltersExpr, filterColumns opt.ColSet) {
 
-	optionalFilters = c.checkConstraintFilters(scanPrivate.Table)
+	optionalFilters = c.CheckConstraintFilters(scanPrivate.Table)
 	computedColFilters := c.ComputedColFilters(scanPrivate, explicitFilters, optionalFilters)
 	optionalFilters = append(optionalFilters, computedColFilters...)
 
@@ -727,7 +727,7 @@ func (c *CustomFuncs) isPrefixOf(pre []tree.Datum, other []tree.Datum) bool {
 // partitionValuesFilters constructs filters with the purpose of
 // constraining an index scan using the partition values similar to
 // the filters added from the check constraints (see
-// checkConstraintFilters). It returns two sets of filters, one to
+// CheckConstraintFilters). It returns two sets of filters, one to
 // create the partition spans, and one to create the spans for all
 // the in between ranges that are not part of any partitions.
 //
@@ -823,7 +823,7 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 
 	// Generate implicit filters from constraints and computed columns as
 	// optional filters to help constrain an index scan.
-	optionalFilters := c.checkConstraintFilters(scanPrivate.Table)
+	optionalFilters := c.CheckConstraintFilters(scanPrivate.Table)
 	computedColFilters := c.ComputedColFilters(scanPrivate, filters, optionalFilters)
 	optionalFilters = append(optionalFilters, computedColFilters...)
 

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -2704,23 +2704,23 @@ project
       │    │    ├── limit hint: 3.00
       │    │    ├── union-all
       │    │    │    ├── columns: a:2!null rowid:7!null
-      │    │    │    ├── left columns: a:48 rowid:53
-      │    │    │    ├── right columns: a:57 rowid:62
+      │    │    │    ├── left columns: a:30 rowid:35
+      │    │    │    ├── right columns: a:39 rowid:44
       │    │    │    ├── ordering: +2
       │    │    │    ├── limit hint: 3.00
       │    │    │    ├── scan regional@partial_a,partial
-      │    │    │    │    ├── columns: a:48!null rowid:53!null
-      │    │    │    │    ├── constraint: /47/48: [/'east' - /'east']
-      │    │    │    │    ├── key: (53)
-      │    │    │    │    ├── fd: (53)-->(48), (48)-->(53)
-      │    │    │    │    ├── ordering: +48
+      │    │    │    │    ├── columns: a:30!null rowid:35!null
+      │    │    │    │    ├── constraint: /29/30: [/'east' - /'east']
+      │    │    │    │    ├── key: (35)
+      │    │    │    │    ├── fd: (35)-->(30), (30)-->(35)
+      │    │    │    │    ├── ordering: +30
       │    │    │    │    └── limit hint: 3.00
       │    │    │    └── scan regional@partial_a,partial
-      │    │    │         ├── columns: a:57!null rowid:62!null
-      │    │    │         ├── constraint: /56/57: [/'west' - /'west']
-      │    │    │         ├── key: (62)
-      │    │    │         ├── fd: (62)-->(57), (57)-->(62)
-      │    │    │         ├── ordering: +57
+      │    │    │         ├── columns: a:39!null rowid:44!null
+      │    │    │         ├── constraint: /38/39: [/'west' - /'west']
+      │    │    │         ├── key: (44)
+      │    │    │         ├── fd: (44)-->(39), (39)-->(44)
+      │    │    │         ├── ordering: +39
       │    │    │         └── limit hint: 3.00
       │    │    └── aggregations
       │    │         └── count-rows [as=count_rows:10]

--- a/pkg/sql/opt/xform/testdata/rules/insert
+++ b/pkg/sql/opt/xform/testdata/rules/insert
@@ -175,17 +175,15 @@ insert t
       │         ├── columns: t.k:26!null t.r:27!null t.a:28!null t.b:29 t.c:30
       │         ├── key: (26)
       │         ├── fd: ()-->(28), (26)-->(27,29,30)
-      │         ├── index-join t
+      │         ├── scan t
       │         │    ├── columns: t.k:26!null t.r:27!null t.a:28 t.b:29 t.c:30
+      │         │    ├── check constraint expressions
+      │         │    │    └── t.r:27 IN ('east', 'west') [outer=(27), constraints=(/27: [/'east' - /'east'] [/'west' - /'west']; tight)]
+      │         │    ├── computed column expressions
+      │         │    │    └── t.b:29
+      │         │    │         └── t.k:26 % 9
       │         │    ├── key: (26)
-      │         │    ├── fd: (26)-->(27-30)
-      │         │    └── scan t@t_r_c_idx
-      │         │         ├── columns: t.k:26!null t.r:27!null t.c:30
-      │         │         ├── constraint: /27/30/26
-      │         │         │    ├── [/'east' - /'east']
-      │         │         │    └── [/'west' - /'west']
-      │         │         ├── key: (26)
-      │         │         └── fd: (26)-->(27,30)
+      │         │    └── fd: (26)-->(27-30)
       │         └── filters
       │              └── t.a:28 = 10 [outer=(28), constraints=(/28: [/10 - /10]; tight), fd=()-->(28)]
       └── fast-path-unique-checks-item: t(c)
@@ -525,19 +523,15 @@ insert t
       │         ├── key: (22)
       │         └── fd: ()-->(24), (22)-->(23,25)
       ├── fast-path-unique-checks-item: t(b)
-      │    └── select
+      │    └── index-join t
       │         ├── columns: t.k:38!null t.r:39!null t.a:40 t.b:41!null
       │         ├── key: (38)
       │         ├── fd: ()-->(41), (38)-->(39,40)
-      │         ├── scan t@t_r_a_b_idx
-      │         │    ├── columns: t.k:38!null t.r:39!null t.a:40 t.b:41
-      │         │    ├── constraint: /39/40/41/38
-      │         │    │    ├── [/'east' - /'east']
-      │         │    │    └── [/'west' - /'west']
-      │         │    ├── key: (38)
-      │         │    └── fd: (38)-->(39-41)
-      │         └── filters
-      │              └── t.b:41 = 2 [outer=(41), constraints=(/41: [/2 - /2]; tight), fd=()-->(41)]
+      │         └── scan t@t_b_a_idx
+      │              ├── columns: t.k:38!null t.a:40 t.b:41!null
+      │              ├── constraint: /41/40/38: [/2 - /2]
+      │              ├── key: (38)
+      │              └── fd: ()-->(41), (38)-->(40)
       ├── fast-path-unique-checks-item: t(r,a,b)
       │    └── scan t@t_r_a_b_idx
       │         ├── columns: t.k:54!null t.r:55!null t.a:56!null t.b:57!null

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -13010,7 +13010,6 @@ explain
            │    │    │    ├── columns: u85353.a:6 u85353.b:7
            │    │    │    └── scan u85353@b_idx
            │    │    │         ├── columns: u85353.b:7 u85353.rowid:10!null
-           │    │    │         ├── constraint: /9/7/10: [/0 - /7]
            │    │    │         ├── flags: force-index=b_idx
            │    │    │         ├── key: (10)
            │    │    │         └── fd: (10)-->(7)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -5576,7 +5576,7 @@ project
 # Non-covering case. Virtual column is the lookup column and there is an extra
 # filter on a column not in the index.
 opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
-SELECT m, virt.j FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND j > 0
+SELECT m, virt.j FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND j > 10
 ----
 project
  ├── columns: m:1!null j:8!null
@@ -5596,10 +5596,10 @@ project
       │    │    └── columns: m:1
       │    └── filters (true)
       └── filters
-           └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+           └── j:8 > 10 [outer=(8), constraints=(/8: [/11 - ]; tight)]
 
 opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
-SELECT m, virt.j, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND j > 0
+SELECT m, virt.j, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND j > 10
 ----
 inner-join (lookup virt)
  ├── columns: m:1!null j:8!null v1:9!null
@@ -5616,12 +5616,12 @@ inner-join (lookup virt)
  │    │    └── columns: m:1
  │    └── filters (true)
  └── filters
-      └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+      └── j:8 > 10 [outer=(8), constraints=(/8: [/11 - ]; tight)]
 
 # Non-covering case. Join on virtual column expression with an extra filter on the
 # non-virtual column.
 opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
-SELECT m, virt.j FROM small INNER LOOKUP JOIN virt ON m = virt.i + 10 AND j > 0
+SELECT m, virt.j FROM small INNER LOOKUP JOIN virt ON m = virt.i + 10 AND j > 10
 ----
 project
  ├── columns: m:1!null j:8!null
@@ -5641,7 +5641,7 @@ project
       │    │    └── columns: m:1
       │    └── filters (true)
       └── filters
-           └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+           └── j:8 > 10 [outer=(8), constraints=(/8: [/11 - ]; tight)]
 
 # Non-covering case. Virtual column is the lookup column and there is an extra
 # filter on a column not in the index, but the column is not selected. We do not
@@ -5650,7 +5650,7 @@ project
 # IndexJoin to fetch i and filter by it, then wrapping the index join in a
 # Project that removes i.
 opt
-SELECT m, virt.k FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND j > 0
+SELECT m, virt.k FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND j > 10
 ----
 project
  ├── columns: m:1!null k:6!null
@@ -5689,7 +5689,7 @@ project
       │    │    │    ├── key: (6)
       │    │    │    └── fd: (6)-->(7,8)
       │    │    └── filters
-      │    │         └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+      │    │         └── j:8 > 10 [outer=(8), constraints=(/8: [/11 - ]; tight)]
       │    └── projections
       │         └── i:7 + 10 [as=v1:9, outer=(7), immutable]
       └── filters
@@ -5698,7 +5698,7 @@ project
 # Left join, covering case. Virtual column is the lookup column and there is an
 # extra filter on the non-virtual column.
 opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
-SELECT m, virt.i FROM small LEFT LOOKUP JOIN virt ON m = virt.v1 AND i > 0
+SELECT m, virt.i FROM small LEFT LOOKUP JOIN virt ON m = virt.v1 AND i > 10
 ----
 project
  ├── columns: m:1 i:7
@@ -5712,13 +5712,13 @@ project
       ├── scan small
       │    └── columns: m:1
       └── filters
-           └── i:7 > 0 [outer=(7), constraints=(/7: [/1 - ]; tight)]
+           └── i:7 > 10 [outer=(7), constraints=(/7: [/11 - ]; tight)]
 
 # Left join, covering case. Virtual column is the lookup column and there is an
 # extra filter on the non-virtual column, but the column is not selected.
 # TODO(mgartner): We do not handle this case yet.
 opt
-SELECT m, virt.k FROM small LEFT LOOKUP JOIN virt ON m = virt.v1 AND i > 0
+SELECT m, virt.k FROM small LEFT LOOKUP JOIN virt ON m = virt.v1 AND i > 10
 ----
 project
  ├── columns: m:1 k:6
@@ -5744,7 +5744,7 @@ project
       │    │    │    ├── key: (6)
       │    │    │    └── fd: (6)-->(7)
       │    │    └── filters
-      │    │         └── i:7 > 0 [outer=(7), constraints=(/7: [/1 - ]; tight)]
+      │    │         └── i:7 > 10 [outer=(7), constraints=(/7: [/11 - ]; tight)]
       │    └── projections
       │         └── i:7 + 10 [as=v1:9, outer=(7), immutable]
       └── filters
@@ -5755,7 +5755,7 @@ project
 # TODO(#90771): To plan a lookup join here, we'd need to project the virtual
 # column expression after the upper join.
 opt expect-not=GenerateLookupJoinsWithVirtualColsAndFilter
-SELECT m, virt.j FROM small LEFT LOOKUP JOIN virt ON m = virt.v1 AND j > 0
+SELECT m, virt.j FROM small LEFT LOOKUP JOIN virt ON m = virt.v1 AND j > 10
 ----
 project
  ├── columns: m:1 j:8
@@ -5786,7 +5786,7 @@ project
       │    │    │         └── v4:12
       │    │    │              └── i:7 + 1
       │    │    └── filters
-      │    │         └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+      │    │         └── j:8 > 10 [outer=(8), constraints=(/8: [/11 - ]; tight)]
       │    └── projections
       │         └── i:7 + 10 [as=v1:9, outer=(7), immutable]
       └── filters
@@ -5796,7 +5796,7 @@ project
 # an extra filter on a column not in the index, but the column is not selected.
 # TODO(mgartner): We do not handle this case yet.
 opt
-SELECT m, virt.k FROM small LEFT LOOKUP JOIN virt ON m = virt.v1 AND j > 0
+SELECT m, virt.k FROM small LEFT LOOKUP JOIN virt ON m = virt.v1 AND j > 10
 ----
 project
  ├── columns: m:1 k:6
@@ -5834,7 +5834,7 @@ project
       │    │    │    ├── key: (6)
       │    │    │    └── fd: (6)-->(7,8)
       │    │    └── filters
-      │    │         └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+      │    │         └── j:8 > 10 [outer=(8), constraints=(/8: [/11 - ]; tight)]
       │    └── projections
       │         └── i:7 + 10 [as=v1:9, outer=(7), immutable]
       └── filters
@@ -6129,31 +6129,18 @@ semi-join (lookup virt@l_v1)
 opt
 SELECT m FROM small WHERE EXISTS (SELECT * FROM virt WHERE virt.l = 1 AND m = virt.v1 AND j > 0)
 ----
-semi-join (hash)
+semi-join (lookup virt@l_v1)
  ├── columns: m:1
+ ├── key columns: [16 1] = [13 9]
  ├── immutable
- ├── scan small
- │    └── columns: m:1
  ├── project
- │    ├── columns: v1:9
- │    ├── immutable
- │    ├── select
- │    │    ├── columns: i:7 j:8!null l:13!null
- │    │    ├── fd: ()-->(13)
- │    │    ├── index-join virt
- │    │    │    ├── columns: i:7 j:8!null l:13
- │    │    │    ├── fd: ()-->(13)
- │    │    │    └── scan virt@l_v1
- │    │    │         ├── columns: k:6!null l:13!null
- │    │    │         ├── constraint: /13/9/6: [/1 - /1]
- │    │    │         ├── key: (6)
- │    │    │         └── fd: ()-->(13)
- │    │    └── filters
- │    │         └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+ │    ├── columns: "lookup_join_const_col_@13":16!null m:1
+ │    ├── fd: ()-->(16)
+ │    ├── scan small
+ │    │    └── columns: m:1
  │    └── projections
- │         └── i:7 + 10 [as=v1:9, outer=(7), immutable]
- └── filters
-      └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │         └── 1 [as="lookup_join_const_col_@13":16]
+ └── filters (true)
 
 # Generate lookup joins with virtual columns for anti-joins.
 opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
@@ -6194,31 +6181,18 @@ anti-join (lookup virt@l_v1)
 opt
 SELECT m FROM small WHERE NOT EXISTS (SELECT * FROM virt WHERE virt.l = 2 AND m = virt.v1 AND j > 0)
 ----
-anti-join (hash)
+anti-join (lookup virt@l_v1)
  ├── columns: m:1
+ ├── key columns: [16 1] = [13 9]
  ├── immutable
- ├── scan small
- │    └── columns: m:1
  ├── project
- │    ├── columns: v1:9
- │    ├── immutable
- │    ├── select
- │    │    ├── columns: i:7 j:8!null l:13!null
- │    │    ├── fd: ()-->(13)
- │    │    ├── index-join virt
- │    │    │    ├── columns: i:7 j:8!null l:13
- │    │    │    ├── fd: ()-->(13)
- │    │    │    └── scan virt@l_v1
- │    │    │         ├── columns: k:6!null l:13!null
- │    │    │         ├── constraint: /13/9/6: [/2 - /2]
- │    │    │         ├── key: (6)
- │    │    │         └── fd: ()-->(13)
- │    │    └── filters
- │    │         └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+ │    ├── columns: "lookup_join_const_col_@13":16!null m:1
+ │    ├── fd: ()-->(16)
+ │    ├── scan small
+ │    │    └── columns: m:1
  │    └── projections
- │         └── i:7 + 10 [as=v1:9, outer=(7), immutable]
- └── filters
-      └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │         └── 2 [as="lookup_join_const_col_@13":16]
+ └── filters (true)
 
 exec-ddl
 DROP INDEX l_v1
@@ -6722,7 +6696,7 @@ anti-join (hash)
 # implication if the index does not contain columns in the remaining filter,
 # as long as those columns are output by the Project.
 opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
-SELECT m, virt.k, virt.j FROM small INNER LOOKUP JOIN virt ON m = virt.v3 AND j > 0
+SELECT m, virt.k, virt.j FROM small INNER LOOKUP JOIN virt ON m = virt.v3 AND j > 10
 ----
 project
  ├── columns: m:1!null k:6!null j:8!null
@@ -6743,7 +6717,7 @@ project
       │    │    └── columns: m:1
       │    └── filters (true)
       └── filters
-           └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+           └── j:8 > 10 [outer=(8), constraints=(/8: [/11 - ]; tight)]
 
 # Left join, same case as above.
 # TODO(#90771): To plan a lookup join here, we'd need to project the virtual
@@ -6767,31 +6741,25 @@ project
       │    ├── immutable
       │    ├── key: (6)
       │    ├── fd: (6)-->(8,11)
-      │    ├── select
+      │    ├── scan virt
       │    │    ├── columns: k:6!null i:7 j:8!null
+      │    │    ├── check constraint expressions
+      │    │    │    ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+      │    │    │    └── v4:12 IN (1, 2, 3) [outer=(12), constraints=(/12: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+      │    │    ├── computed column expressions
+      │    │    │    ├── v1:9
+      │    │    │    │    └── i:7 + 10
+      │    │    │    ├── v2:10
+      │    │    │    │    └── i:7 + 100
+      │    │    │    ├── v3:11
+      │    │    │    │    └── i:7 + j:8
+      │    │    │    └── v4:12
+      │    │    │         └── i:7 + 1
+      │    │    ├── partial index predicates
+      │    │    │    └── v3_partial: filters
+      │    │    │         └── (((i:7 > 0) OR (j:8 > 0)) OR (i:7 > -100)) OR ((i:7 + j:8) > 0) [outer=(7,8), immutable]
       │    │    ├── key: (6)
-      │    │    ├── fd: (6)-->(7,8)
-      │    │    ├── scan virt
-      │    │    │    ├── columns: k:6!null i:7 j:8!null
-      │    │    │    ├── check constraint expressions
-      │    │    │    │    ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
-      │    │    │    │    └── v4:12 IN (1, 2, 3) [outer=(12), constraints=(/12: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
-      │    │    │    ├── computed column expressions
-      │    │    │    │    ├── v1:9
-      │    │    │    │    │    └── i:7 + 10
-      │    │    │    │    ├── v2:10
-      │    │    │    │    │    └── i:7 + 100
-      │    │    │    │    ├── v3:11
-      │    │    │    │    │    └── i:7 + j:8
-      │    │    │    │    └── v4:12
-      │    │    │    │         └── i:7 + 1
-      │    │    │    ├── partial index predicates
-      │    │    │    │    └── v3_partial: filters
-      │    │    │    │         └── (((i:7 > 0) OR (j:8 > 0)) OR (i:7 > -100)) OR ((i:7 + j:8) > 0) [outer=(7,8), immutable]
-      │    │    │    ├── key: (6)
-      │    │    │    └── fd: (6)-->(7,8)
-      │    │    └── filters
-      │    │         └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+      │    │    └── fd: (6)-->(7,8)
       │    └── projections
       │         └── i:7 + j:8 [as=v3:11, outer=(7,8), immutable]
       └── filters
@@ -6810,27 +6778,23 @@ semi-join (hash)
  ├── project
  │    ├── columns: v3:11
  │    ├── immutable
- │    ├── select
+ │    ├── scan virt
  │    │    ├── columns: i:7 j:8!null
- │    │    ├── scan virt
- │    │    │    ├── columns: i:7 j:8!null
- │    │    │    ├── check constraint expressions
- │    │    │    │    ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
- │    │    │    │    └── v4:12 IN (1, 2, 3) [outer=(12), constraints=(/12: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
- │    │    │    ├── computed column expressions
- │    │    │    │    ├── v1:9
- │    │    │    │    │    └── i:7 + 10
- │    │    │    │    ├── v2:10
- │    │    │    │    │    └── i:7 + 100
- │    │    │    │    ├── v3:11
- │    │    │    │    │    └── i:7 + j:8
- │    │    │    │    └── v4:12
- │    │    │    │         └── i:7 + 1
- │    │    │    └── partial index predicates
- │    │    │         └── v3_partial: filters
- │    │    │              └── (((i:7 > 0) OR (j:8 > 0)) OR (i:7 > -100)) OR ((i:7 + j:8) > 0) [outer=(7,8), immutable]
- │    │    └── filters
- │    │         └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+ │    │    ├── check constraint expressions
+ │    │    │    ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+ │    │    │    └── v4:12 IN (1, 2, 3) [outer=(12), constraints=(/12: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+ │    │    ├── computed column expressions
+ │    │    │    ├── v1:9
+ │    │    │    │    └── i:7 + 10
+ │    │    │    ├── v2:10
+ │    │    │    │    └── i:7 + 100
+ │    │    │    ├── v3:11
+ │    │    │    │    └── i:7 + j:8
+ │    │    │    └── v4:12
+ │    │    │         └── i:7 + 1
+ │    │    └── partial index predicates
+ │    │         └── v3_partial: filters
+ │    │              └── (((i:7 > 0) OR (j:8 > 0)) OR (i:7 > -100)) OR ((i:7 + j:8) > 0) [outer=(7,8), immutable]
  │    └── projections
  │         └── i:7 + j:8 [as=v3:11, outer=(7,8), immutable]
  └── filters
@@ -6849,27 +6813,23 @@ anti-join (hash)
  ├── project
  │    ├── columns: v3:11
  │    ├── immutable
- │    ├── select
+ │    ├── scan virt
  │    │    ├── columns: i:7 j:8!null
- │    │    ├── scan virt
- │    │    │    ├── columns: i:7 j:8!null
- │    │    │    ├── check constraint expressions
- │    │    │    │    ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
- │    │    │    │    └── v4:12 IN (1, 2, 3) [outer=(12), constraints=(/12: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
- │    │    │    ├── computed column expressions
- │    │    │    │    ├── v1:9
- │    │    │    │    │    └── i:7 + 10
- │    │    │    │    ├── v2:10
- │    │    │    │    │    └── i:7 + 100
- │    │    │    │    ├── v3:11
- │    │    │    │    │    └── i:7 + j:8
- │    │    │    │    └── v4:12
- │    │    │    │         └── i:7 + 1
- │    │    │    └── partial index predicates
- │    │    │         └── v3_partial: filters
- │    │    │              └── (((i:7 > 0) OR (j:8 > 0)) OR (i:7 > -100)) OR ((i:7 + j:8) > 0) [outer=(7,8), immutable]
- │    │    └── filters
- │    │         └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+ │    │    ├── check constraint expressions
+ │    │    │    ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+ │    │    │    └── v4:12 IN (1, 2, 3) [outer=(12), constraints=(/12: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+ │    │    ├── computed column expressions
+ │    │    │    ├── v1:9
+ │    │    │    │    └── i:7 + 10
+ │    │    │    ├── v2:10
+ │    │    │    │    └── i:7 + 100
+ │    │    │    ├── v3:11
+ │    │    │    │    └── i:7 + j:8
+ │    │    │    └── v4:12
+ │    │    │         └── i:7 + 1
+ │    │    └── partial index predicates
+ │    │         └── v3_partial: filters
+ │    │              └── (((i:7 > 0) OR (j:8 > 0)) OR (i:7 > -100)) OR ((i:7 + j:8) > 0) [outer=(7,8), immutable]
  │    └── projections
  │         └── i:7 + j:8 [as=v3:11, outer=(7,8), immutable]
  └── filters

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -12,6 +12,32 @@ CREATE TABLE a
 )
 ----
 
+exec-ddl
+CREATE TABLE checks (
+  a INT NOT NULL,
+  b INT NOT NULL,
+  c INT,
+  d INT NOT NULL,
+  e INT NOT NULL,
+  f INT NOT NULL,
+  g INT,
+  h INT NOT NULL,
+  x INT,
+  CHECK (a = 5),
+  CHECK (b > 5),
+  CHECK (c = 5),
+  CHECK (d > 5 AND e = 5),
+  CHECK (f > 5 AND g = 5),
+  CHECK (h < 5 OR h > 5),
+  INDEX idx1 (x) WHERE a = 5,
+  INDEX idx2 (x) WHERE b > 5,
+  INDEX idx3 (x) WHERE d > 5 AND e = 5,
+  INDEX idx4 (x) WHERE h < 5 OR h > 5,
+  INDEX idx5 (x) WHERE c = 5,
+  INDEX idx6 (x) WHERE f > 5 AND g = 5
+)
+----
+
 # --------------------------------------------------
 # GenerateIndexScans
 # --------------------------------------------------
@@ -1328,3 +1354,159 @@ locality-optimized-search
       ├── limit: 3
       ├── flags: force-index=def_part_pkey
       └── key: (14)
+
+# --------------------------------------------------
+# GeneratePseudoPartialIndexScans
+# --------------------------------------------------
+
+opt expect=GeneratePseudoPartialIndexScans
+SELECT x FROM checks@idx1;
+----
+select
+ ├── columns: x:9
+ ├── scan checks@idx1,partial
+ │    ├── columns: x:9
+ │    └── flags: force-index=idx1
+ └── filters
+      ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+      ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+      └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+
+opt expect=GeneratePseudoPartialIndexScans
+SELECT x FROM checks@idx1 ORDER BY x;
+----
+select
+ ├── columns: x:9
+ ├── ordering: +9
+ ├── scan checks@idx1,partial
+ │    ├── columns: x:9
+ │    ├── flags: force-index=idx1
+ │    └── ordering: +9
+ └── filters
+      ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+      ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+      └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+
+opt expect=GeneratePseudoPartialIndexScans
+SELECT x FROM checks@idx1 ORDER BY x DESC;
+----
+select
+ ├── columns: x:9
+ ├── ordering: -9
+ ├── scan checks@idx1,rev,partial
+ │    ├── columns: x:9
+ │    ├── flags: force-index=idx1
+ │    └── ordering: -9
+ └── filters
+      ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+      ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+      └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+
+opt expect=GeneratePseudoPartialIndexScans
+SELECT x FROM checks@idx2 ORDER BY x;
+----
+select
+ ├── columns: x:9
+ ├── ordering: +9
+ ├── scan checks@idx2,partial
+ │    ├── columns: x:9
+ │    ├── flags: force-index=idx2
+ │    └── ordering: +9
+ └── filters
+      ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+      ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+      └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+
+# Case with two referenced variables.
+opt expect=GeneratePseudoPartialIndexScans
+SELECT x FROM checks@idx3 ORDER BY x;
+----
+select
+ ├── columns: x:9
+ ├── ordering: +9
+ ├── scan checks@idx3,partial
+ │    ├── columns: x:9
+ │    ├── flags: force-index=idx3
+ │    └── ordering: +9
+ └── filters
+      ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+      ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+      └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+
+# Case with a disjunction.
+opt expect=GeneratePseudoPartialIndexScans
+SELECT x FROM checks@idx4 ORDER BY x;
+----
+select
+ ├── columns: x:9
+ ├── ordering: +9
+ ├── scan checks@idx4,partial
+ │    ├── columns: x:9
+ │    ├── flags: force-index=idx4
+ │    └── ordering: +9
+ └── filters
+      ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+      ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+      └── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+
+# No-op because column "c" is nullable.
+opt expect-not=GeneratePseudoPartialIndexScans
+SELECT x FROM checks@idx5 ORDER BY x;
+----
+sort
+ ├── columns: x:9
+ ├── ordering: +9
+ └── scan checks
+      ├── columns: x:9
+      ├── check constraint expressions
+      │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+      │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+      │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+      │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+      ├── partial index predicates
+      │    ├── idx1: filters
+      │    │    └── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+      │    ├── idx2: filters
+      │    │    └── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+      │    ├── idx3: filters
+      │    │    ├── d:4 > 5 [outer=(4), constraints=(/4: [/6 - ]; tight)]
+      │    │    └── e:5 = 5 [outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
+      │    ├── idx4: filters
+      │    │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+      │    ├── idx5: filters
+      │    │    └── c:3 = 5 [outer=(3), constraints=(/3: [/5 - /5]; tight), fd=()-->(3)]
+      │    └── idx6: filters
+      │         ├── f:6 > 5 [outer=(6), constraints=(/6: [/6 - ]; tight)]
+      │         └── g:7 = 5 [outer=(7), constraints=(/7: [/5 - /5]; tight), fd=()-->(7)]
+      └── flags: force-index=idx5
+
+# No-op because column "g" is nullable.
+opt expect-not=GeneratePseudoPartialIndexScans
+SELECT x FROM checks@idx6 ORDER BY x;
+----
+sort
+ ├── columns: x:9
+ ├── ordering: +9
+ └── scan checks
+      ├── columns: x:9
+      ├── check constraint expressions
+      │    ├── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+      │    ├── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+      │    ├── (d:4 > 5) AND (e:5 = 5) [outer=(4,5), constraints=(/4: [/6 - ]; /5: [/5 - /5]; tight), fd=()-->(5)]
+      │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+      ├── partial index predicates
+      │    ├── idx1: filters
+      │    │    └── a:1 = 5 [outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+      │    ├── idx2: filters
+      │    │    └── b:2 > 5 [outer=(2), constraints=(/2: [/6 - ]; tight)]
+      │    ├── idx3: filters
+      │    │    ├── d:4 > 5 [outer=(4), constraints=(/4: [/6 - ]; tight)]
+      │    │    └── e:5 = 5 [outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
+      │    ├── idx4: filters
+      │    │    └── (h:8 < 5) OR (h:8 > 5) [outer=(8), constraints=(/8: (/NULL - /4] [/6 - ]; tight)]
+      │    ├── idx5: filters
+      │    │    └── c:3 = 5 [outer=(3), constraints=(/3: [/5 - /5]; tight), fd=()-->(3)]
+      │    └── idx6: filters
+      │         ├── f:6 > 5 [outer=(6), constraints=(/6: [/6 - ]; tight)]
+      │         └── g:7 = 5 [outer=(7), constraints=(/7: [/5 - /5]; tight), fd=()-->(7)]
+      └── flags: force-index=idx6

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2609,7 +2609,8 @@ project
       ├── fd: ()-->(3)
       ├── scan t114250
       │    ├── columns: x:1!null z:3!null
-      │    └── constraint: /1/2: [/1 - /4]
+      │    └── check constraint expressions
+      │         └── (x:1 > 0) AND (x:1 < 5) [outer=(1), constraints=(/1: [/1 - /4]; tight)]
       └── filters
            └── z:3 = 5 [outer=(3), constraints=(/3: [/5 - /5]; tight), fd=()-->(3)]
 


### PR DESCRIPTION
#### opt: add rule to generate pseudo partial index scans

This commit adds a new exploration rule, `GeneratePseudoPartialIndexScans`,
which plans partial index scans when the index predicate is implied by
the table's check constraints. This will allow following commits to remove
`SELECT` filters that are implied by the table's check constraints without
introducing plan regressions. Not that this isn't expected to be a common
case, but has arisen in tests.

Informs #114470

Release note: None

#### opt: add rule to eliminate trivial Select filters

This patch adds a new normalize rule, `EliminateTrivialFilter`, which
attempts to prove that a Select filter is trivial using check constraints
when the input is a table scan. This can avoid the need for extra work
evaluating the filter, and may allow other optimizer rules to match.

Informs #114470

Release note: None

#### opt: revert the reversion for the trivial constrained scan fix

This patch reverts the revert of `45b8d05` because the previous commit
fixes the flaking test that motivated the revert. The flakes seem to have
been due to a regression introduced by `45b8d05` in the case of a trivial
explicit filter (as opposed to a generated "optional" filter). Before
`45b8d05`, generating a constrained scan with that filter would effectively
remove the `Select` operator even though the constraint wasn't selective.
After `45b8d05`, the `Select` would remain. This slightly increased the
latency for an internal query that inserts into the `system.span_count`
table, which could cause (or increase) contention on that table.
This apparently caused the `temp_table` logic test to flake by preventing
or slowing the creation and cleanup of tables.

Fixes #114470

Release note: None