### PR TITLE
sqlsmith: don't lose type for generated REFCURSOR constant

### DIFF
--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -204,7 +204,13 @@ func makeConstDatum(s *Smither, typ *types.T) tree.Datum {
 		if typ.Width() > 0 {
 			sv = util.TruncateString(sv, int(typ.Width()))
 		}
-		datum = tree.NewDString(sv)
+		if typ.Family() == types.RefCursorFamily {
+			// REFCURSOR is not compatible with the other string-like types, so make
+			// sure not to lose the type of the datum.
+			datum = tree.NewDRefCursor(sv)
+		} else {
+			datum = tree.NewDString(sv)
+		}
 	}
 	return datum
 }


### PR DESCRIPTION
The sqlsmith random syntax generator contains some logic to test that PII is properly redacted. This works by adding a "PII" prefix to randomly generated string values. Previously, this logic incorrectly converted REFCURSOR datums to STRING datums, which could cause a panic because REFCURSOR is not compatible for comparison with other types. This patch converts the "PII" string back to a REFCURSOR when necessary.

Fixes #114789

Release note: None