### PR TITLE
release-23.2: changefeedccl:  Add continuous telemetry for emitted messages

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2790,6 +2790,7 @@ An event of type `changefeed_emitted_bytes` is an event representing the bytes e
 |--|--|--|
 | `JobId` | The job id for enterprise changefeeds. | no |
 | `EmittedBytes` | The number of bytes emitted. | no |
+| `EmittedMessages` | The number of messages emitted. | no |
 | `LoggingInterval` | The time period in nanoseconds between emitting telemetry events of this type (per-aggregator). | no |
 | `Closing` | Flag to indicate that the changefeed is closing. | no |
 

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -993,6 +993,15 @@ func (m *ChangefeedEmittedBytes) AppendJSONFields(printComma bool, b redact.Reda
 		b = strconv.AppendInt(b, int64(m.EmittedBytes), 10)
 	}
 
+	if m.EmittedMessages != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"EmittedMessages\":"...)
+		b = strconv.AppendInt(b, int64(m.EmittedMessages), 10)
+	}
+
 	if m.LoggingInterval != 0 {
 		if printComma {
 			b = append(b, ',')

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -370,6 +370,9 @@ message ChangefeedEmittedBytes {
   // The number of bytes emitted.
   int64 emitted_bytes = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
+  // The number of messages emitted.
+  int64 emitted_messages = 6 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
   // The time period in nanoseconds between emitting telemetry events of this type (per-aggregator).
   int64 logging_interval = 4 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 


### PR DESCRIPTION
Backport 1/1 commits from #114272.

Release justification: Logging improvement to keep track of the number
of emitted changefeed messages (need for product billing).

/cc @cockroachdb/release

---

Keep track of emitted messages, and log this information into continuous telemetry.

Fixes #113902

Release notes: None
