### PR TITLE
gossip: extract network connectivity

### DIFF
--- a/pkg/gossip/BUILD.bazel
+++ b/pkg/gossip/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "info.go",
         "infostore.go",
         "keys.go",
+        "network.go",
         "node_set.go",
         "server.go",
         "status.go",
@@ -86,7 +87,6 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
-        "@org_golang_google_grpc//:go_default_library",
     ],
 )
 

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -43,7 +43,8 @@ func TestGossipInfoStore(t *testing.T) {
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	g := NewTest(1, stopper, metric.NewRegistry())
+	tn := NewTestNetwork()
+	g := tn.StartGossip(1, stopper, metric.NewRegistry())
 	slice := []byte("b")
 	if err := g.AddInfo("s", slice, time.Hour); err != nil {
 		t.Fatal(err)
@@ -63,7 +64,9 @@ func TestGossipMoveNode(t *testing.T) {
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	g := NewTest(1, stopper, metric.NewRegistry())
+	tn := NewTestNetwork()
+
+	g := tn.StartGossip(1, stopper, metric.NewRegistry())
 	var nodes []*roachpb.NodeDescriptor
 	for i := 1; i <= 3; i++ {
 		node := &roachpb.NodeDescriptor{
@@ -113,7 +116,8 @@ func TestGossipGetNextBootstrapAddress(t *testing.T) {
 		util.MakeUnresolvedAddr("tcp", "localhost:9004"),
 	}
 
-	g := NewTest(0, stopper, metric.NewRegistry())
+	tn := NewTestNetwork()
+	g := tn.StartGossip(0, stopper, metric.NewRegistry())
 	g.setAddresses(addresses)
 
 	// Using specified addresses, fetch bootstrap addresses 3 times
@@ -172,7 +176,8 @@ func TestGossipLocalityResolver(t *testing.T) {
 	var node2LocalityList []roachpb.LocalityAddress
 	node2LocalityList = append(node2LocalityList, nodeLocalityAddress2)
 
-	g := NewTestWithLocality(1, stopper, metric.NewRegistry(), gossipLocalityAdvertiseList)
+	tn := NewTestNetwork()
+	g := tn.StartGossipWithLocality(1, stopper, metric.NewRegistry(), gossipLocalityAdvertiseList)
 	node1 := &roachpb.NodeDescriptor{
 		NodeID:          1,
 		Address:         node1PublicAddressRPC,
@@ -224,14 +229,12 @@ func TestGossipRaceLogStatus(t *testing.T) {
 
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
-	// Shared cluster ID by all gossipers (this ensures that the gossipers
-	// don't talk to servers from unrelated tests by accident).
-	clusterID := uuid.MakeV4()
-	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	tn := NewTestNetwork()
+	local := tn.StartGossip(1, stopper, metric.NewRegistry())
 
 	local.mu.Lock()
-	peer, _ := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
-	local.startClientLocked(peer.mu.is.NodeAddr, localCtx)
+	peer := tn.StartGossip(2, stopper, metric.NewRegistry())
+	local.startClientLocked(peer.mu.is.NodeAddr)
 	local.mu.Unlock()
 
 	// Race gossiping against LogStatus.
@@ -273,11 +276,8 @@ func TestGossipOutgoingLimitEnforced(t *testing.T) {
 		t.Fatalf("maxPeers(5)=%d, which is higher than this test's assumption", maxPeers)
 	}
 
-	// Shared cluster ID by all gossipers (this ensures that the gossipers
-	// don't talk to servers from unrelated tests by accident).
-	clusterID := uuid.MakeV4()
-
-	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	tn := NewTestNetwork()
+	local := tn.StartGossip(1, stopper, metric.NewRegistry())
 	local.mu.Lock()
 	localAddr := local.mu.is.NodeAddr
 	local.mu.Unlock()
@@ -286,9 +286,9 @@ func TestGossipOutgoingLimitEnforced(t *testing.T) {
 		// After creating a new node, join it to the first node to ensure that the
 		// network is connected (and thus all nodes know each other's addresses)
 		// before we start the actual test.
-		newPeer, peerCtx := startGossip(clusterID, roachpb.NodeID(i+2), stopper, t, metric.NewRegistry())
+		newPeer := tn.StartGossip(roachpb.NodeID(i+2), stopper, metric.NewRegistry())
 		newPeer.mu.Lock()
-		newPeer.startClientLocked(localAddr, peerCtx)
+		newPeer.startClientLocked(localAddr)
 		newPeer.mu.Unlock()
 		peers = append(peers, newPeer)
 	}
@@ -318,7 +318,7 @@ func TestGossipOutgoingLimitEnforced(t *testing.T) {
 		t.Fatal(err)
 	}
 	for range peers {
-		local.tightenNetwork(context.Background(), localCtx)
+		local.tightenNetwork(context.Background())
 	}
 
 	if outgoing := local.outgoing.gauge.Value(); outgoing > int64(maxPeers) {
@@ -337,12 +337,12 @@ func TestGossipMostDistant(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	connect := func(from, to *Gossip, fromCtx *rpc.Context) {
+	connect := func(from, to *Gossip) {
 		to.mu.Lock()
 		addr := to.mu.is.NodeAddr
 		to.mu.Unlock()
 		from.mu.Lock()
-		from.startClientLocked(addr, fromCtx)
+		from.startClientLocked(addr)
 		from.mu.Unlock()
 	}
 
@@ -365,21 +365,17 @@ func TestGossipMostDistant(t *testing.T) {
 
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			// Shared cluster ID by all gossipers (this ensures that the gossipers
-			// don't talk to servers from unrelated tests by accident).
-			clusterID := uuid.MakeV4()
-
 			// Set up a gossip network of 10 nodes connected in a single line:
 			//
 			//   1 <- 2 <- 3 <- 4 <- 5 <- 6 <- 7 <- 8 <- 9 <- 10
 			nodes := make([]*Gossip, n)
-			nodesCtx := make([]*rpc.Context, n)
+			tn := NewTestNetwork()
 			for i := range nodes {
-				nodes[i], nodesCtx[i] = startGossip(clusterID, roachpb.NodeID(i+1), stopper, t, metric.NewRegistry())
+				nodes[i] = tn.StartGossip(roachpb.NodeID(i+1), stopper, metric.NewRegistry())
 				if i == 0 {
 					continue
 				}
-				connect(nodes[i], nodes[i-1], nodesCtx[i])
+				connect(nodes[i], nodes[i-1])
 			}
 
 			// Wait for n1 to determine that n10 is the most distant node.
@@ -410,7 +406,7 @@ func TestGossipMostDistant(t *testing.T) {
 			// Connect the network in a loop. This will cut the distance to the most
 			// distant node in half.
 			log.Infof(context.Background(), "connecting from n%d to n%d", c.from, c.to)
-			connect(nodes[c.from], nodes[c.to], nodesCtx[c.from])
+			connect(nodes[c.from], nodes[c.to])
 
 			// Wait for n1 to determine that n6 is now the most distant hops from 9
 			// to 5 and change the most distant node to n6.
@@ -458,52 +454,32 @@ func TestGossipNoForwardSelf(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	// Shared cluster ID by all gossipers (this ensures that the gossipers
-	// don't talk to servers from unrelated tests by accident).
-	clusterID := uuid.MakeV4()
+	tn := NewTestNetwork()
+	local := tn.StartGossip(1, stopper, metric.NewRegistry())
 
-	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
-
-	ctx, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start one loopback client plus enough additional clients to fill the
 	// incoming clients.
 	peers := []*Gossip{local}
-	peerCtx := []*rpc.Context{localCtx}
 
 	local.server.mu.Lock()
 	maxSize := local.server.mu.incoming.maxSize
 	local.server.mu.Unlock()
 	for i := 0; i < maxSize; i++ {
-		g, gCtx := startGossip(clusterID, roachpb.NodeID(i+2), stopper, t, metric.NewRegistry())
+		g := tn.StartGossip(roachpb.NodeID(i+2), stopper, metric.NewRegistry())
 		peers = append(peers, g)
-		peerCtx = append(peerCtx, gCtx)
 	}
 
-	for i, peer := range peers {
-		c := newClient(log.MakeTestingAmbientCtxWithNewTracer(), local.GetNodeAddr(), makeMetrics())
+	// FIXME: Where is this client coming from - call startLocked?
+	// for _, peer := range peers {
+	//c := newClient(log.MakeTestingAmbientCtxWithNewTracer(), peer.GetNodeAddr(), makeMetrics())
+	//		require.NoError(t, c.requestGossip(peer, mainClient))
 
-		testutils.SucceedsSoon(t, func() error {
-			conn, err := peerCtx[i].GRPCUnvalidatedDial(c.addr.String()).Connect(ctx)
-			if err != nil {
-				return err
-			}
-
-			stream, err := NewGossipClient(conn).Gossip(ctx)
-			if err != nil {
-				return err
-			}
-
-			if err := c.requestGossip(peer, stream); err != nil {
-				return err
-			}
-
-			// Wait until the server responds, so we know we're connected.
-			_, err = stream.Recv()
-			return err
-		})
-	}
+	// Wait until the server responds, so we know we're connected.
+	// _, err = stream.Recv()
+	// }
 
 	numClients := len(peers) * 2
 	disconnectedCh := make(chan *client)
@@ -514,13 +490,13 @@ func TestGossipNoForwardSelf(t *testing.T) {
 		local.server.mu.Lock()
 		maxSize := local.server.mu.incoming.maxSize
 		local.server.mu.Unlock()
-		peer, peerCtx := startGossip(clusterID, roachpb.NodeID(i+maxSize+2), stopper, t, metric.NewRegistry())
+		peer := tn.StartGossip(roachpb.NodeID(i+maxSize+2), stopper, metric.NewRegistry())
 
 		for {
 			localAddr := local.GetNodeAddr()
 			c := newClient(log.MakeTestingAmbientCtxWithNewTracer(), localAddr, makeMetrics())
 			peer.mu.Lock()
-			c.startLocked(peer, disconnectedCh, peerCtx, stopper)
+			c.startLocked(peer, disconnectedCh, stopper)
 			peer.mu.Unlock()
 
 			disconnectedClient := <-disconnectedCh
@@ -547,17 +523,14 @@ func TestGossipCullNetwork(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	// Shared cluster ID by all gossipers (this ensures that the gossipers
-	// don't talk to servers from unrelated tests by accident).
-	clusterID := uuid.MakeV4()
-
-	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	tn := NewTestNetwork()
+	local := tn.StartGossip(1, stopper, metric.NewRegistry())
 	local.SetCullInterval(5 * time.Millisecond)
 
 	local.mu.Lock()
 	for i := 0; i < minPeers; i++ {
-		peer, peerCtx := startGossip(clusterID, roachpb.NodeID(i+2), stopper, t, metric.NewRegistry())
-		local.startClientLocked(*peer.GetNodeAddr(), peerCtx)
+		peer := tn.StartGossip(roachpb.NodeID(i+2), stopper, metric.NewRegistry())
+		local.startClientLocked(*peer.GetNodeAddr())
 	}
 	local.mu.Unlock()
 
@@ -572,7 +545,7 @@ func TestGossipCullNetwork(t *testing.T) {
 		t.Fatalf("condition failed to evaluate within %s: %s", slowGossipDuration, err)
 	}
 
-	local.manage(localCtx)
+	local.manage()
 
 	if err := retry.ForDuration(slowGossipDuration, func() error {
 		// Verify that a client is closed within the cull interval.
@@ -591,11 +564,8 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	// Shared cluster ID by all gossipers (this ensures that the gossipers
-	// don't talk to servers from unrelated tests by accident).
-	clusterID := uuid.MakeV4()
-
-	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	tn := NewTestNetwork()
+	local := tn.StartGossip(1, stopper, metric.NewRegistry())
 	local.SetStallInterval(5 * time.Millisecond)
 
 	// Make sure we have the sentinel to ensure that its absence is not the
@@ -605,14 +575,14 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 	}
 
 	peerStopper := stop.NewStopper()
-	peer, _ := startGossip(clusterID, 2, peerStopper, t, metric.NewRegistry())
+	peer := tn.StartGossip(2, peerStopper, metric.NewRegistry())
 
 	peerNodeID := peer.NodeID.Get()
 	peerAddr := peer.GetNodeAddr()
 	peerAddrStr := peerAddr.String()
 
 	local.mu.Lock()
-	local.startClientLocked(*peerAddr, localCtx)
+	local.startClientLocked(*peerAddr)
 	local.mu.Unlock()
 
 	testutils.SucceedsSoon(t, func() error {
@@ -633,8 +603,8 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 		return errors.Errorf("n%d descriptor not yet available", peerNodeID)
 	})
 
-	local.bootstrap(localCtx)
-	local.manage(localCtx)
+	local.bootstrap()
+	local.manage()
 
 	peerStopper.Stop(context.Background())
 
@@ -649,7 +619,8 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 
 	peerStopper = stop.NewStopper()
 	defer peerStopper.Stop(context.Background())
-	startGossipAtAddr(clusterID, peerNodeID, peerAddr, peerStopper, t, metric.NewRegistry())
+	// TODO: peerAddr
+	tn.StartGossip(peerNodeID, peerStopper, metric.NewRegistry())
 
 	testutils.SucceedsSoon(t, func() error {
 		for _, peerID := range local.Outgoing() {
@@ -709,8 +680,8 @@ func TestGossipJoinTwoClusters(t *testing.T) {
 		server, err := rpc.NewServer(ctx, rpcContext)
 		require.NoError(t, err)
 
-		// node ID must be non-zero
-		gnode := NewTest(roachpb.NodeID(i+1), stopper, metric.NewRegistry())
+		tn := NewTestNetwork()
+		gnode := tn.StartGossip(roachpb.NodeID(i+1), stopper, metric.NewRegistry())
 		RegisterGossipServer(server, gnode)
 		g = append(g, gnode)
 		gnode.SetStallInterval(interval)
@@ -729,7 +700,7 @@ func TestGossipJoinTwoClusters(t *testing.T) {
 				addresses = append(addresses, util.MakeUnresolvedAddr("tcp", addrs[j].String()))
 			}
 		}
-		gnode.Start(ln.Addr(), addresses, rpcContext)
+		gnode.Start(ln.Addr(), addresses)
 	}
 
 	// Wait for connections.
@@ -770,17 +741,14 @@ func TestGossipPropagation(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	// Shared cluster ID by all gossipers (this ensures that the gossipers
-	// don't talk to servers from unrelated tests by accident).
-	clusterID := uuid.MakeV4()
-
-	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
-	remote, remoteCtx := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
+	tn := NewTestNetwork()
+	local := tn.StartGossip(1, stopper, metric.NewRegistry())
+	remote := tn.StartGossip(2, stopper, metric.NewRegistry())
 	remote.mu.Lock()
 	rAddr := remote.mu.is.NodeAddr
 	remote.mu.Unlock()
-	local.manage(localCtx)
-	remote.manage(remoteCtx)
+	local.manage()
+	remote.manage()
 
 	mustAdd := func(g *Gossip, key string, val []byte, ttl time.Duration) {
 		if err := g.AddInfo(key, val, ttl); err != nil {
@@ -797,7 +765,7 @@ func TestGossipPropagation(t *testing.T) {
 			// Restart the client connection in the loop. It might have failed due to
 			// a heartbeat timeout.
 			local.mu.Lock()
-			local.startClientLocked(rAddr, localCtx)
+			local.startClientLocked(rAddr)
 			local.mu.Unlock()
 			return fmt.Errorf("unable to find local to remote client")
 		}
@@ -886,17 +854,14 @@ func TestGossipLoopbackInfoPropagation(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	// Shared cluster ID by all gossipers (this ensures that the gossipers
-	// don't talk to servers from unrelated tests by accident).
-	clusterID := uuid.MakeV4()
-
-	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
-	remote, remoteCtx := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
+	tn := NewTestNetwork()
+	local := tn.StartGossip(1, stopper, metric.NewRegistry())
+	remote := tn.StartGossip(2, stopper, metric.NewRegistry())
 	remote.mu.Lock()
 	rAddr := remote.mu.is.NodeAddr
 	remote.mu.Unlock()
-	local.manage(localCtx)
-	remote.manage(remoteCtx)
+	local.manage()
+	remote.manage()
 
 	// Add a gossip info for "foo" on remote, that was generated by local. This
 	// simulates what happens if local was to gossip an info, and later restart
@@ -922,7 +887,7 @@ func TestGossipLoopbackInfoPropagation(t *testing.T) {
 
 	// Start a client connection to the remote node.
 	local.mu.Lock()
-	local.startClientLocked(rAddr, localCtx)
+	local.startClientLocked(rAddr)
 	local.mu.Unlock()
 
 	getInfo := func(g *Gossip, key string) *Info {

--- a/pkg/gossip/network.go
+++ b/pkg/gossip/network.go
@@ -1,0 +1,170 @@
+package gossip
+
+import (
+	"context"
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
+	"net"
+	"sync"
+)
+
+type GRPCDialer struct {
+	*rpc.Context
+}
+
+func (d GRPCDialer) Connect(ctx context.Context, _ *stop.Stopper, addr net.Addr) (EndpointClient, error) {
+	// Note: avoid using `grpc.WithBlock` here. This code is already
+	// asynchronous from the caller's perspective, so the only effect of
+	// `WithBlock` here is blocking shutdown - at the time of this writing,
+	// that ends up making `kv` tests take twice as long.
+	conn, err := d.GRPCUnvalidatedDial(addr.String()).Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	stream, err := NewGossipClient(conn).Gossip(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return stream, nil
+}
+
+// TestNetwork represents the entire gossip network on all nodes.
+type TestNetwork struct {
+	sync.Mutex
+	servers map[string]testServer
+	nextId  int
+}
+
+// A test server has the gossip struct as well as the
+type testServer struct {
+	gossip  *Gossip
+	server  TestDialerServer
+	stopper *stop.Stopper
+}
+
+func NewTestNetwork() TestNetwork {
+	return TestNetwork{
+		servers: make(map[string]testServer),
+		nextId:  1,
+	}
+}
+
+// StartGossip is a simplified wrapper around New that creates the
+// ClusterIDContainer and NodeIDContainer internally. Used for testing.
+func (tn *TestNetwork) StartGossip(nodeID roachpb.NodeID, stopper *stop.Stopper, registry *metric.Registry) *Gossip {
+	return tn.StartGossipWithLocality(nodeID, stopper, registry, roachpb.Locality{})
+}
+
+// StartGossipWithLocality calls StartGossip with an explicit locality value.
+func (tn *TestNetwork) StartGossipWithLocality(nodeID roachpb.NodeID, stopper *stop.Stopper, registry *metric.Registry, locality roachpb.Locality) *Gossip {
+	ctx := context.TODO()
+	c := &base.ClusterIDContainer{}
+	n := &base.NodeIDContainer{}
+	var ac log.AmbientContext
+	ac.AddLogTag("n", n)
+	gossip := New(ac, c, n, stopper, registry, locality, tn)
+	if nodeID != 0 {
+		n.Set(ctx, nodeID)
+	}
+	addr := util.MakeUnresolvedAddr("tcp", net.IP{127, 0, byte(tn.nextId >> 8), byte(tn.nextId)}.String())
+	tn.Lock()
+	defer tn.Unlock()
+	tn.nextId++
+	if _, ok := tn.servers[addr.String()]; ok {
+		// Don't allow repeats.
+		return nil
+	}
+	ts := testServer{
+		gossip,
+		TestDialerServer{stopper, addr.String(), tn, make(chan *Request, 100)},
+		stopper,
+	}
+	tn.servers[addr.String()] = ts
+	gossip.start(&addr)
+	return gossip
+}
+
+func (tn *TestNetwork) Connect(ctx context.Context, stopper *stop.Stopper, addr net.Addr) (EndpointClient, error) {
+	tn.Lock()
+	defer tn.Unlock()
+	// Verify the server exists.
+	if ts, ok := tn.servers[addr.String()]; ok {
+		// Start the server gossip thread
+		tc := TestDialerClient{stopper, addr.String(), &ts.server, make(chan *Response, 100)}
+		stream := connection{
+			client: tc,
+			server: ts.server,
+		}
+		_ = stopper.RunAsyncTask(ctx, "gossip-listener", func(ctx context.Context) {
+			if err := ts.gossip.GossipInternal(ctx, stream); err != nil {
+				log.Infof(ctx, "Error running gossip %v", err)
+			}
+		})
+		return tc, nil
+	}
+	return nil, errors.Newf("can't find node for %v", addr)
+}
+
+// connection represents a connection between a client and a server. Anything
+// the client sends, the server will receive and vice versa.
+type connection struct {
+	client TestDialerClient
+	server TestDialerServer
+}
+
+// TestDialerClient represents a TCP connection from a client to a server.
+// Each client is connected to exactly one server.
+type TestDialerClient struct {
+	stopper *stop.Stopper
+	addr    string
+	server  *TestDialerServer
+	ch      chan *Response
+}
+
+// TestDialerServer represents a listening port. Each server can have multiple incoming clients that are indexed by ???
+type TestDialerServer struct {
+	stopper *stop.Stopper
+	addr    string
+	tn      *TestNetwork
+	ch      chan *Request
+}
+
+func (d TestDialerClient) Send(request *Request) error {
+	log.Infof(context.TODO(), "%s: sending request %v", d.addr, request)
+	d.server.ch <- request
+	return nil
+}
+
+func (d TestDialerClient) Recv() (*Response, error) {
+	select {
+	case response := <-d.ch:
+		log.Infof(context.TODO(), "%s: received response %v", d.addr, response)
+		return response, nil
+		// continue
+	case <-d.stopper.ShouldQuiesce():
+		return nil, errors.New("server shutting down")
+	}
+}
+
+func (d connection) Send(response *Response) error {
+	log.Infof(context.TODO(), "%s: sending response %v", d.server.addr, response)
+	d.client.ch <- response
+	return nil
+}
+
+func (d connection) Recv() (*Request, error) {
+	select {
+	case request := <-d.server.ch:
+		log.Infof(context.TODO(), "%s: received request %v", d.server.addr, request)
+		return request, nil
+		// continue
+	case <-d.server.stopper.ShouldQuiesce():
+		return nil, errors.New("server shutting down")
+	}
+}

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -111,7 +111,8 @@ func (n *Network) CreateNode() (*Node, error) {
 		return nil, err
 	}
 	node := &Node{Server: server, Listener: ln, Registry: metric.NewRegistry()}
-	node.Gossip = gossip.NewTest(0, n.Stopper, node.Registry)
+	tn := gossip.NewTestNetwork()
+	node.Gossip = tn.StartGossip(0, n.Stopper, node.Registry)
 	gossip.RegisterGossipServer(server, node.Gossip)
 	n.Stopper.AddCloser(stop.CloserFn(server.Stop))
 	_ = n.Stopper.RunAsyncTask(ctx, "node-wait-quiesce", func(context.Context) {
@@ -126,7 +127,7 @@ func (n *Network) CreateNode() (*Node, error) {
 // StartNode initializes a gossip instance for the simulation node and
 // starts it.
 func (n *Network) StartNode(node *Node) error {
-	node.Gossip.Start(node.Addr(), node.Addresses, n.RPCContext)
+	node.Gossip.Start(node.Addr(), node.Addresses)
 	node.Gossip.EnableSimulationCycler(true)
 	n.nodeIDAllocator++
 	node.Gossip.NodeID.Set(context.TODO(), n.nodeIDAllocator)

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -219,7 +219,7 @@ func (l *simpleTransportAdapter) Release() {}
 
 func makeGossip(t *testing.T, stopper *stop.Stopper, rpcContext *rpc.Context) *gossip.Gossip {
 	const nodeID = 1
-	g := gossip.NewTest(nodeID, stopper, metric.NewRegistry())
+	g := gossip.NewTest(nodeID, stopper, metric.NewRegistry(), nil)
 	if err := g.SetNodeDescriptor(newNodeDesc(nodeID)); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/allocator/allocatorimpl/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/BUILD.bazel
@@ -66,7 +66,6 @@ go_test(
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_kr_pretty//:pretty",
-        "@com_github_olekukonko_tablewriter//:tablewriter",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_etcd_go_raft_v3//:raft",

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
-	"github.com/olekukonko/tablewriter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/raft/v3"
@@ -8460,7 +8459,7 @@ func TestAllocatorFullDisks(t *testing.T) {
 	tr := tracing.NewTracer()
 	clock := hlc.NewClockForTesting(nil)
 
-	g := gossip.NewTest(1, stopper, metric.NewRegistry())
+	g := gossip.NewTest(1, stopper, metric.NewRegistry(), nil)
 
 	liveness.TimeUntilNodeDead.Override(ctx, &st.SV, liveness.TestTimeUntilNodeDeadOff)
 
@@ -8918,7 +8917,7 @@ func exampleRebalancing(
 
 	// Model a set of stores in a cluster,
 	// adding / rebalancing ranges of random sizes.
-	g := gossip.NewTest(1, stopper, metric.NewRegistry())
+	g := gossip.NewTest(1, stopper, metric.NewRegistry(), nil)
 
 	liveness.TimeUntilNodeDead.Override(ctx, &st.SV, liveness.TestTimeUntilNodeDeadOff)
 

--- a/pkg/kv/kvserver/allocator/storepool/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/storepool/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",
-        "//pkg/util/metric",
         "//pkg/util/shuffle",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/kv/kvserver/allocator/storepool/test_helpers.go
+++ b/pkg/kv/kvserver/allocator/storepool/test_helpers.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -78,7 +77,9 @@ func CreateTestStorePool(
 	mc := timeutil.NewManualTime(time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC))
 	clock := hlc.NewClockForTesting(mc)
 	ambientCtx := log.MakeTestingAmbientContext(stopper.Tracer())
-	g := gossip.NewTest(1, stopper, metric.NewRegistry())
+	// One node gossip network with nodeId 1.
+	gn := gossip.NewTestNetwork()
+	g := gn.StartGossip(1, stopper, nil)
 	mnl := NewMockNodeLiveness(defaultNodeStatus)
 
 	liveness.TimeUntilNodeDead.Override(ctx, &st.SV, timeUntilNodeDeadValue)

--- a/pkg/kv/kvserver/asim/state/helpers.go
+++ b/pkg/kv/kvserver/asim/state/helpers.go
@@ -73,7 +73,7 @@ func NewStorePool(
 	ambientCtx := log.MakeTestingAmbientContext(stopper.Tracer())
 
 	// Never gossip, pass in nil values.
-	g := gossip.NewTest(1, stopper, metric.NewRegistry())
+	g := gossip.NewTest(1, stopper, metric.NewRegistry(), nil)
 	sp := storepool.NewStorePool(
 		ambientCtx,
 		st,

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -137,7 +137,7 @@ func newRaftTransportTestContext(t testing.TB, st *cluster.Settings) *raftTransp
 	// we can't enforce some of the RPC check validation.
 	rttc.nodeRPCContext.TestingAllowNamedRPCToAnonymousServer = true
 
-	rttc.gossip = gossip.NewTest(1, rttc.stopper, metric.NewRegistry())
+	rttc.gossip = gossip.NewTest(1, rttc.stopper, metric.NewRegistry(), nil)
 
 	return rttc
 }

--- a/pkg/kv/kvserver/replica_range_lease_test.go
+++ b/pkg/kv/kvserver/replica_range_lease_test.go
@@ -125,7 +125,7 @@ func TestReplicaLeaseStatus(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			cache :=
 				liveness.NewCache(
-					gossip.NewTest(roachpb.NodeID(1), stopper, metric.NewRegistry()),
+					gossip.NewTest(roachpb.NodeID(1), stopper, metric.NewRegistry(), nil),
 					clock,
 					cluster.MakeTestingClusterSettings(),
 					nil,

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -198,7 +198,7 @@ func createTestStoreWithoutStart(
 	// TestChooseLeaseToTransfer and TestNoLeaseTransferToBehindReplicas. This is
 	// generally considered bad and should eventually be refactored away.
 	if cfg.Gossip == nil {
-		cfg.Gossip = gossip.NewTest(1, stopper, metric.NewRegistry())
+		cfg.Gossip = gossip.NewTest(1, stopper, metric.NewRegistry(), nil)
 	}
 	if cfg.StorePool == nil {
 		cfg.StorePool = NewTestStorePool(*cfg)

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -940,7 +940,7 @@ func TestPartitionSpans(t *testing.T) {
 	ctx := context.Background()
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
-	mockGossip := gossip.NewTest(roachpb.NodeID(1), s.Stopper(), metric.NewRegistry())
+	mockGossip := gossip.NewTest(roachpb.NodeID(1), s.Stopper(), metric.NewRegistry(), nil)
 	var nodeDescs []*roachpb.NodeDescriptor
 	mockInstances := make(mockAddressResolver)
 	for i := 1; i <= 10; i++ {
@@ -1158,7 +1158,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 			// reflect tc.nodesNotAdvertisingDistSQLVersion.
 			testStopper := stop.NewStopper()
 			defer testStopper.Stop(context.Background())
-			mockGossip := gossip.NewTest(roachpb.NodeID(1), testStopper, metric.NewRegistry())
+			mockGossip := gossip.NewTest(roachpb.NodeID(1), testStopper, metric.NewRegistry(), nil)
 			var nodeDescs []*roachpb.NodeDescriptor
 			for i := 1; i <= 2; i++ {
 				sqlInstanceID := base.SQLInstanceID(i)
@@ -1252,7 +1252,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	mockGossip := gossip.NewTest(roachpb.NodeID(1), stopper, metric.NewRegistry())
+	mockGossip := gossip.NewTest(roachpb.NodeID(1), stopper, metric.NewRegistry(), nil)
 	var nodeDescs []*roachpb.NodeDescriptor
 	for i := 1; i <= 2; i++ {
 		sqlInstanceID := base.SQLInstanceID(i)
@@ -1347,7 +1347,7 @@ func TestCheckNodeHealth(t *testing.T) {
 
 	const sqlInstanceID = base.SQLInstanceID(5)
 
-	mockGossip := gossip.NewTest(roachpb.NodeID(sqlInstanceID), stopper, metric.NewRegistry())
+	mockGossip := gossip.NewTest(roachpb.NodeID(sqlInstanceID), stopper, metric.NewRegistry(), nil)
 
 	desc := &roachpb.NodeDescriptor{
 		NodeID:  roachpb.NodeID(sqlInstanceID),

--- a/pkg/sql/physicalplan/replicaoracle/oracle_test.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle_test.go
@@ -90,7 +90,7 @@ func makeGossip(t *testing.T, stopper *stop.Stopper, nodeIDs []int) (*gossip.Gos
 	clock := hlc.NewClockForTesting(nil)
 
 	const nodeID = 1
-	g := gossip.NewTest(nodeID, stopper, metric.NewRegistry())
+	g := gossip.NewTest(nodeID, stopper, metric.NewRegistry(), nil)
 	if err := g.SetNodeDescriptor(newNodeDesc(nodeID)); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -154,7 +154,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 
 	cfg.RPCContext.NodeID.Set(ctx, nodeID)
 	clusterID := cfg.RPCContext.StorageClusterID
-	ltc.Gossip = gossip.New(ambient, clusterID, nc, ltc.stopper, metric.NewRegistry(), roachpb.Locality{})
+	ltc.Gossip = gossip.New(ambient, clusterID, nc, ltc.stopper, metric.NewRegistry(), roachpb.Locality{}, gossip.GRPCDialer{Context: cfg.RPCContext})
 	var err error
 	ltc.Eng, err = storage.Open(
 		ctx,

--- a/pkg/testutils/soon.go
+++ b/pkg/testutils/soon.go
@@ -24,7 +24,7 @@ import (
 const (
 	// DefaultSucceedsSoonDuration is the maximum amount of time unittests
 	// will wait for a condition to become true. See SucceedsSoon().
-	DefaultSucceedsSoonDuration = 45 * time.Second
+	DefaultSucceedsSoonDuration = 5 * time.Second
 
 	// RaceSucceedsSoonDuration is the maximum amount of time
 	// unittests will wait for a condition to become true when


### PR DESCRIPTION
Currently gossip uses an internal GRPC connection to create connections between nodes. This makes testing slower and increases the complexity of scale testing. This commit moves the network connectivity to a seperate file and allows creating in-memory connections for testing.

Epic: none

Release note: None