### PR TITLE
ui: refer to "lag" rather than "latency" on changefeed dashboard

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
@@ -117,7 +117,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Max Checkpoint Latency"
+      title="Max Checkpoint Lag"
       isKvGraph={false}
       tooltip={`The most any changefeed's persisted checkpoint is behind the present.
           Larger values indicate issues with successfully ingesting or emitting


### PR DESCRIPTION
Currently, the time between "now" and the last time a changefeed was checkpointed is referred to as "latency". This often causes confusion with operators, who can interpret this metric as the latency of data arriving into the sink (which exists as a separate metric, `commit_latency`).

Tweak the dashboard name to refer to "lag", which better reflects the metric - the time between "now" and when the changefeed was _checkpointed_.

Touches: #114650.

Epic: None.

Release note (ui change): The "Max Checkpoint Latency" chart title was updated to refer to "Lag" rather than latency. This better reflects the intention of the underlying metric - a measure of time between "now" and when the changefeed was last checkpointed.