### PR TITLE
release-23.1: server, ui: show internal stats with custer setting enabled

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -198,6 +198,11 @@ func activityTablesHaveFullData(
 		return false, nil
 	}
 
+	// Top Activity table doesn't store internal data.
+	if SQLStatsShowInternal.Get(&settings.SV) {
+		return false, nil
+	}
+
 	if (limit > 0 && !isLimitOnActivityTable(limit)) || !isSortOptionOnActivityTable(order) {
 		return false, nil
 	}

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.spec.tsx
@@ -70,7 +70,7 @@ describe("filteredStatementsData", () => {
     filterAndCheckStmts(stmtsRaw, {}, "giraffe", expectedIDs);
   });
 
-  it("should show non-internal statements when no app filters are applied", () => {
+  it("should show internal statements when no app filters are applied", () => {
     const stmtsRaw = [
       { id: 1, app: "hello" },
       { id: 2, app: "$ internal hello" },
@@ -85,7 +85,7 @@ describe("filteredStatementsData", () => {
     );
 
     const filters: Filters = {};
-    const expected = [1, 4, 5];
+    const expected = [1, 2, 3, 4, 5];
     filterAndCheckStmts(stmtsRaw, filters, null, expected);
   });
 

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.tsx
@@ -77,7 +77,7 @@ export function filteredStatementsData(
         INTERNAL_APP_NAME_PREFIX,
       );
       return (
-        (!appNames?.length && !isInternal) ||
+        !appNames?.length ||
         (includeInternalApps && isInternal) ||
         appNames?.includes(
           statement.applicationName ? statement.applicationName : unset,

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
@@ -44,7 +44,7 @@ describe("getStatementsByFingerprintId", () => {
 const txData = data.transactions as Transaction[];
 
 describe("Filter transactions", () => {
-  it("show non internal if no filters applied", () => {
+  it("show internal if no filters applied", () => {
     const filter: Filters = {
       app: "",
       timeNumber: "0",
@@ -61,7 +61,7 @@ describe("Filter transactions", () => {
         nodeRegions,
         false,
       ).transactions.length,
-      4,
+      11,
     );
   });
 

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -193,8 +193,7 @@ export const filterTransactions = (
           apps.includes(app)
         );
       } else {
-        // We don't want to show internal transactions by default.
-        return !isInternal;
+        return true;
       }
     })
     .filter(


### PR DESCRIPTION
Backport 1/1 commits from #114743.

/cc @cockroachdb/release

---

Previously, when the cluster setting `sql.stats.response.show_internal.enabled` was set to true, we were still trying to use the activity tables to return data to the UI, but that tables doesn't have data from internal stats.

This commit does that proper check to not use the Activity tables if that value is enabled.

Also, since enabling that setting means the user wants to see the internal stats, this commit also changes the UI so that it returns the internal stats, oterhwise it might be confusing selecting top 100 but the UI only showing 40 for example.

Fixes #114460

https://www.loom.com/share/8f3279ae4fd441999c24c68fb0fa8b14

Release note (bug fix): SQL Activity properly showing internal statements when cluster setting `sql.stats.response.show_internal.enabled` is set to true.

---

Release justification: bug fix
