### PR TITLE
types: make Family.Name return redact.SafeString

### DIFF
--- a/pkg/sql/rowenc/valueside/BUILD.bazel
+++ b/pkg/sql/rowenc/valueside/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//pkg/util/tsearch",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",
     ],
 )

--- a/pkg/sql/rowenc/valueside/array.go
+++ b/pkg/sql/rowenc/valueside/array.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/tsearch"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/redact"
 )
 
 // encodeArray produces the value encoding for an array.
@@ -239,9 +238,7 @@ func DatumTypeToArrayElementEncodingType(t *types.T) (encoding.Type, error) {
 	case types.TupleFamily:
 		return encoding.Tuple, nil
 	default:
-		return 0, errors.AssertionFailedf(
-			"no known encoding type for %s", redact.Safe(t.Family().Name()),
-		)
+		return 0, errors.AssertionFailedf("no known encoding type for %s", t.Family().Name())
 	}
 }
 func checkElementType(paramType *types.T, elemType *types.T) error {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -592,11 +592,7 @@ func onCastTypeCheckHook(from, to types.Family) {
 		f()
 		return
 	}
-	panic(errors.AssertionFailedf(
-		"no cast counter found for cast from %s to %s",
-		// Family names are always safe for redacting.
-		redact.Safe(from.Name()), redact.Safe(to.Name()),
-	))
+	panic(errors.AssertionFailedf("no cast counter found for cast from %s to %s", from.Name(), to.Name()))
 }
 
 func isArrayExpr(expr Expr) bool {

--- a/pkg/sql/telemetry.go
+++ b/pkg/sql/telemetry.go
@@ -94,7 +94,7 @@ func init() {
 			case from == types.EnumFamily && to == types.EnumFamily:
 				c = sqltelemetry.EnumCastCounter
 			default:
-				c = sqltelemetry.CastOpCounter(from.Name(), to.Name())
+				c = sqltelemetry.CastOpCounter(string(from.Name()), string(to.Name()))
 			}
 			tree.OnCastTypeCheck[tree.CastCounterType{From: from, To: to}] = func() {
 				telemetry.Inc(c)

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1467,7 +1467,7 @@ func IsOIDUserDefinedType(o oid.Oid) bool {
 	return catid.IsOIDUserDefined(o)
 }
 
-var familyNames = map[Family]string{
+var familyNames = map[Family]redact.SafeString{
 	AnyFamily:            "any",
 	ArrayFamily:          "array",
 	BitFamily:            "bit",
@@ -1506,7 +1506,7 @@ var familyNames = map[Family]string{
 //
 // TODO(radu): investigate whether anything breaks if we use
 // enumvalue_customname and use String() instead.
-func (f Family) Name() string {
+func (f Family) Name() redact.SafeString {
 	ret, ok := familyNames[f]
 	if !ok {
 		panic(errors.AssertionFailedf("unexpected Family: %d", f))
@@ -1595,7 +1595,7 @@ func (t *T) Name() string {
 		return t.TypeMeta.Name.Basename()
 
 	default:
-		return fam.Name()
+		return string(fam.Name())
 	}
 }
 


### PR DESCRIPTION
All family names are safe constant strings.

Epic: None

Release note: None