### PR TITLE
roachtest: reduce tpcc chaos node downtime from 5m to 4m

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -707,8 +707,8 @@ func registerTPCC(r registry.Registry) {
 						Chaos: func() Chaos {
 							return Chaos{
 								Timer: Periodic{
-									Period:   300 * time.Second,
-									DownTime: 300 * time.Second,
+									Period:   240 * time.Second,
+									DownTime: 240 * time.Second,
 								},
 								Target: func() option.NodeListOption {
 									ret := tc.chaosTarget(iter)


### PR DESCRIPTION
The `tpcc/multiregion/survive=X/chaos=true` roachtests periodically stop nodes and assert on the number of errors. These roachtests previously used a 5 minute timer for keeping a node down, as well as 5 minute post-restart to recover.

In #114173 we saw that at 5 minutes (or slightly before, depending on the last heartbeat), the leaseholders would begin replacing the dead node's replicas elsewhere in the cluster, as expected. If the replaced replicas were not rebalanced back to the restarted region within the next 5 minutes and the next nodes stopped contained a quorum, the range would become unavailable.

Reduce the down time, and recovery period from 5 minutes to 4 minutes to dead stores.

Resolves: #114173
Release note: None