### PR TITLE
server: delay job scheduler startup

### DIFF
--- a/pkg/server/external_storage_builder.go
+++ b/pkg/server/external_storage_builder.go
@@ -76,11 +76,18 @@ func (e *externalStorageBuilder) init(
 	registry.AddMetricStruct(e.metrics)
 }
 
+func (e *externalStorageBuilder) assertInitComplete() error {
+	if !e.initCalled {
+		return errors.AssertionFailedf("external storage not initialized")
+	}
+	return nil
+}
+
 func (e *externalStorageBuilder) makeExternalStorage(
 	ctx context.Context, dest cloudpb.ExternalStorage, opts ...cloud.ExternalStorageOption,
 ) (cloud.ExternalStorage, error) {
 	if !e.initCalled {
-		return nil, errors.New("cannot create external storage before init")
+		return nil, errors.AssertionFailedf("cannot create external storage before init")
 	}
 	return cloud.MakeExternalStorage(
 		ctx, dest, e.conf, e.settings, e.blobClientFactory, e.db, e.limiters, e.metrics,
@@ -92,7 +99,7 @@ func (e *externalStorageBuilder) makeExternalStorageFromURI(
 	ctx context.Context, uri string, user username.SQLUsername, opts ...cloud.ExternalStorageOption,
 ) (cloud.ExternalStorage, error) {
 	if !e.initCalled {
-		return nil, errors.New("cannot create external storage before init")
+		return nil, errors.AssertionFailedf("cannot create external storage before init")
 	}
 	return cloud.ExternalStorageFromURI(
 		ctx, uri, e.conf, e.settings, e.blobClientFactory, user, e.db, e.limiters, e.metrics,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2082,6 +2082,12 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		return err
 	}
 
+	// Start the job scheduler now that the SQL Server and
+	// external storage is initialized.
+	if err := s.initJobScheduler(ctx); err != nil {
+		return err
+	}
+
 	// If enabled, start reporting diagnostics.
 	if s.cfg.StartDiagnosticsReporting && !cluster.TelemetryOptOut {
 		s.startDiagnostics(workersCtx)
@@ -2196,6 +2202,29 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 	case <-firstTSDBPollDone:
 	}
 	return maybeImportTS(ctx, s)
+}
+
+// initJobScheduler starts the job scheduler. This must be called
+// after sqlServer.preStart and after our external storage providers
+// have been initialized.
+//
+// TODO(ssd): We need to clean up the ordering/ownership here. The SQL
+// server owns the job scheduler because the job scheduler needs an
+// internal executor. But, the topLevelServer owns initialization of
+// the external storage providers.
+func (s *topLevelServer) initJobScheduler(ctx context.Context) error {
+	if s.cfg.DisableSQLServer {
+		return nil
+	}
+	// The job scheduler may immediately start jobs that require
+	// external storage providers to be available. We expect the
+	// server start up ordering to ensure this. Hitting this error
+	// is a programming error somewhere in server startup.
+	if err := s.externalStorageBuilder.assertInitComplete(); err != nil {
+		return err
+	}
+	s.sqlServer.startJobScheduler(ctx, s.cfg.TestingKnobs)
+	return nil
 }
 
 // AcceptClients starts listening for incoming SQL clients over the network.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1053,6 +1053,19 @@ func TestAssertEnginesEmpty(t *testing.T) {
 	require.Error(t, assertEnginesEmpty([]storage.Engine{eng}))
 }
 
+// TestAssertExternalStorageInitializedBeforeJobSchedulerStart is a
+// bit silly, but the goal is to make sure we don't accidentally move
+// things around related to external storage in a way that would break
+// the job scheduler.
+func TestAssertExternalStorageInitializedBeforeJobSchedulerStart(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	tlServer := &topLevelServer{
+		externalStorageBuilder: &externalStorageBuilder{},
+	}
+	require.Error(t, tlServer.initJobScheduler(context.Background()))
+}
+
 func Test_makeFakeNodeStatuses(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -845,6 +845,12 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 		s.registry,
 	)
 
+	// Start the job scheduler now that the SQL Server and
+	// external storage is initialized.
+	if err := s.initJobScheduler(ctx); err != nil {
+		return err
+	}
+
 	// If enabled, start reporting diagnostics.
 	if s.sqlServer.cfg.StartDiagnosticsReporting && !cluster.TelemetryOptOut {
 		s.startDiagnostics(workersCtx)
@@ -918,6 +924,31 @@ func (s *SQLServerWrapper) serveConn(
 	default:
 		return errors.AssertionFailedf("programming error: missing case %v", status.State)
 	}
+}
+
+// initJobScheduler starts the job scheduler. This must be called
+// after sqlServer.preStart and after our external storage providers
+// have been initialized.
+//
+// TODO(ssd): We need to clean up the ordering/ownership here. The SQL
+// server owns the job scheduler because the job scheduler needs an
+// internal executor. But, the topLevelServer owns initialization of
+// the external storage providers.
+//
+// TODO(ssd): Remove duplication with *topLevelServer.
+func (s *SQLServerWrapper) initJobScheduler(ctx context.Context) error {
+	if s.cfg.DisableSQLServer {
+		return nil
+	}
+	// The job scheduler may immediately start jobs that require
+	// external storage providers to be available. We expect the
+	// server start up ordering to ensure this. Hitting this error
+	// is a programming error somewhere in server startup.
+	if err := s.externalStorageBuilder.assertInitComplete(); err != nil {
+		return err
+	}
+	s.sqlServer.startJobScheduler(ctx, s.cfg.TestingKnobs)
+	return nil
 }
 
 // AcceptClients starts listening for incoming SQL clients over the network.


### PR DESCRIPTION
We previously moved external storage init after the sqlServer preStart
to ensure we have a SQL instance ID. Unfortunately, sqlServer.preStart
also started the job scheduler, which may immediately execute a job
that assumes that external storage has been initialized.

This is a minimal fix intended for backport that starts the job
scheduler after we initialize external storage.

Fixes https://github.com/cockroachdb/cockroach/issues/114842

Epic: none

Release note (bug fix): Fix a bug where scheduled jobs using external
storage providers may fail shortly after node startup.