### PR TITLE
sql: add admissionWorkQueueWait to optional traces in TestTrace

### DIFF
--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -51,6 +51,7 @@ func TestTrace(t *testing.T) {
 		"request range lease",
 		"range lookup",
 		"local proposal",
+		"admissionWorkQueueWait",
 	}
 
 	testData := []struct {


### PR DESCRIPTION
Fixes: #114791.

Release note: None