### PR TITLE
parser: disallow custom ORDER BY <index> syntax in function calls

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -323,8 +323,8 @@ analyze_target ::=
 
 func_application ::=
 	func_application_name '(' ')'
-	| func_application_name '(' expr_list opt_sort_clause ')'
-	| func_application_name '(' 'ALL' expr_list opt_sort_clause ')'
+	| func_application_name '(' expr_list opt_sort_clause_no_index ')'
+	| func_application_name '(' 'ALL' expr_list opt_sort_clause_no_index ')'
 	| func_application_name '(' 'DISTINCT' expr_list ')'
 	| func_application_name '(' '*' ')'
 
@@ -999,6 +999,10 @@ func_application_name ::=
 
 expr_list ::=
 	( a_expr ) ( ( ',' a_expr ) )*
+
+opt_sort_clause_no_index ::=
+	sort_clause_no_index
+	| 
 
 db_object_name ::=
 	simple_db_object_name
@@ -2061,6 +2065,9 @@ func_name ::=
 iconst32 ::=
 	'ICONST'
 
+sort_clause_no_index ::=
+	'ORDER' 'BY' sortby_no_index_list
+
 simple_db_object_name ::=
 	db_object_name_component
 
@@ -2776,6 +2783,9 @@ type_function_name ::=
 	'identifier'
 	| unreserved_keyword
 	| type_func_name_keyword
+
+sortby_no_index_list ::=
+	( sortby ) ( ( ',' sortby | ',' sortby_index ) )*
 
 type_func_name_crdb_extra_keyword ::=
 	'FAMILY'
@@ -4537,7 +4547,7 @@ single_sort_clause ::=
 	| 'ORDER' 'BY' sortby_index ',' sortby_list
 
 window_specification ::=
-	'(' opt_existing_window_name opt_partition_clause opt_sort_clause opt_frame_clause ')'
+	'(' opt_existing_window_name opt_partition_clause opt_sort_clause_no_index opt_frame_clause ')'
 
 window_name ::=
 	name

--- a/docs/generated/sql/bnf/window_definition.bnf
+++ b/docs/generated/sql/bnf/window_definition.bnf
@@ -1,2 +1,2 @@
 window_definition ::=
-	window_name 'AS' '(' opt_existing_window_name opt_partition_clause opt_sort_clause opt_frame_clause ')'
+	window_name 'AS' '(' opt_existing_window_name opt_partition_clause opt_sort_clause_no_index opt_frame_clause ')'

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -357,7 +357,7 @@ CREATE TABLE unrelated(x INT); SELECT * FROM unrelated ORDER BY PRIMARY KEY kv
 statement ok
 PREPARE a AS (TABLE kv) ORDER BY PRIMARY KEY kv
 
-statement error ORDER BY INDEX in window definition is not supported
+statement error pq: at or near "primary": syntax error
 SELECT avg(k) OVER (ORDER BY PRIMARY KEY kv) FROM kv
 
 statement ok

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1461,8 +1461,10 @@ func (u *sqlSymUnion) showFingerprintOptions() *tree.ShowFingerprintOptions {
 %type <bool> distinct_clause opt_with_data
 %type <tree.DistinctOn> distinct_on_clause
 %type <tree.NameList> opt_column_list insert_column_list opt_stats_columns query_stats_cols
-%type <tree.OrderBy> sort_clause single_sort_clause opt_sort_clause
-%type <[]*tree.Order> sortby_list
+// Note that "no index" variants exist to disable custom ORDER BY <index> syntax
+// in some places like function calls.
+%type <tree.OrderBy> sort_clause sort_clause_no_index single_sort_clause opt_sort_clause opt_sort_clause_no_index
+%type <[]*tree.Order> sortby_list sortby_no_index_list
 %type <tree.IndexElemList> index_params create_as_params
 %type <tree.IndexInvisibility> opt_index_visible alter_index_visible
 %type <tree.NameList> name_list privilege_list
@@ -12973,8 +12975,24 @@ opt_sort_clause:
     $$.val = tree.OrderBy(nil)
   }
 
+opt_sort_clause_no_index:
+  sort_clause_no_index
+  {
+    $$.val = $1.orderBy()
+  }
+| /* EMPTY */
+  {
+    $$.val = tree.OrderBy(nil)
+  }
+
 sort_clause:
   ORDER BY sortby_list
+  {
+    $$.val = tree.OrderBy($3.orders())
+  }
+
+sort_clause_no_index:
+  ORDER BY sortby_no_index_list
   {
     $$.val = tree.OrderBy($3.orders())
   }
@@ -13013,6 +13031,20 @@ sortby_list:
     $$.val = append($1.orders(), $3.order())
   }
 | sortby_list ',' sortby_index
+  {
+    $$.val = append($1.orders(), $3.order())
+  }
+
+sortby_no_index_list:
+  sortby
+  {
+    $$.val = []*tree.Order{$1.order()}
+  }
+| sortby_no_index_list ',' sortby
+  {
+    $$.val = append($1.orders(), $3.order())
+  }
+| sortby_no_index_list ',' sortby_index
   {
     $$.val = append($1.orders(), $3.order())
   }
@@ -15131,7 +15163,7 @@ d_expr:
     if err != nil { return setErr(sqllex, err) }
     $$.val = d
   }
-| func_application_name '(' expr_list opt_sort_clause ')' SCONST { return unimplemented(sqllex, $1.resolvableFuncRef().String() + "(...) SCONST") }
+| func_application_name '(' expr_list opt_sort_clause_no_index ')' SCONST { return unimplemented(sqllex, $1.resolvableFuncRef().String() + "(...) SCONST") }
 | typed_literal
   {
     $$.val = $1.expr()
@@ -15222,13 +15254,13 @@ func_application:
   {
     $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRef()}
   }
-| func_application_name '(' expr_list opt_sort_clause ')'
+| func_application_name '(' expr_list opt_sort_clause_no_index ')'
   {
     $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRef(), Exprs: $3.exprs(), OrderBy: $4.orderBy(), AggType: tree.GeneralAgg}
   }
-| func_application_name '(' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex, "variadic") }
-| func_application_name '(' expr_list ',' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex, "variadic") }
-| func_application_name '(' ALL expr_list opt_sort_clause ')'
+| func_application_name '(' VARIADIC a_expr opt_sort_clause_no_index ')' { return unimplemented(sqllex, "variadic") }
+| func_application_name '(' expr_list ',' VARIADIC a_expr opt_sort_clause_no_index ')' { return unimplemented(sqllex, "variadic") }
+| func_application_name '(' ALL expr_list opt_sort_clause_no_index ')'
   {
     $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRef(), Type: tree.AllFuncType, Exprs: $4.exprs(), OrderBy: $5.orderBy(), AggType: tree.GeneralAgg}
   }
@@ -15626,7 +15658,7 @@ over_clause:
 
 window_specification:
   '(' opt_existing_window_name opt_partition_clause
-    opt_sort_clause opt_frame_clause ')'
+    opt_sort_clause_no_index opt_frame_clause ')'
   {
     $$.val = &tree.WindowDef{
       RefName: tree.Name($2),

--- a/pkg/sql/parser/testdata/select_numeric_func_expr
+++ b/pkg/sql/parser/testdata/select_numeric_func_expr
@@ -53,3 +53,14 @@ SELECT [FUNCTION 1074](DISTINCT 'hello', 'world')
 SELECT ([FUNCTION 1074](DISTINCT ('hello'), ('world'))) -- fully parenthesized
 SELECT [FUNCTION 1074](DISTINCT '_', '_') -- literals removed
 SELECT [FUNCTION 1074](DISTINCT 'hello', 'world') -- identifiers removed
+
+# Regression test for not allowing custom "ORDER BY <index>" syntax in function
+# calls (#114788).
+error
+SELECT [FUNCTION 1074]('hello','word' ORDER BY PRIMARY KEY FAMILY DESC)
+----
+at or near "primary": syntax error
+DETAIL: source SQL:
+SELECT [FUNCTION 1074]('hello','word' ORDER BY PRIMARY KEY FAMILY DESC)
+                                               ^
+HINT: try \hf [FUNCTION 1074]


### PR DESCRIPTION
This commit adjusts the parser to no longer allow custom (i.e. Cockroach extension) `ORDER BY <index>` syntax in function calls. Previously, this would pass the parser but later would hit an internal error during the type checking since `OrderBy.Expr` would be `nil`. The original motivation behind this custom syntax doesn't make sense in the context of function calls.

It seems unlikely anyone will actually run into this problem, so there is no release note.

Fixes: #114788.
Fixes: https://github.com/cockroachdb/cockroach/issues/115153.

Release note: None