### PR TITLE
logictest: update versions referenced in upgrade test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_upgrade_preserve_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_upgrade_preserve_ttl
@@ -1,5 +1,13 @@
 # LogicTest: cockroach-go-testserver-upgrade-to-master
 
+# This test verifies that when a cluster is upgraded, it preserves the TTL
+# job configuration on a table.
+
+query T
+SELECT version FROM [SHOW CLUSTER SETTING version]
+----
+23.1
+
 statement ok
 CREATE TABLE tbl (
   id INT PRIMARY KEY
@@ -7,8 +15,10 @@ CREATE TABLE tbl (
 
 upgrade all
 
+# Verify that the cluster version upgrades have begun. Note that the first
+# cluster upgrade is the one that repairs all descriptors.
 query B retry
-SELECT version LIKE '%23.1-%' FROM [SHOW CLUSTER SETTING version]
+SELECT version LIKE '%23.2-%' FROM [SHOW CLUSTER SETTING version]
 ----
 true
 

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/generated_test.go
@@ -176,11 +176,11 @@ func TestLogic_mixed_version_udf_mutations(
 	runLogicTest(t, "mixed_version_udf_mutations")
 }
 
-func TestLogic_mixed_version_upgrade_repair_descriptors(
+func TestLogic_mixed_version_upgrade_preserve_ttl(
 	t *testing.T,
 ) {
 	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "mixed_version_upgrade_repair_descriptors")
+	runLogicTest(t, "mixed_version_upgrade_preserve_ttl")
 }
 
 func TestLogic_pg_lsn_mixed(

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -1083,9 +1083,9 @@ func TestSchemaChangeComparator_mixed_version_udf_mutations(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_udf_mutations"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
-func TestSchemaChangeComparator_mixed_version_upgrade_repair_descriptors(t *testing.T) {
+func TestSchemaChangeComparator_mixed_version_upgrade_preserve_ttl(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_upgrade_repair_descriptors"
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/mixed_version_upgrade_preserve_ttl"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
 func TestSchemaChangeComparator_multi_region(t *testing.T) {


### PR DESCRIPTION
The test is checking that the cluster version upgrade ran, so it needs to assert on the next major version.

fixes https://github.com/cockroachdb/cockroach/issues/114656
Release note: None