### PR TITLE
ui: change cursor to pointer

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/refreshControl/refreshControl.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/refreshControl/refreshControl.module.scss
@@ -32,6 +32,7 @@
 
 .refresh-button {
   align-items: center;
+  cursor: pointer;
 }
 
 .refresh-divider {


### PR DESCRIPTION
Previously, the refresh button was not using a cursor pointer, making it look like it wasn't clickable.
This commit changes, so it now uses the proper cursor.

Fixes #114691

https://www.loom.com/share/40785331360f46faa55b9c1c9bb9604d

Release note: None