### PR TITLE
opt: use EquivSet instead of FuncDepSet for some rules

### DIFF
--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -80,12 +80,12 @@
             (CanMapJoinOpFilter
                 $item
                 $leftCols:(OutputCols $left)
-                $equivFD:(GetEquivFD $on $left $right)
+                $equivSet:(GetEquivSet $on $left $right)
             ) &
             (CanMapJoinOpFilter
                 $item
                 $rightCols:(OutputCols $right)
-                $equivFD
+                $equivSet
             )
         ...
     ]
@@ -97,7 +97,7 @@
         $left
         [
             (FiltersItem
-                (MapJoinOpFilter $item $leftCols $equivFD)
+                (MapJoinOpFilter $item $leftCols $equivSet)
             )
         ]
     )
@@ -105,7 +105,7 @@
         $right
         [
             (FiltersItem
-                (MapJoinOpFilter $item $rightCols $equivFD)
+                (MapJoinOpFilter $item $rightCols $equivSet)
             )
         ]
     )
@@ -140,7 +140,7 @@
             (CanMapJoinOpFilter
                 $item
                 $leftCols
-                $equivFD:(GetEquivFD $on $left $right)
+                $equivSet:(GetEquivSet $on $left $right)
             )
         ...
     ]
@@ -153,7 +153,7 @@
     (ReplaceFiltersItem
         $on
         $item
-        (MapJoinOpFilter $item $leftCols $equivFD)
+        (MapJoinOpFilter $item $leftCols $equivSet)
     )
     $private
 )
@@ -174,7 +174,7 @@
             (CanMapJoinOpFilter
                 $item
                 $rightCols
-                $equivFD:(GetEquivFD $on $left $right)
+                $equivSet:(GetEquivSet $on $left $right)
             )
         ...
     ]
@@ -187,7 +187,7 @@
     (ReplaceFiltersItem
         $on
         $item
-        (MapJoinOpFilter $item $rightCols $equivFD)
+        (MapJoinOpFilter $item $rightCols $equivSet)
     )
     $private
 )

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -200,7 +200,7 @@ $input
             (CanMapJoinOpFilter
                 $item
                 $rightCols:(OutputCols $right)
-                $equivFD:(GetEquivFD $on $left $right)
+                $equivSet:(GetEquivSet $on $left $right)
             )
         ...
     ]
@@ -213,7 +213,7 @@ $input
             $right
             [
                 (FiltersItem
-                    (MapJoinOpFilter $item $rightCols $equivFD)
+                    (MapJoinOpFilter $item $rightCols $equivSet)
                 )
             ]
         )

--- a/pkg/sql/opt/props/equiv_set.go
+++ b/pkg/sql/opt/props/equiv_set.go
@@ -86,6 +86,18 @@ func (eq *EquivSet) AreColsEquiv(left, right opt.ColumnID) bool {
 	return false
 }
 
+// Group returns the group of columns equivalent to the given column. It
+// returns the empty set if no such group exists. The returned should not be
+// mutated without being copied first.
+func (eq *EquivSet) Group(col opt.ColumnID) opt.ColSet {
+	for i := range eq.groups {
+		if eq.groups[i].Contains(col) {
+			return eq.groups[i]
+		}
+	}
+	return opt.ColSet{}
+}
+
 // tryMergeGroups attempts to merge the equality group at the given index with
 // any of the *following* groups. If a group can be merged, it is removed after
 // its columns are added to the given group.


### PR DESCRIPTION
This commit updates several normalization rules to use `EquivSet` rather
than `FuncDepSet`. `EquivSet` is more efficient, in both time and space,
than `FuncDepSet`, when only column equivalencies need to be tracked.
This reduces the time to optimize some queries.

Epic: None

Release note: None
