### PR TITLE
backupccl: delete TestBackupRestoreJobTagAndLabel

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -328,7 +328,6 @@ go_test(
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
-        "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_pebble//sstable",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_cockroachdb_redact//:redact",


### PR DESCRIPTION
This is just testing that a distsql processor has the ctx tags that match the tags of the ctx that ran the flow. That's a distsql behavior, not a backup behavior, so backup doesn't need to be testing it.

Release note: none.
Epic: none.