### PR TITLE
release-23.1: roachtest: revert recent changes to tpch_concurrency

### DIFF
--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -53,7 +53,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 
 	restartCluster := func(ctx context.Context, c cluster.Cluster, t test.Test) {
 		c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Range(1, numNodes-1))
-		c.Start(ctx, t.L(), maybeUseMemoryBudget(t, 35), install.MakeClusterSettings(), c.Range(1, numNodes-1))
+		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), c.Range(1, numNodes-1))
 	}
 
 	// checkConcurrency returns an error if at least one node of the cluster


### PR DESCRIPTION
Backport 1/1 commits from #113998.

/cc @cockroachdb/release

---

This commit reverts a couple of changes to `tpch_concurrency` that were recently added in 581e671f813102b521b6ac0eed480bbf4e23ee18. In particular, this test is extremely sensitive to startup parameters, so we need to use the default `--max-sql-memory` parameter.

Fixes: #113921.

Release note: None

---

Release justification: test only change