### PR TITLE
cluster-ui: allow multiple transaction details to show multiple apps

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsUtils.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsUtils.tsx
@@ -10,9 +10,10 @@
 
 import { createSelector } from "@reduxjs/toolkit";
 import {
-  appNamesAttr,
+  addExecStats,
+  aggregateNumericStats,
+  FixLong,
   getMatchParamByName,
-  queryByName,
   txnFingerprintIdAttr,
   unset,
 } from "../util";
@@ -21,6 +22,7 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { match } from "react-router";
 import { Location } from "history";
 import { statementFingerprintIdsToText } from "../transactionsPage/utils";
+import { cloneDeep } from "lodash";
 
 type Transaction =
   cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
@@ -28,13 +30,18 @@ type Transaction =
 type Statement =
   cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 
-/**
- * getTxnFromSqlStatsTxns returns the txn from the txns list with the
- * specified txn fingerprint ID and app anme.
+type TransactionStats = cockroach.sql.ITransactionStatistics;
+
+/*
+ * getTxnFromSqlStatsTxns aggregates txn stats from the provided list which match the
+ * specified txn fingerprint ID and contains one of the provided app names.
+ * Note that the returned txn will have other properties matching the first txn
+ * in the list matching the provided criteria, but its stats_data.stats will be
+ * aggregated from all matching txns.
  *
  * @param txns List of txns to search through.
- * @param txnFingerprintID
- * @param apps
+ * @param txnFingerprintID Txn fingerprint ID to search for.
+ * @param apps list of app names to filter by.
  */
 export const getTxnFromSqlStatsTxns = (
   txns: Transaction[] | null,
@@ -45,21 +52,21 @@ export const getTxnFromSqlStatsTxns = (
     return null;
   }
 
-  return txns.find(
-    txn =>
-      txn.stats_data.transaction_fingerprint_id.toString() ===
-        txnFingerprintID &&
-      (apps?.length ? apps.includes(txn.stats_data.app ?? unset) : true),
+  return mergeTransactionStats(
+    txns.filter(
+      txn =>
+        txn.stats_data.transaction_fingerprint_id.toString() ===
+          txnFingerprintID &&
+        (!apps?.length || apps.includes(txn.stats_data.app || unset)),
+    ),
   );
 };
 
 export const getTxnFromSqlStatsMemoized = createSelector(
-  (resp: SqlStatsResponse, _match: match, _location: Location): Transaction[] =>
+  (resp: SqlStatsResponse, _match: match, _apps: string): Transaction[] =>
     resp?.transactions ?? [],
-  (_resp, _match, location): string[] =>
-    queryByName(location, appNamesAttr)
-      ?.split(",")
-      .map(s => s.trim()) ?? [],
+  (_resp, _match, apps): string[] =>
+    apps?.split(",").map((s: string) => s.trim()) ?? [],
   (_resp, routeMatch, _location: Location): string =>
     getMatchParamByName(routeMatch, txnFingerprintIdAttr),
   (txns, apps, fingerprintID): Transaction => {
@@ -89,21 +96,93 @@ export const getTxnQueryString = (
 
 /**
  * getStatementsForTransaction returns the list of stmts with transaction ids
- * matching the txn id of the provided txn.
- * @param txn Txn for which we will find matching stmts.
+ * matching and app name matching that of the provided txn.
+ * @param txnFingerprintIDString Txn fingerprint id for which we will find matching stmts.
+ * @param apps List of app names to filter stmts by.
  * @param stmts List of available stmts.
  */
 export const getStatementsForTransaction = (
-  txn: Transaction | null,
+  txnFingerprintIDString: string,
+  apps: string[],
   stmts: Statement[] | null,
 ): Statement[] => {
-  if (!txn || !stmts?.length) return [];
-
-  const txnIDString = txn.stats_data?.transaction_fingerprint_id?.toString();
+  if (!txnFingerprintIDString || !stmts?.length) return [];
 
   return stmts.filter(
     s =>
-      s.key.key_data?.transaction_fingerprint_id?.toString() === txnIDString ||
-      s.txn_fingerprint_ids?.map(t => t.toString()).includes(txnIDString),
+      (s.key.key_data?.transaction_fingerprint_id?.toString() ===
+        txnFingerprintIDString ||
+        s.txn_fingerprint_ids
+          ?.map(t => t.toString())
+          .includes(txnFingerprintIDString)) &&
+      (!apps?.length ||
+        apps.includes(s.key.key_data.app ? s.key.key_data.app : unset)),
   );
+};
+
+// addTransactionStats adds together two stat objects into one using their counts to compute a new
+// average for the numeric statistics. It's modeled after the similar `addStatementStats` function
+function addTransactionStats(
+  a: TransactionStats,
+  b: TransactionStats,
+): Required<TransactionStats> {
+  const countA = FixLong(a.count).toInt();
+  const countB = FixLong(b.count).toInt();
+  return {
+    count: a.count.add(b.count),
+    max_retries: a.max_retries.greaterThan(b.max_retries)
+      ? a.max_retries
+      : b.max_retries,
+    num_rows: aggregateNumericStats(a.num_rows, b.num_rows, countA, countB),
+    service_lat: aggregateNumericStats(
+      a.service_lat,
+      b.service_lat,
+      countA,
+      countB,
+    ),
+    retry_lat: aggregateNumericStats(a.retry_lat, b.retry_lat, countA, countB),
+    commit_lat: aggregateNumericStats(
+      a.commit_lat,
+      b.commit_lat,
+      countA,
+      countB,
+    ),
+    idle_lat: aggregateNumericStats(a.idle_lat, b.idle_lat, countA, countB),
+    rows_read: aggregateNumericStats(a.rows_read, b.rows_read, countA, countB),
+    rows_written: aggregateNumericStats(
+      a.rows_written,
+      b.rows_written,
+      countA,
+      countB,
+    ),
+    bytes_read: aggregateNumericStats(
+      a.bytes_read,
+      b.bytes_read,
+      countA,
+      countB,
+    ),
+    exec_stats: addExecStats(a.exec_stats, b.exec_stats),
+  };
+}
+
+// mergeTransactionStats takes a list of transactions (assuming they're all for the same fingerprint)
+// and returns a copy of the first element with its `stats_data.stats` object replaced with a
+// merged stats object that aggregates statistics from every copy of the fingerprint in the list
+// provided. This function SHOULD NOT mutate any objects in the provided txns array.
+const mergeTransactionStats = function (txns: Transaction[]): Transaction {
+  if (txns.length === 0) {
+    return null;
+  }
+
+  if (txns.length === 1) {
+    return txns[0];
+  }
+
+  const txn = cloneDeep(txns[0]);
+
+  txn.stats_data.stats = txns
+    .map(t => t.stats_data.stats)
+    .reduce(addTransactionStats);
+
+  return txn;
 };

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -155,7 +155,7 @@ export function makeTransactionsColumns(
               item.stats_data.statement_fingerprint_ids,
               statements,
             ) || "Transaction query unavailable.",
-          appName: item.stats_data.app,
+          appName: item.stats_data.app ? item.stats_data.app : unset,
           transactionFingerprintId:
             item.stats_data.transaction_fingerprint_id.toString(),
           search,

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -315,7 +315,7 @@ export function statementKey(stmt: ExecutionStatistics): string {
 export function transactionScopedStatementKey(
   stmt: ExecutionStatistics,
 ): string {
-  return statementKey(stmt) + stmt.txn_fingerprint_ids?.toString();
+  return statementKey(stmt) + stmt.txn_fingerprint_ids?.toString() + stmt.app;
 }
 
 export const generateStmtDetailsToID = (


### PR DESCRIPTION
This patch fixes a bug in the transaction details page where we could
only show a transaction fingerprint id from a single application at a
time. In the statements page, specifying multiple app names in the
URL search params (or none for all apps) would show statement fingerprint
ids from all of those applications. This behaviour did not exist for
the transaction details page. In fact, the aggregation functions we
previously had for transactions was only being used on the transaction
overview page (which no longer aggregates transactions with the same
app name). This patch allows viewing a transaction fingerprint id from
multiple applications. The user can specify which applications to view
using the `appNames` URL search param containing a comma separated list
of application names. Not specifying any applications will result in
viewing all applications containing the requested fingerprint.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/114254

Release note (bug fix): In the SQL Activity Transaction Details page,
users can now view a transaction fingerprint id across  multiple
applications. To do so, they can specify the app name in the
`appNames` URL search param using a comma separated encoded string  of
transaction fingerprint ids.


Before
---------------------------
Note the differing application names of the statement and transaction when looking at transaction details. This indicates that a statement with a different app name was included in the aggregation.
https://www.loom.com/share/a2a7ddda922d435a8172fc31d2df6762

After
--------------------------
https://www.loom.com/share/95ce0ee2f94a4130a819b2dc652e23d4