### PR TITLE
backupccl: wrap some errors to make debugging easier

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -371,7 +371,7 @@ func backup(
 			progCh,
 			tracingAggCh,
 			backupSpecs,
-		), "exporting %d ranges", errors.Safe(numTotalSpans))
+		), "running distributed backup to export %d ranges", errors.Safe(numTotalSpans))
 	}
 
 	if err := ctxgroup.GoAndWait(

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -7521,7 +7521,7 @@ func TestBackupExportRequestTimeout(t *testing.T) {
 	// should hang. The timeout should save us in this case.
 	_, err := sqlSessions[1].DB.ExecContext(ctx, "BACKUP data.bank TO 'nodelocal://1/timeout'")
 	require.Regexp(t,
-		`exporting .*/Table/\d+/.*\: context deadline exceeded`,
+		`running distributed backup to export.*/Table/\d+/.*\: context deadline exceeded`,
 		err.Error())
 }
 

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -332,7 +332,7 @@ func restore(
 	countSpansCh := make(chan execinfrapb.RestoreSpanEntry, 1000)
 	genSpan := func(ctx context.Context, spanCh chan execinfrapb.RestoreSpanEntry) error {
 		defer close(spanCh)
-		return generateAndSendImportSpans(
+		return errors.Wrap(generateAndSendImportSpans(
 			ctx,
 			dataToRestore.getSpans(),
 			backupManifests,
@@ -340,7 +340,7 @@ func restore(
 			backupLocalityMap,
 			filter,
 			spanCh,
-		)
+		), "generate and send import spans")
 	}
 
 	// Count number of import spans.
@@ -371,9 +371,9 @@ func restore(
 		progressLogger := jobs.NewChunkProgressLogger(job, numImportSpans, job.FractionCompleted(), progressTracker.updateJobCallback)
 
 		jobProgressLoop := func(ctx context.Context) error {
-			ctx, progressSpan := tracing.ChildSpan(ctx, "progress-log")
+			ctx, progressSpan := tracing.ChildSpan(ctx, "progress-loop")
 			defer progressSpan.Finish()
-			return progressLogger.Loop(ctx, requestFinishedCh)
+			return errors.Wrap(progressLogger.Loop(ctx, requestFinishedCh), "job progress loop")
 		}
 		tasks = append(tasks, jobProgressLoop)
 	}
@@ -425,7 +425,7 @@ func restore(
 	runRestore := func(ctx context.Context) error {
 		if details.ExperimentalOnline {
 			log.Warningf(ctx, "EXPERIMENTAL ONLINE RESTORE being used")
-			return sendAddRemoteSSTs(
+			return errors.Wrap(sendAddRemoteSSTs(
 				ctx,
 				execCtx,
 				job,
@@ -436,7 +436,7 @@ func restore(
 				progCh,
 				tracingAggCh,
 				genSpan,
-			)
+			), "sending remote AddSSTable requests")
 		}
 		md := restoreJobMetadata{
 			jobID:              job.ID(),
@@ -450,20 +450,17 @@ func restore(
 			numImportSpans:     numImportSpans,
 			execLocality:       details.ExecutionLocality,
 		}
-		return distRestore(
+		return errors.Wrap(distRestore(
 			ctx,
 			execCtx,
 			md,
 			progCh,
 			tracingAggCh,
-		)
+		), "running distributed restore")
 	}
 	tasks = append(tasks, runRestore)
 
 	if err := ctxgroup.GoAndWait(restoreCtx, tasks...); err != nil {
-		// This leaves the data that did get imported in case the user wants to
-		// retry.
-		// TODO(dan): Build tooling to allow a user to restart a failed restore.
 		return emptyRowCount, errors.Wrapf(err, "importing %d ranges", numImportSpans)
 	}
 	// progress go routines should be shutdown, but use lock just to be safe.

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -94,7 +94,7 @@ func distRestore(
 	if md.encryption != nil && md.encryption.Mode == jobspb.EncryptionMode_KMS {
 		kms, err := cloud.KMSFromURI(ctx, md.encryption.KMSInfo.Uri, md.kmsEnv)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "creating KMS")
 		}
 		defer func() {
 			err := kms.Close()
@@ -276,7 +276,7 @@ func distRestore(
 
 	p, planCtx, err := makePlan(ctx, dsp)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "making distSQL plan")
 	}
 
 	replanner, stopReplanner := sql.PhysicalPlanChangeChecker(ctx,
@@ -322,7 +322,7 @@ func distRestore(
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx
 		dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
-		return rowResultWriter.Err()
+		return errors.Wrap(rowResultWriter.Err(), "running distSQL flow")
 	})
 
 	g.GoCtx(replanner)


### PR DESCRIPTION
This change wraps some of the errors thrown in the different goroutines spawned during backup and restore.

Informs: #113843
Release note: None