### PR TITLE
release-23.2: plpgsql: disallow RECORD-type variables as unsupported

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1409,6 +1409,13 @@ func TestTenantLogic_plpgsql_cursor(
 	runLogicTest(t, "plpgsql_cursor")
 }
 
+func TestTenantLogic_plpgsql_unsupported(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_unsupported")
+}
+
 func TestTenantLogic_poison_after_push(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/plpgsql_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/plpgsql_unsupported
@@ -1,0 +1,10 @@
+# LogicTest: !local-mixed-23.1
+
+statement error pq: unimplemented: RECORD type for PL/pgSQL variables is not yet supported.*
+CREATE OR REPLACE PROCEDURE foo() AS $$
+  DECLARE
+    x RECORD;
+  BEGIN
+    RAISE NOTICE 'x: %', x;
+  END
+$$ LANGUAGE plpgsql;

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1387,6 +1387,13 @@ func TestLogic_plpgsql_cursor(
 	runLogicTest(t, "plpgsql_cursor")
 }
 
+func TestLogic_plpgsql_unsupported(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_unsupported")
+}
+
 func TestLogic_poison_after_push(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1387,6 +1387,13 @@ func TestLogic_plpgsql_cursor(
 	runLogicTest(t, "plpgsql_cursor")
 }
 
+func TestLogic_plpgsql_unsupported(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_unsupported")
+}
+
 func TestLogic_poison_after_push(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1401,6 +1401,13 @@ func TestLogic_plpgsql_cursor(
 	runLogicTest(t, "plpgsql_cursor")
 }
 
+func TestLogic_plpgsql_unsupported(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_unsupported")
+}
+
 func TestLogic_poison_after_push(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1373,6 +1373,13 @@ func TestLogic_plpgsql_cursor(
 	runLogicTest(t, "plpgsql_cursor")
 }
 
+func TestLogic_plpgsql_unsupported(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_unsupported")
+}
+
 func TestLogic_poison_after_push(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1401,6 +1401,13 @@ func TestLogic_plpgsql_cursor(
 	runLogicTest(t, "plpgsql_cursor")
 }
 
+func TestLogic_plpgsql_unsupported(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_unsupported")
+}
+
 func TestLogic_poison_after_push(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1527,6 +1527,13 @@ func TestLogic_plpgsql_cursor(
 	runLogicTest(t, "plpgsql_cursor")
 }
 
+func TestLogic_plpgsql_unsupported(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "plpgsql_unsupported")
+}
+
 func TestLogic_poison_after_push(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -188,6 +188,12 @@ func (b *plpgsqlBuilder) init(
 				"collation for PL/pgSQL variables is not yet supported",
 			))
 		}
+		if types.IsRecordType(typ) {
+			panic(unimplemented.NewWithIssueDetail(114874,
+				"RECORD variable",
+				"RECORD type for PL/pgSQL variables is not yet supported",
+			))
+		}
 	}
 }
 

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -1258,6 +1258,11 @@ func TestSchemaChangeComparator_plpgsql_cursor(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/plpgsql_cursor"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
+func TestSchemaChangeComparator_plpgsql_unsupported(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/plpgsql_unsupported"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_poison_after_push(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/poison_after_push"


### PR DESCRIPTION
Backport 1/1 commits from #114875.

/cc @cockroachdb/release

---

Fixes: #114682.

Release note: None

Release justification: low-risk cleanup.