### PR TITLE
streamingccl: only return lag replanning error if lagging node has not advanced

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
@@ -152,3 +152,78 @@ func TestHeartbeatLoop(t *testing.T) {
 		}
 	}
 }
+
+func TestLaggingNodeErrorHandler(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	type testCase struct {
+		name                        string
+		replicatedTime              int64
+		previousReplicatedTimeOnLag int64
+		inputLagErr                 error
+
+		expectedNewReplicatedTimeOnLag int64
+		expectedErrMsg                 string
+	}
+
+	for _, tc := range []testCase{
+		{
+			name:                           "no more lag",
+			previousReplicatedTimeOnLag:    1,
+			expectedNewReplicatedTimeOnLag: 0,
+		},
+		{
+			name:                           "new lag",
+			previousReplicatedTimeOnLag:    0,
+			replicatedTime:                 1,
+			expectedNewReplicatedTimeOnLag: 1,
+			inputLagErr:                    ErrNodeLagging,
+		},
+		{
+			name:                           "repeated lag, no hwm advance",
+			previousReplicatedTimeOnLag:    1,
+			replicatedTime:                 1,
+			expectedNewReplicatedTimeOnLag: 1,
+			inputLagErr:                    ErrNodeLagging,
+			expectedErrMsg:                 ErrNodeLagging.Error(),
+		},
+		{
+			name:                           "repeated lag, with hwm advance",
+			previousReplicatedTimeOnLag:    1,
+			replicatedTime:                 2,
+			expectedNewReplicatedTimeOnLag: 2,
+			inputLagErr:                    ErrNodeLagging,
+		},
+		{
+			name:           "non lag error",
+			inputLagErr:    errors.New("unexpected"),
+			expectedErrMsg: "unexpected",
+		},
+		{
+			name:                           "unhandlable lag error",
+			previousReplicatedTimeOnLag:    2,
+			replicatedTime:                 1,
+			expectedNewReplicatedTimeOnLag: 2,
+			inputLagErr:                    ErrNodeLagging,
+			expectedErrMsg:                 "unable to handle replanning",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			sf := streamIngestionFrontier{
+				persistedReplicatedTime:                  hlc.Timestamp{WallTime: tc.replicatedTime},
+				replicatedTimeAtLastPositiveLagNodeCheck: hlc.Timestamp{WallTime: tc.previousReplicatedTimeOnLag},
+			}
+			err := sf.handleLaggingNodeError(ctx, tc.inputLagErr)
+			if tc.expectedErrMsg == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.expectedErrMsg)
+			}
+			require.Equal(t, hlc.Timestamp{WallTime: tc.expectedNewReplicatedTimeOnLag}, sf.replicatedTimeAtLastPositiveLagNodeCheck)
+		})
+	}
+}

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1752,7 +1752,7 @@ func destClusterSettings(t test.Test, db *sqlutils.SQLRunner, additionalDuration
 	db.ExecMultiple(t, `SET CLUSTER SETTING cross_cluster_replication.enabled = true;`,
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true;`,
 		`SET CLUSTER SETTING stream_replication.replan_flow_threshold = 0.1;`,
-		`SET CLUSTER SETTING physical_replication.consumer.node_lag_replanning_threshold = '10m';`)
+		`SET CLUSTER SETTING physical_replication.consumer.node_lag_replanning_threshold = '5m';`)
 
 	if additionalDuration != 0 {
 		replanFrequency := additionalDuration / 2


### PR DESCRIPTION
Previously, the frontier processor would return a lag replanning error if it detected a lagging node and after the hwm had advanced during the flow. This implies the frontier processor could replan as soon as a lagging node finished its catchup scan and bumped the hwm, but was still far behind the other nodes, as we observed in #114706. Ideally, the frontier processor should not throw this replanning error because the lagging node is making progress and because replanning can cause repeated work.

This patch prevents this scenario by teaching the frontier processor to only throw a replanning error if:
- the hwm has advanced in the flow
- two consecutive lagging node checks detected a lagging node and the hwm has not advanced during those two checks.

Informs #114706

Release note: none