### PR TITLE
schemafeed: store codec instead of reading it from the lease manager

### DIFF
--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
@@ -374,10 +374,6 @@ func (t *testLeaseAcquirer) AcquireFreshestFromStore(ctx context.Context, id des
 	return nil
 }
 
-func (t *testLeaseAcquirer) Codec() keys.SQLCodec {
-	panic("should not be called")
-}
-
 type testLeasedDescriptor struct {
 	lease.LeasedDescriptor
 	timestamp hlc.Timestamp


### PR DESCRIPTION
It seems strange that we are reading the codec off of the lease
manager. We should instead store the codec from the server config
at the time the schema feed is instantiated.

Epic: None

Release note: None