### PR TITLE
roachtest: delete home directory between cluster reuse

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2666,12 +2666,19 @@ func (c *clusterImpl) StopGrafana(ctx context.Context, l *logger.Logger, dumpDir
 func (c *clusterImpl) WipeForReuse(
 	ctx context.Context, l *logger.Logger, newClusterSpec spec.ClusterSpec,
 ) error {
+	if c.IsLocal() {
+		return errors.New("cluster reuse is disabled for local clusters to guarantee a clean slate for each test")
+	}
 	l.PrintfCtx(ctx, "Using existing cluster: %s (arch=%q). Wiping", c.name, c.arch)
 	if err := c.WipeE(ctx, l, false /* preserveCerts */); err != nil {
 		return err
 	}
-	if err := c.RunE(ctx, c.All(), fmt.Sprintf("rm -rf %s %s", perfArtifactsDir, goCoverArtifactsDir)); err != nil {
-		return errors.Wrapf(err, "failed to remove perf/gocover artifacts dirs")
+	// We remove the entire shared user directory between tests to ensure we aren't
+	// reusing files from previous tests, i.e. cockroach binaries, perf artifacts.
+	// N.B. we don't remove the entire home directory to safeguard against this ever
+	// running locally and deleting someone's local directory.
+	if err := c.RunE(ctx, c.All(), fmt.Sprintf("rm -rf /home/%s/*", config.SharedUser)); err != nil {
+		return errors.Wrapf(err, "failed to remove home directory")
 	}
 	if c.localCertsDir != "" {
 		if err := os.RemoveAll(c.localCertsDir); err != nil {

--- a/pkg/cmd/roachtest/tests/gopg.go
+++ b/pkg/cmd/roachtest/tests/gopg.go
@@ -140,6 +140,11 @@ func registerGopg(r registry.Registry) {
 							cat %s | %s/bin/go-junit-report`,
 				destPath, goPath, resultsFilePath, goPath),
 		)
+		// It's safer to clean up dependencies this way than it is to give the cluster
+		// wipe root access.
+		defer func() {
+			c.Run(ctx, c.All(), "go clean -modcache")
+		}()
 
 		// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.
 		// Proceed for any other (command) errors

--- a/pkg/cmd/roachtest/tests/gorm.go
+++ b/pkg/cmd/roachtest/tests/gorm.go
@@ -78,6 +78,11 @@ func registerGORM(r registry.Registry) {
 		); err != nil {
 			t.Fatal(err)
 		}
+		// It's safer to clean up dependencies this way than it is to give the cluster
+		// wipe root access.
+		defer func() {
+			c.Run(ctx, c.All(), "go clean -modcache")
+		}()
 
 		if err := repeatGitCloneE(
 			ctx,

--- a/pkg/cmd/roachtest/tests/libpq.go
+++ b/pkg/cmd/roachtest/tests/libpq.go
@@ -75,6 +75,11 @@ func registerLibPQ(r registry.Registry) {
 			fmt.Sprintf("GOPATH=%s go install github.com/jstemmer/go-junit-report@latest", goPath),
 		)
 		require.NoError(t, err)
+		// It's safer to clean up dependencies this way than it is to give the cluster
+		// wipe root access.
+		defer func() {
+			c.Run(ctx, c.All(), "go clean -modcache")
+		}()
 
 		err = repeatGitCloneE(
 			ctx,

--- a/pkg/cmd/roachtest/tests/pgx.go
+++ b/pkg/cmd/roachtest/tests/pgx.go
@@ -83,6 +83,11 @@ func registerPgx(r registry.Registry) {
 		); err != nil {
 			t.Fatal(err)
 		}
+		// It's safer to clean up dependencies this way than it is to give the cluster
+		// wipe root access.
+		defer func() {
+			c.Run(ctx, c.All(), "go clean -modcache")
+		}()
 
 		RunningStatus := fmt.Sprintf("Running cockroach version %s, using blocklist %s, using ignorelist %s",
 			version, "pgxBlocklist", "pgxIgnorelist")


### PR DESCRIPTION
The cockroach binary was not deleted in wipe, leading to unexpected behavior where a reused cluster could use the binary without uploading it first. Now we delete the entire home directory to make sure we don't reuse files between runs.

To further strengthen the guarantee that we run each test from a clean slate, we also disable cluster reuse for local runs. The destroy create loop is cheap for local runs so minimal cost is added.

Release note: none
Epic: none
Fixes: #114246