### PR TITLE
ui: improve unable to find session error message

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -269,6 +269,11 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
           <h3>Unable to find session</h3>
           There is no session with the id{" "}
           {getMatchParamByName(this.props.match, sessionAttr)}.
+          <br />
+          {`The session’s details may no longer be available because they were
+          removed from cache, which is controlled by the cluster settings
+          'sql.closed_session_cache.capacity' and
+          'sql.closed_session_cache.time_to_live'.`}
         </section>
       );
     }


### PR DESCRIPTION
Adds a message when a session details is no longer available, to explain why that might be the case.

Fixes CRDB-33705

Before
<img width="487" alt="Screenshot 2023-11-22 at 5 24 50 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/81421c12-90c2-4586-9702-597a93f2fd71">



After
<img width="1056" alt="Screenshot 2023-11-22 at 5 26 11 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/fd56285d-0877-49fe-b7eb-00de18fbbf5f">



Release note: None