### PR TITLE
backupccl: remove code to revlidate offline indexes

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -441,17 +441,7 @@ message RestoreDetails {
   ];
   BackupEncryptionOptions encryption = 12;
 
-  message RevalidateIndex {
-    uint32 id = 1 [
-      (gogoproto.customname) = "TableID",
-      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID"
-    ];
-    uint32 parent_id = 2 [
-      (gogoproto.customname) = "IndexID",
-      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.IndexID"
-    ];
-  }
-  repeated RevalidateIndex revalidate_indexes = 18 [(gogoproto.nullable) = false];
+  reserved 18;
 
   message DatabaseModifier {
     // ExtraTypeDescs enumerates additional type descriptors to add as part of


### PR DESCRIPTION
No longer required since we don't support restoring older backups where these indexes were untrusted.

Release note: none.
Epic: none.