### PR TITLE
pgwire: support text decoding of composite types

### DIFF
--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -313,9 +313,7 @@ func validateArrayDimensions(nDimensions int, nElements int) error {
 	return nil
 }
 
-// DecodeDatum decodes bytes with specified type and format code into
-// a datum. If res is nil, then user defined types are not attempted
-// to be resolved.
+// DecodeDatum decodes bytes with specified type and format code into a datum.
 func DecodeDatum(
 	ctx context.Context, evalCtx *eval.Context, typ *types.T, code FormatCode, b []byte,
 ) (tree.Datum, error) {
@@ -469,9 +467,10 @@ func DecodeDatum(
 			}
 			return &tree.DTSVector{TSVector: ret}, nil
 		}
-		if typ.Family() == types.ArrayFamily {
-			// Arrays come in in their string form, so we parse them as such and later
-			// convert them to their actual datum form.
+		switch typ.Family() {
+		case types.ArrayFamily, types.TupleFamily:
+			// Arrays and tuples come in in their string form, so we parse them
+			// as such and later convert them to their actual datum form.
 			if err := validateStringBytes(b); err != nil {
 				return nil, err
 			}

--- a/pkg/sql/pgwire/testdata/pgtest/tuple
+++ b/pkg/sql/pgwire/testdata/pgtest/tuple
@@ -127,6 +127,22 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+# Same as above, but using the text format (ParameterFormatCodes = [0] is for
+# text format).
+send
+Bind {"DestinationPortal": "p_valid_param_text", "PreparedStatement": "s_valid_param", "ParameterFormatCodes": [0], "Parameters": [{"text":"(t)"}], "ResultFormatCodes": [0]}
+Execute {"Portal": "p_valid_param_text"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"(t)"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
 # empty parameter
 send
 Parse {"Name": "s_empty_param", "Query": "SELECT $1::r"}


### PR DESCRIPTION
This commit adds the decoding of composite types from the text format (i.e. it's a similar to 072f8d81569bf2af8b0b4d538bf88f8d3f4d7e6e fix). Previously, this would cause an internal error.

Fixes: #113723.

Release note (bug fix): Previously, CockroachDB could encounter an internal error when using the text format (as opposed to binary) when preparing statements with user-defined composite types. The bug was introduced in 23.1 and is now fixed.