### PR TITLE
storage: reduce EFOSWait during tests

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -66,7 +66,12 @@ var maxSyncDurationDefault = envutil.EnvOrDefaultDuration("COCKROACH_ENGINE_MAX_
 
 // Default maximum wait time before an EventuallyFileOnlySnapshot transitions
 // to a file-only snapshot.
-var MaxEFOSWait = envutil.EnvOrDefaultDuration("COCKROACH_EFOS_MAX_WAIT", 3*time.Second)
+var MaxEFOSWait = envutil.EnvOrDefaultDuration("COCKROACH_EFOS_MAX_WAIT", func() time.Duration {
+	if buildutil.CrdbTestBuild {
+		return 100 * time.Millisecond
+	}
+	return 3 * time.Second
+}())
 
 // MaxSyncDuration is the threshold above which an observed engine sync duration
 // triggers either a warning or a fatal error.


### PR DESCRIPTION
In shared-process multi-tenancy tests, we've seen this stalling server shutdown for the entire wait time. It isn't entirely clear to me why this impacts shared-process mode more than a standard test server.

Epic: none

Release note: None