### PR TITLE
ui: keep timewindow with fixed range after Now button click

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.tsx
@@ -183,7 +183,12 @@ export const TimeScaleDropdown: React.FC<TimeScaleDropdownProps> = ({
       case ArrowDirection.CENTER:
         // CENTER is used to set the time window to the current time.
         endTime = now;
-        isMoving = true;
+        // Only predefined time ranges are considered to be moving window (ie Past Hour, Past 3 days, etc).
+        // Custom time window has specific start/end time and constant duration, and in this case we
+        // move time window with the same duration with end time = now() and keep it fixed as before.
+        if (key !== "Custom") {
+          isMoving = true;
+        }
         break;
       default:
         getLogger().error("Unknown direction: ", direction);


### PR DESCRIPTION
This change fixes behavior of Now button in TimeScale component. Before, when user selected some custom time range then clicked Now button - it would not update charts because there was inconsistency. Custom time range cannot be with "moving" attribute, it cannot be updated every time to reflect most recent data as custom range has fixed end time.

This change checks if current preset is custom and doesn't set "moving" attribute in this case.

Epic: None

Resolves: #113091

Release note (ui change): proper handling of "Now" button on Time range selector when custom time period was selected before.

![Screen Recording 2023-11-23 at 17 42 09 mov](https://github.com/cockroachdb/cockroach/assets/3106437/a7748ab0-d779-4b55-ad4f-f56493a9e836)
