### PR TITLE
roachtest : add --use-spot option

### DIFF
--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -304,6 +304,12 @@ var (
 			run at least one test per prefix.`,
 	})
 
+	UseSpotVM bool
+	_         = registerRunFlag(&UseSpotVM, FlagInfo{
+		Name:  "use-spot",
+		Usage: `Use SpotVM to run tests, If the provider does not support spotVM, it will be ignored`,
+	})
+
 	GlobalSeed int64 = randutil.NewPseudoSeed()
 	_                = registerRunFlag(&GlobalSeed, FlagInfo{
 		Name:  "global-seed",

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -648,6 +648,10 @@ func (r *testRunner) runWorker(
 			}
 		}
 
+		if roachtestflags.UseSpotVM {
+			testToRun.spec.Cluster.UseSpotVMs = true
+		}
+
 		// Verify that required native libraries are available.
 		//
 		// TODO(radu): the arch is not guaranteed and another arch can be selected


### PR DESCRIPTION
This options enables use of SpotVM to run tests, If the provider does not support spotVM, it will be ignored

Epic: none

Release note: None