### PR TITLE
roachtest: add `UploadCockroach` and `UploadWorkload` APIs

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -701,7 +701,7 @@ func (s startStep) Description() string {
 // Run uploads the binary associated with the given version and starts
 // the cockroach binary on the nodes.
 func (s startStep) Run(ctx context.Context, l *logger.Logger, c cluster.Cluster, h *Helper) error {
-	binaryPath, err := clusterupgrade.UploadVersion(ctx, s.rt, l, c, s.crdbNodes, s.version)
+	binaryPath, err := clusterupgrade.UploadCockroach(ctx, s.rt, l, c, s.crdbNodes, s.version)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -67,7 +67,7 @@ func registerDatabaseDrop(r registry.Registry) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				path, err := clusterupgrade.UploadVersion(
+				path, err := clusterupgrade.UploadCockroach(
 					ctx, t, t.L(), c, c.All(), clusterupgrade.MustParseVersion(pred),
 				)
 				if err != nil {

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -79,7 +79,7 @@ func registerIndexBackfill(r registry.Registry) {
 							t.Fatal(err)
 						}
 
-						path, err := clusterupgrade.UploadVersion(
+						path, err := clusterupgrade.UploadCockroach(
 							ctx, t, t.L(), c, c.All(), clusterupgrade.MustParseVersion(pred),
 						)
 						if err != nil {

--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -132,7 +132,7 @@ func (bd *backupDriver) prepareCluster(ctx context.Context) {
 		// For now, only run the test on the cloud provider that also stores the backup.
 		bd.t.Skip(fmt.Sprintf("test configured to run on %s", bd.sp.backup.cloud))
 	}
-	binaryPath, err := clusterupgrade.UploadVersion(ctx, bd.t, bd.t.L(), bd.c,
+	binaryPath, err := clusterupgrade.UploadCockroach(ctx, bd.t, bd.t.L(), bd.c,
 		bd.sp.hardware.getCRDBNodes(), clusterupgrade.MustParseVersion(bd.sp.backup.version))
 	require.NoError(bd.t, err)
 

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -96,8 +96,8 @@ func backupRestoreRoundTrip(
 	testRNG, seed := randutil.NewLockedPseudoRand()
 	t.L().Printf("random seed: %d", seed)
 
-	// Upload binaries and start cluster.
-	uploadVersion(ctx, t, c, c.All(), clusterupgrade.CurrentVersion())
+	// Upload cockroach and start cluster.
+	uploadCockroach(ctx, t, c, c.All(), clusterupgrade.CurrentVersion())
 
 	envOption := install.EnvOption([]string{
 		"COCKROACH_MIN_RANGE_MAX_BYTES=1",

--- a/pkg/cmd/roachtest/tests/decommission_self.go
+++ b/pkg/cmd/roachtest/tests/decommission_self.go
@@ -24,7 +24,7 @@ import (
 func runDecommissionSelf(ctx context.Context, t test.Test, c cluster.Cluster) {
 	allNodes := c.All()
 	u := newVersionUpgradeTest(c,
-		uploadVersionStep(allNodes, clusterupgrade.CurrentVersion()),
+		uploadCockroachStep(allNodes, clusterupgrade.CurrentVersion()),
 		startVersion(allNodes, clusterupgrade.CurrentVersion()),
 		fullyDecommissionStep(2, 2, clusterupgrade.CurrentVersion()),
 		func(ctx context.Context, t test.Test, u *versionUpgradeTest) {

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -896,7 +896,7 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 
 	// Start the cluster at the old version.
 	settings := install.MakeClusterSettings()
-	settings.Binary = uploadVersion(
+	settings.Binary = uploadCockroach(
 		ctx, t, c, c.All(), clusterupgrade.MustParseVersion(predecessorVersion),
 	)
 	startOpts := option.DefaultStartOpts()

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2293,7 +2293,7 @@ func (u *CommonTestUtils) resetCluster(
 		return fmt.Errorf("failed to wipe cluster: %w", err)
 	}
 
-	cockroachPath := clusterupgrade.BinaryPathForVersion(u.t, version)
+	cockroachPath := clusterupgrade.CockroachPathForVersion(u.t, version)
 	return clusterupgrade.StartWithSettings(
 		ctx, l, u.cluster, u.roachNodes, option.DefaultStartOptsNoBackups(),
 		install.BinaryOption(cockroachPath), install.SecureOption(true),
@@ -2485,7 +2485,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 			)
 			testRNG := mvt.RNG()
 
-			uploadVersion(ctx, t, c, workloadNode, clusterupgrade.CurrentVersion())
+			uploadCockroach(ctx, t, c, workloadNode, clusterupgrade.CurrentVersion())
 
 			dbs := []string{"bank", "tpcc"}
 			backupTest, err := newMixedVersionBackup(t, c, roachNodes, dbs)

--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -168,7 +168,7 @@ func runDeclSchemaChangeCompatMixedVersions(ctx context.Context, t test.Test, c 
 		},
 	}
 	for _, testInfo := range compatTests {
-		binaryName := uploadVersion(ctx, t, c, c.All(), testInfo.binaryVersion)
+		binaryName := uploadCockroach(ctx, t, c, c.All(), testInfo.binaryVersion)
 		corpusPath, cleanupFn := fetchCorpusToTmpDir(ctx, t, c, testInfo.corpusVersion, testInfo.alternateCorpusVersion)
 		func() {
 			defer cleanupFn()

--- a/pkg/cmd/roachtest/tests/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decommission.go
@@ -54,8 +54,8 @@ func runDecommissionMixedVersions(
 	u := newVersionUpgradeTest(c,
 		// We upload both binaries to each node, to be able to vary the binary
 		// used when issuing `cockroach node` subcommands.
-		uploadVersionStep(allNodes, predecessorVersion),
-		uploadVersionStep(allNodes, clusterupgrade.CurrentVersion()),
+		uploadCockroachStep(allNodes, predecessorVersion),
+		uploadCockroachStep(allNodes, clusterupgrade.CurrentVersion()),
 
 		startVersion(allNodes, predecessorVersion),
 		waitForUpgradeStep(allNodes),
@@ -149,7 +149,7 @@ func preloadDataStep(target int) versionStep {
 func partialDecommissionStep(target, from int, binaryVersion *clusterupgrade.Version) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		c := u.c
-		c.Run(ctx, c.Node(from), clusterupgrade.BinaryPathForVersion(t, binaryVersion), "node", "decommission",
+		c.Run(ctx, c.Node(from), clusterupgrade.CockroachPathForVersion(t, binaryVersion), "node", "decommission",
 			"--wait=none", "--insecure", strconv.Itoa(target), "--port", fmt.Sprintf("{pgport:%d}", from))
 	}
 }
@@ -160,7 +160,7 @@ func partialDecommissionStep(target, from int, binaryVersion *clusterupgrade.Ver
 func recommissionAllStep(from int, binaryVersion *clusterupgrade.Version) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		c := u.c
-		c.Run(ctx, c.Node(from), clusterupgrade.BinaryPathForVersion(t, binaryVersion), "node", "recommission",
+		c.Run(ctx, c.Node(from), clusterupgrade.CockroachPathForVersion(t, binaryVersion), "node", "recommission",
 			"--insecure", c.All().NodeIDsString(), "--port", fmt.Sprintf("{pgport:%d}", from))
 	}
 }
@@ -170,7 +170,7 @@ func recommissionAllStep(from int, binaryVersion *clusterupgrade.Version) versio
 func fullyDecommissionStep(target, from int, binaryVersion *clusterupgrade.Version) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		c := u.c
-		c.Run(ctx, c.Node(from), clusterupgrade.BinaryPathForVersion(t, binaryVersion), "node", "decommission",
+		c.Run(ctx, c.Node(from), clusterupgrade.CockroachPathForVersion(t, binaryVersion), "node", "decommission",
 			"--wait=all", "--insecure", strconv.Itoa(target), "--port", fmt.Sprintf("{pgport:%d}", from))
 
 		// If we are decommissioning a target node from the same node, the drain
@@ -316,12 +316,11 @@ func checkAllMembership(from int, membership string) versionStep {
 	}
 }
 
-// uploadVersionStep uploads the specified cockroach binary version on the specified
+// uploadCockroachStep uploads the specified cockroach binary version on the specified
 // nodes.
-func uploadVersionStep(nodes option.NodeListOption, version *clusterupgrade.Version) versionStep {
+func uploadCockroachStep(nodes option.NodeListOption, version *clusterupgrade.Version) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
-		// Put the binary.
-		uploadVersion(ctx, t, u.c, nodes, version)
+		uploadCockroach(ctx, t, u.c, nodes, version)
 	}
 }
 
@@ -330,7 +329,7 @@ func uploadVersionStep(nodes option.NodeListOption, version *clusterupgrade.Vers
 func startVersion(nodes option.NodeListOption, version *clusterupgrade.Version) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		settings := install.MakeClusterSettings(install.BinaryOption(
-			clusterupgrade.BinaryPathForVersion(t, version),
+			clusterupgrade.CockroachPathForVersion(t, version),
 		))
 		startOpts := option.DefaultStartOpts()
 		u.c.Start(ctx, t.L(), startOpts, settings, nodes)

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -89,8 +89,8 @@ func runMultiTenantUpgrade(
 	require.NoError(t, err)
 	predecessor := clusterupgrade.MustParseVersion(predecessorVersionStr)
 
-	currentBinary := uploadVersion(ctx, t, c, c.All(), clusterupgrade.CurrentVersion())
-	predecessorBinary := uploadVersion(ctx, t, c, c.All(), predecessor)
+	currentBinary := uploadCockroach(ctx, t, c, c.All(), clusterupgrade.CurrentVersion())
+	predecessorBinary := uploadCockroach(ctx, t, c, c.All(), predecessor)
 
 	kvNodes := c.Node(1)
 

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -99,7 +99,7 @@ func registerRebalanceLoad(r registry.Registry) {
 			predecessorVersionStr, err := release.LatestPredecessor(t.BuildVersion())
 			require.NoError(t, err)
 			predecessorVersion := clusterupgrade.MustParseVersion(predecessorVersionStr)
-			settings.Binary = uploadVersion(ctx, t, c, c.All(), predecessorVersion)
+			settings.Binary = uploadCockroach(ctx, t, c, c.All(), predecessorVersion)
 			// Upgrade some (or all) of the first N-1 CRDB nodes. We ignore the last
 			// CRDB node (to leave at least one node on the older version), and the
 			// app node.

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -440,7 +440,7 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 		return c.RunE(ctx, workloadNode, cmd)
 	}
 
-	uploadVersion(ctx, t, c, workloadNode, clusterupgrade.CurrentVersion())
+	uploadCockroach(ctx, t, c, workloadNode, clusterupgrade.CurrentVersion())
 	mvt.OnStartup("load TPCC dataset", importTPCC)
 	mvt.OnStartup("load bank dataset", importLargeBank)
 	mvt.InMixedVersion("TPCC workload", runTPCCWorkload)

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -208,17 +208,17 @@ func (u *versionUpgradeTest) conn(ctx context.Context, t test.Test, i int) *gosq
 	return db
 }
 
-// uploadVersion is a thin wrapper around
-// `clusterupgrade.UploadVersion` that calls t.Fatal if that call
-// returns an error
-func uploadVersion(
+// uploadCockroach is a thin wrapper around
+// `clusterupgrade.UploadCockroach` that calls t.Fatal if that call
+// returns an error.
+func uploadCockroach(
 	ctx context.Context,
 	t test.Test,
 	c cluster.Cluster,
 	nodes option.NodeListOption,
 	newVersion *clusterupgrade.Version,
 ) string {
-	path, err := clusterupgrade.UploadVersion(ctx, t, t.L(), c, nodes, newVersion)
+	path, err := clusterupgrade.UploadCockroach(ctx, t, t.L(), c, nodes, newVersion)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +266,7 @@ func uploadAndStartFromCheckpointFixture(
 		if err := clusterupgrade.InstallFixtures(ctx, t.L(), u.c, nodes, v); err != nil {
 			t.Fatal(err)
 		}
-		binary := uploadVersion(ctx, t, u.c, nodes, v)
+		binary := uploadCockroach(ctx, t, u.c, nodes, v)
 		startOpts := option.DefaultStartOpts()
 		if err := clusterupgrade.StartWithSettings(
 			ctx, t.L(), u.c, nodes, startOpts, install.BinaryOption(binary),
@@ -384,7 +384,7 @@ func makeVersionFixtureAndFatal(
 			name := clusterupgrade.CheckpointName(u.binaryVersion(ctx, t, 1).String())
 			u.c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.All())
 
-			binaryPath := clusterupgrade.BinaryPathForVersion(t, fixtureVersion)
+			binaryPath := clusterupgrade.CockroachPathForVersion(t, fixtureVersion)
 			c.Run(ctx, c.All(), binaryPath, "debug", "pebble", "db", "checkpoint",
 				"{store-dir}", "{store-dir}/"+name)
 			// The `cluster-bootstrapped` marker can already be found within

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/release"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
+	"github.com/cockroachdb/errors"
 )
 
 type versionFeatureTest struct {
@@ -99,7 +100,6 @@ DROP TABLE splitmerge.t;
 }
 
 func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.All())
 	mvt := mixedversion.NewTest(
 		ctx, t, t.L(), c, c.All(),
 		mixedversion.AlwaysUseFixtures, mixedversion.AlwaysUseLatestPredecessors,
@@ -108,8 +108,15 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 		"setup schema changer workload",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
 			node := h.RandomNode(rng, c.All())
+			workloadPath, err := clusterupgrade.UploadWorkload(
+				ctx, t, l, c, c.Node(node), h.Context.ToVersion,
+			)
+			if err != nil {
+				return errors.Wrap(err, "uploading workload binary")
+			}
+
 			l.Printf("executing workload init on node %d", node)
-			return c.RunE(ctx, c.Node(node), fmt.Sprintf("./workload init schemachange {pgurl%s}", c.All()))
+			return c.RunE(ctx, c.Node(node), fmt.Sprintf("%s init schemachange {pgurl%s}", workloadPath, c.All()))
 		})
 	mvt.InMixedVersion(
 		"run backup",
@@ -138,22 +145,27 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 	mvt.InMixedVersion(
 		"test schema change step",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			// We currently only stage the `workload` binary built off the
-			// SHA being tested; therefore, we skip testing the schemachange
-			// workload if this is not an upgrade or downgrade involving the
-			// current cockroach binary.
-			// TODO(renato): stage different workload binaries for the
-			// releases being used in the test and use the appropriate
-			// binary in this step.
-			if !h.Context.ToVersion.IsCurrent() {
-				l.Printf("skipping this step -- only supported when current version is involved")
-				return nil
+			randomNode := h.RandomNode(rng, c.All())
+			// The schemachange workload is designed to work up to one
+			// version back. Therefore, we upload a compatible `workload`
+			// binary to `randomNode`, where the workload will run.
+			workloadPath, err := clusterupgrade.UploadWorkload(
+				ctx, t, l, c, c.Node(randomNode), h.Context.ToVersion,
+			)
+			if err != nil {
+				return errors.Wrap(err, "uploading workload binary")
 			}
 
-			l.Printf("running schema workload step")
-			runCmd := roachtestutil.NewCommand("./workload run schemachange").Flag("verbose", 1).Flag("max-ops", 10).Flag("concurrency", 2).Arg("{pgurl:1-%d}", len(c.All()))
-			randomNode := h.RandomNode(rng, c.All())
-			return c.RunE(ctx, option.NodeListOption{randomNode}, runCmd.String())
+			l.Printf("running schemachange workload")
+			runCmd := roachtestutil.
+				NewCommand("%s run schemachange", workloadPath).
+				Flag("verbose", 1).
+				Flag("max-ops", 10).
+				Flag("concurrency", 2).
+				Arg("{pgurl:1-%d}", len(c.All())).
+				String()
+
+			return c.RunE(ctx, c.Node(randomNode), runCmd)
 		},
 	)
 


### PR DESCRIPTION
**roachtest: add `UploadCockroach` and `UploadWorkload` APIs**

This commit updates the `clusterupgrade` package to provide functions to allow tests to upload arbitrary versions of `cockroach` and `workload` binaries.

Previously, the `UploadVersion` function was focused only on cockroach binaries. With recent focus in upgrade testing, we would like to be able to stage different versions of the `workload` binary during tests as well. This will be especially useful for the `schemachange` workload, since it only supports interactions between the current and the previous version.

Fixes: #114518.

Release note: None

**roachtest: use UploadWorkload API in acceptance/version-upgrade**

This commit makes use of the recently introduced `UploadWorkload` API
to upload a `workload` binary for a specific version. In this test, we
use a version that should be compatible with the upgrade currently
being performed.

Epic: none

Release note: None