### PR TITLE
roachtest: add schemachange workload to backup-restore/roundtrip 

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -191,6 +191,8 @@ var (
 		3,
 		5,
 	}
+
+	schemaChangeDB = "schemachange"
 )
 
 // sanitizeVersionForBackup takes the string representation of a
@@ -513,7 +515,9 @@ func newTableBackup(rng *rand.Rand, dbs []string, tables [][]string) *tableBacku
 	// have foreign keys to other tables, making restoring them
 	// difficult. We could pass the `skip_missing_foreign_keys` option,
 	// but that would be a less interesting test.
-	for targetDB == "" || targetDB == "tpcc" {
+	//
+	// Avoid creating table backups for the schemachange database, as it inits with 0 tables.
+	for targetDB == "" || targetDB == "tpcc" || targetDB == schemaChangeDB {
 		targetDBIdx = rng.Intn(len(dbs))
 		targetDB = dbs[targetDBIdx]
 	}
@@ -2301,6 +2305,10 @@ func (bc *backupCollection) verifyBackupCollection(
 			return fmt.Errorf("backup %s: %w", bc.name, err)
 		}
 	}
+	_, db := d.testUtils.RandomDB(rng, d.testUtils.roachNodes)
+	if err := roachtestutil.CheckInvalidDescriptors(ctx, db); err != nil {
+		return fmt.Errorf("failed descriptor check: %w", err)
+	}
 
 	l.Printf("%s: OK", bc.name)
 	return nil
@@ -2600,6 +2608,52 @@ func bankWorkloadCmd(
 	l.Printf("bank init: %s", init)
 	l.Printf("bank run: %s", run)
 	return init, run
+}
+
+func schemaChangeWorkloadCmd(
+	l *logger.Logger, testRNG *rand.Rand, roachNodes option.NodeListOption, mock bool,
+) (init *roachtestutil.Command, run *roachtestutil.Command) {
+	maxOps := 1000
+	concurrency := 5
+	if mock {
+		maxOps = 10
+		concurrency = 2
+	}
+	initCmd := roachtestutil.NewCommand("./workload init schemachange").
+		Arg("{pgurl%s}", roachNodes)
+	// TODO (msbutler): ideally we'd use the `db` flag to explicitly set the
+	// database, but it is currently broken:
+	// https://github.com/cockroachdb/cockroach/issues/115545
+	runCmd := roachtestutil.NewCommand(fmt.Sprintf("COCKROACH_RANDOM_SEED=%d ./workload run schemachange", testRNG.Int63())).
+		Flag("verbose", 1).
+		Flag("max-ops", maxOps).
+		Flag("concurrency", concurrency).
+		Arg("{pgurl%s}", roachNodes)
+	l.Printf("sc init: %s", initCmd)
+	l.Printf("sc run: %s", runCmd)
+	return initCmd, runCmd
+}
+
+// prepSchemaChangeWorkload creates the schemaChange workload database and a non
+// empty table within it, so the test can properly fingerprint the database.
+// Without a non-empty table, the test's fingerprint logic erroneously fails.
+func prepSchemaChangeWorkload(
+	ctx context.Context,
+	workloadNode option.NodeListOption,
+	testUtils *CommonTestUtils,
+	testRNG *rand.Rand,
+) error {
+	testUtils.cluster.Put(ctx, testUtils.t.DeprecatedWorkload(), "./workload", workloadNode)
+	if err := testUtils.Exec(ctx, testRNG, fmt.Sprintf("CREATE DATABASE %s", schemaChangeDB)); err != nil {
+		return err
+	}
+	if err := testUtils.Exec(ctx, testRNG, fmt.Sprintf("CREATE TABLE %s.%s (x INT)", schemaChangeDB, "dummy")); err != nil {
+		return err
+	}
+	if err := testUtils.Exec(ctx, testRNG, fmt.Sprintf("INSERT INTO %s.%s VALUES (1)", schemaChangeDB, "dummy")); err != nil {
+		return err
+	}
+	return nil
 }
 
 type CommonTestUtils struct {


### PR DESCRIPTION
This patch adds a the schema change workload to the backup-restore/roundtrip
roachtest to increase coverage around schema changes. A future PR will add this
workload to backup-restore/mixed-version.

Informs https://github.com/cockroachdb/cockroach/issues/111890

Release note: none