### PR TITLE
sql: wait for local orchestrator during ALTER TENANT SERVICE

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1595,6 +1595,7 @@ GO_TARGETS = [
     "//pkg/server/profiler:profiler_test",
     "//pkg/server/rangetestutils:rangetestutils",
     "//pkg/server/serverctl:serverctl",
+    "//pkg/server/serverorchestrator:serverorchestrator",
     "//pkg/server/serverpb:serverpb",
     "//pkg/server/serverpb:serverpb_test",
     "//pkg/server/serverrules:serverrules",

--- a/pkg/ccl/backupccl/backup_tenant_test.go
+++ b/pkg/ccl/backupccl/backup_tenant_test.go
@@ -153,7 +153,10 @@ func TestBackupTenantImportingTable(t *testing.T) {
 	}
 	// Destroy the tenant, then restore it.
 	tSrv.AppStopper().Stop(ctx)
-	if _, err := sqlDB.DB.ExecContext(ctx, "ALTER TENANT [10] STOP SERVICE; DROP TENANT [10] IMMEDIATE"); err != nil {
+	if _, err := sqlDB.DB.ExecContext(ctx, "ALTER TENANT [10] STOP SERVICE"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlDB.DB.ExecContext(ctx, "DROP TENANT [10] IMMEDIATE"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := sqlDB.DB.ExecContext(ctx, "RESTORE TENANT 10 FROM $1", dst); err != nil {

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
@@ -15,7 +15,11 @@ SELECT crdb_internal.create_tenant(6);
 
 # Drop one of them.
 exec-sql
-ALTER TENANT [5] STOP SERVICE; DROP TENANT [5]
+ALTER TENANT [5] STOP SERVICE
+----
+
+exec-sql
+DROP TENANT [5]
 ----
 
 exec-sql
@@ -27,11 +31,11 @@ CREATE DATABASE db1;
 ----
 
 query-sql
-SELECT id,name,data_state,service_mode,active,json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'deprecatedDataState'),json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'droppedName') FROM system.tenants;
+SELECT id,name,data_state,service_mode,active,crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true)->>'droppedName', crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true)->>'deprecatedDataState' FROM system.tenants;
 ----
-1 system 1 2 true READY 
-5 <nil> 2 0 false DROP cluster-5
-6 cluster-6 1 1 true READY 
+1 system 1 2 true  READY
+5 <nil> 2 0 false cluster-5 DROP
+6 cluster-6 1 1 true  READY
 
 exec-sql
 BACKUP INTO 'nodelocal://1/cluster_without_tenants'
@@ -79,10 +83,10 @@ job paused at pausepoint
 # Application tenants backed up in an ACTIVE state should be moved to an ADD
 # state during restore.
 query-sql
-SELECT id,active,json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'deprecatedDataState'),json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'droppedName') FROM system.tenants;
+SELECT id,active,crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true)->>'deprecatedDataState' FROM system.tenants;
 ----
-1 true READY 
-6 false ADD 
+1 true READY
+6 false ADD
 
 exec-sql
 SET CLUSTER SETTING jobs.debug.pausepoints = ''
@@ -98,13 +102,12 @@ exec-sql
 USE defaultdb;
 ----
 
-# A dropped tenant should be restored as an inactive tenant.
+# Dropped tenants are not backed up and thus not restored.
 query-sql
-SELECT id,name,data_state,service_mode,active,json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'deprecatedDataState'),json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'droppedName') FROM system.tenants;
+SELECT id,name,data_state,service_mode,active,crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true)->>'deprecatedDataState' FROM system.tenants;
 ----
-1 system 1 2 true READY 
-6 cluster-6 1 1 true READY 
-
+1 system 1 2 true READY
+6 cluster-6 1 1 true READY
 
 exec-sql expect-error-regex=(tenant 6 not in backup)
 RESTORE TENANT 6 FROM LATEST IN 'nodelocal://1/cluster_without_tenants'
@@ -131,15 +134,19 @@ RESTORE TENANT 6 FROM LATEST IN 'nodelocal://1/tenant6' WITH virtual_cluster_nam
 ----
 
 query-sql
-SELECT id,name,data_state,service_mode,active,json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'deprecatedDataState'),json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'droppedName') FROM system.tenants;
+SELECT id,name,data_state,service_mode,active,crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true)->>'deprecatedDataState' FROM system.tenants;
 ----
-1 system 1 2 true READY 
-2 newname 1 1 true READY 
-6 cluster-6 1 1 true READY 
+1 system 1 2 true READY
+2 newname 1 1 true READY
+6 cluster-6 1 1 true READY
 
 # Check that another service mode is also preserved.
 exec-sql
-ALTER TENANT newname STOP SERVICE; ALTER TENANT newname START SERVICE SHARED
+ALTER TENANT newname STOP SERVICE;
+----
+
+exec-sql
+ALTER TENANT newname START SERVICE SHARED;
 ----
 
 query-sql

--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_usage
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_usage
@@ -20,7 +20,9 @@ SELECT crdb_internal.update_tenant_resource_limits(5, 1000, 100, 0, now(), 0)
 # Note this marks the tenant as dropped. The GC will not delete the tenant
 # until after the ttl expires.
 statement ok
-ALTER TENANT [5] STOP SERVICE;
+ALTER TENANT [5] STOP SERVICE
+
+statement ok
 DROP TENANT [5]
 
 query error tenant "5" is not active

--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -84,9 +84,9 @@ func TestSharedProcessTenantNodeLocalAccess(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
-	db.Exec(t, `CREATE TENANT application;
-ALTER TENANT application GRANT CAPABILITY can_use_nodelocal_storage;
-ALTER TENANT application START SERVICE SHARED`)
+	db.Exec(t, `CREATE TENANT application`)
+	db.Exec(t, `ALTER TENANT application GRANT CAPABILITY can_use_nodelocal_storage`)
+	db.Exec(t, `ALTER TENANT application START SERVICE SHARED`)
 
 	var tenantID uint64
 	db.QueryRow(t, "SELECT id FROM [SHOW TENANT application]").Scan(&tenantID)
@@ -405,7 +405,10 @@ func TestServerControllerMultiNodeTenantStartup(t *testing.T) {
 
 	t.Logf("starting tenant servers")
 	db := tc.ServerConn(0)
-	_, err := db.Exec("CREATE TENANT hello; ALTER TENANT hello START SERVICE SHARED")
+	_, err := db.Exec("CREATE TENANT hello")
+	require.NoError(t, err)
+
+	_, err = db.Exec("ALTER TENANT hello START SERVICE SHARED")
 	require.NoError(t, err)
 
 	// Pick a random node, try to run some SQL inside that tenant.

--- a/pkg/ccl/serverccl/shared_process_tenant_test.go
+++ b/pkg/ccl/serverccl/shared_process_tenant_test.go
@@ -34,7 +34,10 @@ func TestSharedProcessTenantNoSpanLimit(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	db := tc.ServerConn(0)
-	_, err := db.Exec("CREATE TENANT hello; ALTER TENANT hello START SERVICE SHARED")
+	_, err := db.Exec("CREATE TENANT hello")
+	require.NoError(t, err)
+
+	_, err = db.Exec("ALTER TENANT hello START SERVICE SHARED")
 	require.NoError(t, err)
 
 	_, err = db.Exec("SET CLUSTER SETTING spanconfig.virtual_cluster.max_spans = 1000")

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_manager_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_manager_test.go
@@ -115,8 +115,6 @@ func TestRevertTenantToTimestamp(t *testing.T) {
 		tenantSQL.CheckQueryResults(t, "SELECT max(k) FROM test.revert1", [][]string{{"1100"}})
 
 		systemSQL.Exec(t, "ALTER VIRTUAL CLUSTER target STOP SERVICE")
-		waitUntilTenantServerStopped(t, srv.SystemLayer(), "target")
-
 		systemSQL.Exec(t, fmt.Sprintf("SELECT crdb_internal.unsafe_revert_tenant_to_timestamp('target', %s)", ts))
 		systemSQL.Exec(t, "ALTER VIRTUAL CLUSTER target START SERVICE SHARED")
 

--- a/pkg/configprofiles/profiles.go
+++ b/pkg/configprofiles/profiles.go
@@ -132,13 +132,13 @@ var virtClusterInitTasks = []autoconfigpb.Task{
 var virtClusterWithAppServiceInitTasks = append(
 	virtClusterInitTasks[:len(virtClusterInitTasks):len(virtClusterInitTasks)],
 	makeTask("create an application virtual cluster",
-		nil, /* nonTxnSQL */
-		/* txnSQL */ []string{
+		/* nonTxnSQL */ []string{
 			// Create the app tenant record.
-			"CREATE VIRTUAL CLUSTER application",
+			"CREATE VIRTUAL CLUSTER IF NOT EXISTS application",
 			// Run the service for the application tenant.
 			"ALTER VIRTUAL CLUSTER application START SERVICE SHARED",
 		},
+		nil, /* txnSQL */
 	),
 	makeTask("activate application virtual cluster",
 		/* nonTxnSQL */ []string{

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -192,6 +192,7 @@ go_library(
         "//pkg/server/privchecker",
         "//pkg/server/profiler",
         "//pkg/server/serverctl",
+        "//pkg/server/serverorchestrator",
         "//pkg/server/serverpb",
         "//pkg/server/serverrules",
         "//pkg/server/settingswatcher",

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/apiconstants"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/privchecker"
+	"github.com/cockroachdb/cockroach/pkg/server/serverorchestrator"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
@@ -1037,8 +1038,8 @@ func (s *adminServer) tableDetailsHelper(
 				SELECT
 					sum((d->>'live_bytes')::INT8) AS live,
 					sum(
-						(d->>'key_bytes')::INT8 + 
-						(d->>'val_bytes')::INT8 + 
+						(d->>'key_bytes')::INT8 +
+						(d->>'val_bytes')::INT8 +
 						COALESCE((d->>'range_key_bytes')::INT8, 0) +
 						COALESCE((d->>'range_val_bytes')::INT8, 0) +
 						(d->>'sys_bytes')::INT8) AS total
@@ -1066,8 +1067,8 @@ func (s *adminServer) tableDetailsHelper(
 				SELECT
 					sum((d->>'live_bytes')::INT8) AS live,
 					sum(
-						(d->>'key_bytes')::INT8 + 
-						(d->>'val_bytes')::INT8 + 
+						(d->>'key_bytes')::INT8 +
+						(d->>'val_bytes')::INT8 +
 						COALESCE((d->>'range_key_bytes')::INT8, 0) +
 						COALESCE((d->>'range_val_bytes')::INT8, 0) +
 						(d->>'sys_bytes')::INT8) AS total
@@ -4047,7 +4048,7 @@ func (s *systemAdminServer) ListTenants(
 	for _, tenantName := range tenantNames {
 		server, _, err := s.server.serverController.getServer(ctx, tenantName)
 		if err != nil {
-			if errors.Is(err, errNoTenantServerRunning) {
+			if errors.Is(err, serverorchestrator.ErrNoTenantServerRunning) {
 				// The service for this tenant is not started yet. This is not
 				// an error - the services are started asynchronously. The
 				// client can try again later.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -74,6 +74,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics"
 	"github.com/cockroachdb/cockroach/pkg/server/privchecker"
 	"github.com/cockroachdb/cockroach/pkg/server/serverctl"
+	"github.com/cockroachdb/cockroach/pkg/server/serverorchestrator"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverrules"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
@@ -1101,6 +1102,18 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		node.storeCfg.KVFlowController,
 	)
 
+	// Create a server controller.
+	sc := newServerController(ctx,
+		cfg.BaseConfig.AmbientCtx,
+		node, cfg.BaseConfig.IDContainer,
+		stopper, st,
+		lateBoundServer,
+		&systemServerWrapper{server: lateBoundServer},
+		systemTenantNameContainer,
+		pgPreServer.SendRoutingError,
+		tenantCapabilitiesWatcher,
+	)
+
 	// Instantiate the SQL server proper.
 	sqlServer, err := newSQLServer(ctx, sqlServerArgs{
 		sqlServerOptionalKVArgs: sqlServerOptionalKVArgs{
@@ -1153,6 +1166,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		admissionPacerFactory:    gcoords.Elastic,
 		rangeDescIteratorFactory: rangedesc.NewIteratorFactory(db),
 		tenantCapabilitiesReader: sql.MakeSystemTenantOnly[tenantcapabilities.Reader](tenantCapabilitiesWatcher),
+		serverOrchestrator:       sql.MakeSystemTenantOnly[serverorchestrator.ServerOrchestrator](sc),
 	})
 	if err != nil {
 		return nil, err
@@ -1179,6 +1193,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 
 	// Create a drain server.
 	drain := newDrainServer(cfg.BaseConfig, stopper, stopTrigger, grpcServer, sqlServer)
+	drain.serverCtl = sc
 	drain.setNode(node, nodeLiveness)
 
 	// Instantiate the admin API server.
@@ -1215,19 +1230,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	// Tell the status server how to access SQL structures.
 	sStatus.setStmtDiagnosticsRequester(sqlServer.execCfg.StmtDiagnosticsRecorder)
 	sStatus.baseStatusServer.sqlServer = sqlServer
-
-	// Create a server controller.
-	sc := newServerController(ctx,
-		cfg.BaseConfig.AmbientCtx,
-		node, cfg.BaseConfig.IDContainer,
-		stopper, st,
-		lateBoundServer,
-		&systemServerWrapper{server: lateBoundServer},
-		systemTenantNameContainer,
-		pgPreServer.SendRoutingError,
-		tenantCapabilitiesWatcher,
-	)
-	drain.serverCtl = sc
 
 	// Create the debug API server.
 	debugServer := debug.NewServer(

--- a/pkg/server/server_controller_http.go
+++ b/pkg/server/server_controller_http.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
+	"github.com/cockroachdb/cockroach/pkg/server/serverorchestrator"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -171,7 +172,7 @@ func (c *serverController) attemptLoginToAllTenants() http.Handler {
 		for i, name := range tenantNames {
 			server, _, err := c.getServer(ctx, name)
 			if err != nil {
-				if errors.Is(err, errNoTenantServerRunning) {
+				if errors.Is(err, serverorchestrator.ErrNoTenantServerRunning) {
 					// Server has stopped after the call to
 					// getCurrentTenantNames(), or may not be fully started yet.
 					// This is OK. Just skip over it.
@@ -303,7 +304,7 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 		for _, name := range tenantNames {
 			server, _, err := c.getServer(ctx, name)
 			if err != nil {
-				if errors.Is(err, errNoTenantServerRunning) {
+				if errors.Is(err, serverorchestrator.ErrNoTenantServerRunning) {
 					// Server has stopped after the call to
 					// getCurrentTenantNames(), or may not be started yet. This
 					// is OK. Just skip over it.

--- a/pkg/server/server_controller_test.go
+++ b/pkg/server/server_controller_test.go
@@ -54,22 +54,13 @@ func TestServerController(t *testing.T) {
 	require.Nil(t, d)
 	require.Error(t, err, `no tenant found with name "somename"`)
 
-	_, err = db.Exec("CREATE TENANT hello; ALTER TENANT hello START SERVICE SHARED")
+	_, err = db.Exec("CREATE TENANT hello")
+	require.NoError(t, err)
+	_, err = db.Exec("ALTER TENANT hello START SERVICE SHARED")
 	require.NoError(t, err)
 
 	_, _, err = sc.getServer(ctx, "hello")
-	// TODO(knz): We're not really expecting an error here.
-	// The actual error seen will exist as long as in-memory
-	// servers use the standard KV connector.
-	//
-	// To make this error go away, we need either to place
-	// this test in a separate CCL package, or to make these servers
-	// use a new non-CCL connector.
-	//
-	// However, none of this is necessary to test the
-	// controller itself: it's sufficient to see that the
-	// tenant constructor was called.
-	require.Error(t, err, "tenant connector requires a CCL binary")
+	require.NoError(t, err)
 	// TODO(knz): test something about d.
 }
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -59,6 +59,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics"
 	"github.com/cockroachdb/cockroach/pkg/server/pgurl"
 	"github.com/cockroachdb/cockroach/pkg/server/serverctl"
+	"github.com/cockroachdb/cockroach/pkg/server/serverorchestrator"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/settingswatcher"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
@@ -420,6 +421,7 @@ type sqlServerArgs struct {
 	tenantTimeSeriesServer *ts.TenantServer
 
 	tenantCapabilitiesReader sql.SystemTenantOnly[tenantcapabilities.Reader]
+	serverOrchestrator       sql.SystemTenantOnly[serverorchestrator.ServerOrchestrator]
 }
 
 type monitorAndMetrics struct {
@@ -1035,6 +1037,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		EventsExporter:             cfg.eventsExporter,
 		NodeDescs:                  cfg.nodeDescs,
 		TenantCapabilitiesReader:   cfg.tenantCapabilitiesReader,
+		ServerOrchestrator:         cfg.serverOrchestrator,
 		AutoConfigProvider:         cfg.AutoConfigProvider,
 	}
 

--- a/pkg/server/serverorchestrator/BUILD.bazel
+++ b/pkg/server/serverorchestrator/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "serverorchestrator",
+    srcs = ["orchestrator.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/server/serverorchestrator",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)

--- a/pkg/server/serverorchestrator/orchestrator.go
+++ b/pkg/server/serverorchestrator/orchestrator.go
@@ -1,0 +1,36 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package serverorchestrator
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/errors"
+)
+
+// A ServerOrchestrator allows the SQL-layer to check on the status of
+// on-demand servers.
+type ServerOrchestrator interface {
+	// CheckRunningServer returns an error if there isn't a server
+	// ready for the given tenant.
+	CheckRunningServer(context.Context, roachpb.TenantName) (<-chan struct{}, error)
+}
+
+var (
+	// ErrTenantServerNotReady is returned from CheckRunningServer when the
+	// ServerOrchestrator knows about a tenant server but it is not yet
+	// fully started.
+	ErrTenantServerNotReady error = errors.New("tenant server not ready")
+	// ErrNoTenantServerRunning is returned from CheckRunningServer when the
+	// ServerOrchestrator has no record of the given tenant.
+	ErrNoTenantServerRunning error = errors.New("no server for tenant")
+)

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
 	"github.com/cockroachdb/cockroach/pkg/server/privchecker"
 	"github.com/cockroachdb/cockroach/pkg/server/serverctl"
+	"github.com/cockroachdb/cockroach/pkg/server/serverorchestrator"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/server/structlogging"
@@ -1352,6 +1353,7 @@ func makeTenantSQLServerArgs(
 		rangeDescIteratorFactory: tenantConnect,
 		tenantTimeSeriesServer:   sTS,
 		tenantCapabilitiesReader: sql.EmptySystemTenantOnly[tenantcapabilities.Reader](),
+		serverOrchestrator:       sql.EmptySystemTenantOnly[serverorchestrator.ServerOrchestrator](),
 	}, nil
 }
 

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -355,6 +355,7 @@ go_library(
         "//pkg/security/username",
         "//pkg/server/autoconfig/acprovider",
         "//pkg/server/pgurl",
+        "//pkg/server/serverorchestrator",
         "//pkg/server/serverpb",
         "//pkg/server/settingswatcher",
         "//pkg/server/status/statuspb",

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/autoconfig/acprovider"
 	"github.com/cockroachdb/cockroach/pkg/server/pgurl"
+	"github.com/cockroachdb/cockroach/pkg/server/serverorchestrator"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -1455,6 +1456,7 @@ type ExecutorConfig struct {
 	NodeDescs kvcoord.NodeDescStore
 
 	TenantCapabilitiesReader SystemTenantOnly[tenantcapabilities.Reader]
+	ServerOrchestrator       SystemTenantOnly[serverorchestrator.ServerOrchestrator]
 
 	// AutoConfigProvider informs the auto config runner job of new
 	// tasks to run.

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -407,6 +407,8 @@ INSERT INTO system.tenant_usage(
         ru_burst_limit, ru_refill_rate, ru_current, current_share_sum, total_consumption)
 VALUES ($tmplid, 0, 0, now(),
         11, 22, 33, 44, ''::BYTES);
+
+statement ok
 ALTER TENANT tmpl START SERVICE SHARED; -- will not be copied.
 
 # Use it to create a new tenant.
@@ -495,8 +497,12 @@ FROM system.tenant_usage WHERE tenant_id = $otherid
 
 # Clean up.
 statement ok
-DROP TENANT othertenant;
-ALTER TENANT tmpl STOP SERVICE;
+DROP TENANT othertenant
+
+statement ok
+ALTER TENANT tmpl STOP SERVICE
+
+statement ok
 DROP TENANT tmpl
 
 statement ok
@@ -540,8 +546,12 @@ statement ok
 RESET CLUSTER SETTING server.controller.default_target_cluster
 
 statement ok
-DROP TENANT noservice;
-CREATE TENANT withservice;
+DROP TENANT noservice
+
+statement ok
+CREATE TENANT withservice
+
+statement ok
 ALTER TENANT withservice START SERVICE SHARED
 
 statement ok

--- a/pkg/sql/tenant_update.go
+++ b/pkg/sql/tenant_update.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverorchestrator"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -27,8 +28,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
 )
 
@@ -203,6 +206,9 @@ func (p *planner) setTenantService(
 	if p.EvalContext().TxnReadOnly {
 		return readOnlyError("ALTER VIRTUAL CLUSTER SERVICE")
 	}
+	if !p.extendedEvalCtx.TxnIsSingleStmt {
+		return errors.Errorf("ALTER VIRTUAL CLUSTER SERVICE cannot be used inside a multi-statement transaction")
+	}
 
 	if err := CanManageTenant(ctx, p); err != nil {
 		return err
@@ -228,7 +234,81 @@ func (p *planner) setTenantService(
 
 	info.ServiceMode = newMode
 	info.LastRevertTenantTimestamp = hlc.Timestamp{}
-	return UpdateTenantRecord(ctx, p.ExecCfg().Settings, p.InternalSQLTxn(), info)
+	if err := UpdateTenantRecord(ctx, p.ExecCfg().Settings, p.InternalSQLTxn(), info); err != nil {
+		return err
+	}
+
+	// If we are in an InternalExecutor, we don't wait for the
+	// server controller since it may not be started
+	// yet.
+	//
+	// Currently, the only place we call `ALTER VIRTUAL CLUSTER
+	// <name> [STOP|START] SERVICE' using an internal executor is
+	// from a configuraton profile. Since we wait on configuration
+	// profiles during startup, we cannot wait on the server
+	// controller which starts after the configuration profiles
+	// run.
+	if p.extendedEvalCtx.SessionData().Internal {
+		return nil
+	}
+
+	if err := p.InternalSQLTxn().KV().Commit(ctx); err != nil {
+		return err
+	}
+
+	switch info.ServiceMode {
+	case mtinfopb.ServiceModeNone:
+		return p.waitForNoServiceForTenant(ctx, info.Name)
+	case mtinfopb.ServiceModeShared:
+		return p.waitForServiceForTenant(ctx, info.Name)
+	default:
+		return nil
+	}
+}
+
+func (p *planner) waitForServiceForTenant(ctx context.Context, name roachpb.TenantName) error {
+	srvOrch, err := p.ExecCfg().ServerOrchestrator.Get("alter service")
+	if err != nil {
+		return err
+	}
+
+	r := retry.StartWithCtx(ctx, retry.Options{})
+	for r.Next() {
+		waitCh, err := srvOrch.CheckRunningServer(ctx, name)
+		if err != nil {
+			log.Infof(ctx, "waiting on %v for tenant %s after err: %s", waitCh, name, err)
+			select {
+			case <-waitCh:
+			case <-ctx.Done():
+			}
+			continue
+		}
+		return nil
+	}
+	return ctx.Err()
+}
+
+func (p *planner) waitForNoServiceForTenant(ctx context.Context, name roachpb.TenantName) error {
+	srvOrch, err := p.ExecCfg().ServerOrchestrator.Get("alter service")
+	if err != nil {
+		return err
+	}
+
+	r := retry.StartWithCtx(ctx, retry.Options{})
+	for r.Next() {
+		waitCh, err := srvOrch.CheckRunningServer(ctx, name)
+		if errors.Is(err, serverorchestrator.ErrTenantServerNotReady) {
+			select {
+			case <-waitCh:
+			case <-ctx.Done():
+			}
+		} else if errors.Is(err, serverorchestrator.ErrNoTenantServerRunning) {
+			return nil
+		} else {
+			return err
+		}
+	}
+	return ctx.Err()
 }
 
 func (p *planner) renameTenant(


### PR DESCRIPTION
Similar to SET CLUSTER SETTING, this waits for the local server orcehstrator to start or stop a server before returning from an ALTER TENANT command that modifies the service_mode.

As a result, you can no longer issue ALTER TENANT inside anything but an implicit transaction.

Epic: none

Fixes #112554