### PR TITLE
server: add trace ID to context log tags

### DIFF
--- a/pkg/server/debug/BUILD.bazel
+++ b/pkg/server/debug/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "logspy.go",
         "queries_writer.go",
         "server.go",
+        "traceprofile.go",
         "vmodule.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/server/debug",

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -102,7 +102,9 @@ func setupProcessWideRoutes(
 		CPUProfileHandler(st, w, r)
 	}))
 	mux.HandleFunc("/debug/pprof/symbol", authzFunc(pprof.Symbol))
-	mux.HandleFunc("/debug/pprof/trace", authzFunc(pprof.Trace))
+	mux.HandleFunc("/debug/pprof/trace", authzFunc(func(w http.ResponseWriter, r *http.Request) {
+		TraceProfileHandler(st, w, r)
+	}))
 
 	// Cribbed straight from trace's `init()` method. See:
 	// https://github.com/golang/net/blob/master/trace/trace.go

--- a/pkg/server/debug/traceprofile.go
+++ b/pkg/server/debug/traceprofile.go
@@ -1,0 +1,36 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package debug
+
+import (
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+)
+
+func TraceProfileDo(st *cluster.Settings, do func() error) error {
+	if err := st.SetTraceProfiling(1); err != nil {
+		return err
+	}
+	defer func() { _ = st.SetTraceProfiling(0) }()
+	return do()
+}
+
+func TraceProfileHandler(st *cluster.Settings, w http.ResponseWriter, r *http.Request) {
+	if err := TraceProfileDo(st, func() error {
+		pprof.Trace(w, r)
+		return nil
+	}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1446,7 +1446,9 @@ func (n *Node) Batch(ctx context.Context, args *kvpb.BatchRequest) (*kvpb.BatchR
 	// pprof labels in the BatchRequest, then we apply them to the context that is
 	// going to execute the BatchRequest. These labels will help correlate server
 	// side CPU profile samples to the sender.
-	if len(args.ProfileLabels) != 0 && n.execCfg.Settings.CPUProfileType() == cluster.CPUProfileWithLabels {
+	if len(args.ProfileLabels) != 0 &&
+		(n.execCfg.Settings.CPUProfileType() == cluster.CPUProfileWithLabels ||
+			n.execCfg.Settings.ExecutionTraceEnabled()) {
 		var undo func()
 		ctx, undo = pprofutil.SetProfilerLabels(ctx, args.ProfileLabels...)
 		defer undo()

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -1165,6 +1165,7 @@ child operation: %s, tracer created at:
 	if traceID == 0 {
 		traceID = tracingpb.TraceID(randutil.FastInt63())
 	}
+	ctx = logtags.AddTag(ctx, "trace", fmt.Sprintf("%d", traceID))
 	spanID := tracingpb.SpanID(randutil.FastInt63())
 
 	s := t.newSpan(


### PR DESCRIPTION
This change adds the trace ID of the tracing span to the logtags of the context that the span is created with. The motivation for this change is to have the trace ID show up as a pprof label in the processes that call SetProfilerLabelsFromCtxTags.

This change also adds logic to know when an execution trace is being collected on a node so that we can decorate the server side processes with the client side pprof labels as well.

Release note: None
Informs: none