### PR TITLE
server: reduce log spam on canceled batch requests

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1366,7 +1366,10 @@ func (n *Node) batchInternal(
 	// replica to notice the cancellation and return a response. For this reason,
 	// we log the server-side trace of the cancelled request to help debug what
 	// the request was doing at the time it noticed the cancellation.
-	if pErr != nil && ctx.Err() != nil {
+	//
+	// To avoid log spam for now we only log the trace if the request was an
+	// ExportRequest.
+	if pErr != nil && ctx.Err() != nil && args.IsSingleExportRequest() {
 		if sp := tracing.SpanFromContext(ctx); sp != nil && !sp.IsNoop() {
 			recording := sp.GetConfiguredRecording()
 			if recording.Len() != 0 {


### PR DESCRIPTION
In #102793 we added server side logging for batch requests that would encounted a context cancelation or timeout. This was primarily motivated by the need to understand why export requests sent during a backup were spending most of their time and timing out. This unintentionally added log spam for other kinds of internal requests such as HeartbeatTxn, QueryTxn, and EndTxn requests. This change limits this log line to only be printed when the corresponding request is an export request.

Fixes: None
Epic: none
Release note: None