### PR TITLE
sql: return proper error when referencing "" user

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -467,7 +467,7 @@ func (p *planner) CheckAnyPrivilege(ctx context.Context, privilegeObject privile
 // Requires a valid transaction to be open.
 func (p *planner) UserHasAdminRole(ctx context.Context, user username.SQLUsername) (bool, error) {
 	if user.Undefined() {
-		return false, errors.AssertionFailedf("empty user")
+		return false, sqlerrors.NewUndefinedUserError(user)
 	}
 	// Verify that the txn is valid in any case, so that
 	// we don't get the risk to say "OK" to root requests

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -534,6 +534,18 @@ CREATE ROLE roleb
 statement ok
 GRANT rolea,roleb TO testuser WITH ADMIN OPTION
 
+statement error role/user "" does not exist
+GRANT rolea TO ""
+
+statement error role/user "" does not exist
+REVOKE rolea FROM ""
+
+statement error role/user "" does not exist
+GRANT "" TO rolea
+
+statement error role/user "" does not exist
+REVOKE "" FROM rolea
+
 query TTBOO colnames,rowsort
 SELECT * FROM system.role_members
 ----


### PR DESCRIPTION
This improves the error message so it shows a normal error rather than an assertion error.

fixes https://github.com/cockroachdb/cockroach/issues/115108
Release note: None