### PR TITLE
util/mon: fix "used" field in MonitorState in some cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1312,11 +1312,10 @@ NULL 100 KiB
 
 # Sanity checks of the crdb_internal.node_memory_monitors table.
 
-# The root monitor has a standalone budget, so its 'used' field is zero.
-query BB
-SELECT used = 0, reserved_used > 0 FROM crdb_internal.node_memory_monitors WHERE name = 'root'
+query BBB
+SELECT used > 0, reserved_used > 0, used < reserved_used FROM crdb_internal.node_memory_monitors WHERE name = 'root'
 ----
-true true
+true true true
 
 query B
 SELECT used > 0 FROM crdb_internal.node_memory_monitors WHERE name = 'sql'

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -329,7 +329,7 @@ func (mm *BytesMonitor) traverseTree(level int, monitorStateCb func(MonitorState
 		Name:             string(mm.name),
 		ID:               int64(id),
 		ParentID:         int64(parentID),
-		Used:             mm.mu.curBudget.used,
+		Used:             mm.mu.curAllocated,
 		ReservedUsed:     reservedUsed,
 		ReservedReserved: reservedReserved,
 	}


### PR DESCRIPTION
This commit fixes the `Used` field from `MonitorState` in cases when the memory usage counts towards the "reserved" memory account. As a reminder, each memory monitor can have two accounts to draw from: it always has "curBudget" memory account, but it can also have optional "reserved" account. The actual memory usage is a sum of usages against these two accounts, but previously we would only report the usage of the "curBudget" one. More concretely, we'd always have the root memory monitor with zero "used" because it has a standalone budget.

This fix makes it so that the output of `crdb_internal.node_memory_monitors` is correct, but there is no release note given it's an internal virtual table.

Epic: None

Release note: None