### PR TITLE
opt: hoist uncorrelated subqueries at most once

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -4847,6 +4847,238 @@ select
                           └── max [as=max:12, outer=(8)]
                                └── x:8
 
+# The subquery should only be hoisted once to avoid creating an expression with
+# children that have intersecting columns. See #114703.
+norm expect=HoistSelectSubquery
+SELECT NULL
+FROM a AS t1
+JOIN a AS t2 ON t1.i = t2.i
+WHERE t2.i = (SELECT 0 FROM a)
+----
+project
+ ├── columns: "?column?":23
+ ├── fd: ()-->(23)
+ ├── inner-join (hash)
+ │    ├── columns: t1.i:2!null t2.i:9!null "?column?":22!null
+ │    ├── fd: ()-->(2,9,22), (2)==(9,22), (22)==(2,9), (9)==(2,22)
+ │    ├── inner-join (hash)
+ │    │    ├── columns: t1.i:2!null "?column?":22!null
+ │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    ├── fd: ()-->(2,22), (2)==(22), (22)==(2)
+ │    │    ├── scan a [as=t1]
+ │    │    │    └── columns: t1.i:2
+ │    │    ├── max1-row
+ │    │    │    ├── columns: "?column?":22!null
+ │    │    │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(22)
+ │    │    │    └── project
+ │    │    │         ├── columns: "?column?":22!null
+ │    │    │         ├── fd: ()-->(22)
+ │    │    │         ├── scan a
+ │    │    │         └── projections
+ │    │    │              └── 0 [as="?column?":22]
+ │    │    └── filters
+ │    │         └── t1.i:2 = "?column?":22 [outer=(2,22), constraints=(/2: (/NULL - ]; /22: (/NULL - ]), fd=(2)==(22), (22)==(2)]
+ │    ├── select
+ │    │    ├── columns: t2.i:9!null
+ │    │    ├── scan a [as=t2]
+ │    │    │    └── columns: t2.i:9
+ │    │    └── filters
+ │    │         └── eq [outer=(9), subquery, constraints=(/9: (/NULL - ])]
+ │    │              ├── t2.i:9
+ │    │              └── subquery
+ │    │                   └── max1-row
+ │    │                        ├── columns: "?column?":22!null
+ │    │                        ├── error: "more than one row returned by a subquery used as an expression"
+ │    │                        ├── cardinality: [0 - 1]
+ │    │                        ├── key: ()
+ │    │                        ├── fd: ()-->(22)
+ │    │                        └── project
+ │    │                             ├── columns: "?column?":22!null
+ │    │                             ├── fd: ()-->(22)
+ │    │                             ├── scan a
+ │    │                             └── projections
+ │    │                                  └── 0 [as="?column?":22]
+ │    └── filters
+ │         └── t1.i:2 = t2.i:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── projections
+      └── NULL [as="?column?":23]
+
+# Each subquery should only be hoisted once.
+norm expect=HoistSelectSubquery
+SELECT NULL
+FROM a AS t1
+JOIN a AS t2 ON t1.i = t2.i
+WHERE t2.i = (SELECT 0 FROM a) AND t1.i = (SELECT 0 FROM a)
+----
+project
+ ├── columns: "?column?":31
+ ├── fd: ()-->(31)
+ ├── inner-join (hash)
+ │    ├── columns: t1.i:2!null t2.i:9!null "?column?":22!null "?column?":30!null
+ │    ├── fd: ()-->(2,9,22,30), (2)==(9,22,30), (30)==(2,9,22), (22)==(2,9,30), (9)==(2,22,30)
+ │    ├── inner-join (hash)
+ │    │    ├── columns: t1.i:2!null "?column?":22!null "?column?":30!null
+ │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    ├── fd: ()-->(2,22,30), (2)==(22,30), (30)==(2,22), (22)==(2,30)
+ │    │    ├── inner-join (hash)
+ │    │    │    ├── columns: t1.i:2!null "?column?":30!null
+ │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    │    ├── fd: ()-->(2,30), (2)==(30), (30)==(2)
+ │    │    │    ├── scan a [as=t1]
+ │    │    │    │    └── columns: t1.i:2
+ │    │    │    ├── max1-row
+ │    │    │    │    ├── columns: "?column?":30!null
+ │    │    │    │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(30)
+ │    │    │    │    └── project
+ │    │    │    │         ├── columns: "?column?":30!null
+ │    │    │    │         ├── fd: ()-->(30)
+ │    │    │    │         ├── scan a
+ │    │    │    │         └── projections
+ │    │    │    │              └── 0 [as="?column?":30]
+ │    │    │    └── filters
+ │    │    │         └── t1.i:2 = "?column?":30 [outer=(2,30), constraints=(/2: (/NULL - ]; /30: (/NULL - ]), fd=(2)==(30), (30)==(2)]
+ │    │    ├── select
+ │    │    │    ├── columns: "?column?":22!null
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(22)
+ │    │    │    ├── max1-row
+ │    │    │    │    ├── columns: "?column?":22!null
+ │    │    │    │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(22)
+ │    │    │    │    └── project
+ │    │    │    │         ├── columns: "?column?":22!null
+ │    │    │    │         ├── fd: ()-->(22)
+ │    │    │    │         ├── scan a
+ │    │    │    │         └── projections
+ │    │    │    │              └── 0 [as="?column?":22]
+ │    │    │    └── filters
+ │    │    │         └── eq [outer=(22), subquery, constraints=(/22: (/NULL - ])]
+ │    │    │              ├── "?column?":22
+ │    │    │              └── subquery
+ │    │    │                   └── max1-row
+ │    │    │                        ├── columns: "?column?":30!null
+ │    │    │                        ├── error: "more than one row returned by a subquery used as an expression"
+ │    │    │                        ├── cardinality: [0 - 1]
+ │    │    │                        ├── key: ()
+ │    │    │                        ├── fd: ()-->(30)
+ │    │    │                        └── project
+ │    │    │                             ├── columns: "?column?":30!null
+ │    │    │                             ├── fd: ()-->(30)
+ │    │    │                             ├── scan a
+ │    │    │                             └── projections
+ │    │    │                                  └── 0 [as="?column?":30]
+ │    │    └── filters
+ │    │         └── t1.i:2 = "?column?":22 [outer=(2,22), constraints=(/2: (/NULL - ]; /22: (/NULL - ]), fd=(2)==(22), (22)==(2)]
+ │    ├── select
+ │    │    ├── columns: t2.i:9!null
+ │    │    ├── scan a [as=t2]
+ │    │    │    └── columns: t2.i:9
+ │    │    └── filters
+ │    │         ├── eq [outer=(9), subquery, constraints=(/9: (/NULL - ])]
+ │    │         │    ├── t2.i:9
+ │    │         │    └── subquery
+ │    │         │         └── max1-row
+ │    │         │              ├── columns: "?column?":22!null
+ │    │         │              ├── error: "more than one row returned by a subquery used as an expression"
+ │    │         │              ├── cardinality: [0 - 1]
+ │    │         │              ├── key: ()
+ │    │         │              ├── fd: ()-->(22)
+ │    │         │              └── project
+ │    │         │                   ├── columns: "?column?":22!null
+ │    │         │                   ├── fd: ()-->(22)
+ │    │         │                   ├── scan a
+ │    │         │                   └── projections
+ │    │         │                        └── 0 [as="?column?":22]
+ │    │         └── eq [outer=(9), subquery, constraints=(/9: (/NULL - ])]
+ │    │              ├── t2.i:9
+ │    │              └── subquery
+ │    │                   └── max1-row
+ │    │                        ├── columns: "?column?":30!null
+ │    │                        ├── error: "more than one row returned by a subquery used as an expression"
+ │    │                        ├── cardinality: [0 - 1]
+ │    │                        ├── key: ()
+ │    │                        ├── fd: ()-->(30)
+ │    │                        └── project
+ │    │                             ├── columns: "?column?":30!null
+ │    │                             ├── fd: ()-->(30)
+ │    │                             ├── scan a
+ │    │                             └── projections
+ │    │                                  └── 0 [as="?column?":30]
+ │    └── filters
+ │         └── t1.i:2 = t2.i:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── projections
+      └── NULL [as="?column?":31]
+
+exec-ddl
+CREATE FUNCTION f114703() RETURNS INT STABLE LANGUAGE SQL AS $$
+  SELECT x FROM xy
+$$
+----
+
+# The filter "t2.a = f()" is pushed into both sides of the join, and inlined as
+# a subquery that is only hoisted once.
+norm expect=HoistSelectSubquery
+SELECT NULL
+FROM a AS t1
+JOIN a AS t2 ON t1.i = t2.i
+WHERE t2.i = f114703()
+----
+project
+ ├── columns: "?column?":19
+ ├── fd: ()-->(19)
+ ├── inner-join (hash)
+ │    ├── columns: t1.i:2!null t2.i:9!null x:15!null
+ │    ├── fd: ()-->(2,9,15), (2)==(9,15), (15)==(2,9), (9)==(2,15)
+ │    ├── inner-join (hash)
+ │    │    ├── columns: t1.i:2!null x:15!null
+ │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    ├── fd: ()-->(2,15), (2)==(15), (15)==(2)
+ │    │    ├── scan a [as=t1]
+ │    │    │    └── columns: t1.i:2
+ │    │    ├── limit
+ │    │    │    ├── columns: x:15!null
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(15)
+ │    │    │    ├── scan xy
+ │    │    │    │    ├── columns: x:15!null
+ │    │    │    │    ├── key: (15)
+ │    │    │    │    └── limit hint: 1.00
+ │    │    │    └── 1
+ │    │    └── filters
+ │    │         └── t1.i:2 = x:15 [outer=(2,15), constraints=(/2: (/NULL - ]; /15: (/NULL - ]), fd=(2)==(15), (15)==(2)]
+ │    ├── select
+ │    │    ├── columns: t2.i:9!null
+ │    │    ├── scan a [as=t2]
+ │    │    │    └── columns: t2.i:9
+ │    │    └── filters
+ │    │         └── eq [outer=(9), subquery, constraints=(/9: (/NULL - ])]
+ │    │              ├── t2.i:9
+ │    │              └── subquery
+ │    │                   └── limit
+ │    │                        ├── columns: x:15!null
+ │    │                        ├── cardinality: [0 - 1]
+ │    │                        ├── key: ()
+ │    │                        ├── fd: ()-->(15)
+ │    │                        ├── scan xy
+ │    │                        │    ├── columns: x:15!null
+ │    │                        │    ├── key: (15)
+ │    │                        │    └── limit hint: 1.00
+ │    │                        └── 1
+ │    └── filters
+ │         └── t1.i:2 = t2.i:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── projections
+      └── NULL [as="?column?":19]
+
 
 # --------------------------------------------------
 # HoistProjectSubquery


### PR DESCRIPTION
Since #100881, the optimizer has hoisted uncorrelated subqueries used in
an equality expression (only when the
`optimizer_hoist_uncorrelated_equality_subqueries` session setting is
enabled). This can cause problems when the hoisted subquery has been
duplicated in the expression tree, e.g., when pushing a filter into both
sides of a join.

A subquery is a scalar expression, so the columns of its child
expression are never emitted from the subquery. This makes it safe
duplicate a subquery in an expression tree. However, when a subquery is
hoisted, it is transformed into a join which can produce the columns of
the child expression. Hoisting the same subquery multiple times can
produce query plans with duplicate column IDs in two logically different
expressions. This can lead to incorrect query plans (see the comment for
`opt.Metadata`), as well as produce expressions with children that have
intersecting column IDs (after additional normalization rules fire).

To avoid these dangers, this commit ensures that each unique subquery is
hoisted at most once. This will prevent bad plans, but it may not
inhibit the optimizer from finding optimal plans. In the future, it may
be possible to lift this restriction by generating new column IDs for
uncorrelated subqueries each time they are hoisted.

Fixes #114703

There is no release note because the session setting enabling this bug
is disabled by default, and because the possible correctness bug is
theoretical - we have not found a reproduction of a correctness bug, but
it could exist in theory.

Release note: None
