### PR TITLE
sql: add rewrite logic tests for udfs

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
@@ -1,0 +1,131 @@
+# LogicTest: !local-mixed-23.1
+
+statement ok
+CREATE SEQUENCE seq;
+
+statement ok
+CREATE TYPE weekday AS ENUM ('monday', 'tuesday', 'wednesday', 'thursday', 'friday');
+
+statement ok
+CREATE TABLE t_rewrite (
+  v INT DEFAULT 0,
+  w weekday DEFAULT 'monday'::weekday
+);
+
+# Need to turn declarative schema changer off because function `get_body_str`
+# created below would resolve a descriptorless public schema "system.public"
+# which is not supported in declarative schema changer. Declarative schema
+# changer falls back to legacy schema changer, and the descriptor id counter is
+# increased twice. It cause the test to fail due to id inconsistency.
+skipif config local-legacy-schema-changer
+statement ok
+SET use_declarative_schema_changer = 'off'
+
+statement ok
+CREATE FUNCTION get_body_str(fn_name STRING) RETURNS STRING
+LANGUAGE SQL
+AS $$
+  SELECT crdb_internal.pb_to_json(
+    'cockroach.sql.sqlbase.Descriptor', descriptor, false
+  )->'function'->'functionBody'
+  FROM system.descriptor WHERE id = fn_name::regproc::int - 100000;
+$$;
+
+skipif config local-legacy-schema-changer
+statement ok
+SET use_declarative_schema_changer = 'on'
+
+subtest rewrite_plpgsql
+
+statement ok
+DROP FUNCTION IF EXISTS f_rewrite
+
+statement ok
+CREATE OR REPLACE FUNCTION f_rewrite() RETURNS INT AS
+$$
+  BEGIN
+    SELECT nextval('seq');
+  END
+$$ LANGUAGE PLPGSQL
+
+query T
+SELECT get_body_str('f_rewrite');
+----
+"BEGIN\nSELECT nextval('seq':::STRING);\nEND\n;"
+
+statement ok
+CREATE OR REPLACE FUNCTION f_rewrite() RETURNS INT AS
+$$
+  BEGIN
+    INSERT INTO t_rewrite(v) VALUES (nextval('seq')) RETURNING v;
+  END
+$$ LANGUAGE PLPGSQL
+
+query T
+SELECT get_body_str('f_rewrite');
+----
+"BEGIN\nINSERT INTO test.public.t_rewrite(v) VALUES (nextval('seq':::STRING)) RETURNING v;\nEND\n;"
+
+statement ok
+DROP FUNCTION f_rewrite();
+
+statement ok
+CREATE OR REPLACE FUNCTION f_rewrite() RETURNS weekday AS
+$$
+  BEGIN
+    SELECT 'wednesday'::weekday;
+  END
+$$ LANGUAGE PLPGSQL
+
+query T
+SELECT get_body_str('f_rewrite');
+----
+"BEGIN\nSELECT 'wednesday'::@100107;\nEND\n;"
+
+statement ok
+CREATE OR REPLACE FUNCTION f_rewrite() RETURNS weekday AS
+$$
+  BEGIN
+    UPDATE t_rewrite SET w = 'thursday'::weekday WHERE w = 'wednesday'::weekday RETURNING w;
+  END
+$$ LANGUAGE PLPGSQL
+
+query T
+SELECT get_body_str('f_rewrite');
+----
+"BEGIN\nUPDATE test.public.t_rewrite SET w = 'thursday'::@100107 WHERE w = 'wednesday'::@100107 RETURNING w;\nEND\n;"
+
+subtest end
+
+subtest rewrite_proc
+
+statement ok
+CREATE OR REPLACE PROCEDURE p_rewrite() AS
+$$
+  BEGIN
+    INSERT INTO t_rewrite(v) VALUES (nextval('seq')) RETURNING v;
+  END
+$$ LANGUAGE PLPGSQL
+
+query T
+SELECT get_body_str('p_rewrite');
+----
+"BEGIN\nINSERT INTO test.public.t_rewrite(v) VALUES (nextval('seq':::STRING)) RETURNING v;\nEND\n;"
+
+statement ok
+DROP PROCEDURE p_rewrite();
+
+statement ok
+CREATE OR REPLACE PROCEDURE p_rewrite() AS
+$$
+  BEGIN
+    UPDATE t_rewrite SET w = 'thursday'::weekday WHERE w = 'wednesday'::weekday RETURNING w;
+  END
+$$ LANGUAGE PLPGSQL
+
+query T
+SELECT get_body_str('p_rewrite');
+----
+"BEGIN\nUPDATE test.public.t_rewrite SET w = 'thursday'::@100107 WHERE w = 'wednesday'::@100107 RETURNING w;\nEND\n;"
+
+subtest end

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2305,6 +2305,13 @@ func TestTenantLogic_udf_regressions(
 	runLogicTest(t, "udf_regressions")
 }
 
+func TestTenantLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_rewrite")
+}
+
 func TestTenantLogic_udf_schema_change(
 	t *testing.T,
 ) {
@@ -2681,6 +2688,13 @@ func TestTenantLogicCCL_udf_plpgsql(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "udf_plpgsql")
+}
+
+func TestTenantLogicCCL_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "udf_rewrite")
 }
 
 func TestTenantLogicCCL_udf_volatility_check(

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"Pool": "large"},
-    shard_count = 15,
+    shard_count = 16,
     tags = [
         "ccl_test",
         "cpu:2",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
@@ -176,6 +176,13 @@ func TestCCLLogic_udf_plpgsql(
 	runCCLLogicTest(t, "udf_plpgsql")
 }
 
+func TestCCLLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "udf_rewrite")
+}
+
 func TestCCLLogic_udf_volatility_check(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"Pool": "large"},
-    shard_count = 15,
+    shard_count = 16,
     tags = [
         "ccl_test",
         "cpu:2",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
@@ -176,6 +176,13 @@ func TestCCLLogic_udf_plpgsql(
 	runCCLLogicTest(t, "udf_plpgsql")
 }
 
+func TestCCLLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "udf_rewrite")
+}
+
 func TestCCLLogic_udf_volatility_check(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"Pool": "large"},
-    shard_count = 16,
+    shard_count = 17,
     tags = [
         "ccl_test",
         "cpu:2",

--- a/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
@@ -183,6 +183,13 @@ func TestCCLLogic_udf_plpgsql(
 	runCCLLogicTest(t, "udf_plpgsql")
 }
 
+func TestCCLLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "udf_rewrite")
+}
+
 func TestCCLLogic_udf_volatility_check(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"Pool": "large"},
-    shard_count = 15,
+    shard_count = 16,
     tags = [
         "ccl_test",
         "cpu:1",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
@@ -176,6 +176,13 @@ func TestCCLLogic_udf_plpgsql(
 	runCCLLogicTest(t, "udf_plpgsql")
 }
 
+func TestCCLLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "udf_rewrite")
+}
+
 func TestCCLLogic_udf_volatility_check(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-23.2/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-23.2/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"Pool": "large"},
-    shard_count = 15,
+    shard_count = 16,
     tags = [
         "ccl_test",
         "cpu:1",

--- a/pkg/ccl/logictestccl/tests/local-mixed-23.2/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-23.2/generated_test.go
@@ -176,6 +176,13 @@ func TestCCLLogic_udf_plpgsql(
 	runCCLLogicTest(t, "udf_plpgsql")
 }
 
+func TestCCLLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "udf_rewrite")
+}
+
 func TestCCLLogic_udf_volatility_check(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"Pool": "large"},
-    shard_count = 15,
+    shard_count = 16,
     tags = [
         "ccl_test",
         "cpu:1",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
@@ -176,6 +176,13 @@ func TestCCLLogic_udf_plpgsql(
 	runCCLLogicTest(t, "udf_plpgsql")
 }
 
+func TestCCLLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "udf_rewrite")
+}
+
 func TestCCLLogic_udf_volatility_check(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"Pool": "large"},
-    shard_count = 29,
+    shard_count = 30,
     tags = [
         "ccl_test",
         "cpu:1",

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -274,6 +274,13 @@ func TestCCLLogic_udf_plpgsql(
 	runCCLLogicTest(t, "udf_plpgsql")
 }
 
+func TestCCLLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "udf_rewrite")
+}
+
 func TestCCLLogic_udf_volatility_check(
 	t *testing.T,
 ) {

--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -470,7 +470,7 @@ func setFuncOptions(
 		}
 		udfDesc.SetFuncBody(typeReplacedFuncBody)
 	case catpb.Function_PLPGSQL:
-		// TODO(drewk): make replaceSeqNamesWithIDs and serializeUserDefinedTypes
+		// TODO(#115627): make replaceSeqNamesWithIDs and serializeUserDefinedTypes
 		// play nice with PL/pgSQL.
 		udfDesc.SetFuncBody(body)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/udf_rewrite
+++ b/pkg/sql/logictest/testdata/logic_test/udf_rewrite
@@ -1,0 +1,119 @@
+# LogicTest: !local-mixed-23.1
+
+statement ok
+CREATE SEQUENCE seq;
+
+statement ok
+CREATE TYPE weekday AS ENUM ('monday', 'tuesday', 'wednesday', 'thursday', 'friday');
+
+statement ok
+CREATE TABLE t_rewrite (
+  v INT DEFAULT 0,
+  w weekday DEFAULT 'monday'::weekday
+);
+
+# Need to turn declarative schema changer off because function `get_body_str`
+# created below would resolve a descriptorless public schema "system.public"
+# which is not supported in declarative schema changer. Declarative schema
+# changer falls back to legacy schema changer, and the descriptor id counter is
+# increased twice. It cause the test to fail due to id inconsistency.
+skipif config local-legacy-schema-changer
+statement ok
+SET use_declarative_schema_changer = 'off'
+
+statement ok
+CREATE FUNCTION get_body_str(fn_name STRING) RETURNS STRING
+LANGUAGE SQL
+AS $$
+  SELECT crdb_internal.pb_to_json(
+    'cockroach.sql.sqlbase.Descriptor', descriptor, false
+  )->'function'->'functionBody'
+  FROM system.descriptor WHERE id = fn_name::regproc::int - 100000;
+$$;
+
+skipif config local-legacy-schema-changer
+statement ok
+SET use_declarative_schema_changer = 'on'
+
+subtest rewrite_sql
+
+statement ok
+CREATE OR REPLACE FUNCTION f_rewrite() RETURNS INT AS
+$$
+  SELECT nextval('seq');
+$$ LANGUAGE SQL
+
+query T
+SELECT get_body_str('f_rewrite');
+----
+"SELECT nextval(106:::REGCLASS);"
+
+statement ok
+CREATE OR REPLACE FUNCTION f_rewrite() RETURNS INT AS
+$$
+  INSERT INTO t_rewrite(v) VALUES (nextval('seq')) RETURNING v;
+$$ LANGUAGE SQL
+
+query T
+SELECT get_body_str('f_rewrite');
+----
+"INSERT INTO test.public.t_rewrite(v) VALUES (nextval(106:::REGCLASS)) RETURNING v;"
+
+statement ok
+DROP FUNCTION f_rewrite();
+
+statement ok
+CREATE OR REPLACE FUNCTION f_rewrite() RETURNS weekday AS
+$$
+  SELECT 'wednesday'::weekday;
+$$ LANGUAGE SQL
+
+query T
+SELECT get_body_str('f_rewrite');
+----
+"SELECT b'\\x80':::@100107;"
+
+statement ok
+CREATE OR REPLACE FUNCTION f_rewrite() RETURNS weekday AS
+$$
+  UPDATE t_rewrite SET w = 'thursday'::weekday WHERE w = 'wednesday'::weekday RETURNING w;
+$$ LANGUAGE SQL
+
+query T
+SELECT get_body_str('f_rewrite');
+----
+"UPDATE test.public.t_rewrite SET w = b'\\xa0':::@100107 WHERE w = b'\\x80':::@100107 RETURNING w;"
+
+subtest end
+
+subtest rewrite_proc
+
+statement ok
+CREATE OR REPLACE PROCEDURE p_rewrite() AS
+$$
+  INSERT INTO t_rewrite(v) VALUES (nextval('seq')) RETURNING v;
+$$ LANGUAGE SQL
+
+query T
+SELECT get_body_str('p_rewrite');
+----
+"INSERT INTO test.public.t_rewrite(v) VALUES (nextval(106:::REGCLASS)) RETURNING v;"
+
+statement ok
+DROP PROCEDURE p_rewrite();
+
+statement ok
+CREATE OR REPLACE PROCEDURE p_rewrite() AS
+$$
+  UPDATE t_rewrite SET w = 'thursday'::weekday WHERE w = 'wednesday'::weekday RETURNING w;
+$$ LANGUAGE SQL
+
+query T
+SELECT get_body_str('p_rewrite');
+----
+"UPDATE test.public.t_rewrite SET w = b'\\xa0':::@100107 WHERE w = b'\\x80':::@100107 RETURNING w;"
+
+statement ok
+DROP PROCEDURE p_rewrite();
+
+subtest end

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -2262,6 +2262,13 @@ func TestLogic_udf_regressions(
 	runLogicTest(t, "udf_regressions")
 }
 
+func TestLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_rewrite")
+}
+
 func TestLogic_udf_schema_change(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -2269,6 +2269,13 @@ func TestLogic_udf_regressions(
 	runLogicTest(t, "udf_regressions")
 }
 
+func TestLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_rewrite")
+}
+
 func TestLogic_udf_schema_change(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2283,6 +2283,13 @@ func TestLogic_udf_regressions(
 	runLogicTest(t, "udf_regressions")
 }
 
+func TestLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_rewrite")
+}
+
 func TestLogic_udf_schema_change(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -2269,6 +2269,13 @@ func TestLogic_udf_regressions(
 	runLogicTest(t, "udf_regressions")
 }
 
+func TestLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_rewrite")
+}
+
 func TestLogic_udf_schema_change(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-23.2/generated_test.go
@@ -2283,6 +2283,13 @@ func TestLogic_udf_regressions(
 	runLogicTest(t, "udf_regressions")
 }
 
+func TestLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_rewrite")
+}
+
 func TestLogic_udf_schema_change(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2297,6 +2297,13 @@ func TestLogic_udf_regressions(
 	runLogicTest(t, "udf_regressions")
 }
 
+func TestLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_rewrite")
+}
+
 func TestLogic_udf_schema_change(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2500,6 +2500,13 @@ func TestLogic_udf_regressions(
 	runLogicTest(t, "udf_regressions")
 }
 
+func TestLogic_udf_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_rewrite")
+}
+
 func TestLogic_udf_schema_change(
 	t *testing.T,
 ) {

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -1958,6 +1958,11 @@ func TestSchemaChangeComparator_udf_regressions(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_regressions"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
+func TestSchemaChangeComparator_udf_rewrite(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_rewrite"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_udf_schema_change(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_schema_change"

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1490,7 +1490,7 @@ func (b *builderState) WrapFunctionBody(
 	refProvider scbuildstmt.ReferenceProvider,
 ) *scpb.FunctionBody {
 	if lang != catpb.Function_PLPGSQL {
-		// TODO(drewk): fix this to work with PL/pgSQL.
+		// TODO(#115627): fix this to work with PL/pgSQL.
 		bodyStr = b.replaceSeqNamesWithIDs(bodyStr)
 		bodyStr = b.serializeUserDefinedTypes(bodyStr)
 	}


### PR DESCRIPTION
This PR adds logic tests to verify that sequences and UDTs are rewritten in UDF bodies that are both read-only and contain mutations.

Epic: none
Informs: #105478

Release note: None