### PR TITLE
kvserver: make replicaProposer rlocker RLocker again

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1297,7 +1297,7 @@ func (rp *replicaProposer) locker() sync.Locker {
 }
 
 func (rp *replicaProposer) rlocker() sync.Locker {
-	return &rp.mu.ReplicaMutex
+	return rp.mu.ReplicaMutex.RLocker()
 }
 
 func (rp *replicaProposer) getReplicaID() roachpb.ReplicaID {


### PR DESCRIPTION
Commit 3faf1e1 unintentionally made `replicaProposer.rlocker()` return a write locker instead of read locker. This effectively disabled the proposal buffer's concurrent [Insert](https://github.com/cockroachdb/cockroach/blob/ba6423f916dc4006bb590c786cf53ad2b0213417/pkg/kv/kvserver/replica_proposal_buf.go#L257-L262).

Touches #106574
Epic: none
Release note: none