### PR TITLE
opt: fix subquery type-checking

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/suboperators
+++ b/pkg/sql/logictest/testdata/logic_test/suboperators
@@ -473,3 +473,15 @@ query B
 SELECT NULL = ALL(NULL::INTEGER[]);
 ----
 NULL
+
+# Regression test for #102017 - don't throw a "too few columns" error.
+query II
+SELECT * FROM (VALUES (1, 2)) foo(a, b)
+WHERE (a, b) = ANY(ARRAY(SELECT ROW(x, y) FROM (VALUES (1, 2)) bar(x, y)));
+----
+1  2
+
+query II
+SELECT a, b FROM abc WHERE (a, b) = ANY(ARRAY(SELECT ROW(a, b) FROM abc LIMIT 1));
+----
+1  10

--- a/pkg/sql/logictest/testdata/logic_test/suboperators
+++ b/pkg/sql/logictest/testdata/logic_test/suboperators
@@ -4,6 +4,15 @@ CREATE TABLE abc (a INT, b INT, C INT)
 statement ok
 INSERT INTO abc VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300), (NULL, NULL, NULL)
 
+statement ok
+CREATE TYPE typ AS (x INT, y INT);
+
+statement ok
+CREATE TABLE comp (v typ);
+
+statement ok
+INSERT INTO comp VALUES (ROW(1, 2)), (ROW(3, 4));
+
 # ANY/SOME with arrays.
 
 query B
@@ -485,3 +494,9 @@ query II
 SELECT a, b FROM abc WHERE (a, b) = ANY(ARRAY(SELECT ROW(a, b) FROM abc LIMIT 1));
 ----
 1  10
+
+query T rowsort
+SELECT * FROM comp WHERE v IN (SELECT v FROM comp);
+----
+(1,2)
+(3,4)

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -249,8 +249,9 @@ func (s *subquery) buildSubquery(desiredTypes []*types.T) {
 		numSubqueryCols := len(outScope.cols)
 		if !desireAnyType && len(desiredTypes) != numSubqueryCols {
 			if s.wrapInTuple && numSubqueryCols == 1 {
-				if tupleExpr, ok := outScope.cols[0].scalar.(*memo.TupleExpr); ok {
-					numSubqueryCols = len(tupleExpr.Elems)
+				colTyp := outScope.cols[0].typ
+				if colTyp.Family() == types.TupleFamily {
+					numSubqueryCols = len(colTyp.TupleContents())
 				}
 			}
 			if len(desiredTypes) != numSubqueryCols {


### PR DESCRIPTION
#### opt: fix type-checking for ArrayFlatten

Previously, type-checking for a subquery would unconditionally use the
"desired" types to determine how many columns the subquery should produce.
This number would then be used to throw an error, if it didn't match the
actual number of columns. The desired number of columns can also be directly
supplied via the `desiredNumColumns`. Checking this field previously
happened after the unconditional "desired types" check. This could cause
some queries to return a "too few columns" error incorrectly.

This patch makes the "desired types" check conditional on `desiredNumColumns`
being unset. This prevents the incorrect error for `ArrayFlatten` expressions,
which always desire exactly one column from the subquery.

Informs #102017

Release note (bug fix): Fixes a bug that could result in an incorrect
"too few columns" error for queries that use `ANY <array>` syntax with
a subquery.

#### opt: check tuple type instead of expression for subquery type-checking

Subquery type-checking ensures that the columns returned by the subquery
line up with the expected types, and throws an error if they do not match.
This was over-eager for the case when the subquery returns a single tuple
column with the correct types, because the scalar expression for the column
was checked instead of its type. This led to "too few/many columns" errors
when the output column was not a simple projection of a tuple.
This patch fixes the over-eager error by checking the type of the subquery
output column instead of its scalar value.

Informs #102017

Release note (bug fix): Fixed a bug that could cause "too few/many columns"
errors for queries that used `IN` or `NOT IN` with a non-trivial right
operand, such as a subquery (rather than a constant tuple).