### PR TITLE
cloud: reduce default chunk size to 5mb

### DIFF
--- a/pkg/cloud/cloud_io.go
+++ b/pkg/cloud/cloud_io.go
@@ -54,7 +54,7 @@ var WriteChunkSize = settings.RegisterByteSizeSetting(
 	settings.ApplicationLevel,
 	"cloudstorage.write_chunk.size",
 	"controls the size of each file chunk uploaded by the cloud storage client",
-	8<<20,
+	5<<20,
 )
 
 var retryConnectionTimedOut = settings.RegisterBoolSetting(


### PR DESCRIPTION
The 8MB chunks increase the memory footprint of operations that hold many chunks at once and hashing them can lead to longer periods of cpu usage, which in particular cannot be preempted for STW gc as it is in asm. Reducing this from 8mb to 5mb will mean 30% smaller chunks, and thus 30% smaller heap usage and shorter hashing durations, at the cost of more chunks, but given our files are typically around 100mb or often smaller this should be a minimal amount of overhead.

Release note: none.
Epic: none.