### PR TITLE
ui: fix timezone formatting for bar charts

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
@@ -56,6 +56,7 @@ export const BarGraphTimeSeries: React.FC<BarGraphTimeSeriesProps> = ({
       alignedData[0][0], // startMillis
       alignedData[0][alignedData[0].length - 1], // endMillis
       samplingIntervalMillis,
+      timezone,
     );
 
     const stackedData = stack(alignedData, () => false);

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/utils/domain.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/utils/domain.ts
@@ -333,7 +333,7 @@ export function calculateYAxisDomain(
 export function calculateXAxisDomain(
   startMillis: number,
   endMillis: number,
-  timezone = "UTC",
+  timezone = "Etc/UTC",
 ): AxisDomain {
   return ComputeTimeAxisDomain([startMillis, endMillis] as Extent, timezone);
 }
@@ -342,7 +342,7 @@ export function calculateXAxisDomainBarChart(
   startMillis: number,
   endMillis: number,
   samplingIntervalMillis: number,
-  timezone = "UTC",
+  timezone = "Etc/UTC",
 ): AxisDomain {
   // For bar charts, we want to render past endMillis to fully render the
   // last bar. We should extend the x axis to the next sampling interval.


### PR DESCRIPTION
This change:
1. Fixes naming of UTC timezone that can be consumed by moment.js (more details: The special area of "Etc" is used for some administrative zones, particularly for "Etc/UTC" which represents Coordinated Universal Time (https://en.wikipedia.org/wiki/Tz_database#Area).
2. Propagate `timezone` property to `calculateXAxisDomainBarChart` func from barchart graph.

Epic: None

Release note (ui change): time on X-Axis of bar charts on Statement details page display correctly formatted time in UTC.

Resolves: #115091

After fix: both tooltip and X-Axis show time in UTC.
![Screenshot 2023-11-28 at 16 39 35](https://github.com/cockroachdb/cockroach/assets/3106437/612b37f0-a58e-4081-9313-8bce889789dd)
