### PR TITLE
ui: make goroutine and gc metrics per-node

### DIFF
--- a/monitoring/grafana-dashboards/by-cluster/runtime.json
+++ b/monitoring/grafana-dashboards/by-cluster/runtime.json
@@ -540,7 +540,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "The amount of processor time used by Go’s garbage collector per second across all nodes. During garbage collection, application code execution is paused.",
+      "description": "The amount of time Go’s garbage collector spent in stop-the-world pauses per second across all nodes. During stop-the-world garbage collection phases (sweep termination and mark termination), application code execution is paused.",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {

--- a/monitoring/grafana-dashboards/by-roachtest/runtime.json
+++ b/monitoring/grafana-dashboards/by-roachtest/runtime.json
@@ -577,7 +577,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "The amount of processor time used by Go’s garbage collector per second across all nodes. During garbage collection, application code execution is paused.",
+      "description": "The amount of time Go’s garbage collector spent in stop-the-world pauses per second across all nodes. During stop-the-world garbage collection phases (sweep termination and mark termination), application code execution is paused.",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {

--- a/monitoring/splunk-dashboard/runtime.xml
+++ b/monitoring/splunk-dashboard/runtime.xml
@@ -147,7 +147,7 @@ sum(cgo_total) as cgo_total,</query>
         <title>The number of Goroutines across all nodes. This count should rise and fall based on load.</title>
         <search>
           <query>| mstats sum(sys_goroutines)  as x
-where index=$index_name$ AND cluster_id=$cluster_id$   span=10s
+where index=$index_name$ AND cluster_id=$cluster_id$   span=10s by net.host.name
 |timechart span=10s  
 sum(x) as goroutine_count</query>
           <earliest>$Time_range.earliest$</earliest>
@@ -225,7 +225,7 @@ WHERE index=$index_name$ AND cluster_id=$cluster_id$  span=10s by net.host.name
         <search>
           <query>| mstats 
 rate_sum(sys_gc_count) as x 
-WHERE index=$index_name$ AND cluster_id=$cluster_id$  span=10s
+WHERE index=$index_name$ AND cluster_id=$cluster_id$  span=10s by net.host.name
 | timechart  span=10s sum(x) as gc_runs</query>
           <earliest>$Time_range.earliest$</earliest>
           <latest>$Time_range.latest$</latest>
@@ -273,12 +273,12 @@ WHERE index=$index_name$ AND cluster_id=$cluster_id$  span=10s
     <panel>
       <title>GC Pause Time</title>
       <chart>
-        <title>The amount of processor time used by Go’s garbage collector per second across all nodes. During garbage collection, application code execution is paused.</title>
+        <title>The amount of time Go’s garbage collector spent in stop-the-world pauses per second across all nodes. During stop-the-world garbage collection phases (sweep termination and mark termination), application code execution is paused.</title>
         <search>
           <query>| mstats 
 rate_sum(sys_gc_pause_ns) as x 
 WHERE index=$index_name$ AND cluster_id=$cluster_id$  
-span=10s
+span=10s by net.host.name
 | eval x=round(x/1000/1000, 4)
 | timechart span=10s sum(x) as gc_pause_time</query>
           <earliest>$Time_range.earliest$</earliest>

--- a/pkg/cmd/roachprod/grafana/configs/runtime.json
+++ b/pkg/cmd/roachprod/grafana/configs/runtime.json
@@ -540,7 +540,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "The amount of processor time used by Go’s garbage collector per second across all nodes. During garbage collection, application code execution is paused.",
+      "description": "The amount of time Go’s garbage collector spent in stop-the-world pauses per second across all nodes. During stop-the-world garbage collection phases (sweep termination and mark termination), application code execution is paused.",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -83,7 +83,13 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis label="goroutines">
-        <Metric name="cr.node.sys.goroutines" title="Goroutine Count" />
+        {nodeIDs.map(nid => (
+            <Metric
+                name="cr.node.sys.goroutines"
+                title={nodeDisplayName(nodeDisplayNameByID, nid)}
+                sources={[nid]}
+            />
+        ))}
       </Axis>
     </LineGraph>,
 
@@ -116,25 +122,35 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis label="runs">
-        <Metric name="cr.node.sys.gc.count" title="GC Runs" nonNegativeRate />
+        {nodeIDs.map(nid => (
+            <Metric
+                name="cr.node.sys.gc.count"
+                title={nodeDisplayName(nodeDisplayNameByID, nid)}
+                sources={[nid]}
+                nonNegativeRate
+            />
+        ))}
       </Axis>
     </LineGraph>,
 
     <LineGraph
-      title="GC Pause Time"
+      title="GC Stop-the-World Pause Time"
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`The amount of processor time used by Go’s garbage collector per second
-          ${tooltipSelection}. During garbage collection, application code
-          execution is paused.`}
+      tooltip={`The amount of time Go’s garbage collector spent in stop-the-world pauses per second
+          ${tooltipSelection}. During stop-the-world garbage collection phases (sweep termination
+          and mark termination), application code execution is paused.`}
       showMetricsInTooltip={true}
     >
-      <Axis units={AxisUnits.Duration} label="pause time">
-        <Metric
-          name="cr.node.sys.gc.pause.ns"
-          title="GC Pause Time"
-          nonNegativeRate
-        />
+      <Axis units={AxisUnits.Duration} label="STW pause time">
+        {nodeIDs.map(nid => (
+            <Metric
+                name="cr.node.sys.gc.pause.ns"
+                title={nodeDisplayName(nodeDisplayNameByID, nid)}
+                sources={[nid]}
+                nonNegativeRate
+            />
+        ))}
       </Axis>
     </LineGraph>,
 


### PR DESCRIPTION
This change updates the following three graphs to present per-node information, instead of a sum across nodes:
* Runtime > Goroutine Count
* Runtime > GC Runs
* Runtime > GC Stop-the-World Pause Time

These graphs each include per-node information which loses signal when summed across all nodes in the cluster. For example, it's clear that 5ms/1s STW pause time is too much on a single node, but it's not clear when skimming over the graphs on a larger cluster what value would be concerning.

Examples:

<img width="989" alt="Screenshot 2023-11-28 at 11 52 34 AM" src="https://github.com/cockroachdb/cockroach/assets/5438456/230cf980-aab3-4358-b847-08d3123a413f">
<img width="983" alt="Screenshot 2023-11-28 at 11 52 42 AM" src="https://github.com/cockroachdb/cockroach/assets/5438456/77856f55-2baa-4fb9-a365-720640d899bc">
<img width="985" alt="Screenshot 2023-11-28 at 11 52 49 AM" src="https://github.com/cockroachdb/cockroach/assets/5438456/7537a11e-2c52-47ac-ab66-87bcb295364a">



Epic: None
Release note: None