### PR TITLE
release-23.2: Revert "storage: assert local single delete safety"

### DIFF
--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -434,12 +434,6 @@ func (i *EngineIterator) Stats() storage.IteratorStats {
 	return i.i.Stats()
 }
 
-// CanDeterministicallySingleDelete is part of the storage.EngineIterator
-// interface.
-func (i *EngineIterator) CanDeterministicallySingleDelete() (bool, error) {
-	return i.i.CanDeterministicallySingleDelete()
-}
-
 type spanSetReader struct {
 	r     storage.Reader
 	spans *SpanSet

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -392,22 +392,6 @@ type EngineIterator interface {
 	PrevEngineKeyWithLimit(limit roachpb.Key) (state pebble.IterValidityState, err error)
 	// Stats returns statistics about the iterator.
 	Stats() IteratorStats
-	// CanDeterministicallySingleDelete is a specific purpose-built method for
-	// determining whether the current key (UnsafeRawEngineKey()/EngineKey())
-	// may be deterministically deleted through a single delete key on the local
-	// engine state. The determination is completely to local to the Engine, and
-	// a true return value does not mean that clearing the key with a single
-	// delete will be deterministic on other replicas on other Engines.
-	//
-	// CanDeterministicallySingleDelete does not change the iterator position
-	// (all subsequent iterator operations should behave as if
-	// CanDeterministicallySingleDelete was never invoked), although it DOES
-	// invalidate the memory associated with the current iterator position's
-	// value.
-	//
-	// CanDeterministicallySingleDelete may only be called when oriented in the
-	// forward direction and only once at a given iterator position.
-	CanDeterministicallySingleDelete() (ok bool, err error)
 }
 
 // CloneContext is an opaque type encapsulating sufficient context to construct

--- a/pkg/storage/lock_table_iterator.go
+++ b/pkg/storage/lock_table_iterator.go
@@ -479,11 +479,6 @@ func (i *LockTableIterator) Stats() IteratorStats {
 	return i.iter.Stats()
 }
 
-// CanDeterministicallySingleDelete implements the EngineIterator interface.
-func (i *LockTableIterator) CanDeterministicallySingleDelete() (ok bool, err error) {
-	return i.iter.CanDeterministicallySingleDelete()
-}
-
 //gcassert:inline
 func isLockTableKey(key roachpb.Key) bool {
 	return bytes.HasPrefix(key, keys.LocalRangeLockTablePrefix)

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -366,16 +366,6 @@ func getMaxConcurrentCompactions() int {
 var l0SubLevelCompactionConcurrency = envutil.EnvOrDefaultInt(
 	"COCKROACH_L0_SUB_LEVEL_CONCURRENCY", 2)
 
-// assertSingleDeleteSafety configures whether or not to perform verification
-// that SINGLEDELs are deterministic when applied to the local Engine during
-// intent resolution. See call sites of CanDeterministicallySingleDelete. See
-// cockroach#114421 for the motivation.
-//
-// An environment variable is provided for disabling these assertions in case
-// conditions under which false positives or severe peformance regressions are
-// possible.
-var assertSingleDeleteSafety = envutil.EnvOrDefaultBool("COCKROACH_SINGLEDEL_ASSERT", true)
-
 // MakeValue returns the inline value.
 func MakeValue(meta enginepb.MVCCMetadata) roachpb.Value {
 	return roachpb.Value{RawBytes: meta.RawBytes}
@@ -4981,38 +4971,7 @@ func MVCCResolveWriteIntent(
 		if err != nil {
 			return false, 0, nil, false, err
 		}
-		switch outcome {
-		case lockNoop:
-			// Do nothing.
-		case lockClearedBySingleDelete:
-			ok = true
-			if !assertSingleDeleteSafety {
-				continue
-			}
-
-			// Single deletes rely on subtle invariants and logic. We can detect
-			// misuse if the local store's internal state could result in
-			// nondeterministic behavior if we write a single delete. This
-			// doesn't guard against writes to the key committed to the engine
-			// after we opened ltIter but before the single delete is applied,
-			// and it also doesn't guarantee the single delete will be okay on
-			// other replicas' engines.
-			if isDeterministic, err := ltIter.CanDeterministicallySingleDelete(); err != nil {
-				return false, 0, nil, false, errors.Wrap(err, "validating single delete invariant")
-			} else if !isDeterministic {
-				err := errors.AssertionFailedf("deleting by single delete is unsafe")
-				if key, keyErr := ltIter.EngineKey(); keyErr != nil {
-					err = errors.WithSecondaryError(err, keyErr)
-				} else {
-					err = errors.Wrapf(err, "resolving lock key %s", key)
-				}
-				log.Fatalf(ctx, "intent resolution: %v", err)
-			}
-		case lockClearedByDelete, lockOverwritten:
-			ok = true
-		default:
-			panic("unreachable")
-		}
+		ok = ok || outcome != lockNoop
 	}
 	numBytes = int64(rw.BufferedSize() - beforeBytes)
 	return ok, numBytes, nil, replLocksReleased, nil
@@ -5760,38 +5719,11 @@ func MVCCResolveWriteIntentRange(
 		if err != nil {
 			log.Warningf(ctx, "failed to resolve intent for key %q: %+v", lastResolvedKey, err)
 		}
-
-		switch outcome {
-		case lockNoop:
-			// Do nothing.
-		case lockClearedBySingleDelete:
-			if assertSingleDeleteSafety {
-				// Single deletes rely on subtle invariants and logic. We can
-				// detect misuse if the local store's internal state could
-				// result in nondeterministic behavior if we write a single
-				// delete. This doesn't guard against writes to the key
-				// committed to the engine after we opened ltIter but before the
-				// single delete is applied, and it also doesn't guarantee the
-				// single delete will be okay on other replicas' engines.
-				if ok, err := ltIter.CanDeterministicallySingleDelete(); err != nil {
-					return 0, 0, nil, 0, false, errors.Wrap(err, "validating single delete invariant")
-				} else if !ok {
-					log.Fatalf(ctx, "resolving lock key %s: %+v", ltKey,
-						errors.AssertionFailedf("deleting by single delete is unsafe"))
-				}
-			}
-
-			// Fallthrough to update numKeys and lastResolvedKeyOk if necessary.
-			fallthrough
-		case lockClearedByDelete, lockOverwritten:
-			if !lastResolvedKeyOk {
-				// We only count the first successfully resolved lock/intent on a
-				// given key towards the returned key count and key limit.
-				lastResolvedKeyOk = true
-				numKeys++
-			}
-		default:
-			panic("unreachable")
+		if outcome != lockNoop && !lastResolvedKeyOk {
+			// We only count the first successfully resolved lock/intent on a
+			// given key towards the returned key count and key limit.
+			lastResolvedKeyOk = true
+			numKeys++
 		}
 		numBytes += int64(rw.BufferedSize() - beforeBytes)
 	}

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -462,7 +462,7 @@ func (p *pebbleIterator) Next() {
 	p.iter.Next()
 }
 
-// NextEngineKey implements the EngineIterator interface.
+// NextEngineKey implements the Engineterator interface.
 func (p *pebbleIterator) NextEngineKey() (valid bool, err error) {
 	ok := p.iter.Next()
 	// NB: A Pebble Iterator always returns ok==false when an error is
@@ -945,11 +945,6 @@ func (p *pebbleIterator) IsPrefix() bool {
 // CloneContext is part of the EngineIterator interface.
 func (p *pebbleIterator) CloneContext() CloneContext {
 	return CloneContext{rawIter: p.iter, engine: p.parent}
-}
-
-// CanDeterministicallySingleDelete implements the EngineIterator interface.
-func (p *pebbleIterator) CanDeterministicallySingleDelete() (ok bool, err error) {
-	return pebbleiter.CanDeterministicallySingleDelete(p.iter)
 }
 
 func (p *pebbleIterator) getBlockPropertyFilterMask() pebble.BlockPropertyFilterMask {

--- a/pkg/storage/pebbleiter/crdb_test_off.go
+++ b/pkg/storage/pebbleiter/crdb_test_off.go
@@ -24,9 +24,3 @@ type Iterator = *pebble.Iterator
 func MaybeWrap(iter *pebble.Iterator) Iterator {
 	return iter
 }
-
-// CanDeterministicallySingleDelete wraps
-// pebble.CanDeterministicallySingleDelete.
-func CanDeterministicallySingleDelete(it Iterator) (bool, error) {
-	return pebble.CanDeterministicallySingleDelete(it)
-}

--- a/pkg/storage/pebbleiter/crdb_test_on.go
+++ b/pkg/storage/pebbleiter/crdb_test_on.go
@@ -34,12 +34,6 @@ func MaybeWrap(iter *pebble.Iterator) Iterator {
 	return &assertionIter{Iterator: iter, closedCh: make(chan struct{})}
 }
 
-// CanDeterministicallySingleDelete wraps
-// pebble.CanDeterministicallySingleDelete.
-func CanDeterministicallySingleDelete(it Iterator) (bool, error) {
-	return pebble.CanDeterministicallySingleDelete(it.Iterator)
-}
-
 // assertionIter wraps a *pebble.Iterator with assertion checking.
 type assertionIter struct {
 	*pebble.Iterator


### PR DESCRIPTION
This reverts commit 0f14f44b988d632bbe8eab8c143e66363c644ca9. The "obsolete bit" filtering that now occurs within the block iterator means that the top-level Iterator is not guaranteed to observe the same continuous slice of internal keys as the compaction iterator. The CanDeterministicallySingleDelete mechanics were dependent on this.

Informs #115172.
Epic: none
Release note: none
Release justification: removes invariant assertion capable of false positives, fataling nodes unnecessarily.