### PR TITLE
encoding: use large pool, don't allocate so much

### DIFF
--- a/pkg/util/encoding/BUILD.bazel
+++ b/pkg/util/encoding/BUILD.bazel
@@ -40,6 +40,8 @@ go_test(
         "printer_test.go",
     ],
     embed = [":encoding"],
+    # A test in this package allocates a 2GB array so we need the extra memory.
+    exec_properties = {"Pool": "large"},
     deps = [
         "//pkg/geo",
         "//pkg/geo/geographiclib",

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -2629,27 +2629,32 @@ func TestUnsafeConvertStringToBytes(t *testing.T) {
 	skip.UnderStress(t)
 
 	testCases := []struct {
-		desc     string
-		input    string
-		expected []byte
+		desc           string
+		input          string
+		expectNil      bool
+		expectedLength int
 	}{
 		{
-			desc:     "empty",
-			input:    "",
-			expected: nil,
+			desc:      "empty",
+			input:     "",
+			expectNil: true,
 		},
 		{
 			// Previous impl could not handle strings longer than math.MaxInt32.
 			// See https://github.com/cockroachdb/cockroach/issues/111626
-			desc:     "large input",
-			input:    string(make([]byte, math.MaxInt32+1)),
-			expected: make([]byte, math.MaxInt32+1),
+			desc:           "large input",
+			input:          string(make([]byte, math.MaxInt32+1)),
+			expectedLength: math.MaxInt32 + 1,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			actual := UnsafeConvertStringToBytes(tc.input)
-			require.Equal(t, tc.expected, actual)
+			if tc.expectNil {
+				require.Nil(t, actual)
+			} else {
+				require.Equal(t, len(actual), tc.expectedLength)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This test was written to allocate a 2GB array twice. I update it to avoid the second allocation. Also we use the `large` pool for this as we expect OOM's otherwise.

Epic: none
Release note: None