### PR TITLE
bazel: `race` does not imply disabling sharding

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -45,7 +45,7 @@ query --ui_event_filters=-DEBUG
 clean --ui_event_filters=-WARNING
 info --ui_event_filters=-WARNING
 
-build:race --@io_bazel_rules_go//go/config:race "--test_env=GORACE=halt_on_error=1 log_path=stdout" --test_sharding_strategy=disabled
+build:race --@io_bazel_rules_go//go/config:race "--test_env=GORACE=halt_on_error=1 log_path=stdout"
 test:test --test_env=TZ=
 # Note: these timeout values are used indirectly in `build/teamcity/cockroach/ci/tests/testrace_impl.sh`.
 # If those values are updated, the script should be updated accordingly.

--- a/build/teamcity/cockroach/ci/tests/testrace_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/testrace_impl.sh
@@ -32,6 +32,7 @@ do
             $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=ci --config=race "$test" \
                                 --test_env=COCKROACH_LOGIC_TESTS_SKIP=true \
                                 --test_timeout $timeout \
+                                --test_sharding_strategy=disabled \
                                 --test_env=GOMAXPROCS=8
         done
     done

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
@@ -20,6 +20,7 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --formatter=pebble-metamorphic -- test --c
                                       @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test \
                                       --test_env TC_SERVER_URL=$TC_SERVER_URL \
                                       --test_timeout=14400 '--test_filter=TestMeta$' \
+                                      --test_sharding_strategy=disabled \
                                       --define gotags=bazel,invariants \
                                       --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 3h -maxfails 1 -timeout 30m -stderr -p 1" \
                                       --test_arg -dir --test_arg $ARTIFACTS_DIR \

--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=89
+DEV_VERSION=90
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -233,7 +233,7 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
 	}
 	if race {
-		args = append(args, "--config=race")
+		args = append(args, "--config=race", "--test_sharding_strategy=disabled")
 	}
 	if deadlock {
 		goTags = append(goTags, "deadlock")

--- a/pkg/cmd/dev/testdata/recorderdriven/test
+++ b/pkg/cmd/dev/testdata/recorderdriven/test
@@ -47,7 +47,7 @@ bazel test //pkg/testutils:testutils_test //pkg/util/limit:limit_test //pkg/util
 dev test pkg/spanconfig --count 5 --race
 ----
 bazel query 'kind(.*_test, pkg/spanconfig:all)'
-bazel test --config=race //pkg/spanconfig:spanconfig_test --test_env=GOTRACEBACK=all --runs_per_test=5 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
+bazel test --config=race --test_sharding_strategy=disabled //pkg/spanconfig:spanconfig_test --test_env=GOTRACEBACK=all --runs_per_test=5 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
 
 dev test pkg/cmd/dev -f TestDataDriven/test --rewrite -v
 ----

--- a/pkg/cmd/dev/testdata/recorderdriven/test.rec
+++ b/pkg/cmd/dev/testdata/recorderdriven/test.rec
@@ -79,7 +79,7 @@ bazel query 'kind(.*_test, pkg/spanconfig:all)'
 ----
 //pkg/spanconfig:spanconfig_test
 
-bazel test --config=race //pkg/spanconfig:spanconfig_test --test_env=GOTRACEBACK=all --runs_per_test=5 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
+bazel test --config=race --test_sharding_strategy=disabled //pkg/spanconfig:spanconfig_test --test_env=GOTRACEBACK=all --runs_per_test=5 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
 ----
 
 bazel query 'kind(.*_test, pkg/cmd/dev:all)'

--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -345,9 +345,8 @@ func main() {
 				args = append(args, "--")
 				if target == "stressrace" {
 					args = append(args, "--config=race")
-				} else {
-					args = append(args, "--test_sharding_strategy=disabled")
 				}
+				args = append(args, "--test_sharding_strategy=disabled")
 				var filters []string
 				for test := range pkg.tests {
 					filters = append(filters, "^"+test+"$")


### PR DESCRIPTION
On the EngFlow cluster, we would like to take advantage of `race` without disabling sharding, so updating this configuration is sensible. Anywhere where it's useful to disable sharding, we do it inline.

Epic: CRDB-8308
Release note: None