### PR TITLE
obsservice: create batches for insert insights

### DIFF
--- a/pkg/obsservice/cmd/obsservice/main.go
+++ b/pkg/obsservice/cmd/obsservice/main.go
@@ -263,7 +263,7 @@ func makeStatementInsightsPipeline(
 	}
 
 	processor, err := process.NewMemQueueProcessor[*obspb.StatementInsightsStatistics](
-		memQueue, &process.StmtInsightsProcessor{SinkPGURL: sinkPGURL})
+		memQueue, process.NewStmtInsightsProcessor(sinkPGURL))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/obsservice/obslib/process/BUILD.bazel
+++ b/pkg/obsservice/obslib/process/BUILD.bazel
@@ -18,6 +18,8 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/util/log",
         "//pkg/util/stop",
+        "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_jackc_pgx_v5//stdlib",


### PR DESCRIPTION
Note to reviewers: The values for 100 Insights and the at least 1 minute are random for now. Later we can check if another value makes more sense.

---
Previously, all insights were being inserted as soon as exported to obsservice.
This commit introduces a cache to batch insights and do less inserts.
When the caches reaches 100 entries or it has been at least a minute since last insert, we do an insert.

Fixes CC-26215

Demo: https://www.loom.com/share/ecf706d41155484eb2fd532414a4f7b6

Release note: None