### PR TITLE
sql/sem/builtins: deflake TestGetSSTableMetricsSingleNode

### DIFF
--- a/pkg/sql/sem/builtins/generator_builtins_test.go
+++ b/pkg/sql/sem/builtins/generator_builtins_test.go
@@ -197,5 +197,5 @@ func TestGetSSTableMetricsSingleNode(t *testing.T) {
 		require.NotEqual(t, approximateSpanBytes, 0)
 		count++
 	}
-	require.Equal(t, 1, count)
+	require.GreaterOrEqual(t, count, 1)
 }


### PR DESCRIPTION
This test was dependent on exactly 1 sstable being produced for storing the provided SQL data, which is not a guarantee that can be made.

Fix #115071.
Epic: none
Release note: none