### PR TITLE
clusterversion: remove ByKey

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1670,7 +1670,7 @@ func TestBackupRestoreResume(t *testing.T) {
 				},
 			},
 			// Required because restore checkpointing is version gated.
-			clusterversion.ByKey(clusterversion.V23_1),
+			clusterversion.V23_1.Version(),
 		)
 		// If the restore properly took the (incorrect) low-water mark into account,
 		// the first half of the table will be missing.

--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -177,7 +177,7 @@ func (d *datadrivenTestState) addCluster(t *testing.T, cfg clusterCfg) error {
 		}
 		beforeKey--
 		params.ServerArgs.Knobs.Server = &server.TestingKnobs{
-			BinaryVersionOverride:          clusterversion.ByKey(beforeKey),
+			BinaryVersionOverride:          beforeKey.Version(),
 			DisableAutomaticVersionUpgrade: make(chan struct{}),
 		}
 	}
@@ -576,7 +576,7 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 			if !ok {
 				t.Fatalf("clusterVersion %s does not exist in data driven global map", version)
 			}
-			clusterVersion := clusterversion.ByKey(key)
+			clusterVersion := key.Version()
 			_, err := ds.getSQLDB(t, cluster, user).Exec("SET CLUSTER SETTING version = $1", clusterVersion.String())
 			require.NoError(t, err)
 			return ""

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -290,7 +290,7 @@ func restore(
 		return emptyRowCount, err
 	}
 
-	on231 := clusterversion.ByKey(clusterversion.V23_1).LessEq(job.Payload().CreationClusterVersion)
+	on231 := clusterversion.V23_1.Version().LessEq(job.Payload().CreationClusterVersion)
 	progressTracker, err := makeProgressTracker(
 		dataToRestore.getSpans(),
 		job.Progress().Details.(*jobspb.Progress_Restore).Restore.Checkpoint,

--- a/pkg/ccl/changefeedccl/changefeedbase/options_test.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options_test.go
@@ -68,11 +68,11 @@ func TestLaggingRangesVersionGate(t *testing.T) {
 	// The version does not matter if the default config is used.
 	t.Run("default config", func(t *testing.T) {
 		opts := MakeDefaultOptions()
-		settings := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.ByKey(clusterversion.V23_2_ChangefeedLaggingRangesOpts), clusterversion.ByKey(clusterversion.V23_1), true)
+		settings := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.V23_2_ChangefeedLaggingRangesOpts.Version(), clusterversion.V23_1.Version(), true)
 		_, _, err := opts.GetLaggingRangesConfig(ctx, settings)
 		require.NoError(t, err)
 
-		settings = cluster.MakeTestingClusterSettingsWithVersions(clusterversion.ByKey(clusterversion.V23_2_ChangefeedLaggingRangesOpts-1), clusterversion.ByKey(clusterversion.V23_1), true)
+		settings = cluster.MakeTestingClusterSettingsWithVersions((clusterversion.V23_2_ChangefeedLaggingRangesOpts - 1).Version(), clusterversion.V23_1.Version(), true)
 		_, _, err = opts.GetLaggingRangesConfig(ctx, settings)
 		require.NoError(t, err)
 	})
@@ -83,11 +83,11 @@ func TestLaggingRangesVersionGate(t *testing.T) {
 		opts.m[OptLaggingRangesThreshold] = "25ms"
 		opts.m[OptLaggingRangesPollingInterval] = "250ms"
 
-		settings := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.ByKey(clusterversion.V23_2_ChangefeedLaggingRangesOpts), clusterversion.ByKey(clusterversion.V23_1), true)
+		settings := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.V23_2_ChangefeedLaggingRangesOpts.Version(), clusterversion.V23_1.Version(), true)
 		_, _, err := opts.GetLaggingRangesConfig(ctx, settings)
 		require.NoError(t, err)
 
-		settings = cluster.MakeTestingClusterSettingsWithVersions(clusterversion.ByKey(clusterversion.V23_2_ChangefeedLaggingRangesOpts-1), clusterversion.ByKey(clusterversion.V23_1), true)
+		settings = cluster.MakeTestingClusterSettingsWithVersions((clusterversion.V23_2_ChangefeedLaggingRangesOpts - 1).Version(), clusterversion.V23_1.Version(), true)
 		_, _, err = opts.GetLaggingRangesConfig(ctx, settings)
 		require.Error(t, err, "cluster version must be 23.2 or greater")
 	})

--- a/pkg/ccl/schemachangerccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/BUILD.bazel
@@ -37,7 +37,6 @@ go_test(
         "//pkg/base",
         "//pkg/ccl",
         "//pkg/ccl/multiregionccl/multiregionccltestutils",
-        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
+++ b/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -47,7 +46,7 @@ func (f MultiRegionTestClusterFactory) WithSchemaChangerKnobs(
 // WithMixedVersion implements the sctest.TestServerFactory interface.
 func (f MultiRegionTestClusterFactory) WithMixedVersion() sctest.TestServerFactory {
 	f.server = &server.TestingKnobs{
-		BinaryVersionOverride:          clusterversion.ByKey(sctest.OldVersionKey),
+		BinaryVersionOverride:          sctest.OldVersionKey.Version(),
 		DisableAutomaticVersionUpgrade: make(chan struct{}),
 	}
 	return f

--- a/pkg/ccl/serverccl/server_startup_guardrails_test.go
+++ b/pkg/ccl/serverccl/server_startup_guardrails_test.go
@@ -33,7 +33,7 @@ func TestServerStartupGuardrails(t *testing.T) {
 	// The tests below will use the minimum supported version as the logical
 	// version.
 	logicalVersionKey := clusterversion.MinSupported
-	logicalVersion := clusterversion.ByKey(logicalVersionKey)
+	logicalVersion := logicalVersionKey.Version()
 
 	prev := func(v roachpb.Version) roachpb.Version {
 		t.Helper()

--- a/pkg/clusterversion/clusterversion.go
+++ b/pkg/clusterversion/clusterversion.go
@@ -255,8 +255,7 @@ func (cv ClusterVersion) IsActiveVersion(v roachpb.Version) bool {
 // IsActive returns true if the features of the supplied version are active at
 // the running version.
 func (cv ClusterVersion) IsActive(versionKey Key) bool {
-	v := ByKey(versionKey)
-	return cv.IsActiveVersion(v)
+	return cv.IsActiveVersion(versionKey.Version())
 }
 
 func (cv ClusterVersion) String() string {

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -459,13 +459,6 @@ func SupportedPreviousReleases() []Key {
 	return res
 }
 
-// ByKey returns the roachpb.Version for a given key.
-// It is a fatal error to use an invalid key.
-// DEPRECATED: use key.Version() instead.
-func ByKey(key Key) roachpb.Version {
-	return key.Version()
-}
-
 // ListBetween returns the list of cluster versions in the range
 // (from, to].
 func ListBetween(from, to roachpb.Version) []roachpb.Version {

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -1173,7 +1173,7 @@ func TestTxnErrorWaitPolicyWithOldVersionPushTouch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	cv := clusterversion.ByKey(clusterversion.V23_2_RemoveLockTableWaiterTouchPush - 1)
+	cv := (clusterversion.V23_2_RemoveLockTableWaiterTouchPush - 1).Version()
 	s := createTestDBWithKnobs(t, &kvserver.StoreTestingKnobs{
 		InitialReplicaVersionOverride: &cv,
 	})

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -101,7 +101,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "concurrency_manager"), func(t *testing.T, path string) {
 		c := newCluster()
 		if strings.HasSuffix(path, "_v23_1") {
-			v := clusterversion.ByKey(clusterversion.V23_1)
+			v := clusterversion.V23_1.Version()
 			st := clustersettings.MakeTestingClusterSettingsWithVersions(v, v, true)
 			c = newClusterWithSettings(st)
 		}

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -649,8 +649,8 @@ func newInitServerConfig(
 			// separately when we Activate the server).
 			var bootstrapVersion roachpb.Version
 			for _, v := range bootstrap.VersionsWithInitialValues() {
-				if !overrideVersion.Less(clusterversion.ByKey(v)) {
-					bootstrapVersion = clusterversion.ByKey(v)
+				if !overrideVersion.Less(v.Version()) {
+					bootstrapVersion = v.Version()
 					break
 				}
 			}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -493,7 +493,7 @@ func bootstrapCluster(
 				Codec:                   keys.SystemSQLCodec,
 			}
 			for _, v := range bootstrap.VersionsWithInitialValues() {
-				if initCfg.latestVersion == clusterversion.ByKey(v) {
+				if initCfg.latestVersion == v.Version() {
 					initialValuesOpts.OverrideKey = v
 					break
 				}

--- a/pkg/server/settingswatcher/version_guard_test.go
+++ b/pkg/server/settingswatcher/version_guard_test.go
@@ -119,18 +119,18 @@ func TestVersionGuard(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			settings := cluster.MakeTestingClusterSettingsWithVersions(
-				clusterversion.ByKey(maxVersion),
-				clusterversion.ByKey(initialVersion),
+				maxVersion.Version(),
+				initialVersion.Version(),
 				false,
 			)
-			require.NoError(t, clusterversion.Initialize(ctx, clusterversion.ByKey(test.settingsVersion), &settings.SV))
-			settingVersion := clusterversion.ClusterVersion{Version: clusterversion.ByKey(test.settingsVersion)}
+			require.NoError(t, clusterversion.Initialize(ctx, test.settingsVersion.Version(), &settings.SV))
+			settingVersion := clusterversion.ClusterVersion{Version: test.settingsVersion.Version()}
 			require.NoError(t, settings.Version.SetActiveVersion(ctx, settingVersion))
 
 			if test.storageVersion == nil {
 				tDB.Exec(t, `DELETE FROM system.settings WHERE name = 'version'`)
 			} else {
-				storageVersion := clusterversion.ClusterVersion{Version: clusterversion.ByKey(*test.storageVersion)}
+				storageVersion := clusterversion.ClusterVersion{Version: test.storageVersion.Version()}
 				marshaledVersion, err := protoutil.Marshal(&storageVersion)
 				require.NoError(t, err)
 				tDB.Exec(t, `

--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -1208,7 +1208,7 @@ const SystemDatabaseName = catconstants.SystemDatabaseName
 // SystemDatabaseSchemaBootstrapVersion is the system database schema version
 // that should be used during bootstrap. It should be bumped up alongside any
 // upgrade that creates or modifies the schema of a system table.
-var SystemDatabaseSchemaBootstrapVersion = clusterversion.ByKey(clusterversion.V23_2_AddSystemExecInsightsTable)
+var SystemDatabaseSchemaBootstrapVersion = clusterversion.V23_2_AddSystemExecInsightsTable.Version()
 
 // MakeSystemDatabaseDesc constructs a copy of the system database
 // descriptor.

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -2891,7 +2891,7 @@ func TestValidateTableDesc(t *testing.T) {
 			version := d.version
 			if version != 0 {
 				clusterVersion = clusterversion.ClusterVersion{
-					Version: clusterversion.ByKey(version),
+					Version: version.Version(),
 				}
 			}
 			err := validate.Self(clusterVersion, desc)

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -318,7 +318,7 @@ func (p *planner) createUserDefinedType(params runParams, n *createTypeNode) err
 		if !p.execCfg.Settings.Version.IsActive(params.ctx, clusterversion.V23_1) {
 			return pgerror.Newf(pgcode.FeatureNotSupported,
 				"version %v must be finalized to create composite types",
-				clusterversion.ByKey(clusterversion.V23_1))
+				clusterversion.V23_1)
 		}
 		return params.p.createCompositeWithID(
 			params, id, n.n.CompositeTypeList, n.dbDesc, n.typeName,

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1473,7 +1473,7 @@ func (t *logicTest) newCluster(
 		if params.ServerArgs.Knobs.Server == nil {
 			params.ServerArgs.Knobs.Server = &server.TestingKnobs{}
 		}
-		params.ServerArgs.Knobs.Server.(*server.TestingKnobs).BinaryVersionOverride = clusterversion.ByKey(cfg.BootstrapVersion)
+		params.ServerArgs.Knobs.Server.(*server.TestingKnobs).BinaryVersionOverride = cfg.BootstrapVersion.Version()
 	}
 	if cfg.DisableUpgrade {
 		if params.ServerArgs.Knobs.Server == nil {

--- a/pkg/sql/pgwire/hba_conf.go
+++ b/pkg/sql/pgwire/hba_conf.go
@@ -422,7 +422,7 @@ func requireClusterVersion(versionkey clusterversion.Key) CheckHBAEntry {
 			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 				`HBA authentication method %q requires all nodes to be upgraded to %s`,
 				e.Method,
-				clusterversion.ByKey(versionkey),
+				versionkey,
 			)
 		}
 		return nil

--- a/pkg/sql/schemachanger/scplan/internal/rules/registry.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/registry.go
@@ -168,7 +168,7 @@ func (v NodeVars) TypeFilter(
 	if len(predicatesForTypeOf) == 0 {
 		panic(errors.AssertionFailedf("empty type predicate for %q", v.El))
 	}
-	cv := clusterversion.ClusterVersion{Version: clusterversion.ByKey(version)}
+	cv := clusterversion.ClusterVersion{Version: version.Version()}
 	var valuesForTypeOf []interface{}
 	_ = ForEachElementInActiveVersion(cv, func(e scpb.Element) error {
 		for _, p := range predicatesForTypeOf {

--- a/pkg/sql/schemachanger/scplan/plan.go
+++ b/pkg/sql/schemachanger/scplan/plan.go
@@ -196,7 +196,7 @@ func GetReleasesForRulesRegistries() []clusterversion.ClusterVersion {
 	for _, r := range rulesForReleases {
 		supportedVersions = append(supportedVersions,
 			clusterversion.ClusterVersion{
-				Version: clusterversion.ByKey(r.activeVersion),
+				Version: r.activeVersion.Version(),
 			})
 	}
 	return supportedVersions
@@ -213,7 +213,7 @@ func getMinValidVersionForRules(
 			minVersionForRules,
 			activeVersion)
 		return clusterversion.ClusterVersion{
-			Version: clusterversion.ByKey(minVersionForRules),
+			Version: minVersionForRules.Version(),
 		}
 	}
 	return activeVersion

--- a/pkg/sql/schemachanger/sctest/test_server_factory.go
+++ b/pkg/sql/schemachanger/sctest/test_server_factory.go
@@ -69,7 +69,7 @@ func (f SingleNodeTestClusterFactory) WithSchemaChangerKnobs(
 // WithMixedVersion implements the TestServerFactory interface.
 func (f SingleNodeTestClusterFactory) WithMixedVersion() TestServerFactory {
 	f.server = &server.TestingKnobs{
-		BinaryVersionOverride:          clusterversion.ByKey(OldVersionKey),
+		BinaryVersionOverride:          OldVersionKey.Version(),
 		DisableAutomaticVersionUpgrade: make(chan struct{}),
 	}
 	return f

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -595,7 +595,7 @@ func performCastWithoutPrecisionTruncation(
 		if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.V23_2) {
 			return nil, pgerror.Newf(pgcode.FeatureNotSupported,
 				"version %v must be finalized to use pg_lsn",
-				clusterversion.ByKey(clusterversion.V23_2))
+				clusterversion.V23_2.Version())
 		}
 		switch d := d.(type) {
 		case *tree.DString:
@@ -610,7 +610,7 @@ func performCastWithoutPrecisionTruncation(
 		if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.V23_2) {
 			return nil, pgerror.Newf(pgcode.FeatureNotSupported,
 				"version %v must be finalized to use refcursor",
-				clusterversion.ByKey(clusterversion.V23_2))
+				clusterversion.V23_2.Version())
 		}
 		switch d := d.(type) {
 		case *tree.DString:
@@ -896,7 +896,7 @@ func performCastWithoutPrecisionTruncation(
 		if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.V23_1) {
 			return nil, pgerror.Newf(pgcode.FeatureNotSupported,
 				"version %v must be finalized to use TSVector",
-				clusterversion.ByKey(clusterversion.V23_1))
+				clusterversion.V23_1.Version())
 		}
 		switch v := d.(type) {
 		case *tree.DString:
@@ -910,7 +910,7 @@ func performCastWithoutPrecisionTruncation(
 		if !evalCtx.Settings.Version.IsActive(ctx, clusterversion.V23_1) {
 			return nil, pgerror.Newf(pgcode.FeatureNotSupported,
 				"version %v must be finalized to use TSVector",
-				clusterversion.ByKey(clusterversion.V23_1))
+				clusterversion.V23_1.Version())
 		}
 		switch v := d.(type) {
 		case *tree.DString:

--- a/pkg/sql/tenant_creation.go
+++ b/pkg/sql/tenant_creation.go
@@ -164,14 +164,14 @@ func (p *planner) createTenantInternal(
 	if p.EvalContext().TestingKnobs.TenantLogicalVersionKeyOverride != 0 {
 		// An override was passed using testing knobs. Bootstrap the cluster
 		// using this override.
-		tenantVersion.Version = clusterversion.ByKey(p.EvalContext().TestingKnobs.TenantLogicalVersionKeyOverride)
+		tenantVersion.Version = p.EvalContext().TestingKnobs.TenantLogicalVersionKeyOverride.Version()
 		bootstrapVersionOverride = p.EvalContext().TestingKnobs.TenantLogicalVersionKeyOverride
 	} else if !p.EvalContext().Settings.Version.IsActive(ctx, clusterversion.Latest) {
 		// The cluster is not running the latest version.
 		// Use the previous major version to create the tenant and bootstrap it
 		// just like the previous major version binary would, using hardcoded
 		// initial values.
-		tenantVersion.Version = clusterversion.ByKey(tenantCreationMinSupportedVersionKey)
+		tenantVersion.Version = tenantCreationMinSupportedVersionKey.Version()
 		bootstrapVersionOverride = tenantCreationMinSupportedVersionKey
 	} else {
 		// The cluster is running the latest version.

--- a/pkg/storage/min_version_test.go
+++ b/pkg/storage/min_version_test.go
@@ -105,7 +105,7 @@ func TestSetMinVersion(t *testing.T) {
 	ValueBlocksEnabled.Override(context.Background(), &st.SV, true)
 	// Advancing the store cluster version to one that supports a new feature
 	// should also advance the store's format major version.
-	err = p.SetMinVersion(clusterversion.ByKey(clusterversion.V23_2_PebbleFormatDeleteSizedAndObsolete))
+	err = p.SetMinVersion(clusterversion.V23_2_PebbleFormatDeleteSizedAndObsolete.Version())
 	require.NoError(t, err)
 	require.Equal(t, pebble.FormatDeleteSizedAndObsolete, p.db.FormatMajorVersion())
 }

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2373,7 +2373,7 @@ func pebbleFormatVersion(clusterVersion roachpb.Version) pebble.FormatMajorVersi
 	// pebbleFormatVersionKeys are sorted in descending order; find the first one
 	// that is not newer than clusterVersion.
 	for _, k := range pebbleFormatVersionKeys {
-		if clusterVersion.AtLeast(clusterversion.ByKey(k)) {
+		if clusterVersion.AtLeast(k.Version()) {
 			return pebbleFormatVersionMap[k]
 		}
 	}

--- a/pkg/upgrade/upgrademanager/manager.go
+++ b/pkg/upgrade/upgrademanager/manager.go
@@ -321,7 +321,7 @@ func (m *Manager) runPermanentMigrationsWithoutJobsForTests(
 	ctx context.Context, user username.SQLUsername,
 ) error {
 	log.Infof(ctx, "found test configuration that eliminated all upgrades; running permanent upgrades anyway")
-	vers := clusterversion.ListBetween(roachpb.Version{}, clusterversion.ByKey(clusterversion.VPrimordialMax))
+	vers := clusterversion.ListBetween(roachpb.Version{}, clusterversion.VPrimordialMax.Version())
 	for _, v := range vers {
 		upg, exists := upgrades.GetUpgrade(v)
 		if !exists || !upg.Permanent() {

--- a/pkg/upgrade/upgrades/helpers_test.go
+++ b/pkg/upgrade/upgrades/helpers_test.go
@@ -52,7 +52,7 @@ type Schema struct {
 func Upgrade(
 	t *testing.T, sqlDB *gosql.DB, key clusterversion.Key, done chan struct{}, expectError bool,
 ) {
-	UpgradeToVersion(t, sqlDB, clusterversion.ByKey(key), done, expectError)
+	UpgradeToVersion(t, sqlDB, key.Version(), done, expectError)
 }
 
 func UpgradeToVersion(
@@ -206,7 +206,7 @@ func ExecForCountInTxns(
 func ValidateSystemDatabaseSchemaVersionBumped(
 	t *testing.T, sqlDB *gosql.DB, expectedVersion clusterversion.Key,
 ) {
-	expectedSchemaVersion := clusterversion.ByKey(expectedVersion)
+	expectedSchemaVersion := expectedVersion.Version()
 
 	var actualSchemaVersionBytes []byte
 	require.NoError(t, sqlDB.QueryRow(

--- a/pkg/upgrade/upgrades/v23_2_create_region_liveness_test.go
+++ b/pkg/upgrade/upgrades/v23_2_create_region_liveness_test.go
@@ -36,8 +36,7 @@ func TestRegionLivenessTableMigration(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride: clusterversion.ByKey(
-						clusterversion.V23_2_RegionaLivenessTable - 1),
+					BinaryVersionOverride:          (clusterversion.V23_2_RegionaLivenessTable - 1).Version(),
 				},
 			},
 		},

--- a/pkg/upgrade/upgrades/v23_2_plan_gist_stmt_diagnostics_requests_test.go
+++ b/pkg/upgrade/upgrades/v23_2_plan_gist_stmt_diagnostics_requests_test.go
@@ -43,7 +43,7 @@ func TestStmtDiagForPlanGistMigration(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V23_2_StmtDiagForPlanGist - 1),
+					BinaryVersionOverride:          (clusterversion.V23_2_StmtDiagForPlanGist - 1).Version(),
 				},
 			},
 		},

--- a/pkg/upgrade/upgrades/version_starvation_test.go
+++ b/pkg/upgrade/upgrades/version_starvation_test.go
@@ -52,8 +52,7 @@ func TestLeasingClusterVersionStarvation(t *testing.T) {
 				},
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride: clusterversion.ByKey(
-						clusterversion.V23_2),
+					BinaryVersionOverride:          clusterversion.V23_2.Version(),
 				},
 			},
 		},

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -938,7 +938,7 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (*opSt
 	if notvisible := og.randIntn(20) == 0; notvisible {
 		invisibility.Value = 1.0
 		partiallyVisibleIndexNotSupported, err := isClusterVersionLessThan(
-			ctx, tx, clusterversion.ByKey(clusterversion.V23_2),
+			ctx, tx, clusterversion.V23_2.Version(),
 		)
 		if err != nil {
 			return nil, err
@@ -976,7 +976,7 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (*opSt
 	duplicateRegionColumn := false
 	nonIndexableType := false
 	def.Columns = make(tree.IndexElemList, 1+og.randIntn(len(columnNames)))
-	jsonInvertedIndexesNotSupported, err := isClusterVersionLessThan(ctx, tx, clusterversion.ByKey(clusterversion.V23_2))
+	jsonInvertedIndexesNotSupported, err := isClusterVersionLessThan(ctx, tx, clusterversion.V23_2.Version())
 	if err != nil {
 		return nil, err
 	}
@@ -1206,7 +1206,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	}
 
 	partiallyVisibleIndexNotSupported, err := isClusterVersionLessThan(
-		ctx, tx, clusterversion.ByKey(clusterversion.V23_2),
+		ctx, tx, clusterversion.V23_2.Version(),
 	)
 	if err != nil {
 		return nil, err
@@ -1220,7 +1220,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	tsQueryNotSupported, err := isClusterVersionLessThan(
 		ctx,
 		tx,
-		clusterversion.ByKey(clusterversion.V23_1))
+		clusterversion.V23_1.Version())
 	if err != nil {
 		return nil, err
 	}
@@ -1241,7 +1241,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	pgLSNNotSupported, err := isClusterVersionLessThan(
 		ctx,
 		tx,
-		clusterversion.ByKey(clusterversion.V23_2))
+		clusterversion.V23_2.Version())
 	if err != nil {
 		return nil, err
 	}
@@ -1249,7 +1249,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	refCursorNotSupported, err := isClusterVersionLessThan(
 		ctx,
 		tx,
-		clusterversion.ByKey(clusterversion.V23_2))
+		clusterversion.V23_2.Version())
 	if err != nil {
 		return nil, err
 	}
@@ -1258,7 +1258,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	forwardIndexesOnArraysNotSupported, err := isClusterVersionLessThan(
 		ctx,
 		tx,
-		clusterversion.ByKey(clusterversion.V23_1))
+		clusterversion.V23_1.Version())
 	if err != nil {
 		return nil, err
 	}
@@ -1266,7 +1266,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	forwardIndexesOnJSONNotSupported, err := isClusterVersionLessThan(
 		ctx,
 		tx,
-		clusterversion.ByKey(clusterversion.V23_2))
+		clusterversion.V23_2.Version())
 	if err != nil {
 		return nil, err
 	}
@@ -1274,7 +1274,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	indexVisibilityNotSupported, err := isClusterVersionLessThan(
 		ctx,
 		tx,
-		clusterversion.ByKey(clusterversion.V23_2))
+		clusterversion.V23_2.Version())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -477,7 +477,7 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 
 	// Enable extra schema changes, if they are available this moment.
 	if !w.workload.declarativeStatementsEnabled.Load() {
-		cannotEnableSchemaChanges, err := isClusterVersionLessThan(ctx, tx, clusterversion.ByKey(clusterversion.V23_2))
+		cannotEnableSchemaChanges, err := isClusterVersionLessThan(ctx, tx, clusterversion.V23_2.Version())
 		if err != nil {
 			return errors.Wrap(err, "cannot to get active")
 		}


### PR DESCRIPTION
Remove `ByKey`, replacing usage with `.Version()`.

Epic: none
Release note: None

Informs #112629.