### PR TITLE
roachtest: bump max latency to 5 mins on c2c/weekly/kv0

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1153,7 +1153,8 @@ func registerClusterToCluster(r registry.Registry) {
 				maxBlockBytes: 4096,
 				maxQPS:        2000,
 			},
-			timeout: 12 * time.Hour,
+			maxAcceptedLatency: time.Minute * 5,
+			timeout:            12 * time.Hour,
 			// We bump the TTL on the source and destination tenants to 12h to give
 			// the fingerprinting post cutover adequate time to complete before GC
 			// kicks in.


### PR DESCRIPTION
This patch prevents the roachtest from failing on a temporary latency spike of 2 minutes. A 5 minute latency spike likely indicates something is wrong in the system.

Fixes: #115069

Release note: none