### PR TITLE
sql: don't store primary key col when rewriting secondary indexes during ALTER PK

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -776,29 +776,33 @@ func addIndexMutationWithSpecificPrimaryKey(
 		return err
 	}
 
-	if err := setKeySuffixColumnIDsFromPrimary(table, toAdd, primary); err != nil {
+	if err := setKeySuffixAndStoredColumnIDsFromPrimary(table, toAdd, primary); err != nil {
 		return err
 	}
 	if tempIdx := catalog.FindCorrespondingTemporaryIndexByID(table, toAdd.ID); tempIdx != nil {
-		if err := setKeySuffixColumnIDsFromPrimary(table, tempIdx.IndexDesc(), primary); err != nil {
+		if err := setKeySuffixAndStoredColumnIDsFromPrimary(table, tempIdx.IndexDesc(), primary); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// setKeySuffixColumnIDsFromPrimary uses the columns in the given
-// primary index to construct this toAdd's KeySuffixColumnIDs list.
-func setKeySuffixColumnIDsFromPrimary(
+// setKeySuffixAndStoredColumnIDsFromPrimary uses the columns in the given
+// primary index to construct this toAdd's KeySuffixColumnIDs and
+// StoredColumnIDs list.
+func setKeySuffixAndStoredColumnIDsFromPrimary(
 	table *tabledesc.Mutable, toAdd *descpb.IndexDescriptor, primary *descpb.IndexDescriptor,
 ) error {
-	presentColIDs := catalog.MakeTableColSet(toAdd.KeyColumnIDs...)
-	presentColIDs.UnionWith(catalog.MakeTableColSet(toAdd.StoreColumnIDs...))
+	// First, find all key columns in the secondary index.
+	idxColIDs := catalog.MakeTableColSet(toAdd.KeyColumnIDs...)
+	// Second, determine the key suffix columns: add all primary key columns
+	// which have not already been in the key columns in the secondary index.
 	toAdd.KeySuffixColumnIDs = nil
 	invIdx := toAdd.Type == descpb.IndexDescriptor_INVERTED
 	for _, colID := range primary.KeyColumnIDs {
-		if !presentColIDs.Contains(colID) {
+		if !idxColIDs.Contains(colID) {
 			toAdd.KeySuffixColumnIDs = append(toAdd.KeySuffixColumnIDs, colID)
+			idxColIDs.Add(colID)
 		} else if invIdx && colID == toAdd.InvertedColumnID() {
 			// In an inverted index, the inverted column's value is not equal to the
 			// actual data in the row for that column. As a result, if the inverted
@@ -816,6 +820,18 @@ func setKeySuffixColumnIDsFromPrimary(
 				"primary key column %s cannot be present in an inverted index",
 				col.GetName(),
 			)
+		}
+	}
+	// Finally, add all the stored columns if it is not already a key or key suffix column.
+	toAddOldStoredColumnIDs := toAdd.StoreColumnIDs
+	toAddOldStoredColumnNames := toAdd.StoreColumnNames
+	toAdd.StoreColumnIDs = nil
+	toAdd.StoreColumnNames = nil
+	for i, colID := range toAddOldStoredColumnIDs {
+		if !idxColIDs.Contains(colID) {
+			toAdd.StoreColumnIDs = append(toAdd.StoreColumnIDs, colID)
+			toAdd.StoreColumnNames = append(toAdd.StoreColumnNames, toAddOldStoredColumnNames[i])
+			idxColIDs.Add(colID)
 		}
 	}
 	return nil

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -270,9 +270,9 @@ t  CREATE TABLE public.t (
      CONSTRAINT t_pkey PRIMARY KEY (y ASC),
      INDEX i1 (w ASC),
      INDEX i2 (y ASC),
-     UNIQUE INDEX i3 (z ASC) STORING (y),
+     UNIQUE INDEX i3 (z ASC),
      UNIQUE INDEX i4 (z ASC),
-     UNIQUE INDEX i5 (w ASC) STORING (y),
+     UNIQUE INDEX i5 (w ASC),
      INVERTED INDEX i6 (v),
      INDEX i7 (z ASC) USING HASH WITH (bucket_count=4),
      UNIQUE INDEX t_x_key (x ASC),
@@ -398,6 +398,20 @@ query IIIIT
 SELECT * FROM t@i5
 ----
 1 2 3 4 {}
+
+# Make sure the create_statement from `SHOW CREATE` can indeed recreate the
+# table without error.
+
+let $index_rewrites_t_create_statement
+SELECT create_statement FROM [SHOW CREATE t];
+
+statement ok
+DROP TABLE IF EXISTS t;
+
+statement ok
+$index_rewrites_t_create_statement
+
+subtest end
 
 subtest hash_sharded
 


### PR DESCRIPTION
Fixes #114758

Release note (bug fix): Previously, if we have a table with secondary indexes that store some columns `col` via the `STORING` clause, and we alter primary key to `col` on this table, then we'd end up with incorrect secondary index where it continues to have the `STORING` clause, even though that column is already in the primary key and we don't allow creating a secondary index storing any primary key columns. This commit fixes that such that after the ALTER PK, the `STORING` clause is dropped on those secondary indexes.