### PR TITLE
*: remove cluster id argument from license check

### DIFF
--- a/pkg/base/license.go
+++ b/pkg/base/license.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
 
@@ -29,15 +28,15 @@ var errEnterpriseNotEnabled = errors.New("OSS binaries do not include enterprise
 // enable it.
 //
 // This function is overridden by an init hook in CCL builds.
-var CheckEnterpriseEnabled = func(_ *cluster.Settings, _ uuid.UUID, feature string) error {
+var CheckEnterpriseEnabled = func(_ *cluster.Settings, feature string) error {
 	return errEnterpriseNotEnabled // nb: this is squarely in the hot path on OSS builds
 }
 
 // CCLDistributionAndEnterpriseEnabled is a simpler version of
 // CheckEnterpriseEnabled which doesn't take in feature-related info and doesn't
 // return an error with a nice message.
-var CCLDistributionAndEnterpriseEnabled = func(st *cluster.Settings, clusterID uuid.UUID) bool {
-	return CheckEnterpriseEnabled(st, clusterID, "" /* feature */) == nil
+var CCLDistributionAndEnterpriseEnabled = func(st *cluster.Settings) bool {
+	return CheckEnterpriseEnabled(st, "" /* feature */) == nil
 }
 
 var licenseTTLMetadata = metric.Metadata{

--- a/pkg/ccl/auditloggingccl/BUILD.bazel
+++ b/pkg/ccl/auditloggingccl/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/auditlogging",
         "//pkg/util/log",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/auditloggingccl/audit_log_config.go
+++ b/pkg/ccl/auditloggingccl/audit_log_config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/auditlogging"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
 
@@ -96,8 +95,8 @@ var ConfigureRoleBasedAuditClusterSettings = func(ctx context.Context, acl *audi
 	UpdateAuditConfigOnChange(ctx, acl, st)
 }
 
-var UserAuditEnabled = func(st *cluster.Settings, clusterID uuid.UUID) bool {
-	return UserAuditLogConfig.Get(&st.SV) != "" && utilccl.IsEnterpriseEnabled(st, clusterID, "role-based audit logging")
+var UserAuditEnabled = func(st *cluster.Settings) bool {
+	return UserAuditLogConfig.Get(&st.SV) != "" && utilccl.IsEnterpriseEnabled(st, "role-based audit logging")
 }
 
 var UserAuditReducedConfigEnabled = func(sv *settings.Values) bool {

--- a/pkg/ccl/backupccl/alter_backup_schedule.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule.go
@@ -709,7 +709,7 @@ func makeAlterBackupScheduleSpec(
 	}
 
 	enterpriseCheckErr := utilccl.CheckEnterpriseEnabled(
-		p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(),
+		p.ExecCfg().Settings,
 		"BACKUP INTO LATEST")
 	spec.isEnterpriseUser = enterpriseCheckErr == nil
 

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -746,7 +746,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 
 		// Collect telemetry, once per backup after resolving its destination.
 		lic := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), "",
+			p.ExecCfg().Settings, "",
 		) != nil
 		collectTelemetry(ctx, backupManifest, initialDetails, details, lic, b.job.ID())
 	}

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -377,7 +377,7 @@ func checkPrivilegesForBackup(
 
 func requireEnterprise(execCfg *sql.ExecutorConfig, feature string) error {
 	if err := utilccl.CheckEnterpriseEnabled(
-		execCfg.Settings, execCfg.NodeInfo.LogicalClusterID(),
+		execCfg.Settings,
 		fmt.Sprintf("BACKUP with %s", feature),
 	); err != nil {
 		return err

--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -630,7 +630,7 @@ func makeScheduledBackupSpec(
 	}
 
 	enterpriseCheckErr := utilccl.CheckEnterpriseEnabled(
-		p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(),
+		p.ExecCfg().Settings,
 		"BACKUP INTO LATEST")
 	spec.isEnterpriseUser = enterpriseCheckErr == nil
 

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -2395,7 +2395,7 @@ func planDatabaseModifiersForRestore(
 		return nil, nil, nil
 	}
 	if err := multiregionccl.CheckClusterSupportsMultiRegion(
-		p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(),
+		p.ExecCfg().Settings,
 	); err != nil {
 		return nil, nil, errors.WithHintf(
 			err,

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -605,7 +605,7 @@ func createChangefeedJobRecord(
 
 	if scope, ok := opts.GetMetricScope(); ok {
 		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), "CHANGEFEED",
+			p.ExecCfg().Settings, "CHANGEFEED",
 		); err != nil {
 			return nil, errors.Wrapf(err,
 				"use of %q option requires an enterprise license.", changefeedbase.OptMetricsScope)
@@ -634,7 +634,7 @@ func createChangefeedJobRecord(
 
 		if details.Select != `` {
 			if err := utilccl.CheckEnterpriseEnabled(
-				p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), "CHANGEFEED",
+				p.ExecCfg().Settings, "CHANGEFEED",
 			); err != nil {
 				return nil, errors.Wrap(err, "use of AS SELECT requires an enterprise license.")
 			}
@@ -654,7 +654,7 @@ func createChangefeedJobRecord(
 	}
 
 	if err := utilccl.CheckEnterpriseEnabled(
-		p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), "CHANGEFEED",
+		p.ExecCfg().Settings, "CHANGEFEED",
 	); err != nil {
 		return nil, err
 	}
@@ -691,7 +691,7 @@ func createChangefeedJobRecord(
 			)
 		}
 		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), changefeedbase.OptExecutionLocality,
+			p.ExecCfg().Settings, changefeedbase.OptExecutionLocality,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/changefeedccl/scheduled_changefeed.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed.go
@@ -322,7 +322,7 @@ func makeScheduledChangefeedSpec(
 	}
 
 	enterpriseCheckErr := utilccl.CheckEnterpriseEnabled(
-		p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(),
+		p.ExecCfg().Settings,
 		opName)
 
 	if !(enterpriseCheckErr == nil) {

--- a/pkg/ccl/gssapiccl/gssapi.go
+++ b/pkg/ccl/gssapiccl/gssapi.go
@@ -107,7 +107,7 @@ func authGSS(
 		// their GSS configuration is correct. That is, the presence of this error
 		// message means they have a correctly functioning GSS/Kerberos setup,
 		// but now need to enable enterprise features.
-		return utilccl.CheckEnterpriseEnabled(execCfg.Settings, execCfg.NodeInfo.LogicalClusterID(), "GSS authentication")
+		return utilccl.CheckEnterpriseEnabled(execCfg.Settings, "GSS authentication")
 	})
 	return behaviors, nil
 }

--- a/pkg/ccl/jwtauthccl/authentication_jwt.go
+++ b/pkg/ccl/jwtauthccl/authentication_jwt.go
@@ -228,7 +228,7 @@ func (authenticator *jwtAuthenticator) ValidateJWTLogin(
 			"token issued with an audience of %s", parsedToken.Audience())
 	}
 
-	if err = utilccl.CheckEnterpriseEnabled(st, authenticator.clusterUUID, "JWT authentication"); err != nil {
+	if err = utilccl.CheckEnterpriseEnabled(st, "JWT authentication"); err != nil {
 		return err
 	}
 

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvfollowerreadsccl",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/ccl/utilccl",
         "//pkg/kv",
         "//pkg/kv/kvclient/kvcoord",
@@ -30,7 +29,6 @@ go_library(
         "//pkg/util/duration",
         "//pkg/util/hlc",
         "//pkg/util/randutil",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )
@@ -84,7 +82,6 @@ go_test(
         "//pkg/util/syncutil",
         "//pkg/util/tracing",
         "//pkg/util/tracing/tracingpb",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness.go
@@ -25,7 +25,6 @@ import (
 func checkBoundedStalenessEnabled(evalCtx *eval.Context) error {
 	return utilccl.CheckEnterpriseEnabled(
 		evalCtx.Settings,
-		evalCtx.ClusterID,
 		"bounded staleness",
 	)
 }

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
@@ -15,7 +15,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
@@ -31,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 // ClosedTimestampPropagationSlack is used by follower_read_timestamp() as a
@@ -76,27 +74,25 @@ func getGlobalReadsLead(clock *hlc.Clock) time.Duration {
 // checkEnterpriseEnabled checks whether the enterprise feature for follower
 // reads is enabled, returning a detailed error if not. It is not suitable for
 // use in hot paths since a new error may be instantiated on each call.
-func checkEnterpriseEnabled(logicalClusterID uuid.UUID, st *cluster.Settings) error {
-	return utilccl.CheckEnterpriseEnabled(st, logicalClusterID, "follower reads")
+func checkEnterpriseEnabled(st *cluster.Settings) error {
+	return utilccl.CheckEnterpriseEnabled(st, "follower reads")
 }
 
 // isEnterpriseEnabled is faster than checkEnterpriseEnabled, and suitable
 // for hot paths.
-func isEnterpriseEnabled(logicalClusterID uuid.UUID, st *cluster.Settings) bool {
-	return utilccl.IsEnterpriseEnabled(st, logicalClusterID, "follower reads")
+func isEnterpriseEnabled(st *cluster.Settings) bool {
+	return utilccl.IsEnterpriseEnabled(st, "follower reads")
 }
 
-func checkFollowerReadsEnabled(logicalClusterID uuid.UUID, st *cluster.Settings) bool {
+func checkFollowerReadsEnabled(st *cluster.Settings) bool {
 	if !kvserver.FollowerReadsEnabled.Get(&st.SV) {
 		return false
 	}
-	return isEnterpriseEnabled(logicalClusterID, st)
+	return isEnterpriseEnabled(st)
 }
 
-func evalFollowerReadOffset(
-	logicalClusterID uuid.UUID, st *cluster.Settings,
-) (time.Duration, error) {
-	if err := checkEnterpriseEnabled(logicalClusterID, st); err != nil {
+func evalFollowerReadOffset(st *cluster.Settings) (time.Duration, error) {
+	if err := checkEnterpriseEnabled(st); err != nil {
 		return 0, err
 	}
 	// NOTE: we assume that at least some of the ranges being queried use a
@@ -131,7 +127,6 @@ func closedTimestampLikelySufficient(
 // canSendToFollower implements the logic for checking whether a batch request
 // may be sent to a follower.
 func canSendToFollower(
-	logicalClusterID uuid.UUID,
 	st *cluster.Settings,
 	clock *hlc.Clock,
 	ctPolicy roachpb.RangeClosedTimestampPolicy,
@@ -140,13 +135,12 @@ func canSendToFollower(
 	return kvserver.BatchCanBeEvaluatedOnFollower(ba) &&
 		closedTimestampLikelySufficient(st, clock, ctPolicy, ba.RequiredFrontier()) &&
 		// NOTE: this call can be expensive, so perform it last. See #62447.
-		checkFollowerReadsEnabled(logicalClusterID, st)
+		checkFollowerReadsEnabled(st)
 }
 
 type followerReadOracle struct {
-	logicalClusterID *base.ClusterIDContainer
-	st               *cluster.Settings
-	clock            *hlc.Clock
+	st    *cluster.Settings
+	clock *hlc.Clock
 
 	closest    replicaoracle.Oracle
 	binPacking replicaoracle.Oracle
@@ -154,11 +148,10 @@ type followerReadOracle struct {
 
 func newFollowerReadOracle(cfg replicaoracle.Config) replicaoracle.Oracle {
 	return &followerReadOracle{
-		logicalClusterID: cfg.RPCContext.LogicalClusterID,
-		st:               cfg.Settings,
-		clock:            cfg.Clock,
-		closest:          replicaoracle.NewOracle(replicaoracle.ClosestChoice, cfg),
-		binPacking:       replicaoracle.NewOracle(replicaoracle.BinPackingChoice, cfg),
+		st:         cfg.Settings,
+		clock:      cfg.Clock,
+		closest:    replicaoracle.NewOracle(replicaoracle.ClosestChoice, cfg),
+		binPacking: replicaoracle.NewOracle(replicaoracle.BinPackingChoice, cfg),
 	}
 }
 
@@ -198,7 +191,7 @@ func (o *followerReadOracle) useClosestOracle(
 	return txn != nil &&
 		closedTimestampLikelySufficient(o.st, o.clock, ctPolicy, txn.RequiredFrontier()) &&
 		// NOTE: this call can be expensive, so perform it last. See #62447.
-		checkFollowerReadsEnabled(o.logicalClusterID.Get(), o.st)
+		checkFollowerReadsEnabled(o.st)
 }
 
 // followerReadOraclePolicy is a leaseholder choosing policy that detects
@@ -227,7 +220,7 @@ func (r bulkOracle) ChoosePreferredReplica(
 	_ roachpb.RangeClosedTimestampPolicy,
 	_ replicaoracle.QueryState,
 ) (_ roachpb.ReplicaDescriptor, ignoreMisplannedRanges bool, _ error) {
-	if leaseholder != nil && !checkFollowerReadsEnabled(uuid.UUID{} /*not used*/, r.cfg.Settings) {
+	if leaseholder != nil && !checkFollowerReadsEnabled(r.cfg.Settings) {
 		return *leaseholder, false, nil
 	}
 

--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
-        "//pkg/util/uuid",
     ],
 )
 

--- a/pkg/ccl/multiregionccl/multiregion.go
+++ b/pkg/ccl/multiregionccl/multiregion.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 func init() {
@@ -35,7 +34,6 @@ func initializeMultiRegionMetadata(
 	ctx context.Context,
 	descIDGenerator eval.DescIDGenerator,
 	settings *cluster.Settings,
-	clusterID uuid.UUID,
 	liveRegions sql.LiveClusterRegions,
 	goal tree.SurvivalGoal,
 	primaryRegion catpb.RegionName,
@@ -44,7 +42,7 @@ func initializeMultiRegionMetadata(
 	secondaryRegion catpb.RegionName,
 ) (*multiregion.RegionConfig, error) {
 	if err := CheckClusterSupportsMultiRegion(
-		settings, clusterID,
+		settings,
 	); err != nil {
 		return nil, err
 	}
@@ -129,10 +127,9 @@ func initializeMultiRegionMetadata(
 
 // CheckClusterSupportsMultiRegion returns whether the current cluster supports
 // multi-region features.
-func CheckClusterSupportsMultiRegion(settings *cluster.Settings, clusterID uuid.UUID) error {
+func CheckClusterSupportsMultiRegion(settings *cluster.Settings) error {
 	return utilccl.CheckEnterpriseEnabled(
 		settings,
-		clusterID,
 		"multi-region features",
 	)
 }
@@ -142,7 +139,6 @@ func getMultiRegionEnumAddValuePlacement(
 ) (tree.AlterTypeAddValue, error) {
 	if err := utilccl.CheckEnterpriseEnabled(
 		execCfg.Settings,
-		execCfg.NodeInfo.LogicalClusterID(),
 		"ADD REGION",
 	); err != nil {
 		return tree.AlterTypeAddValue{}, err

--- a/pkg/ccl/oidcccl/authentication_oidc.go
+++ b/pkg/ccl/oidcccl/authentication_oidc.go
@@ -474,7 +474,7 @@ var ConfigureOIDC = func(
 			return
 		}
 
-		if err := utilccl.CheckEnterpriseEnabled(st, cluster, "OIDC"); err != nil {
+		if err := utilccl.CheckEnterpriseEnabled(st, "OIDC"); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}

--- a/pkg/ccl/partitionccl/BUILD.bazel
+++ b/pkg/ccl/partitionccl/BUILD.bazel
@@ -85,7 +85,6 @@ go_test(
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -351,7 +351,7 @@ func createPartitioning(
 	allowedNewColumnNames []tree.Name,
 	allowImplicitPartitioning bool,
 ) (newImplicitCols []catalog.Column, newPartitioning catpb.PartitioningDescriptor, err error) {
-	if err := utilccl.CheckEnterpriseEnabled(st, evalCtx.ClusterID, "partitions"); err != nil {
+	if err := utilccl.CheckEnterpriseEnabled(st, "partitions"); err != nil {
 		return nil, newPartitioning, err
 	}
 

--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
@@ -1068,10 +1067,9 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
-			clusterID := uuid.MakeV4()
 			hasNewSubzones := false
 			spans, err := sql.GenerateSubzoneSpans(
-				cluster.NoSettings, clusterID, keys.SystemSQLCodec, parse.tableDesc, parse.subzones, hasNewSubzones)
+				cluster.NoSettings, keys.SystemSQLCodec, parse.tableDesc, parse.subzones, hasNewSubzones)
 			if err != nil {
 				t.Fatalf("generating subzone spans: %+v", err)
 			}

--- a/pkg/ccl/pgcryptoccl/pgcryptoccl.go
+++ b/pkg/ccl/pgcryptoccl/pgcryptoccl.go
@@ -36,7 +36,6 @@ var EnterpriseLicenseCheckFeatureName = fmt.Sprintf(
 func checkEnterpriseEnabledForCryptoFunction(evalCtx *eval.Context) error {
 	return utilccl.CheckEnterpriseEnabled(
 		evalCtx.Settings,
-		evalCtx.ClusterID,
 		EnterpriseLicenseCheckFeatureName,
 	)
 }

--- a/pkg/ccl/securityccl/fipsccl/sql.go
+++ b/pkg/ccl/securityccl/fipsccl/sql.go
@@ -27,7 +27,7 @@ func init() {
 		ReturnType: tree.FixedReturnType(types.Bool),
 		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			if err := utilccl.CheckEnterpriseEnabled(
-				evalCtx.Settings, evalCtx.ClusterID, "fips_ready",
+				evalCtx.Settings, "fips_ready",
 			); err != nil {
 				return nil, err
 			}

--- a/pkg/ccl/storageccl/engineccl/shared_storage.go
+++ b/pkg/ccl/storageccl/engineccl/shared_storage.go
@@ -44,7 +44,7 @@ func iterateReplicaKeySpansShared(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,
 	st *cluster.Settings,
-	clusterID uuid.UUID,
+	_ uuid.UUID,
 	reader storage.Reader,
 	visitPoint func(key *pebble.InternalKey, val pebble.LazyValue, info pebble.IteratorLevel) error,
 	visitRangeDel func(start, end []byte, seqNum uint64) error,
@@ -54,7 +54,7 @@ func iterateReplicaKeySpansShared(
 	if !reader.ConsistentIterators() {
 		panic("reader must provide consistent iterators")
 	}
-	if err := utilccl.CheckEnterpriseEnabled(st, clusterID, "disaggregated shared storage"); err != nil {
+	if err := utilccl.CheckEnterpriseEnabled(st, "disaggregated shared storage"); err != nil {
 		// NB: ScanInternal returns ErrInvalidSkipSharedIteration if we can't do
 		// a skip-shared iteration. Return the same error here so the caller can
 		// fall back to regular, non-shared snapshots.

--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job.go
@@ -184,7 +184,7 @@ func alterReplicationJobHook(
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
 		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(),
+			p.ExecCfg().Settings,
 			alterReplicationJobOp,
 		); err != nil {
 			return err

--- a/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
@@ -165,7 +165,7 @@ func newStreamIngestManagerWithPrivilegesCheck(
 ) (eval.StreamIngestManager, error) {
 	execCfg := evalCtx.Planner.ExecutorConfig().(*sql.ExecutorConfig)
 	enterpriseCheckErr := utilccl.CheckEnterpriseEnabled(
-		execCfg.Settings, execCfg.NodeInfo.LogicalClusterID(), "REPLICATION")
+		execCfg.Settings, "REPLICATION")
 	if enterpriseCheckErr != nil {
 		return nil, pgerror.Wrap(enterpriseCheckErr,
 			pgcode.CCLValidLicenseRequired, "physical replication requires an enterprise license on the secondary (and primary) cluster")

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -153,7 +153,7 @@ func ingestionPlanHook(
 		defer span.Finish()
 
 		if err := utilccl.CheckEnterpriseEnabled(
-			p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(),
+			p.ExecCfg().Settings,
 			"CREATE VIRTUAL CLUSTER FROM REPLICATION",
 		); err != nil {
 			return err

--- a/pkg/ccl/streamingccl/streamproducer/replication_manager.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_manager.go
@@ -91,7 +91,7 @@ func newReplicationStreamManagerWithPrivilegesCheck(
 
 	execCfg := evalCtx.Planner.ExecutorConfig().(*sql.ExecutorConfig)
 	enterpriseCheckErr := utilccl.CheckEnterpriseEnabled(
-		execCfg.Settings, execCfg.NodeInfo.LogicalClusterID(), "REPLICATION")
+		execCfg.Settings, "REPLICATION")
 	if enterpriseCheckErr != nil {
 		return nil, pgerror.Wrap(enterpriseCheckErr,
 			pgcode.CCLValidLicenseRequired, "physical replication requires an enterprise license on the primary (and secondary) cluster")

--- a/pkg/ccl/utilccl/BUILD.bazel
+++ b/pkg/ccl/utilccl/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ],
@@ -49,7 +48,6 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
-        "//pkg/util/uuid",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/utilccl/license_check_test.go
+++ b/pkg/ccl/utilccl/license_check_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,7 +54,7 @@ func TestSettingAndCheckingLicense(t *testing.T) {
 		if err := setLicense(ctx, updater, tc.lic); err != nil {
 			t.Fatal(err)
 		}
-		err := checkEnterpriseEnabledAt(st, tc.checkTime, uuid.UUID{}, "", true)
+		err := checkEnterpriseEnabledAt(st, tc.checkTime, "", true)
 		if !testutils.IsError(err, tc.err) {
 			l, _ := decode(tc.lic)
 			t.Fatalf("%d: lic %v, update by %T, checked at %s, got %q", i, l, updater, tc.checkTime, err)
@@ -212,11 +211,11 @@ func TestApplyTenantLicenseWithLicense(t *testing.T) {
 
 	settings := cluster.MakeClusterSettings()
 
-	require.Error(t, CheckEnterpriseEnabled(settings, uuid.MakeV4(), ""))
-	require.False(t, IsEnterpriseEnabled(settings, uuid.MakeV4(), ""))
+	require.Error(t, CheckEnterpriseEnabled(settings, ""))
+	require.False(t, IsEnterpriseEnabled(settings, ""))
 	require.NoError(t, ApplyTenantLicense())
-	require.NoError(t, CheckEnterpriseEnabled(settings, uuid.MakeV4(), ""))
-	require.True(t, IsEnterpriseEnabled(settings, uuid.MakeV4(), ""))
+	require.NoError(t, CheckEnterpriseEnabled(settings, ""))
+	require.True(t, IsEnterpriseEnabled(settings, ""))
 }
 
 func TestApplyTenantLicenseWithoutLicense(t *testing.T) {
@@ -227,11 +226,11 @@ func TestApplyTenantLicenseWithoutLicense(t *testing.T) {
 	envutil.ClearEnvCache()
 	require.False(t, ok)
 
-	require.Error(t, CheckEnterpriseEnabled(settings, uuid.MakeV4(), ""))
-	require.False(t, IsEnterpriseEnabled(settings, uuid.MakeV4(), ""))
+	require.Error(t, CheckEnterpriseEnabled(settings, ""))
+	require.False(t, IsEnterpriseEnabled(settings, ""))
 	require.NoError(t, ApplyTenantLicense())
-	require.Error(t, CheckEnterpriseEnabled(settings, uuid.MakeV4(), ""))
-	require.False(t, IsEnterpriseEnabled(settings, uuid.MakeV4(), ""))
+	require.Error(t, CheckEnterpriseEnabled(settings, ""))
+	require.False(t, IsEnterpriseEnabled(settings, ""))
 }
 
 func TestApplyTenantLicenseWithInvalidLicense(t *testing.T) {

--- a/pkg/ccl/utilccl/license_test.go
+++ b/pkg/ccl/utilccl/license_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/licenseccl"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 func TestLicense(t *testing.T) {
@@ -74,7 +73,7 @@ func TestLicense(t *testing.T) {
 				}
 			}
 			if err := check(
-				lic, tc.checkTime, uuid.UUID{}, tc.checkOrg, "", true,
+				lic, tc.checkTime, tc.checkOrg, "", true,
 			); !testutils.IsError(err, tc.err) {
 				t.Fatalf("%d: lic to %s, checked at %s.\n got %q", i,
 					tc.expiration, tc.checkTime, err)
@@ -100,7 +99,7 @@ func TestExpiredLicenseLanguage(t *testing.T) {
 		Type:              licenseccl.License_Evaluation,
 		ValidUntilUnixSec: 1,
 	}
-	err := check(lic, timeutil.Now(), uuid.MakeV4(), "", "RESTORE", true)
+	err := check(lic, timeutil.Now(), "", "RESTORE", true)
 	expected := "Use of RESTORE requires an enterprise license. Your evaluation license expired on " +
 		"January 1, 1970. If you're interested in getting a new license, please contact " +
 		"subscriptions@cockroachlabs.com and we can help you out."

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -46,7 +46,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -229,7 +228,6 @@ This counts the number of ranges with an active rangefeed that are performing ca
 // followerreadsccl code to inject logic to check if follower reads are enabled.
 // By default, without CCL code, this function returns false.
 var CanSendToFollower = func(
-	_ uuid.UUID,
 	_ *cluster.Settings,
 	_ *hlc.Clock,
 	_ roachpb.RangeClosedTimestampPolicy,
@@ -2252,7 +2250,7 @@ func (ds *DistSender) sendToReplicas(
 	// otherwise, we may send a request to a remote region unnecessarily.
 	if ba.RoutingPolicy == kvpb.RoutingPolicy_LEASEHOLDER &&
 		CanSendToFollower(
-			ds.logicalClusterID.Get(), ds.st, ds.clock,
+			ds.st, ds.clock,
 			routing.ClosedTimestampPolicy(defaultSendClosedTimestampPolicy), ba,
 		) {
 		ba = ba.ShallowCopy()

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -53,7 +53,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/errutil"
 	"github.com/cockroachdb/redact"
@@ -385,7 +384,6 @@ func TestSendRPCOrder(t *testing.T) {
 	old := CanSendToFollower
 	defer func() { CanSendToFollower = old }()
 	CanSendToFollower = func(
-		_ uuid.UUID,
 		_ *cluster.Settings,
 		_ *hlc.Clock,
 		p roachpb.RangeClosedTimestampPolicy,
@@ -893,7 +891,6 @@ func TestNoBackoffOnNotLeaseHolderErrorFromFollowerRead(t *testing.T) {
 	old := CanSendToFollower
 	defer func() { CanSendToFollower = old }()
 	CanSendToFollower = func(
-		_ uuid.UUID,
 		_ *cluster.Settings,
 		_ *hlc.Clock,
 		_ roachpb.RangeClosedTimestampPolicy,
@@ -3975,7 +3972,6 @@ func TestCanSendToFollower(t *testing.T) {
 	defer func() { CanSendToFollower = old }()
 	canSend := true
 	CanSendToFollower = func(
-		_ uuid.UUID,
 		_ *cluster.Settings,
 		_ *hlc.Clock,
 		_ roachpb.RangeClosedTimestampPolicy,

--- a/pkg/kv/kvserver/reports/BUILD.bazel
+++ b/pkg/kv/kvserver/reports/BUILD.bazel
@@ -90,7 +90,6 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//proto",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/reports/constraint_stats_report_test.go
+++ b/pkg/kv/kvserver/reports/constraint_stats_report_test.go
@@ -47,7 +47,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/keysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
@@ -1055,7 +1054,7 @@ func generateTableZone(t table, tableDesc descpb.TableDescriptor) (*zonepb.ZoneC
 	if tableZone != nil {
 		var err error
 		tableZone.SubzoneSpans, err = sql.GenerateSubzoneSpans(
-			nil, uuid.UUID{} /* clusterID */, keys.SystemSQLCodec,
+			nil, keys.SystemSQLCodec,
 			tabledesc.NewBuilder(&tableDesc).BuildImmutableTable(), tableZone.Subzones, false /* hasNewSubzones */)
 		if err != nil {
 			return nil, errors.Wrap(err, "error generating subzone spans")

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2125,7 +2125,6 @@ func (s *adminServer) Cluster(
 	// between different features.
 	enterpriseEnabled := base.CheckEnterpriseEnabled(
 		s.st,
-		s.rpcContext.LogicalClusterID.Get(),
 		"BACKUP") == nil
 
 	return &serverpb.ClusterResponse{

--- a/pkg/server/application_api/config_test.go
+++ b/pkg/server/application_api/config_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/safesql"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
@@ -272,7 +271,7 @@ func TestClusterAPI(t *testing.T) {
 			// Override server license check.
 			if enterpriseOn {
 				old := base.CheckEnterpriseEnabled
-				base.CheckEnterpriseEnabled = func(_ *cluster.Settings, _ uuid.UUID, _ string) error {
+				base.CheckEnterpriseEnabled = func(_ *cluster.Settings, _ string) error {
 					return nil
 				}
 				defer func() { base.CheckEnterpriseEnabled = old }()

--- a/pkg/sql/audit_logging.go
+++ b/pkg/sql/audit_logging.go
@@ -138,7 +138,7 @@ func (p *planner) shouldNotRoleBasedAudit(execType executorType) bool {
 	// Do not emit audit events for reserved users/roles. This does not omit the
 	// root user.
 	// Do not emit audit events for internal executors.
-	return !auditlogging.UserAuditEnabled(p.execCfg.Settings, p.EvalContext().ClusterID) ||
+	return !auditlogging.UserAuditEnabled(p.execCfg.Settings) ||
 		p.User().IsReserved() ||
 		execType == executorTypeInternal
 }

--- a/pkg/sql/auditlogging/BUILD.bazel
+++ b/pkg/sql/auditlogging/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logpb",
         "//pkg/util/syncutil",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_olekukonko_tablewriter//:tablewriter",
     ],

--- a/pkg/sql/auditlogging/audit_log.go
+++ b/pkg/sql/auditlogging/audit_log.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/olekukonko/tablewriter"
 )
 
@@ -33,7 +32,7 @@ var ConfigureRoleBasedAuditClusterSettings = func(ctx context.Context, acl *Audi
 }
 
 // UserAuditEnabled is a noop global var injected by CCL hook.
-var UserAuditEnabled = func(st *cluster.Settings, clusterID uuid.UUID) bool {
+var UserAuditEnabled = func(st *cluster.Settings) bool {
 	return false
 }
 

--- a/pkg/sql/catalog/schematelemetry/schema_telemetry_job.go
+++ b/pkg/sql/catalog/schematelemetry/schema_telemetry_job.go
@@ -75,7 +75,7 @@ func (t schemaTelemetryResumer) Resume(ctx context.Context, execCtx interface{})
 	if knobs.AOSTDuration != nil {
 		aostDuration = *knobs.AOSTDuration
 	} else if fn := builtins.EvalFollowerReadOffset; fn != nil {
-		if d, err := fn(p.ExtendedEvalContext().ClusterID, p.ExecCfg().Settings); err == nil {
+		if d, err := fn(p.ExecCfg().Settings); err == nil {
 			aostDuration = d
 		}
 	}

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
 
@@ -336,7 +335,6 @@ var InitializeMultiRegionMetadataCCL = func(
 	ctx context.Context,
 	descIDGenerator eval.DescIDGenerator,
 	settings *cluster.Settings,
-	clusterID uuid.UUID,
 	liveClusterRegions LiveClusterRegions,
 	survivalGoal tree.SurvivalGoal,
 	primaryRegion catpb.RegionName,
@@ -429,7 +427,6 @@ func (p *planner) maybeInitializeMultiRegionMetadata(
 		ctx,
 		p.EvalContext().DescIDGenerator,
 		p.EvalContext().Settings,
-		p.ExecCfg().NodeInfo.LogicalClusterID(),
 		liveRegions,
 		survivalGoal,
 		catpb.RegionName(primaryRegion),

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -362,7 +362,6 @@ func (p *planner) dropIndexByName(
 		if s.IndexID != uint32(idx.GetID()) {
 			_, err = GenerateSubzoneSpans(
 				p.ExecCfg().Settings,
-				p.ExecCfg().NodeInfo.LogicalClusterID(),
 				p.ExecCfg().Codec,
 				tableDesc,
 				zone.Subzones,

--- a/pkg/sql/partition_utils.go
+++ b/pkg/sql/partition_utils.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/covering"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 // GenerateSubzoneSpans constructs from a TableDescriptor the entries mapping
@@ -71,7 +70,6 @@ import (
 // all subzones at once is introduced.
 func GenerateSubzoneSpans(
 	st *cluster.Settings,
-	logicalClusterID uuid.UUID,
 	codec keys.SQLCodec,
 	tableDesc catalog.TableDescriptor,
 	subzones []zonepb.Subzone,
@@ -79,7 +77,7 @@ func GenerateSubzoneSpans(
 ) ([]zonepb.SubzoneSpan, error) {
 	// Removing zone configs does not require a valid license.
 	if hasNewSubzones {
-		if err := base.CheckEnterpriseEnabled(st, logicalClusterID,
+		if err := base.CheckEnterpriseEnabled(st,
 			"replication zones on indexes or partitions"); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -11187,7 +11187,7 @@ var errInsufficientPriv = pgerror.New(
 // to determine the appropriate offset from now which is likely to be safe for
 // follower reads. It is injected by followerreadsccl. An error may be returned
 // if an enterprise license is not installed.
-var EvalFollowerReadOffset func(logicalClusterID uuid.UUID, _ *cluster.Settings) (time.Duration, error)
+var EvalFollowerReadOffset func(_ *cluster.Settings) (time.Duration, error)
 
 func recentTimestamp(ctx context.Context, evalCtx *eval.Context) (time.Time, error) {
 	if EvalFollowerReadOffset == nil {
@@ -11198,7 +11198,7 @@ func recentTimestamp(ctx context.Context, evalCtx *eval.Context) (time.Time, err
 		)
 		return evalCtx.StmtTimestamp.Add(builtinconstants.DefaultFollowerReadDuration), nil
 	}
-	offset, err := EvalFollowerReadOffset(evalCtx.ClusterID, evalCtx.Settings)
+	offset, err := EvalFollowerReadOffset(evalCtx.Settings)
 	if err != nil {
 		if code := pgerror.GetPGCode(err); code == pgcode.CCLValidLicenseRequired {
 			telemetry.Inc(sqltelemetry.FollowerReadDisabledNoEnterpriseLicense)

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -101,7 +101,6 @@ func init() {
 				}
 				return base.CheckEnterpriseEnabled(
 					execCfg.Settings,
-					execCfg.NodeInfo.LogicalClusterID(),
 					"global_reads",
 				)
 			},
@@ -1211,7 +1210,7 @@ func prepareZoneConfigWrites(
 	if len(z.Subzones) > 0 {
 		st := execCfg.Settings
 		z.SubzoneSpans, err = GenerateSubzoneSpans(
-			st, execCfg.NodeInfo.LogicalClusterID(), execCfg.Codec, table, z.Subzones, hasNewSubzones)
+			st, execCfg.Codec, table, z.Subzones, hasNewSubzones)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/upgrade/upgradejob/upgrade_job.go
+++ b/pkg/upgrade/upgradejob/upgrade_job.go
@@ -66,7 +66,7 @@ func (r resumer) Resume(ctx context.Context, execCtxI interface{}) error {
 	db := execCtx.ExecCfg().InternalDB
 	ex := db.Executor()
 	enterpriseEnabled := base.CCLDistributionAndEnterpriseEnabled(
-		execCtx.ExecCfg().Settings, execCtx.ExecCfg().NodeInfo.LogicalClusterID())
+		execCtx.ExecCfg().Settings)
 	alreadyCompleted, err := migrationstable.CheckIfMigrationCompleted(
 		ctx, v, nil /* txn */, ex,
 		enterpriseEnabled, migrationstable.ConsistentRead,

--- a/pkg/upgrade/upgrademanager/manager.go
+++ b/pkg/upgrade/upgrademanager/manager.go
@@ -212,7 +212,7 @@ func (m *Manager) RunPermanentUpgrades(ctx context.Context, upToVersion roachpb.
 	// because upgrades run in order.
 	latest := permanentUpgrades[len(permanentUpgrades)-1]
 	lastVer := latest.Version()
-	enterpriseEnabled := base.CCLDistributionAndEnterpriseEnabled(m.settings, m.clusterID.Get())
+	enterpriseEnabled := base.CCLDistributionAndEnterpriseEnabled(m.settings)
 	lastUpgradeCompleted, err := startup.RunIdempotentWithRetryEx(ctx,
 		m.deps.Stopper.ShouldQuiesce(),
 		"check if migration completed",
@@ -760,7 +760,7 @@ func (m *Manager) getOrCreateMigrationJob(
 ) (alreadyCompleted, alreadyExisting bool, jobID jobspb.JobID, _ error) {
 	newJobID := m.jr.MakeJobID()
 	if err := m.deps.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) (err error) {
-		enterpriseEnabled := base.CCLDistributionAndEnterpriseEnabled(m.settings, m.clusterID.Get())
+		enterpriseEnabled := base.CCLDistributionAndEnterpriseEnabled(m.settings)
 		alreadyCompleted, err = migrationstable.CheckIfMigrationCompleted(
 			ctx, version, txn.KV(), txn, enterpriseEnabled, migrationstable.ConsistentRead,
 		)


### PR DESCRIPTION
This is unused since 619ee1c3 but many callers were still doing all the work to plumb it in.

Release note: none.
Epic: none.