### PR TITLE
release-23.1: rttanalysis, catalog: add benchmark for scanning comments, database-aware scans for comments

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -79,8 +79,8 @@ exp,benchmark
 5,ORMQueries/hasura_column_descriptions_modified
 4,ORMQueries/information_schema._pg_index_position
 4,ORMQueries/introspection_description_join
-3,ORMQueries/liquibase_migrations
-7,ORMQueries/liquibase_migrations_on_multiple_dbs
+4,ORMQueries/liquibase_migrations
+8,ORMQueries/liquibase_migrations_on_multiple_dbs
 5,ORMQueries/npgsql_fields
 5,ORMQueries/npgsql_types
 4,ORMQueries/pg_attribute

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -79,6 +79,8 @@ exp,benchmark
 5,ORMQueries/hasura_column_descriptions_modified
 4,ORMQueries/information_schema._pg_index_position
 4,ORMQueries/introspection_description_join
+3,ORMQueries/liquibase_migrations
+7,ORMQueries/liquibase_migrations_on_multiple_dbs
 5,ORMQueries/npgsql_fields
 5,ORMQueries/npgsql_types
 4,ORMQueries/pg_attribute

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -727,13 +727,14 @@ func (tc *Collection) GetAll(ctx context.Context, txn *kv.Txn) (nstree.Catalog, 
 	return ret.Catalog, nil
 }
 
-// GetAllComments gets all comments for all descriptors. This method never
-// returns the underlying catalog, since it will be incomplete and only
+// GetAllComments gets all comments for all descriptors in the given database.
+// This method never returns the underlying catalog, since it will be incomplete and only
 // contain comments.
+// If the dbContext is nil, we return the database-level comments.
 func (tc *Collection) GetAllComments(
-	ctx context.Context, txn *kv.Txn,
+	ctx context.Context, txn *kv.Txn, db catalog.DatabaseDescriptor,
 ) (nstree.CommentCatalog, error) {
-	kvComments, err := tc.cr.ScanAllComments(ctx, txn)
+	kvComments, err := tc.cr.ScanAllComments(ctx, txn, db)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/catalog/internal/catkv/catalog_reader.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader.go
@@ -54,8 +54,9 @@ type CatalogReader interface {
 	// ScanAll scans the entirety of the descriptor and namespace tables.
 	ScanAll(ctx context.Context, txn *kv.Txn) (nstree.Catalog, error)
 
-	// ScanAllComments scans only the entirety of the comments table.
-	ScanAllComments(ctx context.Context, txn *kv.Txn) (nstree.Catalog, error)
+	// ScanAllComments scans the entirety of the comments table as well as the namespace entries for the given database.
+	// If the dbContext is nil, we scan the database-level namespace entries.
+	ScanAllComments(ctx context.Context, txn *kv.Txn, db catalog.DatabaseDescriptor) (nstree.Catalog, error)
 
 	// ScanNamespaceForDatabases scans the portion of the namespace table which
 	// contains all database name entries.
@@ -163,11 +164,18 @@ func (cr catalogReader) ScanAll(ctx context.Context, txn *kv.Txn) (nstree.Catalo
 }
 
 // ScanAllComments is part of the CatalogReader interface.
-func (cr catalogReader) ScanAllComments(ctx context.Context, txn *kv.Txn) (nstree.Catalog, error) {
+func (cr catalogReader) ScanAllComments(
+	ctx context.Context, txn *kv.Txn, db catalog.DatabaseDescriptor,
+) (nstree.Catalog, error) {
 	var mc nstree.MutableCatalog
 	cq := catalogQuery{codec: cr.codec}
 	err := cq.query(ctx, txn, &mc, func(codec keys.SQLCodec, b *kv.Batch) {
-		scan(ctx, b, codec.IndexPrefix(keys.NamespaceTableID, catconstants.NamespaceTablePrimaryIndexID))
+		// N.B. the primary key of system.namespace is ("parentID" ASC, "parentSchemaID" ASC, name ASC).
+		parentID := descpb.ID(0)
+		if db != nil {
+			parentID = db.GetID()
+		}
+		scan(ctx, b, catalogkeys.MakeDatabaseChildrenNameKeyPrefix(codec, parentID))
 		scan(ctx, b, catalogkeys.CommentsMetadataPrefix(codec))
 	})
 	if err != nil {

--- a/pkg/sql/catalog/internal/catkv/catalog_reader_cached.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader_cached.go
@@ -152,13 +152,13 @@ func (c *cachedCatalogReader) Reset(ctx context.Context) {
 
 // ScanAllComments is part of the CatalogReader interface.
 func (c *cachedCatalogReader) ScanAllComments(
-	ctx context.Context, txn *kv.Txn,
+	ctx context.Context, txn *kv.Txn, db catalog.DatabaseDescriptor,
 ) (nstree.Catalog, error) {
 	if c.hasScanAllComments {
 		return c.cache.Catalog, nil
 	}
 	// Scan all catalog comments.
-	read, err := c.cr.ScanAllComments(ctx, txn)
+	read, err := c.cr.ScanAllComments(ctx, txn, db)
 	if err != nil {
 		return nstree.Catalog{}, err
 	}

--- a/pkg/sql/catalog/internal/catkv/catalog_reader_test.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader_test.go
@@ -121,8 +121,15 @@ func TestDataDriven(t *testing.T) {
 				return h.doCatalogQuery(ctx, q)
 
 			case "scan_all_comments":
+				db := h.argDesc(ctx, "db_id", catalog.Database).(catalog.DatabaseDescriptor)
 				q := func(ctx context.Context, txn *kv.Txn, cr catkv.CatalogReader) (nstree.Catalog, error) {
-					return cr.ScanAllComments(ctx, txn)
+					return cr.ScanAllComments(ctx, txn, db)
+				}
+				return h.doCatalogQuery(ctx, q)
+
+			case "scan_all_comments_nil_db":
+				q := func(ctx context.Context, txn *kv.Txn, cr catkv.CatalogReader) (nstree.Catalog, error) {
+					return cr.ScanAllComments(ctx, txn, nil)
 				}
 				return h.doCatalogQuery(ctx, q)
 

--- a/pkg/sql/catalog/internal/catkv/testdata/testdata
+++ b/pkg/sql/catalog/internal/catkv/testdata/testdata
@@ -465,128 +465,18 @@ reset
 ----
 
 # Scanning all comments after resetting should only
-# give us comments
-scan_all_comments
+# give us comments belonging to the db with db_id=100 -
+# alongside the system.comments table
+scan_all_comments db_id=100
 ----
 catalog:
-  "001":
-    namespace: (0, 0, "system")
-  "003":
-    namespace: (1, 29, "descriptor")
-  "004":
-    namespace: (1, 29, "users")
-  "005":
-    namespace: (1, 29, "zones")
-  "006":
-    namespace: (1, 29, "settings")
-  "007":
-    namespace: (1, 29, "descriptor_id_seq")
-  "008":
-    namespace: (1, 29, "tenants")
-  "011":
-    namespace: (1, 29, "lease")
-  "012":
-    namespace: (1, 29, "eventlog")
-  "013":
-    namespace: (1, 29, "rangelog")
-  "014":
-    namespace: (1, 29, "ui")
-  "015":
-    namespace: (1, 29, "jobs")
-  "019":
-    namespace: (1, 29, "web_sessions")
-  "020":
-    namespace: (1, 29, "table_statistics")
-  "021":
-    namespace: (1, 29, "locations")
-  "023":
-    namespace: (1, 29, "role_members")
-  "024":
-    namespace: (1, 29, "comments")
-  "025":
-    namespace: (1, 29, "replication_constraint_stats")
-  "026":
-    namespace: (1, 29, "replication_critical_localities")
-  "027":
-    namespace: (1, 29, "replication_stats")
-  "028":
-    namespace: (1, 29, "reports_meta")
-  "029":
-    namespace: (1, 0, "public")
-  "030":
-    namespace: (1, 29, "namespace")
-  "031":
-    namespace: (1, 29, "protected_ts_meta")
-  "032":
-    namespace: (1, 29, "protected_ts_records")
-  "033":
-    namespace: (1, 29, "role_options")
-  "034":
-    namespace: (1, 29, "statement_bundle_chunks")
-  "035":
-    namespace: (1, 29, "statement_diagnostics_requests")
-  "036":
-    namespace: (1, 29, "statement_diagnostics")
-  "037":
-    namespace: (1, 29, "scheduled_jobs")
-  "039":
-    namespace: (1, 29, "sqlliveness")
-  "040":
-    namespace: (1, 29, "migrations")
-  "041":
-    namespace: (1, 29, "join_tokens")
-  "042":
-    namespace: (1, 29, "statement_statistics")
-  "043":
-    namespace: (1, 29, "transaction_statistics")
-  "044":
-    namespace: (1, 29, "database_role_settings")
-  "045":
-    namespace: (1, 29, "tenant_usage")
-  "046":
-    namespace: (1, 29, "sql_instances")
-  "047":
-    namespace: (1, 29, "span_configurations")
-  "048":
-    namespace: (1, 29, "role_id_seq")
-  "050":
-    namespace: (1, 29, "tenant_settings")
-  "051":
-    namespace: (1, 29, "privileges")
-  "052":
-    namespace: (1, 29, "external_connections")
-  "053":
-    namespace: (1, 29, "job_info")
-  "054":
-    namespace: (1, 29, "span_stats_unique_keys")
-  "055":
-    namespace: (1, 29, "span_stats_buckets")
-  "056":
-    namespace: (1, 29, "span_stats_samples")
-  "057":
-    namespace: (1, 29, "span_stats_tenant_boundaries")
-  "058":
-    namespace: (1, 29, "task_payloads")
-  "059":
-    namespace: (1, 29, "tenant_tasks")
-  "060":
-    namespace: (1, 29, "statement_activity")
-  "061":
-    namespace: (1, 29, "transaction_activity")
-  "062":
-    namespace: (1, 29, "tenant_id_seq")
   "100":
     comments:
       database: this is the default database
-    namespace: (0, 0, "defaultdb")
   "101":
     comments:
       schema: this is the public schema
     namespace: (100, 0, "public")
-  "102":
-    namespace: (0, 0, "postgres")
-  "103":
-    namespace: (102, 0, "public")
   "104":
     comments:
       schema: this is a schema
@@ -606,5 +496,41 @@ catalog:
       index_2: this is an index
     namespace: (100, 101, "mv")
 trace:
-- Scan /NamespaceTable/30/1
+- Scan /NamespaceTable/30/1/100
+- Scan /Table/24/1
+
+# Reset to clear any caching
+reset
+----
+
+# On a nil database descriptor (pg_catalog.pg_shdescription),
+# scanning comments should only involve looking at all databases -
+# alongside the system.comments table
+scan_all_comments_nil_db
+----
+catalog:
+  "001":
+    namespace: (0, 0, "system")
+  "100":
+    comments:
+      database: this is the default database
+    namespace: (0, 0, "defaultdb")
+  "101":
+    comments:
+      schema: this is the public schema
+  "102":
+    namespace: (0, 0, "postgres")
+  "104":
+    comments:
+      schema: this is a schema
+  "108":
+    comments:
+      constraint_1: this is a primary key constraint
+      constraint_2: this is a check constraint
+      table: this is a table
+  "109":
+    comments:
+      index_2: this is an index
+trace:
+- Scan /NamespaceTable/30/1/0
 - Scan /Table/24/1

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5468,7 +5468,7 @@ var crdbInternalCatalogCommentsTable = virtualSchemaTable{
 		ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
 	) error {
 		h := makeOidHasher()
-		all, err := p.Descriptors().GetAllComments(ctx, p.Txn())
+		all, err := p.Descriptors().GetAllComments(ctx, p.Txn(), dbContext)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -407,7 +407,7 @@ var informationSchemaColumnsTable = virtualSchemaTable{
 https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 	schema: vtable.InformationSchemaColumns,
 	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		allComments, err := p.Descriptors().GetAllComments(ctx, p.Txn())
+		allComments, err := p.Descriptors().GetAllComments(ctx, p.Txn(), dbContext)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Backport 2/2 commits from #114993.

/cc @cockroachdb/release

---

### rttanalysis: add a benchmark for scanning comments

This patch adds a query made by liquibase migrations
as a benchmark test. The example setup (15 dbs, 40 tables each)
mimicks a pattern we have seen before that causes said query to
be particularly slow during the scanning of comments. In addition
to the multiple database setup, this query is benchmarked under
a single database setup as well - allowing us to compare the
behaviors of both patterns.

Epic: none
Informs: https://github.com/cockroachdb/cockroach/issues/114822

Release note: None

---

### catalog: perform database-aware scans for comments in namespace

Previously, we would look at the entirety of system.namespace
when we performed a scan of all comments (even though we only wanted to
pull comments for the current database). We saw that this operation
proved to be slow in cases where we had multiple databases with
multiple tables each. This patch ensures that we only perform a scan
for comments in the current database.

Benchmarks from multiple database test:
```
ORMQueries/liquibase_migrations_on_multiple_dbs-10     sec/op             sec/op vs base
                    				       163.03m ± 41%      22.50m ± 2%   -86.20% (p=0.000 n=10)

ORMQueries/liquibase_migrations_on_multiple_dbs-10     roundtrips         roundtrips vs base
			  			       7.000   ± 0% 	  8.000 ± 0%    +14.29% (p=0.000 n=10)

ORMQueries/liquibase_migrations_on_multiple_dbs-10     B/op               B/op vs base
			  			       44.82Mi ± 11%      27.47Mi ± 6%  -38.71% (p=0.000 n=10)

ORMQueries/liquibase_migrations_on_multiple_dbs-10     allocs/op          allocs/op vs base
			 			       407.3k  ± 15%      253.7k ± 4%   -37.71% (p=0.000 n=10)
```

Benchmarks from single database test:
```
ORMQueries/liquibase_migrations-10     sec/op             sec/op vs base
                                       9.86m    ± 1%      14.29m ± 4%   -28.06% (p=0.000 n=10)

ORMQueries/liquibase_migrations-10     roundtrips         roundtrips vs base
                                       3.000    ± 0%      4.000 ± 0%    +33.33% (p=0.000 n=10)

ORMQueries/liquibase_migrations-10     B/op               B/op vs base
                                       11.739Mi ± 2%      7.606Mi ± 5%  -35.20% (p=0.000 n=10)

ORMQueries/liquibase_migrations-10     allocs/op          allocs/op vs base
			 	       107.51k  ± 4%      67.53k ± 8%   -37.19% (p=0.000 n=10)
```

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/114822

Release note: None


Release justification: Corrects a significant performance regression in getting comments
