### PR TITLE
bazelrc: make bazel quieter on macos

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -107,6 +107,9 @@ build:devdarwinx86_64 --config=dev
 build:macos --action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 
+build:macos --linkopt="-Xlinker"
+build:macos --linkopt="-no_warn_duplicate_libraries"
+
 # --config=simplestamp configures the build to stamp the build with inferred
 # information about the configuration.
 # All `dev` builds will use this configuration; all `cross` builds will use a


### PR DESCRIPTION
Previously on recent macos versions, large builds would print page after page of warnings of the form:

```
INFO: From GoLink pkg/sql/syntheticprivilege/syntheticprivilege_test_/syntheticprivilege_test:
ld: warning: ignoring duplicate libraries: '-lc++', '-lm'
INFO: From GoLink pkg/sql/ttl/ttlbase/ttlbase_test_/ttlbase_test:
ld: warning: ignoring duplicate libraries: '-lc++', '-lm'
INFO: From GoLink pkg/sql/rowcontainer/rowcontainer_test_/rowcontainer_test:
ld: warning: ignoring duplicate libraries: '-lc++', '-lm'
INFO: From GoLink pkg/sql/sqltestutils/sqltestutils_test_/sqltestutils_test:
ld: warning: ignoring duplicate libraries: '-lc++', '-lm'
INFO: From GoLink pkg/sql/tests/tests_test_/tests_test:
ld: warning: ignoring duplicate libraries: '-lc++', '-lm', 'external/archived_cdep_libjemalloc_macosarm/lib/libjemalloc.a'
INFO: From GoLink pkg/sql/sqlstats/persistedsqlstats/persistedsqlstats_test_/persistedsqlstats_test:
ld: warning: ignoring duplicate libraries: '-lc++', '-lm'
INFO: From GoLink pkg/sql/sqlstats/sslocal/sslocal_test_/sslocal_test:
ld: warning: ignoring duplicate libraries: '-lc++', '-lm'
```

Release note: none.
Epic: none.