### PR TITLE
 base: include Spec in TempStorageConfig's created in tests

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -526,6 +526,7 @@ func DefaultTestTempStorageConfigWithSize(
 	return TempStorageConfig{
 		InMemory: true,
 		Mon:      monitor,
+		Spec:     DefaultTestStoreSpec,
 		Settings: st,
 	}
 }
@@ -548,6 +549,7 @@ func InheritTestTempStorageConfig(
 	return TempStorageConfig{
 		InMemory: parentConfig.InMemory,
 		Path:     parentConfig.Path,
+		Spec:     parentConfig.Spec,
 		Mon:      monitor,
 		Settings: st,
 	}

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -531,30 +531,6 @@ func DefaultTestTempStorageConfigWithSize(
 	}
 }
 
-// InheritTestTempStorageConfig is the associated temp storage for
-// a secondary tenant.
-func InheritTestTempStorageConfig(
-	st *cluster.Settings, parentConfig TempStorageConfig,
-) TempStorageConfig {
-	monitor := mon.NewMonitor(
-		"in-mem temp storage",
-		mon.DiskResource,
-		nil,                                    /* curCount */
-		nil,                                    /* maxHist */
-		1024*1024,                              /* increment */
-		DefaultInMemTempStorageMaxSizeBytes/10, /* noteworthy */
-		st,
-	)
-	monitor.Start(context.Background(), parentConfig.Mon, nil /* reserved */)
-	return TempStorageConfig{
-		InMemory: parentConfig.InMemory,
-		Path:     parentConfig.Path,
-		Spec:     parentConfig.Spec,
-		Mon:      monitor,
-		Settings: st,
-	}
-}
-
 // TestSharedProcessTenantArgs are the arguments to
 // TestServer.StartSharedProcessTenant.
 type TestSharedProcessTenantArgs struct {

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -321,15 +321,18 @@ func makeSharedProcessTenantServerConfig(
 	useStore := kvServerCfg.SQLConfig.TempStorageConfig.Spec
 	tempStorageCfg := base.TempStorageConfigFromEnv(
 		ctx, st, useStore, "" /* parentDir */, kvServerCfg.SQLConfig.TempStorageConfig.Mon.Limit())
-	// TODO(knz): Make tempDir configurable.
-	tempDir := useStore.Path
-	if tempStorageCfg.Path, err = fs.CreateTempDir(tempDir, TempDirPrefix, stopper); err != nil {
-		return BaseConfig{}, SQLConfig{}, errors.Wrap(err, "could not create temporary directory for temp storage")
-	}
-	if useStore.Path != "" {
-		recordPath := filepath.Join(useStore.Path, TempDirsRecordFilename)
-		if err := fs.RecordTempDir(recordPath, tempStorageCfg.Path); err != nil {
-			return BaseConfig{}, SQLConfig{}, errors.Wrap(err, "could not record temp dir")
+
+	if !tempStorageCfg.InMemory {
+		// TODO(knz): Make tempDir configurable.
+		tempDir := useStore.Path
+		if tempStorageCfg.Path, err = fs.CreateTempDir(tempDir, TempDirPrefix, stopper); err != nil {
+			return BaseConfig{}, SQLConfig{}, errors.Wrap(err, "could not create temporary directory for temp storage")
+		}
+		if useStore.Path != "" {
+			recordPath := filepath.Join(useStore.Path, TempDirsRecordFilename)
+			if err := fs.RecordTempDir(recordPath, tempStorageCfg.Path); err != nil {
+				return BaseConfig{}, SQLConfig{}, errors.Wrap(err, "could not record temp dir")
+			}
 		}
 	}
 

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -318,11 +318,9 @@ func makeSharedProcessTenantServerConfig(
 		baseCfg.InflightTraceDirName = traceDir
 	}
 
-	useStore := kvServerCfg.SQLConfig.TempStorageConfig.Spec
-	tempStorageCfg := base.TempStorageConfigFromEnv(
-		ctx, st, useStore, "" /* parentDir */, kvServerCfg.SQLConfig.TempStorageConfig.Mon.Limit())
-
+	tempStorageCfg := base.InheritTempStorageConfig(ctx, st, kvServerCfg.SQLConfig.TempStorageConfig)
 	if !tempStorageCfg.InMemory {
+		useStore := tempStorageCfg.Spec
 		// TODO(knz): Make tempDir configurable.
 		tempDir := useStore.Path
 		if tempStorageCfg.Path, err = fs.CreateTempDir(tempDir, TempDirPrefix, stopper); err != nil {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -611,7 +611,7 @@ func (ts *testServer) startDefaultTestTenant(
 
 	var tempStorageConfig base.TempStorageConfig
 	if tsc := ts.params.TempStorageConfig; tsc.Settings != nil {
-		tempStorageConfig = base.InheritTestTempStorageConfig(tenantSettings, tsc)
+		tempStorageConfig = base.InheritTempStorageConfig(ctx, tenantSettings, tsc)
 	} else {
 		tempStorageConfig = base.DefaultTestTempStorageConfig(tenantSettings)
 	}

--- a/pkg/sql/colflow/draining_test.go
+++ b/pkg/sql/colflow/draining_test.go
@@ -53,7 +53,7 @@ func TestDrainingAfterRemoteError(t *testing.T) {
 	diskMonitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(1))
 
 	// Set up a two node cluster.
-	tempStorageConfig := base.TempStorageConfig{InMemory: true, Mon: diskMonitor, Settings: st}
+	tempStorageConfig := base.TempStorageConfig{InMemory: true, Mon: diskMonitor, Settings: st, Spec: base.DefaultTestStoreSpec}
 	args := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Settings:          st,


### PR DESCRIPTION
 For shared-process virtual clusters, the spec is later used to
 determine whether the temp engine should be in-memory or
 not. Previously, by not setting this field, shared-process SQL servers
 were always started with on-disk temporary storage during tests.
    
 I believe this is the cause of at least some of the slowness we've
 seen during server startup and shutdown in CI.
    
 This likely isn't a complete story (other sources of slowness include
 the time it takes to run permanent migrations and the KV-side rate
 limiter), but stack traces related to this temporary directory have
 been seen in the 4 most recent timeouts I've investigated.
    
 Fixes #114210
 Fixes #114253
    
 Release note: None