### PR TITLE
admission: add extra info when deadline reached in flowcontrol

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller.go
@@ -198,11 +198,11 @@ func (c *Controller) Admit(
 			return true, nil
 		}
 	} else if waitEndState == contextCanceled {
-		log.VEventf(ctx, 2,
-			"canceled after waiting (pri=%s stream=%s wait-duration=%s mode=%s)",
-			pri, connection.Stream(), waitDuration, c.mode())
+		const formatStr = "canceled after waiting (pri=%s stream=%s wait-duration=%s mode=%s)"
+		log.VEventf(ctx, 2, formatStr, pri, connection.Stream(), waitDuration, c.mode())
 		c.metrics.onErrored(class, waitDuration)
-		return false, ctx.Err()
+		err := errors.Newf(formatStr, pri, connection.Stream(), waitDuration, c.mode())
+		return false, errors.CombineErrors(err, ctx.Err())
 	} else {
 		log.VEventf(ctx, 2,
 			"bypassed as stream disconnected (pri=%s stream=%s wait-duration=%s mode=%s)",


### PR DESCRIPTION
This patch improves the error message when context deadline is reached in flowcontrol wait queue. It includes priority, wait duration, stream.

Informs: #113990

Release note: None