### PR TITLE
roachtest: require license in disagg-rebalance

### DIFF
--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -35,6 +35,7 @@ func registerDisaggRebalance(r registry.Registry) {
 		Tags:              registry.Tags("aws"),
 		Owner:             registry.OwnerStorage,
 		Cluster:           disaggRebalanceSpec,
+		RequiresLicense:   true,
 		EncryptionSupport: registry.EncryptionAlwaysDisabled,
 		Timeout:           1 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
Since #114267, disaggregated storage rebalance
requires an enterprise license to happen quickly.
This change updates the disagg-rebalance roachtest to pass in a license.

Epic: none

Release note: None