### PR TITLE
builtins: support bit_count for bytea and varbit

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2806,6 +2806,10 @@ Can be used to define the tile bounds required by ST_AsMVTGeom to convert geomet
 <tbody>
 <tr><td><a name="ascii"></a><code>ascii(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the character code of the first character in <code>val</code>. Despite the name, the function supports Unicode too.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="bit_count"></a><code>bit_count(val: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bits set used to represent <code>val</code>.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="bit_count"></a><code>bit_count(val: varbit) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bits set used to represent <code>val</code>.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="bit_length"></a><code>bit_length(val: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bits used to represent <code>val</code>.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="bit_length"></a><code>bit_length(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bits used to represent <code>val</code>.</p>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -41,6 +41,18 @@ SELECT bit_length('Hello'), bit_length('世界'), bit_length(b'世界')
 ----
 40 48 48
 
+statement ok
+CREATE TABLE bit_count_test (a BIT(3), b varbit, c bytea)
+
+statement ok
+INSERT INTO bit_count_test VALUES (B'101', B'00', '\x10'), (B'100', B'101', '\x10A2')
+
+query TTTIII rowsort
+SELECT a, b, encode(c, 'hex'), bit_count(a), bit_count(b), bit_count(c) FROM bit_count_test
+----
+101  00   10    2  0  1
+100  101  10a2  1  2  4
+
 query TTTTTTTT
 SELECT quote_ident('abc'), quote_ident('ab.c'), quote_ident('ab"c'), quote_ident('世界'),
        quote_ident('array'), -- reserved keyword

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -239,6 +239,34 @@ var regularBuiltins = map[string]builtinDefinition{
 		),
 	),
 
+	"bit_count": makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategoryString},
+		bytesOverload1(
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
+				total := int64(0)
+				for _, b := range []byte(s) {
+					total += int64(bits.OnesCount8(b))
+				}
+				return tree.NewDInt(tree.DInt(total)), nil
+			},
+			types.Int,
+			"Calculates the number of bits set used to represent `val`.",
+			volatility.Immutable,
+		),
+		bitsOverload1(
+			func(_ context.Context, _ *eval.Context, s *tree.DBitArray) (tree.Datum, error) {
+				total := int64(0)
+				parts, _ := s.BitArray.EncodingParts()
+				for _, b := range parts {
+					total += int64(bits.OnesCount64(b))
+				}
+				return tree.NewDInt(tree.DInt(total)), nil
+			},
+			types.Int,
+			"Calculates the number of bits set used to represent `val`.",
+			volatility.Immutable,
+		),
+	),
+
 	"format": formatImpls,
 
 	"octet_length": makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategoryString},

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2537,6 +2537,8 @@ var builtinOidsArray = []string{
 	2568: `array_position(array: tuple[], elem: tuple, start: int) -> int`,
 	2569: `array_position(array: pg_lsn[], elem: pg_lsn, start: int) -> int`,
 	2570: `array_position(array: refcursor[], elem: refcursor, start: int) -> int`,
+	2571: `bit_count(val: bytes) -> int`,
+	2572: `bit_count(val: varbit) -> int`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/testdata/eval/builtins
+++ b/pkg/sql/sem/eval/testdata/eval/builtins
@@ -94,6 +94,21 @@ bit_length('1011'::bit(4))
 4
 
 eval
+bit_count('0101011100'::bit(10))
+----
+5
+
+eval
+bit_count('1111111111'::bit(10))
+----
+10
+
+eval
+bit_count('\x1234567890'::bytea)
+----
+15
+
+eval
 octet_length('1011'::bit(4))
 ----
 1


### PR DESCRIPTION
Fixes: #114817

Release note (sql change): Added the bit_count builtin function
for BIT and BYTEA types.

