### PR TITLE
sql: disallow some options in procedure definitions

### DIFF
--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -75,7 +75,7 @@ func (n *alterFunctionOptionsNode) startExec(params runParams) error {
 	// referenced by other objects. This is needed when want to allow function
 	// references. Need to think about in what condition a function can be altered
 	// or not.
-	if err := tree.ValidateRoutineOptions(n.n.Options); err != nil {
+	if err := tree.ValidateRoutineOptions(n.n.Options, fnDesc.IsProcedure()); err != nil {
 		return err
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -387,3 +387,28 @@ statement error pgcode 42809 family\(val: inet\) is not a procedure
 CALL family(ALL NULL);
 
 subtest end
+
+subtest attributes
+
+statement error pgcode 42P13 volatility attribute not allowed in procedure definition
+CREATE PROCEDURE pv() AS 'SELECT 1' VOLATILE LANGUAGE SQL;
+
+statement error pgcode 42P13 volatility attribute not allowed in procedure definition
+CREATE PROCEDURE pv() AS 'SELECT 1' IMMUTABLE LANGUAGE SQL;
+
+statement error pgcode 42P13 volatility attribute not allowed in procedure definition
+CREATE PROCEDURE pv() AS 'SELECT 1' STABLE LANGUAGE SQL;
+
+statement error pgcode 42P13 leakproof attribute not allowed in procedure definition
+CREATE PROCEDURE pv() AS 'SELECT 1' LEAKPROOF LANGUAGE SQL;
+
+statement error pgcode 42P13 leakproof attribute not allowed in procedure definition
+CREATE PROCEDURE pv() AS 'SELECT 1' NOT LEAKPROOF LANGUAGE SQL;
+
+statement error pgcode 42P13 null input attribute not allowed in procedure definition
+CREATE PROCEDURE pv() AS 'SELECT 1' CALLED ON NULL INPUT LANGUAGE SQL;
+
+statement error pgcode 42P13 null input attribute not allowed in procedure definition
+CREATE PROCEDURE pv() AS 'SELECT 1' STRICT LANGUAGE SQL;
+
+subtest end

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -93,7 +93,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		panic(unimplemented.New("CREATE FUNCTION sql_body", "CREATE FUNCTION...sql_body unimplemented"))
 	}
 
-	if err := tree.ValidateRoutineOptions(cf.Options); err != nil {
+	if err := tree.ValidateRoutineOptions(cf.Options, cf.IsProcedure); err != nil {
 		panic(err)
 	}
 

--- a/pkg/sql/parser/testdata/alter_procedure
+++ b/pkg/sql/parser/testdata/alter_procedure
@@ -30,3 +30,30 @@ DETAIL: source SQL:
 ALTER PROCEDURE p()
                    ^
 HINT: try \h ALTER PROCEDURE
+
+error
+ALTER PROCEDURE p() IMMUTABLE
+----
+at or near "immutable": syntax error
+DETAIL: source SQL:
+ALTER PROCEDURE p() IMMUTABLE
+                    ^
+HINT: try \h ALTER PROCEDURE
+
+error
+ALTER PROCEDURE p() STRICT
+----
+at or near "strict": syntax error
+DETAIL: source SQL:
+ALTER PROCEDURE p() STRICT
+                    ^
+HINT: try \h ALTER PROCEDURE
+
+error
+ALTER PROCEDURE p() LEAKPROOF
+----
+at or near "leakproof": syntax error
+DETAIL: source SQL:
+ALTER PROCEDURE p() LEAKPROOF
+                    ^
+HINT: try \h ALTER PROCEDURE

--- a/pkg/sql/sem/tree/create_routine.go
+++ b/pkg/sql/sem/tree/create_routine.go
@@ -615,7 +615,7 @@ func ComputedColumnExprContext(isVirtual bool) SchemaExprContext {
 
 // ValidateRoutineOptions checks whether there are conflicting or redundant
 // routine options in the given slice.
-func ValidateRoutineOptions(options RoutineOptions) error {
+func ValidateRoutineOptions(options RoutineOptions, isProc bool) error {
 	var hasLang, hasBody, hasLeakProof, hasVolatility, hasNullInputBehavior bool
 	conflictingErr := func(opt RoutineOption) error {
 		return errors.Wrapf(ErrConflictingRoutineOption, "%s", AsString(opt))
@@ -633,16 +633,25 @@ func ValidateRoutineOptions(options RoutineOptions) error {
 			}
 			hasBody = true
 		case RoutineLeakproof:
+			if isProc {
+				return pgerror.Newf(pgcode.InvalidFunctionDefinition, "leakproof attribute not allowed in procedure definition")
+			}
 			if hasLeakProof {
 				return conflictingErr(option)
 			}
 			hasLeakProof = true
 		case RoutineVolatility:
+			if isProc {
+				return pgerror.Newf(pgcode.InvalidFunctionDefinition, "volatility attribute not allowed in procedure definition")
+			}
 			if hasVolatility {
 				return conflictingErr(option)
 			}
 			hasVolatility = true
 		case RoutineNullInputBehavior:
+			if isProc {
+				return pgerror.Newf(pgcode.InvalidFunctionDefinition, "null input attribute not allowed in procedure definition")
+			}
 			if hasNullInputBehavior {
 				return conflictingErr(option)
 			}

--- a/pkg/sql/sem/tree/create_routine_test.go
+++ b/pkg/sql/sem/tree/create_routine_test.go
@@ -26,6 +26,7 @@ func TestConflictingFunctionOptions(t *testing.T) {
 	testCases := []struct {
 		testName    string
 		options     tree.RoutineOptions
+		isProc      bool
 		expectedErr string
 	}{
 		{
@@ -77,11 +78,35 @@ func TestConflictingFunctionOptions(t *testing.T) {
 			},
 			expectedErr: "AS $$others$$: conflicting or redundant options",
 		},
+		{
+			testName: "proc volatility",
+			options: tree.RoutineOptions{
+				tree.RoutineVolatile,
+			},
+			isProc:      true,
+			expectedErr: "volatility attribute not allowed in procedure definition",
+		},
+		{
+			testName: "proc leakproof",
+			options: tree.RoutineOptions{
+				tree.RoutineLeakproof(true),
+			},
+			isProc:      true,
+			expectedErr: "leakproof attribute not allowed in procedure definition",
+		},
+		{
+			testName: "proc null input",
+			options: tree.RoutineOptions{
+				tree.RoutineStrict,
+			},
+			isProc:      true,
+			expectedErr: "null input attribute not allowed in procedure definition",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			err := tree.ValidateRoutineOptions(tc.options)
+			err := tree.ValidateRoutineOptions(tc.options, tc.isProc)
 			if tc.expectedErr == "" {
 				require.NoError(t, err)
 				return


### PR DESCRIPTION
Certain options (i.e., volatility, leakproof, and null input behavior) are not allowed in procedure definitions. This PR causes an error to be thrown at procedure creation if one of these options is present, similar to postgres behavior.

Collaborator:mgartner

Epic: none
Fixes: #114825

Release note: None