### PR TITLE
workflows: add self-hosted test job

### DIFF
--- a/.github/workflows/experimental-github-actions-testing.yml
+++ b/.github/workflows/experimental-github-actions-testing.yml
@@ -1,0 +1,10 @@
+name: EXPERIMENTAL GitHub actions testing
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, edited ]
+    branches: [ master ]
+jobs:
+  test_job:
+    runs-on: [self-hosted, basic_runner_group]
+    steps:
+      - run: echo hi


### PR DESCRIPTION
This workflow is for testing our self-hosted auto-scaling actions runners. Failures can be ignored for now.

Epic: CRDB-8308
Release note: None