### PR TITLE
server: load stores in parallel during node startup 

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/future"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -65,6 +66,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/pprofutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/startup"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -248,6 +250,11 @@ var (
 		time.Second*30,
 	)
 )
+
+// By default, stores will be started concurrently.
+// To start stores sequentially set the environment variable
+// COCKROACH_CONCURRENT_STORE_START=false
+var startStoresAsync = envutil.EnvOrDefaultBool("COCKROACH_CONCURRENT_STORE_START", true)
 
 type nodeMetrics struct {
 	Latency metric.IHistogram
@@ -651,15 +658,47 @@ func (n *Node) start(
 		return errors.Wrapf(err, "couldn't gossip descriptor for node %d", n.Descriptor.NodeID)
 	}
 
-	// Create stores from the engines that were already initialized.
-	for _, e := range state.initializedEngines {
-		s := kvserver.NewStore(ctx, n.storeCfg, e, &n.Descriptor)
-		if err := s.Start(workersCtx, n.stopper); err != nil {
-			return errors.Wrap(err, "failed to start store")
+	// Create stores from engines that are already initialized. This uses a
+	// channel to collect errors when starting stores in separate goroutines.
+	// The channel is a buffered channel with the same size as the number of
+	// stores so worker go routines will never wait on the channel.
+	var sem *quotapool.IntPool
+	if !startStoresAsync {
+		sem = quotapool.NewIntPool("store start concurrency", 1)
+	}
+	engineErrC := make(chan error, len(state.initializedEngines))
+	for i := range state.initializedEngines {
+		engine := state.initializedEngines[i]
+		err := n.stopper.RunAsyncTaskEx(ctx,
+			stop.TaskOpts{TaskName: "initialize-stores", SpanOpt: stop.FollowsFromSpan, Sem: sem, WaitForSem: true},
+			func(ctx context.Context) {
+				s := kvserver.NewStore(ctx, n.storeCfg, engine, &n.Descriptor)
+				if err := s.Start(workersCtx, n.stopper); err != nil {
+					engineErrC <- errors.Wrap(err, "failed to start store")
+					return
+				}
+				n.addStore(ctx, s)
+				log.Infof(ctx, "initialized store s%s", s.StoreID())
+				engineErrC <- nil
+			})
+		if err != nil {
+			return err
 		}
+	}
 
-		n.addStore(ctx, s)
-		log.Infof(ctx, "initialized store s%s", s.StoreID())
+	// Collect errors from the go routines and return the first error received.
+	// This also waits for all stores to finish starting.
+	for range state.initializedEngines {
+		select {
+		case <-n.stopper.ShouldQuiesce():
+			return errors.New("shutting down")
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-engineErrC:
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	// Verify all initialized stores agree on cluster and node IDs.


### PR DESCRIPTION
Previously, stores for initialized engines were loaded sequentially, resulting in long startup times. This commit adds the option to load stores for initialized engines in parallel. To disable parallel store start, set the environment variable `COCKROACH_CONCURRENT_STORE_START=false`.

Fixes: https://github.com/cockroachdb/cockroach/issues/114137

Release note (performance improvement): Allows stores to start in parallel reducing start times for nodes with many stores.

@erikgrinaker 