### PR TITLE
opt: fix tests on ARM64

### DIFF
--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -3008,6 +3008,15 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 	}
 }
 
+// TODO(#115278): We should be able to replace this with Go's built-in max
+// function, but doing breaks some optimizer tests on ARM64.
+func max(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 //////////////////////////////////////////////////
 // Helper functions for selectivity calculation //
 //////////////////////////////////////////////////


### PR DESCRIPTION
For some reason, using Go's built-in `max` function in the statistics
builder causes optimizer tests to fail on ARM64. This commit reverts
part of #115228 as a temporary fix until we can diagnose the issue.

Informs #115278

Release note: None
