### PR TITLE
explain: remove duplicated order info for sort ops

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -1167,7 +1167,6 @@ vectorized: true
 ·
 • sort
 │ columns: (v int, count int)
-│ ordering: +count
 │ estimated row count: 100 (missing stats)
 │ order: +count_rows
 │
@@ -1191,7 +1190,6 @@ vectorized: true
 ·
 • sort
 │ columns: (v int, count int)
-│ ordering: +count
 │ estimated row count: 100 (missing stats)
 │ order: +count_rows
 │
@@ -1218,7 +1216,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (v int, count int, count_rows int)
-    │ ordering: +count_rows
     │ estimated row count: 100 (missing stats)
     │ order: +count_rows
     │
@@ -1455,7 +1452,6 @@ vectorized: true
 │
 └── • top-k
     │ columns: (column5 int)
-    │ ordering: +column5
     │ estimated row count: 1 (missing stats)
     │ order: +column5
     │ k: 1
@@ -1773,7 +1769,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (v)
-    │ ordering: +v
     │ estimated row count: 1,000 (missing stats)
     │ order: +v
     │
@@ -1796,7 +1791,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (v, arr)
-    │ ordering: +v
     │ estimated row count: 1,000 (missing stats)
     │ order: +v
     │
@@ -1817,7 +1811,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (k, s)
-    │ ordering: +s
     │ estimated row count: 1,000 (missing stats)
     │ order: +s
     │
@@ -1858,7 +1851,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (k, s)
-    │ ordering: +s
     │ estimated row count: 1,000 (missing stats)
     │ order: +s
     │
@@ -1996,7 +1988,6 @@ vectorized: true
 ·
 • sort
 │ columns: (company_id, string_agg)
-│ ordering: +company_id
 │ estimated row count: 100 (missing stats)
 │ order: +company_id
 │
@@ -2034,7 +2025,6 @@ vectorized: true
 ·
 • sort
 │ columns: (company_id, string_agg)
-│ ordering: +company_id
 │ estimated row count: 100 (missing stats)
 │ order: +company_id
 │
@@ -2072,7 +2062,6 @@ vectorized: true
 ·
 • sort
 │ columns: (company_id, string_agg)
-│ ordering: +company_id
 │ estimated row count: 100 (missing stats)
 │ order: +company_id
 │
@@ -2110,7 +2099,6 @@ vectorized: true
 ·
 • sort
 │ columns: (company_id, string_agg)
-│ ordering: +company_id
 │ estimated row count: 100 (missing stats)
 │ order: +company_id
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_union
@@ -68,7 +68,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a)
-│ ordering: +a
 │ estimated row count: 100 (missing stats)
 │ order: +a
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -95,7 +95,6 @@ vectorized: true
 ·
 • sort
 │ columns: (b)
-│ ordering: +b
 │ estimated row count: 1,000 (missing stats)
 │ order: +b
 │
@@ -264,7 +263,6 @@ vectorized: true
     │
     └── • sort
         │ columns: (a, b, c)
-        │ ordering: +a,-c,+b
         │ estimated row count: 1,000 (missing stats)
         │ order: +a,-c,+b
         │ already ordered: +a
@@ -288,7 +286,6 @@ vectorized: true
 ·
 • sort
 │ columns: (x)
-│ ordering: -x
 │ estimated row count: 100 (missing stats)
 │ order: -x
 │
@@ -311,7 +308,6 @@ vectorized: true
 ·
 • sort
 │ columns: (y, z, x)
-│ ordering: +z
 │ estimated row count: 1,000 (missing stats)
 │ order: +z
 │
@@ -341,7 +337,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (x, y, z)
-    │ ordering: +x,-z,-y
     │ estimated row count: 1,000 (missing stats)
     │ order: +x,-z,-y
     │
@@ -583,7 +578,6 @@ vectorized: true
 ·
 • sort
 │ columns: (x, y, z)
-│ ordering: +x,+y
 │ estimated row count: 1,000 (missing stats)
 │ order: +x,+y
 │
@@ -604,7 +598,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (x, y, z, pk1)
-    │ ordering: +x
     │ estimated row count: 1,000 (missing stats)
     │ order: +x
     │
@@ -628,7 +621,6 @@ vectorized: true
 ·
 • top-k
 │ columns: (x, y)
-│ ordering: +y
 │ estimated row count: 1 (missing stats)
 │ order: +y
 │ k: 1
@@ -660,7 +652,6 @@ vectorized: true
     │
     └── • top-k
         │ columns: (x, y)
-        │ ordering: +y
         │ estimated row count: 1 (missing stats)
         │ order: +y
         │ k: 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_distinct_on
@@ -107,7 +107,6 @@ vectorized: true
 ·
 • sort
 │ columns: (x, y, z)
-│ ordering: +x
 │ estimated row count: 1,000 (missing stats)
 │ order: +x
 │
@@ -158,7 +157,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (x, y)
-    │ ordering: +y,+x
     │ estimated row count: 1,000 (missing stats)
     │ order: +y,+x
     │

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -128,7 +128,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a, b, c, d)
-│ ordering: +b,+a
 │ estimated row count: 100 (missing stats)
 │ order: +b,+a
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_numtables
@@ -356,7 +356,6 @@ vectorized: true
 ·
 • sort
 │ columns: (y, str, res)
-│ ordering: +res
 │ estimated row count: 1,000 (missing stats)
 │ order: +res
 │
@@ -380,7 +379,6 @@ vectorized: true
 ·
 • top-k
 │ columns: (y, str, res)
-│ ordering: +res
 │ estimated row count: 10 (missing stats)
 │ order: +res
 │ k: 10

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -966,7 +966,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a, b)
-│ ordering: +b
 │ estimated row count: 10 (missing stats)
 │ order: +b
 │
@@ -995,7 +994,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a, b)
-│ ordering: +b
 │ estimated row count: 10 (missing stats)
 │ order: +b
 │
@@ -1236,7 +1234,6 @@ vectorized: true
 ·
 • sort
 │ columns: (v int)
-│ ordering: +v
 │ estimated row count: 1,000 (missing stats)
 │ order: +v
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -3321,7 +3321,6 @@ vectorized: true
 │
 └── • top-k
     │ columns: (column6, c, d)
-    │ ordering: +column6
     │ estimated row count: 3 (missing stats)
     │ order: +column6
     │ k: 3

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -322,7 +322,6 @@ vectorized: true
     │
     └── • top-k
         │ columns: (x, v)
-        │ ordering: -v
         │ estimated row count: 10 (missing stats)
         │ order: -v
         │ k: 10
@@ -463,7 +462,6 @@ vectorized: true
         │
         └── • top-k
             │ columns: (length, "?column?", column12)
-            │ ordering: +column12
             │ estimated row count: 10 (missing stats)
             │ order: +column12
             │ k: 10
@@ -605,7 +603,6 @@ vectorized: true
 │
 ├── • sort
 │   │ columns: (z)
-│   │ ordering: +z
 │   │ estimated row count: 1,000 (missing stats)
 │   │ order: +z
 │   │

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -1177,7 +1177,6 @@ vectorized: true
     │
     └── • sort
         │ columns: (a)
-        │ ordering: +a
         │ estimated row count: 111 (missing stats)
         │ order: +a
         │
@@ -1342,7 +1341,6 @@ vectorized: true
         │
         └── • sort
             │ columns: (a)
-            │ ordering: +a
             │ estimated row count: 111 (missing stats)
             │ order: +a
             │
@@ -1376,7 +1374,6 @@ vectorized: true
         │
         └── • sort
             │ columns: (a)
-            │ ordering: +a
             │ estimated row count: 111 (missing stats)
             │ order: +a
             │
@@ -1410,7 +1407,6 @@ vectorized: true
         │
         └── • sort
             │ columns: (a)
-            │ ordering: +a
             │ estimated row count: 111 (missing stats)
             │ order: +a
             │
@@ -1440,7 +1436,6 @@ vectorized: true
     │
     └── • sort
         │ columns: (a)
-        │ ordering: +a
         │ estimated row count: 12 (missing stats)
         │ order: +a
         │

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -93,7 +93,6 @@ vectorized: true
 ·
 • sort
 │ columns: (lk, rk1)
-│ ordering: +lk,+rk1
 │ estimated row count: 326,700 (missing stats)
 │ order: +lk,+rk1
 │ already ordered: +lk
@@ -143,7 +142,6 @@ vectorized: true
 ·
 • sort
 │ columns: (lk, rk1)
-│ ordering: +lk,+rk1
 │ estimated row count: 9,801 (missing stats)
 │ order: +lk,+rk1
 │ already ordered: +lk

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -298,7 +298,6 @@ vectorized: true
 ·
 • sort
 │ columns: (k, u, w)
-│ ordering: +u
 │ estimated row count: 2
 │ order: +column1
 │
@@ -402,7 +401,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (pktable_cat, update_rule, delete_rule, deferrability, nspname, relname, attname, nspname, relname, attname, conname, generate_series, relname)
-    │ ordering: +nspname,+relname,+conname,+generate_series
     │ estimated row count: 110,908 (missing stats)
     │ order: +nspname,+relname,+conname,+generate_series
     │

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -56,7 +56,6 @@ vectorized: true
     │
     └── • top-k
         │ columns: (w)
-        │ ordering: +w
         │ estimated row count: 100 (missing stats)
         │ order: +w
         │ k: 100
@@ -149,7 +148,6 @@ vectorized: true
     │
     └── • top-k
         │ columns: (k, sum, any_not_null)
-        │ ordering: -any_not_null
         │ estimated row count: 10 (missing stats)
         │ order: -any_not_null
         │ k: 10
@@ -278,7 +276,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (k, v, w)
-    │ ordering: +v
     │ estimated row count: 10 (missing stats)
     │ order: +v
     │
@@ -464,7 +461,6 @@ vectorized: true
 ·
 • top-k
 │ columns: (k, v, w)
-│ ordering: +v,+w
 │ estimated row count: 5 (missing stats)
 │ order: +v,+w
 │ k: 5

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -664,7 +664,6 @@ vectorized: true
     │
     └── • sort
         │ columns: (name, book)
-        │ ordering: +name
         │ estimated row count: 100
         │ order: +name
         │
@@ -1283,7 +1282,6 @@ vectorized: true
 ·
 • sort
 │ columns: (d, e, f, a, b, c)
-│ ordering: +f
 │ estimated row count: 100
 │ order: +f
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -60,7 +60,6 @@ vectorized: true
 ·
 • top-k
 │ columns: (c, b)
-│ ordering: +b
 │ estimated row count: 2 (missing stats)
 │ order: +b
 │ k: 2
@@ -130,7 +129,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a, b, c)
-│ ordering: +b,+a
 │ estimated row count: 1,000 (missing stats)
 │ order: +b,+a
 │
@@ -148,7 +146,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a, b, c)
-│ ordering: +b,+a
 │ estimated row count: 1,000 (missing stats)
 │ order: +b,+a
 │
@@ -166,7 +163,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a, b, c)
-│ ordering: +b,+a
 │ estimated row count: 1,000 (missing stats)
 │ order: +b,+a
 │
@@ -184,7 +180,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a, b, c)
-│ ordering: +b,+a
 │ estimated row count: 1,000 (missing stats)
 │ order: +b,+a
 │
@@ -239,7 +234,6 @@ vectorized: true
 ·
 • sort
 │ columns: (r)
-│ ordering: +r
 │ estimated row count: 1,000 (missing stats)
 │ order: +r
 │
@@ -262,7 +256,6 @@ vectorized: true
 ·
 • sort
 │ columns: (y)
-│ ordering: +y
 │ estimated row count: 1,000 (missing stats)
 │ order: +y
 │
@@ -390,7 +383,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a, b, c, d)
-│ ordering: +b,+a,+c
 │ estimated row count: 333 (missing stats)
 │ order: +b,+a,+c
 │
@@ -694,7 +686,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (column1)
-    │ ordering: +column1
     │ estimated row count: 3
     │ order: +column1
     │
@@ -860,7 +851,6 @@ vectorized: true
     │
     └── • sort
         │ columns: (a, b)
-        │ ordering: +a
         │ estimated row count: 1,000 (missing stats)
         │ order: +a
         │
@@ -888,7 +878,6 @@ vectorized: true
     │
     └── • sort
         │ columns: (a, b)
-        │ ordering: +b
         │ estimated row count: 1,000 (missing stats)
         │ order: +b
         │
@@ -915,7 +904,6 @@ vectorized: true
 ·
 • sort
 │ columns: (x, y)
-│ ordering: +x,+y
 │ estimated row count: 1,000 (missing stats)
 │ order: +x,+y
 │
@@ -933,7 +921,6 @@ vectorized: true
 ·
 • sort
 │ columns: (x, y)
-│ ordering: +x,+y
 │ estimated row count: 1,000 (missing stats)
 │ order: +x,+y
 │
@@ -1010,7 +997,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (k, v)
-    │ ordering: +v,+k
     │ estimated row count: 1,000 (missing stats)
     │ order: +v,+k
     │
@@ -1102,7 +1088,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (k, v)
-    │ ordering: -v,+k
     │ estimated row count: 2 (missing stats)
     │ order: -v,+k
     │
@@ -1201,7 +1186,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a, b)
-│ ordering: +b
 │ estimated row count: 1,000 (missing stats)
 │ order: +b
 │
@@ -1222,7 +1206,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (nulls_ordering_b, a, b)
-    │ ordering: +nulls_ordering_b,+b
     │ estimated row count: 1,000 (missing stats)
     │ order: +nulls_ordering_b,+b
     │
@@ -1249,7 +1232,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (nulls_ordering_b, a, b)
-    │ ordering: -nulls_ordering_b,-b
     │ estimated row count: 1,000 (missing stats)
     │ order: -nulls_ordering_b,-b
     │
@@ -1273,7 +1255,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a, b)
-│ ordering: -b
 │ estimated row count: 1,000 (missing stats)
 │ order: -b
 │
@@ -1294,7 +1275,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (nulls_ordering_b, nulls_ordering_c, a, b, c)
-    │ ordering: -nulls_ordering_b,-b,+nulls_ordering_c,+c
     │ estimated row count: 1,000 (missing stats)
     │ order: -nulls_ordering_b,-b,+nulls_ordering_c,+c
     │
@@ -1329,7 +1309,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (nulls_ordering_b, a, b)
-    │ ordering: +nulls_ordering_b,+b
     │ estimated row count: 1,000 (missing stats)
     │ order: +nulls_ordering_b,+b
     │

--- a/pkg/sql/opt/exec/execbuilder/testdata/ordinality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ordinality
@@ -54,7 +54,6 @@ vectorized: true
 ·
 • sort
 │ columns: (x, "ordinality")
-│ ordering: -"ordinality"
 │ estimated row count: 333 (missing stats)
 │ order: -"ordinality"
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -1221,7 +1221,6 @@ vectorized: true
     │
     └── • sort
         │ columns: (generate_series)
-        │ ordering: -generate_series
         │ estimated row count: 10
         │ order: -generate_series
         │
@@ -1257,7 +1256,6 @@ vectorized: true
         │
         └── • sort
             │ columns: (a, b)
-            │ ordering: +b
             │ estimated row count: 1,000 (missing stats)
             │ order: +b
             │

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1371,7 +1371,6 @@ vectorized: true
 │
 └── • sort
     │ columns: ("?column?", b)
-    │ ordering: +b
     │ estimated row count: 1,000 (missing stats)
     │ order: +b
     │

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -1353,7 +1353,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a, b, c, d)
-│ ordering: -c
 │ estimated row count: 330 (missing stats)
 │ order: -c
 │
@@ -1376,7 +1375,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a, b, c, d)
-│ ordering: +c
 │ estimated row count: 330 (missing stats)
 │ order: +c
 │
@@ -1452,7 +1450,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (a, b, c, d)
-    │ ordering: +c
     │ estimated row count: 1,000 (missing stats)
     │ order: +c
     │
@@ -1496,7 +1493,6 @@ vectorized: true
 ·
 • top-k
 │ columns: (a, b, c, d)
-│ ordering: +c
 │ estimated row count: 1,000 (missing stats)
 │ order: +c
 │ k: 1000000

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_statistics_persisted
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_statistics_persisted
@@ -480,7 +480,6 @@ vectorized: true
 │   │   │   │   │   │
 │   │   │   │   │   └── • top-k
 │   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, execution_count)
-│   │   │   │   │       │ ordering: -execution_count
 │   │   │   │   │       │ estimated row count: 500
 │   │   │   │   │       │ order: -execution_count
 │   │   │   │   │       │ k: 500
@@ -499,7 +498,6 @@ vectorized: true
 │   │   │   │       │
 │   │   │   │       └── • top-k
 │   │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, service_latency)
-│   │   │   │           │ ordering: -service_latency
 │   │   │   │           │ estimated row count: 500
 │   │   │   │           │ order: -service_latency
 │   │   │   │           │ k: 500
@@ -518,7 +516,6 @@ vectorized: true
 │   │   │       │
 │   │   │       └── • top-k
 │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, cpu_sql_nanos)
-│   │   │           │ ordering: -cpu_sql_nanos
 │   │   │           │ estimated row count: 500
 │   │   │           │ order: -cpu_sql_nanos
 │   │   │           │ k: 500
@@ -537,7 +534,6 @@ vectorized: true
 │   │       │
 │   │       └── • top-k
 │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, contention_time)
-│   │           │ ordering: -contention_time
 │   │           │ estimated row count: 500
 │   │           │ order: -contention_time
 │   │           │ k: 500
@@ -556,7 +552,6 @@ vectorized: true
 │       │
 │       └── • top-k
 │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, total_estimated_execution_time)
-│           │ ordering: -total_estimated_execution_time
 │           │ estimated row count: 500
 │           │ order: -total_estimated_execution_time
 │           │ k: 500
@@ -575,7 +570,6 @@ vectorized: true
     │
     └── • top-k
         │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, p99_latency)
-        │ ordering: -p99_latency
         │ estimated row count: 500
         │ order: -p99_latency
         │ k: 500
@@ -716,7 +710,6 @@ vectorized: true
 │   │   │   │   │   │
 │   │   │   │   │   └── • top-k
 │   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, execution_count)
-│   │   │   │   │       │ ordering: -execution_count
 │   │   │   │   │       │ estimated row count: 500
 │   │   │   │   │       │ order: -execution_count
 │   │   │   │   │       │ k: 500
@@ -735,7 +728,6 @@ vectorized: true
 │   │   │   │       │
 │   │   │   │       └── • top-k
 │   │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, service_latency)
-│   │   │   │           │ ordering: -service_latency
 │   │   │   │           │ estimated row count: 500
 │   │   │   │           │ order: -service_latency
 │   │   │   │           │ k: 500
@@ -754,7 +746,6 @@ vectorized: true
 │   │   │       │
 │   │   │       └── • top-k
 │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, cpu_sql_nanos)
-│   │   │           │ ordering: -cpu_sql_nanos
 │   │   │           │ estimated row count: 500
 │   │   │           │ order: -cpu_sql_nanos
 │   │   │           │ k: 500
@@ -773,7 +764,6 @@ vectorized: true
 │   │       │
 │   │       └── • top-k
 │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, contention_time)
-│   │           │ ordering: -contention_time
 │   │           │ estimated row count: 500
 │   │           │ order: -contention_time
 │   │           │ k: 500
@@ -792,7 +782,6 @@ vectorized: true
 │       │
 │       └── • top-k
 │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, total_estimated_execution_time)
-│           │ ordering: -total_estimated_execution_time
 │           │ estimated row count: 500
 │           │ order: -total_estimated_execution_time
 │           │ k: 500
@@ -811,7 +800,6 @@ vectorized: true
     │
     └── • top-k
         │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, p99_latency)
-        │ ordering: -p99_latency
         │ estimated row count: 500
         │ order: -p99_latency
         │ k: 500
@@ -1210,7 +1198,6 @@ vectorized: true
 │   │   │   │   │   │
 │   │   │   │   │   └── • top-k
 │   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, execution_count)
-│   │   │   │   │       │ ordering: -execution_count
 │   │   │   │   │       │ estimated row count: 500
 │   │   │   │   │       │ order: -execution_count
 │   │   │   │   │       │ k: 500
@@ -1229,7 +1216,6 @@ vectorized: true
 │   │   │   │       │
 │   │   │   │       └── • top-k
 │   │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, service_latency)
-│   │   │   │           │ ordering: -service_latency
 │   │   │   │           │ estimated row count: 500
 │   │   │   │           │ order: -service_latency
 │   │   │   │           │ k: 500
@@ -1248,7 +1234,6 @@ vectorized: true
 │   │   │       │
 │   │   │       └── • top-k
 │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, cpu_sql_nanos)
-│   │   │           │ ordering: -cpu_sql_nanos
 │   │   │           │ estimated row count: 500
 │   │   │           │ order: -cpu_sql_nanos
 │   │   │           │ k: 500
@@ -1267,7 +1252,6 @@ vectorized: true
 │   │       │
 │   │       └── • top-k
 │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, contention_time)
-│   │           │ ordering: -contention_time
 │   │           │ estimated row count: 500
 │   │           │ order: -contention_time
 │   │           │ k: 500
@@ -1286,7 +1270,6 @@ vectorized: true
 │       │
 │       └── • top-k
 │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, total_estimated_execution_time)
-│           │ ordering: -total_estimated_execution_time
 │           │ estimated row count: 500
 │           │ order: -total_estimated_execution_time
 │           │ k: 500
@@ -1305,7 +1288,6 @@ vectorized: true
     │
     └── • top-k
         │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, p99_latency)
-        │ ordering: -p99_latency
         │ estimated row count: 500
         │ order: -p99_latency
         │ k: 500
@@ -1440,7 +1422,6 @@ vectorized: true
 │   │   │   │   │   │
 │   │   │   │   │   └── • top-k
 │   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, execution_count)
-│   │   │   │   │       │ ordering: -execution_count
 │   │   │   │   │       │ estimated row count: 500
 │   │   │   │   │       │ order: -execution_count
 │   │   │   │   │       │ k: 500
@@ -1459,7 +1440,6 @@ vectorized: true
 │   │   │   │       │
 │   │   │   │       └── • top-k
 │   │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, service_latency)
-│   │   │   │           │ ordering: -service_latency
 │   │   │   │           │ estimated row count: 500
 │   │   │   │           │ order: -service_latency
 │   │   │   │           │ k: 500
@@ -1478,7 +1458,6 @@ vectorized: true
 │   │   │       │
 │   │   │       └── • top-k
 │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, cpu_sql_nanos)
-│   │   │           │ ordering: -cpu_sql_nanos
 │   │   │           │ estimated row count: 500
 │   │   │           │ order: -cpu_sql_nanos
 │   │   │           │ k: 500
@@ -1497,7 +1476,6 @@ vectorized: true
 │   │       │
 │   │       └── • top-k
 │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, contention_time)
-│   │           │ ordering: -contention_time
 │   │           │ estimated row count: 500
 │   │           │ order: -contention_time
 │   │           │ k: 500
@@ -1516,7 +1494,6 @@ vectorized: true
 │       │
 │       └── • top-k
 │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, total_estimated_execution_time)
-│           │ ordering: -total_estimated_execution_time
 │           │ estimated row count: 500
 │           │ order: -total_estimated_execution_time
 │           │ k: 500
@@ -1535,7 +1512,6 @@ vectorized: true
     │
     └── • top-k
         │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, p99_latency)
-        │ ordering: -p99_latency
         │ estimated row count: 500
         │ order: -p99_latency
         │ k: 500

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -122,7 +122,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a, generate_series)
-│ ordering: +a,+generate_series
 │ estimated row count: 10,000 (missing stats)
 │ order: +a,+generate_series
 │
@@ -152,7 +151,6 @@ vectorized: true
 ·
 • sort
 │ columns: (x, y, z, "information_schema._pg_expandarray")
-│ ordering: +x
 │ estimated row count: 3,267 (missing stats)
 │ order: +x
 │
@@ -418,7 +416,6 @@ vectorized: true
 ·
 • top-k
 │ columns: (id, body, description, title, slug, tag_list, user_id, created_at, updated_at)
-│ ordering: +created_at
 │ estimated row count: 10 (missing stats)
 │ order: +any_not_null
 │ k: 10

--- a/pkg/sql/opt/exec/execbuilder/testdata/topk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/topk
@@ -12,7 +12,6 @@ vectorized: true
 ·
 • top-k
 │ columns: (k, v, w)
-│ ordering: +w
 │ estimated row count: 10 (missing stats)
 │ order: +w
 │ k: 10
@@ -54,7 +53,6 @@ vectorized: true
 ·
 • top-k
 │ columns: (k, v, w)
-│ ordering: -w
 │ estimated row count: 10 (missing stats)
 │ order: -w
 │ k: 10
@@ -77,7 +75,6 @@ vectorized: true
 │
 └── • top-k
     │ columns: (k, w)
-    │ ordering: +w
     │ estimated row count: 2 (missing stats)
     │ order: +w
     │ k: 2
@@ -97,7 +94,6 @@ vectorized: true
 ·
 • top-k
 │ columns: (k, v, w)
-│ ordering: +w
 │ estimated row count: 10 (missing stats)
 │ order: +w
 │ k: 10
@@ -122,7 +118,6 @@ vectorized: true
 ·
 • top-k
 │ columns: (k, v, w)
-│ ordering: +v,+w
 │ estimated row count: 10 (missing stats)
 │ order: +v,+w
 │ k: 10

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -68,7 +68,6 @@ vectorized: true
 ·
 • sort
 │ columns: (a)
-│ ordering: +a
 │ estimated row count: 100 (missing stats)
 │ order: +a
 │
@@ -450,7 +449,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (a, c, b, d, e)
-    │ ordering: +a
     │ estimated row count: 1 (missing stats)
     │ order: +a
     │
@@ -771,7 +769,6 @@ vectorized: true
         │
         ├── • sort
         │   │ columns: (column1, column2)
-        │   │ ordering: +column1
         │   │ estimated row count: 3
         │   │ order: +column1
         │   │
@@ -1015,7 +1012,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (a, b, c, d)
-    │ ordering: +a,+b,-c,+d
     │ estimated row count: 1,000 (missing stats)
     │ order: +a,+b,-c,+d
     │ already ordered: +a,+b,-c

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -371,7 +371,6 @@ vectorized: true
 │
 ├── • sort
 │   │ columns: (a)
-│   │ ordering: +a
 │   │ estimated row count: 1,000 (missing stats)
 │   │ order: +a
 │   │

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -24,7 +24,6 @@ vectorized: true
     │
     └── • top-k
         │ columns: (k, v)
-        │ ordering: -v
         │ estimated row count: 2 (missing stats)
         │ order: -v
         │ k: 2
@@ -53,7 +52,6 @@ vectorized: true
     │
     └── • top-k
         │ columns: (k, v)
-        │ ordering: -v
         │ estimated row count: 2 (missing stats)
         │ order: -v
         │ k: 2
@@ -82,7 +80,6 @@ vectorized: true
     │
     └── • top-k
         │ columns: (k, v)
-        │ ordering: -v
         │ estimated row count: 2 (missing stats)
         │ order: -v
         │ k: 2
@@ -115,7 +112,6 @@ vectorized: true
     │
     └── • top-k
         │ columns: (k, v)
-        │ ordering: -v
         │ estimated row count: 2 (missing stats)
         │ order: -v
         │ k: 2
@@ -401,7 +397,6 @@ vectorized: true
 │
 ├── • sort
 │   │ columns: (z)
-│   │ ordering: +z
 │   │ estimated row count: 1,000 (missing stats)
 │   │ order: +z
 │   │

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -134,7 +134,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (k int, stddev decimal, variance decimal)
-    │ ordering: +variance,+k
     │ estimated row count: 1,000 (missing stats)
     │ order: +variance,+k
     │
@@ -164,7 +163,6 @@ vectorized: true
 │
 └── • sort
     │ columns: (k int, stddev decimal, variance decimal)
-    │ ordering: +variance,+k
     │ estimated row count: 1,000 (missing stats)
     │ order: +variance,+k
     │
@@ -195,7 +193,6 @@ vectorized: true
 ·
 • sort
 │ columns: (k int, stddev decimal)
-│ ordering: +k
 │ estimated row count: 1,000 (missing stats)
 │ order: +k
 │
@@ -224,7 +221,6 @@ vectorized: true
 │
 └── • sort
     │ columns: ("?column?" decimal, k int, variance decimal)
-    │ ordering: +variance,+k
     │ estimated row count: 1,000 (missing stats)
     │ order: +variance,+k
     │
@@ -261,7 +257,6 @@ vectorized: true
 │
 └── • sort
     │ columns: ("?column?" decimal, max int, variance decimal)
-    │ ordering: +variance
     │ estimated row count: 1,000 (missing stats)
     │ order: +variance
     │
@@ -301,7 +296,6 @@ vectorized: true
 ·
 • sort
 │ columns: (max int, stddev decimal)
-│ ordering: +max
 │ estimated row count: 1,000 (missing stats)
 │ order: +max
 │
@@ -368,7 +362,6 @@ vectorized: true
 ·
 • sort
 │ columns: (k, v, rank)
-│ ordering: +k
 │ estimated row count: 1,000 (missing stats)
 │ order: +k
 │

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -147,7 +147,7 @@ func omitTrivialProjections(n *Node) (*Node, colinfo.ResultColumns, colinfo.Colu
 	input, inputColumns, inputOrdering := omitTrivialProjections(n.children[0])
 
 	// Check if the projection is a bijection (i.e. permutation of all input
-	// columnns), and construct the inverse projection.
+	// columns), and construct the inverse projection.
 	if len(projection) != len(inputColumns) {
 		return n, n.Columns(), n.Ordering()
 	}

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -213,7 +213,13 @@ func (ob *OutputBuilder) BuildStringRows() []string {
 			child.AddLine(fmt.Sprintf("columns: %s", entry.columns))
 		}
 		if entry.ordering != "" {
-			child.AddLine(fmt.Sprintf("ordering: %s", entry.ordering))
+			// Do not print "ordering" redundantly  with "order" attribute of
+			// sort operators. Note that we choose to keep the latter so that
+			// "already ordered" and "K" attributes are printed right after the
+			// order.
+			if entry.node != nodeNames[sortOp] && entry.node != nodeNames[topKOp] {
+				child.AddLine(fmt.Sprintf("ordering: %s", entry.ordering))
+			}
 		}
 		// Add any fields for the node.
 		for entry = popField(); entry != nil; entry = popField() {

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -92,7 +92,6 @@ quality of service: regular
 │
 └── • sort
     │ columns: (column8 decimal, cid int, sum decimal)
-    │ ordering: +column8
     │ estimated row count: 98 (missing stats)
     │ order: +column8
     │


### PR DESCRIPTION
Currently, for `sort` and `top-k` nodes we emit the ordering information twice:
- once as "ordering" which we do for each node, using the output column names
- and second time as "order" for both sort operators specifically, using the input column names.

This information seems quite redundant, so this commit keeps the latter.

I chose the latter option so that "already ordered" and "K" attributes (which are sort-specific) would be right after "order".

Epic: None

Release note: None