### PR TITLE
sql: plumb disable_changefeed_replication session var down to KV

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3539,6 +3539,21 @@ func (ex *connExecutor) asOfClauseWithSessionDefault(expr tree.AsOfClause) tree.
 	return expr
 }
 
+// omitInRangefeeds returns a bool representing whether the KV writes
+// originating from this session should be omitted in rangefeeds.
+// The primary use case for this function is to set the OmitInRangefeeds
+// transaction attribute on roachpb.Transaction.
+//
+// Currently, the only way to exclude writes from rangefeeds is through
+// the CDC session-based filtering feature, which is configured with the
+// disable_changefeed_replication session variable.
+func (ex *connExecutor) omitInRangefeeds() bool {
+	if ex.sessionData() == nil {
+		return false
+	}
+	return ex.sessionData().DisableChangefeedReplication
+}
+
 // initEvalCtx initializes the fields of an extendedEvalContext that stay the
 // same across multiple statements. resetEvalCtx must also be called before each
 // statement, to reinitialize other fields.

--- a/pkg/sql/conn_fsm.go
+++ b/pkg/sql/conn_fsm.go
@@ -124,6 +124,7 @@ type eventTxnStartPayload struct {
 	// any new Txn started using this payload.
 	qualityOfService sessiondatapb.QoSLevel
 	isoLevel         isolation.Level
+	omitInRangefeeds bool
 }
 
 // makeEventTxnStartPayload creates an eventTxnStartPayload.
@@ -135,6 +136,7 @@ func makeEventTxnStartPayload(
 	tranCtx transitionCtx,
 	qualityOfService sessiondatapb.QoSLevel,
 	isoLevel isolation.Level,
+	omitInRangefeeds bool,
 ) eventTxnStartPayload {
 	return eventTxnStartPayload{
 		pri:                 pri,
@@ -144,6 +146,7 @@ func makeEventTxnStartPayload(
 		tranCtx:             tranCtx,
 		qualityOfService:    qualityOfService,
 		isoLevel:            isoLevel,
+		omitInRangefeeds:    omitInRangefeeds,
 	}
 }
 
@@ -514,6 +517,7 @@ func noTxnToOpen(args fsm.Args) error {
 		payload.tranCtx,
 		payload.qualityOfService,
 		payload.isoLevel,
+		payload.omitInRangefeeds,
 	)
 	ts.setAdvanceInfo(
 		advCode,

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -423,6 +423,7 @@ func (ie *InternalExecutor) newConnExecutorWithTxn(
 		ex.transitionCtx,
 		ex.QualityOfService(),
 		isolation.Serializable,
+		txn.GetOmitInRangefeeds(),
 	)
 
 	// Modify the Collection to match the parent executor's Collection.

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -465,7 +465,6 @@ message LocalOnlySessionData {
   bool optimizer_use_provided_ordering_fix = 115;
   // DisableChangefeedReplication, when true, disables changefeed events from
   // being emitted for changes to data made in a session.
-  // TODO(yang): Plumb this session variable down to KV.
   bool disable_changefeed_replication = 116;
   // CopyTxnQualityOfService indicates the default QoSLevel/WorkPriority of the
   // transactions used to evaluate COPY commands.

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -189,6 +189,7 @@ func (ts *txnState) resetForNewSQLTxn(
 	tranCtx transitionCtx,
 	qualityOfService sessiondatapb.QoSLevel,
 	isoLevel isolation.Level,
+	omitInRangefeeds bool,
 ) (txnID uuid.UUID) {
 	// Reset state vars to defaults.
 	ts.sqlTimestamp = sqlTimestamp
@@ -229,6 +230,9 @@ func (ts *txnState) resetForNewSQLTxn(
 		if txn == nil {
 			ts.mu.txn = kv.NewTxnWithSteppingEnabled(ts.Ctx, tranCtx.db, tranCtx.nodeIDOrZero, qualityOfService)
 			ts.mu.txn.SetDebugName(opName)
+			if omitInRangefeeds {
+				ts.mu.txn.SetOmitInRangefeeds()
+			}
 			if err := ts.setPriorityLocked(priority); err != nil {
 				panic(err)
 			}

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -299,7 +299,9 @@ func TestTransitions(t *testing.T) {
 			},
 			ev: eventTxnStart{ImplicitTxn: fsm.True},
 			evPayload: makeEventTxnStartPayload(pri, tree.ReadWrite, timeutil.Now(),
-				nil /* historicalTimestamp */, tranCtx, sessiondatapb.Normal, isolation.Serializable),
+				nil /* historicalTimestamp */, tranCtx, sessiondatapb.Normal, isolation.Serializable,
+				false, /* omitInRangefeeds */
+			),
 			expState: stateOpen{ImplicitTxn: fsm.True, WasUpgraded: fsm.False},
 			expAdv: expAdvance{
 				// We expect to stayInPlace; upon starting a txn the statement is
@@ -324,7 +326,9 @@ func TestTransitions(t *testing.T) {
 			},
 			ev: eventTxnStart{ImplicitTxn: fsm.False},
 			evPayload: makeEventTxnStartPayload(pri, tree.ReadWrite, timeutil.Now(),
-				nil /* historicalTimestamp */, tranCtx, sessiondatapb.Normal, isolation.Serializable),
+				nil /* historicalTimestamp */, tranCtx, sessiondatapb.Normal, isolation.Serializable,
+				false, /* omitInRangefeeds */
+			),
 			expState: stateOpen{ImplicitTxn: fsm.False, WasUpgraded: fsm.False},
 			expAdv: expAdvance{
 				expCode: advanceOne,


### PR DESCRIPTION
The SQL layer will now plumb the `disable_changefeed_replication` down
to the KV layer so that it can be used to omit writes from rangefeeds
on a per-session basis.

Fixes #114083

Release note: None