### PR TITLE
lease: use db.Txn helper rather than creating txn manually

### DIFF
--- a/pkg/ccl/multiregionccl/regionliveness_test.go
+++ b/pkg/ccl/multiregionccl/regionliveness_test.go
@@ -284,9 +284,13 @@ func TestRegionLivenessProberForLeases(t *testing.T) {
 	// Second attempt should skip the dead region for both
 	// CountLeases and WaitForNoVersion.
 	testutils.SucceedsSoon(t, func() error {
-		_, err = tenantSQL[1].Exec("ALTER TABLE t1 ADD COLUMN i INT")
-		_, err = tenantSQL[1].Exec("DROP TABLE t1")
-		return err
+		if _, err := tenantSQL[1].Exec("ALTER TABLE t1 ADD COLUMN IF NOT EXISTS i INT"); err != nil {
+			return err
+		}
+		if _, err := tenantSQL[1].Exec("DROP TABLE t1"); err != nil {
+			return err
+		}
+		return nil
 	})
 
 	require.NoError(t, tx.Rollback())

--- a/pkg/sql/catalog/lease/count.go
+++ b/pkg/sql/catalog/lease/count.go
@@ -37,105 +37,127 @@ func CountLeases(
 	at hlc.Timestamp,
 	forAnyVersion bool,
 ) (int, error) {
-	var count = 0
-	txn := db.KV().NewTxn(ctx, "count-lease")
-	executor := db.Executor()
-	err := txn.SetFixedTimestamp(ctx, at)
-	if err != nil {
-		return 0, err
-	}
-	prober := regionliveness.NewLivenessProber(db, cachedDatabaseRegions, settings)
-	regionMap, err := prober.QueryLiveness(ctx, txn)
-	if err != nil {
-		return 0, err
-	}
 	var whereClauses []string
 	for _, t := range versions {
 		versionClause := ""
 		if !forAnyVersion {
 			versionClause = fmt.Sprintf("AND version = %d", t.Version)
 		}
-		whereClauses = append(whereClauses,
-			fmt.Sprintf(`("descID" = %d %s AND expiration > $1)`,
-				t.ID, versionClause),
+		whereClauses = append(
+			whereClauses,
+			fmt.Sprintf(`("descID" = %d %s AND expiration > $1)`, t.ID, versionClause),
 		)
 	}
 
-	// Counts leases in non multi-region environments.
-	countLeases := func() error {
-		stmt := fmt.Sprintf(`SELECT count(1) FROM system.public.lease AS OF SYSTEM TIME '%s' WHERE `,
-			at.AsOfSystemTime()) +
-			strings.Join(whereClauses, " OR ")
+	var count int
+	if err := db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		txn.KV().SetDebugName("count-leases")
+		if err := txn.KV().SetFixedTimestamp(ctx, at); err != nil {
+			return err
+		}
+		prober := regionliveness.NewLivenessProber(db, cachedDatabaseRegions, settings)
+		regionMap, err := prober.QueryLiveness(ctx, txn.KV())
+		if err != nil {
+			return err
+		}
+		// Depending on the database configuration query by region or the
+		// entire table.
+		if cachedDatabaseRegions != nil && cachedDatabaseRegions.IsMultiRegion() {
+			count, err = countLeasesByRegion(ctx, txn, prober, regionMap, at, whereClauses)
+		} else {
+			count, err = countLeasesNonMultiRegion(ctx, txn, at, whereClauses)
+		}
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// Counts leases in non multi-region environments.
+func countLeasesNonMultiRegion(
+	ctx context.Context, txn isql.Txn, at hlc.Timestamp, whereClauses []string,
+) (int, error) {
+	stmt := fmt.Sprintf(
+		`SELECT count(1) FROM system.public.lease AS OF SYSTEM TIME '%s' WHERE `,
+		at.AsOfSystemTime(),
+	) + strings.Join(whereClauses, " OR ")
+	values, err := txn.QueryRowEx(
+		ctx, "count-leases", txn.KV(),
+		sessiondata.NodeUserSessionDataOverride,
+		stmt, at.GoTime(),
+	)
+	if err != nil {
+		return 0, err
+	}
+	if values == nil {
+		return 0, errors.New("failed to count leases")
+	}
+	count := int(tree.MustBeDInt(values[0]))
+	return count, nil
+}
+
+// Counts leases by region in MR environments.
+func countLeasesByRegion(
+	ctx context.Context,
+	txn isql.Txn,
+	prober regionliveness.Prober,
+	regionMap regionliveness.LiveRegions,
+	at hlc.Timestamp,
+	whereClauses []string,
+) (int, error) {
+	stmt := fmt.Sprintf(
+		`SELECT count(1) FROM system.public.lease AS OF SYSTEM TIME '%s' WHERE `,
+		at.AsOfSystemTime(),
+	) + `crdb_region=$2::system.crdb_internal_region AND (` + strings.Join(whereClauses, " OR ") + ")"
+	var count int
+	if err := regionMap.ForEach(func(region string) error {
 		var values tree.Datums
-		values, err = executor.QueryRowEx(
-			ctx, "count-leases", txn, /* txn */
-			sessiondata.RootUserSessionDataOverride,
-			stmt, at.GoTime(),
-		)
+		queryRegionRows := func(countCtx context.Context) error {
+			var err error
+			values, err = txn.QueryRowEx(
+				countCtx, "count-leases", txn.KV(),
+				sessiondata.NodeUserSessionDataOverride,
+				stmt, at.GoTime(), region,
+			)
+			return err
+		}
+		var err error
+		if hasTimeout, timeout := prober.GetTableTimeout(); hasTimeout {
+			err = timeutil.RunWithTimeout(ctx, "count-leases-region", timeout, queryRegionRows)
+		} else {
+			err = queryRegionRows(ctx)
+		}
+		if err != nil {
+			if regionliveness.IsQueryTimeoutErr(err) {
+				// Probe and mark the region potentially.
+				probeErr := prober.ProbeLiveness(ctx, region)
+				if probeErr != nil {
+					err = errors.WithSecondaryError(err, probeErr)
+					return err
+				}
+				return errors.Wrapf(err, "count-lease timed out reading from a region")
+			} else if regionliveness.IsMissingRegionEnumErr(err) {
+				// Skip this region because we were unable to find region in
+				// type descriptor. Since the database regions are cached, they
+				// may be stale and have dropped regions.
+				log.Infof(ctx, "count-lease is skipping region %s because of the "+
+					"following error %v", region, err)
+				return nil
+			}
+			return err
+		}
 		if values == nil {
 			return errors.New("failed to count leases")
 		}
-		count = int(tree.MustBeDInt(values[0]))
+		count += int(tree.MustBeDInt(values[0]))
 		return nil
+	}); err != nil {
+		return 0, err
 	}
-
-	// Counts leases by region in MR environments.
-	countLeasesByRegion := func() error {
-		stmt := fmt.Sprintf(`SELECT count(1) FROM system.public.lease AS OF SYSTEM TIME '%s' WHERE `,
-			at.AsOfSystemTime()) +
-			`crdb_region=$2::system.crdb_internal_region AND (` +
-			strings.Join(whereClauses, " OR ") +
-			")"
-		return regionMap.ForEach(func(region string) error {
-			var values tree.Datums
-			queryRegionRows := func(countCtx context.Context) error {
-				var err error
-				values, err = executor.QueryRowEx(
-					countCtx, "count-leases", txn, /* txn */
-					sessiondata.RootUserSessionDataOverride,
-					stmt, at.GoTime(), region,
-				)
-				return err
-			}
-			if hasTimeout, timeout := prober.GetTableTimeout(); hasTimeout {
-				err = timeutil.RunWithTimeout(ctx, "count-leases-region", timeout, queryRegionRows)
-			} else {
-				err = queryRegionRows(ctx)
-			}
-			if err != nil {
-				if regionliveness.IsQueryTimeoutErr(err) {
-					// Probe and mark the region potentially.
-					probeErr := prober.ProbeLiveness(ctx, region)
-					if probeErr != nil {
-						err = errors.WithSecondaryError(err, probeErr)
-						return err
-					}
-					return errors.Wrapf(err, "count-lease timed out reading from a region")
-				} else if regionliveness.IsMissingRegionEnumErr(err) {
-					// Skip this region because we were unable to find region in
-					// type descriptor. Since the database regions are cached, they
-					// may be stale and have dropped regions.
-					log.Infof(ctx, "count-lease is skipping region %s because of the "+
-						"following error %v", region, err)
-					return nil
-				}
-				return err
-			}
-			if values == nil {
-				return errors.New("failed to count leases")
-			}
-			count += int(tree.MustBeDInt(values[0]))
-			return nil
-		})
-	}
-
-	// Depending on the database configuration query by region or the
-	// entire table.
-	if cachedDatabaseRegions != nil &&
-		cachedDatabaseRegions.IsMultiRegion() {
-		err = countLeasesByRegion()
-	} else {
-		err = countLeases()
-	}
-	return count, err
+	return count, nil
 }


### PR DESCRIPTION
The isql.DB.Txn helper is important to use because it takes care of
releasing leases and other transaction cleanup steps.

As part of this, some functions were factored out of the CountLeases
function to make it more readable.

### regionlivenss: use ON CONFLICT .. DO NOTHING to avoid a query

This makes it possible to avoid an extra query to check if a row already
exists.

### multiregionccl: make test assertion more clear

The old code was swallowing an error on purpose, but it would miss other
unexpected errors. This is fixed by using IF NOT EXISTS.

Epic: CC-24173
Release note: None