### PR TITLE
release-23.2: roachprod: use storage cluster when available

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -406,17 +406,24 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 	}
 
 	if !startOpts.SkipInit {
-		if err := c.waitForDefaultTargetCluster(ctx, l, startOpts); err != nil {
-			return errors.Wrap(err, "failed to wait for default target cluster")
+		storageCluster := c
+		if startOpts.KVCluster != nil {
+			storageCluster = startOpts.KVCluster
+		}
+		if startOpts.Target == StartDefault {
+			if err := storageCluster.waitForDefaultTargetCluster(ctx, l, startOpts); err != nil {
+				return errors.Wrap(err, "failed to wait for default target cluster")
+			}
+			// Only after a successful cluster initialization should we attempt to schedule backups.
+			if startOpts.ScheduleBackups && shouldInit && config.CockroachDevLicense != "" {
+				if err := c.createFixedBackupSchedule(ctx, l, startOpts.ScheduleBackupArgs); err != nil {
+					return err
+				}
+			}
 		}
 		c.createAdminUserForSecureCluster(ctx, l, startOpts)
-		if err = c.setClusterSettings(ctx, l, startOpts.GetInitTarget(), startOpts.VirtualClusterName); err != nil {
+		if err = storageCluster.setClusterSettings(ctx, l, startOpts.GetInitTarget(), startOpts.VirtualClusterName); err != nil {
 			return err
-		}
-
-		// Only after a successful cluster initialization should we attempt to schedule backups.
-		if startOpts.ScheduleBackups && shouldInit && config.CockroachDevLicense != "" {
-			return c.createFixedBackupSchedule(ctx, l, startOpts.ScheduleBackupArgs)
 		}
 	}
 
@@ -1064,8 +1071,10 @@ func (c *SyncedCluster) createAdminUserForSecureCluster(
 	// work for shared-process virtual clusters.
 	retryOpts := retry.Options{MaxRetries: 20}
 	if err := retryOpts.Do(ctx, func(ctx context.Context) error {
+		// We use the first node in the virtual cluster to create the user.
+		firstNode := c.TargetNodes()[0]
 		results, err := c.ExecSQL(
-			ctx, l, Nodes{startOpts.GetInitTarget()}, startOpts.VirtualClusterName, startOpts.SQLInstance, []string{
+			ctx, l, Nodes{firstNode}, startOpts.VirtualClusterName, startOpts.SQLInstance, []string{
 				"-e", stmts,
 			})
 


### PR DESCRIPTION
Backport 1/1 commits from #114731.

/cc @cockroachdb/release

---

Previously there were scenarios where starting an external process virtual cluster could fail, because the assumption is that a storage cluster is running on the same node. This could be done by creating for instance a 4 node cluster, and starting the storage layer on the first 3, and attempting to start an external process virtual cluster on the 4th node, with the first 3 as the KV addresses.

We should support starting a SQL process (virtual clusters) on nodes that do not necessarily have a storage (system) process running on it as well. This change updates start up to use the appropriate cluster for relevant commands.

Epic: None
Release Note: None

Release justification: Test only change.