### PR TITLE
Change workload split param from 1000 to 0

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -66,19 +66,19 @@ func registerKV(r registry.Registry) {
 		owner                    registry.Owner // defaults to KV
 		sharedProcessMT          bool
 	}
-	computeNumSplits := func(opts kvOptions) int {
-		// TODO(ajwerner): set this default to a more sane value or remove it and
-		// rely on load-based splitting.
-		const defaultNumSplits = 1000
-		switch {
-		case opts.splits == 0:
-			return defaultNumSplits
-		case opts.splits < 0:
-			return 0
-		default:
-			return opts.splits
-		}
-	}
+	//computeNumSplits := func(opts kvOptions) int {
+	//	// TODO(ajwerner): set this default to a more sane value or remove it and
+	//	// rely on load-based splitting.
+	//	const defaultNumSplits = 0
+	//	switch {
+	//	case opts.splits == 0:
+	//		return defaultNumSplits
+	//	case opts.splits < 0:
+	//		return 0
+	//	default:
+	//		return opts.splits
+	//	}
+	//}
 	computeConcurrency := func(opts kvOptions) int {
 		// Scale the workload concurrency with the number of nodes in the cluster to
 		// account for system capacity, then scale inversely with the batch size to
@@ -147,7 +147,7 @@ func registerKV(r registry.Registry) {
 		m := c.NewMonitor(ctx, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
 			concurrency := ifLocal(c, "", " --concurrency="+fmt.Sprint(computeConcurrency(opts)))
-			splits := " --splits=" + strconv.Itoa(computeNumSplits(opts))
+			splits := " --splits=" + strconv.Itoa(opts.splits)
 			if opts.duration == 0 {
 				opts.duration = 30 * time.Minute
 			}
@@ -218,14 +218,14 @@ func registerKV(r registry.Registry) {
 		{nodes: 3, cpus: 8, readPercent: 95},
 		{nodes: 3, cpus: 8, readPercent: 95, sharedProcessMT: true},
 		{nodes: 3, cpus: 8, readPercent: 95, tracing: true, owner: registry.OwnerObsInf},
-		{nodes: 3, cpus: 8, readPercent: 0, splits: -1 /* no splits */},
-		{nodes: 3, cpus: 8, readPercent: 95, splits: -1 /* no splits */},
+		{nodes: 3, cpus: 8, readPercent: 0, splits: 1000 /* no splits */},
+		{nodes: 3, cpus: 8, readPercent: 95, splits: 1000 /* no splits */},
 		{nodes: 3, cpus: 32, readPercent: 0},
 		{nodes: 3, cpus: 32, readPercent: 0, sharedProcessMT: true},
 		{nodes: 3, cpus: 32, readPercent: 95},
 		{nodes: 3, cpus: 32, readPercent: 95, sharedProcessMT: true},
-		{nodes: 3, cpus: 32, readPercent: 0, splits: -1 /* no splits */},
-		{nodes: 3, cpus: 32, readPercent: 95, splits: -1 /* no splits */},
+		{nodes: 3, cpus: 32, readPercent: 0, splits: 1000 /* no splits */},
+		{nodes: 3, cpus: 32, readPercent: 95, splits: 1000 /* no splits */},
 		{nodes: 3, cpus: 32, readPercent: 0, globalMVCCRangeTombstone: true},
 		{nodes: 3, cpus: 32, readPercent: 95, globalMVCCRangeTombstone: true},
 
@@ -268,8 +268,8 @@ func registerKV(r registry.Registry) {
 		{nodes: 3, cpus: 32, readPercent: 95, sequential: true},
 
 		// Configs with reads, that are of limited spans, along with SFU writes.
-		{nodes: 1, cpus: 8, readPercent: 95, spanReads: true, splits: -1 /* no splits */, disableLoadSplits: true, sequential: true},
-		{nodes: 1, cpus: 32, readPercent: 95, spanReads: true, splits: -1 /* no splits */, disableLoadSplits: true, sequential: true},
+		{nodes: 1, cpus: 8, readPercent: 95, spanReads: true, splits: 0 /* no splits */, disableLoadSplits: true, sequential: true},
+		{nodes: 1, cpus: 32, readPercent: 95, spanReads: true, splits: 0 /* no splits */, disableLoadSplits: true, sequential: true},
 
 		// Weekly larger scale configurations.
 		{nodes: 32, cpus: 8, readPercent: 0, weekly: true, duration: time.Hour},
@@ -298,7 +298,7 @@ func registerKV(r registry.Registry) {
 			nameParts = append(nameParts, fmt.Sprintf("size=%dkb", opts.blockSize>>10))
 		}
 		if opts.splits != 0 { // support legacy test name which didn't include splits
-			nameParts = append(nameParts, fmt.Sprintf("splt=%d", computeNumSplits(opts)))
+			nameParts = append(nameParts, fmt.Sprintf("splt=%d", opts.splits))
 		}
 		if opts.sequential {
 			nameParts = append(nameParts, "seq")


### PR DESCRIPTION
As per issue https://github.com/cockroachdb/cockroach/issues/98649#issue-1624655967, @nvanbenschoten argues that hardcoded `kv` workload split value `1000` as default behaviour should be changed to no split range explicitly passed.

In above issue, he also pointed out there is pending TODO in code too.

This PR implements the changes requested above, by making following changes in code.

1. Removed computeNumSplits function.
2. Directly assign splits using `opts.splits` which can be non-zero if explicitly passed by caller or zero if not passed.
3. Still keeping test configs running with both split values, 0 and 1000, by explicitly providing split value 1000 as default changed to 0.