### PR TITLE
release-23.2: kv: add a transaction attribute for rangefeed filtering

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -975,6 +975,12 @@ func MakeTransaction(
 		ReadTimestamp:          now,
 		GlobalUncertaintyLimit: gul,
 		AdmissionPriority:      int32(admissionPriority),
+		// When set to true OmitInRangefeeds indicates that none of the
+		// transaction's writes will appear in rangefeeds. Should be set to false
+		// for all transactions that write to internal system tables and most other
+		// transactions unless specifically stated otherwise (e.g. by the
+		// disable_changefeed_replication session variable).
+		OmitInRangefeeds: false,
 	}
 }
 
@@ -1340,6 +1346,8 @@ func (t *Transaction) Update(o *Transaction) {
 	// handled the case of t being uninitialized at the beginning of this
 	// function.
 	t.AdmissionPriority = o.AdmissionPriority
+	// OmitInRangefeeds doesn't change.
+	t.OmitInRangefeeds = o.OmitInRangefeeds
 }
 
 // UpgradePriority sets transaction priority to the maximum of current

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -515,6 +515,11 @@ message Transaction {
   // admissionpb.WorkPriority.
   sint32 admission_priority = 19;
 
+  // When set to true, all of the transaction's writes will be filtered out by
+  // rangefeeds, and will not be available in changefeeds. This allows users to
+  // choose which writes are exported on a per-transaction basis.
+  bool omit_in_rangefeeds = 20;
+
   reserved 3, 6, 9, 13, 14;
 }
 

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -569,6 +569,7 @@ var nonZeroTxn = Transaction{
 	ReadTimestampFixed: true,
 	IgnoredSeqNums:     []enginepb.IgnoredSeqNumRange{{Start: 888, End: 999}},
 	AdmissionPriority:  1,
+	OmitInRangefeeds:   true,
 }
 
 func TestTransactionUpdate(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #113522.

/cc @cockroachdb/release

---

A new boolean transaction attribute allows users to choose which writes are exported to rangefeeds and changefeeds on a per-transaction basis. When the attribute is true, all of the transaction's writes will be filtered out by rangefeeds, and will not be available in changefeeds.

Fixes: #112991

Release note: None

Epic: CRDB-13169

---

Release justification: this is a proto-only change; backporting it will de-risk backporting the CDC write-time filtering feature to 23.2 later on.