### PR TITLE
workflows: add release-eng as reviewer in `update_releases`

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -48,6 +48,7 @@ jobs:
           base: "${{ matrix.branch }}"
           branch: 'crdb-releases-yaml-update-${{ matrix.branch }}'
           title: "${{ matrix.branch }}: Update pkg/testutils/release/cockroach_releases.yaml"
+          team-reviewers: release-eng
           body: |
             Update pkg/testutils/release/cockroach_releases.yaml with recent values.
 


### PR DESCRIPTION
Previously, the PRs created would have no reviewers assigned, making them very easy to be overlooked.

Epic: none

Release note: None