### PR TITLE
sql: Carry over primary index name for ALTER PK

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -472,6 +472,9 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 
 		case *tree.AlterTableAlterPrimaryKey:
+			// For `ALTER PRIMARY KEY`, carry over the primary index name, like how we
+			// carried over comments associated with the old primary index.
+			t.Name = tree.Name(n.tableDesc.PrimaryIndex.Name)
 			if err := params.p.AlterPrimaryKey(
 				params.ctx,
 				n.tableDesc,

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1607,27 +1607,21 @@ COMMENT ON CONSTRAINT i2 ON public.pkey_comment IS 'idx3'
 statement ok
 ALTER TABLE pkey_comment ALTER PRIMARY KEY USING COLUMNS (b);
 
-# Verify that all comments are appropriately carried over. The output of `SHOW
-# CREATE` between LSC and DSC are slightly different so we query them
-# separately.
-skipif config local-legacy-schema-changer
+# Verify that all comments are appropriately carried over. The order of comments
+# from `SHOW CREATE` between LSC and DSC are slightly different so we used
+# slightly complicated query to extract all comments from `SHOW CREATE` and
+# order them by comments for a unified output.
 query T
-SELECT substring(create_statement, strpos(create_statement, 'COMMENT')) FROM [SHOW CREATE pkey_comment];
+SELECT trim(trailing ';' from unnest(regexp_split_to_array(substring(create_statement, strpos(create_statement, 'COMMENT')), '\n', 'g'))) AS comment
+FROM [SHOW CREATE pkey_comment]
+ORDER BY comment;
 ----
-COMMENT ON INDEX public.pkey_comment@i2 IS 'idx2';
-COMMENT ON INDEX public.pkey_comment@pkey IS 'idx';
-COMMENT ON CONSTRAINT i2 ON public.pkey_comment IS 'idx3';
-COMMENT ON CONSTRAINT pkey ON public.pkey_comment IS 'const'
-
-onlyif config local-legacy-schema-changer
-query T
-SELECT substring(create_statement, strpos(create_statement, 'COMMENT')) FROM [SHOW CREATE pkey_comment];
-----
-COMMENT ON INDEX public.pkey_comment@pkey_comment_pkey IS 'idx';
-COMMENT ON INDEX public.pkey_comment@i2 IS 'idx2';
-COMMENT ON CONSTRAINT pkey_comment_pkey ON public.pkey_comment IS 'const';
 COMMENT ON CONSTRAINT i2 ON public.pkey_comment IS 'idx3'
+COMMENT ON CONSTRAINT pkey ON public.pkey_comment IS 'const'
+COMMENT ON INDEX public.pkey_comment@i2 IS 'idx2'
+COMMENT ON INDEX public.pkey_comment@pkey IS 'idx'
 
+subtest end
 
 subtest test-index-deduplication
 


### PR DESCRIPTION
Previously, when `use_declarative_schema_changer=off` and when we attempt a ALTER PRIMARY KEY, the resulting new primary key would have a newly generated name. This is inconsistent with the default behavior (when `use_declarative_schema_changer=on`, default setting) where the new primary index would have the same name as the old primary index.

Fixes #115343
Informs #113351

Release note (bug fix): ALTER PRIMARY KEY now preserves the name of the original primary index when `use_declarative_schema_changer=off`