### PR TITLE
release-23.1: roachtest: mark ruby-pg and npgsql tests as flaky

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -729,6 +729,7 @@ var npgsqlIgnoreList = blocklist{
 	`Npgsql.Tests.CommandTests(Multiplexing).SingleQuery`:                                                  "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).Statement_mapped_output_parameters(Default)`:                  "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).TableDirect`:                                                  "flaky",
+	`Npgsql.Tests.CommandTests(Multiplexing).Unreferenced_positional_parameter_works`:                      "flaky",
 	`Npgsql.Tests.CommandTests(Multiplexing).Use_across_connection_change(NotPrepared)`:                    "flaky",
 	`Npgsql.Tests.CommandTests(NonMultiplexing).Cached_command_clears_parameters_placeholder_type`:         "flaky",
 	`Npgsql.Tests.CommandTests(NonMultiplexing).CloseConnection_with_exception`:                            "flaky",

--- a/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
@@ -204,4 +204,6 @@ var rubyPGBlocklist = blocklist{
 var rubyPGIgnorelist = blocklist{
 	`PG::Connection OS thread support Connection.new shouldn't block a second thread`:                             "flaky",
 	`running with sync_* methods PG::Connection consume_input should raise ConnectionBad for a closed connection`: "flaky",
+	`running with sync_* methods PG::Connection OS thread support Connection.new shouldn't block a second thread`: "flaky",
+	`running with sync_* methods PG::Connection handles server close while asynchronous connect`:                  "flaky",
 }


### PR DESCRIPTION
Backport 1/1 commits from #115315.

/cc @cockroachdb/release

Release justification: test only change

---

These are upstream tests that can flake on CockroachDB.

fixes https://github.com/cockroachdb/cockroach/issues/114699
fixes https://github.com/cockroachdb/cockroach/issues/114739
Release note: None
