### PR TITLE
release-23.1: parser: disallow custom ORDER BY <index> syntax in function calls

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -4241,8 +4241,8 @@ opt_interval_qualifier ::=
 
 func_application ::=
 	func_application_name '(' ')'
-	| func_application_name '(' expr_list opt_sort_clause ')'
-	| func_application_name '(' 'ALL' expr_list opt_sort_clause ')'
+	| func_application_name '(' expr_list opt_sort_clause_no_index ')'
+	| func_application_name '(' 'ALL' expr_list opt_sort_clause_no_index ')'
 	| func_application_name '(' 'DISTINCT' expr_list ')'
 	| func_application_name '(' '*' ')'
 
@@ -4437,13 +4437,17 @@ func_application_name ::=
 	func_name
 	| '[' 'FUNCTION' iconst32 ']'
 
+opt_sort_clause_no_index ::=
+	sort_clause_no_index
+	| 
+
 single_sort_clause ::=
 	'ORDER' 'BY' sortby
 	| 'ORDER' 'BY' sortby ',' sortby_list
 	| 'ORDER' 'BY' sortby_index ',' sortby_list
 
 window_specification ::=
-	'(' opt_existing_window_name opt_partition_clause opt_sort_clause opt_frame_clause ')'
+	'(' opt_existing_window_name opt_partition_clause opt_sort_clause_no_index opt_frame_clause ')'
 
 window_name ::=
 	name
@@ -4524,6 +4528,9 @@ func_name ::=
 	| prefixed_column_path
 	| 'INDEX'
 
+sort_clause_no_index ::=
+	'ORDER' 'BY' sortby_no_index_list
+
 opt_existing_window_name ::=
 	name
 	| 
@@ -4598,6 +4605,9 @@ reference_action ::=
 	| 'CASCADE'
 	| 'SET' 'NULL'
 	| 'SET' 'DEFAULT'
+
+sortby_no_index_list ::=
+	( sortby ) ( ( ',' sortby | ',' sortby_index ) )*
 
 frame_extent ::=
 	frame_bound

--- a/docs/generated/sql/bnf/window_definition.bnf
+++ b/docs/generated/sql/bnf/window_definition.bnf
@@ -1,2 +1,2 @@
 window_definition ::=
-	window_name 'AS' '(' opt_existing_window_name opt_partition_clause opt_sort_clause opt_frame_clause ')'
+	window_name 'AS' '(' opt_existing_window_name opt_partition_clause opt_sort_clause_no_index opt_frame_clause ')'

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -357,7 +357,7 @@ CREATE TABLE unrelated(x INT); SELECT * FROM unrelated ORDER BY PRIMARY KEY kv
 statement ok
 PREPARE a AS (TABLE kv) ORDER BY PRIMARY KEY kv
 
-statement error ORDER BY INDEX in window definition is not supported
+statement error pq: at or near "primary": syntax error
 SELECT avg(k) OVER (ORDER BY PRIMARY KEY kv) FROM kv
 
 statement ok

--- a/pkg/sql/parser/testdata/select_numeric_func_expr
+++ b/pkg/sql/parser/testdata/select_numeric_func_expr
@@ -53,3 +53,14 @@ SELECT [FUNCTION 1074](DISTINCT 'hello', 'world')
 SELECT ([FUNCTION 1074](DISTINCT ('hello'), ('world'))) -- fully parenthesized
 SELECT [FUNCTION 1074](DISTINCT '_', '_') -- literals removed
 SELECT [FUNCTION 1074](DISTINCT 'hello', 'world') -- identifiers removed
+
+# Regression test for not allowing custom "ORDER BY <index>" syntax in function
+# calls (#114788).
+error
+SELECT [FUNCTION 1074]('hello','word' ORDER BY PRIMARY KEY FAMILY DESC)
+----
+at or near "primary": syntax error
+DETAIL: source SQL:
+SELECT [FUNCTION 1074]('hello','word' ORDER BY PRIMARY KEY FAMILY DESC)
+                                               ^
+HINT: try \hf [FUNCTION 1074]


### PR DESCRIPTION
Backport 1/1 commits from #114873.

/cc @cockroachdb/release

---

This commit adjusts the parser to no longer allow custom (i.e. Cockroach extension) `ORDER BY <index>` syntax in function calls. Previously, this would pass the parser but later would hit an internal error during the type checking since `OrderBy.Expr` would be `nil`. The original motivation behind this custom syntax doesn't make sense in the context of function calls.

It seems unlikely anyone will actually run into this problem, so there is no release note.

Fixes: #114788.
Fixes: https://github.com/cockroachdb/cockroach/issues/115153.

Release note: None

Release justification: bug fix.