### PR TITLE
workflows: hardcode reviewer usernames instead of adding team

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -48,7 +48,7 @@ jobs:
           base: "${{ matrix.branch }}"
           branch: 'crdb-releases-yaml-update-${{ matrix.branch }}'
           title: "${{ matrix.branch }}: Update pkg/testutils/release/cockroach_releases.yaml"
-          team-reviewers: release-eng
+          reviewers: rail,jlinder,celiala
           body: |
             Update pkg/testutils/release/cockroach_releases.yaml with recent values.
 


### PR DESCRIPTION
Being able to reference a team would involve us either changing the
default permissions of the `GITHUB_TOKEN` used by Actions to be
permissive [1], or creating a GitHub app [2]. We take the easier
approach for now and directly reference current members of the
`release-eng` team.

[1]
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

[2] https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens

Epic: none

Release note: None