### PR TITLE
sql: Allow unique-without-index not valid constraint in table creation

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -1039,3 +1039,30 @@ public  generated_by_default_t_notnull_b_seq     INT8
 public  generated_always_t_notnull_b_seq         INT8
 public  generated_by_default_t_b_seq             INT8
 public  generated_always_t_b_seq                 INT8
+
+subtest end
+
+# This subtest ensures we can create not valid unique-without-index constraint
+# during table creation, which will be treated as a "normal"
+# unique-without-index constraint (meaning the NOT VALID will be dropped).
+subtest 115352
+
+statement ok
+SET experimental_enable_unique_without_index_constraints = true
+
+statement ok
+CREATE TABLE t_115352 (i INT, UNIQUE WITHOUT INDEX (i) NOT VALID);
+
+# NOT VALID constraint specified within `CREATE TABLE` is a no-op and does not
+# skip validation.
+query T
+SELECT create_statement FROM [SHOW CREATE t_115352];
+----
+CREATE TABLE public.t_115352 (
+    i INT8 NULL,
+    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+    CONSTRAINT t_115352_pkey PRIMARY KEY (rowid ASC),
+    CONSTRAINT unique_i UNIQUE WITHOUT INDEX (i)
+)
+
+subtest end

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -9821,7 +9821,7 @@ table_elem:
   {
     def := $1.constraintDef()
     valBehavior := $2.validationBehavior()
-    if u, ok := def.(*tree.UniqueConstraintTableDef); ok && valBehavior == tree.ValidationSkip {
+    if u, ok := def.(*tree.UniqueConstraintTableDef); ok && valBehavior == tree.ValidationSkip && !u.WithoutIndex {
       typ := "PRIMARY KEY"
       if !u.PrimaryKey {
         typ = "UNIQUE"


### PR DESCRIPTION
Fixes #115352
Release note (bug fix): we fixed a bug where if we add a unique-without-index-not-valid constraint to a table, then the `create_statement` from `SHOW CREATE t` is not executable and errors with "unique constraint cannot be NOT VALID". The intention here is to disallow index-backed-unique constraint and this patch fixes that.