### PR TITLE
backupccl: move compatible backup version check to Restore resume

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -8420,6 +8420,33 @@ func TestRestoringAcrossVersions(t *testing.T) {
 		sqlDB.ExpectErr(t, "the backup is from a version older than our minimum restorable version",
 			`RESTORE DATABASE r1 FROM 'nodelocal://1/cross_version'`)
 	})
+	t.Run("restore-nil-version-after-pause", func(t *testing.T) {
+		minSupportedVersion := tc.ApplicationLayer(0).ClusterSettings().Version.MinSupportedVersion()
+		setManifestClusterVersion(minSupportedVersion)
+		sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_load_descriptors_from_backup'")
+		var jobID int
+		sqlDB.QueryRow(t, `RESTORE DATABASE r1 FROM 'nodelocal://1/cross_version' with DETACHED`).Scan(&jobID)
+		jobutils.WaitForJobToPause(t, sqlDB, jobspb.JobID(jobID))
+
+		setManifestClusterVersion(roachpb.Version{})
+
+		sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = ''")
+		sqlDB.Exec(t, "RESUME JOB $1", jobID)
+		jobutils.WaitForJobToFail(t, sqlDB, jobspb.JobID(jobID))
+		payload := jobutils.GetJobPayload(t, sqlDB, jobspb.JobID(jobID))
+		require.Contains(t, payload.Error, "the backup is from a version older than our minimum restorable version")
+
+	})
+	t.Run("restore-nil-version-unsafe", func(t *testing.T) {
+		var jobID int
+		sqlDB.QueryRow(t, `RESTORE DATABASE r1 FROM 'nodelocal://1/cross_version' with DETACHED, UNSAFE_RESTORE_INCOMPATIBLE_VERSION`).Scan(&jobID)
+		jobutils.WaitForJobToSucceed(t, sqlDB, jobspb.JobID(jobID))
+		payload := jobutils.GetJobPayload(t, sqlDB, jobspb.JobID(jobID))
+
+		// Ensure this option is uncapitalized in the job description, which a
+		// 23.1/23.2 mixed version unsafe restore relies upon to pass the check.
+		require.Contains(t, payload.Description, "unsafe_restore_incompatible_version")
+	})
 }
 
 // TestManifestBitFlip tests that we can detect a corrupt manifest when a bit

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupencryption"
@@ -1622,10 +1623,6 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		return err
 	}
 
-	if err := r.validateJobIsResumable(p.ExecCfg()); err != nil {
-		return err
-	}
-
 	kmsEnv := backupencryption.MakeBackupKMSEnv(
 		p.ExecCfg().Settings,
 		&p.ExecCfg().ExternalIODirConfig,
@@ -1636,6 +1633,9 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		ctx, &mem, p, details, details.Encryption, &kmsEnv,
 	)
 	if err != nil {
+		return err
+	}
+	if err := r.validateJobIsResumable(ctx, p.ExecCfg(), backupManifests); err != nil {
 		return err
 	}
 	defer func() {
@@ -1926,8 +1926,26 @@ func clusterRestoreDuringUpgradeErr(
 }
 
 // validateJobDetails returns an error if this job cannot be resumed.
-func (r *restoreResumer) validateJobIsResumable(execConfig *sql.ExecutorConfig) error {
+func (r *restoreResumer) validateJobIsResumable(
+	ctx context.Context,
+	execConfig *sql.ExecutorConfig,
+	mainBackupManifests []backuppb.BackupManifest,
+) error {
 	details := r.job.Details().(jobspb.RestoreDetails)
+
+	allowUnsafeRestore := details.UnsafeRestoreIncompatibleVersion
+	if strings.Contains(r.job.Payload().Description, "unsafe_restore_incompatible_version") {
+		// This added check ensures we continue with unsafe restore in the
+		// following mixed version case: user plans a restore on 23.1 which will
+		// not set the unsafe restore field in the job proto, and resumes it on
+		// a 23.2.
+		allowUnsafeRestore = true
+	}
+
+	if err := checkBackupManifestVersionCompatability(ctx, execConfig.Settings.Version,
+		mainBackupManifests, allowUnsafeRestore); err != nil {
+		return err
+	}
 
 	// Validate that we aren't in the middle of an upgrade. To avoid unforseen
 	// issues, we want to avoid full cluster restores if it is possible that an

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -2156,14 +2156,15 @@ func doRestorePlan(
 		// compatability.
 		//
 		// TODO(msbutler): Delete in 23.1
-		RestoreSystemUsers:  restoreStmt.DescriptorCoverage == tree.SystemUsers,
-		PreRewriteTenantId:  oldTenantID,
-		SchemaOnly:          restoreStmt.Options.SchemaOnly,
-		VerifyData:          restoreStmt.Options.VerifyData,
-		SkipLocalitiesCheck: restoreStmt.Options.SkipLocalitiesCheck,
-		ExecutionLocality:   execLocality,
-		ExperimentalOnline:  restoreStmt.Options.ExperimentalOnline,
-		RemoveRegions:       restoreStmt.Options.RemoveRegions,
+		RestoreSystemUsers:               restoreStmt.DescriptorCoverage == tree.SystemUsers,
+		PreRewriteTenantId:               oldTenantID,
+		SchemaOnly:                       restoreStmt.Options.SchemaOnly,
+		VerifyData:                       restoreStmt.Options.VerifyData,
+		SkipLocalitiesCheck:              restoreStmt.Options.SkipLocalitiesCheck,
+		ExecutionLocality:                execLocality,
+		ExperimentalOnline:               restoreStmt.Options.ExperimentalOnline,
+		RemoveRegions:                    restoreStmt.Options.RemoveRegions,
+		UnsafeRestoreIncompatibleVersion: restoreStmt.Options.UnsafeRestoreIncompatibleVersion,
 	}
 
 	jr := jobs.Record{

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -496,6 +496,10 @@ message RestoreDetails {
   // Removes regions.
   bool RemoveRegions = 33;
 
+  // UnsafeRestoreIncompatibleVersion allows restoring a backup older than the min compatible
+  // version.
+  bool unsafe_restore_incompatible_version = 34;
+
   // NEXT ID: 34.
 }
 


### PR DESCRIPTION
This patch moves the min compatible backup check from restore planning to resume. This ensures a restore job that resumes after a cluster upgrade still checks if the backup is compatible.

Epic: none

Release note: none