### PR TITLE
roachtest: fix sqlalchemy test dependencies

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -30,7 +30,7 @@ import (
 var sqlAlchemyResultRegex = regexp.MustCompile(`^(?P<test>test.*::.*::[^ \[\]]*(?:\[.*])?) (?P<result>\w+)\s+\[.+]$`)
 var sqlAlchemyReleaseTagRegex = regexp.MustCompile(`^rel_(?P<major>\d+)_(?P<minor>\d+)_(?P<point>\d+)$`)
 
-var supportedSQLAlchemyTag = "2.0.20"
+var supportedSQLAlchemyTag = "2.0.23"
 
 // This test runs the SQLAlchemy dialect test suite against a single Cockroach
 // node.
@@ -99,7 +99,7 @@ func runSQLAlchemy(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	if err := repeatRunE(ctx, t, c, node, "install pytest", fmt.Sprintf(`
 		source venv/bin/activate &&
-			pip3 install --upgrade --force-reinstall setuptools pytest==7.2.1 pytest-xdist psycopg2 alembic sqlalchemy==%s`,
+			pip3 install --upgrade --force-reinstall setuptools pytest==7.2.1 pytest-xdist psycopg2 psycopg alembic sqlalchemy==%s`,
 		supportedSQLAlchemyTag)); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
We now need to use sqlalchemy 2.0.23 and psycopg3

fixes https://github.com/cockroachdb/cockroach/issues/115326
fixes https://github.com/cockroachdb/cockroach/issues/115325
fixes https://github.com/cockroachdb/cockroach/issues/115324
fixes https://github.com/cockroachdb/cockroach/issues/115322
fixes https://github.com/cockroachdb/cockroach/issues/115321

Release note: None