### PR TITLE
floatcmp: handle NULL float comparison

### DIFF
--- a/pkg/testutils/floatcmp/floatcmp.go
+++ b/pkg/testutils/floatcmp/floatcmp.go
@@ -86,6 +86,10 @@ func EqualApprox(expected interface{}, actual interface{}, fraction float64, mar
 // FloatsMatchApprox returns whether two floating point represented as
 // strings are equal within a tolerance.
 func FloatsMatchApprox(expectedString, actualString string) (bool, error) {
+	if expectedString == "NULL" || actualString == "NULL" {
+		// Default to string matching for NULL, since it can't be parsed as a float.
+		return expectedString == actualString, nil
+	}
 	expected, actual, err := parseExpectedAndActualFloats(expectedString, actualString)
 	if err != nil {
 		return false, err
@@ -97,6 +101,10 @@ func FloatsMatchApprox(expectedString, actualString string) (bool, error) {
 // strings have matching 15 significant decimal digits (this is the precision
 // that Postgres supports for 'double precision' type).
 func FloatsMatch(expectedString, actualString string) (bool, error) {
+	if expectedString == "NULL" || actualString == "NULL" {
+		// Default to string matching for NULL, since it can't be parsed as a float.
+		return expectedString == actualString, nil
+	}
 	expected, actual, err := parseExpectedAndActualFloats(expectedString, actualString)
 	if err != nil {
 		return false, err

--- a/pkg/testutils/floatcmp/floatcmp_test.go
+++ b/pkg/testutils/floatcmp/floatcmp_test.go
@@ -179,6 +179,8 @@ func TestFloatsMatch(t *testing.T) {
 		{f1: "-0.1234567890123456", f2: "0.1234567890123456", match: false},
 		{f1: "-0.1234567890123456", f2: "-0.1234567890123455", match: true},
 		{f1: "0.142857142857143", f2: "0.14285714285714285", match: true},
+		{f1: "NULL", f2: "0.14285714285714285", match: false},
+		{f1: "NULL", f2: "NULL", match: true},
 	} {
 		match, err := FloatsMatch(tc.f1, tc.f2)
 		if err != nil {


### PR DESCRIPTION
This patch adds special handling to the `FloatsMatchApprox` and `FloatsMatch` testing utility functions for NULL values. Previously, attempting to compare query results with NULL float values would result in an error.

Fixes #115079

Release note: None