### PR TITLE
kvserver: make min-required load impact a cluster setting

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -752,27 +752,27 @@ func TestChooseLeaseToTransfer(t *testing.T) {
 		// NB: The lease has just enough load to be worthwhile rebalancing.
 		{
 			storeIDs:     []roachpb.StoreID{1, 4},
-			qps:          minLeaseLoadFraction * localDesc.Capacity.QueriesPerSecond,
-			reqCPU:       minLeaseLoadFraction * localDesc.Capacity.CPUPerSecond,
+			qps:          defaultMinLeaseLoadFraction * localDesc.Capacity.QueriesPerSecond,
+			reqCPU:       defaultMinLeaseLoadFraction * localDesc.Capacity.CPUPerSecond,
 			expectTarget: 4,
 		},
 		{
 			storeIDs:     []roachpb.StoreID{1, 5},
-			qps:          minLeaseLoadFraction * localDesc.Capacity.QueriesPerSecond,
-			reqCPU:       minLeaseLoadFraction * localDesc.Capacity.CPUPerSecond,
+			qps:          defaultMinLeaseLoadFraction * localDesc.Capacity.QueriesPerSecond,
+			reqCPU:       defaultMinLeaseLoadFraction * localDesc.Capacity.CPUPerSecond,
 			expectTarget: 5,
 		},
 		// NB: The lease is no longer worth rebalancing.
 		{
 			storeIDs:     []roachpb.StoreID{1, 4},
-			qps:          minLeaseLoadFraction*localDesc.Capacity.QueriesPerSecond - 1,
-			reqCPU:       minLeaseLoadFraction*localDesc.Capacity.CPUPerSecond - 1,
+			qps:          defaultMinLeaseLoadFraction*localDesc.Capacity.QueriesPerSecond - 1,
+			reqCPU:       defaultMinLeaseLoadFraction*localDesc.Capacity.CPUPerSecond - 1,
 			expectTarget: 0,
 		},
 		{
 			storeIDs:     []roachpb.StoreID{1, 5},
-			qps:          minLeaseLoadFraction*localDesc.Capacity.QueriesPerSecond - 1,
-			reqCPU:       minLeaseLoadFraction*localDesc.Capacity.CPUPerSecond - 1,
+			qps:          defaultMinLeaseLoadFraction*localDesc.Capacity.QueriesPerSecond - 1,
+			reqCPU:       defaultMinLeaseLoadFraction*localDesc.Capacity.CPUPerSecond - 1,
 			expectTarget: 0,
 		},
 		{


### PR DESCRIPTION
Introduce two new cluster settings which are system only and not public:

```
kv.allocator.load_based_rebalancing.min_lease_load_fraction
kv.allocator.load_based_rebalancing.min_replica_load_fraction
```

These settings control the minimum fraction a replica must contribute to the local store's load in order to be considered for load based replica/lease rebalancing.

The default values of these settings remain the same as the previous constants, 0.5% for lease rebalancing and 2% for replica rebalancing.

Informs: #115111
Epic: None
Release note: None