### PR TITLE
release-23.1: roachtest: add --suite and --owner flags, improve test filtering

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "monitor.go",
         "run.go",
         "slack.go",
+        "test_filter.go",
         "test_impl.go",
         "test_registry.go",
         "test_runner.go",

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -186,7 +186,7 @@ func (g *githubIssues) createPostRequest(
 		return issues.PostRequest{}, err
 	}
 
-	if sl, ok := teams.GetAliasesForPurpose(ownerToAlias(issueOwner), team.PurposeRoachtest); ok {
+	if sl, ok := teams.GetAliasesForPurpose(issueOwner.ToTeamAlias(), team.PurposeRoachtest); ok {
 		for _, alias := range sl {
 			mention = append(mention, "@"+string(alias))
 			if label := teams[alias].Label; label != "" {

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -83,7 +83,7 @@ func TestShouldPost(t *testing.T) {
 		{false, 1, "token", "master", true, ""},
 	}
 
-	reg := makeTestRegistry(spec.GCE, "", "", false, false)
+	reg := makeTestRegistry(spec.GCE, "", "", false)
 	for _, c := range testCases {
 		t.Setenv("GITHUB_API_TOKEN", c.envGithubAPIToken)
 		t.Setenv("TC_BUILD_BRANCH", c.envTcBuildBranch)
@@ -184,7 +184,7 @@ func TestCreatePostRequest(t *testing.T) {
 		{true, false, false, false, false, "", createFailure(gce.ErrDNSOperation), true, false, true, nil},
 	}
 
-	reg := makeTestRegistry(spec.GCE, "", "", false, false)
+	reg := makeTestRegistry(spec.GCE, "", "", false)
 	for idx, c := range testCases {
 		t.Run(fmt.Sprintf("%d", idx+1), func(t *testing.T) {
 			clusterSpec := reg.MakeClusterSpec(1, spec.Arch(c.arch))

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
@@ -96,48 +97,50 @@ func main() {
 		}},
 	)
 
-	var listBench bool
-
 	var listCmd = &cobra.Command{
-		Use:   "list [tests]",
-		Short: "list tests matching the patterns",
-		Long: `List tests that match the given name patterns.
+		Use:   "list [regex...]",
+		Short: "list tests",
+		Long: `List tests that match the flags and given name patterns.
 
-If no pattern is passed, all tests are matched.
-Use --bench to list benchmarks instead of tests.
+Tests are restricted by the specified --cloud (gce by default). Use
+--cloud=all to show tests for all clouds.
 
-Each test has a set of tags. The tags are used to skip tests which don't match
-the tag filter. The tag filter is specified by specifying a pattern with the
-"tag:" prefix. 
+Use --bench to restrict to benchmarks.
+Use --suite to restrict to tests that are part of the given suite.
+Use --owner to restrict to tests that have the given owner.
 
-If multiple "tag:" patterns are specified, the test must match at
-least one of them.
-
-Within a single "tag:" pattern, multiple tags can be specified by separating them
-with a comma. In this case, the test must match all of the tags.
+If patterns are specified, only tests that match either of the given patterns
+are listed.
 
 Examples:
 
    roachtest list acceptance copy/bank/.*false
-   roachtest list tag:owner-kv
-   roachtest list tag:weekly
+   roachtest list --owner kv
+   roachtest list --suite weekly
 
    # match weekly kv owned tests
-   roachtest list tag:owner-kv,weekly
-
-   # match weekly kv owner tests or aws tests
-   roachtest list tag:owner-kv,weekly tag:aws
+   roachtest list --suite weekly --owner kv
 `,
-		RunE: func(_ *cobra.Command, args []string) error {
-			r := makeTestRegistry(cloud, instanceType, zonesF, localSSDArg, listBench)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := makeTestRegistry(cloud, instanceType, zonesF, localSSDArg)
 			tests.RegisterTests(&r)
 
-			filter := registry.NewTestFilter(args)
-			specs := testsToRun(r, filter, runSkipped, selectProbability, false)
+			filter, err := makeTestFilter(args)
+			if err != nil {
+				return err
+			}
+			// Print a description of the filter to stderr (to keep stdout clean for scripts).
+			fmt.Fprintf(cmd.OutOrStderr(), "Listing %s.\n\n", filter.String())
+			cmd.SilenceUsage = true
+
+			specs, hint := filter.FilterWithHint(r.AllTests())
+			if len(specs) == 0 {
+				return errors.Newf("%s", filter.NoMatchesHintString(hint))
+			}
 
 			for _, s := range specs {
 				var skip string
-				if s.Skip != "" && !runSkipped {
+				if s.Skip != "" {
 					skip = " (skipped: " + s.Skip + ")"
 				}
 				fmt.Printf("%s [%s]%s\n", s.Name, s.Owner, skip)
@@ -145,21 +148,22 @@ Examples:
 			return nil
 		},
 	}
+	addSuiteAndOwnerFlags(listCmd)
 	listCmd.Flags().BoolVar(
-		&listBench, "bench", false, "list benchmarks instead of tests")
+		&onlyBenchmarks, "bench", false, "Restricts to benchmarks")
 	listCmd.Flags().StringVar(
-		&cloud, "cloud", cloud, "cloud provider to use (aws, azure, or gce)")
+		&cloud, "cloud", spec.GCE, "Restricts tests to those compatible with the given cloud (local, aws, azure, gce, or all)")
 
 	var runCmd = &cobra.Command{
 		// Don't display usage when tests fail.
 		SilenceUsage: true,
-		Use:          "run [tests]",
+		Use:          "run [regex..]",
 		Short:        "run automated tests on cockroach cluster",
 		Long: `Run automated tests on existing or ephemeral cockroach clusters.
 
-roachtest run takes a list of regex patterns and runs all the matching tests.
-If no pattern is given, all tests are run. See "help list" for more details on
-the test tags.
+roachtest run takes a list of regex patterns and runs tests matching the tests
+as well as the --cloud, --suite, --owner flags. See "help list" for more details
+on specifying tests.
 
 If all invoked tests passed, the exit status is zero. If at least one test
 failed, it is 10. Any other exit status reports a problem with the test
@@ -169,25 +173,37 @@ runner itself.
 			if err := initRunFlagsBinariesAndLibraries(cmd); err != nil {
 				return err
 			}
-			return runTests(tests.RegisterTests, args, false /* benchOnly */)
+			filter, err := makeTestFilter(args)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("\nRunning %s.\n\n", filter.String())
+			cmd.SilenceUsage = true
+			return runTests(tests.RegisterTests, filter)
 		},
 	}
 
 	var benchCmd = &cobra.Command{
 		// Don't display usage when tests fail.
 		SilenceUsage: true,
-		Use:          "bench [benchmarks]",
+		Use:          "bench [regex...]",
 		Short:        "run automated benchmarks on cockroach cluster",
 		Long:         `Run automated benchmarks on existing or ephemeral cockroach clusters.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := initRunFlagsBinariesAndLibraries(cmd); err != nil {
 				return err
 			}
-			return runTests(tests.RegisterTests, args, true /* benchOnly */)
+			onlyBenchmarks = true
+			filter, err := makeTestFilter(args)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("\nRunning %s.\n\n", filter.String())
+			cmd.SilenceUsage = true
+			return runTests(tests.RegisterTests, filter)
 		},
 	}
 
-	// Register flags shared between `run` and `bench`.
 	addRunFlags(runCmd)
 	addBenchFlags(benchCmd)
 
@@ -231,8 +247,15 @@ func testsToRun(
 	runSkipped bool,
 	selectProbability float64,
 	print bool,
-) []registry.TestSpec {
-	specs, tagMismatch := r.GetTests(filter)
+) ([]registry.TestSpec, error) {
+	specs, hint := filter.FilterWithHint(r.AllTests())
+	if len(specs) == 0 {
+		msg := filter.NoMatchesHintString(hint)
+		if hint == registry.IncompatibleCloud {
+			msg += "\nTo include tests that are not compatible with this cloud, use --force-cloud-compat."
+		}
+		return nil, errors.Newf("%s", msg)
+	}
 
 	var notSkipped []registry.TestSpec
 	for _, s := range specs {
@@ -248,24 +271,34 @@ func testsToRun(
 			}
 		}
 	}
-	for _, s := range tagMismatch {
-		if print && teamCity {
-			fmt.Fprintf(os.Stdout, "##teamcity[testIgnored name='%s' message='tag mismatch']\n",
-				s.Name)
+
+	if print {
+		// We want to show information about all tests/benchmarks which match the
+		// pattern(s) but were excluded for other reasons.
+		relaxedFilter := registry.TestFilter{
+			Name:           filter.Name,
+			OnlyBenchmarks: filter.OnlyBenchmarks,
 		}
-		if print {
-			fmt.Fprintf(os.Stdout, "--- SKIP: %s (%s)\n\ttag mismatch\n", s.Name, "0.00s")
+		for _, s := range relaxedFilter.Filter(r.AllTests()) {
+			if matches, r := filter.Matches(&s); !matches {
+				reason := filter.MatchFailReasonString(r)
+				// This test matches the "relaxed" filter but not the original filter.
+				if teamCity {
+					fmt.Fprintf(os.Stdout, "##teamcity[testIgnored name='%s' message='%s']\n", s.Name, reason)
+				}
+				fmt.Fprintf(os.Stdout, "--- SKIP: %s (%s)\n\t%s\n", s.Name, "0.00s", reason)
+			}
 		}
 	}
 
-	return selectSpecs(notSkipped, selectProbability, true, print)
+	return selectSpecs(notSkipped, selectProbability, true, print), nil
 }
 
 // selectSpecs returns a random sample of the given test specs.
 // If atLeastOnePerPrefix is true, it guarantees that at least one test is
 // selected for each prefix (e.g. kv0/, acceptance/).
 // This assumes that specs are sorted by name, which is the case for
-// testRegistryImpl.GetTests().
+// testRegistryImpl.AllTests().
 // TODO(smg260): Perhaps expose `atLeastOnePerPrefix` via CLI
 func selectSpecs(
 	specs []registry.TestSpec, samplePct float64, atLeastOnePerPrefix bool, print bool,

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -132,8 +132,8 @@ Examples:
 			r := makeTestRegistry(cloud, instanceType, zonesF, localSSDArg, listBench)
 			tests.RegisterTests(&r)
 
-			filter := registry.NewTestFilter(args, runSkipped)
-			specs := testsToRun(r, filter, selectProbability, false)
+			filter := registry.NewTestFilter(args)
+			specs := testsToRun(r, filter, runSkipped, selectProbability, false)
 
 			for _, s := range specs {
 				var skip string
@@ -226,13 +226,17 @@ runner itself.
 }
 
 func testsToRun(
-	r testRegistryImpl, filter *registry.TestFilter, selectProbability float64, print bool,
+	r testRegistryImpl,
+	filter *registry.TestFilter,
+	runSkipped bool,
+	selectProbability float64,
+	print bool,
 ) []registry.TestSpec {
 	specs, tagMismatch := r.GetTests(filter)
 
 	var notSkipped []registry.TestSpec
 	for _, s := range specs {
-		if s.Skip == "" || filter.RunSkipped {
+		if s.Skip == "" || runSkipped {
 			notSkipped = append(notSkipped, s)
 		} else {
 			if print && teamCity {

--- a/pkg/cmd/roachtest/main_test.go
+++ b/pkg/cmd/roachtest/main_test.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 func makeRegistry(names ...string) testRegistryImpl {
-	r := makeTestRegistry(spec.GCE, "", "", false /* preferSSD */, false /* benchOnly */)
+	r := makeTestRegistry(spec.GCE, "", "", false /* preferSSD */)
 	dummyRun := func(context.Context, test.Test, cluster.Cluster) {}
 
 	for _, name := range names {
@@ -49,11 +49,14 @@ func makeRegistry(names ...string) testRegistryImpl {
 
 func TestSampleSpecs(t *testing.T) {
 	r := makeRegistry("abc/1234", "abc/5678", "abc/9292", "abc/2313", "abc/5656", "abc/2233", "abc/1893", "def/1234", "ghi", "jkl/1234")
-	filter := registry.NewTestFilter([]string{})
+	filter, err := registry.NewTestFilter([]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, f := range []float64{0.01, 0.5, 1.0} {
 		t.Run(fmt.Sprintf("Sample-%.3f", f), func(t *testing.T) {
-			specs := testsToRun(r, filter, false /* runSkipped */, f /* selectProbability */, false /* print */)
+			specs, _ := testsToRun(r, filter, false /* runSkipped */, f /* selectProbability */, false /* print */)
 
 			matched := map[string]int{"abc": 0, "def": 0, "ghi": 0, "jkl": 0}
 			for _, s := range specs {
@@ -69,10 +72,13 @@ func TestSampleSpecs(t *testing.T) {
 		})
 	}
 
-	filter = registry.NewTestFilter([]string{"abc"})
+	filter, err = registry.NewTestFilter([]string{"abc"})
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, f := range []float64{0.01, 0.5, 1.0} {
 		t.Run(fmt.Sprintf("Sample-abc-%.3f", f), func(t *testing.T) {
-			specs := testsToRun(r, filter, false /* runSkipped */, f /* selectProbability */, false /* print */)
+			specs, _ := testsToRun(r, filter, false /* runSkipped */, f /* selectProbability */, false /* print */)
 
 			matched := map[string]int{"abc": 0, "def": 0, "ghi": 0, "jkl": 0}
 			for _, s := range specs {

--- a/pkg/cmd/roachtest/main_test.go
+++ b/pkg/cmd/roachtest/main_test.go
@@ -24,11 +24,9 @@ import (
 )
 
 func init() {
-	loadTeams = func() (team.Map, error) {
-		return map[team.Alias]team.Team{
-			ownerToAlias(OwnerUnitTest): {},
-		}, nil
-	}
+	registry.OverrideTeams(team.Map{
+		OwnerUnitTest.ToTeamAlias(): {},
+	})
 }
 
 func makeRegistry(names ...string) testRegistryImpl {

--- a/pkg/cmd/roachtest/main_test.go
+++ b/pkg/cmd/roachtest/main_test.go
@@ -49,11 +49,11 @@ func makeRegistry(names ...string) testRegistryImpl {
 
 func TestSampleSpecs(t *testing.T) {
 	r := makeRegistry("abc/1234", "abc/5678", "abc/9292", "abc/2313", "abc/5656", "abc/2233", "abc/1893", "def/1234", "ghi", "jkl/1234")
-	filter := registry.NewTestFilter([]string{}, false)
+	filter := registry.NewTestFilter([]string{})
 
 	for _, f := range []float64{0.01, 0.5, 1.0} {
 		t.Run(fmt.Sprintf("Sample-%.3f", f), func(t *testing.T) {
-			specs := testsToRun(r, filter, f, false)
+			specs := testsToRun(r, filter, false /* runSkipped */, f /* selectProbability */, false /* print */)
 
 			matched := map[string]int{"abc": 0, "def": 0, "ghi": 0, "jkl": 0}
 			for _, s := range specs {
@@ -69,10 +69,10 @@ func TestSampleSpecs(t *testing.T) {
 		})
 	}
 
-	filter = registry.NewTestFilter([]string{"abc"}, false)
+	filter = registry.NewTestFilter([]string{"abc"})
 	for _, f := range []float64{0.01, 0.5, 1.0} {
 		t.Run(fmt.Sprintf("Sample-abc-%.3f", f), func(t *testing.T) {
-			specs := testsToRun(r, filter, f, false)
+			specs := testsToRun(r, filter, false /* runSkipped */, f /* selectProbability */, false /* print */)
 
 			matched := map[string]int{"abc": 0, "def": 0, "ghi": 0, "jkl": 0}
 			for _, s := range specs {

--- a/pkg/cmd/roachtest/registry/BUILD.bazel
+++ b/pkg/cmd/roachtest/registry/BUILD.bazel
@@ -17,17 +17,24 @@ go_library(
         "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/test",
         "//pkg/internal/team",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_prometheus_client_golang//prometheus/promauto",
     ],
 )
 
 go_test(
     name = "registry_test",
-    srcs = ["test_spec_test.go"],
+    srcs = [
+        "filter_test.go",
+        "test_spec_test.go",
+    ],
     args = ["-test.timeout=295s"],
+    data = glob(["testdata/**"]),
     embed = [":registry"],
     deps = [
         "//pkg/cmd/roachtest/spec",
+        "//pkg/internal/team",
+        "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/cmd/roachtest/registry/BUILD.bazel
+++ b/pkg/cmd/roachtest/registry/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/test",
+        "//pkg/internal/team",
         "@com_github_prometheus_client_golang//prometheus/promauto",
     ],
 )

--- a/pkg/cmd/roachtest/registry/filter.go
+++ b/pkg/cmd/roachtest/registry/filter.go
@@ -27,15 +27,14 @@ type TestFilter struct {
 	//
 	// This set contains each tag, so the above examples would be represented as `["foo,bar"]` and
 	// `["foo", "bar"]` respectively..
-	Tags       map[string]struct{}
-	RunSkipped bool
+	Tags map[string]struct{}
 }
 
 // NewTestFilter initializes a new filter. The strings are interpreted
 // as regular expressions. As a special case, a `tag:` prefix implies
 // that the remainder of the string filters tests by tag, and not by
 // name.
-func NewTestFilter(filter []string, runSkipped bool) *TestFilter {
+func NewTestFilter(filter []string) *TestFilter {
 	var name []string
 	tags := make(map[string]struct{})
 	for _, v := range filter {
@@ -61,8 +60,7 @@ func NewTestFilter(filter []string, runSkipped bool) *TestFilter {
 	}
 
 	return &TestFilter{
-		Name:       makeRE(name),
-		Tags:       tags,
-		RunSkipped: runSkipped,
+		Name: makeRE(name),
+		Tags: tags,
 	}
 }

--- a/pkg/cmd/roachtest/registry/filter.go
+++ b/pkg/cmd/roachtest/registry/filter.go
@@ -11,14 +11,31 @@
 package registry
 
 import (
+	"fmt"
 	"regexp"
+	"sort"
 	"strings"
+
+	"github.com/cockroachdb/errors"
 )
 
 // TestFilter holds the name and tag filters for filtering tests.
 // See NewTestFilter.
 type TestFilter struct {
 	Name *regexp.Regexp
+
+	// Cloud, if set, restricts the set of tests to those compatible with this cloud.
+	Cloud string
+
+	// Suite, if set, restricts the set of tests to those that are part of this suite.
+	Suite string
+
+	// Owner, if set, restricts the set of tests to those with this owner.
+	Owner Owner
+
+	// OnlyBenchmarks, if set, restricts the set of tests to benchmarks.
+	OnlyBenchmarks bool
+
 	// Multiple `tag:` parameters can be passed for which only one needs to match, but the
 	// value of a single `tag:` parameter can be a comma-separated list of tags which all need
 	// to match.
@@ -30,14 +47,35 @@ type TestFilter struct {
 	Tags map[string]struct{}
 }
 
-// NewTestFilter initializes a new filter. The strings are interpreted
-// as regular expressions. As a special case, a `tag:` prefix implies
-// that the remainder of the string filters tests by tag, and not by
-// name.
-func NewTestFilter(filter []string) *TestFilter {
+// TestFilterOption can be passed to NewTestFilter.
+type TestFilterOption func(tf *TestFilter)
+
+// WithCloud restricts the set of tests to those compatible with this cloud.
+func WithCloud(cloud string) TestFilterOption {
+	return func(tf *TestFilter) { tf.Cloud = cloud }
+}
+
+// WithSuite restricts the set of tests to those that are part of this suite.
+func WithSuite(suite string) TestFilterOption {
+	return func(tf *TestFilter) { tf.Suite = suite }
+}
+
+// WithOwner restricts the set of tests to those with this owner.
+func WithOwner(owner Owner) TestFilterOption {
+	return func(tf *TestFilter) { tf.Owner = owner }
+}
+
+func OnlyBenchmarks() TestFilterOption {
+	return func(tf *TestFilter) { tf.OnlyBenchmarks = true }
+}
+
+// NewTestFilter initializes a new filter. The strings are interpreted as
+// regular expressions. As a special case, a `tag:` prefix implies that the
+// remainder of the string filters tests by tag, and not by name.
+func NewTestFilter(regexps []string, options ...TestFilterOption) (*TestFilter, error) {
 	var name []string
 	tags := make(map[string]struct{})
-	for _, v := range filter {
+	for _, v := range regexps {
 		if strings.HasPrefix(v, "tag:") {
 			tags[strings.TrimPrefix(v, "tag:")] = struct{}{}
 		} else {
@@ -59,8 +97,316 @@ func NewTestFilter(filter []string) *TestFilter {
 		}
 	}
 
-	return &TestFilter{
+	tf := &TestFilter{
 		Name: makeRE(name),
 		Tags: tags,
 	}
+	for _, o := range options {
+		o(tf)
+	}
+
+	// Validate Cloud, Suite, Owner fields.
+	if tf.Cloud != "" && !AllClouds.Contains(tf.Cloud) {
+		return nil, errors.Newf("invalid cloud %q; valid clouds are %s", tf.Cloud, AllClouds)
+	}
+	if s := Suites(allSuites...); tf.Suite != "" && !s.Contains(tf.Suite) {
+		return nil, errors.Newf("invalid suite %q; valid suites are %s", tf.Suite, s)
+	}
+	if tf.Owner != "" && !tf.Owner.IsValid() {
+		return nil, errors.Newf("invalid owner %q", tf.Owner)
+	}
+
+	return tf, nil
+}
+
+// MatchFailReason describes the reason(s) a filter did not match the test.
+type MatchFailReason struct {
+	// If true, the filter requires a benchmark and the test is not one.
+	IsNotBenchmark bool
+	// If true, the test name does not match the filter regexp.
+	NameMismatch bool
+	// If true, the test owner does not match the owner in the filter.
+	OwnerMismatch bool
+	// If true, the test is not part of the suite in the filter.
+	NotPartOfSuite bool
+	// If true, the test is not compatible with the cloud in the filter.
+	CloudNotCompatible bool
+	// If true, the tags don't match those in the filter.
+	TagsMismatch bool
+}
+
+// Matches returns true if the filter matches the test. If the test doesn't
+// match, returns the reason(s).
+func (filter *TestFilter) Matches(t *TestSpec) (matches bool, reason MatchFailReason) {
+	reason.IsNotBenchmark = filter.OnlyBenchmarks && !t.Benchmark
+	reason.NameMismatch = !filter.Name.MatchString(t.Name)
+	reason.OwnerMismatch = filter.Owner != "" && t.Owner != filter.Owner
+	reason.NotPartOfSuite = filter.Suite != "" && !t.Suites.Contains(filter.Suite)
+	reason.CloudNotCompatible = filter.Cloud != "" && !t.CompatibleClouds.Contains(filter.Cloud)
+
+	if len(filter.Tags) > 0 {
+		// Tags will go away soon.
+		matchesTags := func() bool {
+			for tag := range filter.Tags {
+				// If the tag is a single CSV e.g. "foo,bar,baz", we match all the tags
+				if matchesAll(t.Tags, strings.Split(tag, ",")) {
+					return true
+				}
+			}
+			return false
+		}()
+		if !matchesTags {
+			reason.TagsMismatch = true
+		}
+	}
+	// We have a match if all fields are false.
+	return reason == MatchFailReason{}, reason
+}
+
+// MatchFailReasonString returns a user-friendly string describing the reason(s)
+// a filter failed to match a test (returned by Matches). Returns the empty
+// string if the reason is zero.
+//
+// Sample results:
+//   - does not match regex "foo"
+//   - does not match regex "foo" and is not part of the "nightly" suite
+//   - does not match regex "foo", is not part of the "nightly" suite, and is
+//     not compatible with cloud "gce"
+func (filter *TestFilter) MatchFailReasonString(r MatchFailReason) string {
+	var reasons []string
+	appendIf := func(b bool, format string, args ...interface{}) {
+		if b {
+			reasons = append(reasons, fmt.Sprintf(format, args...))
+		}
+	}
+	appendIf(r.IsNotBenchmark, "is not a benchmark")
+	appendIf(r.NameMismatch, "does not match regex %q", filter.Name)
+	appendIf(r.OwnerMismatch, "does not have owner %q", filter.Owner)
+	appendIf(r.NotPartOfSuite, "is not part of the %q suite", filter.Suite)
+	appendIf(r.CloudNotCompatible, "is not compatible with %q", filter.Cloud)
+	appendIf(r.TagsMismatch, "does not match tags")
+
+	if len(reasons) <= 2 {
+		// 0 reasons: ""
+		// 1 reason:  "reason0"
+		// 2 reasons: "reason0 and reason1"
+		return strings.Join(reasons, " and ")
+	}
+	// 3 or more reasons: "reason0, reason1, reason2, and reason3
+	return strings.Join(reasons[:len(reasons)-1], ", ") + ", and " + reasons[len(reasons)-1]
+}
+
+// Filter returns the test specs in the given list that match the filter (in the
+// same order).
+func (filter *TestFilter) Filter(tests []TestSpec) []TestSpec {
+	var res []TestSpec
+	for i := range tests {
+		if ok, _ := filter.Matches(&tests[i]); ok {
+			res = append(res, tests[i])
+		}
+	}
+	return res
+}
+
+// NoMatchesHint identifies some common situations when a filter matches no tests.
+//
+// The hints help us produce helpful error message. We want to zero in on most
+// common problems. For example, if there is a typo in one aspect of the filter,
+// we want the message to highlight that.
+type NoMatchesHint int
+
+const (
+	// NoTestsForCloud indicates that there are no tests/benchmarks for this
+	// cloud (in practice, this is only possible with benchmarks).
+	NoTestsForCloud = 1 + iota
+
+	// NoSuchName indicates that no tests/benchmarks match the regexp.
+	NoSuchName
+
+	// NoTestsInSuite indicates that the suite contains no tests/benchmarks (in
+	// practice, this is only possible with benchmarks).
+	NoTestsInSuite
+
+	// NoTestsWithNameAndSuite indicates that there are no tests/benchmarks that
+	// match both the name regexp and the suite.
+	NoTestsWithNameAndSuite
+
+	// NoTestsWithOwner indicates that there are no tests/benchmarks with the
+	// given owner.
+	NoTestsWithOwner
+
+	// NoTestsWithNameAndOwner indicates that there are no tests that match both
+	// the name regexp and the owner.
+	NoTestsWithNameAndOwner
+
+	// IncompatibleCloud indicates that some tests match all aspects of the filter
+	// except the cloud. Since cloud compatibility was added more recently, we want
+	// to have a useful message for this case.
+	IncompatibleCloud = 1 + iota
+
+	// NoHintAvailable indicates any other situation that leads to a match
+	// failure.
+	NoHintAvailable
+)
+
+// FilterWithHint returns the test specs in the given list that match the filter
+// (in the same order). If there are no matches, returns a hint about what might
+// be wrong with the filter.
+func (filter *TestFilter) FilterWithHint(tests []TestSpec) ([]TestSpec, NoMatchesHint) {
+	res := filter.Filter(tests)
+	if len(res) > 0 {
+		return res, 0
+	}
+
+	// noFilter matches all tests/benchmarks.
+	noFilter := TestFilter{Name: regexp.MustCompile(`.`), OnlyBenchmarks: filter.OnlyBenchmarks}
+
+	// 1. Is the cloud valid?
+	if filter.Cloud != "" && !AllClouds.Contains(filter.Cloud) {
+		return nil, NoTestsForCloud
+	}
+
+	// In the checks below, the idea is to create a relaxed filter - one that only
+	// sets one or two fields from the original filter - and see if that still
+	// gets us no matches - in which chase that small number of fields are the
+	// problem.
+
+	// 2. Is the Name regexp valid?
+	// We check if no tests match the regexp, in which case, the regexp is the problem.
+	if filter.Name.String() != "." {
+		nameOnlyFilter := noFilter
+		nameOnlyFilter.Name = filter.Name
+		if len(nameOnlyFilter.Filter(tests)) == 0 {
+			return nil, NoSuchName
+		}
+	}
+
+	// Check potential problems related to the suite.
+	if filter.Suite != "" {
+		// 3. Is the suite incorrect?
+		// We check if no tests match the suite, in which case the suite is the problem.
+		suiteOnlyFilter := noFilter
+		suiteOnlyFilter.Suite = filter.Suite
+		if len(suiteOnlyFilter.Filter(tests)) == 0 {
+			return nil, NoTestsInSuite
+		}
+
+		// 4. Is the suite+regexp incorrect?
+		// We check if no tests match the suite AND the regexp.
+		suiteAndNameFilter := suiteOnlyFilter
+		suiteAndNameFilter.Name = filter.Name
+		if len(suiteAndNameFilter.Filter(tests)) == 0 {
+			return nil, NoTestsWithNameAndSuite
+		}
+	}
+
+	// Check potential problems related to the owner.
+	if filter.Owner != "" {
+		// 5. Is the owner incorrect?
+		// We check if no tests match the owner, in which case the owner is the problem.
+		ownerOnlyFilter := noFilter
+		ownerOnlyFilter.Owner = filter.Owner
+		if len(ownerOnlyFilter.Filter(tests)) == 0 {
+			return nil, NoTestsWithOwner
+		}
+		// 6. Is the owner+regexp incorrect?
+		// We check if no tests match the owner AND the regexp.
+		ownerAndNameFilter := ownerOnlyFilter
+		ownerAndNameFilter.Name = filter.Name
+		if len(ownerAndNameFilter.Filter(tests)) == 0 {
+			return nil, NoTestsWithNameAndOwner
+		}
+	}
+
+	// 7. Are we trying to run some tests on an incompatible cloud?
+	//
+	// We want to see if the desired tests exist but are not compatible with the
+	// given cloud (which is a recent feature). We use all fields from the
+	// original filter except the cloud and see if we get matches.
+	if filter.Cloud != "" {
+		noCloudFilter := *filter
+		noCloudFilter.Cloud = ""
+		if n := len(noCloudFilter.Filter(tests)); n > 0 {
+			return nil, IncompatibleCloud
+		}
+	}
+
+	// We failed to produce a useful message. It's an uncommon combination of
+	// criteria that leads to no tests matching.
+	return nil, NoHintAvailable
+}
+
+// NoMatchesHintString returns a user-friendly string describing the hint.
+func (filter *TestFilter) NoMatchesHintString(h NoMatchesHint) string {
+	noun := filter.noun()
+	switch h {
+	case NoTestsForCloud:
+		return fmt.Sprintf("no %s for cloud %q", noun, filter.Cloud)
+	case NoSuchName:
+		return fmt.Sprintf("no %s match regexp %q", noun, filter.Name)
+	case NoTestsInSuite:
+		return fmt.Sprintf("no %s in suite %q", noun, filter.Suite)
+	case NoTestsWithNameAndSuite:
+		return fmt.Sprintf("no %s in suite %q match regexp %q", noun, filter.Suite, filter.Name)
+	case NoTestsWithOwner:
+		return fmt.Sprintf("no %s with owner %q", noun, filter.Owner)
+	case NoTestsWithNameAndOwner:
+		return fmt.Sprintf("no %s with owner %q match regexp %q", noun, filter.Owner, filter.Name)
+	case IncompatibleCloud:
+		// Get a description of the filter without the cloud.
+		noCloudFilter := *filter
+		noCloudFilter.Cloud = ""
+		return fmt.Sprintf(
+			"no %s match criteria; %s are not compatible with cloud %q",
+			noun, noCloudFilter.String(), filter.Cloud,
+		)
+	default:
+		return fmt.Sprintf("no %s match criteria", noun)
+	}
+}
+
+// String returns a string that describes the filter in a user-friendly way. A
+// verb like "Listing " or "Running " can be prepended.
+//
+// Examples:
+//  1. all tests
+//  2. benchmarks which match regexp "foo"
+//  3. tests which are compatible with cloud "gce"
+//  4. tests which match regex "foo" and are compatible with cloud "gce" and have
+//     owner "foo" and match regexp "bar"
+func (filter *TestFilter) String() string {
+	var criteria []string
+	appendIf := func(test bool, format string, args ...interface{}) {
+		if test {
+			criteria = append(criteria, fmt.Sprintf(format, args...))
+		}
+	}
+	appendIf(filter.Name.String() != ".", "match regex %q", filter.Name)
+	appendIf(filter.Cloud != "", "are compatible with cloud %q", filter.Cloud)
+	appendIf(filter.Suite != "", "are part of the %q suite", filter.Suite)
+	appendIf(filter.Owner != "", "have owner %q", filter.Owner)
+
+	if len(filter.Tags) > 0 {
+		var tags []string
+		for tag := range filter.Tags {
+			tags = append(tags, tag)
+		}
+		sort.Strings(tags)
+		tagsStr := strings.Join(tags, " OR ")
+		appendIf(true, "match tag(s) %s", tagsStr)
+	}
+
+	noun := filter.noun()
+	if len(criteria) == 0 {
+		return "all " + noun
+	}
+	return noun + " which " + strings.Join(criteria, " and ")
+}
+
+// noun returns "tests" or "benchmarks" depending on the OnlyBenchmarks field.
+func (filter *TestFilter) noun() string {
+	if filter.OnlyBenchmarks {
+		return "benchmarks"
+	}
+	return "tests"
 }

--- a/pkg/cmd/roachtest/registry/filter_test.go
+++ b/pkg/cmd/roachtest/registry/filter_test.go
@@ -1,0 +1,130 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package registry
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/team"
+	"github.com/cockroachdb/datadriven"
+)
+
+func init() {
+	OverrideTeams(team.Map{
+		OwnerCDC.ToTeamAlias():         {},
+		OwnerKV.ToTeamAlias():          {},
+		OwnerReplication.ToTeamAlias(): {},
+	})
+}
+
+func TestTestFilter(t *testing.T) {
+	// Create a library of tests.
+	var tests []TestSpec
+
+	for _, name1 := range []string{"component_foo", "component_bar"} {
+		for _, name2 := range []string{"test_foo", "bench_bar"} {
+			for _, owner := range []Owner{OwnerCDC, OwnerKV} {
+				for _, suites := range []SuiteSet{ManualOnly, Suites(Nightly), Suites(Nightly, Weekly)} {
+					cloudSets := []CloudSet{AllClouds, AllExceptAWS}
+					if name2 == "bench_bar" {
+						cloudSets = []CloudSet{OnlyGCE}
+					}
+					for _, clouds := range cloudSets {
+						suite := suites.String()
+						if suite == "<none>" {
+							suite = ""
+						} else {
+							suite = "-" + suite
+						}
+						t := TestSpec{
+							Name:             fmt.Sprintf("%s/%s-%s%s-%s", name1, name2, owner, suite, clouds),
+							Owner:            owner,
+							CompatibleClouds: clouds,
+							Suites:           suites,
+						}
+						if name2 == "bench_bar" {
+							t.Benchmark = true
+						}
+						tests = append(tests, t)
+					}
+				}
+			}
+		}
+	}
+
+	datadriven.Walk(t, "testdata/", func(t *testing.T, path string) {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			filters := strings.Fields(d.Input)
+			var options []TestFilterOption
+			var testName string
+			for _, arg := range d.CmdArgs {
+				switch arg.Key {
+				case "cloud":
+					options = append(options, WithCloud(arg.Vals[0]))
+				case "suite":
+					options = append(options, WithSuite(arg.Vals[0]))
+				case "owner":
+					options = append(options, WithOwner(Owner(arg.Vals[0])))
+				case "benchmarks":
+					options = append(options, OnlyBenchmarks())
+				case "test":
+					testName = arg.Vals[0]
+				default:
+					d.Fatalf(t, "unknown parameter %s", arg)
+				}
+			}
+
+			filter, err := NewTestFilter(filters, options...)
+			if err != nil {
+				return fmt.Sprintf("error: %s", err)
+			}
+
+			switch d.Cmd {
+			case "filter":
+				matches, h := filter.FilterWithHint(tests)
+				if len(matches) == 0 {
+					return fmt.Sprintf("error: %s", filter.NoMatchesHintString(h))
+				}
+				lines := make([]string, len(matches))
+				for i := range matches {
+					lines[i] = matches[i].Name
+				}
+				return strings.Join(lines, "\n")
+
+			case "test-matches":
+				var spec *TestSpec
+				for i := range tests {
+					if tests[i].Name == testName {
+						spec = &tests[i]
+					}
+				}
+				if spec == nil {
+					d.Fatalf(t, "no such test %q", testName)
+				}
+				matches, r := filter.Matches(spec)
+				reason := "matches"
+				if !matches {
+					reason = filter.MatchFailReasonString(r)
+				}
+				return fmt.Sprintf("%s %s", testName, reason)
+
+			case "describe":
+				return filter.String()
+
+			default:
+				d.Fatalf(t, "unknown command %s", d.Cmd)
+				return ""
+			}
+		})
+	})
+}

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -139,41 +139,6 @@ const (
 	PostValidationNoDeadNodes
 )
 
-// MatchType is the type of match a file has to a TestFilter.
-type MatchType int
-
-const (
-	// Matched means that the file passes the filter and the tags.
-	Matched MatchType = iota
-	// FailedFilter means that the file fails the filter.
-	FailedFilter
-	// FailedTags means that the file passed the filter but failed the tags
-	// match.
-	FailedTags
-)
-
-// Match returns Matched if the filter matches the test. If the filter does
-// not match the test because the tag filter does not match, the test is
-// marked as FailedTags.
-func (t *TestSpec) Match(filter *TestFilter) MatchType {
-	if !filter.Name.MatchString(t.Name) {
-		return FailedFilter
-	}
-
-	if len(filter.Tags) == 0 {
-		return Matched
-	}
-
-	for tag := range filter.Tags {
-		// If the tag is a single CSV e.g. "foo,bar,baz", we match all the tags
-		if matchesAll(t.Tags, strings.Split(tag, ",")) {
-			return Matched
-		}
-	}
-
-	return FailedTags
-}
-
 // PromSub replaces all non prometheus friendly chars with "_". Note,
 // before creating a metric, read up on prom metric naming conventions:
 // https://prometheus.io/docs/practices/naming/

--- a/pkg/cmd/roachtest/registry/testdata/filter/describe
+++ b/pkg/cmd/roachtest/registry/testdata/filter/describe
@@ -1,0 +1,44 @@
+describe
+----
+all tests
+
+describe benchmarks
+----
+all benchmarks
+
+describe
+foo
+----
+tests which match regex "foo"
+
+describe cloud=gce
+----
+tests which are compatible with cloud "gce"
+
+describe cloud=gce benchmarks
+foo
+----
+benchmarks which match regex "foo" and are compatible with cloud "gce"
+
+describe cloud=gce suite=nightly
+----
+tests which are compatible with cloud "gce" and are part of the "nightly" suite
+
+describe cloud=local owner=replication benchmarks
+----
+benchmarks which are compatible with cloud "local" and have owner "replication"
+
+describe cloud=gce suite=nightly
+foo
+----
+tests which match regex "foo" and are compatible with cloud "gce" and are part of the "nightly" suite
+
+describe cloud=gce suite=nightly benchmarks
+foo
+----
+benchmarks which match regex "foo" and are compatible with cloud "gce" and are part of the "nightly" suite
+
+describe
+tag:aws tag:default
+----
+tests which match tag(s) aws OR default

--- a/pkg/cmd/roachtest/registry/testdata/filter/errors
+++ b/pkg/cmd/roachtest/registry/testdata/filter/errors
@@ -1,0 +1,88 @@
+# Invalid filters.
+
+filter cloud=badcloud
+----
+error: invalid cloud "badcloud"; valid clouds are local,gce,aws,azure
+
+filter owner=badowner
+----
+error: invalid owner "badowner"
+
+filter suite=badsuite
+----
+error: invalid suite "badsuite"; valid suites are nightly,weekly,release_qualification,orm,driver,tool,smoketest,quick,fixtures,pebble,pebble_nightly_write,pebble_nightly_ycsb,pebble_nightly_ycsb_race,roachtest
+
+filter cloud=badcloud owner=badowner suite=badsuite
+----
+error: invalid cloud "badcloud"; valid clouds are local,gce,aws,azure
+
+# Filters with one field leading to no matches.
+
+filter benchmarks cloud=aws
+component_blargle
+----
+error: no benchmarks match regexp "component_blargle"
+
+filter suite=orm
+----
+error: no tests in suite "orm"
+
+filter owner=replication
+----
+error: no tests with owner "replication"
+
+filter benchmarks
+component_blargle
+----
+error: no benchmarks match regexp "component_blargle"
+
+filter cloud=aws suite=nightly owner=cdc
+component_blargle
+----
+error: no tests match regexp "component_blargle"
+
+filter suite=orm owner=cdc
+foo
+----
+error: no tests in suite "orm"
+
+filter suite=orm owner=cdc benchmarks
+foo
+----
+error: no benchmarks in suite "orm"
+
+filter cloud=gce suite=nightly owner=cdc
+foo-cdc-gce
+----
+error: no tests match regexp "foo-cdc-gce"
+
+filter cloud=gce suite=nightly owner=cdc benchmarks
+foo-cdc-gce
+----
+error: no benchmarks match regexp "foo-cdc-gce"
+
+# Filters with multiple fields leading to no matches.
+
+filter suite=nightly owner=kv
+foo-cdc
+----
+error: no tests with owner "kv" match regexp "foo-cdc"
+
+filter suite=weekly owner=kv
+-nightly-
+----
+error: no tests in suite "weekly" match regexp "-nightly-"
+
+filter cloud=azure suite=weekly owner=kv
+-gce
+----
+error: no tests match criteria; tests which match regex "-gce" and are part of the "weekly" suite and have owner "kv" are not compatible with cloud "azure"
+
+filter cloud=aws suite=weekly owner=kv benchmarks
+----
+error: no benchmarks match criteria; benchmarks which are part of the "weekly" suite and have owner "kv" are not compatible with cloud "aws"
+
+filter suite=weekly owner=cdc
+cdc-nightly- kv-nightly,weekly-
+----
+error: no tests match criteria

--- a/pkg/cmd/roachtest/registry/testdata/filter/filter
+++ b/pkg/cmd/roachtest/registry/testdata/filter/filter
@@ -1,0 +1,72 @@
+# Check filtering.
+
+filter cloud=gce
+component_foo/
+----
+component_foo/test_foo-cdc-local,gce,aws,azure
+component_foo/test_foo-cdc-local,gce,azure
+component_foo/test_foo-cdc-nightly-local,gce,aws,azure
+component_foo/test_foo-cdc-nightly-local,gce,azure
+component_foo/test_foo-cdc-nightly,weekly-local,gce,aws,azure
+component_foo/test_foo-cdc-nightly,weekly-local,gce,azure
+component_foo/test_foo-kv-local,gce,aws,azure
+component_foo/test_foo-kv-local,gce,azure
+component_foo/test_foo-kv-nightly-local,gce,aws,azure
+component_foo/test_foo-kv-nightly-local,gce,azure
+component_foo/test_foo-kv-nightly,weekly-local,gce,aws,azure
+component_foo/test_foo-kv-nightly,weekly-local,gce,azure
+component_foo/bench_bar-cdc-gce
+component_foo/bench_bar-cdc-nightly-gce
+component_foo/bench_bar-cdc-nightly,weekly-gce
+component_foo/bench_bar-kv-gce
+component_foo/bench_bar-kv-nightly-gce
+component_foo/bench_bar-kv-nightly,weekly-gce
+
+filter cloud=gce benchmarks
+component_foo/
+----
+component_foo/bench_bar-cdc-gce
+component_foo/bench_bar-cdc-nightly-gce
+component_foo/bench_bar-cdc-nightly,weekly-gce
+component_foo/bench_bar-kv-gce
+component_foo/bench_bar-kv-nightly-gce
+component_foo/bench_bar-kv-nightly,weekly-gce
+
+filter suite=nightly
+component_foo benchmark_bar
+----
+component_foo/test_foo-cdc-nightly-local,gce,aws,azure
+component_foo/test_foo-cdc-nightly-local,gce,azure
+component_foo/test_foo-cdc-nightly,weekly-local,gce,aws,azure
+component_foo/test_foo-cdc-nightly,weekly-local,gce,azure
+component_foo/test_foo-kv-nightly-local,gce,aws,azure
+component_foo/test_foo-kv-nightly-local,gce,azure
+component_foo/test_foo-kv-nightly,weekly-local,gce,aws,azure
+component_foo/test_foo-kv-nightly,weekly-local,gce,azure
+component_foo/bench_bar-cdc-nightly-gce
+component_foo/bench_bar-cdc-nightly,weekly-gce
+component_foo/bench_bar-kv-nightly-gce
+component_foo/bench_bar-kv-nightly,weekly-gce
+
+filter cloud=gce suite=weekly owner=cdc
+----
+component_foo/test_foo-cdc-nightly,weekly-local,gce,aws,azure
+component_foo/test_foo-cdc-nightly,weekly-local,gce,azure
+component_foo/bench_bar-cdc-nightly,weekly-gce
+component_bar/test_foo-cdc-nightly,weekly-local,gce,aws,azure
+component_bar/test_foo-cdc-nightly,weekly-local,gce,azure
+component_bar/bench_bar-cdc-nightly,weekly-gce
+
+filter cloud=gce suite=weekly owner=cdc
+----
+component_foo/test_foo-cdc-nightly,weekly-local,gce,aws,azure
+component_foo/test_foo-cdc-nightly,weekly-local,gce,azure
+component_foo/bench_bar-cdc-nightly,weekly-gce
+component_bar/test_foo-cdc-nightly,weekly-local,gce,aws,azure
+component_bar/test_foo-cdc-nightly,weekly-local,gce,azure
+component_bar/bench_bar-cdc-nightly,weekly-gce
+
+filter cloud=gce suite=weekly owner=kv benchmarks
+----
+component_foo/bench_bar-kv-nightly,weekly-gce
+component_bar/bench_bar-kv-nightly,weekly-gce

--- a/pkg/cmd/roachtest/registry/testdata/filter/matches
+++ b/pkg/cmd/roachtest/registry/testdata/filter/matches
@@ -1,0 +1,32 @@
+test-matches cloud=aws test=component_foo/test_foo-cdc-local,gce,azure
+component_foo/
+----
+component_foo/test_foo-cdc-local,gce,azure is not compatible with "aws"
+
+test-matches cloud=gce suite=nightly test=component_foo/test_foo-cdc-local,gce,azure
+component_foo/
+----
+component_foo/test_foo-cdc-local,gce,azure is not part of the "nightly" suite
+
+test-matches cloud=aws test=component_bar/test_foo-cdc-local,gce,azure
+component_foo/
+----
+component_bar/test_foo-cdc-local,gce,azure does not match regex "component_foo/" and is not compatible with "aws"
+
+test-matches cloud=aws test=component_bar/test_foo-kv-nightly-local,gce,aws,azure
+component_foo/
+----
+component_bar/test_foo-kv-nightly-local,gce,aws,azure does not match regex "component_foo/"
+
+test-matches cloud=aws suite=weekly owner=cdc test=component_foo/test_foo-kv-local,gce,azure
+----
+component_foo/test_foo-kv-local,gce,azure does not have owner "cdc", is not part of the "weekly" suite, and is not compatible with "aws"
+
+test-matches cloud=gce benchmarks test=component_foo/test_foo-cdc-local,gce,azure
+----
+component_foo/test_foo-cdc-local,gce,azure is not a benchmark
+
+test-matches test=component_foo/test_foo-cdc-local,gce,azure
+tag:aws
+----
+component_foo/test_foo-cdc-local,gce,azure does not match tags

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -110,7 +110,7 @@ func addRunBenchCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&literalArtifactsDir, "artifacts-literal", "", "literal path to on-agent artifacts directory. Used for messages to ##teamcity[publishArtifacts] in --teamcity mode. May be different from --artifacts; defaults to the value of --artifacts if not provided")
 	cmd.Flags().StringVar(
-		&cloud, "cloud", cloud, "cloud provider to use (aws, azure, or gce)")
+		&cloud, "cloud", cloud, "cloud provider to use (local, aws, azure, or gce)")
 	cmd.Flags().StringVar(
 		&clusterID, "cluster-id", "", "an identifier to use in the name of the test cluster(s)")
 	cmd.Flags().IntVar(
@@ -156,6 +156,9 @@ func addRunBenchCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().Int64Var(
 		&globalSeed, "global-seed", randutil.NewPseudoSeed(),
 		"The global random seed used for all tests.")
+	cmd.Flags().BoolVar(
+		&forceCloudCompat, "force-cloud-compat", false, "Includes tests that are not marked as compatible with the cloud used")
+	addSuiteAndOwnerFlags(cmd)
 }
 
 func addRunFlags(runCmd *cobra.Command) {
@@ -181,8 +184,8 @@ func addBenchFlags(benchCmd *cobra.Command) {
 
 // runTests is the main function for the run and bench commands.
 // Assumes initRunFlagsBinariesAndLibraries was called.
-func runTests(register func(registry.Registry), args []string, benchOnly bool) error {
-	r := makeTestRegistry(cloud, instanceType, zonesF, localSSDArg, benchOnly)
+func runTests(register func(registry.Registry), filter *registry.TestFilter) error {
+	r := makeTestRegistry(cloud, instanceType, zonesF, localSSDArg)
 	rand.Seed(globalSeed)
 
 	// actual registering of tests
@@ -193,7 +196,6 @@ func runTests(register func(registry.Registry), args []string, benchOnly bool) e
 	defer stopper.Stop(context.Background())
 	runner := newTestRunner(cr, stopper)
 
-	filter := registry.NewTestFilter(args)
 	clusterType := roachprodCluster
 	bindTo := ""
 	if cloud == spec.Local {
@@ -231,7 +233,10 @@ func runTests(register func(registry.Registry), args []string, benchOnly bool) e
 		return err
 	}
 
-	specs := testsToRun(r, filter, runSkipped, selectProbability, true)
+	specs, err := testsToRun(r, filter, runSkipped, selectProbability, true)
+	if err != nil {
+		return err
+	}
 
 	n := len(specs)
 	if n*count < parallelism {
@@ -280,7 +285,7 @@ func runTests(register func(registry.Registry), args []string, benchOnly bool) e
 	// may still be running long after the test has completed.
 	defer leaktest.AfterTest(l)()
 
-	err := runner.Run(
+	err = runner.Run(
 		ctx, specs, count, parallelism, opt,
 		testOpts{
 			versionsBinaryOverride: versionsBinaryOverride,

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -193,7 +193,7 @@ func runTests(register func(registry.Registry), args []string, benchOnly bool) e
 	defer stopper.Stop(context.Background())
 	runner := newTestRunner(cr, stopper)
 
-	filter := registry.NewTestFilter(args, runSkipped)
+	filter := registry.NewTestFilter(args)
 	clusterType := roachprodCluster
 	bindTo := ""
 	if cloud == spec.Local {
@@ -231,7 +231,7 @@ func runTests(register func(registry.Registry), args []string, benchOnly bool) e
 		return err
 	}
 
-	specs := testsToRun(r, filter, selectProbability, true)
+	specs := testsToRun(r, filter, runSkipped, selectProbability, true)
 
 	n := len(specs)
 	if n*count < parallelism {

--- a/pkg/cmd/roachtest/test_filter.go
+++ b/pkg/cmd/roachtest/test_filter.go
@@ -1,0 +1,53 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/spf13/cobra"
+)
+
+var (
+	suite            string
+	owner            string
+	onlyBenchmarks   bool
+	forceCloudCompat bool
+)
+
+func addSuiteAndOwnerFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&suite, "suite", "",
+		"Restrict tests to those in the given suite (e.g. nightly)",
+	)
+	cmd.Flags().StringVar(
+		&owner, "owner", "",
+		"Restrict tests to those with the given owner (e.g. kv)",
+	)
+}
+
+// makeTestFilter creates a registry.TestFilter based on the current flags and
+// the given regexps.
+func makeTestFilter(regexps []string) (*registry.TestFilter, error) {
+	var options []registry.TestFilterOption
+	if !forceCloudCompat && cloud != "all" && cloud != "" {
+		options = append(options, registry.WithCloud(cloud))
+	}
+	if suite != "" {
+		options = append(options, registry.WithSuite(suite))
+	}
+	if owner != "" {
+		options = append(options, registry.WithOwner(registry.Owner(owner)))
+	}
+	if onlyBenchmarks {
+		options = append(options, registry.OnlyBenchmarks())
+	}
+	return registry.NewTestFilter(regexps, options...)
+}

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -19,18 +19,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
-	"github.com/cockroachdb/cockroach/pkg/internal/team"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
-
-var loadTeams = func() (team.Map, error) {
-	return team.DefaultLoadTeams()
-}
-
-func ownerToAlias(o registry.Owner) team.Alias {
-	return team.Alias(fmt.Sprintf("cockroachdb/%s", o))
-}
 
 type testRegistryImpl struct {
 	m            map[string]*registry.TestSpec
@@ -119,12 +110,8 @@ func (r *testRegistryImpl) prepareSpec(spec *registry.TestSpec) error {
 	if spec.Owner == `` {
 		return fmt.Errorf(`%s: unspecified owner`, spec.Name)
 	}
-	teams, err := loadTeams()
-	if err != nil {
-		return err
-	}
-	if _, ok := teams[ownerToAlias(spec.Owner)]; !ok {
-		return fmt.Errorf(`%s: unknown owner [%s]`, spec.Name, spec.Owner)
+	if !spec.Owner.IsValid() {
+		return fmt.Errorf(`%s: unknown owner %q`, spec.Name, spec.Owner)
 	}
 	if len(spec.Tags) == 0 {
 		spec.Tags = registry.Tags(registry.DefaultTag)

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -142,9 +142,7 @@ func (r *testRegistryImpl) PromFactory() promauto.Factory {
 	return promauto.With(r.promRegistry)
 }
 
-// GetTests returns all the tests that match the given regexp, sorted by name.
-// Skipped tests are included, and tests that don't match their minVersion spec
-// are also included but marked as skipped.
+// GetTests returns all the tests that match the given filter, sorted by name.
 func (r testRegistryImpl) GetTests(
 	filter *registry.TestFilter,
 ) ([]registry.TestSpec, []registry.TestSpec) {
@@ -170,9 +168,8 @@ func (r testRegistryImpl) GetTests(
 
 // List lists tests that match one of the filters.
 func (r testRegistryImpl) List(filters []string) []registry.TestSpec {
-	filter := registry.NewTestFilter(filters, true)
+	filter := registry.NewTestFilter(filters)
 	tests, _ := r.GetTests(filter)
-	sort.Slice(tests, func(i, j int) bool { return tests[i].Name < tests[j].Name })
 	return tests
 }
 

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestMakeTestRegistry(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "preferSSD", func(t *testing.T, preferSSD bool) {
-		r := makeTestRegistry(spec.AWS, "foo", "zone123", preferSSD, false)
+		r := makeTestRegistry(spec.AWS, "foo", "zone123", preferSSD)
 		require.Equal(t, preferSSD, r.preferSSD)
 		require.Equal(t, "zone123", r.zones)
 		require.Equal(t, "foo", r.instanceType)
@@ -55,7 +55,7 @@ func TestMakeTestRegistry(t *testing.T) {
 // TestPrometheusMetricParser tests that the registry.PromSub()
 // helper properly converts a string into a metric name that Prometheus can read.
 func TestPrometheusMetricParser(t *testing.T) {
-	r := makeTestRegistry(spec.AWS, "foo", "zone123", true, false)
+	r := makeTestRegistry(spec.AWS, "foo", "zone123", true)
 	f := r.PromFactory()
 
 	rawName := "restore/nodes=4/duration"

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -43,45 +43,7 @@ const defaultParallelism = 10
 
 func mkReg(t *testing.T) testRegistryImpl {
 	t.Helper()
-	return makeTestRegistry(spec.GCE, "", "", false /* preferSSD */, false /* benchOnly */)
-}
-
-func TestMatchOrSkip(t *testing.T) {
-	testCases := []struct {
-		filter   []string
-		name     string
-		tags     map[string]struct{}
-		expected registry.MatchType
-	}{
-		{nil, "foo", nil, registry.Matched},
-		{nil, "foo", registry.Tags("bar"), registry.Matched},
-		{[]string{"tag:bar"}, "foo", registry.Tags("bar"), registry.Matched},
-		// Partial tag match is not supported
-		{[]string{"tag:b"}, "foo", registry.Tags("bar"), registry.FailedTags},
-		{[]string{"tag:b"}, "foo", nil, registry.FailedTags},
-		{[]string{"tag:f"}, "foo", registry.Tags("bar"), registry.FailedTags},
-		// Specifying no tag filters matches all tags.
-		{[]string{"f"}, "foo", registry.Tags("bar"), registry.Matched},
-		{[]string{"f"}, "bar", registry.Tags("bar"), registry.FailedFilter},
-		{[]string{"f", "tag:bar"}, "foo", registry.Tags("bar"), registry.Matched},
-		{[]string{"f", "tag:b"}, "foo", registry.Tags("bar"), registry.FailedTags},
-		{[]string{"f", "tag:f"}, "foo", registry.Tags("bar"), registry.FailedTags},
-		// Match tests that have both tags 'abc' and 'bar'
-		{[]string{"f", "tag:abc,bar"}, "foo", registry.Tags("abc", "bar"), registry.Matched},
-		{[]string{"f", "tag:abc,bar"}, "foo", registry.Tags("abc"), registry.FailedTags},
-		// Match tests that have tag 'abc' but not 'bar'
-		{[]string{"f", "tag:abc,!bar"}, "foo", registry.Tags("abc"), registry.Matched},
-		{[]string{"f", "tag:abc,!bar"}, "foo", registry.Tags("abc", "bar"), registry.FailedTags},
-	}
-	for _, c := range testCases {
-		t.Run("", func(t *testing.T) {
-			f := registry.NewTestFilter(c.filter)
-			spec := &registry.TestSpec{Name: c.name, Owner: OwnerUnitTest, Tags: c.tags}
-			if value := spec.Match(f); c.expected != value {
-				t.Fatalf("expected %v, but found %v", c.expected, value)
-			}
-		})
-	}
+	return makeTestRegistry(spec.GCE, "", "", false /* preferSSD */)
 }
 
 func nilLogger() *logger.Logger {
@@ -247,7 +209,10 @@ type runnerTest struct {
 func setupRunnerTest(t *testing.T, r testRegistryImpl, testFilters []string) *runnerTest {
 	ctx := context.Background()
 
-	tests := testsToRun(r, registry.NewTestFilter(testFilters), false, 1.0, true)
+	tf, err := registry.NewTestFilter(testFilters)
+	require.NoError(t, err)
+
+	tests, _ := testsToRun(r, tf, false, 1.0, true)
 	cr := newClusterRegistry()
 
 	stopper := stop.NewStopper()
@@ -412,7 +377,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			r := makeTestRegistry(spec.GCE, "", "", false /* preferSSD */, false /* benchOnly */)
+			r := makeTestRegistry(spec.GCE, "", "", false /* preferSSD */)
 			err := r.prepareSpec(&c.spec)
 			if !testutils.IsError(err, c.expectedErr) {
 				t.Fatalf("expected %q, but found %q", c.expectedErr, err.Error())
@@ -448,7 +413,10 @@ func runExitCodeTest(t *testing.T, injectedError error) error {
 			}
 		},
 	})
-	tests := testsToRun(r, registry.NewTestFilter(nil), false, 1.0, true)
+	tf, err := registry.NewTestFilter(nil)
+	require.NoError(t, err)
+
+	tests, _ := testsToRun(r, tf, false, 1.0, true)
 	lopt := loggingOpt{
 		l:            nilLogger(),
 		tee:          logger.NoTee,

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -75,7 +75,7 @@ func TestMatchOrSkip(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			f := registry.NewTestFilter(c.filter, false)
+			f := registry.NewTestFilter(c.filter)
 			spec := &registry.TestSpec{Name: c.name, Owner: OwnerUnitTest, Tags: c.tags}
 			if value := spec.Match(f); c.expected != value {
 				t.Fatalf("expected %v, but found %v", c.expected, value)
@@ -247,7 +247,7 @@ type runnerTest struct {
 func setupRunnerTest(t *testing.T, r testRegistryImpl, testFilters []string) *runnerTest {
 	ctx := context.Background()
 
-	tests := testsToRun(r, registry.NewTestFilter(testFilters, false), 1.0, true)
+	tests := testsToRun(r, registry.NewTestFilter(testFilters), false, 1.0, true)
 	cr := newClusterRegistry()
 
 	stopper := stop.NewStopper()
@@ -448,7 +448,7 @@ func runExitCodeTest(t *testing.T, injectedError error) error {
 			}
 		},
 	})
-	tests := testsToRun(r, registry.NewTestFilter(nil, false), 1.0, true)
+	tests := testsToRun(r, registry.NewTestFilter(nil), false, 1.0, true)
 	lopt := loggingOpt{
 		l:            nilLogger(),
 		tee:          logger.NoTee,


### PR DESCRIPTION
Backport 3/3 commits from #111219.

/cc @cockroachdb/release

Release justification: test-only changes, keeping roachtest in sync

---

Informs #100605.

#### roachtest: remove RunSkipped from TestFilter

The `TestFilter.RunSkipped` field is not actually used when matching
tests; it is only used by higher-level logic in roachtest. This commit
removes it from `TestFilter`.

Epic: none
Release note: None

#### roachtest: don't print out tests which don't match tags

Don't show tests that don't match tags, this is unnecessary clutter.
The relevant code is simplified.

Epic: none
Release note: None

#### roachtest: add --suite and --owner flags, improve test filtering

This commit adds `--suite` and `--owner` flags to `list`, `run`, and
`bench` commands, and adds filtering of tests based on cloud
compatibility.

To ignore cloud compatibility when running tests (the old behavior), a
new flag `--force-cloud-compat` can be used.

As part of this change, we improve usability around test selection:
 - we now print a user-friendly description of the filter;
 - when no tests match we print detailed error messages which identify
   which part of the filter causes no matches.

As part of this change, we move the "benchmarks only" flag from the
registry to the `TestFilter`.

Epic: none
Release note: None

