### PR TITLE
ci: explicitly set author for predecessor update action

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -48,6 +48,7 @@ jobs:
           base: "${{ matrix.branch }}"
           branch: 'crdb-releases-yaml-update-${{ matrix.branch }}'
           title: "${{ matrix.branch }}: Update pkg/testutils/release/cockroach_releases.yaml"
+          author: "CRL Release bot <teamcity@cockroachlabs.com>"
           reviewers: rail,jlinder,celiala
           body: |
             Update pkg/testutils/release/cockroach_releases.yaml with recent values.


### PR DESCRIPTION
Previously, the predecessor update action created PRs and the author of the commits was either the person who triggered the action, or the last committer if the action was scheduled.

Most of the merge commits are made by Bors (aka craig), the committer was set to an unrelated person.

This PR explicitly sets the author prevent the confusion and pass the CLA check.

Epic: none
Release note: None