### PR TITLE
server: support nofallback HTTP query param

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -453,6 +453,7 @@ go_test(
         "nodes_response_test.go",
         "pagination_test.go",
         "purge_auth_session_test.go",
+        "server_controller_http_test.go",
         "server_controller_test.go",
         "server_http_test.go",
         "server_import_ts_test.go",

--- a/pkg/server/server_controller_http_test.go
+++ b/pkg/server/server_controller_http_test.go
@@ -1,0 +1,56 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoFallbackParam(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	httpClient, err := s.SystemLayer().GetUnauthenticatedHTTPClient()
+	require.NoError(t, err)
+	defer httpClient.CloseIdleConnections()
+
+	endpoint := s.SystemLayer().AdminURL().String() + "/health"
+	t.Run("requests for a non-existent tenant return an error when fallback is true", func(t *testing.T) {
+		resp, err := httpClient.Get(endpoint + "?cluster=doesnotexist&nofallback=true")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, resp.StatusCode, http.StatusServiceUnavailable)
+	})
+	t.Run("requests for a non-existent tenant fall backs to default tenant when fallback is false", func(t *testing.T) {
+		resp, err := httpClient.Get(endpoint + "?cluster=doesnotexist&nofallback=false")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, resp.StatusCode, http.StatusOK)
+	})
+	t.Run("requests for a non-existent tenant fall backs to default tenant when fallback is not specified", func(t *testing.T) {
+		resp, err := httpClient.Get(endpoint + "?cluster=doesnotexist")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, resp.StatusCode, http.StatusOK)
+	})
+}


### PR DESCRIPTION
When issuing an HTTP request, the target virtual cluster is taken from a query parameter (`cluster`), an explicit HTTP
header (`X-Cockroach-Tenant`), or a Cookie (`tenant`).  If no tenant is specified, the default target cluster is used.

If that tenant isn't actually found in the running server controller, the request is served from the system tenant.

Here, we allow the user to specify a `nofallback` query parameter to prevent this fallback behaviour.

This does have a security-relevant property in that it allows an unauthenticated user can determine the existence of a tenant. However, I'll note that this is already possible via other means. Further, in our main supported use of this feature (PCR), we expect that the majority of users will be using the pre-created `application` tenant, whose name is well-known.

Epic: none

Release note: None