### PR TITLE
worklows: run `update_releases` in the release-23.2 branch

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository == 'cockroachdb/cockroach'
     strategy:
       matrix:
-        branch: ["master", "release-23.1"]
+        branch: ["master", "release-23.1", "release-23.2"]
     name: Update pkg/testutils/release/cockroach_releases.yaml on ${{ matrix.branch }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Epic: none

Release note: None