### PR TITLE
roachtest: indicate when version is too old in `UploadWorkload`

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
-        "//pkg/util/version",
         "@com_github_pkg_errors//:errors",
     ],
 )

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -89,7 +89,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/testutils/release"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/pkg/errors"
 )
 
@@ -144,7 +143,7 @@ var (
 	// is a published ARM64 build. If we are running a mixedversion test
 	// on ARM64, older versions will be skipped even if the test
 	// requested a certain number of upgrades.
-	minSupportedARM64Version = version.MustParse("v22.2.0")
+	minSupportedARM64Version = clusterupgrade.MustParseVersion("v22.2.0")
 
 	defaultTestOptions = testOptions{
 		// We use fixtures more often than not as they are more likely to

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -108,7 +108,7 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 		"setup schema changer workload",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
 			node := h.RandomNode(rng, c.All())
-			workloadPath, err := clusterupgrade.UploadWorkload(
+			workloadPath, _, err := clusterupgrade.UploadWorkload(
 				ctx, t, l, c, c.Node(node), h.Context.ToVersion,
 			)
 			if err != nil {
@@ -149,11 +149,16 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// The schemachange workload is designed to work up to one
 			// version back. Therefore, we upload a compatible `workload`
 			// binary to `randomNode`, where the workload will run.
-			workloadPath, err := clusterupgrade.UploadWorkload(
+			workloadPath, uploaded, err := clusterupgrade.UploadWorkload(
 				ctx, t, l, c, c.Node(randomNode), h.Context.ToVersion,
 			)
 			if err != nil {
 				return errors.Wrap(err, "uploading workload binary")
+			}
+
+			if !uploaded {
+				l.Printf("Version being upgraded is too old, no workload binary available. Skipping")
+				return nil
 			}
 
 			l.Printf("running schemachange workload")


### PR DESCRIPTION
In #115061, a `UploadWorkload` API was added to allow tests to upload "arbitrary" versions of the `workload` binary, especially useful in upgrade testing.

However, we only have `workload` binaries for v22.2+. In this commit, we add a `bool` return value to `UplodWorkload` indicating whether a binary was actually uploaded. Callers are expected to check this value before attempting to use a workload binary.

The `acceptance/version-upgrade` test is updated in this commit in the way described.

Epic: none

Release note: None