### PR TITLE
engineccl: Use crypto/subtle.XORBytes

### DIFF
--- a/pkg/ccl/storageccl/engineccl/ctr_stream.go
+++ b/pkg/ccl/storageccl/engineccl/ctr_stream.go
@@ -13,6 +13,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/binary"
 	"fmt"
 
@@ -192,7 +193,5 @@ func (s *cTRBlockCipherStream) transform(blockIndex uint64, data []byte, scratch
 	binary.BigEndian.PutUint32(iv[len(iv):len(iv)+4], blockCounter)
 	iv = iv[0 : len(iv)+4]
 	s.cBlock.Encrypt(iv, iv)
-	for i := 0; i < ctrBlockSize; i++ {
-		data[i] = data[i] ^ iv[i]
-	}
+	subtle.XORBytes(data, data, iv)
 }


### PR DESCRIPTION
This function (new in Go 1.20) is faster than our hand-written xor loop. This is good for a nearly 15% increase in encryption throughput (for standard intel builds. 5% in fips mode, 20% on Apple M2)

Release note (performance improvement): Improved performance of encryption-at-rest.
Epic: None

```
bdarnell@gceworker-bdarnell-fips:~/go/src/github.com/cockroachdb/cockroach$ ~/go/bin/benchstat before.bench after-xor.bench goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
                                                    │ before.bench │           after-xor.bench           │
                                                    │    sec/op    │   sec/op     vs base                │
FileCipherStream/fips=false/key=128/block=16/-24       64.63n ± 0%   57.87n ± 2%  -10.45% (p=0.000 n=10)
FileCipherStream/fips=false/key=128/block=1024/-24     2.221µ ± 0%   1.884µ ± 0%  -15.17% (p=0.000 n=10)
FileCipherStream/fips=false/key=128/block=10240/-24    21.75µ ± 0%   18.49µ ± 0%  -14.97% (p=0.000 n=10)
FileCipherStream/fips=false/key=192/block=16/-24       66.86n ± 1%   60.85n ± 1%   -9.00% (p=0.000 n=10)
FileCipherStream/fips=false/key=192/block=1024/-24     2.381µ ± 0%   2.037µ ± 0%  -14.47% (p=0.000 n=10)
FileCipherStream/fips=false/key=192/block=10240/-24    23.34µ ± 0%   20.02µ ± 0%  -14.24% (p=0.000 n=10)
FileCipherStream/fips=false/key=256/block=16/-24       69.34n ± 1%   63.02n ± 1%   -9.11% (p=0.000 n=10)
FileCipherStream/fips=false/key=256/block=1024/-24     2.541µ ± 0%   2.188µ ± 0%  -13.88% (p=0.000 n=10)
FileCipherStream/fips=false/key=256/block=10240/-24    24.95µ ± 0%   21.51µ ± 0%  -13.80% (p=0.000 n=10)
geomean                                                1.548µ        1.349µ       -12.82%

                                                    │ before.bench │           after-xor.bench            │
                                                    │     B/s      │     B/s       vs base                │
FileCipherStream/fips=false/key=128/block=16/-24      236.1Mi ± 0%   263.7Mi ± 2%  +11.67% (p=0.000 n=10)
FileCipherStream/fips=false/key=128/block=1024/-24    439.7Mi ± 0%   518.3Mi ± 0%  +17.89% (p=0.000 n=10)
FileCipherStream/fips=false/key=128/block=10240/-24   449.0Mi ± 0%   528.1Mi ± 0%  +17.61% (p=0.000 n=10)
FileCipherStream/fips=false/key=192/block=16/-24      228.2Mi ± 1%   250.8Mi ± 1%   +9.89% (p=0.000 n=10)
FileCipherStream/fips=false/key=192/block=1024/-24    410.0Mi ± 0%   479.4Mi ± 0%  +16.93% (p=0.000 n=10)
FileCipherStream/fips=false/key=192/block=10240/-24   418.3Mi ± 0%   487.8Mi ± 0%  +16.61% (p=0.000 n=10)
FileCipherStream/fips=false/key=256/block=16/-24      220.1Mi ± 1%   242.1Mi ± 1%  +10.04% (p=0.000 n=10)
FileCipherStream/fips=false/key=256/block=1024/-24    384.4Mi ± 0%   446.4Mi ± 0%  +16.12% (p=0.000 n=10)
FileCipherStream/fips=false/key=256/block=10240/-24   391.4Mi ± 0%   454.1Mi ± 0%  +16.01% (p=0.000 n=10)
geomean                                               339.8Mi        389.8Mi       +14.71%
bdarnell@gceworker-bdarnell-fips:~/go/src/github.com/cockroachdb/cockroach$ ~/go/bin/benchstat before-fips.bench after-xor-fips.bench
goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
                                                   │ before-fips.bench │        after-xor-fips.bench        │
                                                   │      sec/op       │   sec/op     vs base               │
FileCipherStream/fips=true/key=128/block=16/-24            270.9n ± 0%   259.2n ± 1%  -4.32% (p=0.000 n=10)
FileCipherStream/fips=true/key=128/block=1024/-24          14.86µ ± 0%   14.04µ ± 0%  -5.52% (p=0.000 n=10)
FileCipherStream/fips=true/key=128/block=10240/-24         149.2µ ± 1%   140.8µ ± 1%  -5.60% (p=0.000 n=10)
FileCipherStream/fips=true/key=192/block=16/-24            272.3n ± 1%   260.4n ± 1%  -4.37% (p=0.000 n=10)
FileCipherStream/fips=true/key=192/block=1024/-24          14.98µ ± 1%   14.17µ ± 1%  -5.41% (p=0.000 n=10)
FileCipherStream/fips=true/key=192/block=10240/-24         149.3µ ± 0%   141.9µ ± 1%  -4.92% (p=0.000 n=10)
FileCipherStream/fips=true/key=256/block=16/-24            273.7n ± 1%   261.3n ± 1%  -4.53% (p=0.000 n=10)
FileCipherStream/fips=true/key=256/block=1024/-24          15.02µ ± 1%   14.23µ ± 2%  -5.28% (p=0.000 n=10)
FileCipherStream/fips=true/key=256/block=10240/-24         150.0µ ± 1%   142.4µ ± 1%  -5.09% (p=0.000 n=10)
geomean                                                    8.475µ        8.051µ       -5.01%

                                                   │ before-fips.bench │        after-xor-fips.bench         │
                                                   │        B/s        │     B/s       vs base               │
FileCipherStream/fips=true/key=128/block=16/-24           56.33Mi ± 0%   58.87Mi ± 1%  +4.50% (p=0.000 n=10)
FileCipherStream/fips=true/key=128/block=1024/-24         65.71Mi ± 0%   69.55Mi ± 0%  +5.83% (p=0.000 n=10)
FileCipherStream/fips=true/key=128/block=10240/-24        65.46Mi ± 1%   69.35Mi ± 1%  +5.94% (p=0.000 n=10)
FileCipherStream/fips=true/key=192/block=16/-24           56.04Mi ± 1%   58.60Mi ± 1%  +4.57% (p=0.000 n=10)
FileCipherStream/fips=true/key=192/block=1024/-24         65.20Mi ± 1%   68.93Mi ± 1%  +5.72% (p=0.000 n=10)
FileCipherStream/fips=true/key=192/block=10240/-24        65.42Mi ± 0%   68.80Mi ± 1%  +5.17% (p=0.000 n=10)
FileCipherStream/fips=true/key=256/block=16/-24           55.75Mi ± 1%   58.39Mi ± 1%  +4.74% (p=0.000 n=10)
FileCipherStream/fips=true/key=256/block=1024/-24         65.00Mi ± 1%   68.63Mi ± 2%  +5.58% (p=0.000 n=10)
FileCipherStream/fips=true/key=256/block=10240/-24        65.11Mi ± 1%   68.60Mi ± 1%  +5.36% (p=0.000 n=10)
geomean                                                   62.07Mi        65.33Mi       +5.27%

```