### PR TITLE
logictest: deflake upgrade_preserve_ttl test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_upgrade_preserve_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_upgrade_preserve_ttl
@@ -15,10 +15,11 @@ CREATE TABLE tbl (
 
 upgrade all
 
-# Verify that the cluster version upgrades have begun. Note that the first
-# cluster upgrade is the one that repairs all descriptors.
+# Verify that the cluster version upgrades have begun by asserting we're no
+# longer on the previous version. Note that the first cluster upgrade is the
+# one that repairs all descriptors.
 query B retry
-SELECT version LIKE '%23.2-%' FROM [SHOW CLUSTER SETTING version]
+SELECT version != '23.1' FROM [SHOW CLUSTER SETTING version]
 ----
 true
 


### PR DESCRIPTION
The test had an overly aggressive assertion - it was checking that the upgrades from 23.2 to 24.1 began running. We actually want to check that the upgrades from 23.1 (the predecessor) began running.

fixes https://github.com/cockroachdb/cockroach/issues/115195
Release note: None