### PR TITLE
streamingccl: add creating splits job status

### DIFF
--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -98,6 +98,7 @@ type ReplicationStatus uint8
 
 const (
 	InitializingReplication   ReplicationStatus = 0
+	CreatingInitialSplits     ReplicationStatus = 6
 	Replicating               ReplicationStatus = 1
 	ReplicationPaused         ReplicationStatus = 2
 	ReplicationPendingCutover ReplicationStatus = 3
@@ -120,6 +121,8 @@ func (rs ReplicationStatus) String() string {
 		return "replication cutting over"
 	case ReplicationError:
 		return "replication error"
+	case CreatingInitialSplits:
+		return "creating initial splits"
 	default:
 		return fmt.Sprintf("unimplemented-%d", int(rs))
 	}


### PR DESCRIPTION
In a large enough cluster the replication job spends a non-trivial amount of time creating the initial splits at the beginning of its execution. This splitting is necessary to balance the load of ingesting data across different ranges in the cluster. Since these splits are currently only sent by one node they take even longer to get through. During this time the only signal that the job is doing any work is the custom metric that tracks the number of splits sent.

This change adds a new job status that tells the user which stage of the job we are in. It also prints a message indicating the total number of splits and scatters we have to issue before we can start ingesting.

Informs: #115534
Release note: None