### PR TITLE
ci: add release justification to predecessor updates

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -62,4 +62,5 @@ jobs:
 
             Epic: None
             Release note: None
+            Release justification: test-only updates
           delete-branch: true


### PR DESCRIPTION
This PR adds a "Release justification" line in order to pass blathers sanity check.

Epic: None
Release note: None