### PR TITLE
build,ci: add support for "rc-" branches

### DIFF
--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -62,5 +62,5 @@ _tc_build_branch() {
 # local copy of tc_release_branch from teamcity-support.sh to avoid imports.
 _tc_release_branch() {
   branch=$(_tc_build_branch)
-  [[ "$branch" == master || "$branch" == release-* || "$branch" == provisional_* ]]
+  [[ "$branch" == master || "$branch" == release-* || "$branch" == "rc-"* || "$branch" == provisional_* ]]
 }

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -257,7 +257,7 @@ tc_build_branch() {
 # function.
 tc_release_branch() {
   branch=$(tc_build_branch)
-  [[ "$branch" == master || "$branch" == release-* || "$branch" == provisional_* ]]
+  [[ "$branch" == master || "$branch" == release-* || "$branch" == "rc-"* || "$branch" == provisional_* ]]
 }
 
 tc_bors_branch() {

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
@@ -13,7 +13,7 @@ build_name=$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev
 # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
 release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"
 is_customized_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^custombuild-" || echo "")"
-is_release_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^(release-[0-9][0-9]\.[0-9](\.0)?)$|master$" || echo "")"
+is_release_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^((release|rc)-[0-9][0-9]\.[0-9](\.0)?)$|master$" || echo "")"
 
 if [[ -z "${DRY_RUN}" ]] ; then
   if [[ -z "${is_release_build}" ]] ; then

--- a/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
@@ -12,7 +12,7 @@ build_name=$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev
 
 # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
 release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"
-is_release_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^(release-[0-9][0-9]\.[0-9](\.0)?)$" || echo "")"
+is_release_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^((release|rc)-[0-9][0-9]\.[0-9](\.0)?)$" || echo "")"
 is_customized_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^custombuild-" || echo "")"
 github_ssh_key="${GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY}"
 

--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -260,7 +260,10 @@ func (o *Options) CanPost() bool {
 // IsReleaseBranch returns true for branches that we want to treat as
 // "release" branches, including master and provisional branches.
 func (o *Options) IsReleaseBranch() bool {
-	return o.Branch == "master" || strings.HasPrefix(o.Branch, "release-") || strings.HasPrefix(o.Branch, "provisional_")
+	return o.Branch == "master" ||
+		strings.HasPrefix(o.Branch, "release-") ||
+		strings.HasPrefix(o.Branch, "rc-") ||
+		strings.HasPrefix(o.Branch, "provisional_")
 }
 
 // TemplateData is the input on which an IssueFormatter operates. It has

--- a/pkg/cmd/release/update_versions.go
+++ b/pkg/cmd/release/update_versions.go
@@ -377,6 +377,11 @@ func generateRepoList(
 	if err != nil {
 		return []prRepo{}, fmt.Errorf("listing staging branches: %w", err)
 	}
+	if maybeRCBranches, err := listRemoteBranches(fmt.Sprintf("rc-%d.%d.*", releasedVersion.Major(), releasedVersion.Minor())); err != nil {
+		return []prRepo{}, fmt.Errorf("listing staging branches: %w", err)
+	} else {
+		maybeVersionBumpBranches = append(maybeVersionBumpBranches, maybeRCBranches...)
+	}
 	if releasedVersion.Prerelease() == "" {
 		maybeVersionBumpBranches = append(maybeVersionBumpBranches, fmt.Sprintf("release-%d.%d", releasedVersion.Major(), releasedVersion.Minor()))
 	} else {


### PR DESCRIPTION
Previously, we used `release-xx.yy.zz` for release candidate/staging builds. In the nearest future we want to support `rc-xx.yy.zz` style branches as well.

This PR adds support for `rc-*` style branches.

Epic: none
Release note: None