### PR TITLE
sql/pgwire: don't discard cmdStarts buffer on conn.Flush

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1247,7 +1247,9 @@ func (c *conn) Flush(pos sql.CmdPos) error {
 
 	c.writerState.fi.lastFlushed = pos
 	// Make sure that the entire cmdStarts buffer is drained.
-	c.writerState.fi.cmdStarts.Discard()
+	// Use (*ring.Buffer).Reset instead of (*ring.Buffer).Discard to preserve
+	// the underlying ring buffer memory for reuse.
+	c.writerState.fi.cmdStarts.Reset()
 
 	_ /* n */, err := c.writerState.buf.WriteTo(c.conn)
 	if err != nil {


### PR DESCRIPTION
This commit switches `conn.Flush` from calling the cmdStarts's `Discard` method to calling its `Reset` method. This avoids the need to re-allocate the buffer immediately after each flush. For details on the difference between the two methods, see their respective documentation.

The current behavior is not intentional. It was accidentally introduced in 3f3218db.

Spotted when looking at runtime traces.

Epic: None
Release note: None