### PR TITLE
builtin: add null checks to TileEnvelope function

### DIFF
--- a/pkg/geo/geomfn/tile_envelope.go
+++ b/pkg/geo/geomfn/tile_envelope.go
@@ -33,6 +33,13 @@ func TileEnvelope(
 		)
 	}
 
+	if bbox == nil {
+		return geo.Geometry{}, pgerror.Newf(
+			pgcode.InvalidParameterValue,
+			"Geometrics bounds are nil",
+		)
+	}
+
 	if bbox.HiX-bbox.LoX <= 0 || bbox.HiY-bbox.LoY <= 0 {
 		return geo.Geometry{}, pgerror.New(
 			pgcode.InvalidParameterValue,

--- a/pkg/geo/geomfn/tile_envelope_test.go
+++ b/pkg/geo/geomfn/tile_envelope_test.go
@@ -110,6 +110,14 @@ func TestTileEnvelope(t *testing.T) {
 			bounds:   "SRID=4326;POLYGON((-180 -90,-180 90,180 90,180 -90,-180 -90))",
 			margin:   0.0,
 		},
+		{
+			desc:     "Invalid geometric bounds",
+			tileZoom: 1,
+			tileX:    1,
+			tileY:    1,
+			bounds:   "SRID=4326;LINESTRING EMPTY",
+			margin:   0.0,
+		},
 	}
 
 	t.Run("Errors on invalid input", func(t *testing.T) {


### PR DESCRIPTION
The existing `TileEnvelope()` builtin function expects the passed in `bounds` object to have valid `BoundingBoxRef` object, and the nil check is missing, such that certain input can cause server panic. This MR simply adds the nil check to error out when the input is invalid.

Fixes: #115405
Release note: None