### PR TITLE
kv: include conflicting request information in latch manager traces/logs

### DIFF
--- a/pkg/kv/kvserver/concurrency/latch_manager.go
+++ b/pkg/kv/kvserver/concurrency/latch_manager.go
@@ -25,7 +25,7 @@ type latchManagerImpl struct {
 }
 
 func (m *latchManagerImpl) Acquire(ctx context.Context, req Request) (latchGuard, *Error) {
-	lg, err := m.m.Acquire(ctx, req.LatchSpans, req.PoisonPolicy)
+	lg, err := m.m.Acquire(ctx, req.LatchSpans, req.PoisonPolicy, req.BatchRequests)
 	if err != nil {
 		return nil, kvpb.NewError(err)
 	}
@@ -33,7 +33,7 @@ func (m *latchManagerImpl) Acquire(ctx context.Context, req Request) (latchGuard
 }
 
 func (m *latchManagerImpl) AcquireOptimistic(req Request) latchGuard {
-	lg := m.m.AcquireOptimistic(req.LatchSpans, req.PoisonPolicy)
+	lg := m.m.AcquireOptimistic(req.LatchSpans, req.PoisonPolicy, req.BatchRequests)
 	return lg
 }
 
@@ -52,9 +52,9 @@ func (m *latchManagerImpl) WaitUntilAcquired(
 }
 
 func (m *latchManagerImpl) WaitFor(
-	ctx context.Context, ss *spanset.SpanSet, pp poison.Policy,
+	ctx context.Context, ss *spanset.SpanSet, pp poison.Policy, br *kvpb.BatchRequest,
 ) *Error {
-	err := m.m.WaitFor(ctx, ss, pp)
+	err := m.m.WaitFor(ctx, ss, pp, br)
 	if err != nil {
 		return kvpb.NewError(err)
 	}

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -3893,10 +3893,10 @@ func (t *lockTableImpl) newGuardForReq(req Request) *lockTableGuardImpl {
 	g := newLockTableGuardImpl()
 	g.seqNum = t.seqNum.Add(1)
 	g.lt = t
-	g.txn = req.Txn
-	g.ts = req.Timestamp
+	g.txn = req.BatchRequests.Txn
+	g.ts = req.BatchRequests.Timestamp
 	g.spans = req.LockSpans
-	g.waitPolicy = req.WaitPolicy
+	g.waitPolicy = req.BatchRequests.WaitPolicy
 	g.maxWaitQueueLength = req.MaxLockWaitQueueLength
 	g.str = lock.MaxStrength
 	g.index = -1

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/barrier
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/barrier
@@ -53,7 +53,7 @@ sequence req=barrier2
 ----
 [2] sequence barrier2: sequencing request
 [2] sequence barrier2: waiting on latches without acquiring
-[2] sequence barrier2: waiting to acquire write latch ‹{a-f}›@0,0, held by read latch ‹c›@15.000000000,1
+[2] sequence barrier2: waiting to acquire write latch ‹{a-f}›@0,0[Barrier [‹"a"›,‹"f"›)], held by read latch ‹c›@15.000000000,1[Get [‹"c"›,/Min)]
 [2] sequence barrier2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=read1
@@ -96,7 +96,7 @@ sequence req=barrier1
 ----
 [2] sequence barrier1: sequencing request
 [2] sequence barrier1: waiting on latches without acquiring
-[2] sequence barrier1: waiting to acquire write latch ‹{a-f}›@0,0, held by read latch ‹c›@10.000000000,1
+[2] sequence barrier1: waiting to acquire write latch ‹{a-f}›@0,0[Barrier [‹"a"›,‹"f"›)], held by read latch ‹c›@10.000000000,1[Get [‹"c"›,/Min)]
 [2] sequence barrier1: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=read1
@@ -143,7 +143,7 @@ sequence req=barrier1
 ----
 [2] sequence barrier1: sequencing request
 [2] sequence barrier1: waiting on latches without acquiring
-[2] sequence barrier1: waiting to acquire write latch ‹{a-f}›@0,0, held by write latch ‹c›@10.000000000,1
+[2] sequence barrier1: waiting to acquire write latch ‹{a-f}›@0,0[Barrier [‹"a"›,‹"f"›)], held by write latch ‹c›@10.000000000,1[Put [‹"c"›,/Min), [txn: 00000001]]
 [2] sequence barrier1: blocked on select in spanlatch.(*Manager).waitForSignal
 
 debug-latch-manager

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -143,7 +143,7 @@ sequence req=req4
 ----
 [3] sequence req4: sequencing request
 [3] sequence req4: acquiring latches
-[3] sequence req4: waiting to acquire write latch ‹k›@10.000000000,1, held by read latch ‹k{-2}›@14.000000000,1
+[3] sequence req4: waiting to acquire write latch ‹k›@10.000000000,1[Put [‹"k"›,/Min), [txn: 00000001]], held by read latch ‹k{-2}›@14.000000000,1[Get [‹"k"›,/Min), Scan [‹"k"›,‹"k2"›), [txn: 00000003]]
 [3] sequence req4: blocked on select in spanlatch.(*Manager).waitForSignal
 
 debug-latch-manager
@@ -245,13 +245,13 @@ sequence req=req7
 ----
 [4] sequence req7: sequencing request
 [4] sequence req7: acquiring latches
-[4] sequence req7: waiting to acquire write latch ‹k›@12.000000000,1, held by read latch ‹{a-m}›@14.000000000,1
+[4] sequence req7: waiting to acquire write latch ‹k›@12.000000000,1[Put [‹"k"›,/Min)], held by read latch ‹{a-m}›@14.000000000,1[Scan [‹"a"›,‹"m"›)]
 [4] sequence req7: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=req5
 ----
 [-] finish req5: finishing request
-[4] sequence req7: waiting to acquire write latch ‹k›@12.000000000,1, held by read latch ‹{c-z}›@16.000000000,1
+[4] sequence req7: waiting to acquire write latch ‹k›@12.000000000,1[Put [‹"k"›,/Min)], held by read latch ‹{c-z}›@16.000000000,1[Scan [‹"c"›,‹"z"›)]
 [4] sequence req7: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=req6

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
@@ -172,7 +172,7 @@ sequence req=req6 eval-kind=pess-after-opt
 ----
 [8] sequence req6: re-sequencing request after optimistic sequencing failed
 [8] sequence req6: optimistic failed, so waiting for latches
-[8] sequence req6: waiting to acquire read latch ‹{a-e}›@12.000000000,1, held by write latch ‹d›@10.000000000,1
+[8] sequence req6: waiting to acquire read latch ‹{a-e}›@12.000000000,1[Scan [‹"a"›,‹"e"›), [txn: 00000002]], held by write latch ‹d›@10.000000000,1[Put [‹"d"›,/Min), [txn: 00000003]]
 [8] sequence req6: blocked on select in spanlatch.(*Manager).waitForSignal
 
 # req4 finishing releases the latch and allows req6 to proceed.

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_err
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_err
@@ -27,7 +27,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1, held by write latch ‹c›@10.000000000,0
+[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1[Scan [‹"b"›,‹"f"›)], held by write latch ‹c›@10.000000000,0[Put [‹"c"›,/Min)]
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=pute ts=11,0
@@ -38,7 +38,7 @@ sequence req=pute
 ----
 [3] sequence pute: sequencing request
 [3] sequence pute: acquiring latches
-[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0, held by read latch ‹{b-f}›@11.000000000,1
+[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0[Put [‹"e"›,/Min)], held by read latch ‹{b-f}›@11.000000000,1[Scan [‹"b"›,‹"f"›)]
 [3] sequence pute: blocked on select in spanlatch.(*Manager).waitForSignal
 
 poison req=putc

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_err_indirect
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_err_indirect
@@ -26,7 +26,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1, held by write latch ‹c›@10.000000000,0
+[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1[Scan [‹"b"›,‹"f"›)], held by write latch ‹c›@10.000000000,0[Put [‹"c"›,/Min)]
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=pute ts=11,0
@@ -37,7 +37,7 @@ sequence req=pute
 ----
 [3] sequence pute: sequencing request
 [3] sequence pute: acquiring latches
-[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0, held by read latch ‹{b-f}›@11.000000000,1
+[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0[Put [‹"e"›,/Min)], held by read latch ‹{b-f}›@11.000000000,1[Scan [‹"b"›,‹"f"›)]
 [3] sequence pute: blocked on select in spanlatch.(*Manager).waitForSignal
 
 poison req=putc

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_wait_disjoint
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_wait_disjoint
@@ -26,7 +26,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1, held by write latch ‹c›@10.000000000,0
+[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1[Scan [‹"b"›,‹"f"›)], held by write latch ‹c›@10.000000000,0[Put [‹"c"›,/Min)]
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=pute ts=11,0 poison-policy=wait
@@ -37,7 +37,7 @@ sequence req=pute
 ----
 [3] sequence pute: sequencing request
 [3] sequence pute: acquiring latches
-[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0, held by read latch ‹{b-f}›@11.000000000,1
+[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0[Put [‹"e"›,/Min)], held by read latch ‹{b-f}›@11.000000000,1[Scan [‹"b"›,‹"f"›)]
 [3] sequence pute: blocked on select in spanlatch.(*Manager).waitForSignal
 
 poison req=putc

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_wait_overlapping
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_wait_overlapping
@@ -26,7 +26,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1, held by write latch ‹c›@10.000000000,0
+[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1[Scan [‹"b"›,‹"f"›)], held by write latch ‹c›@10.000000000,0[Put [‹"c"›,/Min)]
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=put2 ts=11,0 poison-policy=wait
@@ -37,7 +37,7 @@ sequence req=put2
 ----
 [3] sequence put2: sequencing request
 [3] sequence put2: acquiring latches
-[3] sequence put2: waiting to acquire write latch ‹c›@11.000000000,0, held by write latch ‹c›@10.000000000,0
+[3] sequence put2: waiting to acquire write latch ‹c›@11.000000000,0[Put [‹"c"›,/Min)], held by write latch ‹c›@10.000000000,0[Put [‹"c"›,/Min)]
 [3] sequence put2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 poison req=put1

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -195,7 +195,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 [7] sequence req2: lock wait-queue event: done waiting
 [7] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [7] sequence req2: acquiring latches
-[7] sequence req2: waiting to acquire read latch ‹k2›@10.000000000,1, held by write latch ‹k2›@10.000000000,1
+[7] sequence req2: waiting to acquire read latch ‹k2›@10.000000000,1[Put [‹"k"›,/Min), Get [‹"k2"›,/Min), [txn: 00000002]], held by write latch ‹k2›@10.000000000,1[ResolveIntent [‹"k"›,/Min), ResolveIntent [‹"k2"›,/Min)]
 [7] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 on-lock-updated req=reqRes1 txn=txn1 key=k2 status=committed
@@ -309,7 +309,7 @@ on-lock-updated req=reqRes2 txn=txn2 key=k status=committed
 [13] sequence req3: lock wait-queue event: done waiting
 [13] sequence req3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [13] sequence req3: acquiring latches
-[13] sequence req3: waiting to acquire write latch ‹k›@10.000000000,1, held by write latch ‹k›@10.000000000,1
+[13] sequence req3: waiting to acquire write latch ‹k›@10.000000000,1[Put [‹"k"›,/Min), [txn: 00000003]], held by write latch ‹k›@10.000000000,1[ResolveIntent [‹"k"›,/Min)]
 [13] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=reqRes2
@@ -467,7 +467,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 [4] sequence req2: lock wait-queue event: done waiting
 [4] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [4] sequence req2: acquiring latches
-[4] sequence req2: waiting to acquire write latch ‹k›@10.000000000,1, held by write latch ‹k›@10.000000000,1
+[4] sequence req2: waiting to acquire write latch ‹k›@10.000000000,1[Put [‹"k"›,/Min), [txn: 00000002]], held by write latch ‹k›@10.000000000,1[ResolveIntent [‹"k"›,/Min)]
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=reqRes1
@@ -687,7 +687,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 [8] sequence req2: lock wait-queue event: done waiting
 [8] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [8] sequence req2: acquiring latches
-[8] sequence req2: waiting to acquire write latch ‹k›@10.000000000,1, held by write latch ‹k›@10.000000000,1
+[8] sequence req2: waiting to acquire write latch ‹k›@10.000000000,1[Put [‹"k"›,/Min), [txn: 00000002]], held by write latch ‹k›@10.000000000,1[ResolveIntent [‹"k"›,/Min)]
 [8] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=reqRes1
@@ -845,7 +845,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 [4] sequence req2: lock wait-queue event: done waiting
 [4] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [4] sequence req2: acquiring latches
-[4] sequence req2: waiting to acquire write latch ‹k›@10.000000000,1, held by write latch ‹k›@10.000000000,1
+[4] sequence req2: waiting to acquire write latch ‹k›@10.000000000,1[Put [‹"k"›,/Min), [txn: 00000002]], held by write latch ‹k›@10.000000000,1[ResolveIntent [‹"k"›,/Min)]
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=reqRes1

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks_latches
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks_latches
@@ -176,7 +176,7 @@ sequence req=req10
 ----
 [10] sequence req10: sequencing request
 [10] sequence req10: acquiring latches
-[10] sequence req10: waiting to acquire write latch ‹a›@9.000000000,1, held by read latch ‹a›@9223372036.854775807,2147483647
+[10] sequence req10: waiting to acquire write latch ‹a›@9.000000000,1[Get [‹"a"›,/Min), [txn: 00000003]], held by read latch ‹a›@9223372036.854775807,2147483647[Get [‹"a"›,/Min), [txn: 00000001]]
 [10] sequence req10: blocked on select in spanlatch.(*Manager).waitForSignal
 
 # exclusive_lock(ts) == shared_lock(ts)
@@ -188,7 +188,7 @@ sequence req=req11
 ----
 [11] sequence req11: sequencing request
 [11] sequence req11: acquiring latches
-[11] sequence req11: waiting to acquire write latch ‹b›@10.000000000,1, held by read latch ‹b›@9223372036.854775807,2147483647
+[11] sequence req11: waiting to acquire write latch ‹b›@10.000000000,1[Get [‹"b"›,/Min), [txn: 00000001]], held by read latch ‹b›@9223372036.854775807,2147483647[Get [‹"b"›,/Min), [txn: 00000001]]
 [11] sequence req11: blocked on select in spanlatch.(*Manager).waitForSignal
 
 # exclusive_lock(ts) > shared_lock(ts)
@@ -200,7 +200,7 @@ sequence req=req12
 ----
 [12] sequence req12: sequencing request
 [12] sequence req12: acquiring latches
-[12] sequence req12: waiting to acquire write latch ‹c›@11.000000000,1, held by read latch ‹c›@9223372036.854775807,2147483647
+[12] sequence req12: waiting to acquire write latch ‹c›@11.000000000,1[Get [‹"c"›,/Min), [txn: 00000002]], held by read latch ‹c›@9223372036.854775807,2147483647[Get [‹"c"›,/Min), [txn: 00000001]]
 [12] sequence req12: blocked on select in spanlatch.(*Manager).waitForSignal
 
 debug-latch-manager
@@ -286,7 +286,7 @@ sequence req=req16
 ----
 [16] sequence req16: sequencing request
 [16] sequence req16: acquiring latches
-[16] sequence req16: waiting to acquire write latch ‹a›@9.000000000,1, held by read latch ‹a›@9223372036.854775807,2147483647
+[16] sequence req16: waiting to acquire write latch ‹a›@9.000000000,1[Put [‹"a"›,/Min), [txn: 00000003]], held by read latch ‹a›@9223372036.854775807,2147483647[Get [‹"a"›,/Min), [txn: 00000001]]
 [16] sequence req16: blocked on select in spanlatch.(*Manager).waitForSignal
 
 # write(ts) == shared_lock(ts)
@@ -298,7 +298,7 @@ sequence req=req17
 ----
 [17] sequence req17: sequencing request
 [17] sequence req17: acquiring latches
-[17] sequence req17: waiting to acquire write latch ‹b›@10.000000000,1, held by read latch ‹b›@9223372036.854775807,2147483647
+[17] sequence req17: waiting to acquire write latch ‹b›@10.000000000,1[Put [‹"b"›,/Min), [txn: 00000001]], held by read latch ‹b›@9223372036.854775807,2147483647[Get [‹"b"›,/Min), [txn: 00000001]]
 [17] sequence req17: blocked on select in spanlatch.(*Manager).waitForSignal
 
 # write(ts) > shared_lock(ts)
@@ -310,7 +310,7 @@ sequence req=req18
 ----
 [18] sequence req18: sequencing request
 [18] sequence req18: acquiring latches
-[18] sequence req18: waiting to acquire write latch ‹c›@11.000000000,1, held by read latch ‹c›@9223372036.854775807,2147483647
+[18] sequence req18: waiting to acquire write latch ‹c›@11.000000000,1[Put [‹"c"›,/Min), [txn: 00000002]], held by read latch ‹c›@9223372036.854775807,2147483647[Get [‹"c"›,/Min), [txn: 00000001]]
 [18] sequence req18: blocked on select in spanlatch.(*Manager).waitForSignal
 
 debug-latch-manager
@@ -470,7 +470,7 @@ sequence req=req26
 ----
 [26] sequence req26: sequencing request
 [26] sequence req26: acquiring latches
-[26] sequence req26: waiting to acquire read latch ‹a›@9223372036.854775807,2147483647, held by write latch ‹a›@10.000000000,1
+[26] sequence req26: waiting to acquire read latch ‹a›@9223372036.854775807,2147483647[Get [‹"a"›,/Min), [txn: 00000003]], held by write latch ‹a›@10.000000000,1[Get [‹"a"›,/Min), [txn: 00000001]]
 [26] sequence req26: blocked on select in spanlatch.(*Manager).waitForSignal
 
 # shared_lock(ts) == exclusive_lock(ts)
@@ -482,7 +482,7 @@ sequence req=req27
 ----
 [27] sequence req27: sequencing request
 [27] sequence req27: acquiring latches
-[27] sequence req27: waiting to acquire read latch ‹b›@9223372036.854775807,2147483647, held by write latch ‹b›@10.000000000,1
+[27] sequence req27: waiting to acquire read latch ‹b›@9223372036.854775807,2147483647[Get [‹"b"›,/Min), [txn: 00000001]], held by write latch ‹b›@10.000000000,1[Get [‹"b"›,/Min), [txn: 00000001]]
 [27] sequence req27: blocked on select in spanlatch.(*Manager).waitForSignal
 
 # shared_lock(ts) > exclusive_lock(ts)
@@ -494,7 +494,7 @@ sequence req=req28
 ----
 [28] sequence req28: sequencing request
 [28] sequence req28: acquiring latches
-[28] sequence req28: waiting to acquire read latch ‹c›@9223372036.854775807,2147483647, held by write latch ‹c›@10.000000000,1
+[28] sequence req28: waiting to acquire read latch ‹c›@9223372036.854775807,2147483647[Get [‹"c"›,/Min), [txn: 00000002]], held by write latch ‹c›@10.000000000,1[Get [‹"c"›,/Min), [txn: 00000001]]
 [28] sequence req28: blocked on select in spanlatch.(*Manager).waitForSignal
 
 debug-latch-manager
@@ -580,7 +580,7 @@ sequence req=req32
 ----
 [32] sequence req32: sequencing request
 [32] sequence req32: acquiring latches
-[32] sequence req32: waiting to acquire read latch ‹a›@9223372036.854775807,2147483647, held by write latch ‹a›@10.000000000,1
+[32] sequence req32: waiting to acquire read latch ‹a›@9223372036.854775807,2147483647[Get [‹"a"›,/Min), [txn: 00000003]], held by write latch ‹a›@10.000000000,1[Put [‹"a"›,/Min), [txn: 00000001]]
 [32] sequence req32: blocked on select in spanlatch.(*Manager).waitForSignal
 
 # shared_lock(ts) == write(ts)
@@ -592,7 +592,7 @@ sequence req=req33
 ----
 [33] sequence req33: sequencing request
 [33] sequence req33: acquiring latches
-[33] sequence req33: waiting to acquire read latch ‹b›@9223372036.854775807,2147483647, held by write latch ‹b›@10.000000000,1
+[33] sequence req33: waiting to acquire read latch ‹b›@9223372036.854775807,2147483647[Get [‹"b"›,/Min), [txn: 00000001]], held by write latch ‹b›@10.000000000,1[Put [‹"b"›,/Min), [txn: 00000001]]
 [33] sequence req33: blocked on select in spanlatch.(*Manager).waitForSignal
 
 # shared_lock(ts) > write(ts)
@@ -604,7 +604,7 @@ sequence req=req34
 ----
 [34] sequence req34: sequencing request
 [34] sequence req34: acquiring latches
-[34] sequence req34: waiting to acquire read latch ‹c›@9223372036.854775807,2147483647, held by write latch ‹c›@10.000000000,1
+[34] sequence req34: waiting to acquire read latch ‹c›@9223372036.854775807,2147483647[Get [‹"c"›,/Min), [txn: 00000002]], held by write latch ‹c›@10.000000000,1[Put [‹"c"›,/Min), [txn: 00000001]]
 [34] sequence req34: blocked on select in spanlatch.(*Manager).waitForSignal
 
 debug-latch-manager
@@ -667,7 +667,7 @@ sequence req=req36
 ----
 [36] sequence req36: sequencing request
 [36] sequence req36: acquiring latches
-[36] sequence req36: waiting to acquire write latch ‹/Local/RangeID/1/r/ReplicatedSharedLocksTransactionLatch/"00000002-0000-0000-0000-000000000000"›@0,0, held by write latch ‹/Local/RangeID/1/r/ReplicatedSharedLocksTransactionLatch/"00000002-0000-0000-0000-000000000000"›@0,0
+[36] sequence req36: waiting to acquire write latch ‹/Local/RangeID/1/r/ReplicatedSharedLocksTransactionLatch/"00000002-0000-0000-0000-000000000000"›@0,0[Scan [‹"a"›,‹"f"›), [txn: 00000002]], held by write latch ‹/Local/RangeID/1/r/ReplicatedSharedLocksTransactionLatch/"00000002-0000-0000-0000-000000000000"›@0,0[Get [‹"c"›,/Min), [txn: 00000002]]
 [36] sequence req36: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request name=req37 txn=txn1 ts=11,1

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/slow_latch_observability
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/slow_latch_observability
@@ -28,7 +28,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1, held by write latch ‹c›@10.000000000,0
+[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1[Scan [‹"b"›,‹"f"›)], held by write latch ‹c›@10.000000000,0[Put [‹"c"›,/Min)]
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=pute ts=11,0
@@ -39,7 +39,7 @@ sequence req=pute
 ----
 [3] sequence pute: sequencing request
 [3] sequence pute: acquiring latches
-[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0, held by read latch ‹{b-f}›@11.000000000,1
+[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0[Put [‹"e"›,/Min)], held by read latch ‹{b-f}›@11.000000000,1[Scan [‹"b"›,‹"f"›)]
 [3] sequence pute: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=putc

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -466,17 +466,10 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 		// returns a request guard that must be eventually released.
 		var resp []kvpb.ResponseUnion
 		g, resp, pErr = r.concMgr.SequenceReq(ctx, g, concurrency.Request{
-			Txn:             ba.Txn,
-			Timestamp:       ba.Timestamp,
-			NonTxnPriority:  ba.UserPriority,
-			ReadConsistency: ba.ReadConsistency,
-			WaitPolicy:      ba.WaitPolicy,
-			LockTimeout:     ba.LockTimeout,
-			AdmissionHeader: ba.AdmissionHeader,
-			PoisonPolicy:    pp,
-			Requests:        ba.Requests,
-			LatchSpans:      latchSpans, // nil if g != nil
-			LockSpans:       lockSpans,  // nil if g != nil
+			BatchRequests: ba,
+			PoisonPolicy:  pp,
+			LatchSpans:    latchSpans, // nil if g != nil
+			LockSpans:     lockSpans,  // nil if g != nil
 		}, requestEvalKind)
 		if pErr != nil {
 			if poisonErr := (*poison.PoisonedError)(nil); errors.As(pErr.GoError(), &poisonErr) {

--- a/pkg/kv/kvserver/spanlatch/manager.go
+++ b/pkg/kv/kvserver/spanlatch/manager.go
@@ -85,7 +85,7 @@ func Make(stopper *stop.Stopper, slowReqs *metric.Gauge) Manager {
 // latches are stored in the Manager's btrees. They represent the latching
 // of a single key span.
 type latch struct {
-	*signals
+	guard      *Guard
 	id         uint64
 	span       roachpb.Span
 	ts         hlc.Timestamp
@@ -102,8 +102,13 @@ func (la *latch) String() string {
 }
 
 // SafeFormat implements the redact.SafeFormatter interface.
-func (la *latch) SafeFormat(w redact.SafePrinter, _ rune) {
+func (la *latch) SafeFormat(w redact.SafePrinter, verb rune) {
 	w.Printf("%s@%s", la.span, la.ts)
+	if la.guard.batchRequest != nil {
+		w.Printf("[")
+		la.guard.batchRequest.SafeFormat(w, verb)
+		w.Printf("]")
+	}
 }
 
 //go:generate ../../../util/interval/generic/gen.sh *latch spanlatch
@@ -132,7 +137,8 @@ type Guard struct {
 	latchesLens [spanset.NumSpanScope][spanset.NumSpanAccess]int32
 	// Non-nil only when AcquireOptimistic has retained the snapshot for later
 	// checking of conflicts, and waiting.
-	snap *snapshot
+	snap         *snapshot
+	batchRequest *kvpb.BatchRequest
 }
 
 func (lg *Guard) latches(s spanset.SpanScope, a spanset.SpanAccess) []latch {
@@ -183,10 +189,11 @@ func allocGuardAndLatches(nLatches int) (*Guard, []latch) {
 	return new(Guard), make([]latch, nLatches)
 }
 
-func newGuard(spans *spanset.SpanSet, pp poison.Policy) *Guard {
+func newGuard(spans *spanset.SpanSet, pp poison.Policy, br *kvpb.BatchRequest) *Guard {
 	nLatches := spans.Len()
 	guard, latches := allocGuardAndLatches(nLatches)
 	guard.pp = pp
+	guard.batchRequest = br
 	for s := spanset.SpanScope(0); s < spanset.NumSpanScope; s++ {
 		for a := spanset.SpanAccess(0); a < spanset.NumSpanAccess; a++ {
 			ss := spans.GetSpans(a, s)
@@ -199,7 +206,7 @@ func newGuard(spans *spanset.SpanSet, pp poison.Policy) *Guard {
 			for i := range ssLatches {
 				latch := &latches[i]
 				latch.span = ss[i].Span
-				latch.signals = &guard.signals
+				latch.guard = guard
 				latch.ts = ss[i].Timestamp
 				// latch.setID() in Manager.insert, under lock.
 			}
@@ -222,9 +229,9 @@ func newGuard(spans *spanset.SpanSet, pp poison.Policy) *Guard {
 //
 // It returns a Guard which must be provided to Release.
 func (m *Manager) Acquire(
-	ctx context.Context, spans *spanset.SpanSet, pp poison.Policy,
+	ctx context.Context, spans *spanset.SpanSet, pp poison.Policy, br *kvpb.BatchRequest,
 ) (*Guard, error) {
-	lg, snap := m.sequence(spans, pp)
+	lg, snap := m.sequence(spans, pp, br)
 	defer snap.close()
 
 	err := m.wait(ctx, lg, snap)
@@ -247,8 +254,8 @@ func (m *Manager) Acquire(
 //
 // The method returns a Guard which must be provided to the
 // CheckOptimisticNoConflicts, Release methods.
-func (m *Manager) AcquireOptimistic(spans *spanset.SpanSet, pp poison.Policy) *Guard {
-	lg, snap := m.sequence(spans, pp)
+func (m *Manager) AcquireOptimistic(spans *spanset.SpanSet, pp poison.Policy, br *kvpb.BatchRequest) *Guard {
+	lg, snap := m.sequence(spans, pp, br)
 	lg.snap = &snap
 	return lg
 }
@@ -256,10 +263,10 @@ func (m *Manager) AcquireOptimistic(spans *spanset.SpanSet, pp poison.Policy) *G
 // WaitFor waits for conflicting latches on the spans without adding
 // any latches itself. Fast path for operations that only require past latches
 // to be released without blocking new latches.
-func (m *Manager) WaitFor(ctx context.Context, spans *spanset.SpanSet, pp poison.Policy) error {
+func (m *Manager) WaitFor(ctx context.Context, spans *spanset.SpanSet, pp poison.Policy, br *kvpb.BatchRequest) error {
 	// The guard is only used to store latches by this request. These latches
 	// are not actually inserted using insertLocked.
-	lg := newGuard(spans, pp)
+	lg := newGuard(spans, pp, br)
 
 	m.mu.Lock()
 	snap := m.snapshotLocked(spans)
@@ -355,8 +362,8 @@ func (m *Manager) WaitUntilAcquired(ctx context.Context, lg *Guard) (*Guard, err
 // for each of the specified spans into the manager's interval trees, and
 // unlocks the manager. The role of the method is to sequence latch acquisition
 // attempts.
-func (m *Manager) sequence(spans *spanset.SpanSet, pp poison.Policy) (*Guard, snapshot) {
-	lg := newGuard(spans, pp)
+func (m *Manager) sequence(spans *spanset.SpanSet, pp poison.Policy, br *kvpb.BatchRequest) (*Guard, snapshot) {
+	lg := newGuard(spans, pp, br)
 
 	m.mu.Lock()
 	snap := m.snapshotLocked(spans)
@@ -527,7 +534,7 @@ func (m *Manager) iterAndWait(
 ) error {
 	for it.FirstOverlap(wait); it.Valid(); it.NextOverlap(wait) {
 		held := it.Cur()
-		if held.done.signaled() {
+		if held.guard.done.signaled() {
 			continue
 		}
 		if ignore(wait.ts, held.ts) {
@@ -549,10 +556,10 @@ func (m *Manager) waitForSignal(
 	wait, held *latch,
 ) error {
 	log.Eventf(ctx, "waiting to acquire %s latch %s, held by %s latch %s", waitType, wait, heldType, held)
-	poisonCh := held.poison.signalChan()
+	poisonCh := held.guard.poison.signalChan()
 	for {
 		select {
-		case <-held.done.signalChan():
+		case <-held.guard.done.signalChan():
 			return nil
 		case <-poisonCh:
 			// The latch we're waiting on was poisoned. If we continue to wait, we have to
@@ -564,7 +571,7 @@ func (m *Manager) waitForSignal(
 				return poison.NewPoisonedError(held.span, held.ts)
 			case poison.Policy_Wait:
 				log.Eventf(ctx, "encountered poisoned latch; continuing to wait")
-				wait.poison.signal()
+				wait.guard.poison.signal()
 				// No need to self-poison multiple times.
 				poisonCh = nil
 			default:

--- a/pkg/kv/kvserver/spanlatch/manager_test.go
+++ b/pkg/kv/kvserver/spanlatch/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/poison"
@@ -94,7 +95,7 @@ func testLatchBlocks(t *testing.T, a Attempt) {
 // MustAcquire is like Acquire, except it can't return context cancellation
 // errors.
 func (m *Manager) MustAcquire(spans *spanset.SpanSet) *Guard {
-	lg, err := m.Acquire(context.Background(), spans, poison.Policy_Error)
+	lg, err := m.Acquire(context.Background(), spans, poison.Policy_Error, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -122,7 +123,7 @@ func (m *Manager) MustAcquireChExt(
 	ctx context.Context, spans *spanset.SpanSet, pp poison.Policy,
 ) Attempt {
 	errCh := make(chan error, 1)
-	lg, snap := m.sequence(spans, pp)
+	lg, snap := m.sequence(spans, pp, nil)
 	go func() {
 		err := m.wait(ctx, lg, snap)
 		if err != nil {
@@ -607,13 +608,13 @@ func TestLatchManagerOptimistic(t *testing.T) {
 	var m Manager
 
 	// Acquire latches, no conflict.
-	lg1 := m.AcquireOptimistic(spans("d", "f", write, zeroTS), poison.Policy_Error)
+	lg1 := m.AcquireOptimistic(spans("d", "f", write, zeroTS), poison.Policy_Error, nil)
 	require.True(t, m.CheckOptimisticNoConflicts(lg1, spans("d", "f", write, zeroTS)), poison.Policy_Error)
 	lg1, err := m.WaitUntilAcquired(context.Background(), lg1)
 	require.NoError(t, err)
 
 	// Optimistic acquire encounters conflict in some cases.
-	lg2 := m.AcquireOptimistic(spans("a", "e", read, zeroTS), poison.Policy_Error)
+	lg2 := m.AcquireOptimistic(spans("a", "e", read, zeroTS), poison.Policy_Error, nil)
 	require.False(t, m.CheckOptimisticNoConflicts(lg2, spans("a", "e", read, zeroTS)))
 	require.True(t, m.CheckOptimisticNoConflicts(lg2, spans("a", "d", read, zeroTS)))
 	waitUntilAcquiredCh := func(g *Guard) Attempt {
@@ -630,7 +631,7 @@ func TestLatchManagerOptimistic(t *testing.T) {
 	testLatchSucceeds(t, a2)
 
 	// Optimistic acquire encounters conflict.
-	lg3 := m.AcquireOptimistic(spans("a", "e", write, zeroTS), poison.Policy_Error)
+	lg3 := m.AcquireOptimistic(spans("a", "e", write, zeroTS), poison.Policy_Error, nil)
 	require.False(t, m.CheckOptimisticNoConflicts(lg3, spans("a", "e", write, zeroTS)))
 	m.Release(lg2)
 	// There is still a conflict even though lg2 has been released.
@@ -642,7 +643,7 @@ func TestLatchManagerOptimistic(t *testing.T) {
 	// Optimistic acquire for read below write encounters no conflict.
 	oneTS, twoTS := hlc.Timestamp{WallTime: 1}, hlc.Timestamp{WallTime: 2}
 	lg4 := m.MustAcquire(spans("c", "e", write, twoTS))
-	lg5 := m.AcquireOptimistic(spans("a", "e", read, oneTS), poison.Policy_Error)
+	lg5 := m.AcquireOptimistic(spans("a", "e", read, oneTS), poison.Policy_Error, nil)
 	require.True(t, m.CheckOptimisticNoConflicts(lg5, spans("a", "e", read, oneTS)))
 	require.True(t, m.CheckOptimisticNoConflicts(lg5, spans("a", "c", read, oneTS)))
 	lg5, err = m.WaitUntilAcquired(context.Background(), lg5)
@@ -656,14 +657,14 @@ func TestLatchManagerWaitFor(t *testing.T) {
 	var m Manager
 
 	// Acquire latches, no conflict.
-	lg1, err := m.Acquire(context.Background(), spans("d", "f", write, zeroTS), poison.Policy_Error)
+	lg1, err := m.Acquire(context.Background(), spans("d", "f", write, zeroTS), poison.Policy_Error, nil)
 	require.NoError(t, err)
 
 	// See if WaitFor waits for above latch.
 	waitForCh := func() Attempt {
 		errCh := make(chan error)
 		go func() {
-			errCh <- m.WaitFor(context.Background(), spans("a", "e", read, zeroTS), poison.Policy_Error)
+			errCh <- m.WaitFor(context.Background(), spans("a", "e", read, zeroTS), poison.Policy_Error, nil)
 		}()
 		return Attempt{errCh: errCh}
 	}
@@ -674,7 +675,7 @@ func TestLatchManagerWaitFor(t *testing.T) {
 
 	// Optimistic acquire should _not_ encounter conflict - as WaitFor should
 	// not lay any latches.
-	lg3 := m.AcquireOptimistic(spans("a", "e", write, zeroTS), poison.Policy_Error)
+	lg3 := m.AcquireOptimistic(spans("a", "e", write, zeroTS), poison.Policy_Error, nil)
 	require.True(t, m.CheckOptimisticNoConflicts(lg3, spans("a", "e", write, zeroTS)))
 	lg3, err = m.WaitUntilAcquired(context.Background(), lg3)
 	require.NoError(t, err)
@@ -722,7 +723,7 @@ func BenchmarkLatchManagerReadWriteMix(b *testing.B) {
 
 			b.ResetTimer()
 			for i := range spans {
-				lg, snap := m.sequence(&spans[i], poison.Policy_Error)
+				lg, snap := m.sequence(&spans[i], poison.Policy_Error, nil)
 				snap.close()
 				if len(lgBuf) == cap(lgBuf) {
 					m.Release(<-lgBuf)
@@ -740,4 +741,11 @@ func randBytes(n int) []byte {
 		panic(err)
 	}
 	return b
+}
+
+// TestSizeOfLatch tests the size of the latch struct.
+func TestSizeOfLatch(t *testing.T) {
+	var la latch
+	size := int(unsafe.Sizeof(la))
+	require.Equal(t, 96, size)
 }


### PR DESCRIPTION
[just testing on ci]
This commit add request information in latch conflict logging. This is achieved by refactor Request struct to include *kvpb.BatchRequests and pass it down to Guard. Since the Guard struct contains the signal field, we will make latch to store a pointer to the Guard instead to avoid latch size increase.

Fixes: None
Relase Note: None
