### PR TITLE
span: Re-initialize iterator when forwarding

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
@@ -642,6 +642,7 @@ func TestRangeFeedMetricsManagement(t *testing.T) {
 
 		frontier, err := span.MakeFrontier(fooSpan)
 		require.NoError(t, err)
+		frontier = span.MakeConcurrentFrontier(frontier)
 
 		// This error causes rangefeed to restart.
 		transientErrEvent := kvpb.RangeFeedEvent{
@@ -887,6 +888,7 @@ func TestMuxRangeFeedCanCloseStream(t *testing.T) {
 
 	frontier, err := span.MakeFrontier(fooSpan)
 	require.NoError(t, err)
+	frontier = span.MakeConcurrentFrontier(frontier)
 
 	expectFrontierAdvance := func() {
 		t.Helper()

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -57,6 +57,7 @@ type Frontier interface {
 
 	// Entries invokes the given callback with the current timestamp for each
 	// component span in the tracked span set.
+	// The fn may not mutate this frontier while iterating.
 	Entries(fn Operation)
 
 	// SpanEntries invokes op for each sub-span of the specified span with the
@@ -77,6 +78,7 @@ type Frontier interface {
 	//
 	// Note: neither [a-b) nor [m, q) will be emitted since they do not intersect with the spans
 	// tracked by this frontier.
+	// The fn may not mutate this frontier while iterating.
 	SpanEntries(span roachpb.Span, op Operation)
 
 	// Len returns the number of spans tracked by the frontier.
@@ -161,6 +163,11 @@ type btreeFrontier struct {
 	idAlloc uint64
 
 	mergeAlloc []*btreeFrontierEntry // Amortize allocations.
+
+	// disallowMutationWhileIterating is set when iterating
+	// over frontier entries.  Attempts to mutate this frontier
+	// will panic under the test or return an error.
+	disallowMutationWhileIterating bool
 }
 
 // btreeFrontierEntry represents a timestamped span. It is used as the nodes in both
@@ -199,6 +206,10 @@ type btreeFrontierEntry struct {
 // the underlying keys.  If the caller has to modify underlying key slices, they
 // must pass in the copy.
 func (f *btreeFrontier) AddSpansAt(startAt hlc.Timestamp, spans ...roachpb.Span) (retErr error) {
+	if err := f.checkDisallowedMutation(); err != nil {
+		return err
+	}
+
 	if expensiveChecksEnabled() {
 		defer func() {
 			if err := f.checkUnsafeKeyModification(); err != nil {
@@ -207,34 +218,24 @@ func (f *btreeFrontier) AddSpansAt(startAt hlc.Timestamp, spans ...roachpb.Span)
 		}()
 	}
 
-	collectOverlaps := func(s roachpb.Span) (overlaps []*btreeFrontierEntry) {
-		key := newSearchKey(s.Key, s.EndKey)
-		defer putFrontierEntry(key)
-
-		it := f.tree.MakeIter()
-		for it.FirstOverlap(key); it.Valid(); it.NextOverlap(key) {
-			overlaps = append(overlaps, it.Cur())
-		}
-		return overlaps
-	}
-
-	for _, s := range spans {
+	for _, toAdd := range spans {
 		// Validate caller provided span.
-		if err := checkSpan(s); err != nil {
+		if err := checkSpan(toAdd); err != nil {
 			return err
 		}
 
-		var sg roachpb.SpanGroup
-		sg.Add(s)
-		for _, o := range collectOverlaps(s) {
-			if err := f.deleteEntry(o); err != nil {
+		// Add toAdd sub-spans that do not overlap this frontier. To ensure that
+		// adjacent spans are merged, sub-spans are added in two steps: first,
+		// non-overlapping spans are added with 0 timestamp; then the timestamp for
+		// the entire toAdd span is forwarded.
+		for _, s := range spanDifference(toAdd, f) {
+			e := newFrontierEntry(&f.idAlloc, s.Key, s.EndKey, hlc.Timestamp{})
+			if err := f.setEntry(e); err != nil {
+				putFrontierEntry(e)
 				return err
 			}
 		}
-		if err := sg.ForEach(func(span roachpb.Span) error {
-			e := newFrontierEntry(&f.idAlloc, span.Key, span.EndKey, startAt)
-			return f.setEntry(e)
-		}); err != nil {
+		if err := f.forward(toAdd, startAt); err != nil {
 			return err
 		}
 	}
@@ -283,6 +284,10 @@ func (f *btreeFrontier) PeekFrontierSpan() roachpb.Span {
 func (f *btreeFrontier) Forward(
 	span roachpb.Span, ts hlc.Timestamp,
 ) (forwarded bool, retErr error) {
+	if err := f.checkDisallowedMutation(); err != nil {
+		return false, err
+	}
+
 	// Validate caller provided span.
 	if err := checkSpan(span); err != nil {
 		return false, err
@@ -455,7 +460,6 @@ func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error
 		return f.mergeEntries(e)
 	}
 
-	it := f.tree.MakeIter()
 	for !todoEntry.isEmptyRange() { // Keep going as long as there is work to be done.
 		if expensiveChecksEnabled() {
 			if err := checkSpan(todoEntry.span()); err != nil {
@@ -464,6 +468,7 @@ func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error
 		}
 
 		// Seek to the first entry overlapping todoEntry.
+		it := f.tree.MakeIter()
 		it.FirstOverlap(todoEntry)
 		if !it.Valid() {
 			break
@@ -501,9 +506,9 @@ func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error
 		// At this point, we know that overlap timestamp is not ahead of the
 		// insertTS (otherwise we'd hit fast case above).
 		// We need to split overlap range into multiple parts.
-		// 1. Possibly isEmptyRange part before todoEntry.Start
+		// 1. Possibly empty part before todoEntry.Start
 		// 2. Middle part (with updated timestamp),
-		// 3. Possibly isEmptyRange part after todoEntry end.
+		// 3. Possibly empty part after todoEntry end.
 		if overlap.Start.Compare(todoEntry.Start) < 0 {
 			// Split overlap into 2 entries
 			// [overlap.Start, todoEntry.Start) and [todoEntry.Start, overlap.End)
@@ -549,9 +554,18 @@ func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error
 	return nil
 }
 
+func (f *btreeFrontier) disallowMutations() func() {
+	f.disallowMutationWhileIterating = true
+	return func() {
+		f.disallowMutationWhileIterating = false
+	}
+}
+
 // Entries invokes the given callback with the current timestamp for each
 // component span in the tracked span set.
 func (f *btreeFrontier) Entries(fn Operation) {
+	defer f.disallowMutations()()
+
 	it := f.tree.MakeIter()
 	for it.First(); it.Valid(); it.Next() {
 		if fn(it.Cur().span(), it.Cur().ts) == StopMatch {
@@ -579,6 +593,8 @@ func (f *btreeFrontier) Entries(fn Operation) {
 // Note: neither [a-b) nor [m, q) will be emitted since they do not intersect with the spans
 // tracked by this frontier.
 func (f *btreeFrontier) SpanEntries(span roachpb.Span, op Operation) {
+	defer f.disallowMutations()()
+
 	todoRange := newSearchKey(span.Key, span.EndKey)
 	defer putFrontierEntry(todoRange)
 
@@ -776,10 +792,35 @@ func (f *btreeFrontier) checkUnsafeKeyModification() error {
 	return nil
 }
 
+func (f *btreeFrontier) checkDisallowedMutation() error {
+	if f.disallowMutationWhileIterating {
+		err := errors.AssertionFailedWithDepthf(1, "attempt to mutate frontier while iterating")
+		if buildutil.CrdbTestBuild {
+			panic(err)
+		}
+		return err
+	}
+	return nil
+}
+
 var disableSanityChecksForBenchmark bool
 
 func expensiveChecksEnabled() bool {
 	return buildutil.CrdbTestBuild && !disableSanityChecksForBenchmark
+}
+
+// spanDifference subtracts frontier (spans) from this span, and
+// returns set difference.
+func spanDifference(s roachpb.Span, f Frontier) []roachpb.Span {
+	var sg roachpb.SpanGroup
+	sg.Add(s)
+
+	f.SpanEntries(s, func(overlap roachpb.Span, ts hlc.Timestamp) (done OpResult) {
+		sg.Sub(overlap)
+		return false
+	})
+
+	return sg.Slice()
 }
 
 type concurrentFrontier struct {


### PR DESCRIPTION
Re-initialize iterator when forwarding span
frontier timestamp.  The underlying btree may be
mutated (by merge operation) invalidating previously
constructed iterator.

Btree implementation is also hardened against mis-use
when mutating span frontier while iterating.

Fixes #115411
Fixes #115528
Fixes #115512
Fixes #115490
Fixes #115488
Fixes #115487
Fixes #115483

Release notes: None