### PR TITLE
syncutil: fix `TryLock`/`TryRLock` for race mutexes

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -13,6 +13,7 @@ package kvserver
 import (
 	"context"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -207,6 +208,10 @@ func (mu *ReplicaMutex) AssertRHeld() {
 
 func (mu *ReplicaMutex) RUnlock() {
 	(*syncutil.RWMutex)(mu).RUnlock()
+}
+
+func (mu *ReplicaMutex) RLocker() sync.Locker {
+	return (*syncutil.RWMutex)(mu).RLocker()
 }
 
 // A Replica is a contiguous keyspace with writes managed via an

--- a/pkg/util/syncutil/mutex_deadlock.go
+++ b/pkg/util/syncutil/mutex_deadlock.go
@@ -57,3 +57,8 @@ func (rw *RWMutex) AssertRHeld() {
 func (rw *RWMutex) TryLock() bool {
 	return false
 }
+
+// TryRLock is a no-op for deadlock mutexes.
+func (rw *RWMutex) TryRLock() bool {
+	return false
+}

--- a/pkg/util/syncutil/mutex_sync_race.go
+++ b/pkg/util/syncutil/mutex_sync_race.go
@@ -33,6 +33,15 @@ func (m *Mutex) Lock() {
 	atomic.StoreInt32(&m.wLocked, 1)
 }
 
+// TryLock tries to lock m and reports whether it succeeded.
+func (m *Mutex) TryLock() bool {
+	if !m.mu.TryLock() {
+		return false
+	}
+	atomic.StoreInt32(&m.wLocked, 1)
+	return true
+}
+
 // Unlock unlocks m.
 func (m *Mutex) Unlock() {
 	atomic.StoreInt32(&m.wLocked, 0)
@@ -55,33 +64,51 @@ func (m *Mutex) AssertHeld() {
 
 // An RWMutex is a reader/writer mutual exclusion lock.
 type RWMutex struct {
-	sync.RWMutex
+	mu      sync.RWMutex
 	wLocked int32 // updated atomically
 	rLocked int32 // updated atomically
 }
 
 // Lock locks rw for writing.
 func (rw *RWMutex) Lock() {
-	rw.RWMutex.Lock()
+	rw.mu.Lock()
 	atomic.StoreInt32(&rw.wLocked, 1)
+}
+
+// TryLock tries to lock rw for writing and reports whether it succeeded.
+func (rw *RWMutex) TryLock() bool {
+	if !rw.mu.TryLock() {
+		return false
+	}
+	atomic.StoreInt32(&rw.wLocked, 1)
+	return true
 }
 
 // Unlock unlocks rw for writing.
 func (rw *RWMutex) Unlock() {
 	atomic.StoreInt32(&rw.wLocked, 0)
-	rw.RWMutex.Unlock()
+	rw.mu.Unlock()
 }
 
 // RLock locks m for reading.
 func (rw *RWMutex) RLock() {
-	rw.RWMutex.RLock()
+	rw.mu.RLock()
 	atomic.AddInt32(&rw.rLocked, 1)
+}
+
+// TryRLock tries to lock rw for reading and reports whether it succeeded.
+func (rw *RWMutex) TryRLock() bool {
+	if !rw.mu.TryRLock() {
+		return false
+	}
+	atomic.AddInt32(&rw.rLocked, 1)
+	return true
 }
 
 // RUnlock undoes a single RLock call.
 func (rw *RWMutex) RUnlock() {
 	atomic.AddInt32(&rw.rLocked, -1)
-	rw.RWMutex.RUnlock()
+	rw.mu.RUnlock()
 }
 
 // RLocker returns a Locker interface that implements

--- a/pkg/util/syncutil/mutex_sync_race_test.go
+++ b/pkg/util/syncutil/mutex_sync_race_test.go
@@ -22,6 +22,7 @@ import (
 func TestAssertHeld(t *testing.T) {
 	type mutex interface {
 		Lock()
+		TryLock() bool
 		Unlock()
 		AssertHeld()
 	}
@@ -35,6 +36,11 @@ func TestAssertHeld(t *testing.T) {
 	for _, c := range testCases {
 		// The normal, successful case.
 		c.m.Lock()
+		c.m.AssertHeld()
+		c.m.Unlock()
+
+		// The successful case with TryLock.
+		require.True(t, c.m.TryLock())
 		c.m.AssertHeld()
 		c.m.Unlock()
 
@@ -60,6 +66,23 @@ func TestAssertRHeld(t *testing.T) {
 
 	// The case where a write lock is held.
 	m.Lock()
+	m.AssertRHeld()
+	m.Unlock()
+
+	// The successful case with TryRLock.
+	require.True(t, m.TryRLock())
+	m.AssertRHeld()
+	m.RUnlock()
+
+	// The normal case with two readers and TryRLock.
+	require.True(t, m.TryRLock())
+	require.True(t, m.TryRLock())
+	m.AssertRHeld()
+	m.RUnlock()
+	m.RUnlock()
+
+	// The case where a write lock is held with TryLock.
+	require.True(t, m.TryLock())
 	m.AssertRHeld()
 	m.Unlock()
 


### PR DESCRIPTION
This commit implements the `TryLock` and `TryRLock` methods on the race mutexes. This ensures that the `AssertHeld` and `AssertRHeld` methods work correctly after a successful `TryLock` or `TryRLock`.

Epic: none
Release note: None