### PR TITLE
syncutil: add tracing and timing to mutex acquisition

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -545,7 +545,8 @@ func (r *Replica) GetQueueLastProcessed(ctx context.Context, queue string) (hlc.
 }
 
 func (r *Replica) MaybeUnquiesce() bool {
-	return r.maybeUnquiesce(true /* wakeLeader */, true /* mayCampaign */)
+	ctx := context.Background()
+	return r.maybeUnquiesce(ctx, true /* wakeLeader */, true /* mayCampaign */)
 }
 
 // MaybeUnquiesceAndPropose will unquiesce the range and submit a noop proposal.

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -190,12 +190,20 @@ func (mu *ReplicaMutex) Lock() {
 	(*syncutil.RWMutex)(mu).Lock()
 }
 
+func (mu *ReplicaMutex) TracedLock(ctx context.Context) {
+	(*syncutil.RWMutex)(mu).TracedLock(ctx)
+}
+
 func (mu *ReplicaMutex) Unlock() {
 	(*syncutil.RWMutex)(mu).Unlock()
 }
 
 func (mu *ReplicaMutex) RLock() {
 	(*syncutil.RWMutex)(mu).RLock()
+}
+
+func (mu *ReplicaMutex) TracedRLock(ctx context.Context) {
+	(*syncutil.RWMutex)(mu).TracedRLock(ctx)
 }
 
 func (mu *ReplicaMutex) AssertHeld() {

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -55,8 +55,8 @@ func (r *Replica) quiesceLocked(ctx context.Context, lagging laggingReplicaSet) 
 // maybeUnquiesce unquiesces the replica if it is quiesced and can be
 // unquiesced, returning true in that case. See maybeUnquiesceLocked() for
 // details.
-func (r *Replica) maybeUnquiesce(wakeLeader, mayCampaign bool) bool {
-	r.mu.Lock()
+func (r *Replica) maybeUnquiesce(ctx context.Context, wakeLeader, mayCampaign bool) bool {
+	r.mu.TracedLock(ctx)
 	defer r.mu.Unlock()
 	return r.maybeUnquiesceLocked(wakeLeader, mayCampaign)
 }

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -146,7 +146,7 @@ func (r *Replica) SendWithWriteBytes(
 	r.recordBatchRequestLoad(ctx, ba)
 
 	// If the internal Raft group is quiesced, wake it and the leader.
-	r.maybeUnquiesce(true /* wakeLeader */, true /* mayCampaign */)
+	r.maybeUnquiesce(ctx, true /* wakeLeader */, true /* mayCampaign */)
 
 	isReadOnly := ba.IsReadOnly()
 	if err := r.checkBatchRequest(ba, isReadOnly); err != nil {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2170,7 +2170,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		// known lease instead of relying on shouldUseExpirationLeaseRLocked(). We
 		// also check Sequence > 0 to omit ranges that haven't seen a lease yet.
 		if l, _ := rep.GetLease(); l.Type() == roachpb.LeaseExpiration && l.Sequence > 0 {
-			rep.maybeUnquiesce(true /* wakeLeader */, true /* mayCampaign */)
+			rep.maybeUnquiesce(ctx, true /* wakeLeader */, true /* mayCampaign */)
 		}
 	}
 

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -740,6 +740,7 @@ func (s *Store) processTick(_ context.Context, rangeID roachpb.RangeID) bool {
 // down. Those instances should be rare, however, and we expect the newly live
 // node to eventually unquiesce the range.
 func (s *Store) nodeIsLiveCallback(l livenesspb.Liveness) {
+	ctx := context.TODO()
 	s.updateLivenessMap()
 
 	s.mu.replicasByRangeID.Range(func(r *Replica) {
@@ -748,7 +749,7 @@ func (s *Store) nodeIsLiveCallback(l livenesspb.Liveness) {
 		lagging := r.mu.laggingFollowersOnQuiesce
 		r.mu.RUnlock()
 		if quiescent && lagging.MemberStale(l) {
-			r.maybeUnquiesce(false /* wakeLeader */, false /* mayCampaign */) // already leader
+			r.maybeUnquiesce(ctx, false /* wakeLeader */, false /* mayCampaign */) // already leader
 		}
 	})
 }

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -882,6 +882,7 @@ func TestLint(t *testing.T) {
 			"*.go",
 			":!acceptance/compose/gss/psql/gss_test.go",
 			":!**/embedded.go",
+			":!util/syncutil/mutex_tracing.go",
 			":!util/timeutil/time.go",
 			":!util/timeutil/zoneinfo.go",
 			":!cmd/roachtest/tests/gorm_helpers.go",
@@ -2473,6 +2474,7 @@ func TestLint(t *testing.T) {
 			// instead of ...interface{}.
 			stream.GrepNot(`pkg/util/log/channels\.go:\d+:\d+: logfDepth\(\): format argument is not a constant expression`),
 			stream.GrepNot(`pkg/util/log/channels\.go:\d+:\d+: logfDepthInternal\(\): format argument is not a constant expression`),
+			stream.GrepNot(`pkg/util/log/channels\.go:\d+:\d+: untypedVEventfDepth\(\): format argument is not a constant expression`),
 			// roachprod/logger is not collecting redactable logs so we don't care
 			// about printf hygiene there as much.
 			stream.GrepNot(`pkg/roachprod/logger/log\.go:.*format argument is not a constant expression`),

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -70,6 +70,7 @@ var requireConstFmt = map[string]bool{
 	"github.com/cockroachdb/cockroach/pkg/util/log.shoutfDepth":            true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.logfDepthInternal":      true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.makeStartLine":          true,
+	"github.com/cockroachdb/cockroach/pkg/util/log.untypedVEventfDepth":    true,
 
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash.ReportOrPanic": true,
 

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -829,3 +829,24 @@ func BenchmarkEventf_WithVerboseTraceSpan(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkExpensiveLogEnabled measures the overhead of checking whether
+// expensive logging is enabled.
+//
+// Results with go1.21.4 on a Mac with an Apple M1 Pro processor:
+//
+// name                    time/op
+// ExpensiveLogEnabled-10  13.5ns ± 1%
+func BenchmarkExpensiveLogEnabled(b *testing.B) {
+	ctx := context.Background()
+	// Add a few values to the context, to make sure ctx.Value is not
+	// unrealistically cheap.
+	for i := 0; i < 10; i++ {
+		type key int // avoid lint warning
+		ctx = context.WithValue(ctx, key(i), i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ExpensiveLogEnabled(ctx, 2)
+	}
+}

--- a/pkg/util/syncutil/BUILD.bazel
+++ b/pkg/util/syncutil/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "mutex_deadlock.go",  # keep
         "mutex_sync.go",  # keep
         "mutex_sync_race.go",  # keep
+        "mutex_tracing.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/syncutil",
     visibility = ["//visibility:public"],
@@ -25,6 +26,7 @@ go_test(
         "int_map_reference_test.go",
         "int_map_test.go",
         "mutex_sync_race_test.go",  # keep
+        "mutex_tracing_test.go",
     ],
     embed = [":syncutil"],
     deps = ["@com_github_stretchr_testify//require"],

--- a/pkg/util/syncutil/mutex_tracing.go
+++ b/pkg/util/syncutil/mutex_tracing.go
@@ -1,0 +1,101 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package syncutil
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// TracedLock is like Lock, but logs a trace event using the provided context if
+// the lock acquisition is slow.
+func (m *Mutex) TracedLock(ctx context.Context) { tracedLock(ctx, m) }
+
+// TracedLock is like Lock, but logs a trace event using the provided context if
+// the lock acquisition is slow.
+func (rw *RWMutex) TracedLock(ctx context.Context) { tracedLock(ctx, rw) }
+
+// TracedRLock is like RLock, but logs a trace event using the provided context
+// if the lock acquisition is slow.
+func (rw *RWMutex) TracedRLock(ctx context.Context) { tracedLock(ctx, rw.rTryLocker()) }
+
+// rTryLocker returns a tryLocker interface that implements the Lock, Unlock,
+// and TryLock methods by calling rw.RLock, rw.RUnlock, and rw.TryRLock,
+// respectively.
+func (rw *RWMutex) rTryLocker() tryLocker { return (*rTryLocker)(rw) }
+
+type rTryLocker RWMutex
+
+func (r *rTryLocker) Lock()         { (*RWMutex)(r).RLock() }
+func (r *rTryLocker) Unlock()       { (*RWMutex)(r).RUnlock() }
+func (r *rTryLocker) TryLock() bool { return (*RWMutex)(r).TryRLock() }
+
+// tryLocker extends the sync.Locker interface with a TryLock method.
+type tryLocker interface {
+	sync.Locker
+	TryLock() bool
+}
+
+// tracedLock is like l.Lock, but logs a trace event using the provided context
+// if the lock acquisition is slow.
+//
+// Explanation of logic:
+//
+// The function begins with a fast-path call to TryLock. Most mutexes are
+// uncontended and TryLock amounts to a single atomic CAS. If the CAS succeeds,
+// no additional work is needed. If the CAS fails, we move on to the slow-path.
+//
+// On the slow path, we first check if expensive logging is enabled. If not, we
+// simply call Lock without checking the time. We only time the acquisition if
+// expensive logging is enabled. If we do time the acquisition and it is slow,
+// we log a warning message to the logs/trace.
+//
+// It could be a reasonable choice to switch the order of the TryLock and
+// ExpensiveLogEnabled checks. However, we expect that most mutex acquisitions
+// will be uncontended and the TryLock check is cheaper than the expensive log
+// check.
+func tracedLock(ctx context.Context, l tryLocker) {
+	if enableTracedLockFastPath && l.TryLock() {
+		return // fast-path
+	}
+	const vLevel = 3
+	if !LogExpensiveLogEnabled(ctx, vLevel) {
+		l.Lock()
+		return
+	}
+	start := time.Now()
+	l.Lock()
+	if dur := time.Since(start); dur >= slowLockLogThreshold {
+		LogVEventfDepth(ctx, 2 /* depth */, vLevel, "slow mutex acquisition took %s", dur)
+	}
+}
+
+// enableTracedLockFastPath is used in tests to disable the fast-path of
+// tracedLock.
+var enableTracedLockFastPath = true
+
+// slowLockLogThreshold is the threshold at which a mutex acquisition is
+// considered slow enough to log. It is a variable and not constant so that it
+// can be changed in tests.
+var slowLockLogThreshold = 500 * time.Microsecond
+
+// LogExpensiveLogEnabled is injected from pkg/util/log to avoid an import
+// cycle. This also allows it to be mocked out in tests.
+//
+// See log.ExpensiveLogEnabled for more details.
+var LogExpensiveLogEnabled = func(ctx context.Context, level int32) bool { return false }
+
+// LogVEventfDepth is injected from pkg/util/log to avoid an import
+// cycle. This also allows it to be mocked out in tests.
+//
+// See log.LogVEventfDepth for more details.
+var LogVEventfDepth = func(ctx context.Context, depth int, level int32, format string, args ...interface{}) {}

--- a/pkg/util/syncutil/mutex_tracing_test.go
+++ b/pkg/util/syncutil/mutex_tracing_test.go
@@ -1,0 +1,182 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package syncutil
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// tracedLocker is a variant of sync.Locker that implements TracedLock instead
+// of Lock.
+type tracedLocker interface {
+	TracedLock(context.Context)
+	Unlock()
+}
+
+type rTracedLocker RWMutex
+
+func (r *rTracedLocker) TracedLock(ctx context.Context) { (*RWMutex)(r).TracedRLock(ctx) }
+func (r *rTracedLocker) Unlock()                        { (*RWMutex)(r).RUnlock() }
+
+func TestTracedLock(t *testing.T) {
+	ctx := context.Background()
+
+	// Assume that ExpensiveLogEnabled(ctx, vLevel) is true.
+	defer setExpensiveLogEnabled(true)()
+
+	// Consider any locking duration to be sufficient to log, as long as the
+	// acquisition does not hit the TryLock fast-path. This avoids a timing
+	// dependency.
+	defer setSlowLockLogThreshold(0 * time.Microsecond)()
+
+	// Each test case intercepts the log details and check that they are as
+	// expected. In particular, this checks the log level and the log message.
+	interceptLogLogVEventfDepth := func(t *testing.T) (*bool, func()) {
+		logged := false
+		cleanup := setLogVEventfDepth(func(_ context.Context, depth int, level int32, format string, args ...interface{}) {
+			// Verify that depth is correct so that the log message is
+			// attributed to the caller of TracedLock.
+			require.Equal(t, 2, depth)
+			// NOTE: +1 for the call to runtime.Caller.
+			_, file, _, ok := runtime.Caller(depth + 1)
+			require.True(t, ok)
+			require.Equal(t, "mutex_tracing_test.go", filepath.Base(file))
+			// Verify the log verbosity level.
+			require.Equal(t, int32(3), level)
+			// Verify the log message.
+			logText := fmt.Sprintf(format, args...)
+			require.Regexp(t, `slow mutex acquisition took .*`, logText)
+			logged = true
+		})
+		return &logged, cleanup
+	}
+
+	testCases := []struct {
+		name string
+		mu   tracedLocker
+	}{
+		{"Mutex.TracedLock", &Mutex{}},
+		{"RWMutex.TracedLock", &RWMutex{}},
+		{"RWMutex.TracedRLock", (*rTracedLocker)(&RWMutex{})},
+	}
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			for _, fastPath := range []bool{false, true} {
+				if fastPath && DeadlockEnabled {
+					// TryLock is a no-op for deadlock mutexes.
+					continue
+				}
+				t.Run(fmt.Sprintf("fast-path=%t", fastPath), func(t *testing.T) {
+					defer setEnableTracedLockFastPath(fastPath)()
+
+					logged, cleanup := interceptLogLogVEventfDepth(t)
+					defer cleanup()
+
+					// NOTE: defer the Unlock to unlock even if the test fails.
+					defer c.mu.Unlock()
+
+					c.mu.TracedLock(ctx)
+					require.Equal(t, !fastPath, *logged)
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkTracedLock benchmarks the performance of TracedLock. It includes
+// subtests for uncontended and contended cases, which dictate whether the
+// function's fast-path is hit. It also includes further subtests for if tracing
+// is enabled or disabled and for if the lock duration is long enough to warrant
+// logging.
+//
+// Note that when the fast path is disabled, the benchmark is not measuring the
+// cost of the TryLock call.
+//
+// Note also that even on the slow path when tracing is enabled, the calls to
+// log.ExpensiveLogEnabled and log.VEventfDepth are still mocked out, so this
+// does not measure the full cost of tracing.
+//
+// Results with go1.21.4 on a Mac with an Apple M1 Pro processor:
+//
+// name                                          time/op
+// TracedLock/uncontended-10                     3.82ns ± 7%
+// TracedLock/contended/tracing_disabled-10      4.10ns ± 0%
+// TracedLock/contended/tracing_enabled/fast-10  71.0ns ± 0%
+// TracedLock/contended/tracing_enabled/slow-10   453ns ± 1%
+func BenchmarkTracedLock(b *testing.B) {
+	ctx := context.Background()
+	run := func(b *testing.B) {
+		mus := make([]Mutex, b.N)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			mus[i].TracedLock(ctx)
+		}
+	}
+
+	b.Run("uncontended", func(b *testing.B) {
+		defer setEnableTracedLockFastPath(true)()
+		run(b)
+	})
+
+	b.Run("contended", func(b *testing.B) {
+		defer setEnableTracedLockFastPath(false)()
+
+		b.Run("tracing disabled", func(b *testing.B) {
+			defer setExpensiveLogEnabled(false)()
+			run(b)
+		})
+
+		b.Run("tracing enabled", func(b *testing.B) {
+			defer setExpensiveLogEnabled(true)()
+
+			b.Run("fast", func(b *testing.B) {
+				defer setSlowLockLogThreshold(10 * time.Minute)()
+				run(b)
+			})
+
+			b.Run("slow", func(b *testing.B) {
+				defer setSlowLockLogThreshold(0 * time.Microsecond)()
+				run(b)
+			})
+		})
+	})
+}
+
+func setEnableTracedLockFastPath(b bool) func() {
+	return setGlobal(&enableTracedLockFastPath, b)
+}
+
+func setSlowLockLogThreshold(dur time.Duration) func() {
+	return setGlobal(&slowLockLogThreshold, dur)
+}
+
+func setExpensiveLogEnabled(b bool) func() {
+	return setGlobal(&LogExpensiveLogEnabled, func(ctx context.Context, level int32) bool { return b })
+}
+
+func setLogVEventfDepth(
+	f func(ctx context.Context, depth int, level int32, format string, args ...interface{}),
+) func() {
+	return setGlobal(&LogVEventfDepth, f)
+}
+
+func setGlobal[T any](g *T, v T) (cleanup func()) {
+	old := *g
+	*g = v
+	return func() { *g = old }
+}


### PR DESCRIPTION
Fixes #115506.
Informs #99473.

The first commit adds a new `TracedLock` (and `TracedRLock`) method to the `Mutex` (and `RWMutex`) type. This method behaves like `Lock`, but it also logs a trace event using the provided context if the lock acquisition is slow (> 250μs).

Slow lock acquisitions that use `TracedLock` will now be surfaced in traces. We can use this to track down slow lock acquisitions on the hot path of request handling. These slow lock acquisitions can often be the source of tail latency, and until now, their effect was entirely opaque when looking at traces.

The second commit adds a new `TimedLock` (and `TimedRLock`) method to the `Mutex` (and `RWMutex`) type. This method behaves like `Lock`, but it also returns the time it took to acquire the lock.

Release note: None