### PR TITLE
changefeedccl: redact user-sensitive info from SHOW JOBS output

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -107,7 +107,13 @@ func init() {
 	jobspb.ChangefeedDetailsMarshaler = func(m *jobspb.ChangefeedDetails, marshaller *jsonpb.Marshaler) ([]byte, error) {
 		if protoreflect.ShouldRedact(marshaller) {
 			var err error
-			m.SinkURI, err = cloud.SanitizeExternalStorageURI(m.SinkURI, nil)
+			// Redacts user sensitive information from sinkURI.
+			m.SinkURI, err = cloud.SanitizeExternalStorageURI(m.SinkURI, []string{
+				changefeedbase.SinkParamSASLPassword,
+				changefeedbase.SinkParamCACert,
+				changefeedbase.SinkParamClientCert,
+				changefeedbase.SinkParamConfluentAPISecret,
+			})
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -978,10 +978,12 @@ func changefeedJobDescription(
 	sinkURI string,
 	opts changefeedbase.StatementOptions,
 ) (string, error) {
+	// Redacts user sensitive information from job description.
 	cleanedSinkURI, err := cloud.SanitizeExternalStorageURI(sinkURI, []string{
 		changefeedbase.SinkParamSASLPassword,
 		changefeedbase.SinkParamCACert,
 		changefeedbase.SinkParamClientCert,
+		changefeedbase.SinkParamConfluentAPISecret,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Previously, `SHOW CHANGEFEED JOB` revealed sensitive user data like `api_secret`
for confluent cloud sinks. This patch now redacts `api_secret`, `sasl_password`,
`client_cert`, and `ca_cert` in the job description and sinkURI output column.

Fixes: https://github.com/cockroachdb/cockroach/issues/113503

Release note (enterprise change): SHOW CHANGEFEED JOB,  SHOW CHANGEFEED JOBS,
and SHOW JOBS no longer expose user sensitive infromation(`api_secret`,
`sasl_password`, `client_cert`, and `ca_cert`) in the job description and
sinkURI output column would reveal sensitive user information (api_secret,
sasl_password, client_cert, ca_cert).
