### PR TITLE
roachtest: allocate new cluster when c.Extend fails

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -573,14 +573,18 @@ func (r *testRunner) runWorker(
 			// Try to reuse cluster.
 			testToRun = work.selectTestForCluster(ctx, c.spec, r.cr)
 			if !testToRun.noWork {
+				var err error
 				// We found a test to run on this cluster. Wipe the cluster.
-				if err := c.WipeForReuse(ctx, l, testToRun.spec.Cluster); err != nil {
+				if err = c.WipeForReuse(ctx, l, testToRun.spec.Cluster); err == nil {
+					// Extend the lifetime of the cluster if needed.
+					err = c.MaybeExtendCluster(ctx, l, testToRun.spec)
+				}
+				// We do not count reuse attempt error toward clusterCreateErr. If
+				// either the Wipe or Extend failed, then destroy the cluster and attempt
+				// to create a fresh cluster for the selected test.
+				if err != nil {
 					shout(ctx, l, stdout, "Unable to reuse cluster: %s due to: %s. Will attempt to create a fresh one",
 						c.Name(), err)
-					// We do not count reuse attempt error toward clusterCreateErr. Let's
-					// destroy the cluster and attempt to create a fresh cluster for the
-					// selected test.
-					//
 					// We don't release the quota allocation - the new cluster will be
 					// identical.
 					testToRun.canReuseCluster = false
@@ -1077,23 +1081,6 @@ func (r *testRunner) runTest(
 
 	t.start = timeutil.Now()
 
-	timeout := 3 * time.Hour
-	if d := s.Timeout; d != 0 {
-		timeout = d
-	}
-	// Make sure the cluster has enough life left for the test plus enough headroom
-	// after the test finishes so that the next test can be selected. If it
-	// doesn't, extend it.
-	minExp := timeutil.Now().Add(timeout + time.Hour)
-	if c.expiration.Before(minExp) {
-		extend := minExp.Sub(c.expiration)
-		l.PrintfCtx(ctx, "cluster needs to survive until %s, but has expiration: %s. Extending.",
-			minExp, c.expiration)
-		if err := c.Extend(ctx, extend, l); err != nil {
-			return errors.Wrapf(err, "failed to extend cluster: %s", c.name)
-		}
-	}
-
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	t.mu.Lock()
@@ -1124,6 +1111,7 @@ func (r *testRunner) runTest(
 	}()
 
 	var timedOut bool
+	timeout := testTimeout(t.spec)
 
 	if grafanaAvailable {
 		// Shout this to the log and stdout to make it available to anyone watching the test via CI or locally.
@@ -1708,4 +1696,14 @@ func zipArtifacts(t *testImpl) error {
 		return err
 	}
 	return moveToZipArchive("artifacts.zip", t.ArtifactsDir(), list...)
+}
+
+// testTimeout returns the timeout of a test. The default is set
+// to 3 hours but tests may specify their own timeouts.
+func testTimeout(spec *registry.TestSpec) time.Duration {
+	timeout := 3 * time.Hour
+	if d := spec.Timeout; d != 0 {
+		timeout = d
+	}
+	return timeout
 }


### PR DESCRIPTION
Previously, failure to extend the lifetime of a cluster would propagate to the worker and end up aborting the entire run. Now, we destroy the cluster and let it allocate a new one.

Fixes: #112509
Release note: none
Epic: none