### PR TITLE
engineccl: Reimplement FileCipherStreamV2

### DIFF
--- a/pkg/ccl/storageccl/engineccl/ctr_stream.go
+++ b/pkg/ccl/storageccl/engineccl/ctr_stream.go
@@ -16,9 +16,11 @@ import (
 	"crypto/subtle"
 	"encoding/binary"
 	"fmt"
+	"math/bits"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 // FileCipherStreamCreator wraps the KeyManager interface and provides functions to create a
@@ -30,8 +32,10 @@ type FileCipherStreamCreator struct {
 }
 
 const (
-	// The difference is 4 bytes, which are supplied by the counter.
 	ctrBlockSize = 16
+	// DEPRECATED: The V1 implementation had a distinction between a 12-byte
+	// "nonce" and a 4-byte "counter". This was incorrect and we now treat the
+	// IV/nonce as a single 128-bit value.
 	ctrNonceSize = 12
 )
 
@@ -194,4 +198,76 @@ func (s *cTRBlockCipherStream) transform(blockIndex uint64, data []byte, scratch
 	iv = iv[0 : len(iv)+4]
 	s.cBlock.Encrypt(iv, iv)
 	subtle.XORBytes(data, data, iv)
+}
+
+type fileCipherStreamV2 struct {
+	aesBlock cipher.Block
+	// High and low portions of the 128-bit IV (big-endian).
+	ivHi, ivLo uint64
+	mu         struct {
+		syncutil.Mutex
+		// If ctr is non-nil, it is ready to use at fileOffset. This is
+		// effectively a single-entry cache; it would be reasonable to change it
+		// to a map from fileOffset to CTR objects to track multiple sequential
+		// "cursors".
+		fileOffset int64
+		ctr        cipher.Stream
+	}
+}
+
+func newFileCipherStreamV2(key, iv []byte) (*fileCipherStreamV2, error) {
+	aesBlock, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return &fileCipherStreamV2{
+		aesBlock: aesBlock,
+		ivHi:     binary.BigEndian.Uint64(iv[:8]),
+		ivLo:     binary.BigEndian.Uint64(iv[8:]),
+	}, nil
+}
+
+func (s *fileCipherStreamV2) Encrypt(fileOffset int64, data []byte) {
+	var ctr cipher.Stream
+	func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.mu.fileOffset == fileOffset {
+			ctr = s.mu.ctr
+			s.mu.ctr = nil
+		}
+	}()
+	if ctr == nil {
+		// We need to create a new CTR object seeked to the correct position.
+		// This means we reimplement some of the IV math that appears inside the
+		// CTR implementation.
+		blockIndex := uint64(fileOffset / int64(ctrBlockSize))
+		blockOffset := int(fileOffset % int64(ctrBlockSize))
+		// Add the block index to the 128-bit IV. Overflow in the "hi" portion
+		// just wraps around so we can use plain uint64 addition instead of
+		// bits.Add64.
+		blockIVLo, carry := bits.Add64(s.ivLo, blockIndex, 0)
+		blockIVHi := s.ivHi + carry
+		var iv [ctrBlockSize]byte
+		binary.BigEndian.PutUint64(iv[0:8], blockIVHi)
+		binary.BigEndian.PutUint64(iv[8:], blockIVLo)
+		ctr = cipher.NewCTR(s.aesBlock, iv[:])
+		if blockOffset != 0 {
+			// If our read was not block-aligned, consume and discard the partial block.
+			var scratch [ctrBlockSize]byte
+			ctr.XORKeyStream(scratch[0:blockOffset], scratch[0:blockOffset])
+		}
+	}
+	ctr.XORKeyStream(data, data)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Save our CTR object for reuse in case the next operation follows directly
+	// after this one.
+	s.mu.ctr = ctr
+	s.mu.fileOffset = fileOffset + int64(len(data))
+}
+
+func (s *fileCipherStreamV2) Decrypt(fileOffset int64, data []byte) {
+	// For CTR mode, encryption and decryption are the same.
+	s.Encrypt(fileOffset, data)
 }

--- a/pkg/ccl/storageccl/engineccl/ctr_stream_test.go
+++ b/pkg/ccl/storageccl/engineccl/ctr_stream_test.go
@@ -70,7 +70,7 @@ func writeHex(b []byte) string {
 }
 
 func encryptManySubBlocks(
-	t *testing.T, fcs *fileCipherStream, baseOffset int64, plaintext, ciphertext []byte,
+	t *testing.T, fcs FileStream, baseOffset int64, plaintext, ciphertext []byte,
 ) {
 	// Split the text into many different left/right pairs, encrypt each one
 	// separately, and make sure it matches the corresponding ciphertext.
@@ -98,93 +98,105 @@ func encryptManySubBlocks(
 // ./dev test-binaries --cross=crosslinuxfips pkg/ccl/storageccl/engineccl && mkdir -p fipsbin && tar xf bin/test_binaries.tar.gz -C fipsbin && docker run -v $PWD/fipsbin:/fipsbin -it redhat/ubi9 bash -c 'cd /fipsbin/pkg/ccl/storageccl/engineccl/bin && ./run.sh -test.run CTRStreamDataDriven'
 func TestCTRStreamDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	var data []byte
-	keys := map[string]*enginepbccl.SecretKey{}
-	ivs := map[string][]byte{}
-	seenCiphertexts := map[string]struct{}{}
-	datadriven.RunTest(t, datapathutils.TestDataPath(t, "ctr_stream"),
-		func(t *testing.T, d *datadriven.TestData) string {
-			fmt.Println(d.Pos)
+	for _, impl := range []string{"v1", "v2"} {
+		var data []byte
+		keys := map[string]*enginepbccl.SecretKey{}
+		ivs := map[string][]byte{}
+		seenCiphertexts := map[string]struct{}{}
+		t.Run(impl, func(t *testing.T) {
+			datadriven.RunTest(t, datapathutils.TestDataPath(t, "ctr_stream"),
+				func(t *testing.T, d *datadriven.TestData) string {
+					fmt.Println(d.Pos)
 
-			switch d.Cmd {
-			case "set-data":
-				var err error
-				data, err = readHex(d.Input)
-				require.NoError(t, err)
-				return "ok"
+					switch d.Cmd {
+					case "set-data":
+						var err error
+						data, err = readHex(d.Input)
+						require.NoError(t, err)
+						return "ok"
 
-			case "create-key":
-				var name string
-				d.ScanArgs(t, "name", &name)
-				decoded, err := readHex(d.Input)
-				require.NoError(t, err)
-				key := &enginepbccl.SecretKey{
-					Info: &enginepbccl.KeyInfo{},
-					Key:  decoded,
-				}
-				switch len(decoded) {
-				case 16:
-					key.Info.EncryptionType = enginepbccl.EncryptionType_AES128_CTR
-				case 24:
-					key.Info.EncryptionType = enginepbccl.EncryptionType_AES192_CTR
-				case 32:
-					key.Info.EncryptionType = enginepbccl.EncryptionType_AES256_CTR
-				default:
-					return fmt.Sprintf("invalid key size %d", len(decoded))
-				}
-				keys[name] = key
-				return "ok"
+					case "create-key":
+						var name string
+						d.ScanArgs(t, "name", &name)
+						decoded, err := readHex(d.Input)
+						require.NoError(t, err)
+						key := &enginepbccl.SecretKey{
+							Info: &enginepbccl.KeyInfo{},
+							Key:  decoded,
+						}
+						switch len(decoded) {
+						case 16:
+							key.Info.EncryptionType = enginepbccl.EncryptionType_AES128_CTR
+						case 24:
+							key.Info.EncryptionType = enginepbccl.EncryptionType_AES192_CTR
+						case 32:
+							key.Info.EncryptionType = enginepbccl.EncryptionType_AES256_CTR
+						default:
+							return fmt.Sprintf("invalid key size %d", len(decoded))
+						}
+						keys[name] = key
+						return "ok"
 
-			case "create-iv":
-				var name string
-				d.ScanArgs(t, "name", &name)
-				decoded, err := readHex(d.Input)
-				require.NoError(t, err)
-				if len(decoded) != 16 {
-					return "iv must be 16 bytes"
-				}
-				ivs[name] = decoded
-				return "ok"
+					case "create-iv":
+						var name string
+						d.ScanArgs(t, "name", &name)
+						decoded, err := readHex(d.Input)
+						require.NoError(t, err)
+						if len(decoded) != 16 {
+							return "iv must be 16 bytes"
+						}
+						ivs[name] = decoded
+						return "ok"
 
-			case "encrypt":
-				var offset int64
-				d.ScanArgs(t, "offset", &offset)
-				keyName := "default"
-				d.MaybeScanArgs(t, "key", &keyName)
-				ivName := "default"
-				d.MaybeScanArgs(t, "iv", &ivName)
-				expectDuplicate := false
-				d.MaybeScanArgs(t, "expect_duplicate", &expectDuplicate)
-				iv := ivs[ivName]
-				bcs, err := newCTRBlockCipherStream(keys[keyName], iv[:12], binary.BigEndian.Uint32(iv[12:16]))
-				require.NoError(t, err)
-				fcs := &fileCipherStream{bcs: bcs}
-				// Encrypt() mutates its argument so make a copy of data.
-				output := append([]byte{}, data...)
-				fcs.Encrypt(offset, output)
-				reencrypted := append([]byte{}, output...)
-				fcs.Decrypt(offset, reencrypted)
-				if !bytes.Equal(data, reencrypted) {
-					t.Fatalf("decrypted data didn't match input")
-				}
+					case "encrypt":
+						var offset int64
+						d.ScanArgs(t, "offset", &offset)
+						keyName := "default"
+						d.MaybeScanArgs(t, "key", &keyName)
+						ivName := "default"
+						d.MaybeScanArgs(t, "iv", &ivName)
+						skipV1 := false
+						d.MaybeScanArgs(t, "skip-v1", &skipV1)
+						iv := ivs[ivName]
+						var fcs FileStream
+						if impl == "v1" {
+							bcs, err := newCTRBlockCipherStream(keys[keyName], iv[:12], binary.BigEndian.Uint32(iv[12:16]))
+							require.NoError(t, err)
+							fcs = &fileCipherStream{bcs: bcs}
+						} else {
+							var err error
+							fcs, err = newFileCipherStreamV2(keys[keyName].Key, iv)
+							require.NoError(t, err)
+						}
+						// Encrypt() mutates its argument so make a copy of data.
+						output := append([]byte{}, data...)
+						fcs.Encrypt(offset, output)
+						reencrypted := append([]byte{}, output...)
+						fcs.Decrypt(offset, reencrypted)
+						if !bytes.Equal(data, reencrypted) {
+							t.Fatalf("decrypted data didn't match input")
+						}
 
-				outputString := string(output)
-				_, isDuplicate := seenCiphertexts[outputString]
-				if isDuplicate && !expectDuplicate {
-					// Assume that each test is using different parameters; if we see the same
-					// ciphertext twice something's gone wrong.
-					t.Fatalf("same ciphertext produced more than once")
-				} else if expectDuplicate && !isDuplicate {
-					t.Fatalf("expected duplicate of prior ciphertext")
-				}
-				seenCiphertexts[outputString] = struct{}{}
-				encryptManySubBlocks(t, fcs, offset, data, output)
-				return writeHex(output)
+						outputString := string(output)
+						if skipV1 && impl == "v1" {
+							return d.Expected
+						}
+						_, isDuplicate := seenCiphertexts[outputString]
+						if isDuplicate {
+							// Assume that each test is using different parameters; if we see the same
+							// ciphertext twice something's gone wrong.
+							t.Fatalf("same ciphertext produced more than once")
+						}
+						seenCiphertexts[outputString] = struct{}{}
+						encryptManySubBlocks(t, fcs, offset, data, output)
+						return writeHex(output)
 
-			default:
-				return fmt.Sprintf("unknown command: %s\n", d.Cmd)
-			}
+					default:
+						return fmt.Sprintf("unknown command: %s\n", d.Cmd)
+					}
+				})
 		})
+	}
 }
 
 func TestFileCipherStream(t *testing.T) {
@@ -323,61 +335,85 @@ func TestFileCipherStreamCreator(t *testing.T) {
 // ./dev test-binaries --cross=crosslinuxfips pkg/ccl/storageccl/engineccl && mkdir -p fipsbin && tar xf bin/test_binaries.tar.gz -C fipsbin && docker run -v $PWD/fipsbin:/fipsbin -it redhat/ubi9 /fipsbin/pkg/ccl/storageccl/engineccl/bin/engineccl_test -test.run '^$' -test.bench FileCipherStream
 func BenchmarkFileCipherStream(b *testing.B) {
 	isFips := fipsccl.IsFIPSReady()
-	for _, keySize := range []int{128, 192, 256} {
-		for _, blockSize := range []int{16, 1024, 10240} {
-			b.Run(fmt.Sprintf("fips=%t/key=%d/block=%d/", isFips, keySize, blockSize), func(b *testing.B) {
-				keyBytes := make([]byte, keySize/8)
-				if _, err := rand.Read(keyBytes); err != nil {
-					panic(err)
-				}
-				var encType enginepbccl.EncryptionType
-				switch keySize {
-				case 128:
-					encType = enginepbccl.EncryptionType_AES128_CTR
-				case 192:
-					encType = enginepbccl.EncryptionType_AES192_CTR
-				case 256:
-					encType = enginepbccl.EncryptionType_AES256_CTR
-				default:
-					panic("unknown key size")
-				}
-				key := &enginepbccl.SecretKey{
-					Info: &enginepbccl.KeyInfo{
-						EncryptionType: encType,
-					},
-					Key: keyBytes,
-				}
-				nonce := make([]byte, ctrNonceSize)
-				if _, err := rand.Read(nonce); err != nil {
-					panic(err)
-				}
-				initCounterBytes := make([]byte, 4)
-				if _, err := rand.Read(initCounterBytes); err != nil {
-					panic(err)
-				}
-				// Endianness doesn't matter for converting this random number to an int.
-				initCounter := binary.LittleEndian.Uint32(initCounterBytes)
-				blockStream, err := newCTRBlockCipherStream(key, nonce, initCounter)
-				if err != nil {
-					panic(err)
-				}
+	for _, impl := range []string{"v1", "v2"} {
+		for _, seq := range []bool{false, true} {
+			for _, keySize := range []int{128, 192, 256} {
+				for _, blockSize := range []int{16, 256, 1024, 16 * 1024} {
+					b.Run(fmt.Sprintf("fips=%t/impl=%s/seq=%t/key=%d/block=%d/", isFips, impl, seq, keySize, blockSize), func(b *testing.B) {
+						keyBytes := make([]byte, keySize/8)
+						if _, err := rand.Read(keyBytes); err != nil {
+							panic(err)
+						}
+						var encType enginepbccl.EncryptionType
+						switch keySize {
+						case 128:
+							encType = enginepbccl.EncryptionType_AES128_CTR
+						case 192:
+							encType = enginepbccl.EncryptionType_AES192_CTR
+						case 256:
+							encType = enginepbccl.EncryptionType_AES256_CTR
+						default:
+							panic("unknown key size")
+						}
+						key := &enginepbccl.SecretKey{
+							Info: &enginepbccl.KeyInfo{
+								EncryptionType: encType,
+							},
+							Key: keyBytes,
+						}
+						nonce := make([]byte, ctrNonceSize)
+						if _, err := rand.Read(nonce); err != nil {
+							panic(err)
+						}
+						initCounterBytes := make([]byte, 4)
+						if _, err := rand.Read(initCounterBytes); err != nil {
+							panic(err)
+						}
+						var stream FileStream
+						if impl == "v1" {
+							// Endianness doesn't matter for converting this random number to an int.
+							initCounter := binary.LittleEndian.Uint32(initCounterBytes)
+							blockStream, err := newCTRBlockCipherStream(key, nonce, initCounter)
+							if err != nil {
+								panic(err)
+							}
 
-				stream := fileCipherStream{blockStream}
+							stream = &fileCipherStream{blockStream}
+						} else {
 
-				// Benchmarks are fun! We're just going to encrypt a bunch of zeros
-				// and re-encrypt over the previous output because that doesn't matter
-				// to the speed :)
-				//
-				// TODO(bdarnell): The offset argument to stream.Encrypt *does* matter,
-				// specifically whether the data is aligned to the CTR block size or not.
-				data := make([]byte, blockSize)
-				b.SetBytes(int64(blockSize))
-				b.ResetTimer()
+							fullIv := append([]byte{}, nonce...)
+							fullIv = append(fullIv, initCounterBytes...)
+							var err error
+							stream, err = newFileCipherStreamV2(key.Key, fullIv)
+							require.NoError(b, err)
+						}
 
-				for i := 0; i < b.N; i++ {
-					stream.Encrypt(0, data)
+						// Benchmarks are fun! We're just going to encrypt a bunch of zeros
+						// and re-encrypt over the previous output because that doesn't matter
+						// to the speed :)
+						data := make([]byte, 32*1024)
+						b.SetBytes(int64(len(data)))
+						b.ResetTimer()
+
+						for i := 0; i < b.N; i++ {
+							for j := 0; j < len(data); j += blockSize {
+								var offset int
+								if seq {
+									offset = j
+								} else {
+									offset = len(data) - j
+								}
+								// Add 1 to all offsets so they're not
+								// block-aligned. This gives us more
+								// conservative/pessimistic results compared to
+								// the always-aligned case (makes a bigger
+								// difference for small ops than larger ones).
+								stream.Encrypt(int64(offset+1), data[0:blockSize])
+							}
+						}
+					})
 				}
-			})
+			}
 		}
 	}
 }

--- a/pkg/ccl/storageccl/engineccl/testdata/ctr_stream
+++ b/pkg/ccl/storageccl/engineccl/testdata/ctr_stream
@@ -127,15 +127,14 @@ ba f1 04 5a 3c 96 0e a4 13 aa 61 a2 81 9e aa 0b
 70 0b 5a 9f fe fd 97 da 11 bf ea 5d 53 5e 54 5e
 dd 3b 2d 67 71 8b 10 ac 14 a9 91 29 13 4b 91 1f
 
-# When the 32-bit counter wraps around we see the same data again,
-# but this code is not used for files that can get that large.
-encrypt offset=68719476736 expect_duplicate=true
+# V1 has a bug when the 32-bit counter wraps around.
+encrypt offset=68719476736 skip-v1=true
 ----
-70 54 03 81 d3 f0 e5 f2 ab 28 03 55 f0 53 a3 63
-a8 03 e1 f5 06 48 53 3a 86 81 f8 a6 da 35 80 a3
-4a fb 80 48 39 cf 77 32 17 1e ec 32 cc 22 e9 4a
-3f b7 f9 e4 93 52 89 21 0c bc bc 66 77 3a 23 18
-df 79 ab 4a 7a 29 c7 3d 45 41 dd fc e0 d9 10 e0
-76 22 e8 78 2c 6a cb 3d 62 af 84 3e 3c 9f ee f7
-84 7b 38 01 db fb 98 e5 1d 9b 61 e1 ed ef be 94
-93 3a 79 84 c3 dc 9d 26 be 2f ed 3c 83 68 d4 30
+35 cf c5 43 7e 0b 72 07 d7 c0 c0 fe 97 09 b9 bf
+de 97 8c 3c 9b 9c da f4 bf e8 78 6a 75 cc bd 13
+c2 c8 28 6b 19 ae d5 96 6d aa eb 6f 5c 25 c3 f3
+23 50 60 1f 05 dd 13 d5 3c d4 d0 bc 55 d8 11 6d
+e4 dc aa 44 1f f0 a5 e6 b4 53 a3 5d 72 ca 94 b7
+5e 90 a3 4b 85 5e 77 32 62 0c 63 46 5c 63 23 10
+42 bc 8e 63 df ca b4 d7 b7 05 60 96 3d 08 5e 0d
+0f 0e 97 bf 1f 0c 92 3b 87 62 fc 0b f5 c9 bc e4


### PR DESCRIPTION
First commit is from #115365. #115454 is related and makes v1 look a little better in the benchmarks. 

The new implementation, fileCipherStreamV2, is currently only hooked up
in tests and benchmarks. It's not used in production until we decide on
a feature flagging strategy.

The major change is to defer more to the standard library, and
specifically to pass larger batches to the stdlib at once. Previously we
made a separate call to the crypto library for every 16-byte block; now
we pass the entire buffer at once. The downside is random access is more
expensive. The previous implementation was basically constant-time,
while the new one performs multiple heap allocations for every "seek".

To summarize the performance results below, v2 is significantly slower
than v1 for tiny (16 byte) non-sequential operations. It is about the
same performance for small sequential operations, and substantially
faster for large sequential operations (about twice as fast as the
original version).

The FIPS version is now even faster (for large sequential writes) than
non-FIPS. This is because Go's implementation of CTR mode has not been
as extensively optimized as openssl's. There are open PRs that may
improve this in the future, such as golang/go#53503

```
goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
BenchmarkFileCipherStream/fips=false/impl=v1/key=128/seq=false/block=16/-24                 7521            137392 ns/op         238.50 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=128/seq=false/block=256/-24               15793             75349 ns/op         434.88 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=128/seq=false/block=1024/-24              16778             71159 ns/op         460.49 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=128/seq=false/block=16384/-24             17083             69697 ns/op         470.15 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=128/seq=true/block=16/-24                  7797            137415 ns/op         238.46 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=128/seq=true/block=256/-24                15794             75635 ns/op         433.24 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=128/seq=true/block=1024/-24               16785             71195 ns/op         460.26 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=128/seq=true/block=16384/-24              17169             69813 ns/op         469.37 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=192/seq=false/block=16/-24                 7510            142334 ns/op         230.22 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=192/seq=false/block=256/-24               14797             81525 ns/op         401.94 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=192/seq=false/block=1024/-24              15715             76005 ns/op         431.13 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=192/seq=false/block=16384/-24             15985             74794 ns/op         438.11 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=192/seq=true/block=16/-24                  7558            142334 ns/op         230.22 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=192/seq=true/block=256/-24                14826             80456 ns/op         407.28 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=192/seq=true/block=1024/-24               15757             76231 ns/op         429.85 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=192/seq=true/block=16384/-24              16063             74763 ns/op         438.29 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=256/seq=false/block=16/-24                 7304            146606 ns/op         223.51 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=256/seq=false/block=256/-24               13947             85653 ns/op         382.57 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=256/seq=false/block=1024/-24              14589             81277 ns/op         403.16 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=256/seq=false/block=16384/-24             14989             80079 ns/op         409.19 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=256/seq=true/block=16/-24                  7274            145928 ns/op         224.55 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=256/seq=true/block=256/-24                13935             85680 ns/op         382.45 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=256/seq=true/block=1024/-24               14690             81366 ns/op         402.73 MB/s
BenchmarkFileCipherStream/fips=false/impl=v1/key=256/seq=true/block=16384/-24              15002             80120 ns/op         408.99 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=128/seq=false/block=16/-24                  615           1896677 ns/op          17.28 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=128/seq=false/block=256/-24                9006            119509 ns/op         274.19 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=128/seq=false/block=1024/-24              23329             51281 ns/op         638.99 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=128/seq=false/block=16384/-24             29162             40910 ns/op         800.97 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=128/seq=true/block=16/-24                  8750            132576 ns/op         247.16 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=128/seq=true/block=256/-24                26404             45361 ns/op         722.39 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=128/seq=true/block=1024/-24               28626             41808 ns/op         783.78 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=128/seq=true/block=16384/-24              29336             40935 ns/op         800.48 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=192/seq=false/block=16/-24                  574           2042367 ns/op          16.04 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=192/seq=false/block=256/-24                8706            129528 ns/op         252.98 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=192/seq=false/block=1024/-24              21183             56446 ns/op         580.52 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=192/seq=false/block=16384/-24             26109             45655 ns/op         717.73 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=192/seq=true/block=16/-24                  8504            137355 ns/op         238.56 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=192/seq=true/block=256/-24                23960             50296 ns/op         651.50 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=192/seq=true/block=1024/-24               25696             46679 ns/op         701.99 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=192/seq=true/block=16384/-24              26198             45587 ns/op         718.80 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=256/seq=false/block=16/-24                  531           2206987 ns/op          14.85 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=256/seq=false/block=256/-24                7694            139498 ns/op         234.90 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=256/seq=false/block=1024/-24              19524             61046 ns/op         536.77 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=256/seq=false/block=16384/-24             23745             50562 ns/op         648.07 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=256/seq=true/block=16/-24                  8245            148016 ns/op         221.38 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=256/seq=true/block=256/-24                21739             55280 ns/op         592.76 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=256/seq=true/block=1024/-24               23212             51531 ns/op         635.89 MB/s
BenchmarkFileCipherStream/fips=false/impl=v2/key=256/seq=true/block=16384/-24              23805             50438 ns/op         649.66 MB/s
PASS
goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
BenchmarkFileCipherStream/fips=true/impl=v1/key=128/seq=false/block=16/-24                  2050            569817 ns/op          57.51 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=128/seq=false/block=256/-24                 2499            490116 ns/op          66.86 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=128/seq=false/block=1024/-24                2473            478146 ns/op          68.53 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=128/seq=false/block=16384/-24               2518            477786 ns/op          68.58 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=128/seq=true/block=16/-24                   2067            566694 ns/op          57.82 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=128/seq=true/block=256/-24                  2448            488315 ns/op          67.10 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=128/seq=true/block=1024/-24                 2490            479422 ns/op          68.35 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=128/seq=true/block=16384/-24                2514            481941 ns/op          67.99 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=192/seq=false/block=16/-24                  2008            568220 ns/op          57.67 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=192/seq=false/block=256/-24                 2407            493184 ns/op          66.44 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=192/seq=false/block=1024/-24                2428            480403 ns/op          68.21 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=192/seq=false/block=16384/-24               2421            482593 ns/op          67.90 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=192/seq=true/block=16/-24                   2040            573229 ns/op          57.16 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=192/seq=true/block=256/-24                  2314            496560 ns/op          65.99 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=192/seq=true/block=1024/-24                 2478            476019 ns/op          68.84 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=192/seq=true/block=16384/-24                2449            483360 ns/op          67.79 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=256/seq=false/block=16/-24                  1998            574193 ns/op          57.07 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=256/seq=false/block=256/-24                 2356            488059 ns/op          67.14 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=256/seq=false/block=1024/-24                2454            482139 ns/op          67.96 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=256/seq=false/block=16384/-24               2446            483249 ns/op          67.81 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=256/seq=true/block=16/-24                   2020            565348 ns/op          57.96 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=256/seq=true/block=256/-24                  2388            488736 ns/op          67.05 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=256/seq=true/block=1024/-24                 2418            492126 ns/op          66.58 MB/s
BenchmarkFileCipherStream/fips=true/impl=v1/key=256/seq=true/block=16384/-24                2443            480180 ns/op          68.24 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=128/seq=false/block=16/-24                   259           4733741 ns/op           6.92 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=128/seq=false/block=256/-24                 3481            297358 ns/op         110.20 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=128/seq=false/block=1024/-24               14671             82314 ns/op         398.08 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=128/seq=false/block=16384/-24             135296              9077 ns/op        3609.94 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=128/seq=true/block=16/-24                   2421            452063 ns/op          72.49 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=128/seq=true/block=256/-24                 33729             36362 ns/op         901.15 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=128/seq=true/block=1024/-24                81376             15570 ns/op        2104.61 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=128/seq=true/block=16384/-24              139063              8704 ns/op        3764.70 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=192/seq=false/block=16/-24                   244           5070212 ns/op           6.46 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=192/seq=false/block=256/-24                 3350            313168 ns/op         104.63 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=192/seq=false/block=1024/-24               14427             85797 ns/op         381.93 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=192/seq=false/block=16384/-24             114337             10014 ns/op        3272.32 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=192/seq=true/block=16/-24                   2611            452229 ns/op          72.46 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=192/seq=true/block=256/-24                 32545             37458 ns/op         874.79 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=192/seq=true/block=1024/-24                72807             16660 ns/op        1966.85 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=192/seq=true/block=16384/-24              116131              9992 ns/op        3279.30 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=256/seq=false/block=16/-24                   247           4896561 ns/op           6.69 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=256/seq=false/block=256/-24                 3409            336213 ns/op          97.46 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=256/seq=false/block=1024/-24               13916             86875 ns/op         377.18 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=256/seq=false/block=16384/-24             101763             11161 ns/op        2936.06 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=256/seq=true/block=16/-24                   2326            452598 ns/op          72.40 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=256/seq=true/block=256/-24                 30164             37851 ns/op         865.70 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=256/seq=true/block=1024/-24                68094             17592 ns/op        1862.67 MB/s
BenchmarkFileCipherStream/fips=true/impl=v2/key=256/seq=true/block=16384/-24              104826             11190 ns/op        2928.36 MB/s
```