### PR TITLE
schemafeed: bump size of test

### DIFF
--- a/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
@@ -43,7 +43,7 @@ go_library(
 
 go_test(
     name = "schemafeed_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "helpers_test.go",
         "main_test.go",


### PR DESCRIPTION
This timed out in CI.

https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Ci_TestsGcpLinuxX8664BigVm_CclUnitTests/12973040?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildDeploymentsSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true

Epic: none
Release note: None