### PR TITLE
release-23.2: roachtest: enable more TPCC benchmarks in roachperf

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -452,6 +452,7 @@ func registerTPCC(r registry.Registry) {
 		// running with the max supported warehouses.
 		Name:              "tpcc/headroom/" + headroomSpec.String(),
 		Owner:             registry.OwnerTestEng,
+		Benchmark:         true,
 		CompatibleClouds:  registry.AllClouds,
 		Suites:            registry.Suites(registry.Nightly, registry.ReleaseQualification),
 		Tags:              registry.Tags(`default`, `release_qualification`, `aws`),
@@ -495,6 +496,7 @@ func registerTPCC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:              "tpcc-nowait/nodes=3/w=1",
 		Owner:             registry.OwnerTestEng,
+		Benchmark:         true,
 		Cluster:           r.MakeClusterSpec(4, spec.CPU(16)),
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),
@@ -512,6 +514,7 @@ func registerTPCC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "weekly/tpcc/headroom",
 		Owner:            registry.OwnerTestEng,
+		Benchmark:        true,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Weekly),
 		Tags:             registry.Tags(`weekly`),


### PR DESCRIPTION
Backport 1/1 commits from #115507.

/cc @cockroachdb/release

---

As of [1], roachtest benchmarks must be explicitly specified via `TestSpec.Benchmark`. Otherwise, their performance artifacts are not exported, and hence
unavailable in the roachperf dashboard.

This PR enables roachperf export of several existing TPCC benchmarks, `headroom` and `nowait` (nightly and weekly), including read-committed variants.

[1] https://github.com/cockroachdb/cockroach/pull/104176

Epic: none

Release note: None
Release justification: test-only change
