### PR TITLE
geo: fix st_tileenvelope arg check

### DIFF
--- a/pkg/geo/geomfn/tile_envelope.go
+++ b/pkg/geo/geomfn/tile_envelope.go
@@ -23,6 +23,11 @@ func TileEnvelope(
 	tileZoom int, tileX int, tileY int, bounds geo.Geometry, margin float64,
 ) (geo.Geometry, error) {
 	bbox := bounds.BoundingBoxRef()
+	if bbox == nil {
+		return geo.Geometry{}, pgerror.Newf(
+			pgcode.InvalidParameterValue,
+			"Unable to compute bbox")
+	}
 	srid := bounds.SRID()
 
 	if tileZoom < 0 || tileZoom >= 32 {

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -6290,4 +6290,7 @@ SELECT ST_AsText(ST_TileEnvelope(3, 1, 1, ST_MakeEnvelope(-180, -90, 180, 90, 43
 ----
 POLYGON ((-140.625 42.1875, -140.625 70.3125, -84.375 70.3125, -84.375 42.1875, -140.625 42.1875))
 
+statement error pgcode 22023 pq: st_tileenvelope\(\): Unable to compute bbox
+SELECT st_tileenvelope(0, 0, 0, '010500000000000000');
+
 subtest end


### PR DESCRIPTION
Adds a check that we were able to compute a bbox from the geometry bounds input argument to the st_tileenvelope builtin.

Epic: none
Fixes: #115401

Release note: none