### PR TITLE
stress: re-set GITHUB_API_TOKEN

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_engflow.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow.sh
@@ -6,6 +6,4 @@ export EXTRA_TEST_ARGS="--config use_ci_timeouts"
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 
-unset GITHUB_API_TOKEN
-
 $THIS_DIR/stress_engflow_impl.sh


### PR DESCRIPTION
This change was made accidentally in #114681.

Epic: CRDB-8308
Release note: None