### PR TITLE
kvstreamer: fix cross-range ScanRequests with SingleRowLookup hint

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/requests_provider.go
+++ b/pkg/kv/kvclient/kvstreamer/requests_provider.go
@@ -304,7 +304,7 @@ func (p *outOfOrderRequestsProvider) enqueue(requests []singleRangeBatch) {
 	p.Lock()
 	defer p.Unlock()
 	if len(p.requests) > 0 {
-		panic(errors.AssertionFailedf("outOfOrderRequestsProvider has old requests in enqueue"))
+		panic(errors.AssertionFailedf("outOfOrderRequestsProvider has %d old requests in enqueue", len(p.requests)))
 	}
 	if len(requests) == 0 {
 		panic(errors.AssertionFailedf("outOfOrderRequestsProvider enqueuing zero requests"))
@@ -435,7 +435,7 @@ func (p *inOrderRequestsProvider) enqueue(requests []singleRangeBatch) {
 	p.Lock()
 	defer p.Unlock()
 	if len(p.requests) > 0 {
-		panic(errors.AssertionFailedf("inOrderRequestsProvider has old requests in enqueue"))
+		panic(errors.AssertionFailedf("inOrderRequestsProvider has %d old requests in enqueue", len(p.requests)))
 	}
 	if len(requests) == 0 {
 		panic(errors.AssertionFailedf("inOrderRequestsProvider enqueuing zero requests"))

--- a/pkg/kv/kvclient/kvstreamer/requests_provider.go
+++ b/pkg/kv/kvclient/kvstreamer/requests_provider.go
@@ -74,8 +74,8 @@ type singleRangeBatch struct {
 	// the responses to these single-range requests (which might come back in
 	// any order) correctly.
 	//
-	// subRequestIdx is only allocated in InOrder mode when
-	// Hints.SingleRowLookup is false and some Scan requests were enqueued.
+	// subRequestIdx is only allocated in InOrder mode when some Scan requests
+	// were enqueued.
 	subRequestIdx []int32
 	// isScanStarted tracks whether we have already received at least one
 	// response for the corresponding ScanRequest (i.e. whether the ScanRequest

--- a/pkg/kv/kvclient/kvstreamer/results_buffer.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer.go
@@ -182,7 +182,10 @@ func newResultsBufferBase(budget *budget) *resultsBufferBase {
 func (b *resultsBufferBase) initLocked(isEmpty bool, numExpectedResponses int) error {
 	b.Mutex.AssertHeld()
 	if b.numExpectedResponses != b.numCompleteResponses {
-		b.setErrorLocked(errors.AssertionFailedf("Enqueue is called before the previous requests have been completed"))
+		b.setErrorLocked(errors.AssertionFailedf(
+			"Enqueue is called before the previous requests have been completed (expected %d, complete %d)",
+			b.numExpectedResponses, b.numCompleteResponses,
+		))
 		return b.err
 	}
 	if !isEmpty {
@@ -190,7 +193,7 @@ func (b *resultsBufferBase) initLocked(isEmpty bool, numExpectedResponses int) e
 		return b.err
 	}
 	if b.numUnreleasedResults > 0 {
-		b.setErrorLocked(errors.AssertionFailedf("unexpectedly there are some unreleased Results"))
+		b.setErrorLocked(errors.AssertionFailedf("unexpectedly there are %d unreleased Results", b.numUnreleasedResults))
 		return b.err
 	}
 	b.numExpectedResponses = numExpectedResponses
@@ -341,6 +344,12 @@ func (b *outOfOrderResultsBuffer) get(context.Context) ([]Result, bool, error) {
 	// is done as a way of "amortizing" the reservation.
 	b.results = nil
 	allComplete := b.numCompleteResponses == b.numExpectedResponses
+	if b.err == nil && b.numCompleteResponses > b.numExpectedResponses {
+		b.err = errors.AssertionFailedf(
+			"received %d complete responses when only %d were expected",
+			b.numCompleteResponses, b.numExpectedResponses,
+		)
+	}
 	return results, allComplete, b.err
 }
 
@@ -594,6 +603,12 @@ func (b *inOrderResultsBuffer) get(ctx context.Context) ([]Result, bool, error) 
 	// All requests are complete IFF we have received the complete responses for
 	// all requests and there no buffered Results.
 	allComplete := b.numCompleteResponses == b.numExpectedResponses && len(b.buffered) == 0
+	if b.err == nil && b.numCompleteResponses > b.numExpectedResponses {
+		b.err = errors.AssertionFailedf(
+			"received %d complete responses when only %d were expected",
+			b.numCompleteResponses, b.numExpectedResponses,
+		)
+	}
 	b.resultScratch = res
 	return res, allComplete, b.err
 }

--- a/pkg/kv/kvclient/kvstreamer/results_buffer.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer.go
@@ -237,12 +237,6 @@ func (b *resultsBufferBase) signal() bool {
 }
 
 func (b *resultsBufferBase) wait(ctx context.Context) error {
-	if buildutil.CrdbTestBuild {
-		// Note that here we don't check the context cancellation in hopes of
-		// reproducing #101823.
-		<-b.hasResults
-		return nil
-	}
 	select {
 	case <-b.hasResults:
 		return b.error()

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -104,8 +104,8 @@ type Result struct {
 	}
 	// subRequestIdx allows us to order two Results that come for the same
 	// original Scan request but from different ranges. It is non-zero only in
-	// InOrder mode when Hints.SingleRowLookup is false, in all other cases it
-	// will remain zero. See singleRangeBatch.subRequestIdx for more details.
+	// InOrder mode, in all other cases it will remain zero. See
+	// singleRangeBatch.subRequestIdx for more details.
 	subRequestIdx int32
 	// subRequestDone is true if the current Result is the last one for the
 	// corresponding sub-request. For all Get requests and for Scan requests
@@ -113,8 +113,7 @@ type Result struct {
 	// have a single sub-request.
 	//
 	// Note that for correctness, it is only necessary that this value is set
-	// properly if this Result is a Scan response and Hints.SingleRowLookup is
-	// false.
+	// properly if this Result is a Scan response.
 	subRequestDone bool
 	// If the Result represents a scan result, scanComplete indicates whether
 	// this is the last response for the respective scan, or if there are more
@@ -135,9 +134,12 @@ type Hints struct {
 	// such, there's no point in de-duping them or caching results.
 	UniqueRequests bool
 	// SingleRowLookup tells the Streamer that each enqueued request will result
-	// in a single row lookup (in other words, the request contains a "key"). If
-	// true, then the Streamer knows that no request will be split across
-	// multiple ranges, so some internal state can be optimized away.
+	// in a single row lookup (in other words, the request contains a "key").
+	// TODO(yuzefovich): investigate using this hint to optimize the performance
+	// and / or allocations. In particular, whenever this hint is set, once one
+	// of the truncated single-range ScanRequests receives non-empty result,
+	// then we know for sure that the original cross-range ScanRequest has been
+	// fully satisfied (since we never split SQL rows across ranges).
 	SingleRowLookup bool
 }
 
@@ -286,8 +288,8 @@ type Streamer struct {
 		// enqueued ScanRequest touches. In other words, it contains how many
 		// "sub-requests" the original Scan request was broken down into.
 		//
-		// It is allocated lazily if Hints.SingleRowLookup is false when the
-		// first ScanRequest is encountered in Enqueue.
+		// It is allocated lazily when the first ScanRequest is encountered in
+		// Enqueue.
 		numRangesPerScanRequest []int32
 
 		// numRequestsInFlight tracks the number of single-range batches that
@@ -620,36 +622,38 @@ func (s *Streamer) Enqueue(ctx context.Context, reqs []kvpb.RequestUnion) (retEr
 		for i, pos := range positions {
 			if _, isScan := reqs[pos].GetInner().(*kvpb.ScanRequest); isScan {
 				numScansInReqs++
-				if !s.hints.SingleRowLookup {
-					if firstScanRequest {
-						// We have some ScanRequests, and each might touch
-						// multiple ranges, so we have to set up
-						// numRangesPerScanRequest.
-						streamerLocked = true
-						s.mu.Lock()
-						if cap(s.mu.numRangesPerScanRequest) < len(reqs) {
-							s.mu.numRangesPerScanRequest = make([]int32, len(reqs))
-							newNumRangesPerScanRequestMemoryUsage = int64(cap(s.mu.numRangesPerScanRequest)) * int32Size
-						} else {
-							// We can reuse numRangesPerScanRequest allocated on
-							// the previous call to Enqueue after we zero it
-							// out.
-							s.mu.numRangesPerScanRequest = s.mu.numRangesPerScanRequest[:len(reqs)]
-							for n := 0; n < len(s.mu.numRangesPerScanRequest); {
-								n += copy(s.mu.numRangesPerScanRequest[n:], zeroInt32Slice)
-							}
+				// TODO(yuzefovich): we could avoid using / allocating
+				// numRangesPerScanRequest if allRequestsAreWithinSingleRange is
+				// true. We could also take this further and see whether any of
+				// the original ScanRequests are cross-range, and if not, then
+				// we could avoid using numRangesPerScanRequest even if all
+				// requests touch multiple ranges.
+				if firstScanRequest {
+					// We have some ScanRequests, so we have to set up
+					// numRangesPerScanRequest.
+					streamerLocked = true
+					s.mu.Lock()
+					if cap(s.mu.numRangesPerScanRequest) < len(reqs) {
+						s.mu.numRangesPerScanRequest = make([]int32, len(reqs))
+						newNumRangesPerScanRequestMemoryUsage = int64(cap(s.mu.numRangesPerScanRequest)) * int32Size
+					} else {
+						// We can reuse numRangesPerScanRequest allocated on the
+						// previous call to Enqueue after we zero it out.
+						s.mu.numRangesPerScanRequest = s.mu.numRangesPerScanRequest[:len(reqs)]
+						for n := 0; n < len(s.mu.numRangesPerScanRequest); {
+							n += copy(s.mu.numRangesPerScanRequest[n:], zeroInt32Slice)
 						}
 					}
-					if s.mode == InOrder {
-						if subRequestIdx == nil {
-							subRequestIdx = make([]int32, len(singleRangeReqs))
-							subRequestIdxOverhead = int32SliceOverhead + int32Size*int64(cap(subRequestIdx))
-						}
-						subRequestIdx[i] = s.mu.numRangesPerScanRequest[pos]
-					}
-					s.mu.numRangesPerScanRequest[pos]++
-					firstScanRequest = false
 				}
+				if s.mode == InOrder {
+					if subRequestIdx == nil {
+						subRequestIdx = make([]int32, len(singleRangeReqs))
+						subRequestIdxOverhead = int32SliceOverhead + int32Size*int64(cap(subRequestIdx))
+					}
+					subRequestIdx[i] = s.mu.numRangesPerScanRequest[pos]
+				}
+				s.mu.numRangesPerScanRequest[pos]++
+				firstScanRequest = false
 			}
 		}
 
@@ -1656,12 +1660,11 @@ func processSingleRangeResults(
 	numRequestsStarted := fp.numGetResults + fp.numStartedScans
 	s.mu.avgResponseEstimator.update(fp.memoryFootprintBytes, numRequestsStarted)
 
-	// If we have any Scan results to create and the Scan requests can return
-	// multiple rows, we'll need to consult s.mu.numRangesPerScanRequest, so
-	// we'll defer unlocking the streamer's mutex. However, if only Get results
-	// or Scan results of single rows will be created, we can unlock the
+	// If we have any Scan results to create, we'll need to consult
+	// s.mu.numRangesPerScanRequest, so we'll defer unlocking the streamer's
+	// mutex. However, if only Get results will be created, we can unlock the
 	// streamer's mutex right away.
-	if fp.numScanResults > 0 && !s.hints.SingleRowLookup {
+	if fp.numScanResults > 0 {
 		defer s.mu.Unlock()
 	} else {
 		s.mu.Unlock()
@@ -1736,9 +1739,7 @@ func processSingleRangeResults(
 			result.memoryTok.streamer = s
 			result.memoryTok.toRelease = scanResponseSize(scan) + scanResponseOverhead
 			memoryTokensBytes += result.memoryTok.toRelease
-			if s.hints.SingleRowLookup {
-				result.scanComplete = true
-			} else if scan.ResumeSpan == nil {
+			if scan.ResumeSpan == nil {
 				// The scan within the range is complete.
 				if s.mode == OutOfOrder {
 					s.mu.numRangesPerScanRequest[position]--

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -792,17 +792,6 @@ func (s *Streamer) GetResults(ctx context.Context) (retResults []Result, retErr 
 			s.results.setError(err)
 			return nil, err
 		}
-		if buildutil.CrdbTestBuild {
-			// Check whether the Streamer has been canceled or closed while we
-			// were	waiting for the results.
-			//
-			// Note that this check is done within wait() call above in non-test
-			// builds.
-			if err = ctx.Err(); err != nil {
-				s.results.setError(err)
-				return nil, err
-			}
-		}
 	}
 }
 

--- a/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
@@ -12,7 +12,6 @@ package kvstreamer
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"testing"
 
@@ -83,7 +82,7 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 	acc := monitor.MakeBoundAccount()
 	defer acc.Close(ctx)
 
-	getStreamer := func(singleRowLookup bool) *Streamer {
+	getStreamer := func() *Streamer {
 		require.Zero(t, acc.Used())
 		rootTxn := kv.NewTxn(ctx, s.DB(), s.DistSQLPlanningNodeID())
 		leafInputState, err := rootTxn.GetLeafTxnInputState(ctx)
@@ -104,15 +103,13 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 			lock.None,
 			lock.Unreplicated,
 		)
-		s.Init(OutOfOrder, Hints{UniqueRequests: true, SingleRowLookup: singleRowLookup}, 1 /* maxKeysPerRow */, nil /* diskBuffer */)
+		s.Init(OutOfOrder, Hints{UniqueRequests: true}, 1 /* maxKeysPerRow */, nil /* diskBuffer */)
 		return s
 	}
 
 	t.Run("get", func(t *testing.T) {
 		acc.Clear(ctx)
-		// SingleRowLookup hint only influences the accounting when at least
-		// one Scan request is present.
-		streamer := getStreamer(false /* singleRowLookup */)
+		streamer := getStreamer()
 		defer streamer.Close(ctx)
 
 		// Get the row with pk=0.
@@ -129,40 +126,35 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 		require.Equal(t, expectedUsed, acc.Used())
 	})
 
-	for _, singleRowLookup := range []bool{false, true} {
-		t.Run(fmt.Sprintf("scan/single_row_lookup=%t", singleRowLookup), func(t *testing.T) {
-			acc.Clear(ctx)
-			streamer := getStreamer(singleRowLookup)
-			defer streamer.Close(ctx)
+	t.Run("scan", func(t *testing.T) {
+		acc.Clear(ctx)
+		streamer := getStreamer()
+		defer streamer.Close(ctx)
 
-			// Scan the row with pk=0.
-			reqs := make([]kvpb.RequestUnion, 1)
-			reqs[0] = makeScanRequest(codec, uint32(tableID), 0, 1)
-			require.NoError(t, streamer.Enqueue(ctx, reqs))
-			results, err := streamer.GetResults(ctx)
-			require.NoError(t, err)
-			require.Equal(t, 1, len(results))
-			// 29 is usually the number of bytes in
-			// ScanResponse.BatchResponse[0]. We choose to hard-code this number
-			// rather than consult NumBytes field directly as an additional
-			// sanity-check. We also adjust the estimate to account for possible
-			// tenant prefix.
-			expectedMemToken := scanResponseOverhead + 29 + int64(len(codec.TenantPrefix()))
-			if results[0].ScanResp.NumBytes == 33+int64(len(codec.TenantPrefix())) {
-				// For some reason, sometimes it's not 29, but 33, and we do
-				// allow for this.
-				expectedMemToken += 4
-			}
-			require.Equal(t, expectedMemToken, results[0].memoryTok.toRelease)
-			expectedUsed := expectedMemToken + resultSize
-			if !singleRowLookup {
-				// This is streamer.numRangesPerScanRequestAccountedFor which is
-				// only non-zero when SingleRowLookup hint is false.
-				expectedUsed += 4
-			}
-			require.Equal(t, expectedUsed, acc.Used())
-		})
-	}
+		// Scan the row with pk=0.
+		reqs := make([]kvpb.RequestUnion, 1)
+		reqs[0] = makeScanRequest(codec, uint32(tableID), 0, 1)
+		require.NoError(t, streamer.Enqueue(ctx, reqs))
+		results, err := streamer.GetResults(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(results))
+		// 29 is usually the number of bytes in
+		// ScanResponse.BatchResponse[0]. We choose to hard-code this number
+		// rather than consult NumBytes field directly as an additional
+		// sanity-check. We also adjust the estimate to account for possible
+		// tenant prefix.
+		expectedMemToken := scanResponseOverhead + 29 + int64(len(codec.TenantPrefix()))
+		if results[0].ScanResp.NumBytes == 33+int64(len(codec.TenantPrefix())) {
+			// For some reason, sometimes it's not 29, but 33, and we do
+			// allow for this.
+			expectedMemToken += 4
+		}
+		require.Equal(t, expectedMemToken, results[0].memoryTok.toRelease)
+		expectedUsed := expectedMemToken + resultSize
+		// This is streamer.numRangesPerScanRequestAccountedFor.
+		expectedUsed += 4
+		require.Equal(t, expectedUsed, acc.Used())
+	})
 }
 
 func makeScanRequest(codec keys.SQLCodec, tableID uint32, start, end int) kvpb.RequestUnion {

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -1562,3 +1562,17 @@ SELECT length(c1), length(c3) FROM l_113013 l INNER JOIN r_113013 r ON l.r_id = 
 ----
 2  4000
 2  2
+
+# Regression test for incorrectly treating cross-range ScanRequests by the
+# Streamer when "equality columns are key" in the lookup join (#101823).
+statement ok
+CREATE TABLE l_101823 (a INT, b INT, PRIMARY KEY (a, b));
+INSERT INTO l_101823 VALUES (1, 1);
+CREATE TABLE r_101823 (k INT PRIMARY KEY, u INT, v INT, w BOOL, UNIQUE INDEX (u), UNIQUE INDEX (u, v, w));
+INSERT INTO r_101823 VALUES (1, 1, 1, false);
+ALTER INDEX r_101823_u_v_w_key SPLIT AT VALUES (1, 1, false), (1, 1, true);
+
+query I
+SELECT count(v) FROM l_101823 LEFT LOOKUP JOIN r_101823 ON a = u AND b = v;
+----
+1


### PR DESCRIPTION
This commit fixes a long-standing issue in the streamer when SingleRowLookup hint is set and there are some cross-range ScanRequests. The SingleRowLookup hint indicates that each request can result in at most one SQL row, but that was incorrectly understood as ScanRequests touching exactly one range - it is possible to have a multi-range ScanRequest that only fetches a single SQL row. As a result of this incorrect usage of the SingleRowLookup hint, the streamer could either get stuck (because it would actually receive more responses than were expected, and in `resultsBuffer.get` implementations we say `allComplete` is `true` with exact equality) or could return incorrect results (when one of the truncated ScanRequests came back empty before the non-empty one, but we didn't wait for the latter).

The bug is now fixed by removing optimizations that were in-place when this hint is specified. In particular, it means that now, whenever at least one ScanRequest is enqueued, we will always allocate
- `Streamer.mu.numRangesPerScanRequest []int32` slice
- `subRequestIdx []int32` slices in the InOrder mode.

This would increase the fraction of the streamer's budget dedicated to overhead, but it should be relatively minor in the grand scheme of things.

I decided to not remove the hint altogether since we could introduce some optimizations using it in the future.

Fixes: #101823.
Fixes: #108412.
Fixes: #112490.

Release note (bug fix): Previously, CockroachDB could incorrectly evaluate queries with lookup joins when equality columns are key in some rare cases when looking up into multiple ranges. Sometimes this would manifest as a stuck query, sometimes it could result in incorrect output. The bug was introduced in 22.2 and is now fixed.