### PR TITLE
explain: add missing space between equality column names

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_foreign_key_lookup_join
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_foreign_key_lookup_join
@@ -52,7 +52,7 @@ vectorized: true
 ·
 • lookup join
 │ table: parent@parent_pkey
-│ equality: (cr, c_p_id) = (cr,p_id)
+│ equality: (cr, c_p_id) = (cr, p_id)
 │ equality cols are key
 │
 └── • scan
@@ -130,7 +130,7 @@ vectorized: true
 ·
 • lookup join
 │ table: parent_rbr@parent_rbr_pkey
-│ equality: (crdb_region, c_p_id) = (crdb_region,p_id)
+│ equality: (crdb_region, c_p_id) = (crdb_region, p_id)
 │ equality cols are key
 │
 └── • scan
@@ -158,7 +158,7 @@ vectorized: true
 ·
 • lookup join
 │ table: parent_rbr@parent_rbr_pkey
-│ equality: (crdb_region, c_p_id) = (crdb_region,p_id)
+│ equality: (crdb_region, c_p_id) = (crdb_region, p_id)
 │ equality cols are key
 │
 └── • filter
@@ -188,7 +188,7 @@ vectorized: true
 ·
 • lookup join
 │ table: parent_rbr@parent_rbr_pkey
-│ equality: (crdb_region, c_p_id) = (crdb_region,p_id)
+│ equality: (crdb_region, c_p_id) = (crdb_region, p_id)
 │ equality cols are key
 │ pred: column14 = p_int
 │
@@ -223,7 +223,7 @@ vectorized: true
 ·
 • lookup join
 │ table: parent_rbr@parent_rbr_pkey
-│ equality: (crdb_region, c_p_id) = (crdb_region,p_id)
+│ equality: (crdb_region, c_p_id) = (crdb_region, p_id)
 │ equality cols are key
 │
 └── • scan

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -62,7 +62,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ table: parent@parent_pkey
-            │ equality: (crdb_region_eq, p_id) = (crdb_region,id)
+            │ equality: (crdb_region_eq, p_id) = (crdb_region, id)
             │ equality cols are key
             │
             └── • render

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -850,7 +850,7 @@ vectorized: true
             │
             └── • lookup join
                 │ table: t@t_pkey
-                │ equality: (partition_by, pk) = (partition_by,pk)
+                │ equality: (partition_by, pk) = (partition_by, pk)
                 │ equality cols are key
                 │
                 └── • hash join

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -2976,12 +2976,12 @@ vectorized: true
 ·
 • lookup join
 │ table: user_settings@user_settings_pkey
-│ equality: (crdb_region, id) = (crdb_region,id)
+│ equality: (crdb_region, id) = (crdb_region, id)
 │ equality cols are key
 │
 └── • lookup join
     │ table: user_settings@user_settings_user_id_idx
-    │ equality: (crdb_region, id) = (crdb_region,user_id)
+    │ equality: (crdb_region, id) = (crdb_region, user_id)
     │ pred: user_id = '5ebfedee-0dcf-41e6-a315-5fa0b51b9882'
     │
     └── • union all
@@ -3012,12 +3012,12 @@ vectorized: true
 ·
 • lookup join
 │ table: user_settings@user_settings_pkey
-│ equality: (crdb_region, id) = (crdb_region,id)
+│ equality: (crdb_region, id) = (crdb_region, id)
 │ equality cols are key
 │
 └── • lookup join
     │ table: user_settings@id2_idx
-    │ equality: (crdb_region, column14) = (crdb_region,id2)
+    │ equality: (crdb_region, column14) = (crdb_region, id2)
     │
     └── • render
         │
@@ -3169,7 +3169,7 @@ vectorized: true
         │
         └── • lookup join (semi)
             │ table: user_settings@user_settings_user_id_idx
-            │ equality: (crdb_region, id) = (crdb_region,user_id)
+            │ equality: (crdb_region, id) = (crdb_region, user_id)
             │
             └── • scan buffer
                   label: buffer 1
@@ -3579,13 +3579,13 @@ vectorized: true
 • lookup join
 │ estimated row count: 1
 │ table: abc@abc_pkey
-│ equality: (crdb_region, id) = (crdb_region,id)
+│ equality: (crdb_region, id) = (crdb_region, id)
 │ equality cols are key
 │
 └── • lookup join
     │ estimated row count: 0
     │ table: abc@abc_id1_id2_idx
-    │ equality: (crdb_region, lookup_join_const_col_@2, id2, abc_id) = (crdb_region,id1,id2,id)
+    │ equality: (crdb_region, lookup_join_const_col_@2, id2, abc_id) = (crdb_region, id1, id2, id)
     │ equality cols are key
     │ pred: (id2 = '68088706-02c6-47d1-b993-a421cd761f2b') AND (crdb_region = 'ap-southeast-2')
     │
@@ -4048,7 +4048,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ table: users@users_pkey
-            │ equality: (crdb_region_default, column2) = (crdb_region,id)
+            │ equality: (crdb_region_default, column2) = (crdb_region, id)
             │ equality cols are key
             │
             └── • scan buffer

--- a/pkg/sql/opt/exec/execbuilder/testdata/expression_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/expression_index
@@ -132,7 +132,7 @@ SELECT * FROM [
 │
 └── • lookup join
     │ table: t@t_lower_c_a_plus_b_idx
-    │ equality: (n, m) = (crdb_internal_idx_expr_1,crdb_internal_idx_expr)
+    │ equality: (n, m) = (crdb_internal_idx_expr_1, crdb_internal_idx_expr)
     │
     └── • scan
           missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -306,7 +306,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ table: multi_col_parent@multi_col_parent_pkey
-            │ equality: (column2, column3, column4) = (p,q,r)
+            │ equality: (column2, column3, column4) = (p, q, r)
             │ equality cols are key
             │
             └── • filter
@@ -373,7 +373,7 @@ vectorized: true
         │
         └── • lookup join (anti)
             │ table: multi_ref_parent_bc@multi_ref_parent_bc_pkey
-            │ equality: (column3, column4) = (b,c)
+            │ equality: (column3, column4) = (b, c)
             │ equality cols are key
             │
             └── • filter
@@ -582,7 +582,7 @@ vectorized: true
         │
         └── • lookup join (semi)
             │ table: doublechild@doublechild_p1_p2_idx
-            │ equality: (p1, p2) = (p1,p2)
+            │ equality: (p1, p2) = (p1, p2)
             │
             └── • scan buffer
                   label: buffer 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -1091,7 +1091,7 @@ vectorized: true
                     │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_comp, column1, column2, a, b)
                     │ estimated row count: 2 (missing stats)
                     │ table: t_hash_indexed@idx_t_hash_indexed
-                    │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8,b)
+                    │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8, b)
                     │ equality cols are key
                     │ locking strength: for update
                     │
@@ -1138,7 +1138,7 @@ vectorized: true
             │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_comp)
             │ estimated row count: 0 (missing stats)
             │ table: t_hash_indexed@idx_t_hash_indexed
-            │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8,b)
+            │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8, b)
             │ equality cols are key
             │
             └── • render
@@ -1196,7 +1196,7 @@ vectorized: true
             │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_comp)
             │ estimated row count: 0 (missing stats)
             │ table: t_hash_indexed@idx_t_hash_indexed
-            │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8,b)
+            │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8, b)
             │ equality cols are key
             │
             └── • render
@@ -1294,7 +1294,7 @@ vectorized: true
             │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_comp, column1, column2)
             │ estimated row count: 0 (missing stats)
             │ table: t_hash_indexed@idx_t_hash_indexed
-            │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8,b)
+            │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8, b)
             │ equality cols are key
             │
             └── • render
@@ -1362,7 +1362,7 @@ vectorized: true
                 │ columns: (crdb_internal_id_shard_16_eq, pid)
                 │ estimated row count: 0 (missing stats)
                 │ table: t_parent_pk@t_parent_pk_pkey
-                │ equality: (crdb_internal_id_shard_16_eq, pid) = (crdb_internal_id_shard_16,id)
+                │ equality: (crdb_internal_id_shard_16_eq, pid) = (crdb_internal_id_shard_16, id)
                 │ equality cols are key
                 │
                 └── • render
@@ -1431,7 +1431,7 @@ vectorized: true
                 │ columns: (crdb_internal_real_id_shard_16_eq, pid)
                 │ estimated row count: 0 (missing stats)
                 │ table: t_parent_sec@idx_t_parent_sec_real_id
-                │ equality: (crdb_internal_real_id_shard_16_eq, pid) = (crdb_internal_real_id_shard_16,real_id)
+                │ equality: (crdb_internal_real_id_shard_16_eq, pid) = (crdb_internal_real_id_shard_16, real_id)
                 │ equality cols are key
                 │
                 └── • render

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -27,7 +27,7 @@ vectorized: true
 ·
 • lookup join
 │ table: rtable@rtable_pkey
-│ equality: (rk1, rk2) = (rk1,rk2)
+│ equality: (rk1, rk2) = (rk1, rk2)
 │ equality cols are key
 │ pred: st_intersects(geom1, geom)
 │
@@ -50,7 +50,7 @@ vectorized: true
 ·
 • lookup join
 │ table: rtable@rtable_pkey
-│ equality: (rk1, rk2) = (rk1,rk2)
+│ equality: (rk1, rk2) = (rk1, rk2)
 │ equality cols are key
 │ pred: st_intersects(geom1, geom)
 │
@@ -71,7 +71,7 @@ vectorized: true
 ·
 • lookup join
 │ table: rtable@rtable_pkey
-│ equality: (rk1, rk2) = (rk1,rk2)
+│ equality: (rk1, rk2) = (rk1, rk2)
 │ equality cols are key
 │ pred: st_dwithin(geom1, geom, 5.0)
 │
@@ -110,7 +110,7 @@ vectorized: true
             │ ordering: +lk
             │ estimated row count: 326,700 (missing stats)
             │ table: rtable@rtable_pkey
-            │ equality: (rk1, rk2) = (rk1,rk2)
+            │ equality: (rk1, rk2) = (rk1, rk2)
             │ equality cols are key
             │ pred: st_intersects(geom, geom1) OR st_dwithin(geom1, geom, 2.0)
             │
@@ -159,7 +159,7 @@ vectorized: true
             │ ordering: +lk
             │ estimated row count: 9,801 (missing stats)
             │ table: rtable@rtable_pkey
-            │ equality: (rk1, rk2) = (rk1,rk2)
+            │ equality: (rk1, rk2) = (rk1, rk2)
             │ equality cols are key
             │ pred: st_intersects(geom1, geom) AND st_dwithin(geom, geom1, 2.0)
             │
@@ -200,7 +200,7 @@ vectorized: true
         │ columns: (lk, geom1, geom2, rk1, rk2, rk1, geom)
         │ estimated row count: 3,267 (missing stats)
         │ table: rtable@rtable_pkey
-        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: (st_intersects(geom1, geom) AND st_covers(geom2, geom)) AND (st_dfullywithin(geom, geom1, 100.0) OR st_intersects('0101000000000000000000F03F000000000000F03F', geom))
         │
@@ -238,7 +238,7 @@ vectorized: true
         │ columns: (lk, geom2, rk1, rk2, cont)
         │ estimated row count: 10 (missing stats)
         │ table: rtable@rtable_pkey
-        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: st_intersects(geom2, geom)
         │
@@ -275,7 +275,7 @@ vectorized: true
         │ columns: (lk, geom1, rk1, rk2, cont, rk1, geom)
         │ estimated row count: 10,000 (missing stats)
         │ table: rtable@rtable_pkey
-        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: st_intersects(geom1, geom)
         │
@@ -332,7 +332,7 @@ vectorized: true
 │                   │ columns: (lk, geom1, rk1, rk2, cont, geom)
 │                   │ estimated row count: 3,333 (missing stats)
 │                   │ table: rtable@rtable_pkey
-│                   │ equality: (rk1, rk2) = (rk1,rk2)
+│                   │ equality: (rk1, rk2) = (rk1, rk2)
 │                   │ equality cols are key
 │                   │ pred: st_intersects(geom1, geom)
 │                   │
@@ -404,7 +404,7 @@ vectorized: true
         │ columns: (lk, geom2, rk1, rk2, cont)
         │ estimated row count: 990 (missing stats)
         │ table: rtable@rtable_pkey
-        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: st_intersects(geom2, geom)
         │
@@ -443,7 +443,7 @@ vectorized: true
         │ columns: (lk, geom1, rk1, rk2, cont)
         │ estimated row count: 997 (missing stats)
         │ table: rtable@rtable_pkey
-        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: st_covers(geom1, geom)
         │
@@ -484,7 +484,7 @@ vectorized: true
         │ columns: (lk, geom1, rk1, rk2, rk1, geom, rk2)
         │ estimated row count: 9,801 (missing stats)
         │ table: rtable@rtable_pkey
-        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: geom1 ~ geom
         │
@@ -520,7 +520,7 @@ vectorized: true
         │ columns: (lk, geom1, rk1, rk2, rk1, geom, rk2)
         │ estimated row count: 9,801 (missing stats)
         │ table: rtable@rtable_pkey
-        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: geom ~ geom1
         │
@@ -556,7 +556,7 @@ vectorized: true
         │ columns: (lk, geom1, rk1, rk2, rk1, geom, rk2)
         │ estimated row count: 9,801 (missing stats)
         │ table: rtable@rtable_pkey
-        │ equality: (rk1, rk2) = (rk1,rk2)
+        │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: geom && geom1
         │

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial_dist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial_dist
@@ -470,7 +470,7 @@ vectorized: true
 │
 └── • lookup join
     │ table: rtable2@rtable2_pkey
-    │ equality: (rk1, rk2) = (rk1,rk2)
+    │ equality: (rk1, rk2) = (rk1, rk2)
     │ equality cols are key
     │ pred: st_intersects(geom1, geom)
     │
@@ -498,7 +498,7 @@ vectorized: true
 │
 └── • lookup join (left outer)
     │ table: rtable2@rtable2_pkey
-    │ equality: (rk1, rk2) = (rk1,rk2)
+    │ equality: (rk1, rk2) = (rk1, rk2)
     │ equality cols are key
     │ pred: st_intersects(geom1, geom)
     │
@@ -522,7 +522,7 @@ vectorized: true
 ·
 • lookup join (semi)
 │ table: rtable2@rtable2_pkey
-│ equality: (rk1, rk2) = (rk1,rk2)
+│ equality: (rk1, rk2) = (rk1, rk2)
 │ equality cols are key
 │ pred: st_intersects(geom1, geom)
 │
@@ -546,7 +546,7 @@ vectorized: true
 ·
 • lookup join (anti)
 │ table: rtable2@rtable2_pkey
-│ equality: (rk1, rk2) = (rk1,rk2)
+│ equality: (rk1, rk2) = (rk1, rk2)
 │ equality cols are key
 │ pred: st_intersects(geom1, geom)
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -69,7 +69,7 @@ vectorized: true
 │ columns: (a, b, c, d, e, f)
 │ estimated row count: 0
 │ table: def@def_pkey
-│ equality: (b, c) = (f,e)
+│ equality: (b, c) = (f, e)
 │ equality cols are key
 │
 └── • scan
@@ -456,7 +456,7 @@ vectorized: true
     │ columns: (a, b, c, d, a, b, c, d)
     │ estimated row count: 0
     │ table: data@data_pkey
-    │ equality: (a, b, c, d) = (a,b,c,d)
+    │ equality: (a, b, c, d) = (a, b, c, d)
     │ equality cols are key
     │ pred: c > 0
     │
@@ -483,7 +483,7 @@ vectorized: true
 • lookup join
 │ estimated row count: 0
 │ table: data@data_pkey
-│ equality: (a, b, c, d) = (a,b,c,d)
+│ equality: (a, b, c, d) = (a, b, c, d)
 │ equality cols are key
 │ pred: c > 0
 │
@@ -705,7 +705,7 @@ vectorized: true
 • lookup join
 │ estimated row count: 99
 │ table: books2@books2_pkey
-│ equality: (book, lookup_join_const_col_@7) = (title,edition)
+│ equality: (book, lookup_join_const_col_@7) = (title, edition)
 │ equality cols are key
 │
 └── • render
@@ -797,7 +797,7 @@ vectorized: true
         │ columns: (a, a, b, d)
         │ estimated row count: 1,000
         │ table: large@large_pkey
-        │ equality: (a, b) = (a,b)
+        │ equality: (a, b) = (a, b)
         │ equality cols are key
         │
         └── • lookup join (inner)
@@ -919,7 +919,7 @@ vectorized: true
         │ columns: (c, a, b, d)
         │ estimated row count: 1,000
         │ table: large@large_pkey
-        │ equality: (a, b) = (a,b)
+        │ equality: (a, b) = (a, b)
         │ equality cols are key
         │
         └── • lookup join (left outer)
@@ -974,7 +974,7 @@ vectorized: true
         │ columns: (c, a, b, cont, b, d)
         │ estimated row count: 336
         │ table: large@large_pkey
-        │ equality: (a, b) = (a,b)
+        │ equality: (a, b) = (a, b)
         │ equality cols are key
         │ pred: d < 30
         │
@@ -1004,7 +1004,7 @@ vectorized: true
     │ columns: (c, a, b, cont)
     │ estimated row count: 100
     │ table: large@large_pkey
-    │ equality: (a, b) = (a,b)
+    │ equality: (a, b) = (a, b)
     │ equality cols are key
     │ pred: d < 30
     │
@@ -1034,7 +1034,7 @@ vectorized: true
     │ columns: (c, a, b, cont)
     │ estimated row count: 0
     │ table: large@large_pkey
-    │ equality: (a, b) = (a,b)
+    │ equality: (a, b) = (a, b)
     │ equality cols are key
     │ pred: d < 30
     │
@@ -1077,7 +1077,7 @@ vectorized: true
     │ columns: (a, d, e, a, d)
     │ estimated row count: 1 (missing stats)
     │ table: u@idx
-    │ equality: (d, a) = (d,a)
+    │ equality: (d, a) = (d, a)
     │
     └── • filter
         │ columns: (a, d, e)
@@ -1145,7 +1145,7 @@ vectorized: true
     │ columns: (a, b, d, e, a, b, d)
     │ estimated row count: 0 (missing stats)
     │ table: u@idx
-    │ equality: (d, a, b) = (d,a,b)
+    │ equality: (d, a, b) = (d, a, b)
     │
     └── • filter
         │ columns: (a, b, d, e)
@@ -1178,7 +1178,7 @@ vectorized: true
     │ columns: (a, b, d, e, a, b, d)
     │ estimated row count: 0 (missing stats)
     │ table: u@idx
-    │ equality: (d, b, a) = (d,b,a)
+    │ equality: (d, b, a) = (d, b, a)
     │
     └── • filter
         │ columns: (a, b, d, e)
@@ -1349,7 +1349,7 @@ vectorized: true
 │ columns: (a, b, c)
 │ estimated row count: 100
 │ table: def@def_pkey
-│ equality: (a, c) = (f,e)
+│ equality: (a, c) = (f, e)
 │ equality cols are key
 │
 └── • scan
@@ -1368,7 +1368,7 @@ vectorized: true
 │ columns: (a, b, c)
 │ estimated row count: 0
 │ table: def@def_pkey
-│ equality: (a, c) = (f,e)
+│ equality: (a, c) = (f, e)
 │ equality cols are key
 │
 └── • scan
@@ -2043,7 +2043,7 @@ vectorized: true
                 └── • lookup join
                     │ estimated row count: 80,016
                     │ table: lineitem@lineitem_pkey
-                    │ equality: (l_orderkey, l_linenumber) = (l_orderkey,l_linenumber)
+                    │ equality: (l_orderkey, l_linenumber) = (l_orderkey, l_linenumber)
                     │ equality cols are key
                     │ pred: l_receiptdate > l_commitdate
                     │
@@ -2096,7 +2096,7 @@ vectorized: true
         │ columns: ("lookup_join_const_col_@15", pk, col0, col3)
         │ estimated row count: 10 (missing stats)
         │ table: tab4@tab4_col3_col4_key
-        │ equality: (col0, lookup_join_const_col_@15) = (col3,col4)
+        │ equality: (col0, lookup_join_const_col_@15) = (col3, col4)
         │ equality cols are key
         │
         └── • render

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_spans
@@ -540,7 +540,7 @@ vectorized: true
 └── • lookup join
     │ estimated row count: 3
     │ table: metric_values@metric_values_pkey
-    │ equality: (metric_id, time) = (metric_id,time)
+    │ equality: (metric_id, time) = (metric_id, time)
     │ equality cols are key
     │
     └── • lookup join
@@ -585,7 +585,7 @@ vectorized: true
     └── • lookup join
         │ estimated row count: 0
         │ table: metric_values@metric_values_pkey
-        │ equality: (metric_id, time) = (metric_id,time)
+        │ equality: (metric_id, time) = (metric_id, time)
         │ equality cols are key
         │
         └── • lookup join
@@ -626,7 +626,7 @@ vectorized: true
     └── • lookup join
         │ estimated row count: 0
         │ table: metric_values@metric_values_pkey
-        │ equality: (metric_id, time) = (metric_id,time)
+        │ equality: (metric_id, time) = (metric_id, time)
         │ equality cols are key
         │
         └── • lookup join
@@ -667,7 +667,7 @@ vectorized: true
     └── • lookup join
         │ estimated row count: 0
         │ table: metric_values@metric_values_pkey
-        │ equality: (metric_id, time) = (metric_id,time)
+        │ equality: (metric_id, time) = (metric_id, time)
         │ equality cols are key
         │
         └── • lookup join
@@ -709,7 +709,7 @@ vectorized: true
     └── • lookup join
         │ estimated row count: 0
         │ table: metric_values@metric_values_pkey
-        │ equality: (metric_id, time) = (metric_id,time)
+        │ equality: (metric_id, time) = (metric_id, time)
         │ equality cols are key
         │
         └── • lookup join
@@ -750,7 +750,7 @@ vectorized: true
     └── • lookup join
         │ estimated row count: 0
         │ table: metric_values@metric_values_pkey
-        │ equality: (metric_id, time) = (metric_id,time)
+        │ equality: (metric_id, time) = (metric_id, time)
         │ equality cols are key
         │
         └── • lookup join
@@ -786,7 +786,7 @@ vectorized: true
 └── • lookup join
     │ estimated row count: 3
     │ table: metric_values@metric_values_pkey
-    │ equality: (metric_id, time) = (metric_id,time)
+    │ equality: (metric_id, time) = (metric_id, time)
     │ equality cols are key
     │
     └── • lookup join
@@ -833,7 +833,7 @@ vectorized: true
     └── • lookup join
         │ estimated row count: 0
         │ table: metric_values@metric_values_pkey
-        │ equality: (metric_id, time) = (metric_id,time)
+        │ equality: (metric_id, time) = (metric_id, time)
         │ equality cols are key
         │
         └── • lookup join
@@ -870,7 +870,7 @@ vectorized: true
 └── • lookup join
     │ estimated row count: 33
     │ table: metric_values@metric_values_pkey
-    │ equality: (metric_id, time) = (metric_id,time)
+    │ equality: (metric_id, time) = (metric_id, time)
     │ equality cols are key
     │
     └── • lookup join
@@ -909,7 +909,7 @@ vectorized: true
 └── • lookup join
     │ estimated row count: 33
     │ table: metric_values@metric_values_pkey
-    │ equality: (metric_id, time) = (metric_id,time)
+    │ equality: (metric_id, time) = (metric_id, time)
     │ equality cols are key
     │
     └── • lookup join
@@ -948,7 +948,7 @@ vectorized: true
 └── • lookup join
     │ estimated row count: 33
     │ table: metric_values@metric_values_pkey
-    │ equality: (metric_id, time) = (metric_id,time)
+    │ equality: (metric_id, time) = (metric_id, time)
     │ equality cols are key
     │
     └── • lookup join
@@ -988,7 +988,7 @@ vectorized: true
 └── • lookup join
     │ estimated row count: 33
     │ table: metric_values@metric_values_pkey
-    │ equality: (metric_id, time) = (metric_id,time)
+    │ equality: (metric_id, time) = (metric_id, time)
     │ equality cols are key
     │
     └── • lookup join
@@ -1027,7 +1027,7 @@ vectorized: true
 └── • lookup join
     │ estimated row count: 33
     │ table: metric_values@metric_values_pkey
-    │ equality: (metric_id, time) = (metric_id,time)
+    │ equality: (metric_id, time) = (metric_id, time)
     │ equality cols are key
     │
     └── • lookup join

--- a/pkg/sql/opt/exec/execbuilder/testdata/observability
+++ b/pkg/sql/opt/exec/execbuilder/testdata/observability
@@ -204,7 +204,7 @@ vectorized: true
         │ columns: (query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, service_latency_p99_seconds, fingerprint_id, app_name, max, max, max, merge_transaction_stats, aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, query, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
         │ estimated row count: 27,778
         │ table: transaction_activity@primary
-        │ equality: (max, fingerprint_id, app_name) = (aggregated_ts,fingerprint_id,app_name)
+        │ equality: (max, fingerprint_id, app_name) = (aggregated_ts, fingerprint_id, app_name)
         │ equality cols are key
         │
         └── • render
@@ -307,7 +307,7 @@ vectorized: true
             │ columns: ("lookup_join_const_col_@58", bytea, idx_rec, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", fingerprint_id, plan_hash, app_name, max, max, merge_stats_metadata, merge_statement_stats, max, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
             │ estimated row count: 27,778
             │ table: statement_activity@primary
-            │ equality: (max, fingerprint_id, lookup_join_const_col_@58, plan_hash, app_name) = (aggregated_ts,fingerprint_id,transaction_fingerprint_id,plan_hash,app_name)
+            │ equality: (max, fingerprint_id, lookup_join_const_col_@58, plan_hash, app_name) = (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name)
             │ equality cols are key
             │
             └── • render
@@ -549,7 +549,7 @@ vectorized: true
             │ columns: ("lookup_join_const_col_@99", txn_fingerprint_id, idx_rec, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "coalesce", aggregated_ts, fingerprint_id, plan_hash, app_name, max, max, merge_stats_metadata, merge_statement_stats, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, agg_interval, metadata, statistics, plan, index_recommendations, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
             │ estimated row count: 3
             │ table: statement_activity@primary
-            │ equality: (aggregated_ts, fingerprint_id, lookup_join_const_col_@99, plan_hash, app_name) = (aggregated_ts,fingerprint_id,transaction_fingerprint_id,plan_hash,app_name)
+            │ equality: (aggregated_ts, fingerprint_id, lookup_join_const_col_@99, plan_hash, app_name) = (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name)
             │ equality cols are key
             │
             └── • render
@@ -593,7 +593,7 @@ vectorized: true
                                 │ columns: (aggregated_ts, fingerprint_id, app_name, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, agg_interval, metadata, statistics, plan)
                                 │ estimated row count: 3
                                 │ table: statement_statistics@primary
-                                │ equality: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id) = (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8,aggregated_ts,fingerprint_id,transaction_fingerprint_id,plan_hash,app_name,node_id)
+                                │ equality: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id) = (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id)
                                 │ equality cols are key
                                 │
                                 └── • lookup join (inner)
@@ -864,7 +864,7 @@ vectorized: true
         │ columns: (query, int8, "?column?", execution_total_cluster_seconds, "coalesce", "coalesce", float8, "?column?", aggregated_ts, fingerprint_id, app_name, max, max, merge_stats, aggregated_ts, fingerprint_id, app_name, agg_interval, metadata, statistics, query, execution_count, execution_total_seconds, execution_total_cluster_seconds, contention_time_avg_seconds, cpu_sql_avg_nanos, service_latency_avg_seconds, service_latency_p99_seconds)
         │ estimated row count: 1
         │ table: transaction_activity@primary
-        │ equality: (aggregated_ts, fingerprint_id, app_name) = (aggregated_ts,fingerprint_id,app_name)
+        │ equality: (aggregated_ts, fingerprint_id, app_name) = (aggregated_ts, fingerprint_id, app_name)
         │ equality cols are key
         │
         └── • render

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -1339,7 +1339,7 @@ vectorized: true
                     │ columns: (column1, column2, column3, column4)
                     │ estimated row count: 0
                     │ table: uniq_partial_enum@uniq_partial_enum_pkey
-                    │ equality: (column1, column2) = (r,a)
+                    │ equality: (column1, column2) = (r, a)
                     │ equality cols are key
                     │
                     └── • values
@@ -3807,7 +3807,7 @@ vectorized: true
 │                       │ columns: (column1, column2, column3, column4, r, s, i, j)
 │                       │ estimated row count: 2 (missing stats)
 │                       │ table: uniq_enum@uniq_enum_pkey
-│                       │ equality: (column1, column3) = (r,i)
+│                       │ equality: (column1, column3) = (r, i)
 │                       │ equality cols are key
 │                       │ locking strength: for update
 │                       │
@@ -4436,7 +4436,7 @@ vectorized: true
 │                       │ columns: (column1, column2, column3, column4, r, a, b, c)
 │                       │ estimated row count: 2
 │                       │ table: uniq_partial_enum@uniq_partial_enum_pkey
-│                       │ equality: (column1, column2) = (r,a)
+│                       │ equality: (column1, column2) = (r, a)
 │                       │ equality cols are key
 │                       │ locking strength: for update
 │                       │
@@ -4518,7 +4518,7 @@ vectorized: true
             │ columns: (arbiter_unique_b_distinct, column1, column2, column3, column4, r, a, b, c)
             │ estimated row count: 2
             │ table: uniq_partial_enum@uniq_partial_enum_pkey
-            │ equality: (r, a) = (r,a)
+            │ equality: (r, a) = (r, a)
             │ equality cols are key
             │
             └── • lookup join (left outer)
@@ -4828,7 +4828,7 @@ vectorized: true
         │
         └── • lookup join (semi)
             │ table: t1@t1_b_a_idx
-            │ equality: (column4, column3) = (b,a)
+            │ equality: (column4, column3) = (b, a)
             │ pred: column1 != pk
             │
             └── • scan buffer
@@ -4943,7 +4943,7 @@ vectorized: true
 │       │
 │       └── • lookup join (semi)
 │           │ table: multiple_uniq@multiple_uniq_b_c_idx
-│           │ equality: (column2, column3) = (b,c)
+│           │ equality: (column2, column3) = (b, c)
 │           │ pred: rowid_default != rowid
 │           │
 │           └── • scan buffer
@@ -4956,7 +4956,7 @@ vectorized: true
 │       │
 │       └── • lookup join (semi)
 │           │ table: multiple_uniq@multiple_uniq_a_b_d_idx
-│           │ equality: (column1, column2, column4) = (a,b,d)
+│           │ equality: (column1, column2, column4) = (a, b, d)
 │           │ pred: rowid_default != rowid
 │           │
 │           └── • scan buffer
@@ -5024,7 +5024,7 @@ vectorized: true
 │       │
 │       └── • lookup join (semi)
 │           │ table: multiple_uniq@multiple_uniq_b_c_idx
-│           │ equality: (column2, column3) = (b,c)
+│           │ equality: (column2, column3) = (b, c)
 │           │ pred: rowid_default != rowid
 │           │
 │           └── • scan buffer
@@ -5037,7 +5037,7 @@ vectorized: true
 │       │
 │       └── • lookup join (semi)
 │           │ table: multiple_uniq@multiple_uniq_a_b_d_idx
-│           │ equality: (column1, column2, column4) = (a,b,d)
+│           │ equality: (column1, column2, column4) = (a, b, d)
 │           │ pred: rowid_default != rowid
 │           │
 │           └── • scan buffer
@@ -5119,7 +5119,7 @@ vectorized: true
 │       │
 │       └── • lookup join (semi)
 │           │ table: multiple_uniq@multiple_uniq_b_c_idx
-│           │ equality: (column2, column3) = (b,c)
+│           │ equality: (column2, column3) = (b, c)
 │           │ pred: rowid_default != rowid
 │           │
 │           └── • scan buffer
@@ -5132,7 +5132,7 @@ vectorized: true
 │       │
 │       └── • lookup join (semi)
 │           │ table: multiple_uniq@multiple_uniq_a_b_d_idx
-│           │ equality: (column1, column2, column4) = (a,b,d)
+│           │ equality: (column1, column2, column4) = (a, b, d)
 │           │ pred: rowid_default != rowid
 │           │
 │           └── • scan buffer

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -552,7 +552,7 @@ vectorized: true
             │ columns: (column1, column2, column3, x, y, z)
             │ estimated row count: 2 (missing stats)
             │ table: tdup@tdup_y_z_key
-            │ equality: (column2, column3) = (y,z)
+            │ equality: (column2, column3) = (y, z)
             │ equality cols are key
             │
             └── • distinct

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -746,7 +746,7 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 			ob.Attrf(
 				"equality", "(%s) = (%s)",
 				printColumnList(inputCols, a.EqCols),
-				strings.Join(rightEqCols, ","),
+				strings.Join(rightEqCols, ", "),
 			)
 		}
 		if a.EqColsAreKey {

--- a/pkg/sql/opt/exec/explain/testdata/gists
+++ b/pkg/sql/opt/exec/explain/testdata/gists
@@ -1177,7 +1177,7 @@ AgFWBgCPAQIAABNWCgsGBwwHHA0UAXoCBgEFUCJ6AQ==
 │
 └── • lookup join (left outer)
     │ table: ?@?
-    │ equality: (_, _, _) = (?,?,?)
+    │ equality: (_, _, _) = (?, ?, ?)
     │ equality cols are key
     │
     └── • distinct


### PR DESCRIPTION
Previously, we forgot to add a space between column names in the "equality" attribute on the right side of the lookup join.

Epic: None

Release note: None