### PR TITLE
release-23.1: kvstreamer: fix cross-range ScanRequests with SingleRowLookup hint

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/requests_provider.go
+++ b/pkg/kv/kvclient/kvstreamer/requests_provider.go
@@ -74,8 +74,8 @@ type singleRangeBatch struct {
 	// the responses to these single-range requests (which might come back in
 	// any order) correctly.
 	//
-	// subRequestIdx is only allocated in InOrder mode when
-	// Hints.SingleRowLookup is false and some Scan requests were enqueued.
+	// subRequestIdx is only allocated in InOrder mode when some Scan requests
+	// were enqueued.
 	subRequestIdx []int32
 	// isScanStarted tracks whether we have already received at least one
 	// response for the corresponding ScanRequest (i.e. whether the ScanRequest

--- a/pkg/kv/kvclient/kvstreamer/requests_provider.go
+++ b/pkg/kv/kvclient/kvstreamer/requests_provider.go
@@ -305,7 +305,7 @@ func (p *outOfOrderRequestsProvider) enqueue(requests []singleRangeBatch) {
 	p.Lock()
 	defer p.Unlock()
 	if len(p.requests) > 0 {
-		panic(errors.AssertionFailedf("outOfOrderRequestsProvider has old requests in enqueue"))
+		panic(errors.AssertionFailedf("outOfOrderRequestsProvider has %d old requests in enqueue", len(p.requests)))
 	}
 	p.requests = requests
 	p.hasWork.Signal()
@@ -429,7 +429,7 @@ func (p *inOrderRequestsProvider) enqueue(requests []singleRangeBatch) {
 	p.Lock()
 	defer p.Unlock()
 	if len(p.requests) > 0 {
-		panic(errors.AssertionFailedf("inOrderRequestsProvider has old requests in enqueue"))
+		panic(errors.AssertionFailedf("inOrderRequestsProvider has %d old requests in enqueue", len(p.requests)))
 	}
 	p.requests = requests
 	p.heapInit()

--- a/pkg/kv/kvclient/kvstreamer/results_buffer.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer.go
@@ -181,7 +181,10 @@ func newResultsBufferBase(budget *budget) *resultsBufferBase {
 func (b *resultsBufferBase) initLocked(isEmpty bool, numExpectedResponses int) error {
 	b.Mutex.AssertHeld()
 	if b.numExpectedResponses != b.numCompleteResponses {
-		b.setErrorLocked(errors.AssertionFailedf("Enqueue is called before the previous requests have been completed"))
+		b.setErrorLocked(errors.AssertionFailedf(
+			"Enqueue is called before the previous requests have been completed (expected %d, complete %d)",
+			b.numExpectedResponses, b.numCompleteResponses,
+		))
 		return b.err
 	}
 	if !isEmpty {
@@ -189,7 +192,7 @@ func (b *resultsBufferBase) initLocked(isEmpty bool, numExpectedResponses int) e
 		return b.err
 	}
 	if b.numUnreleasedResults > 0 {
-		b.setErrorLocked(errors.AssertionFailedf("unexpectedly there are some unreleased Results"))
+		b.setErrorLocked(errors.AssertionFailedf("unexpectedly there are %d unreleased Results", b.numUnreleasedResults))
 		return b.err
 	}
 	b.numExpectedResponses = numExpectedResponses
@@ -334,6 +337,12 @@ func (b *outOfOrderResultsBuffer) get(context.Context) ([]Result, bool, error) {
 	// is done as a way of "amortizing" the reservation.
 	b.results = nil
 	allComplete := b.numCompleteResponses == b.numExpectedResponses
+	if b.err == nil && b.numCompleteResponses > b.numExpectedResponses {
+		b.err = errors.AssertionFailedf(
+			"received %d complete responses when only %d were expected",
+			b.numCompleteResponses, b.numExpectedResponses,
+		)
+	}
 	return results, allComplete, b.err
 }
 
@@ -594,6 +603,12 @@ func (b *inOrderResultsBuffer) get(ctx context.Context) ([]Result, bool, error) 
 	// All requests are complete IFF we have received the complete responses for
 	// all requests and there no buffered Results.
 	allComplete := b.numCompleteResponses == b.numExpectedResponses && len(b.buffered) == 0
+	if b.err == nil && b.numCompleteResponses > b.numExpectedResponses {
+		b.err = errors.AssertionFailedf(
+			"received %d complete responses when only %d were expected",
+			b.numCompleteResponses, b.numExpectedResponses,
+		)
+	}
 	b.resultScratch = res
 	return res, allComplete, b.err
 }

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -579,18 +579,16 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 	acc := monitor.MakeBoundAccount()
 	defer acc.Close(ctx)
 
-	getStreamer := func(singleRowLookup bool) *Streamer {
+	getStreamer := func() *Streamer {
 		require.Zero(t, acc.Used())
 		s := getStreamer(ctx, s, math.MaxInt64, &acc)
-		s.Init(OutOfOrder, Hints{UniqueRequests: true, SingleRowLookup: singleRowLookup}, 1 /* maxKeysPerRow */, nil /* diskBuffer */)
+		s.Init(OutOfOrder, Hints{UniqueRequests: true}, 1 /* maxKeysPerRow */, nil /* diskBuffer */)
 		return s
 	}
 
 	t.Run("get", func(t *testing.T) {
 		acc.Clear(ctx)
-		// SingleRowLookup hint only influences the accounting when at least
-		// one Scan request is present.
-		streamer := getStreamer(false /* singleRowLookup */)
+		streamer := getStreamer()
 		defer streamer.Close(ctx)
 
 		// Get the row with pk=0.
@@ -607,39 +605,34 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 		require.Equal(t, expectedUsed, acc.Used())
 	})
 
-	for _, singleRowLookup := range []bool{false, true} {
-		t.Run(fmt.Sprintf("scan/single_row_lookup=%t", singleRowLookup), func(t *testing.T) {
-			acc.Clear(ctx)
-			streamer := getStreamer(singleRowLookup)
-			defer streamer.Close(ctx)
+	t.Run("scan", func(t *testing.T) {
+		acc.Clear(ctx)
+		streamer := getStreamer()
+		defer streamer.Close(ctx)
 
-			// Scan the row with pk=0.
-			reqs := make([]kvpb.RequestUnion, 1)
-			reqs[0] = makeScanRequest(tableID, 0, 1)
-			require.NoError(t, streamer.Enqueue(ctx, reqs))
-			results, err := streamer.GetResults(ctx)
-			require.NoError(t, err)
-			require.Equal(t, 1, len(results))
-			// 29 is usually the number of bytes in
-			// ScanResponse.BatchResponse[0]. We choose to hard-code this number
-			// rather than consult NumBytes field directly as an additional
-			// sanity-check.
-			expectedMemToken := scanResponseOverhead + 29
-			if results[0].ScanResp.NumBytes == 33 {
-				// For some reason, sometimes it's not 29, but 33, and we do
-				// allow for this.
-				expectedMemToken += 4
-			}
-			require.Equal(t, expectedMemToken, results[0].memoryTok.toRelease)
-			expectedUsed := expectedMemToken + resultSize
-			if !singleRowLookup {
-				// This is streamer.numRangesPerScanRequestAccountedFor which is
-				// only non-zero when SingleRowLookup hint is false.
-				expectedUsed += 4
-			}
-			require.Equal(t, expectedUsed, acc.Used())
-		})
-	}
+		// Scan the row with pk=0.
+		reqs := make([]kvpb.RequestUnion, 1)
+		reqs[0] = makeScanRequest(tableID, 0, 1)
+		require.NoError(t, streamer.Enqueue(ctx, reqs))
+		results, err := streamer.GetResults(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(results))
+		// 29 is usually the number of bytes in
+		// ScanResponse.BatchResponse[0]. We choose to hard-code this number
+		// rather than consult NumBytes field directly as an additional
+		// sanity-check.
+		expectedMemToken := scanResponseOverhead + 29
+		if results[0].ScanResp.NumBytes == 33 {
+			// For some reason, sometimes it's not 29, but 33, and we do
+			// allow for this.
+			expectedMemToken += 4
+		}
+		require.Equal(t, expectedMemToken, results[0].memoryTok.toRelease)
+		expectedUsed := expectedMemToken + resultSize
+		// This is streamer.numRangesPerScanRequestAccountedFor.
+		expectedUsed += 4
+		require.Equal(t, expectedUsed, acc.Used())
+	})
 }
 
 // TestStreamerVaryingResponseSizes verifies that the Streamer handles the

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -1534,3 +1534,17 @@ SELECT length(c1), length(c3) FROM l_113013 l INNER JOIN r_113013 r ON l.r_id = 
 ----
 2  4000
 2  2
+
+# Regression test for incorrectly treating cross-range ScanRequests by the
+# Streamer when "equality columns are key" in the lookup join (#101823).
+statement ok
+CREATE TABLE l_101823 (a INT, b INT, PRIMARY KEY (a, b));
+INSERT INTO l_101823 VALUES (1, 1);
+CREATE TABLE r_101823 (k INT PRIMARY KEY, u INT, v INT, w BOOL, UNIQUE INDEX (u), UNIQUE INDEX (u, v, w));
+INSERT INTO r_101823 VALUES (1, 1, 1, false);
+ALTER INDEX r_101823_u_v_w_key SPLIT AT VALUES (1, 1, false), (1, 1, true);
+
+query I
+SELECT count(v) FROM l_101823 LEFT LOOKUP JOIN r_101823 ON a = u AND b = v;
+----
+1


### PR DESCRIPTION
Backport 2/3 commits from #115569.

/cc @cockroachdb/release

---

This commit fixes a long-standing issue in the streamer when SingleRowLookup hint is set and there are some cross-range ScanRequests. The SingleRowLookup hint indicates that each request can result in at most one SQL row, but that was incorrectly understood as ScanRequests touching exactly one range - it is possible to have a multi-range ScanRequest that only fetches a single SQL row. As a result of this incorrect usage of the SingleRowLookup hint, the streamer could either get stuck (because it would actually receive more responses than were expected, and in `resultsBuffer.get` implementations we say `allComplete` is `true` with exact equality) or could return incorrect results (when one of the truncated ScanRequests came back empty before the non-empty one, but we didn't wait for the latter).

The bug is now fixed by removing optimizations that were in-place when this hint is specified. In particular, it means that now, whenever at least one ScanRequest is enqueued, we will always allocate
- `Streamer.mu.numRangesPerScanRequest []int32` slice
- `subRequestIdx []int32` slices in the InOrder mode.

This would increase the fraction of the streamer's budget dedicated to overhead, but it should be relatively minor in the grand scheme of things.

I decided to not remove the hint altogether since we could introduce some optimizations using it in the future.

Fixes: #101823.
Fixes: #108412.
Fixes: #112490.

Release note (bug fix): Previously, CockroachDB could incorrectly evaluate queries with lookup joins when equality columns are key in some rare cases when looking up into multiple ranges. Sometimes this would manifest as a stuck query, sometimes it could result in incorrect output. The bug was introduced in 22.2 and is now fixed.

Release justification: bug fix.