### PR TITLE
backupccl: test export requests bound on ranges

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -386,6 +386,11 @@ func backup(
 		), "running distributed backup to export %d ranges", errors.Safe(numTotalSpans))
 	}
 
+	knobs := execCtx.ExecCfg().BackupRestoreTestingKnobs
+	if knobs != nil && knobs.RunBeforeBackupFlow != nil {
+		knobs.RunBeforeBackupFlow(ctx)
+	}
+
 	if err := ctxgroup.GoAndWait(
 		ctx,
 		jobProgressLoop,

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -9216,7 +9216,7 @@ func TestGCDropIndexSpanExpansion(t *testing.T) {
 
 	// Wait for the GC to complete.
 	jobutils.WaitForJobToSucceed(t, sqlRunner, gcJobID)
-	waitForTableSplit(t, conn, "foo", "test")
+	waitForTableSplit(t, conn, "foo", "test", 1)
 
 	// This backup should succeed since the spans being backed up have a default
 	// GC TTL of 25 hours.
@@ -9492,7 +9492,7 @@ func TestExportRequestBelowGCThresholdOnDataExcludedFromBackup(t *testing.T) {
 	require.NoError(t, err)
 
 	rRand, _ := randutil.NewTestRand()
-	waitForTableSplit(t, conn, "foo", "defaultdb")
+	waitForTableSplit(t, conn, "foo", "defaultdb", 1)
 	waitForReplicaFieldToBeSet(t, tc, conn, "foo", "defaultdb", func(r *kvserver.Replica) (bool, error) {
 		conf, err := r.LoadSpanConfig(ctx)
 		if err != nil {
@@ -9581,7 +9581,7 @@ func TestExcludeDataFromBackupDoesNotHoldupGC(t *testing.T) {
 		"gc.ttlseconds = 1, range_max_bytes = $1, range_min_bytes = 1<<10;", tableRangeMaxBytes)
 
 	// Wait for the span config fields to apply.
-	waitForTableSplit(t, conn, "foo", "test")
+	waitForTableSplit(t, conn, "foo", "test", 1)
 	waitForReplicaFieldToBeSet(t, tc, conn, "foo", "test", func(r *kvserver.Replica) (bool, error) {
 		conf, err := r.LoadSpanConfig(ctx)
 		if err != nil {
@@ -10626,7 +10626,7 @@ func TestBackupDBWithViewOnAdjacentDBRange(t *testing.T) {
 	`)
 
 	// Wait for splits to be created on the new tables.
-	waitForTableSplit(t, tc.Conns[0], "t2", "da")
+	waitForTableSplit(t, tc.Conns[0], "t2", "da", 1)
 
 	sqlDB.Exec(t, `BACKUP DATABASE db INTO 'userfile:///a' WITH revision_history;`)
 
@@ -11203,4 +11203,45 @@ func TestRestoreMemoryMonitoringMinWorkerMemory(t *testing.T) {
 	expectedFingerprints := sqlDB.QueryStr(t, "SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE data.bank")
 	actualFingerprints := sqlDB.QueryStr(t, "SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE restore.bank")
 	require.Equal(t, expectedFingerprints, actualFingerprints)
+}
+
+// TestBoundBackupExportOnRanges tests that export requests never get sent
+// across range boundaries, even if the ranges are empty.
+func TestBoundBackupExportOnRanges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const numAccounts = 1
+
+	waitForSplits := make(chan struct{})
+	var responseCount atomic.Int32
+	params := base.TestClusterArgs{}
+	knobs := base.TestingKnobs{
+		DistSQL: &execinfra.TestingKnobs{
+			BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
+				RunBeforeBackupFlow: func(ctx context.Context) {
+					<-waitForSplits
+				},
+				RunAfterExportingSpanEntry: func(ctx context.Context, response *kvpb.ExportResponse) {
+					responseCount.Add(1)
+				},
+			},
+		},
+	}
+	params.ServerArgs.Knobs = knobs
+	tc, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, params)
+	defer cleanupFn()
+
+	rowsPerRange := 2
+	numRanges := 30
+	sqlDB.Exec(t, "SET CLUSTER SETTING bulkio.backup.presplit_request_spans.enabled=true")
+	var jobID int
+	sqlDB.QueryRow(t, "BACKUP DATABASE data INTO 'userfile:///backup' WITH detached").Scan(&jobID)
+	sqlDB.Exec(t, `ALTER TABLE data.bank SPLIT AT (SELECT * FROM generate_series($1::INT, $2::INT, $3::INT))`,
+		rowsPerRange, (numRanges-1)*rowsPerRange, rowsPerRange)
+	waitForTableSplit(t, tc.Conns[0], "bank", "data", numRanges)
+
+	close(waitForSplits)
+	jobutils.WaitForJobToSucceed(t, sqlDB, jobspb.JobID(jobID))
+	exportRequestCount := responseCount.Load()
+	require.Equal(t, int32(numRanges), exportRequestCount)
 }

--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -292,7 +292,9 @@ func uriFmtStringAndArgs(uris []string, startIndex int) (string, []interface{}) 
 // waitForTableSplit waits for the dbName.tableName range to split. This is
 // often used by tests that rely on SpanConfig fields being applied to the table
 // span.
-func waitForTableSplit(t *testing.T, conn *gosql.DB, tableName, dbName string) {
+func waitForTableSplit(
+	t *testing.T, conn *gosql.DB, tableName, dbName string, passingRangeCount int,
+) {
 	t.Helper()
 	testutils.SucceedsSoon(t, func() error {
 		count := 0
@@ -301,8 +303,8 @@ func waitForTableSplit(t *testing.T, conn *gosql.DB, tableName, dbName string) {
 				tree.NameString(dbName), tree.NameString(tableName))).Scan(&count); err != nil {
 			return err
 		}
-		if count == 0 {
-			return errors.New("waiting for table split")
+		if count < passingRangeCount {
+			return errors.Newf("waiting for table split into at least %d ranges", passingRangeCount)
 		}
 		return nil
 	})

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1748,6 +1748,8 @@ type BackupRestoreTestingKnobs struct {
 	// execution.
 	CaptureResolvedTableDescSpans func([]roachpb.Span)
 
+	RunBeforeBackupFlow func(ctx context.Context)
+
 	// RunAfterSplitAndScatteringEntry allows blocking the RESTORE job after a
 	// single RestoreSpanEntry has been split and scattered.
 	RunAfterSplitAndScatteringEntry func(ctx context.Context)


### PR DESCRIPTION
This patch adds a test that ensures the backup processor sends one export request per range.

Fixes #115575

Release note: none