### PR TITLE
ui: change some references to tenant to virtual cluster

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -413,7 +413,7 @@ export class NodeGraphs extends React.Component<
           {isSystemTenant(currentTenant) && tenantOptions.length > 1 && (
             <PageConfigItem>
               <Dropdown
-                title="Tenant"
+                title="Virtual Cluster"
                 options={tenantOptions}
                 selected={selectedTenant}
                 onChange={selection => this.setClusterPath("tenant", selection)}

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/customMetric.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/customMetric.tsx
@@ -342,10 +342,10 @@ export class CustomChartTable extends React.Component<CustomChartTableProps> {
               <td className="metric-table__header">Source</td>
               <td className="metric-table__header">Per Node</td>
               {canViewTenantOptions && (
-                <td className="metric-table__header">Tenant</td>
+                <td className="metric-table__header">Virtual Cluster</td>
               )}
               {canViewTenantOptions && (
-                <td className="metric-table__header">Per Tenant</td>
+                <td className="metric-table__header">Per Virtual Cluster</td>
               )}
               <td className="metric-table__header"></td>
             </tr>


### PR DESCRIPTION
This changes the "Tenant" selector on the metrics pages to use the new "Virtual Cluster" terminology.

Fixes #114170

Release note: None

<img width="1037" alt="Screenshot 2023-12-05 at 11 05 10" src="https://github.com/cockroachdb/cockroach/assets/852371/54f9ce9c-fc0b-4457-8214-de22c45b32bc">
<img width="1086" alt="Screenshot 2023-12-05 at 11 05 05" src="https://github.com/cockroachdb/cockroach/assets/852371/d0cb2f32-20a6-4522-8727-3c19ce0a91ab">
