### PR TITLE
release-23.1: sql/schemachanger: create index should fallback for materialized views

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -430,3 +430,10 @@ CREATE MATERIALIZED VIEW v (b) AS SELECT a * 2 FROM t WITH DATA;
 
 statement ok
 CREATE INDEX ON v (b);
+
+# Issue #114843 happened because we are unable to create
+# virtual columns on materialized views in the declarative
+# schema changer.
+statement ok
+CREATE INDEX ON v ((b>0));
+

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdecomp"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
@@ -557,6 +558,9 @@ func addColumnsForSecondaryIndex(
 	for i, columnNode := range n.Columns {
 		colName := columnNode.Column
 		if columnNode.Expr != nil {
+			// Add column needs to support materialized views for the
+			// declarative schema changer to work.
+			fallbackIfRelationIsNotTable(n, relation)
 			colNameStr := maybeCreateVirtualColumnForIndex(b, &n.Table, relation.(*scpb.Table), columnNode.Expr, n.Inverted, i == len(n.Columns)-1)
 			colName = tree.Name(colNameStr)
 			if !expressionTelemtryCounted {
@@ -642,6 +646,9 @@ func addColumnsForSecondaryIndex(
 	// Set up sharding.
 	if n.Sharded != nil {
 		b.IncrementSchemaChangeIndexCounter("hash_sharded")
+		// Add column needs to support materialized views for the
+		// declarative schema changer to work.
+		fallbackIfRelationIsNotTable(n, relation)
 		sharding, shardColID, _ := ensureShardColAndMakeShardDesc(b, relation.(*scpb.Table), keyColNames,
 			n.Sharded.ShardBuckets, n.StorageParams, n)
 		idxSpec.secondary.Sharding = sharding
@@ -939,4 +946,17 @@ func maybeApplyStorageParameters(b BuildCtx, n *tree.CreateIndex, idxSpec *index
 	} else {
 		idxSpec.secondary.GeoConfig = nil
 	}
+}
+
+// fallbackIfRelationIsNotTable falls back if a relation element is
+// not a table. This is temporally used in cases involving materialized
+// views, where a column needs to be added.
+func fallbackIfRelationIsNotTable(node tree.NodeFormatter, element scpb.Element) {
+	switch element.(type) {
+	case *scpb.Table:
+		return
+	case *scpb.View, *scpb.Sequence:
+		panic(scerrors.NotImplementedErrorf(node, "relation is not a table"))
+	}
+	panic(errors.AssertionFailedf("element is not a relation type"))
 }


### PR DESCRIPTION
Backport 1/1 commits from #115482.

/cc @cockroachdb/release

---

Previously, the declarative schema changer did not correctly handle CREATE INDEX with expressions on a materialized view. The shared add column code was only designed for relations and could not be used for views. To address this, this patch introduces a temporary fallback if a CREATE INDEX expression involves a materialized view.

Fixes: #114843

Release note (bug fix): CREATE INDEX with expressions could fail on materialized views when the declarative schema changer was used.
Release justification: Low risk fix that adds a fall back to the declarative schema changer when hitting an unsupported code path, which addresses a regression.