### PR TITLE
ui: dispatch refresh action from JobDetailsPageConnected component

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetailsConnected.tsx
@@ -52,7 +52,7 @@ const mapStateToProps = (
 };
 
 const mapDispatchToProps = (dispatch: Dispatch): JobDetailsDispatchProps => ({
-  refreshJob: (req: JobRequest) => jobActions.refresh(req),
+  refreshJob: (req: JobRequest) => dispatch(jobActions.refresh(req)),
   refreshExecutionDetailFiles: (req: ListJobProfilerExecutionDetailsRequest) =>
     dispatch(jobProfilerActions.refresh(req)),
   onRequestExecutionDetails: (jobID: long) => {


### PR DESCRIPTION
Dispatch actual action to refresh Job Details page in JobDetailsPageConnected component. Before, there was a missing invocation of `dispatch` function that led to not loading any job information on Job Details page.

Release note: None

Resolves: https://cockroachlabs.atlassian.net/browse/CC-26515