### PR TITLE
telemetry: allow BEGIN statements to be logged in telemetry transacti…

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3100,7 +3100,9 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent, txnErr err
 		// If we have a commitTimestamp, we should use it.
 		ex.previousTransactionCommitTimestamp.Forward(ev.commitTimestamp)
 		if telemetryLoggingEnabled.Get(&ex.server.cfg.Settings.SV) {
-			ex.server.TelemetryLoggingMetrics.onTxnFinish(ev.txnID.String())
+			txnCounter := int(ex.extraTxnState.txnCounter.Load())
+			txnKey := createTelemetryTransactionID(ex.planner.extendedEvalCtx.SessionID, txnCounter)
+			ex.server.TelemetryLoggingMetrics.onTxnFinish(txnKey)
 		}
 	}
 }

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -1711,7 +1711,7 @@ func TestTelemetryLoggingTxnMode(t *testing.T) {
 	queries := []testQuery{
 		{
 			query:   "BEGIN; TRUNCATE t; COMMIT",
-			logTime: 0, // Logged.
+			logTime: 0.1, // Logged.
 		},
 		{
 			query:   "BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT",
@@ -1750,16 +1750,24 @@ func TestTelemetryLoggingTxnMode(t *testing.T) {
 
 	expectedLogs := []expectedLog{
 		{
+			logMsg:            `BEGIN TRANSACTION`,
+			skippedQueryCount: 0,
+		},
+		{
 			logMsg:            `TRUNCATE TABLE defaultdb.public.t`,
-			skippedQueryCount: 1, // Skipped BEGIN.
+			skippedQueryCount: 0,
 		},
 		{
 			logMsg:            `COMMIT TRANSACTION`,
 			skippedQueryCount: 0,
 		},
 		{
+			logMsg:            `BEGIN TRANSACTION`,
+			skippedQueryCount: 0,
+		},
+		{
 			logMsg:            `SELECT ‹1›`,
-			skippedQueryCount: 1, // BEGIN skipped.
+			skippedQueryCount: 0,
 		},
 		{
 			logMsg:            `SELECT ‹2›`,
@@ -1782,8 +1790,12 @@ func TestTelemetryLoggingTxnMode(t *testing.T) {
 			skippedQueryCount: 2,
 		},
 		{
+			logMsg:            `BEGIN TRANSACTION`,
+			skippedQueryCount: 3,
+		},
+		{
 			logMsg:            `SELECT * FROM ""."".t LIMIT ‹4›`,
-			skippedQueryCount: 4,
+			skippedQueryCount: 0,
 		},
 		{
 			logMsg:            `SELECT * FROM ""."".t LIMIT ‹5›`,
@@ -2060,8 +2072,12 @@ func TestTelemetryLoggingRespectsTxnLimit(t *testing.T) {
 
 	expectedLogs := []expectedLog{
 		{
+			logMsg:            `BEGIN TRANSACTION`,
+			skippedQueryCount: 0,
+		},
+		{
 			logMsg:            `SELECT ‹1›`,
-			skippedQueryCount: 2, // Skipped both BEGIN queries.
+			skippedQueryCount: 1, // Skipped BEGIN in other transaction.
 		},
 		{
 			logMsg:            `SELECT ‹1›, ‹1›`,


### PR DESCRIPTION
…on mode

Previously, we dropped logging BEGIN statements in telemetry transaction sampling mode due to BEGIN not having an associated transaction execution id at the time of logging. For transaction sampling we were using the transaction execution id to track the transaction through its execution in order to log all of its statements. Since BEGIN statements did not have an id, we could not start tracking with BEGIN. This commit enables us to include BEGIN statements by using a combination of the session id and session txn counter as the tracking id for telemetry, instead of the execution id. This allows us to start tracking transactions at BEGIN instead of at the statement after it.

Part of: #108284

Release note (sql change): Telemetry logging - "transaction" sampling mode will now log BEGIN statements when they are present in a sampled transaction.