### PR TITLE
db-console: remove "oss" from imports

### DIFF
--- a/pkg/ui/workspaces/db-console/ccl/src/views/shared/components/licenseType/index.tsx
+++ b/pkg/ui/workspaces/db-console/ccl/src/views/shared/components/licenseType/index.tsx
@@ -10,7 +10,7 @@ import React from "react";
 
 import DebugAnnotation from "src/views/shared/components/debugAnnotation";
 import swapByLicense from "src/views/shared/containers/licenseSwap";
-import OSSLicenseType from "oss/src/views/shared/components/licenseType";
+import OSSLicenseType from "src/views/shared/components/licenseType";
 
 export class CCLLicenseType extends React.Component<{}, {}> {
   render() {
@@ -21,6 +21,6 @@ export class CCLLicenseType extends React.Component<{}, {}> {
 /**
  * LicenseType is an indicator showing the current build license.
  */
-const LicenseType = swapByLicense(OSSLicenseType, CCLLicenseType);
+const LicenseType: any = swapByLicense(OSSLicenseType, CCLLicenseType);
 
 export default LicenseType;

--- a/pkg/ui/workspaces/db-console/src/redux/jobs/jobsSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/jobs/jobsSagas.ts
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import { PayloadAction } from "@reduxjs/toolkit";
-import { refreshListExecutionDetailFiles } from "oss/src/redux/apiReducers";
+import { refreshListExecutionDetailFiles } from "src/redux/apiReducers";
 import { all, call, put, takeEvery } from "redux-saga/effects";
 import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 import {

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -32,8 +32,8 @@ import {
   uiDebugPages,
 } from "src/util/docs";
 import emptyTableResultsImg from "assets/emptyState/empty-table-results.svg";
-import { sortSettingLocalSetting } from "oss/src/redux/hotRanges";
-import { AdminUIState } from "oss/src/redux/state";
+import { sortSettingLocalSetting } from "src/redux/hotRanges";
+import { AdminUIState } from "src/redux/state";
 import { connect } from "react-redux";
 
 const PAGE_SIZE = 50;

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
@@ -23,7 +23,7 @@ import {
 import { AdminUIState, AppDispatch } from "src/redux/state";
 import { ListJobProfilerExecutionDetailsResponseMessage } from "src/util/api";
 import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
-import { collectExecutionDetailsAction } from "oss/src/redux/jobs/jobsActions";
+import { collectExecutionDetailsAction } from "src/redux/jobs/jobsActions";
 import long from "long";
 import { selectHasAdminRole } from "src/redux/user";
 

--- a/pkg/ui/workspaces/db-console/src/views/login/oidc.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/login/oidc.tsx
@@ -10,7 +10,7 @@
 
 import React from "react";
 
-import { LoginAPIState } from "oss/src/redux/login";
+import { LoginAPIState } from "src/redux/login";
 import { Button } from "src/components";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
@@ -26,7 +26,7 @@ import LineGraph from "src/views/cluster/components/linegraph";
 import { DropdownOption } from "src/views/shared/components/dropdown";
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
 import { Metric, Axis } from "src/views/shared/components/metricQuery";
-import TimeScaleDropdown from "oss/src/views/cluster/containers/timeScaleDropdownWithSearchParams";
+import TimeScaleDropdown from "src/views/cluster/containers/timeScaleDropdownWithSearchParams";
 import { AxisUnits, TimeScale } from "@cockroachlabs/cluster-ui";
 import {
   PageConfig,


### PR DESCRIPTION
Some imports were using "oss".
The imports should start with  "src" instead.

Epic: none

Release note: None