### PR TITLE
obsservice: pass obs service flag to sql api

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -368,6 +368,7 @@ var allConsoleKeys = []InternalKey{
 	"keyvisualizer.sample_interval",
 	"sql.index_recommendation.drop_unused_duration",
 	"sql.insights.anomaly_detection.latency_threshold",
+	"sql.insights.export.enabled",
 	"sql.insights.high_retry_count.threshold",
 	"sql.insights.latency_threshold",
 	"sql.stats.automatic_collection.enabled",

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -19,6 +19,7 @@ export type SqlExecutionRequest = {
   database?: string; // Defaults to system
   max_result_size?: number; // Default 10kib
   separate_txns?: boolean;
+  use_obs_service?: boolean; // Flag to use Observability Service. Default is false.
 };
 
 export type SqlStatement = {
@@ -210,6 +211,7 @@ export function sqlApiErrorMessage(message: string): string {
 export function createSqlExecutionRequest(
   dbName: string,
   statements: SqlStatement[],
+  useObsService?: boolean,
 ): SqlExecutionRequest {
   return {
     execute: true,
@@ -217,6 +219,7 @@ export function createSqlExecutionRequest(
     database: dbName,
     max_result_size: LARGE_RESULT_SIZE,
     timeout: LONG_TIMEOUT,
+    use_obs_service: useObsService || false,
   };
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
@@ -35,6 +35,7 @@ export type StmtInsightsReq = {
   end?: moment.Moment;
   stmtExecutionID?: string;
   stmtFingerprintId?: string;
+  csExportInsights?: boolean;
 };
 
 export type StmtInsightsResponseRow = {

--- a/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
@@ -156,6 +156,7 @@ export async function getStmtInsightsApi(
     execute: true,
     max_result_size: LARGE_RESULT_SIZE,
     timeout: LONG_TIMEOUT,
+    use_obs_service: req.csExportInsights,
   };
 
   const result = await executeInternalSql<StmtInsightsResponseRow>(request);

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -43,6 +43,7 @@ export interface StatementInsightDetailsStateProps {
   isTenant?: boolean;
   timeScale?: TimeScale;
   hasAdminRole: boolean;
+  csExportInsights: boolean;
 }
 
 export interface StatementInsightDetailsDispatchProps {
@@ -77,6 +78,7 @@ export const StatementInsightDetails: React.FC<
   timeScale,
   hasAdminRole,
   refreshUserSQLRoles,
+  csExportInsights,
 }) => {
   const [explainPlanState, setExplainPlanState] = useState<ExplainPlanState>({
     explainPlan: null,
@@ -89,6 +91,8 @@ export const StatementInsightDetails: React.FC<
       loaded: insightEventDetails != null,
       error: insightError,
     });
+  const [prevCsExportInsights, setPrevCsExportInsights] =
+    useState(csExportInsights);
 
   const details = insightDetails.details;
 
@@ -116,11 +120,17 @@ export const StatementInsightDetails: React.FC<
 
   useEffect(() => {
     refreshUserSQLRoles();
-    if (details != null) {
+    if (details != null && prevCsExportInsights === csExportInsights) {
       return;
     }
+    setPrevCsExportInsights(csExportInsights);
     const [start, end] = toDateRange(timeScale);
-    getStmtInsightsApi({ stmtExecutionID: executionID, start, end })
+    getStmtInsightsApi({
+      stmtExecutionID: executionID,
+      start,
+      end,
+      csExportInsights,
+    })
       .then(res => {
         setInsightDetails({
           details: res?.results?.length ? res.results[0] : null,
@@ -130,7 +140,14 @@ export const StatementInsightDetails: React.FC<
       .catch(e => {
         setInsightDetails({ details: null, error: e, loaded: true });
       });
-  }, [details, executionID, timeScale, refreshUserSQLRoles]);
+  }, [
+    details,
+    executionID,
+    timeScale,
+    refreshUserSQLRoles,
+    csExportInsights,
+    prevCsExportInsights,
+  ]);
 
   return (
     <div>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
@@ -25,6 +25,7 @@ import { TimeScale } from "../../timeScaleDropdown";
 import { actions as sqlStatsActions } from "../../store/sqlStats";
 import { selectTimeScale } from "../../store/utils/selectors";
 import { actions as analyticsActions } from "../../store/analytics";
+import { selectCsExportInsights } from "src/store/clusterSettings/clusterSettings.selectors";
 
 const mapStateToProps = (
   state: AppState,
@@ -38,6 +39,7 @@ const mapStateToProps = (
     isTenant: selectIsTenant(state),
     timeScale: selectTimeScale(state),
     hasAdminRole: selectHasAdminRole(state),
+    csExportInsights: selectCsExportInsights(state),
   };
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -65,19 +65,20 @@ const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
 
 export type StatementInsightsViewStateProps = {
+  csExportInsights: boolean;
+  filters: WorkloadInsightEventFilters;
+  insightTypes: string[];
   isDataValid: boolean;
   lastUpdated: moment.Moment;
+  selectedColumnNames: string[];
+  sortSetting: SortSetting;
   statements: StmtInsightEvent[];
   statementsError: Error | null;
-  insightTypes: string[];
-  filters: WorkloadInsightEventFilters;
-  sortSetting: SortSetting;
-  selectedColumnNames: string[];
-  isLoading?: boolean;
   dropDownSelect?: React.ReactElement;
-  timeScale?: TimeScale;
-  maxSizeApiReached?: boolean;
+  isLoading?: boolean;
   isTenant?: boolean;
+  maxSizeApiReached?: boolean;
+  timeScale?: TimeScale;
 };
 
 export type StatementInsightsViewDispatchProps = {
@@ -112,6 +113,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
   selectedColumnNames,
   dropDownSelect,
   maxSizeApiReached,
+  csExportInsights,
 }: StatementInsightsViewProps) => {
   const [pagination, setPagination] = useState<ISortedTablePagination>({
     current: 1,
@@ -123,9 +125,14 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
   );
 
   const refresh = useCallback(() => {
-    const req = timeScaleRangeToObj(timeScale);
+    const ts = timeScaleRangeToObj(timeScale);
+    const req = {
+      start: ts.start,
+      end: ts.end,
+      csExportInsights: csExportInsights,
+    };
     refreshStatementInsights(req);
-  }, [refreshStatementInsights, timeScale]);
+  }, [refreshStatementInsights, timeScale, csExportInsights]);
 
   const shouldPoll = timeScale.key !== "Custom";
   const [refetch, clearPolling] = useScheduleFunction(

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
@@ -51,6 +51,7 @@ import { StmtInsightsReq, TxnInsightsRequest } from "src/api";
 import { selectTimeScale } from "../../store/utils/selectors";
 import { actions as analyticsActions } from "../../store/analytics";
 import { selectIsTenant } from "../../store/uiConfig";
+import { selectCsExportInsights } from "src/store/clusterSettings/clusterSettings.selectors";
 
 const transactionMapStateToProps = (
   state: AppState,
@@ -84,6 +85,7 @@ const statementMapStateToProps = (
   isLoading: selectStmtInsightsLoading(state),
   maxSizeApiReached: selectStmtInsightsMaxApiReached(state),
   isTenant: selectIsTenant(state),
+  csExportInsights: selectCsExportInsights(state),
 });
 
 const TransactionDispatchProps = (

--- a/pkg/ui/workspaces/cluster-ui/src/store/clusterSettings/clusterSettings.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/clusterSettings/clusterSettings.selectors.ts
@@ -9,7 +9,11 @@
 // licenses/APL.txt.
 
 import { AppState } from "../reducers";
-import { greaterOrEqualThanVersion, indexUnusedDuration } from "../../util";
+import {
+  exportInsights,
+  greaterOrEqualThanVersion,
+  indexUnusedDuration,
+} from "../../util";
 
 export const selectAutomaticStatsCollectionEnabled = (
   state: AppState,
@@ -49,4 +53,19 @@ export const selectDropUnusedIndexDuration = (state: AppState): string => {
     settings["sql.index_recommendation.drop_unused_duration"]?.value ||
     indexUnusedDuration
   );
+};
+
+export const selectCsExportInsights = (state: AppState): boolean => {
+  const settings = state.adminUI?.clusterSettings.data?.key_values;
+  if (!settings) {
+    return exportInsights;
+  }
+  if (settings["sql.insights.export.enabled"]) {
+    if (settings["sql.insights.export.enabled"]?.value === "false") {
+      return false;
+    }
+    return true;
+  } else {
+    return exportInsights;
+  }
 };

--- a/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
@@ -38,6 +38,7 @@ export const idAttr = "id";
 
 // Default value for cluster settings
 export const indexUnusedDuration = "168h";
+export const exportInsights = false;
 
 export const REMOTE_DEBUGGING_ERROR_TEXT =
   "This information is not available due to the current value of the 'server.remote_debugging.mode' setting.";

--- a/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
@@ -13,7 +13,7 @@ import { AdminUIState } from "src/redux/state";
 import { cockroach } from "src/js/protos";
 import moment from "moment-timezone";
 import { CoordinatedUniversalTime, util } from "@cockroachlabs/cluster-ui";
-import { indexUnusedDuration } from "src/util/constants";
+import { indexUnusedDuration, exportInsights } from "src/util/constants";
 
 export const selectClusterSettings = createSelector(
   (state: AdminUIState) => state.cachedData.settings?.data,
@@ -117,5 +117,22 @@ export const selectDropUnusedIndexDuration = createSelector(
       settings["sql.index_recommendation.drop_unused_duration"]?.value ||
       indexUnusedDuration
     );
+  },
+);
+
+export const selectCsExportInsights = createSelector(
+  selectClusterSettings,
+  (settings): boolean => {
+    if (!settings) {
+      return exportInsights;
+    }
+    if (settings["sql.insights.export.enabled"]) {
+      if (settings["sql.insights.export.enabled"]?.value === "false") {
+        return false;
+      }
+      return true;
+    } else {
+      return exportInsights;
+    }
   },
 );

--- a/pkg/ui/workspaces/db-console/src/util/constants.ts
+++ b/pkg/ui/workspaces/db-console/src/util/constants.ts
@@ -37,4 +37,5 @@ export const {
   REMOTE_DEBUGGING_ERROR_TEXT,
   idAttr,
   indexUnusedDuration,
+  exportInsights,
 } = util;

--- a/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
@@ -20,6 +20,7 @@ import { selectStatementInsightDetails } from "src/views/insights/insightsSelect
 import { setGlobalTimeScaleAction } from "src/redux/statements";
 import { selectTimeScale } from "src/redux/timeScale";
 import { selectHasAdminRole } from "src/redux/user";
+import { selectCsExportInsights } from "src/redux/clusterSettings/clusterSettings.selectors";
 
 const mapStateToProps = (
   state: AdminUIState,
@@ -30,6 +31,7 @@ const mapStateToProps = (
     insightError: state.cachedData?.stmtInsights?.lastError,
     timeScale: selectTimeScale(state),
     hasAdminRole: selectHasAdminRole(state),
+    csExportInsights: selectCsExportInsights(state),
   };
 };
 

--- a/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPage.tsx
@@ -37,6 +37,7 @@ import { bindActionCreators } from "redux";
 import { LocalSetting } from "src/redux/localsettings";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
 import { selectTimeScale } from "src/redux/timeScale";
+import { selectCsExportInsights } from "src/redux/clusterSettings/clusterSettings.selectors";
 
 export const insightStatementColumnsLocalSetting = new LocalSetting<
   AdminUIState,
@@ -79,6 +80,7 @@ const statementMapStateToProps = (
   timeScale: selectTimeScale(state),
   isLoading: selectStmtInsightsLoading(state),
   maxSizeApiReached: selectStmtInsightsMaxApiReached(state),
+  csExportInsights: selectCsExportInsights(state),
 });
 
 const TransactionDispatchProps = {


### PR DESCRIPTION
Note to reviewers: Only last commit is relevant to this PR

---

Once we start using Obs Service, the SQL API needs to know
which source to use for the data, so it can pass to the proxy.
The SQL API will still be able to make operation on CRDB directly,
so a flag was added to differentiate the source of the data.

This commit makes this flag visible to the SQL API and a following PR
will make use of it on the proxy.

For now, the Insights API is the only one passing the flag, and
everything else uses the default value (false).

Part Of [CC-26438](https://cockroachlabs.atlassian.net/browse/CC-26438)

Release note: None