### PR TITLE
cluster-ui: remove leading `/` in settings request

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/clusterSettingsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/clusterSettingsApi.ts
@@ -25,7 +25,7 @@ export function getClusterSettings(
 ): Promise<SettingsResponseMessage> {
   return fetchData(
     cockroach.server.serverpb.SettingsResponse,
-    `/${ADMIN_API_PREFIX}/settings?unredacted_values=true`,
+    `${ADMIN_API_PREFIX}/settings?unredacted_values=true`,
     cockroach.server.serverpb.SettingsRequest,
     req,
     timeout,


### PR DESCRIPTION
Recently we required that all requests paths from cluster-ui do not start with `/` so that they may be used with any given subpath when constructing proxy requests.

We missed removing the prefix from the `settings` api which requests all cluster settings.

Release note: None

Epic: none


----------------------
Previously, this auto stats enabled label would show disabled even though auto stats collection is enabled. This is because this value comes from the settings request which was not being issued correctly.
https://www.loom.com/share/42847f2c63484a508a128c5808df7bdd