### PR TITLE
opt: fix insert fast path uniqueness check bug

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_insert_fast_path
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_insert_fast_path
@@ -201,3 +201,18 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
 WHERE message LIKE '%batch%' AND message LIKE '%Scan%'
 ----
 r67: sending batch 4 Scan to (n1,s1):1
+
+# Regression test for #115377.
+statement ok
+CREATE TABLE t115377 (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  UNIQUE (a, b)
+) LOCALITY REGIONAL BY ROW
+
+statement ok
+INSERT INTO t115377 VALUES (2, 0, 0)
+
+statement error pgcode 23505 duplicate key value violates unique constraint \"t115377_pkey\"
+INSERT INTO t115377 VALUES (2, 1, 1)

--- a/pkg/sql/logictest/testdata/logic_test/unique
+++ b/pkg/sql/logictest/testdata/logic_test/unique
@@ -1026,3 +1026,25 @@ ALTER TABLE multiple_uniq ADD CONSTRAINT uniq_fk FOREIGN KEY (d) REFERENCES uniq
 statement error pq: insert on table "multiple_uniq" violates foreign key constraint "uniq_fk"\nDETAIL: Key \(d\)=\(14\) is not present in table "uniq"\.
 INSERT INTO multiple_uniq (a,b,c,d)
 VALUES (11,12,13,14), (15,16,17,18)
+
+# Regression test for #115377.
+statement ok
+CREATE TABLE t115377 (
+  k INT,
+  a INT,
+  b INT,
+  s TEXT NOT NULL,
+  PRIMARY KEY (s, k),
+  UNIQUE WITHOUT INDEX (k),
+  UNIQUE (s, a, b),
+  UNIQUE WITHOUT INDEX (a, b),
+  CHECK (s IN ('east', 'west'))
+)
+
+statement ok
+INSERT INTO t115377 VALUES (2, 0, 0, 'east')
+
+statement error pgcode 23505 duplicate key value violates unique constraint \"unique_k\"
+INSERT INTO t115377 VALUES (2, 1, 1, 'east')
+
+subtest end

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -197,8 +197,9 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 				execFastPathCheck.DatumsFromConstraint[j][execFastPathCheck.InsertCols[k]] = constExpr.Value
 			}
 		}
+		uniqCheck := &ins.UniqueChecks[i]
 		execFastPathCheck.MkErr = func(values tree.Datums) error {
-			return mkFastPathUniqueCheckErr(md, &ins.UniqueChecks[i], values, execFastPathCheck.ReferencedIndex)
+			return mkFastPathUniqueCheckErr(md, uniqCheck, values, execFastPathCheck.ReferencedIndex)
 		}
 	}
 


### PR DESCRIPTION
This commit fixes a bug caused by creating a closure over an
incrementing integer in a loop.

Fixes #115377
Fixes #115378

Release note (bug fix): A bug has been fixed that caused node crashes
and panics when running `INSERT` queries on `REGIONAL BY ROW` tables
with `UNIQUE` constraints or indexes. The bug is only present in
version 23.2.0-beta.1.
