### PR TITLE
dev: make `gen testlogic` also invoke `gen schemachanger`

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=90
+DEV_VERSION=91
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -47,7 +47,7 @@ func makeGenerateCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.
         dev generate execgen       # execgen targets (subset of 'dev generate go')
         dev generate schemachanger # schemachanger targets (subset of 'dev generate go')
         dev generate stringer      # stringer targets (subset of 'dev generate go')
-        dev generate testlogic     # logictest generated code (subset of 'dev generate bazel')
+        dev generate testlogic     # logictest generated code (includes 'dev generate schemachanger')
         dev generate ui            # Create UI assets to be consumed by 'go build'
 `,
 		Args: cobra.MinimumNArgs(0),
@@ -225,9 +225,12 @@ func (d *dev) generateLogicTest(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	return d.exec.CommandContextInheritingStdStreams(
+	if err = d.exec.CommandContextInheritingStdStreams(
 		ctx, "bazel", "run", "pkg/cmd/generate-logictest", "--", fmt.Sprintf("-out-dir=%s", workspace),
-	)
+	); err != nil {
+		return err
+	}
+	return d.generateSchemaChanger(cmd)
 }
 
 func (d *dev) generateAcceptanceTests(cmd *cobra.Command) error {

--- a/pkg/cmd/dev/testdata/datadriven/testlogic
+++ b/pkg/cmd/dev/testdata/datadriven/testlogic
@@ -4,6 +4,7 @@ dev testlogic
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
+bazel run //pkg/gen:schemachanger
 bazel test //pkg/sql/logictest/tests/... //pkg/ccl/logictestccl/tests/... //pkg/sql/opt/exec/execbuilder/tests/... --test_env=GOTRACEBACK=all --test_output errors
 
 exec
@@ -12,6 +13,7 @@ dev testlogic ccl
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
+bazel run //pkg/gen:schemachanger
 bazel test //pkg/ccl/logictestccl/tests/... --test_env=GOTRACEBACK=all --test_output errors
 
 exec
@@ -20,6 +22,7 @@ dev testlogic ccl opt
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
+bazel run //pkg/gen:schemachanger
 bazel test //pkg/ccl/logictestccl/tests/... //pkg/sql/opt/exec/execbuilder/tests/... --test_env=GOTRACEBACK=all --test_output errors
 
 exec
@@ -28,6 +31,7 @@ dev testlogic base --ignore-cache
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
+bazel run //pkg/gen:schemachanger
 bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --nocache_test_results --test_output errors
 
 exec
@@ -36,6 +40,7 @@ dev testlogic base --show-sql
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
+bazel run //pkg/gen:schemachanger
 bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_output errors
 
 exec
@@ -44,6 +49,7 @@ dev testlogic base --files=auto_span_config_reconciliation --stress
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
+bazel run //pkg/gen:schemachanger
 getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
@@ -53,6 +59,7 @@ dev testlogic base --files=auto_span_config_reconciliation --stress --timeout 1m
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
+bazel run //pkg/gen:schemachanger
 getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_timeout=60 --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
@@ -62,6 +69,7 @@ dev testlogic base --files=auto_span_config_reconciliation --stress
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
+bazel run //pkg/gen:schemachanger
 getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
@@ -71,6 +79,7 @@ dev testlogic base --files=auto_span_config_reconciliation --stress
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
+bazel run //pkg/gen:schemachanger
 getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
@@ -80,5 +89,6 @@ dev testlogic base --files=auto_span_config_reconciliation --stress
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
+bazel run //pkg/gen:schemachanger
 getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors


### PR DESCRIPTION
This commit makes it so that `dev gen testlogic` is executed, under the hood it also calls `dev gen schemachanger`. This is needed in case some of the logic test files are added / renamed / removed to update the schemachanger comparator tests.

Epic: None

Release note: None