### PR TITLE
sql: review some TODOs introduced in 23.2

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cursor
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cursor
@@ -49,7 +49,7 @@ FETCH FORWARD 3 FROM foo;
 ----
 10
 
-# TODO(drewk): postgres returns an ambiguous column error here by default,
+# TODO(#115680): postgres returns an ambiguous column error here by default,
 # although it can be configured to prefer either the variable or the column.
 statement ok
 ABORT;
@@ -280,7 +280,7 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
-# TODO(drewk): once CTEs in routines are supported, the error should be:
+# TODO(#92961): once CTEs in routines are supported, the error should be:
 # pgcode 0A000 pq: DECLARE CURSOR must not contain data-modifying statements in WITH
 statement error pgcode 0A000 pq: unimplemented: CTE usage inside a function definition
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -331,7 +331,7 @@ SELECT f(1, 5), f(-5, 5), f(0, 1)
 ----
 10  10  0
 
-# TODO(drewk): add back the dijkstra test once UDFs calling other UDFs is
+# TODO(#88198): add back the dijkstra test once UDFs calling other UDFs is
 # allowed.
 
 # --------------------------------------------------
@@ -2530,7 +2530,6 @@ SELECT f();
 ----
 a
 
-# TODO(drewk): postgres doesn't truncate the values.
 # string -> char succeeds even though the string is too long.
 statement ok
 DROP FUNCTION f();

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -324,7 +324,6 @@ func (v *distSQLExprCheckVisitor) VisitPre(expr tree.Expr) (recurse bool, newExp
 			return false, expr
 		}
 	case *tree.RoutineExpr:
-		// TODO(#86310): enable UDFs in DistSQL.
 		v.err = newQueryNotSupportedErrorf("user-defined routine %s cannot be executed with distsql", t)
 		return false, expr
 	case *tree.DOid:

--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -465,8 +465,8 @@ NaN        Infinity   NaN        NaN        NaN
 NaN        -Infinity  NaN        NaN        NaN
 NaN        NaN        NaN        NaN        NaN
 
-# TODO(drewk): There are a few differences vs postgres in the number of decimal
-# places and negative zeros.
+# TODO(#115679): There are a few differences vs postgres in the number of
+# decimal places and negative zeros.
 query RRRRR
 WITH v(id, x) AS (VALUES (1, '0'::numeric), (2, '1'::numeric), (3, '-1'::numeric), 
   (4, '4.2'::numeric), (5, 'inf'::numeric), (6, '-inf'::numeric), (7, 'nan'::numeric)

--- a/pkg/sql/logictest/testdata/logic_test/udf_star
+++ b/pkg/sql/logictest/testdata/logic_test/udf_star
@@ -208,8 +208,6 @@ statement error pgcode 2BP01 pq: cannot drop column "b" because function "f_unqu
 ALTER TABLE t_twocol DROP COLUMN b;
 
 # Drop all but one of the functions with an implicit record return value.
-# TODO(#96368): Allow these UDFs to be dropped in the CASCADE when the cross-
-# references are fixed instead.
 statement ok
 DROP FUNCTION f_tuplestar;
 DROP FUNCTION f_allcolsel_alias;

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -2951,9 +2951,7 @@ inner-join (hash)
            ├── variable: xyz.x:1 [type=int]
            └── variable: foo.x:6 [type=int]
 
-# Self-join filters can only be inferred even if the join key was a key in the
-# base table.
-# TODO(drewk): if the optimizer could see that the same row is being selected
+# TODO(#39054): if the optimizer could see that the same row is being selected
 # from each input, we could still infer equalities.
 norm
 SELECT * FROM xyz INNER JOIN xyz foo ON xyz.x = foo.x AND xyz.y = 1 AND foo.y = 1

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -872,7 +872,7 @@ upsert xy
                      └── x:27 = r2:32 [outer=(27,32), constraints=(/27: (/NULL - ]; /32: (/NULL - ]), fd=(27)==(32), (32)==(27)]
 
 # Case with a multi-row data source with a lax key.
-# TODO(drewk): the UpsertDistinctOn isn't removed in this case because the lax
+# TODO(#75070): the UpsertDistinctOn isn't removed in this case because the lax
 # key for nullablecols isn't fully simplified.
 norm
 INSERT INTO xy SELECT c1, c2 FROM nullablecols ON CONFLICT (x) DO UPDATE SET x = xy.x + 100

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -1707,7 +1707,6 @@ SELECT f(5)
 ----
 error (0A000): unimplemented: conditional CONTINUE statements are not yet supported
 
-# TODO(drewk): consider adding a norm rules to fold nested UDFs.
 # Testing RAISE statements.
 exec-ddl
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
@@ -4297,7 +4296,7 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
 $$ LANGUAGE PLpgSQL;
 ----
 
-# TODO(drewk): add norm rule to fold the non-output body statements of nested
+# TODO(#115681): add norm rule to fold the non-output body statements of nested
 # routines.
 build format=show-scalars
 SELECT f();

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -331,7 +331,7 @@ func (u *plpgsqlSymUnion) sqlStatement() tree.Statement {
 
 %type <[]plpgsqltree.Statement> proc_sect
 %type <[]plpgsqltree.ElseIf> stmt_elsifs
-%type <[]plpgsqltree.Statement> stmt_else loop_body // TODO is this a list of statement?
+%type <[]plpgsqltree.Statement> stmt_else loop_body
 %type <plpgsqltree.Statement>  pl_block
 %type <plpgsqltree.Statement>	proc_stmt
 %type <plpgsqltree.Statement>	stmt_assign stmt_if stmt_loop stmt_while stmt_exit stmt_continue
@@ -354,8 +354,8 @@ func (u *plpgsqlSymUnion) sqlStatement() tree.Statement {
 %type <[]plpgsqltree.Statement> opt_case_else
 
 %type <bool>	getdiag_area_opt
-%type <plpgsqltree.GetDiagnosticsItemList>	getdiag_list // TODO don't know what this is
-%type <*plpgsqltree.GetDiagnosticsItem> getdiag_list_item // TODO don't know what this is
+%type <plpgsqltree.GetDiagnosticsItemList>	getdiag_list
+%type <*plpgsqltree.GetDiagnosticsItem> getdiag_list_item
 %type <int32> getdiag_item
 
 %type <*plpgsqltree.RaiseOption> option_expr
@@ -434,7 +434,7 @@ decl_stmt	: decl_statement
     // This is to allow useless extra "DECLARE" keywords in the declare section.
     $$.val = (plpgsqltree.Statement)(nil)
   }
-// TODO(chengxiong): turn this block on and throw useful error if user
+// TODO(drewk): turn this block on and throw useful error if user
 // tries to put the block label just before BEGIN instead of before
 // DECLARE.
 //| LESS_LESS any_identifier GREATER_GREATER
@@ -767,7 +767,7 @@ stmt_getdiag: GET getdiag_area_opt DIAGNOSTICS getdiag_list ';'
     IsStacked: $2.bool(),
     DiagItems: $4.getDiagnosticsItemList(),
   }
-  // TODO(jane): Check information items are valid for area option.
+  // TODO(drewk): Check information items are valid for area option.
   }
 ;
 
@@ -800,7 +800,7 @@ getdiag_list_item: IDENT assign_operator getdiag_item
     $$.val = &plpgsqltree.GetDiagnosticsItem{
       Kind : $3.getDiagnosticsKind(),
       TargetName: $1,
-      // TODO(jane): set the target from $1.
+      // TODO(drewk): set the target from $1.
     }
   }
 ;
@@ -832,14 +832,14 @@ getdiag_item: unreserved_keyword {
     case "returned_sqlstate":
       $$.val = plpgsqltree.GetDiagnosticsReturnedSQLState;
     default:
-      // TODO(jane): Should this use an unimplemented error instead?
+      // TODO(drewk): Should this use an unimplemented error instead?
       return setErr(plpgsqllex, errors.Newf("unrecognized GET DIAGNOSTICS item: %s", redact.Safe($1)))
   }
 }
 ;
 
 getdiag_target:
-// TODO(jane): remove ident.
+// TODO(drewk): remove ident.
 IDENT
   {
   }
@@ -952,8 +952,6 @@ opt_case_else:
 
 stmt_loop: opt_loop_label LOOP loop_body opt_label ';'
   {
-    // TODO(drewk): does the second usage of the label actually
-    // do anything?
     $$.val = &plpgsqltree.Loop{
       Label: $1,
       Body: $3.statements(),
@@ -963,8 +961,6 @@ stmt_loop: opt_loop_label LOOP loop_body opt_label ';'
 
 stmt_while: opt_loop_label WHILE expr_until_loop LOOP loop_body opt_label ';'
   {
-    // TODO(drewk): does the second usage of the label actually
-    // do anything?
     cond, err := plpgsqllex.(*lexer).ParseExpr($3)
     if err != nil {
       return setErr(plpgsqllex, err)
@@ -984,7 +980,7 @@ stmt_for: opt_loop_label FOR for_control loop_body
 ;
 
 for_control: for_variable IN
-  // TODO need to parse the sql expression here.
+  // TODO(drewk) need to parse the sql expression here.
   {
     return unimplemented(plpgsqllex, "for loop")
   }
@@ -1045,12 +1041,6 @@ stmt_continue: CONTINUE opt_label opt_exitcond
     }
   }
 ;
-
-  // TODO handle variable names
-  // 1. verify if the first token is a variable (this means that we need to track variable scope during parsing)
-  // 2. if yes, check next token is ';'
-  // 3. if no, expecting a sql expression "read_sql_expression"
-  //    we can just read until a ';', then do the sql expression validation during compile time.
 
 stmt_return: RETURN return_variable ';'
   {

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -485,8 +485,8 @@ func (g *routineGenerator) newCursorHelper(plan *planComponents) (*plpgsqlCursor
 // plpgsqlCursorHelper wraps a row container in order to feed the results of
 // executing a SQL statement to a SQL cursor. Note that the SQL statement is not
 // lazily executed; its entire result is written to the container.
-// TODO(drewk): while the row container can spill to disk, we should default to
-// lazy execution for cursors for performance reasons.
+// TODO(#111479): while the row container can spill to disk, we should default
+// to lazy execution for cursors for performance reasons.
 type plpgsqlCursorHelper struct {
 	ctx         context.Context
 	cursorName  tree.Name

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1490,7 +1490,7 @@ func (b *builderState) WrapFunctionBody(
 	refProvider scbuildstmt.ReferenceProvider,
 ) *scpb.FunctionBody {
 	if lang != catpb.Function_PLPGSQL {
-		// TODO(drewk): fix this to work with PL/pgSQL.
+		// TODO(#115627): fix this to work with PL/pgSQL.
 		bodyStr = b.replaceSeqNamesWithIDs(bodyStr)
 		bodyStr = b.serializeUserDefinedTypes(bodyStr)
 	}

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -33,14 +33,14 @@ type TaggedStatement interface {
 }
 
 type StatementImpl struct {
-	// TODO(Chengxiong): figure out how to get line number from scanner.
+	// TODO(drewk): figure out how to get line number from scanner.
 	LineNo int
 	/*
 	 * Unique statement ID in this function (starting at 1; 0 is invalid/not
 	 * set).  This can be used by a profiler as the index for an array of
 	 * per-statement metrics.
 	 */
-	// TODO(Chengxiong): figure out how to get statement id from parser.
+	// TODO(drewk): figure out how to get statement id from parser.
 	StmtID uint
 }
 
@@ -471,7 +471,7 @@ func (s *ForSelect) WalkStmt(visitor StatementVisitor) {
 
 type ForCursor struct {
 	ForQuery
-	CurVar   int // TODO(drewk): is this CursorVariable?
+	CurVar   int
 	ArgQuery Expr
 }
 
@@ -857,7 +857,7 @@ func (s *GetDiagnostics) Format(ctx *tree.FmtCtx) {
 
 type GetDiagnosticsItem struct {
 	Kind GetDiagnosticsKind
-	// TODO(jane): TargetName is temporary -- should be removed and use Target.
+	// TODO(drewk): TargetName is temporary -- should be removed and use Target.
 	TargetName string
 	Target     int // where to assign it?
 }

--- a/pkg/sql/sem/tree/create_routine.go
+++ b/pkg/sql/sem/tree/create_routine.go
@@ -451,7 +451,7 @@ func (node *RoutineObj) Format(ctx *FmtCtx) {
 func (node RoutineObj) ParamTypes(
 	ctx context.Context, res TypeReferenceResolver,
 ) ([]*types.T, error) {
-	// TODO(chengxiong): handle INOUT, OUT and VARIADIC argument classes when we
+	// TODO(#100405): handle INOUT, OUT and VARIADIC argument classes when we
 	// support them. This is because only IN and INOUT arg types need to be
 	// considered to match a overload.
 	var argTypes []*types.T


### PR DESCRIPTION
This patch removes some dangling TODOs that were introduced in the 23.2 cycle. It also updates some other TODOs with tracking issue numbers.

Informs #101875

Release note: None