### PR TITLE
builtins: skip TestSerialNormalizationWithUniqueUnorderedID under deadlock

### DIFF
--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -241,6 +241,7 @@ func TestSerialNormalizationWithUniqueUnorderedID(t *testing.T) {
 
 	skip.UnderRace(t, "the test is too slow and the goodness of fit test "+
 		"assumes large N")
+	skip.UnderDeadlock(t, "the test is too slow")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
This test is extremely slow -- it takes ~30s to run normally. The addition of test-only verification pushed it over the edge, such that running it under the deadlock detector would cause spurious failures, so we skip it.

Closes #115541
Release note: None