### PR TITLE
stmtdiagnostics: skip TestDiagnosticsRequest under deadlock

### DIFF
--- a/pkg/sql/stmtdiagnostics/BUILD.bazel
+++ b/pkg/sql/stmtdiagnostics/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//pkg/sql/sqlerrors",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -43,6 +44,9 @@ import (
 func TestDiagnosticsRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderShort(t)
+	skip.UnderDeadlock(t, "the test is too slow")
 
 	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	ctx := context.Background()


### PR DESCRIPTION
This test takes a really long time to run (~30s) normally. The introduction of test-only pushed this test over the edge when run under the deadlock detector -- it started reporting spurious deadlocks. This patch skips it under deadlock, and while here, also skips it under short.

Closes #115620

Release note: None