### PR TITLE
kv,admission: only log empty admission warning for non-release builds

### DIFF
--- a/pkg/kv/kvserver/intentresolver/BUILD.bazel
+++ b/pkg/kv/kvserver/intentresolver/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/build",
         "//pkg/internal/client/requestbatcher",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/kv/kvserver/intentresolver/intent_resolver.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/internal/client/requestbatcher"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -1025,7 +1026,9 @@ func (ir *IntentResolver) resolveIntents(
 	var singleReq [1]kvpb.Request //gcassert:noescape
 	reqs := resolveIntentReqs(intents, opts, singleReq[:])
 	h := opts.AdmissionHeader
-	if h == (kvpb.AdmissionHeader{}) && ir.everyAdmissionHeaderMissing.ShouldLog() {
+	// We skip the warning for release builds to avoid printing out verbose stack traces.
+	// TODO(aaditya): reconsider this once #112680 is resolved.
+	if !build.IsRelease() && h == (kvpb.AdmissionHeader{}) && ir.everyAdmissionHeaderMissing.ShouldLog() {
 		log.Warningf(ctx, "empty admission header provided by %s", string(debug.Stack()))
 	}
 	// Send the requests ...


### PR DESCRIPTION
This error message, while useful for debugging, spams the logs with a stack trace which can be distracting when reading the logs.

Since AC defaults to skip when there is an empty header, this is not a concern, unless we see real-world performance impact (which we have not).

This patch removes it from release builds while we figure out all the sources for missing headers.

Informs #112680

Release note: None