### PR TITLE
generate-logictest: fix order of lines in generated BUILD.bazel 

### DIFF
--- a/pkg/ccl/logictestccl/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
@@ -6,8 +6,8 @@ go_test(
     srcs = ["generated_test.go"],
     data = [
         "//c-deps:libgeos",  # keep
-        "//pkg/cmd/cockroach-short",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
+        "//pkg/cmd/cockroach-short",  # keep
         "//pkg/sql/logictest:cockroach_predecessor_version",  # keep
     ],
     exec_properties = {"Pool": "large"},

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -263,9 +263,9 @@ go_test(
     srcs = ["generated_test.go"],
     data = [
         "//c-deps:libgeos",  # keep{{ if .SqliteLogicTest }}
-        "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep{{ end }}{{ if .CockroachGoTestserverTest }}
-        "//pkg/cmd/cockroach-short",  # keep{{ end }}{{ if .CclLogicTest }}
+        "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep{{ end }}{{ if .CclLogicTest }}
         "//pkg/ccl/logictestccl:testdata",  # keep{{ end }}{{ if .CockroachGoTestserverTest }}
+        "//pkg/cmd/cockroach-short",  # keep
         "//pkg/sql/logictest:cockroach_predecessor_version",  # keep{{ end }}{{ if .LogicTest }}
         "//pkg/sql/logictest:testdata",  # keep{{ end }}{{ if .ExecBuildLogicTest }}
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep{{ end }}


### PR DESCRIPTION
These should be alphabetized.

Epic: none
Release note: None