### PR TITLE
release-23.1: sql/contention: TestInsightsIntegrationForContention improvements

### DIFF
--- a/pkg/sql/sqlstats/insights/integration/BUILD.bazel
+++ b/pkg/sql/sqlstats/insights/integration/BUILD.bazel
@@ -10,6 +10,8 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/settings/cluster",
+        "//pkg/sql",
+        "//pkg/sql/appstatspb",
         "//pkg/sql/sqlstats/insights",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
@@ -19,6 +21,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/timeutil",
+        "//pkg/util/uuid",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
Backport 1/1 commits from #114423.

/cc @cockroachdb/release

Release justification: test fixes

---

TestInsightsIntegrationForContention tests that the insights system
records queries experiencing contention. The test executes sql that
joins information from `crdb_internal.cluster_execution_insights`
with `crdb_internal.transaction_contention_events`. We are getting
unexpected failures on this test where it is unable to find the
corresponding contention event on `crdb_internal.transaction_events`.
This table shows the events recorded by the contention event store,
which means either this event is not being recorded properly or the
event has not yet been attempted to be 'resolved' by the transaction
fingerprint id resolver. Events are resolved on an interval set by
the cluster setting `sql.contention.event_store.resolution_interval`,
which has a default value of 30s but has been set to 100ms for this test.

This commit makes the following changes to ensure the event resolution
occurs in time, and also includes some test improvements to prevent
flakiness:
- The callback installation for the resolution interval  is moved outside
of the async task to ensure it exists by the time we change the cluster setting
- Increases the insights latency threshold for the test from 1ms to
100ms. 100ms is enough to capture the event observed  by the test, 1ms
is too relaxed and would capture unnecessary queries.
- Allows NULL waiting_txn_fingerprint_id to be scanned so that if this
test fails again we get a more descriptive error message.
- Removes the stipulation that the total contention time from the insight
event and the contention time from the contention events table must be within
0.1s. This is usually true but not something we can guarantee, as the insight
event contention is the sum of all contention events experienced by this
statement, while the contention event store value is just the lock
contention.
- Manually trigger the event resolver in the contention event store instead
of relying on the resolution interval. The automated resolution process
can cause flakes as the retry budget assigned can be too low for the test,
leading to us never resolving the  txn fingerprint id.

Fixes: #114372

Release note: None
