### PR TITLE
sql: prevent crash with COPY FROM in an edge case

### DIFF
--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -370,6 +370,9 @@ type CopyIn struct {
 	// CopyDone is decremented once execution finishes, signaling that control of
 	// the connection is being handed back to the network routine.
 	CopyDone *sync.WaitGroup
+	// WaitGroupDone is set to true once CopyDone.Done() is called. It should
+	// only be accessed by the goroutine handling the COPY.
+	WaitGroupDone bool
 	// TimeReceived is the time at which the message was received
 	// from the client. Used to compute the service latency.
 	TimeReceived time.Time


### PR DESCRIPTION
We've recently seen "negative WaitGroup counter" server crash during COPY FROM execution a few times, but we have been unable to understand the root cause. It appears that the problem can happen right after the COPY execution is canceled due to `statement_timeout`. The synchronization setup is the following:
- the network-handling goroutine calls `wg.Add(1)`, pushes CopyIn command onto the stmt buf, and then blocks via `wg.Wait()`
- the copy-handling connExecutor calls `wg.Done()` in the defer of `execCopyIn`. It must be the case that that defer is executed at least twice, but it's unclear to me how that can happen.

In the absence of understanding of how this can happen and with no reproduction, this commit attempts to mitigate the problem by storing an extra boolean on the CopyIn command that indicates whether `wg.Done()` has been called and short-circuiting the execution if it has (an error is returned right away).

Fixes: #112095.

Release note: None