### PR TITLE
telemetry: log transaction exec events to TELEMETRY

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -3081,6 +3081,7 @@ An event of type `sampled_transaction` is the event logged to telemetry at the e
 | `RowsRead` | RowsRead is the number of rows read from disk. | no |
 | `RowsWritten` | RowsWritten is the number of rows written to disk. | no |
 | `SampledExecStats` | SampledExecStats is a nested field containing execution statistics. This field will be omitted if the stats were not sampled. | yes |
+| `SkippedTransactions` | SkippedTransactions is the number of transactions that were skipped as part of sampling prior to this one. We only count skipped transactions when telemetry logging is enabled and the sampling mode is set to "transaction". | no |
 
 
 #### Common fields

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -355,7 +355,10 @@ func (p *planner) maybeLogStatementInternal(
 			})
 		}
 
-		sampledQuery := eventpb.SampledQuery{
+		sampledQuery := getSampledQuery()
+		defer releaseSampledQuery(sampledQuery)
+
+		*sampledQuery = eventpb.SampledQuery{
 			CommonSQLExecDetails:                  execDetails,
 			SkippedQueries:                        skippedQueries,
 			CostEstimate:                          p.curPlan.instrumentation.costEstimate,
@@ -431,7 +434,7 @@ func (p *planner) maybeLogStatementInternal(
 			SchemaChangerMode:                     p.curPlan.instrumentation.schemaChangerMode.String(),
 		}
 
-		p.logOperationalEventsOnlyExternally(ctx, &sampledQuery)
+		p.logOperationalEventsOnlyExternally(ctx, sampledQuery)
 	}
 }
 

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -179,7 +179,7 @@ func (p *planner) maybeLogStatementInternal(
 	slowInternalQueryLogEnabled := slowInternalQueryLogEnabled.Get(&p.execCfg.Settings.SV)
 	auditEventsDetected := len(p.curPlan.auditEventBuilders) != 0
 	logConsoleQuery := telemetryInternalConsoleQueriesEnabled.Get(&p.execCfg.Settings.SV) &&
-		strings.HasPrefix(p.SessionData().ApplicationName, "$ internal-console")
+		strings.HasPrefix(p.SessionData().ApplicationName, internalConsoleAppName)
 
 	// We only consider non-internal SQL statements for telemetry logging unless
 	// the telemetryInternalQueriesEnabled is true.
@@ -436,6 +436,86 @@ func (p *planner) maybeLogStatementInternal(
 
 		p.logOperationalEventsOnlyExternally(ctx, sampledQuery)
 	}
+}
+
+// logTransaction records the current transaction to the TELEMETRY channel.
+func (p *planner) logTransaction(
+	ctx context.Context,
+	txnCounter int,
+	txnFingerprintID appstatspb.TransactionFingerprintID,
+	txnStats *sqlstats.RecordedTxnStats,
+	skippedTransactions uint64,
+) {
+
+	// Redact error messages.
+	var execErrStr, retryErr redact.RedactableString
+	sqlErrState := ""
+	if txnStats.TxnErr != nil {
+		execErrStr = redact.Sprint(txnStats.TxnErr)
+		sqlErrState = pgerror.GetPGCode(txnStats.TxnErr).String()
+	}
+
+	if txnStats.AutoRetryReason != nil {
+		retryErr = redact.Sprint(txnStats.AutoRetryReason)
+	}
+
+	sampledTxn := getSampledTransaction()
+	defer releaseSampledTransaction(sampledTxn)
+
+	*sampledTxn = eventpb.SampledTransaction{
+		SkippedTransactions:      int64(skippedTransactions),
+		User:                     txnStats.SessionData.SessionUser().Normalized(),
+		ApplicationName:          txnStats.SessionData.ApplicationName,
+		TxnCounter:               uint32(txnCounter),
+		SessionID:                txnStats.SessionID.String(),
+		TransactionID:            txnStats.TransactionID.String(),
+		TransactionFingerprintID: txnFingerprintID,
+		Committed:                txnStats.Committed,
+		ImplicitTxn:              txnStats.ImplicitTxn,
+		StartTimeUnixNanos:       txnStats.StartTime.UnixNano(),
+		EndTimeUnixNanos:         txnStats.EndTime.UnixNano(),
+		ServiceLatNanos:          txnStats.ServiceLatency.Nanoseconds(),
+		SQLSTATE:                 sqlErrState,
+		ErrorText:                execErrStr,
+		NumRetries:               txnStats.RetryCount,
+		LastAutoRetryReason:      retryErr,
+		StatementFingerprintIDs:  txnStats.StatementFingerprintIDs,
+		NumRows:                  int64(txnStats.RowsAffected),
+		RetryLatNanos:            txnStats.RetryLatency.Nanoseconds(),
+		CommitLatNanos:           txnStats.CommitLatency.Nanoseconds(),
+		IdleLatNanos:             txnStats.IdleLatency.Nanoseconds(),
+		BytesRead:                txnStats.BytesRead,
+		RowsRead:                 txnStats.RowsRead,
+		RowsWritten:              txnStats.RowsWritten,
+	}
+
+	if txnStats.CollectedExecStats {
+		sampledTxn.SampledExecStats = &eventpb.SampledExecStats{
+			NetworkBytes:    txnStats.ExecStats.NetworkBytesSent,
+			MaxMemUsage:     txnStats.ExecStats.MaxMemUsage,
+			ContentionTime:  int64(txnStats.ExecStats.ContentionTime.Seconds()),
+			NetworkMessages: txnStats.ExecStats.NetworkMessages,
+			MaxDiskUsage:    txnStats.ExecStats.MaxDiskUsage,
+			CPUSQLNanos:     txnStats.ExecStats.CPUTime.Nanoseconds(),
+			MVCCIteratorStats: eventpb.MVCCIteratorStats{
+				StepCount:                      txnStats.ExecStats.MvccSteps,
+				StepCountInternal:              txnStats.ExecStats.MvccStepsInternal,
+				SeekCount:                      txnStats.ExecStats.MvccSeeks,
+				SeekCountInternal:              txnStats.ExecStats.MvccSeeksInternal,
+				BlockBytes:                     txnStats.ExecStats.MvccBlockBytes,
+				BlockBytesInCache:              txnStats.ExecStats.MvccBlockBytesInCache,
+				KeyBytes:                       txnStats.ExecStats.MvccKeyBytes,
+				ValueBytes:                     txnStats.ExecStats.MvccValueBytes,
+				PointCount:                     txnStats.ExecStats.MvccPointCount,
+				PointsCoveredByRangeTombstones: txnStats.ExecStats.MvccPointsCoveredByRangeTombstones,
+				RangeKeyCount:                  txnStats.ExecStats.MvccRangeKeyCount,
+				RangeKeyContainedPoints:        txnStats.ExecStats.MvccRangeKeyContainedPoints,
+				RangeKeySkippedPoints:          txnStats.ExecStats.MvccRangeKeySkippedPoints,
+			},
+		}
+	}
+
+	log.StructuredEvent(ctx, sampledTxn)
 }
 
 func (p *planner) logEventsOnlyExternally(ctx context.Context, entries ...logpb.EventPayload) {

--- a/pkg/sql/telemetry_logging.go
+++ b/pkg/sql/telemetry_logging.go
@@ -125,6 +125,9 @@ type telemetryLoggingMetrics struct {
 
 	// skippedQueryCount is used to produce the count of non-sampled queries.
 	skippedQueryCount atomic.Uint64
+
+	// skippedTransactionCount is used to produce the count of non-sampled transactions.
+	skippedTransactionCount atomic.Uint64
 }
 
 func newTelemetryLoggingMetrics(
@@ -332,4 +335,12 @@ func (t *telemetryLoggingMetrics) resetLastSampledTime() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.mu.lastSampledTime = time.Time{}
+}
+
+func (t *TelemetryLoggingMetrics) resetSkippedTransactionCount() (res uint64) {
+	return t.skippedTransactionCount.Swap(0)
+}
+
+func (t *TelemetryLoggingMetrics) incSkippedTransactionCount() {
+	t.skippedTransactionCount.Add(1)
 }

--- a/pkg/sql/testdata/telemetry_logging/logging/force_logging
+++ b/pkg/sql/testdata/telemetry_logging/logging/force_logging
@@ -1,0 +1,254 @@
+subtest txn_mode_tracing_on
+# When tracing is on we should log all execution events.
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.transaction_sampling.max_event_frequency = 10;
+----
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.transaction_sampling.statement_events_per_transaction.max = 100;
+----
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.query_sampling.mode = "transaction";
+----
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;
+----
+
+exec-sql
+CREATE TABLE t()
+----
+
+spy-sql unixSecs=0.1
+SET TRACING = ON;
+----
+
+spy-sql unixSecs=0.1 useRealTracing=true
+SELECT * FROM t LIMIT 1;
+----
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Database": "defaultdb",
+	"Distribution": "full",
+	"EventType": "sampled_query",
+	"PlanGist": "AgHQAQIAAAAAAg==",
+	"ScanCount": 1,
+	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹1›",
+	"StatementFingerprintID": 17888549871399373000,
+	"StmtPosInTxn": 1,
+	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 0,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"StatementFingerprintIDs": [
+		17888549871399373000
+	],
+	"TransactionFingerprintID": 6278959165882708000,
+	"User": "root"
+}
+
+spy-sql unixSecs=0.1 useRealTracing=true
+SELECT 1, 2, 3;
+----
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"EventType": "sampled_query",
+	"NumRows": 1,
+	"OutputRowsEstimate": 1,
+	"PlanGist": "AgICBgYG",
+	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
+	"StatementFingerprintID": 16698501115058330000,
+	"StmtPosInTxn": 1,
+	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 1,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"StatementFingerprintIDs": [
+		16698501115058330000
+	],
+	"TransactionFingerprintID": 5250989384299556000,
+	"User": "root"
+}
+
+spy-sql unixSecs=0.1 useRealTracing=true
+SELECT 'hello';
+----
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"EventType": "sampled_query",
+	"NumRows": 1,
+	"OutputRowsEstimate": 1,
+	"PlanGist": "AgICAgYC",
+	"Statement": "SELECT ‹'hello'›",
+	"StatementFingerprintID": 15578946620736494000,
+	"StmtPosInTxn": 1,
+	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 1,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"StatementFingerprintIDs": [
+		15578946620736494000
+	],
+	"TransactionFingerprintID": 8597429024882746000,
+	"User": "root"
+}
+
+spy-sql unixSecs=0.1
+SET TRACING = off;
+----
+
+subtest end
+
+subtest txn_mode_console_query
+# When tracing is on we should log all execution events.
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.transaction_sampling.max_event_frequency = 10;
+----
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.transaction_sampling.statement_events_per_transaction.max = 100;
+----
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.query_sampling.mode = "transaction";
+----
+
+exec-sql
+SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;
+----
+
+spy-sql unixSecs=0.1
+SET application_name = '$ internal-console-app';
+----
+{
+	"ApplicationName": "$ internal-console-app",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"EventType": "sampled_query",
+	"PlanGist": "Ais=",
+	"Statement": "SET application_name = ‹'$ internal-console-app'›",
+	"StatementFingerprintID": 13549091137440920000,
+	"StmtPosInTxn": 1,
+	"Tag": "SET",
+	"User": "root"
+}
+
+spy-sql unixSecs=0.1
+SELECT * FROM t LIMIT 1;
+----
+{
+	"ApplicationName": "$ internal-console-app",
+	"Database": "defaultdb",
+	"Distribution": "full",
+	"EventType": "sampled_query",
+	"PlanGist": "AgHQAQIAAAAAAg==",
+	"ScanCount": 1,
+	"Statement": "SELECT * FROM \"\".\"\".t LIMIT ‹1›",
+	"StatementFingerprintID": 17888549871399373000,
+	"StmtPosInTxn": 1,
+	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "$ internal-console-app",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 0,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"SkippedTransactions": 5,
+	"StatementFingerprintIDs": [
+		17888549871399373000
+	],
+	"TransactionFingerprintID": 6278959165882708000,
+	"User": "root"
+}
+
+spy-sql unixSecs=0.1
+SELECT 1, 2, 3;
+----
+{
+	"ApplicationName": "$ internal-console-app",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"EventType": "sampled_query",
+	"NumRows": 1,
+	"OutputRowsEstimate": 1,
+	"PlanGist": "AgICBgYG",
+	"Statement": "SELECT ‹1›, ‹2›, ‹3›",
+	"StatementFingerprintID": 16698501115058330000,
+	"StmtPosInTxn": 1,
+	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "$ internal-console-app",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 1,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"StatementFingerprintIDs": [
+		16698501115058330000
+	],
+	"TransactionFingerprintID": 5250989384299556000,
+	"User": "root"
+}
+
+spy-sql unixSecs=0.1
+SELECT 'hello';
+----
+{
+	"ApplicationName": "$ internal-console-app",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"EventType": "sampled_query",
+	"NumRows": 1,
+	"OutputRowsEstimate": 1,
+	"PlanGist": "AgICAgYC",
+	"Statement": "SELECT ‹'hello'›",
+	"StatementFingerprintID": 15578946620736494000,
+	"StmtPosInTxn": 1,
+	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "$ internal-console-app",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 1,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"StatementFingerprintIDs": [
+		15578946620736494000
+	],
+	"TransactionFingerprintID": 8597429024882746000,
+	"User": "root"
+}
+
+subtest end

--- a/pkg/sql/testdata/telemetry_logging/logging/stmts_per_txn_limit
+++ b/pkg/sql/testdata/telemetry_logging/logging/stmts_per_txn_limit
@@ -32,6 +32,20 @@ BEGIN; SELECT 1; SELECT 2; COMMIT;
 	"Tag": "SELECT",
 	"User": "root"
 }
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 2,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"StatementFingerprintIDs": [
+		16085855936700856000,
+		16085855936700856000
+	],
+	"TransactionFingerprintID": 14263644654231036000,
+	"User": "root"
+}
 
 spy-sql
 SELECT 5;
@@ -49,6 +63,19 @@ SELECT 5;
 	"StatementFingerprintID": 16085855936700856000,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 1,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"StatementFingerprintIDs": [
+		16085855936700856000
+	],
+	"TransactionFingerprintID": 8097417102642120000,
 	"User": "root"
 }
 
@@ -100,6 +127,23 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"StatementFingerprintID": 16085855936700856000,
 	"StmtPosInTxn": 3,
 	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 4,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"SkippedTransactions": 1,
+	"StatementFingerprintIDs": [
+		16085855936700856000,
+		16085855936700856000,
+		16085855936700856000,
+		16085855936700856000
+	],
+	"TransactionFingerprintID": 63991751604173224,
 	"User": "root"
 }
 
@@ -165,5 +209,22 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"StatementFingerprintID": 16085855936700856000,
 	"StmtPosInTxn": 4,
 	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 4,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"SkippedTransactions": 1,
+	"StatementFingerprintIDs": [
+		16085855936700856000,
+		16085855936700856000,
+		16085855936700856000,
+		16085855936700856000
+	],
+	"TransactionFingerprintID": 63991751604173224,
 	"User": "root"
 }

--- a/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
+++ b/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
@@ -1,5 +1,7 @@
 # Test that transaction mode for telemetry logging logs all stmts for a tracked txn.
 
+subtest transaction_mode_events
+
 exec-sql
 SET CLUSTER SETTING sql.telemetry.transaction_sampling.max_event_frequency = 10;
 ----
@@ -45,6 +47,19 @@ BEGIN; TRUNCATE t; COMMIT
 	"StatementFingerprintID": 14457747517729698000,
 	"StmtPosInTxn": 2,
 	"Tag": "COMMIT",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 0,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"StatementFingerprintIDs": [
+		802230861479752300
+	],
+	"TransactionFingerprintID": 11835923794509859000,
 	"User": "root"
 }
 
@@ -108,6 +123,21 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; COMMIT
 	"Tag": "COMMIT",
 	"User": "root"
 }
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 3,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"StatementFingerprintIDs": [
+		16085855936700856000,
+		16085855936700856000,
+		16085855936700856000
+	],
+	"TransactionFingerprintID": 17099066530943440000,
+	"User": "root"
+}
 
 # Skipped due to not enough time elapsed.
 spy-sql unixSecs=1
@@ -131,6 +161,20 @@ SELECT 1, 2
 	"StatementFingerprintID": 1569305422589581000,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 1,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"SkippedTransactions": 1,
+	"StatementFingerprintIDs": [
+		1569305422589581000
+	],
+	"TransactionFingerprintID": 13449146770429469000,
 	"User": "root"
 }
 
@@ -160,6 +204,20 @@ SELECT * FROM t LIMIT 2
 	"StatementFingerprintID": 17888549871399373000,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 0,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"SkippedTransactions": 2,
+	"StatementFingerprintIDs": [
+		17888549871399373000
+	],
+	"TransactionFingerprintID": 6278959165882708000,
 	"User": "root"
 }
 
@@ -210,6 +268,23 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 	"Tag": "COMMIT",
 	"User": "root"
 }
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 0,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"SkippedTransactions": 1,
+	"StatementFingerprintIDs": [
+		17888549871399373000,
+		17888549871399373000
+	],
+	"TransactionFingerprintID": 5223910247858315000,
+	"User": "root"
+}
+
+subtest end
 
 subtest txn_retry_is_sampled
 
@@ -239,6 +314,20 @@ SELECT 1, 2, 3
 	"StatementFingerprintID": 16698501115058330000,
 	"StmtPosInTxn": 1,
 	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"NumRows": 1,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"SkippedTransactions": 1,
+	"StatementFingerprintIDs": [
+		16698501115058330000
+	],
+	"TransactionFingerprintID": 5250989384299556000,
 	"User": "root"
 }
 
@@ -293,6 +382,67 @@ COMMIT;
 	"StmtPosInTxn": 3,
 	"Tag": "COMMIT",
 	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": true,
+	"EventType": "sampled_transaction",
+	"LastAutoRetryReason": "crdb_internal.force_retry(): TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()",
+	"NumRetries": 1,
+	"NumRows": 2,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"SkippedTransactions": 1,
+	"StatementFingerprintIDs": [
+		15578946620736494000,
+		9891387630896048000
+	],
+	"TransactionFingerprintID": 823601646009140400,
+	"User": "root"
+}
+
+subtest end
+
+subtest redacts_sensitive_info
+
+reset-last-sampled
+----
+
+
+# testuser name should be redacted
+spy-sql user=testuser unixSecs=1
+SELECT 1/0
+----
+pq: division by zero
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"ErrorText": "division by zero",
+	"EventType": "sampled_query",
+	"OutputRowsEstimate": 1,
+	"PlanGist": "AgICAgYC",
+	"SQLSTATE": "22012",
+	"Statement": "SELECT ‹1› / ‹0›",
+	"StatementFingerprintID": 16154612194363576000,
+	"StmtPosInTxn": 1,
+	"Tag": "SELECT",
+	"User": "‹testuser›"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Committed": false,
+	"ErrorText": "division by zero",
+	"EventType": "sampled_transaction",
+	"NumRows": 0,
+	"RowsRead": 0,
+	"RowsWritten": 0,
+	"SQLSTATE": "22012",
+	"StatementFingerprintIDs": [
+		16154612194363576000
+	],
+	"TransactionFingerprintID": 5715924995226314000,
+	"User": "‹testuser›"
 }
 
 subtest end

--- a/pkg/sql/testdata/telemetry_logging/logging_decisions/shouldEmitStatementLog
+++ b/pkg/sql/testdata/telemetry_logging/logging_decisions/shouldEmitStatementLog
@@ -6,19 +6,19 @@ set-cluster-settings telemetryLoggingEnabled=false samplingMode=statement stmtSa
 
 shouldEmitStatementLog unixSecs=1 isTrackedTxn=false stmtNum=1 force=false
 ----
-false
+emit: false, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=1 isTrackedTxn=false stmtNum=1 force=true
 ----
-false
+emit: false, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=1 isTrackedTxn=true stmtNum=1 force=false
 ----
-false
+emit: false, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=2 isTrackedTxn=false stmtNum=1 force=false
 ----
-false
+emit: false, skippedQueries: 0
 
 subtest end
 
@@ -30,19 +30,19 @@ set-cluster-settings telemetryLoggingEnabled=true samplingMode=statement stmtSam
 
 shouldEmitStatementLog unixSecs=1 isTrackedTxn=false stmtNum=1 force=false
 ----
-false
+emit: false, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=1 isTrackedTxn=false stmtNum=1 force=true
 ----
-false
+emit: false, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=1 isTrackedTxn=true stmtNum=1 force=false
 ----
-false
+emit: false, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=2 isTrackedTxn=false stmtNum=1 force=false
 ----
-false
+emit: false, skippedQueries: 0
 
 subtest end
 
@@ -54,31 +54,31 @@ set-cluster-settings telemetryLoggingEnabled=true samplingMode=statement stmtSam
 
 shouldEmitStatementLog unixSecs=1 isTrackedTxn=false stmtNum=1 force=false
 ----
-true
+emit: true, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=1.05 isTrackedTxn=false stmtNum=1 force=false
 ----
-false
+emit: false, skippedQueries: 1
 
 # Force should override the sampling frequency.
 shouldEmitStatementLog unixSecs=1.05 isTrackedTxn=false stmtNum=1 force=true
 ----
-true
+emit: true, skippedQueries: 1
 
 # Tracked txn is true but we are not in txn mode.
 shouldEmitStatementLog unixSecs=1.1 isTrackedTxn=true stmtNum=1 force=false
 ----
-false
+emit: false, skippedQueries: 1
 
 # Enough time has elapsed. stmtNum is greater than stmtsPerTxnMax but we are not in txn mode.
 shouldEmitStatementLog unixSecs=1.15 isTrackedTxn=false stmtNum=1000 force=false
 ----
-true
+emit: true, skippedQueries: 1
 
 # Enough time has elapsed.
 shouldEmitStatementLog unixSecs=2 isTrackedTxn=false stmtNum=1 force=false
 ----
-true
+emit: true, skippedQueries: 0
 
 subtest end
 
@@ -91,35 +91,35 @@ set-cluster-settings telemetryLoggingEnabled=true samplingMode=transaction stmtS
 
 shouldEmitStatementLog unixSecs=1 isTrackedTxn=true stmtNum=1 force=false
 ----
-true
+emit: true, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=1 isTrackedTxn=true stmtNum=2 force=false
 ----
-true
+emit: true, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=1 isTrackedTxn=true stmtNum=3 force=false
 ----
-true
+emit: true, skippedQueries: 0
 
 # Enough time has elapsed but stmtNum is greater than stmtsPerTxnMax.
 shouldEmitStatementLog unixSecs=1 isTrackedTxn=true stmtNum=4 force=false
 ----
-false
+emit: false, skippedQueries: 1
 
 # stmtNum is greater than stmtsPerTxnMax but force is true.
 shouldEmitStatementLog unixSecs=4 isTrackedTxn=true stmtNum=4 force=true
 ----
-true
+emit: true, skippedQueries: 1
 
 # Enough time has elapsed but txn is not tracked.
 shouldEmitStatementLog unixSecs=5 isTrackedTxn=false stmtNum=1 force=false
 ----
-false
+emit: false, skippedQueries: 1
 
 # Txn is not tracked but force is true.
 shouldEmitStatementLog unixSecs=6 isTrackedTxn=false stmtNum=1 force=true
 ----
-true
+emit: true, skippedQueries: 1
 
 subtest end
 
@@ -131,27 +131,26 @@ set-cluster-settings telemetryLoggingEnabled=true samplingMode=transaction stmtS
 
 shouldEmitStatementLog unixSecs=1 isTrackedTxn=true stmtNum=1 force=false
 ----
-false
+emit: false, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=2 isTrackedTxn=true stmtNum=2 force=false
 ----
-false
+emit: false, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=3 isTrackedTxn=true stmtNum=3 force=false
 ----
-false
+emit: false, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=4 isTrackedTxn=true stmtNum=4 force=false
 ----
-false
+emit: false, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=5 isTrackedTxn=false stmtNum=1 force=false
 ----
-false
+emit: false, skippedQueries: 0
 
 shouldEmitStatementLog unixSecs=6 isTrackedTxn=false stmtNum=1 force=true
 ----
-false
+emit: false, skippedQueries: 0
 
 subtest end
-

--- a/pkg/sql/testdata/telemetry_logging/logging_decisions/shouldEmitTransactionLog
+++ b/pkg/sql/testdata/telemetry_logging/logging_decisions/shouldEmitTransactionLog
@@ -5,21 +5,21 @@ subtest telemetry_disabled
 set-cluster-settings telemetryLoggingEnabled=false samplingMode=transaction stmtSampleFreq=10 txnSampleFreq=10
 ----
 
-shouldEmitTransactionLog unixSecs=1 force=false
+shouldEmitTransactionLog unixSecs=1 isTracing=false appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=2 force=true
+shouldEmitTransactionLog unixSecs=2 isTracing=true appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=3 force=false
+shouldEmitTransactionLog unixSecs=3 isTracing=false appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=4 force=true
+shouldEmitTransactionLog unixSecs=4 isTracing=true appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
 
 subtest end
 
@@ -28,21 +28,21 @@ subtest telemetry_enabled_txn_freq_0
 set-cluster-settings telemetryLoggingEnabled=true samplingMode=transaction txnSampleFreq=0
 ----
 
-shouldEmitTransactionLog unixSecs=1 force=false
+shouldEmitTransactionLog unixSecs=1 isTracing=false appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=2 force=true
+shouldEmitTransactionLog unixSecs=2 isTracing=true appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=3 force=false
+shouldEmitTransactionLog unixSecs=3 isTracing=false appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=4 force=true
+shouldEmitTransactionLog unixSecs=4 isTracing=true appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
 
 subtest end
 
@@ -51,21 +51,21 @@ subtest telemetry_enabled_txn_mode_off
 set-cluster-settings telemetryLoggingEnabled=true samplingMode=statement txnSampleFreq=10
 ----
 
-shouldEmitTransactionLog unixSecs=1 force=false
+shouldEmitTransactionLog unixSecs=1 isTracing=false appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=2 force=true
+shouldEmitTransactionLog unixSecs=2 isTracing=true appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=3 force=false
+shouldEmitTransactionLog unixSecs=3 isTracing=false appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=4 force=true
+shouldEmitTransactionLog unixSecs=4 isTracing=true appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
 
 subtest end
 
@@ -74,34 +74,59 @@ subtest telemetry_enabled_txn_mode_on
 set-cluster-settings telemetryLoggingEnabled=true samplingMode=transaction txnSampleFreq=1
 ----
 
-shouldEmitTransactionLog unixSecs=1 force=false
+shouldEmitTransactionLog unixSecs=1 isTracing=false appName="telemetry-logging"
 ----
-true
+emit: true, skippedTxns: 0
 
 # Not enough time elapsed.
-shouldEmitTransactionLog unixSecs=1.5 force=false
+shouldEmitTransactionLog unixSecs=1.5 isTracing=false appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 1
 
 # Enough time elapsed.
-shouldEmitTransactionLog unixSecs=2 force=false
+shouldEmitTransactionLog unixSecs=2 isTracing=false appName="telemetry-logging"
 ----
-true
+emit: true, skippedTxns: 1
 
-# Force should override the sampling frequency.
-shouldEmitTransactionLog unixSecs=2.5 force=true
+# isTracing should override the sampling frequency.
+shouldEmitTransactionLog unixSecs=2.5 isTracing=true appName="telemetry-logging"
 ----
-true
+emit: true, skippedTxns: 0
 
 
 # Sampling internal queries is off.
-shouldEmitTransactionLog unixSecs=4 force=false isInternal=true
+shouldEmitTransactionLog unixSecs=4 isTracing=false isInternal=true appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=4 force=true isInternal=true
+shouldEmitTransactionLog unixSecs=4 isTracing=true isInternal=true appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 0
+
+subtest end
+
+subtest log_internal_console_queries
+# Transactions with app name prefix '$ internal-console' should be force logged when
+# sql.telemetry.query_sampling.internal_console.enabled is on.
+
+set-cluster-settings telemetryLoggingEnabled=true telemetryInternalConsoleQueriesEnabled=false samplingMode=transaction txnSampleFreq=1
+----
+
+# Should return false because telemetryInternalConsoleQueriesEnabled is false and internal queries logging is off.
+shouldEmitTransactionLog unixSecs=1 isTracing=false isInternal=true appName="$ internal-console"
+----
+emit: false, skippedTxns: 0
+
+set-cluster-settings telemetryLoggingEnabled=true telemetryInternalConsoleQueriesEnabled=true samplingMode=transaction txnSampleFreq=1
+----
+
+shouldEmitTransactionLog unixSecs=1 isTracing=false isInternal=true appName=($ internal-console)
+----
+emit: true, skippedTxns: 0
+
+shouldEmitTransactionLog unixSecs=1 isTracing=false isInternal=true appName=($ internal-console)
+----
+emit: true, skippedTxns: 0
 
 subtest end
 
@@ -111,32 +136,32 @@ subtest telemetry_enabled_txn_mode_on_internal_queries_on
 set-cluster-settings telemetryLoggingEnabled=true samplingMode=transaction txnSampleFreq=1 internalStmtsOn=true
 ----
 
-shouldEmitTransactionLog unixSecs=1 force=false isInternal=true
+shouldEmitTransactionLog unixSecs=1 isTracing=false isInternal=true appName="telemetry-logging"
 ----
-true
+emit: true, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=1.5 force=false isInternal=true
+shouldEmitTransactionLog unixSecs=1.5 isTracing=false isInternal=true appName="telemetry-logging"
 ----
-false
+emit: false, skippedTxns: 1
 
-shouldEmitTransactionLog unixSecs=2 force=false isInternal=true
+shouldEmitTransactionLog unixSecs=2 isTracing=false isInternal=true appName="telemetry-logging"
 ----
-true
+emit: true, skippedTxns: 1
 
-shouldEmitTransactionLog unixSecs=2.5 force=true isInternal=true
+shouldEmitTransactionLog unixSecs=2.5 isTracing=true isInternal=true appName="telemetry-logging"
 ----
-true
+emit: true, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=2.5 force=true isInternal=true
+shouldEmitTransactionLog unixSecs=2.5 isTracing=true isInternal=true appName="telemetry-logging"
 ----
-true
+emit: true, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=4 force=false isInternal=false
+shouldEmitTransactionLog unixSecs=4 isTracing=false isInternal=false appName="telemetry-logging"
 ----
-true
+emit: true, skippedTxns: 0
 
-shouldEmitTransactionLog unixSecs=5 force=true isInternal=false
+shouldEmitTransactionLog unixSecs=5 isTracing=true isInternal=false appName="telemetry-logging"
 ----
-true
+emit: true, skippedTxns: 0
 
 subtest end

--- a/pkg/util/log/eventpb/eventpbgen/gen.go
+++ b/pkg/util/log/eventpb/eventpbgen/gen.go
@@ -84,6 +84,7 @@ type fieldInfo struct {
 	Inherited           bool
 	IsEnum              bool
 	AllowZeroValue      bool
+	Nullable            bool
 }
 
 var (
@@ -380,6 +381,8 @@ func readInput(
 				return errors.Newf("unknown field definition syntax: %q", line)
 			}
 
+			notNullable := notNullableRe.MatchString(line)
+
 			// Allow zero values if the field is annotated with 'includeempty'.
 			allowZeroValue := strings.Contains(line, "includeempty")
 
@@ -461,6 +464,7 @@ func readInput(
 					MixedRedactable:     mixed,
 					IsEnum:              isEnum,
 					AllowZeroValue:      allowZeroValue,
+					Nullable:            !notNullable,
 				}
 				curMsg.Fields = append(curMsg.Fields, fi)
 				curMsg.AllFields = append(curMsg.AllFields, fi)
@@ -491,6 +495,8 @@ var fieldDefRe = regexp.MustCompile(`\s*(?P<typ>[a-z._A-Z0-9]+)` +
 	`).*$`)
 
 var reservedDefRe = regexp.MustCompile(`\s*(reserved ([1-9][0-9]*);)`)
+
+var notNullableRe = regexp.MustCompile(`\s*\(\s*gogoproto\.nullable\s*\)\s*=\s*false`)
 
 func camelToSnake(typeName string) string {
 	var res strings.Builder
@@ -712,13 +718,17 @@ func (m *{{.GoType}}) AppendJSONFields(printComma bool, b redact.RedactableBytes
      }
    }
    {{- else if eq .FieldType "nestedMessage"}}
-if m.{{.FieldName}} != nil {
+   {{ if .Nullable -}}
+   if m.{{.FieldName}} != nil {
+   {{- end }}
      if printComma { b = append(b, ',')}; printComma = true
      b = append(b, "\"{{.FieldName}}\":"...)
      b = append(b, '{')
      printComma, b = m.{{.FieldName}}.AppendJSONFields(false, b)
      b = append(b, '}')
+   {{ if .Nullable -}}
    }
+   {{- end }}
    {{- else}}
    {{ error  .FieldType }}
    {{- end}}

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -4301,16 +4301,14 @@ func (m *SampledExecStats) AppendJSONFields(printComma bool, b redact.Redactable
 	b = append(b, "\"CPUSQLNanos\":"...)
 	b = strconv.AppendInt(b, int64(m.CPUSQLNanos), 10)
 
-	if m.MVCCIteratorStats != nil {
-		if printComma {
-			b = append(b, ',')
-		}
-		printComma = true
-		b = append(b, "\"MVCCIteratorStats\":"...)
-		b = append(b, '{')
-		printComma, b = m.MVCCIteratorStats.AppendJSONFields(false, b)
-		b = append(b, '}')
+	if printComma {
+		b = append(b, ',')
 	}
+	printComma = true
+	b = append(b, "\"MVCCIteratorStats\":"...)
+	b = append(b, '{')
+	printComma, b = m.MVCCIteratorStats.AppendJSONFields(false, b)
+	b = append(b, '}')
 
 	return printComma, b
 }

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -5227,6 +5227,15 @@ func (m *SampledTransaction) AppendJSONFields(printComma bool, b redact.Redactab
 		b = append(b, '}')
 	}
 
+	if m.SkippedTransactions != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SkippedTransactions\":"...)
+		b = strconv.AppendInt(b, int64(m.SkippedTransactions), 10)
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -327,7 +327,7 @@ message SampledExecStats {
   int64 cpu_sql_nanos = 6 [(gogoproto.customname) = "CPUSQLNanos", (gogoproto.jsontag) = "CPUSQLNanos,includeempty"];
 
   // Internal storage iteration statistics.
-  MVCCIteratorStats mvcc_iterator_stats = 7 [(gogoproto.customname) = "MVCCIteratorStats", (gogoproto.jsontag) = ",omitempty"];
+  MVCCIteratorStats mvcc_iterator_stats = 7 [(gogoproto.nullable) = false, (gogoproto.customname) = "MVCCIteratorStats"];
 }
 
 // Internal storage iteration statistics for a single execution.

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -457,27 +457,32 @@ message SampledTransaction {
   int64 num_rows = 18 [(gogoproto.jsontag) = ",includeempty"];
 
   // RetryLatNanos is the amount of time spent retrying the transaction.
- int64 retry_lat_nanos  = 19 [(gogoproto.jsontag) = ",omitempty"];
+  int64 retry_lat_nanos  = 19 [(gogoproto.jsontag) = ",omitempty"];
 
- // CommitLatNanos is the amount of time spent committing the transaction after all statement operations.
- int64 commit_lat_nanos = 20 [(gogoproto.jsontag) = ",includeempty"];
+  // CommitLatNanos is the amount of time spent committing the transaction after all statement operations.
+  int64 commit_lat_nanos = 20 [(gogoproto.jsontag) = ",includeempty"];
 
- // IdleLatNanos is the amount of time spent waiting for the client to send statements
+  // IdleLatNanos is the amount of time spent waiting for the client to send statements
   // while the transaction is open.
- int64 idle_lat_nanos = 21 [(gogoproto.jsontag) = ",includeempty"];
+  int64 idle_lat_nanos = 21 [(gogoproto.jsontag) = ",includeempty"];
 
- // BytesRead is the number of bytes read from disk.
- int64 bytes_read = 22 [(gogoproto.jsontag) = ",includeempty"];
+  // BytesRead is the number of bytes read from disk.
+  int64 bytes_read = 22 [(gogoproto.jsontag) = ",includeempty"];
 
- // RowsRead is the number of rows read from disk.
- int64 rows_read = 23 [(gogoproto.jsontag) = ",includeempty"];
+  // RowsRead is the number of rows read from disk.
+  int64 rows_read = 23 [(gogoproto.jsontag) = ",includeempty"];
 
- // RowsWritten is the number of rows written to disk.
- int64 rows_written = 24 [(gogoproto.jsontag) = ",includeempty"];
+  // RowsWritten is the number of rows written to disk.
+  int64 rows_written = 24 [(gogoproto.jsontag) = ",includeempty"];
 
- // SampledExecStats is a nested field containing execution statistics.
- // This field will be omitted if the stats were not sampled.
- SampledExecStats sampled_exec_stats = 25 [(gogoproto.jsontag) = ",omitempty"];
+  // SampledExecStats is a nested field containing execution statistics.
+  // This field will be omitted if the stats were not sampled.
+  SampledExecStats sampled_exec_stats = 25 [(gogoproto.jsontag) = ",omitempty"];
+
+  // SkippedTransactions is the number of transactions that were skipped as part of sampling prior to
+  // this one. We only count skipped transactions when telemetry logging is enabled and the sampling
+  // mode is set to "transaction".
+  int64 skipped_transactions = 26 [(gogoproto.jsontag) = ",omitempty"];
 }
 
 // CapturedIndexUsageStats


### PR DESCRIPTION
### 1. [sql/telemetry: add SkippedTransactions to SampledTransaction proto](https://github.com/cockroachdb/cockroach/pull/115722/commits/a356e63d5466075ff0ba8ad7fe1a2985f4e50fbe) 

This commit adds the field SkippedTransactions to the
SampledTransaction protobuf to count the number of transactions
that were not sampled while telemetry transaction logging
is enabled. The corresponding field is added to the
telemetryLogging struct and will be used in the following
commit to track skipped transactions. Some whitespace in the
SampledTransaction proto definition is adjusted.

Epic: none

Release note (sql change): New field `SkippedTransactions` in
the SampledTransaction event, which is emitted to the TELEMETRY
logging channel when telemetry logging is enabled and set to
"transaction" mode.

### 2. [eventpb: make MVCCIteratorStats in SampledExecStats non-nullable](https://github.com/cockroachdb/cockroach/pull/115722/commits/6610467a63bef884a21835a0f5637341f8ee8034) 

This field should always exist in SampledExecStats. Since
SampledTransaction is the only user of this message right now
and is yet to be used we can safely change the proto definition.

Epic: none

Release note: None

### 3. [eventpb: make MVCCIteratorStats in SampledExecStats non-nullable](https://github.com/cockroachdb/cockroach/pull/115722/commits/6610467a63bef884a21835a0f5637341f8ee8034) 

This field should always exist in SampledExecStats. Since
SampledTransaction is the only user of this message right now
and is yet to be used we can safely change the proto definition.

Epic: none

Release note: None

### 4.  [telemetry: log transaction exec events to TELEMETRY](https://github.com/cockroachdb/cockroach/pull/115722/commits/cc0d1bb97ae79894e5e39092ef3f4d442758fcc6)

This commit sends SampledTransaction events to the telemetry channel.
In "transaction" sampling mode, if a transaction is marked to be logged
to telemetry, we will emit a SampledTranaction event on transaction
end containing transaction level stats. It is expected that if a transaction
event exists in telemetry, its statement events will also have been logged
(with a maximum number according to the setting
sql.telemetry.transaction_sampling.statement_events_per_transaction.max.

Closes: https://github.com/cockroachdb/cockroach/issues/108284

Release note (ops change): Transactions sampled for the telemetry logging
channel will now emit a SampledTransaction event. To sample transactions,
set the cluster setting `sql.telemetry.query_sampling.mode = 'transaction'`
and enable telemetry logging via `sql.telemetry.query_sampling.enabled = true`.