### PR TITLE
release-23.1: generate-logictest: fix order of lines in generated BUILD.bazel 

### DIFF
--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -259,9 +259,9 @@ go_test(
     args = ["-test.timeout=3595s"],{{ end }}
     data = [
         "//c-deps:libgeos",  # keep{{ if .SqliteLogicTest }}
-        "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep{{ end }}{{ if .CockroachGoTestserverTest }}
-        "//pkg/cmd/cockroach-short",  # keep{{ end }}{{ if .CclLogicTest }}
-        "//pkg/ccl/logictestccl:testdata",  # keep{{ end }}{{ if .LogicTest }}
+        "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep{{ end }}{{ if .CclLogicTest }}
+        "//pkg/ccl/logictestccl:testdata",  # keep{{ end }}{{ if .CockroachGoTestserverTest }}
+        "//pkg/cmd/cockroach-short",  # keep{{ end }}{{ if .LogicTest }}
         "//pkg/sql/logictest:testdata",  # keep{{ end }}{{ if .ExecBuildLogicTest }}
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep{{ end }}
     ],


### PR DESCRIPTION
Backport 1/1 commits from #115715.

/cc @cockroachdb/release

---

These should be alphabetized.

Epic: none
Release note: None
Release justification: Build-only code changes