### PR TITLE
ui,obsservice: update queries

### DIFF
--- a/pkg/obsservice/obslib/process/stmt_insights_processor.go
+++ b/pkg/obsservice/obslib/process/stmt_insights_processor.go
@@ -48,7 +48,7 @@ func (p *StmtInsightsProcessor) Process(
 	p.addInsight(stmtInsight)
 	insightsSize, lastExportTs := p.getInsightsInfo()
 
-	if insightsSize >= InsightsBatchMax || lastExportTs > time.Minute {
+	if insightsSize >= InsightsBatchMax || lastExportTs > time.Second*30 {
 		insertStmt, args := p.prepareInsightExport()
 		err := p.exportInsights(ctx, insertStmt, args)
 		if err != nil {

--- a/pkg/sql/sqlstats/insights/registry.go
+++ b/pkg/sql/sqlstats/insights/registry.go
@@ -96,6 +96,9 @@ func (r *lockingRegistry) ObserveTransaction(
 	if !r.enabled() {
 		return
 	}
+	if transaction.ID.String() == "00000000-0000-0000-0000-000000000000" {
+		return
+	}
 	statements, ok := r.statements[sessionID]
 	if !ok {
 		return

--- a/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
@@ -35,7 +35,7 @@ export type StmtInsightsReq = {
   end?: moment.Moment;
   stmtExecutionID?: string;
   stmtFingerprintId?: string;
-  csExportInsights?: boolean;
+  useObsService?: boolean;
 };
 
 export type StmtInsightsResponseRow = {
@@ -70,6 +70,34 @@ export type StmtInsightsResponseRow = {
   status: StatementStatus;
 };
 
+export type StmtInsightsObsServiceResponseRow = {
+  session_id: string;
+  transaction_id: string;
+  transaction_fingerprint_id: string; // hex string
+  implicit_txn: boolean;
+  statement_id: string;
+  statement_fingerprint_id: string; // hex string
+  query: string;
+  start_time: string; // Timestamp
+  end_time: string; // Timestamp
+  full_scan: boolean;
+  user_name: string;
+  app_name: string;
+  database_name: string;
+  priority: string;
+  retries: number;
+  exec_node_ids: number[];
+  contention: string; // interval
+  last_retry_reason?: string;
+  causes: string[];
+  problem: string;
+  index_recommendations: string[];
+  plan_gist: string;
+  cpu_sql_nanos: number;
+  error_code: string;
+  status: StatementStatus;
+};
+
 const stmtColumns = `
 session_id,
 txn_id,
@@ -101,40 +129,73 @@ last_error_redactable,
 status
 `;
 
-const stmtInsightsOverviewQuery = (filters?: StmtInsightsReq): string => {
-  if (filters?.stmtExecutionID) {
-    return `
-SELECT ${stmtColumns} FROM crdb_internal.cluster_execution_insights
-WHERE stmt_id = '${filters.stmtExecutionID}'`;
+// TODO(maryliag): update columns list once we store values for
+// rows_read, rows_written and last_error_redactable.
+const stmtColumnsObsService = `
+session_id,
+transaction_id,
+transaction_fingerprint_id,
+implicit_txn,
+statement_id,
+statement_fingerprint_id,
+query,
+start_time,
+end_time,
+full_scan,
+user_name,
+app_name,
+database_name,
+user_priority,
+retries,
+execution_node_ids,
+contention_time,
+last_retry_reason,
+causes,
+problem,
+index_recommendations,
+plan_gist,
+cpu_sql_nanos,
+error_code,
+status
+`;
+
+const stmtInsightsOverviewQuery = (req?: StmtInsightsReq): string => {
+  const columns = req.useObsService ? stmtColumnsObsService : stmtColumns;
+  const table = req.useObsService
+    ? "obsservice.statement_execution_insights"
+    : "crdb_internal.cluster_execution_insights";
+  const stmtIdColumnName = req.useObsService ? "statement_id" : "stmt_id";
+  if (req?.stmtExecutionID) {
+    return `SELECT ${columns} FROM ${table} WHERE ${stmtIdColumnName} = '${req.stmtExecutionID}'`;
   }
 
+  const txnIdColumnName = req.useObsService ? "transaction_id" : "txn_id";
+  const stmtFingerprintIDColumnName = req.useObsService
+    ? "statement_fingerprint_id"
+    : "stmt_fingerprint_id";
   let whereClause = `
   WHERE app_name NOT LIKE '${INTERNAL_APP_NAME_PREFIX}%'
   AND problem != 'None'
-  AND txn_id != '00000000-0000-0000-0000-000000000000'`;
-  if (filters?.start) {
+  AND ${txnIdColumnName} != '00000000-0000-0000-0000-000000000000'`;
+  if (req?.start) {
     whereClause =
-      whereClause + ` AND start_time >= '${filters.start.toISOString()}'`;
+      whereClause + ` AND start_time >= '${req.start.toISOString()}'`;
   }
-  if (filters?.end) {
-    whereClause =
-      whereClause + ` AND end_time <= '${filters.end.toISOString()}'`;
+  if (req?.end) {
+    whereClause = whereClause + ` AND end_time <= '${req.end.toISOString()}'`;
   }
-  if (filters?.stmtFingerprintId) {
+  if (req?.stmtFingerprintId) {
     whereClause =
       whereClause +
-      ` AND encode(stmt_fingerprint_id, 'hex') = '${filters.stmtFingerprintId}'`;
+      ` AND encode(${stmtFingerprintIDColumnName}, 'hex') = '${req.stmtFingerprintId}'`;
   }
 
-  return `
-SELECT ${stmtColumns} FROM
+  return `SELECT ${columns} FROM
    (
-     SELECT DISTINCT ON (stmt_fingerprint_id, problem, causes)
+     SELECT DISTINCT ON (${stmtFingerprintIDColumnName}, problem, causes)
        *
-     FROM
-       crdb_internal.cluster_execution_insights
-         ${whereClause}
-     ORDER BY stmt_fingerprint_id, problem, causes, end_time DESC
+     FROM ${table} ${whereClause}
+     ORDER BY ${stmtFingerprintIDColumnName}, problem, causes, end_time DESC
    )`;
 };
 
@@ -156,10 +217,12 @@ export async function getStmtInsightsApi(
     execute: true,
     max_result_size: LARGE_RESULT_SIZE,
     timeout: LONG_TIMEOUT,
-    use_obs_service: req.csExportInsights,
+    use_obs_service: req.useObsService,
   };
 
-  const result = await executeInternalSql<StmtInsightsResponseRow>(request);
+  const result = await executeInternalSql<
+    StmtInsightsResponseRow | StmtInsightsObsServiceResponseRow
+  >(request);
 
   if (sqlResultsAreEmpty(result)) {
     return formatApiResult<StmtInsightEvent[]>(
@@ -168,7 +231,10 @@ export async function getStmtInsightsApi(
       "retrieving insights information",
     );
   }
-  const stmtInsightEvent = formatStmtInsights(result.execution?.txn_results[0]);
+  const stmtInsightEvent = formatStmtInsights(
+    result.execution?.txn_results[0],
+    req.useObsService,
+  );
   await addStmtContentionInfoApi(stmtInsightEvent);
   return formatApiResult<StmtInsightEvent[]>(
     stmtInsightEvent,
@@ -205,49 +271,82 @@ async function addStmtContentionInfoApi(
 }
 
 export function formatStmtInsights(
-  response: SqlTxnResult<StmtInsightsResponseRow>,
+  response: SqlTxnResult<
+    StmtInsightsResponseRow | StmtInsightsObsServiceResponseRow
+  >,
+  useObsService?: boolean,
 ): StmtInsightEvent[] {
   if (!response?.rows?.length) {
     return [];
   }
 
-  return response.rows.map((row: StmtInsightsResponseRow) => {
-    const start = moment.utc(row.start_time);
-    const end = moment.utc(row.end_time);
+  let txnID;
+  let txnFingerprintID;
+  let stmtID;
+  let stmtFingerprintID;
+  let rowsRead;
+  let rowsWritten;
+  let lastErrorRedactable;
 
-    return {
-      transactionExecutionID: row.txn_id,
-      transactionFingerprintID: FixFingerprintHexValue(row.txn_fingerprint_id),
-      implicitTxn: row.implicit_txn,
-      databaseName: row.database_name,
-      application: row.app_name,
-      username: row.user_name,
-      sessionID: row.session_id,
-      priority: row.priority,
-      retries: row.retries,
-      lastRetryReason: row.last_retry_reason,
-      query: row.query,
-      startTime: start,
-      endTime: end,
-      elapsedTimeMillis: end.diff(start, "milliseconds"),
-      statementExecutionID: row.stmt_id,
-      statementFingerprintID: FixFingerprintHexValue(row.stmt_fingerprint_id),
-      isFullScan: row.full_scan,
-      rowsRead: row.rows_read,
-      rowsWritten: row.rows_written,
-      // This is the total stmt contention.
-      contentionTime: row.contention ? moment.duration(row.contention) : null,
-      indexRecommendations: row.index_recommendations,
-      insights: getInsightsFromProblemsAndCauses(
-        [row.problem],
-        row.causes,
-        InsightExecEnum.STATEMENT,
-      ),
-      planGist: row.plan_gist,
-      cpuSQLNanos: row.cpu_sql_nanos,
-      errorCode: row.error_code,
-      errorMsg: row.last_error_redactable,
-      status: row.status,
-    } as StmtInsightEvent;
-  });
+  return response.rows.map(
+    (row: StmtInsightsResponseRow | StmtInsightsObsServiceResponseRow) => {
+      const start = moment.utc(row.start_time);
+      const end = moment.utc(row.end_time);
+      if (useObsService) {
+        const r = row as StmtInsightsObsServiceResponseRow;
+        txnID = r.transaction_id;
+        txnFingerprintID = r.transaction_fingerprint_id;
+        stmtID = r.statement_id;
+        stmtFingerprintID = r.statement_fingerprint_id;
+        // TODO(maryliag); collect the values for rows read, rows written and last error redactable.
+        rowsRead = 0;
+        rowsWritten = 0;
+        lastErrorRedactable = "";
+      } else {
+        const r = row as StmtInsightsResponseRow;
+        txnID = r.txn_id;
+        txnFingerprintID = r.txn_fingerprint_id;
+        stmtID = r.stmt_id;
+        stmtFingerprintID = r.stmt_fingerprint_id;
+        rowsRead = r.rows_read;
+        rowsWritten = r.rows_written;
+        lastErrorRedactable = r.last_error_redactable;
+      }
+
+      return {
+        transactionExecutionID: txnID,
+        transactionFingerprintID: FixFingerprintHexValue(txnFingerprintID),
+        implicitTxn: row.implicit_txn,
+        databaseName: row.database_name,
+        application: row.app_name,
+        username: row.user_name,
+        sessionID: row.session_id,
+        priority: row.priority,
+        retries: row.retries,
+        lastRetryReason: row.last_retry_reason,
+        query: row.query,
+        startTime: start,
+        endTime: end,
+        elapsedTimeMillis: end.diff(start, "milliseconds"),
+        statementExecutionID: stmtID,
+        statementFingerprintID: FixFingerprintHexValue(stmtFingerprintID),
+        isFullScan: row.full_scan,
+        rowsRead: rowsRead,
+        rowsWritten: rowsWritten,
+        // This is the total stmt contention.
+        contentionTime: row.contention ? moment.duration(row.contention) : null,
+        indexRecommendations: row.index_recommendations,
+        insights: getInsightsFromProblemsAndCauses(
+          [row.problem],
+          row.causes,
+          InsightExecEnum.STATEMENT,
+        ),
+        planGist: row.plan_gist,
+        cpuSQLNanos: row.cpu_sql_nanos,
+        errorCode: row.error_code,
+        errorMsg: lastErrorRedactable,
+        status: row.status,
+      } as StmtInsightEvent;
+    },
+  );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -396,23 +396,23 @@ export function getStmtInsightRecommendations(
   if (!insightDetails) return [];
 
   const execDetails: ExecutionDetails = {
-    application: insightDetails.application,
-    statement: insightDetails.query,
-    fingerprintID: insightDetails.statementFingerprintID,
-    retries: insightDetails.retries,
-    indexRecommendations: insightDetails.indexRecommendations,
-    databaseName: insightDetails.databaseName,
-    elapsedTimeMillis: insightDetails.elapsedTimeMillis,
-    contentionTimeMs: insightDetails.contentionTime?.asMilliseconds(),
-    statementExecutionID: insightDetails.statementExecutionID,
-    transactionExecutionID: insightDetails.transactionExecutionID,
+    application: insightDetails?.application,
+    statement: insightDetails?.query,
+    fingerprintID: insightDetails?.statementFingerprintID,
+    retries: insightDetails?.retries,
+    indexRecommendations: insightDetails?.indexRecommendations,
+    databaseName: insightDetails?.databaseName,
+    elapsedTimeMillis: insightDetails?.elapsedTimeMillis,
+    contentionTimeMs: insightDetails?.contentionTime?.asMilliseconds(),
+    statementExecutionID: insightDetails?.statementExecutionID,
+    transactionExecutionID: insightDetails?.transactionExecutionID,
     execType: InsightExecEnum.STATEMENT,
-    errorCode: insightDetails.errorCode,
-    errorMsg: insightDetails.errorMsg,
-    status: insightDetails.status,
+    errorCode: insightDetails?.errorCode,
+    errorMsg: insightDetails?.errorMsg,
+    status: insightDetails?.status,
   };
 
-  const recs: InsightRecommendation[] = insightDetails.insights?.map(insight =>
+  const recs: InsightRecommendation[] = insightDetails?.insights?.map(insight =>
     getRecommendationForExecInsight(insight, execDetails),
   );
 
@@ -425,14 +425,14 @@ export function getTxnInsightRecommendations(
   if (!insightDetails) return [];
 
   const execDetails: ExecutionDetails = {
-    application: insightDetails.application,
-    transactionExecutionID: insightDetails.transactionExecutionID,
-    retries: insightDetails.retries,
-    contentionTimeMs: insightDetails.contentionTime.asMilliseconds(),
-    elapsedTimeMillis: insightDetails.elapsedTimeMillis,
+    application: insightDetails?.application,
+    transactionExecutionID: insightDetails?.transactionExecutionID,
+    retries: insightDetails?.retries,
+    contentionTimeMs: insightDetails?.contentionTime.asMilliseconds(),
+    elapsedTimeMillis: insightDetails?.elapsedTimeMillis,
     execType: InsightExecEnum.TRANSACTION,
-    errorCode: insightDetails.errorCode,
-    errorMsg: insightDetails.errorMsg,
+    errorCode: insightDetails?.errorCode,
+    errorMsg: insightDetails?.errorMsg,
   };
   const recs: InsightRecommendation[] = [];
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -43,7 +43,7 @@ export interface StatementInsightDetailsStateProps {
   isTenant?: boolean;
   timeScale?: TimeScale;
   hasAdminRole: boolean;
-  csExportInsights: boolean;
+  useObsService: boolean;
 }
 
 export interface StatementInsightDetailsDispatchProps {
@@ -78,7 +78,7 @@ export const StatementInsightDetails: React.FC<
   timeScale,
   hasAdminRole,
   refreshUserSQLRoles,
-  csExportInsights,
+  useObsService,
 }) => {
   const [explainPlanState, setExplainPlanState] = useState<ExplainPlanState>({
     explainPlan: null,
@@ -91,10 +91,9 @@ export const StatementInsightDetails: React.FC<
       loaded: insightEventDetails != null,
       error: insightError,
     });
-  const [prevCsExportInsights, setPrevCsExportInsights] =
-    useState(csExportInsights);
+  const [prevUseObsService, setPrevUseObsService] = useState(useObsService);
 
-  const details = insightDetails.details;
+  const details = insightDetails?.details;
 
   const prevPage = (): void => history.goBack();
 
@@ -120,16 +119,16 @@ export const StatementInsightDetails: React.FC<
 
   useEffect(() => {
     refreshUserSQLRoles();
-    if (details != null && prevCsExportInsights === csExportInsights) {
+    if (details != null && prevUseObsService === useObsService) {
       return;
     }
-    setPrevCsExportInsights(csExportInsights);
+    setPrevUseObsService(useObsService);
     const [start, end] = toDateRange(timeScale);
     getStmtInsightsApi({
       stmtExecutionID: executionID,
       start,
       end,
-      csExportInsights,
+      useObsService,
     })
       .then(res => {
         setInsightDetails({
@@ -145,8 +144,8 @@ export const StatementInsightDetails: React.FC<
     executionID,
     timeScale,
     refreshUserSQLRoles,
-    csExportInsights,
-    prevCsExportInsights,
+    useObsService,
+    prevUseObsService,
   ]);
 
   return (
@@ -167,10 +166,10 @@ export const StatementInsightDetails: React.FC<
       </h3>
       <div>
         <Loading
-          loading={!insightDetails.loaded}
+          loading={!insightDetails?.loaded}
           page="Statement Insight details"
-          error={insightDetails.error}
-          renderError={() => InsightsError(insightDetails.error?.message)}
+          error={insightDetails?.error}
+          renderError={() => InsightsError(insightDetails?.error?.message)}
         >
           <section className={cx("section")}>
             <Row>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
@@ -25,7 +25,7 @@ import { TimeScale } from "../../timeScaleDropdown";
 import { actions as sqlStatsActions } from "../../store/sqlStats";
 import { selectTimeScale } from "../../store/utils/selectors";
 import { actions as analyticsActions } from "../../store/analytics";
-import { selectCsExportInsights } from "src/store/clusterSettings/clusterSettings.selectors";
+import { selectUseObsService } from "src/store/clusterSettings/clusterSettings.selectors";
 
 const mapStateToProps = (
   state: AppState,
@@ -39,7 +39,7 @@ const mapStateToProps = (
     isTenant: selectIsTenant(state),
     timeScale: selectTimeScale(state),
     hasAdminRole: selectHasAdminRole(state),
-    csExportInsights: selectCsExportInsights(state),
+    useObsService: selectUseObsService(state),
   };
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -76,12 +76,12 @@ export const StatementInsightDetailsOverviewTab: React.FC<
         <Col className="gutter-row">
           <Heading type="h5">
             {WaitTimeInsightsLabels.BLOCKED_TXNS_TABLE_TITLE(
-              insightDetails.statementExecutionID,
+              insightDetails?.statementExecutionID,
               "statement",
             )}
           </Heading>
           <ContentionStatementDetailsTable
-            data={insightDetails.contentionEvents}
+            data={insightDetails?.contentionEvents}
             sortSetting={insightsDetailsContentionSortSetting}
             onChangeSortSetting={setDetailsContentionSortSetting}
           />
@@ -104,7 +104,7 @@ export const StatementInsightDetailsOverviewTab: React.FC<
               label="Start Time"
               value={
                 <Timestamp
-                  time={insightDetails.startTime}
+                  time={insightDetails?.startTime}
                   format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
                 />
               }
@@ -113,34 +113,34 @@ export const StatementInsightDetailsOverviewTab: React.FC<
               label="End Time"
               value={
                 <Timestamp
-                  time={insightDetails.endTime}
+                  time={insightDetails?.endTime}
                   format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
                 />
               }
             />
             <SummaryCardItem
               label="Elapsed Time"
-              value={Duration(insightDetails.elapsedTimeMillis * 1e6)}
+              value={Duration(insightDetails?.elapsedTimeMillis * 1e6)}
             />
             <SummaryCardItem
               label={"CPU Time"}
-              value={Duration(insightDetails.cpuSQLNanos)}
+              value={Duration(insightDetails?.cpuSQLNanos)}
             />
             <SummaryCardItem
               label="Rows Read"
-              value={Count(insightDetails.rowsRead)}
+              value={Count(insightDetails?.rowsRead)}
             />
             <SummaryCardItem
               label="Rows Written"
-              value={Count(insightDetails.rowsWritten)}
+              value={Count(insightDetails?.rowsWritten)}
             />
             <SummaryCardItem
               label="Transaction Priority"
-              value={capitalize(insightDetails.priority)}
+              value={capitalize(insightDetails?.priority)}
             />
             <SummaryCardItem
               label="Full Scan"
-              value={capitalize(String(insightDetails.isFullScan))}
+              value={capitalize(String(insightDetails?.isFullScan))}
             />
           </SummaryCard>
         </Col>
@@ -148,29 +148,29 @@ export const StatementInsightDetailsOverviewTab: React.FC<
           <SummaryCard>
             <SummaryCardItem
               label="Transaction Retries"
-              value={Count(insightDetails.retries)}
+              value={Count(insightDetails?.retries)}
             />
-            {insightDetails.lastRetryReason && (
+            {insightDetails?.lastRetryReason && (
               <SummaryCardItem
                 label="Last Retry Reason"
-                value={insightDetails.lastRetryReason.toString()}
+                value={insightDetails?.lastRetryReason.toString()}
               />
             )}
             <p className={summaryCardStylesCx("summary--card__divider")} />
             <SummaryCardItem
               label="Session ID"
-              value={String(insightDetails.sessionID)}
+              value={String(insightDetails?.sessionID)}
             />
             <SummaryCardItem
               label="Transaction Fingerprint ID"
               value={TransactionDetailsLink(
-                insightDetails.transactionFingerprintID,
-                insightDetails.application,
+                insightDetails?.transactionFingerprintID,
+                insightDetails?.application,
               )}
             />
             <SummaryCardItem
               label="Transaction Execution ID"
-              value={String(insightDetails.transactionExecutionID)}
+              value={String(insightDetails?.transactionExecutionID)}
             />
             <SummaryCardItem
               label="Statement Fingerprint ID"

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -65,7 +65,7 @@ const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
 
 export type StatementInsightsViewStateProps = {
-  csExportInsights: boolean;
+  useObsService: boolean;
   filters: WorkloadInsightEventFilters;
   insightTypes: string[];
   isDataValid: boolean;
@@ -113,7 +113,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
   selectedColumnNames,
   dropDownSelect,
   maxSizeApiReached,
-  csExportInsights,
+  useObsService,
 }: StatementInsightsViewProps) => {
   const [pagination, setPagination] = useState<ISortedTablePagination>({
     current: 1,
@@ -129,10 +129,10 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
     const req = {
       start: ts.start,
       end: ts.end,
-      csExportInsights: csExportInsights,
+      useObsService: useObsService,
     };
     refreshStatementInsights(req);
-  }, [refreshStatementInsights, timeScale, csExportInsights]);
+  }, [refreshStatementInsights, timeScale, useObsService]);
 
   const shouldPoll = timeScale.key !== "Custom";
   const [refetch, clearPolling] = useScheduleFunction(

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/detailsLinks.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/detailsLinks.tsx
@@ -37,15 +37,15 @@ export function StatementDetailsLink(
 ): React.ReactElement {
   const linkProps = {
     statementFingerprintID: HexStringToInt64String(
-      insightDetails.statementFingerprintID,
+      insightDetails?.statementFingerprintID,
     ),
-    appNames: [insightDetails.application],
-    implicitTxn: insightDetails.implicitTxn,
+    appNames: [insightDetails?.application],
+    implicitTxn: insightDetails?.implicitTxn,
   };
 
   return (
     <Link to={StatementLinkTarget(linkProps)}>
-      <div>{String(insightDetails.statementFingerprintID)}</div>
+      <div>{String(insightDetails?.statementFingerprintID)}</div>
     </Link>
   );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
@@ -51,7 +51,7 @@ import { StmtInsightsReq, TxnInsightsRequest } from "src/api";
 import { selectTimeScale } from "../../store/utils/selectors";
 import { actions as analyticsActions } from "../../store/analytics";
 import { selectIsTenant } from "../../store/uiConfig";
-import { selectCsExportInsights } from "src/store/clusterSettings/clusterSettings.selectors";
+import { selectUseObsService } from "src/store/clusterSettings/clusterSettings.selectors";
 
 const transactionMapStateToProps = (
   state: AppState,
@@ -85,7 +85,7 @@ const statementMapStateToProps = (
   isLoading: selectStmtInsightsLoading(state),
   maxSizeApiReached: selectStmtInsightsMaxApiReached(state),
   isTenant: selectIsTenant(state),
-  csExportInsights: selectCsExportInsights(state),
+  useObsService: selectUseObsService(state),
 });
 
 const TransactionDispatchProps = (

--- a/pkg/ui/workspaces/cluster-ui/src/store/clusterSettings/clusterSettings.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/clusterSettings/clusterSettings.selectors.ts
@@ -55,7 +55,7 @@ export const selectDropUnusedIndexDuration = (state: AppState): string => {
   );
 };
 
-export const selectCsExportInsights = (state: AppState): boolean => {
+export const selectUseObsService = (state: AppState): boolean => {
   const settings = state.adminUI?.clusterSettings.data?.key_values;
   if (!settings) {
     return exportInsights;

--- a/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
@@ -13,7 +13,7 @@ import { AdminUIState } from "src/redux/state";
 import { cockroach } from "src/js/protos";
 import moment from "moment-timezone";
 import { CoordinatedUniversalTime, util } from "@cockroachlabs/cluster-ui";
-import { indexUnusedDuration, exportInsights } from "src/util/constants";
+import { indexUnusedDuration } from "src/util/constants";
 
 export const selectClusterSettings = createSelector(
   (state: AdminUIState) => state.cachedData.settings?.data,
@@ -117,22 +117,5 @@ export const selectDropUnusedIndexDuration = createSelector(
       settings["sql.index_recommendation.drop_unused_duration"]?.value ||
       indexUnusedDuration
     );
-  },
-);
-
-export const selectCsExportInsights = createSelector(
-  selectClusterSettings,
-  (settings): boolean => {
-    if (!settings) {
-      return exportInsights;
-    }
-    if (settings["sql.insights.export.enabled"]) {
-      if (settings["sql.insights.export.enabled"]?.value === "false") {
-        return false;
-      }
-      return true;
-    } else {
-      return exportInsights;
-    }
   },
 );

--- a/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
@@ -20,7 +20,6 @@ import { selectStatementInsightDetails } from "src/views/insights/insightsSelect
 import { setGlobalTimeScaleAction } from "src/redux/statements";
 import { selectTimeScale } from "src/redux/timeScale";
 import { selectHasAdminRole } from "src/redux/user";
-import { selectCsExportInsights } from "src/redux/clusterSettings/clusterSettings.selectors";
 
 const mapStateToProps = (
   state: AdminUIState,
@@ -31,7 +30,7 @@ const mapStateToProps = (
     insightError: state.cachedData?.stmtInsights?.lastError,
     timeScale: selectTimeScale(state),
     hasAdminRole: selectHasAdminRole(state),
-    csExportInsights: selectCsExportInsights(state),
+    useObsService: false,
   };
 };
 

--- a/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPage.tsx
@@ -37,7 +37,6 @@ import { bindActionCreators } from "redux";
 import { LocalSetting } from "src/redux/localsettings";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
 import { selectTimeScale } from "src/redux/timeScale";
-import { selectCsExportInsights } from "src/redux/clusterSettings/clusterSettings.selectors";
 
 export const insightStatementColumnsLocalSetting = new LocalSetting<
   AdminUIState,
@@ -80,7 +79,7 @@ const statementMapStateToProps = (
   timeScale: selectTimeScale(state),
   isLoading: selectStmtInsightsLoading(state),
   maxSizeApiReached: selectStmtInsightsMaxApiReached(state),
-  csExportInsights: selectCsExportInsights(state),
+  useObsService: false,
 });
 
 const TransactionDispatchProps = {


### PR DESCRIPTION
Update queries on the Insights API to use Obs Service or CRDB,
depending on the cluster setting `sql.insights.export.enabled`.

Also updates the parsing when we get the results, depending on
the source of the data.

Fixes CC-26437
Fixes CC-26440

Release note: None