### PR TITLE
*: tweak test configurations

### DIFF
--- a/pkg/ccl/backupccl/testgen/templates.go
+++ b/pkg/ccl/backupccl/testgen/templates.go
@@ -69,6 +69,7 @@ func TestDataDriven_{{.TestName}}(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes ~3mins to run")
+	skip.UnderDeadlock(t, "takes a very long time to run")
 
 	runTestDataDriven(t, "{{.TestFilePath}}")
 }

--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -109,6 +109,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":streamingest"],
+    exec_properties = {"Pool": "large"},
     shard_count = 16,
     tags = ["ccl_test"],
     deps = [

--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -198,6 +198,8 @@ func TestStatusAPITransactions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderDeadlock(t, "test is very slow under deadlock")
+
 	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
 	ctx := context.Background()
 	defer testCluster.Stopper().Stop(ctx)

--- a/pkg/sql/colexec/colexecdisk/external_sort_test.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort_test.go
@@ -51,6 +51,7 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderStress(t, "the test is very memory-intensive and is likely to OOM under stress")
+	skip.UnderRace(t, "likely to OOM due to increased memory pressure under race")
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()

--- a/pkg/testutils/testcluster/BUILD.bazel
+++ b/pkg/testutils/testcluster/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "testcluster_test.go",
     ],
     embed = [":testcluster"],
+    exec_properties = {"Pool": "large"},
     deps = [
         "//pkg/base",
         "//pkg/keys",


### PR DESCRIPTION
All of these tests are either timing out or OOM'ing under `race` or `deadlock` under remote execution. A couple of them we bump up to the `large` pool, and a few I'm skipping under `race` or `deadlock` to avoid similar issues.

Epic: CRDB-8308
Release note: None