### PR TITLE
sql: add ULID entropy to eval context

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -585,6 +585,7 @@ go_library(
         "//pkg/util/tracing/tracingpb",
         "//pkg/util/tsearch",
         "//pkg/util/uint128",
+        "//pkg/util/ulid",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	crypto_rand "crypto/rand"
 	"fmt"
 	"io"
 	"math"
@@ -85,6 +86,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tochar"
+	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
@@ -3571,6 +3573,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			DescIDGenerator:                ex.getDescIDGenerator(),
 			RangeStatsFetcher:              p.execCfg.RangeStatsFetcher,
 			JobsProfiler:                   p,
+			ULIDEntropy:                    ulid.Monotonic(crypto_rand.Reader, 0),
 		},
 		Tracing:              &ex.sessionTracing,
 		MemMetrics:           &ex.memMetrics,

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/util/tochar",
         "//pkg/util/tracing",
         "//pkg/util/tracing/grpcinterceptor",
+        "//pkg/util/ulid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ],

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -12,6 +12,7 @@ package distsql
 
 import (
 	"context"
+	crypto_rand "crypto/rand"
 	"io"
 	"time"
 
@@ -42,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tochar"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/grpcinterceptor"
+	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -371,6 +373,7 @@ func (ds *ServerImpl) setupFlow(
 			SchemaTelemetryController: ds.ServerConfig.SchemaTelemetryController,
 			IndexUsageStatsController: ds.ServerConfig.IndexUsageStatsController,
 			RangeStatsFetcher:         ds.ServerConfig.RangeStatsFetcher,
+			ULIDEntropy:               ulid.Monotonic(crypto_rand.Reader, 0),
 		}
 		// Most processors will override this Context with their own context in
 		// ProcessorBase. StartInternal().

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	crypto_rand "crypto/rand"
 	"sync/atomic"
 	"time"
 
@@ -56,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
@@ -541,6 +543,7 @@ func internalExtendedEvalCtx(
 			ConsistencyChecker:             execCfg.ConsistencyChecker,
 			StmtDiagnosticsRequestInserter: execCfg.StmtDiagnosticsRecorder.InsertRequest,
 			RangeStatsFetcher:              execCfg.RangeStatsFetcher,
+			ULIDEntropy:                    ulid.Monotonic(crypto_rand.Reader, 0),
 		},
 		Tracing:         &SessionTracing{},
 		Descs:           tables,

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	crypto_rand "crypto/rand"
 	"fmt"
 	"math"
 	"strings"
@@ -64,6 +65,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )
@@ -2588,6 +2590,7 @@ func createSchemaChangeEvalCtx(
 			Locality:             execCfg.Locality,
 			OriginalLocality:     execCfg.Locality,
 			Tracer:               execCfg.AmbientCtx.Tracer,
+			ULIDEntropy:          ulid.Monotonic(crypto_rand.Reader, 0),
 		},
 	}
 	// TODO(andrei): This is wrong (just like on the main code path on

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logpb",
         "//pkg/util/mon",
+        "//pkg/util/ulid",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/schemachanger/scbuild/tree_context_builder.go
+++ b/pkg/sql/schemachanger/scbuild/tree_context_builder.go
@@ -12,12 +12,14 @@ package scbuild
 
 import (
 	"context"
+	crypto_rand "crypto/rand"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/faketreeeval"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild/internal/scbuildstmt"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 )
 
 var _ scbuildstmt.TreeContextBuilder = buildCtx{}
@@ -60,6 +62,7 @@ func newEvalCtx(ctx context.Context, d Dependencies) *eval.Context {
 		Settings:             d.ClusterSettings(),
 		Codec:                d.Codec(),
 		DescIDGenerator:      d.DescIDGenerator(),
+		ULIDEntropy:          ulid.Monotonic(crypto_rand.Reader, 0),
 	}
 	evalCtx.SetDeprecatedContext(ctx)
 	return evalCtx

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5"
-	cryptorand "crypto/rand"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
@@ -790,9 +789,8 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ParamTypes{},
 			ReturnType: tree.FixedReturnType(types.Uuid),
-			Fn: func(_ context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
-				entropy := ulid.Monotonic(cryptorand.Reader, 0)
-				uv := ulid.MustNew(ulid.Now(), entropy)
+			Fn: func(_ context.Context, evalCtx *eval.Context, _ tree.Datums) (tree.Datum, error) {
+				uv := ulid.MustNew(ulid.Now(), evalCtx.ULIDEntropy)
 				return tree.NewDUuid(tree.DUuid{UUID: uuid.UUID(uv)}), nil
 			},
 			Info:       "Generates a random ULID and returns it as a value of UUID type.",

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -95,6 +95,7 @@ go_library(
         "//pkg/util/tracing",
         "//pkg/util/trigram",
         "//pkg/util/tsearch",
+        "//pkg/util/ulid",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/tochar"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
@@ -286,6 +287,9 @@ type Context struct {
 	// execution until control returns to the parent routine. It is only valid
 	// during local execution. It may be unset.
 	RoutineSender DeferredRoutineSender
+
+	// ULIDEntropy is the entropy source for ULID generation.
+	ULIDEntropy ulid.MonotonicReader
 }
 
 // JobsProfiler is the interface used to fetch job specific execution details


### PR DESCRIPTION
Rather than making a new entropy source for each invocation, now it is
shared for all usages of the same eval context.

```
goos: darwin
goarch: arm64
                                        │    old.txt    │               new.txt                │
                                        │    sec/op     │    sec/op     vs base                │
GenerateID/gen_random_uuid/rows=1-10        82.94µ ± 1%   82.97µ ±  1%        ~ (p=0.870 n=10)
GenerateID/gen_random_uuid/rows=10-10       91.06µ ± 1%   91.22µ ±  1%        ~ (p=0.631 n=10)
GenerateID/gen_random_uuid/rows=100-10      164.8µ ± 3%   164.9µ ±  1%        ~ (p=1.000 n=10)
GenerateID/gen_random_uuid/rows=1000-10     926.2µ ± 3%   926.7µ ±  5%        ~ (p=0.529 n=10)
GenerateID/gen_random_ulid/rows=1-10       101.88µ ± 1%   80.07µ ±  1%  -21.41% (p=0.000 n=10)
GenerateID/gen_random_ulid/rows=10-10      223.72µ ± 9%   85.15µ ± 33%  -61.94% (p=0.000 n=10)
GenerateID/gen_random_ulid/rows=100-10     1174.6µ ± 1%   120.5µ ± 39%  -89.74% (p=0.000 n=10)
GenerateID/gen_random_ulid/rows=1000-10   10386.2µ ± 1%   464.5µ ±  8%  -95.53% (p=0.000 n=10)
geomean                                     365.8µ        160.5µ        -56.11%

                                        │    old.txt     │                new.txt                │
                                        │      B/op      │     B/op       vs base                │
GenerateID/gen_random_uuid/rows=1-10       32.27Ki ±  6%   32.28Ki ±  7%        ~ (p=1.000 n=10)
GenerateID/gen_random_uuid/rows=10-10      34.57Ki ±  6%   34.55Ki ±  6%        ~ (p=0.529 n=10)
GenerateID/gen_random_uuid/rows=100-10     49.94Ki ±  0%   49.91Ki ±  0%        ~ (p=0.382 n=10)
GenerateID/gen_random_uuid/rows=1000-10    318.9Ki ± 46%   319.3Ki ± 61%        ~ (p=0.796 n=10)
GenerateID/gen_random_ulid/rows=1-10       40.52Ki ±  0%   32.16Ki ±  0%  -20.63% (p=0.000 n=10)
GenerateID/gen_random_ulid/rows=10-10      80.37Ki ±  7%   34.46Ki ±  5%  -57.12% (p=0.000 n=10)
GenerateID/gen_random_ulid/rows=100-10    470.89Ki ±  0%   49.81Ki ±  0%  -89.42% (p=0.000 n=10)
GenerateID/gen_random_ulid/rows=1000-10   4489.5Ki ±  0%   318.4Ki ±  4%  -92.91% (p=0.000 n=10)
geomean                                    136.7Ki         64.84Ki        -52.59%

                                        │    old.txt    │               new.txt                │
                                        │   allocs/op   │  allocs/op    vs base                │
GenerateID/gen_random_uuid/rows=1-10        405.0 ±  9%    405.0 ±  9%        ~ (p=0.940 n=10)
GenerateID/gen_random_uuid/rows=10-10       480.0 ±  1%    480.0 ±  0%        ~ (p=0.463 n=10)
GenerateID/gen_random_uuid/rows=100-10      975.0 ±  0%    975.0 ±  0%        ~ (p=0.685 n=10)
GenerateID/gen_random_uuid/rows=1000-10    7.041k ± 18%   7.041k ± 17%        ~ (p=0.639 n=10)
GenerateID/gen_random_ulid/rows=1-10        411.0 ±  0%    405.0 ±  0%   -1.46% (p=0.000 n=10)
GenerateID/gen_random_ulid/rows=10-10       513.5 ± 18%    480.0 ±  8%   -6.52% (p=0.006 n=10)
GenerateID/gen_random_ulid/rows=100-10     1281.5 ±  0%    975.0 ±  0%  -23.92% (p=0.000 n=10)
GenerateID/gen_random_ulid/rows=1000-10   10.062k ±  0%   7.040k ±  3%  -30.03% (p=0.000 n=10)
geomean                                    1.175k         1.075k         -8.52%
```

fixes https://github.com/cockroachdb/cockroach/issues/115666
Release note (performance improvement): Improved the performance of the gen_random_ulid builtin function.