### PR TITLE
jobs: avoid crdb_internal.system_jobs in test utils 

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -899,8 +899,7 @@ func TestChangefeedCursor(t *testing.T) {
 		// statement timestamp, so only verify this for enterprise.
 		if e, ok := fooLogical.(cdctest.EnterpriseTestFeed); ok {
 			var bytes []byte
-			sqlDB.QueryRow(t, fmt.Sprintf(`SELECT payload FROM (%s)`,
-				jobutils.InternalSystemJobsBaseQuery), e.JobID()).Scan(&bytes)
+			sqlDB.QueryRow(t, jobutils.JobPayloadByIDQuery, e.JobID()).Scan(&bytes)
 			var payload jobspb.Payload
 			require.NoError(t, protoutil.Unmarshal(bytes, &payload))
 			require.Equal(t, tsLogical, payload.GetChangefeed().StatementTime)
@@ -7578,10 +7577,10 @@ func TestChangefeedPredicates(t *testing.T) {
 			sqlDB.Exec(t, `CREATE TYPE status AS ENUM ('open', 'closed', 'inactive')`)
 			sqlDB.Exec(t, `
 CREATE TABLE foo (
-  a INT, 
-  b STRING, 
+  a INT,
+  b STRING,
   c STRING,
-  d STRING AS (concat(b, c)) VIRTUAL, 
+  d STRING AS (concat(b, c)) VIRTUAL,
   e status DEFAULT 'inactive',
   PRIMARY KEY (a, b)
 )`)
@@ -7596,9 +7595,9 @@ INSERT INTO foo (a, b, e) VALUES (2, 'two', 'closed');
 				topic, fromClause = "foo", "foo AS "+alias
 			}
 			feed := feed(t, f, `
-CREATE CHANGEFEED 
+CREATE CHANGEFEED
 WITH schema_change_policy='stop'
-AS SELECT * FROM `+fromClause+` 
+AS SELECT * FROM `+fromClause+`
 WHERE e IN ('open', 'closed') AND event_op() != 'delete'`)
 			defer closeFeed(t, feed)
 
@@ -7644,10 +7643,10 @@ func TestChangefeedInvalidPredicate(t *testing.T) {
 	sqlDB.Exec(t, `CREATE TYPE status AS ENUM ('open', 'closed', 'inactive')`)
 	sqlDB.Exec(t, `
 CREATE TABLE foo (
-  a INT, 
-  b STRING, 
+  a INT,
+  b STRING,
   c STRING,
-  d STRING AS (concat(b, c)) VIRTUAL, 
+  d STRING AS (concat(b, c)) VIRTUAL,
   e status DEFAULT 'inactive',
   PRIMARY KEY (a, b)
 )`)
@@ -7705,8 +7704,8 @@ func TestChangefeedPredicateWithSchemaChange(t *testing.T) {
 		`CREATE SCHEMA alt`,
 		`CREATE TYPE alt.status AS ENUM ('alt_open', 'alt_closed')`,
 		`CREATE TABLE foo (
-  a INT, 
-  b STRING, 
+  a INT,
+  b STRING,
   c STRING,
   e status DEFAULT 'inactive',
   PRIMARY KEY (a, b)

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -460,11 +460,8 @@ func (f *jobFeed) Resume() error {
 
 // Details implements FeedJob interface.
 func (f *jobFeed) Details() (*jobspb.ChangefeedDetails, error) {
-	stmt := fmt.Sprintf(`
-SELECT payload FROM (%s)
-`, jobutils.InternalSystemJobsBaseQuery)
 	var payloadBytes []byte
-	if err := f.db.QueryRow(stmt, f.jobID).Scan(&payloadBytes); err != nil {
+	if err := f.db.QueryRow(jobutils.JobPayloadByIDQuery, f.jobID).Scan(&payloadBytes); err != nil {
 		return nil, errors.Wrapf(err, "Details for job %d", f.jobID)
 	}
 	var payload jobspb.Payload
@@ -476,11 +473,8 @@ SELECT payload FROM (%s)
 
 // HighWaterMark implements FeedJob interface.
 func (f *jobFeed) HighWaterMark() (hlc.Timestamp, error) {
-	stmt := fmt.Sprintf(`
-SELECT progress FROM (%s)
-`, jobutils.InternalSystemJobsBaseQuery)
 	var details []byte
-	if err := f.db.QueryRow(stmt, f.jobID).Scan(&details); err != nil {
+	if err := f.db.QueryRow(jobutils.JobProgressByIDQuery, f.jobID).Scan(&details); err != nil {
 		return hlc.Timestamp{}, errors.Wrapf(err, "HighWaterMark for job %d", f.jobID)
 	}
 	var progress jobspb.Progress

--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -147,7 +147,7 @@ func (c *TenantStreamingClusters) init(ctx context.Context) {
 	c.SrcSysSQL.Exec(c.T, `ALTER TENANT $1 SET CLUSTER SETTING sql.virtual_cluster.feature_access.zone_configs.enabled=true`, c.Args.SrcTenantName)
 	c.SrcSysSQL.Exec(c.T, `ALTER TENANT $1 SET CLUSTER SETTING sql.virtual_cluster.feature_access.multiregion.enabled=true`, c.Args.SrcTenantName)
 	c.SrcSysSQL.Exec(c.T, `ALTER TENANT $1 GRANT CAPABILITY can_use_nodelocal_storage`, c.Args.SrcTenantName)
-	require.NoError(c.T, c.SrcCluster.Server(0).WaitForTenantCapabilities(ctx, c.Args.SrcTenantID, map[tenantcapabilities.ID]string{
+	require.NoError(c.T, c.SrcCluster.Server(0).TenantController().WaitForTenantCapabilities(ctx, c.Args.SrcTenantID, map[tenantcapabilities.ID]string{
 		tenantcapabilities.CanUseNodelocalStorage: "true",
 	}, ""))
 	if c.Args.SrcInitFunc != nil {
@@ -171,7 +171,7 @@ func (c *TenantStreamingClusters) StartDestTenant(
 ) func() error {
 	if withTestingKnobs != nil {
 		var err error
-		_, c.DestTenantConn, err = c.DestCluster.Server(server).StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
+		_, c.DestTenantConn, err = c.DestCluster.Server(server).TenantController().StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
 			TenantID:    c.Args.DestTenantID,
 			TenantName:  c.Args.DestTenantName,
 			Knobs:       *withTestingKnobs,
@@ -190,7 +190,7 @@ func (c *TenantStreamingClusters) StartDestTenant(
 	// TODO (msbutler): consider granting the new tenant some capabilities.
 	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 SET CLUSTER SETTING sql.virtual_cluster.feature_access.zone_configs.enabled=true`, c.Args.DestTenantName)
 	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 GRANT CAPABILITY can_use_nodelocal_storage`, c.Args.DestTenantName)
-	require.NoError(c.T, c.DestCluster.Server(server).WaitForTenantCapabilities(ctx, c.Args.DestTenantID, map[tenantcapabilities.ID]string{
+	require.NoError(c.T, c.DestCluster.Server(server).TenantController().WaitForTenantCapabilities(ctx, c.Args.DestTenantID, map[tenantcapabilities.ID]string{
 		tenantcapabilities.CanUseNodelocalStorage: "true",
 	}, ""))
 	return func() error {

--- a/pkg/ccl/streamingccl/replicationutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/replicationutils/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/testutils/sqlutils",
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
-        "//pkg/util/protoutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -68,14 +68,21 @@ func WaitForJobReverting(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobI
 	waitForJobToHaveStatus(t, db, jobID, jobs.StatusReverting)
 }
 
-// InternalSystemJobsBaseQuery runs the query against an empty database string.
-// Since crdb_internal.system_jobs is a virtual table, by default, the query
-// will take a lease on the current database the SQL session is connected to. If
-// this database has been dropped or is unavailable then the query on the
-// virtual table will fail. The "" prefix prevents this lease acquisition.
-var InternalSystemJobsBaseQuery = `
-SELECT status, payload, progress FROM "".crdb_internal.system_jobs WHERE id = $1
-`
+const (
+	// InternalSystemJobsBaseQuery runs the query against an empty database string.
+	// Since crdb_internal.system_jobs is a virtual table, by default, the query
+	// will take a lease on the current database the SQL session is connected to. If
+	// this database has been dropped or is unavailable then the query on the
+	// virtual table will fail. The "" prefix prevents this lease acquisition.
+	//
+	// NB: Until the crdb_internal.system_jobs is turned into a
+	// view structured such that unnecessary joins can be elided,
+	// some users may prefer JobPayloadByIDQuery or
+	// JobPayloadByIDQuery
+	InternalSystemJobsBaseQuery = `SELECT status, payload, progress FROM "".crdb_internal.system_jobs WHERE id = $1`
+	JobProgressByIDQuery        = "SELECT value FROM system.job_info WHERE job_id = $1 AND info_key::string = 'legacy_progress' ORDER BY written DESC LIMIT 1"
+	JobPayloadByIDQuery         = "SELECT value FROM system.job_info WHERE job_id = $1 AND info_key::string = 'legacy_payload' ORDER BY written DESC LIMIT 1"
+)
 
 func waitForJobToHaveStatus(
 	t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID, expectedStatus jobs.Status,
@@ -83,18 +90,13 @@ func waitForJobToHaveStatus(
 	t.Helper()
 	testutils.SucceedsWithin(t, func() error {
 		var status string
-		var payloadBytes []byte
-		query := fmt.Sprintf("SELECT status, payload FROM (%s)", InternalSystemJobsBaseQuery)
-		db.QueryRow(t, query, jobID).Scan(&status, &payloadBytes)
+		db.QueryRow(t, "SELECT status FROM system.jobs WHERE id = $1", jobID).Scan(&status)
 		if jobs.Status(status) == jobs.StatusFailed {
 			if expectedStatus == jobs.StatusFailed {
 				return nil
 			}
-			payload := &jobspb.Payload{}
-			if err := protoutil.Unmarshal(payloadBytes, payload); err == nil {
-				t.Fatalf("job failed: %s", payload.Error)
-			}
-			t.Fatalf("job failed")
+			payload := GetJobPayload(t, db, jobID)
+			t.Fatalf("job failed: %s", payload.Error)
 		}
 		if e, a := expectedStatus, jobs.Status(status); e != a {
 			return errors.Errorf("expected job status %s, but got %s", e, a)
@@ -248,8 +250,8 @@ func VerifySystemJob(
 // GetJobID gets a particular job's ID.
 func GetJobID(t testing.TB, db *sqlutils.SQLRunner, offset int) jobspb.JobID {
 	var jobID jobspb.JobID
-	db.QueryRow(t, `
-	SELECT job_id FROM crdb_internal.jobs ORDER BY created LIMIT 1 OFFSET $1`, offset,
+	db.QueryRow(t,
+		"SELECT id FROM system.jobs ORDER BY created LIMIT 1 OFFSET $1", offset,
 	).Scan(&jobID)
 	return jobID
 }
@@ -257,17 +259,17 @@ func GetJobID(t testing.TB, db *sqlutils.SQLRunner, offset int) jobspb.JobID {
 // GetLastJobID gets the most recent job's ID.
 func GetLastJobID(t testing.TB, db *sqlutils.SQLRunner) jobspb.JobID {
 	var jobID jobspb.JobID
-	db.QueryRow(
-		t, `SELECT id FROM system.jobs ORDER BY created DESC LIMIT 1`,
+	db.QueryRow(t,
+		"SELECT id FROM system.jobs ORDER BY created DESC LIMIT 1",
 	).Scan(&jobID)
 	return jobID
 }
 
 // GetJobProgress loads the Progress message associated with the job.
-func GetJobProgress(t *testing.T, db *sqlutils.SQLRunner, jobID jobspb.JobID) *jobspb.Progress {
+func GetJobProgress(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) *jobspb.Progress {
 	ret := &jobspb.Progress{}
 	var buf []byte
-	db.QueryRow(t, `SELECT progress FROM crdb_internal.system_jobs WHERE id = $1`, jobID).Scan(&buf)
+	db.QueryRow(t, JobProgressByIDQuery, jobID).Scan(&buf)
 	if err := protoutil.Unmarshal(buf, ret); err != nil {
 		t.Fatal(err)
 	}
@@ -275,11 +277,10 @@ func GetJobProgress(t *testing.T, db *sqlutils.SQLRunner, jobID jobspb.JobID) *j
 }
 
 // GetJobPayload loads the Payload message associated with the job.
-func GetJobPayload(t *testing.T, db *sqlutils.SQLRunner, jobID jobspb.JobID) *jobspb.Payload {
+func GetJobPayload(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) *jobspb.Payload {
 	ret := &jobspb.Payload{}
-	query := fmt.Sprintf(`SELECT payload FROM (%s)`, InternalSystemJobsBaseQuery)
 	var buf []byte
-	db.QueryRow(t, query, jobID).Scan(&buf)
+	db.QueryRow(t, JobPayloadByIDQuery, jobID).Scan(&buf)
 	if err := protoutil.Unmarshal(buf, ret); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This use is probably fine since the virtual table handles single-value
ID predicates well, but our various job verification utilities retry
rather aggressively and using the system_jobs virtual table when we
can typically get away with reading a single system.jobs row is a
little silly.

Epic: none
Release note: None