### PR TITLE
jobs: minor performance improvements

### DIFF
--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -252,6 +252,7 @@ WHERE id = $1
 
 	// Insert the job payload and progress into the system.jobs_info table.
 	infoStorage := j.InfoStorage(u.txn)
+	infoStorage.claimChecked = true
 	if payloadBytes != nil {
 		if err := infoStorage.WriteLegacyPayload(ctx, payloadBytes); err != nil {
 			return err


### PR DESCRIPTION
This test adds a new benchmark that tests simply creates an empty job and waits for it to execute. It then makes two small performance improvements, one which improves the benchmark and one which doesn't because of how limited it is.

The goal of this PR is really just to get this benchmark in place so that we can start
making a series of more invasive changes that rather substantially improve the performance.

However, since bugs in job system changes _often_ only show up after days or weeks of running in CI, I want to do this series of changes in small steps.

Epic: none