### PR TITLE
kvserver: log progress during store initialization

### DIFF
--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -268,7 +268,7 @@ func IterateRangeDescriptorsFromDisk(
 	}
 	lastReportTime := timeutil.Now()
 	kvToDesc := func(kv roachpb.KeyValue) error {
-		const reportPeriod = 15 * time.Second
+		const reportPeriod = 10 * time.Second
 		if timeutil.Since(lastReportTime) >= reportPeriod {
 			// Note: MVCCIterate scans and buffers 1000 keys at a time which could
 			// make the scan stats confusing. However, because this callback can't


### PR DESCRIPTION
**server: log store initialization duration and replica count**

**kvserver: log progress during store initialization**

With large numbers of replicas, store initialization can take a long time. This patch adds progress logging every 10 seconds showing the current and total number of replicas initialized.

Here's an edited example of what it looks like (with injected delay):

```
I231207 12:21:16.799510 63 server/config.go:872 ⋮ [T1,Vsystem,n?] 16  1 storage engine initialized
I231207 12:21:17.387374 63 kv/kvserver/kvstorage/init.go:255 ⋮ [T1,Vsystem,n1,s1] 28  beginning range descriptor iteration
I231207 12:21:17.408276 63 kv/kvserver/kvstorage/init.go:316 ⋮ [T1,Vsystem,n1,s1] 31  range descriptor iteration done: 10125 keys, 8060 range descriptors (by suffix: map[qlpt:1938 rdsc:8060 txn-:127]); scan stats: stepped 65.158k times (115.088k internal); seeked 132 times (77 internal); block-bytes: (total 5.2 MiB, cached 581 KiB); points: (count 115.153k, key-bytes 2.8 MiB, value-bytes 4.2 MiB, tombstoned: 0) ranges: (count 0), (contained-points 0, skipped-points 0) evaluated requests: 0 gets, 11 scans, 0 reverse scans separated: (count: 50.573k, bytes: 3.9 MiB, bytes-fetched: 0 B)
I231207 12:21:17.578048 63 kv/kvserver/store.go:2126 ⋮ [T1,Vsystem,n1,s1] 32  loaded 8060 replicas, initializing
I231207 12:21:27.581307 63 kv/kvserver/store.go:2182 ⋮ [T1,Vsystem,n1,s1] 46  initialized 2876/8060 replicas
I231207 12:21:37.581983 63 kv/kvserver/store.go:2182 ⋮ [T1,Vsystem,n1,s1] 67  initialized 5740/8060 replicas
I231207 12:21:45.657393 63 kv/kvserver/store.go:2187 ⋮ [T1,Vsystem,n1,s1] 85  initialized 8060/8060 replicas
I231207 12:21:45.658419 63 server/node.go:663 ⋮ [T1,Vsystem,n1] 87  initialized store s1 in 28.272s (8060 replicas)
```

**kvserver: reduce range descriptor iteration logging to 10 seconds**

This harmonizes it with the replica initialization log interval during store initialization.

Resolves #115757.
Epic: none
Release note (ui change): store initialization now logs progress every 10 seconds.