### PR TITLE
release-23.2: workload/schemachange: `Release` connection only when acquired

### DIFF
--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -427,10 +427,10 @@ func (w *schemaChangeWorker) runInTxn(
 
 func (w *schemaChangeWorker) run(ctx context.Context) error {
 	conn, err := w.pool.Get().Acquire(ctx)
-	defer conn.Release()
 	if err != nil {
 		return errors.Wrap(err, "cannot get a connection")
 	}
+	defer conn.Release()
 	useDeclarativeSchemaChanger := w.opGen.randIntn(100) > w.workload.declarativeSchemaChangerPct
 	if useDeclarativeSchemaChanger {
 		if _, err := conn.Exec(ctx, "SET use_declarative_schema_changer='unsafe_always';"); err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #115735.

/cc @cockroachdb/release

Release justification: change in private workload.

---

Previously, we would call `defer conn.Release` before the we were sure if we actually acquired a connection, which could lead to nil pointer dereference panics in case of error.

Epic: none

Release note: None
