### PR TITLE
release-23.1: roachtest: WipeForReuse clears DNS entries

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1050,6 +1050,15 @@ var grafanaURLCmd = &cobra.Command{
 	}),
 }
 
+var destroyDNSCmd = &cobra.Command{
+	Use:   `destroy-dns <cluster>`,
+	Short: `cleans up DNS entries for the cluster`,
+	Args:  cobra.ExactArgs(1),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		return roachprod.DestroyDNS(context.Background(), config.Logger, args[0])
+	}),
+}
+
 var rootStorageCmd = &cobra.Command{
 	Use:   `storage`,
 	Short: "storage enables administering storage related commands and configurations",
@@ -1180,6 +1189,7 @@ func main() {
 		runCmd,
 		signalCmd,
 		wipeCmd,
+		destroyDNSCmd,
 		reformatCmd,
 		installCmd,
 		distributeCertsCmd,

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2673,11 +2673,20 @@ func (c *clusterImpl) WipeForReuse(
 		}
 		c.localCertsDir = ""
 	}
+	// Clear DNS records for the cluster.
+	if err := c.DestroyDNS(ctx, l); err != nil {
+		return err
+	}
 	// Overwrite the spec of the cluster with the one coming from the test. In
 	// particular, this overwrites the reuse policy to reflect what the test
 	// intends to do with it.
 	c.spec = newClusterSpec
 	return nil
+}
+
+// DestroyDNS destroys the DNS records for the cluster.
+func (c *clusterImpl) DestroyDNS(ctx context.Context, l *logger.Logger) error {
+	return roachprod.DestroyDNS(ctx, l, c.name)
 }
 
 // MaybeExtendCluster checks if the cluster has enough life left for the

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -124,6 +124,10 @@ type Cluster interface {
 	WipeE(ctx context.Context, l *logger.Logger, preserveCerts bool, opts ...option.Option) error
 	Wipe(ctx context.Context, preserveCerts bool, opts ...option.Option)
 
+	// DNS
+
+	DestroyDNS(ctx context.Context, l *logger.Logger) error
+
 	// Internal niche tools.
 
 	Reformat(ctx context.Context, l *logger.Logger, node option.NodeListOption, filesystem string) error

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1761,6 +1761,20 @@ func isWorkloadCollectorVolume(v vm.Volume) bool {
 	return false
 }
 
+// DestroyDNS destroys the DNS records for the given cluster.
+func DestroyDNS(ctx context.Context, l *logger.Logger, clusterName string) error {
+	if err := LoadClusters(); err != nil {
+		return err
+	}
+	c, err := newCluster(l, clusterName)
+	if err != nil {
+		return err
+	}
+	return vm.FanOutDNS(c.VMs, func(p vm.DNSProvider, vms vm.List) error {
+		return p.DeleteRecordsBySubdomain(ctx, c.Name)
+	})
+}
+
 // StorageCollectionPerformAction either starts or stops workload collection on
 // a target cluster.
 //


### PR DESCRIPTION
Backport 2/2 commits from #115424.

/cc @cockroachdb/release

---

Previously, after wiping a cluster, the DNS entries for the services created, during a test, would remain tied to the cluster causing the next test to re-use the entries instead of having the chance to specify its own ports or services.

This PR ensures the DNS entries are wiped if the cluster is intended for reuse.

In addition the `destroy-dns` command is exposed on the `roachprod` CLI if a user wants to manually clear DNS entries for any cluster.

Epic: None
Release Note: None

Release justification: Test only change.