### PR TITLE
kvserver: filter rangefeed events based on OmitInRangefeeds flag

### DIFF
--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -103,6 +103,16 @@ func incrementArgs(key roachpb.Key, inc int64) *kvpb.IncrementRequest {
 	}
 }
 
+// delRangeArgs returns a DeleteRangeRequest for the specified span.
+func delRangeArgs(
+	key roachpb.Key, endKey roachpb.Key, useRangeTombstone bool,
+) *kvpb.DeleteRangeRequest {
+	return &kvpb.DeleteRangeRequest{
+		RequestHeader:     kvpb.RequestHeader{Key: key, EndKey: endKey},
+		UseRangeTombstone: useRangeTombstone,
+	}
+}
+
 func truncateLogArgs(index kvpb.RaftIndex, rangeID roachpb.RangeID) *kvpb.TruncateLogRequest {
 	return &kvpb.TruncateLogRequest{
 		Index:   index,

--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -280,6 +280,13 @@ func (i *CatchUpIterator) CatchUpScan(
 		}
 		unsafeVal := mvccVal.Value.RawBytes
 
+		// If this value has the flag to omit from rangefeeds, move to the next
+		// version for this the key.
+		if mvccVal.OmitInRangefeeds {
+			i.Next()
+			continue
+		}
+
 		// Ignore the version if its timestamp is at or before the registration's
 		// (exclusive) starting timestamp.
 		ts := unsafeKey.Timestamp

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -400,6 +400,47 @@ func TestReplicaRangefeed(t *testing.T) {
 		true /* ingestAsWrites */, ts7)
 	require.Nil(t, pErr)
 
+	// Delete range non-transactionally.
+	ts8 := initTime.Add(0, 3)
+	dArgs := delRangeArgs(roachpb.Key("c"), roachpb.Key("d"), true /* useRangeTombstone */)
+	_, err = kv.SendWrappedWith(ctx, db, kvpb.Header{Timestamp: ts8}, dArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert a key transactionally with omitInRangefeeds = true.
+	ts9 := initTime.Add(0, 3)
+	if err := store1.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		if err := txn.SetFixedTimestamp(ctx, ts9); err != nil {
+			return err
+		}
+		txn.SetOmitInRangefeeds()
+		return txn.Put(ctx, roachpb.Key("n"), []byte("val"))
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Read to force intent resolution.
+	if _, err := store1.DB().Get(ctx, roachpb.Key("n")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete range transactionally with omitInRangefeeds = true.
+	ts10 := initTime.Add(0, 3)
+	if err := store1.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		if err := txn.SetFixedTimestamp(ctx, ts10); err != nil {
+			return err
+		}
+		txn.SetOmitInRangefeeds()
+		_, err := txn.DelRange(ctx, "f", "g", false)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Read to force intent resolution.
+	if _, err := store1.DB().Get(ctx, roachpb.Key("f")); err != nil {
+		t.Fatal(err)
+	}
+
 	// Wait for all streams to observe the expected events.
 	expVal2 := roachpb.MakeValueFromBytesAndTimestamp([]byte("val2"), ts2)
 	expVal3 := roachpb.MakeValueFromBytesAndTimestamp([]byte("val3"), ts3)
@@ -436,6 +477,9 @@ func TestReplicaRangefeed(t *testing.T) {
 		}},
 		{Val: &kvpb.RangeFeedValue{
 			Key: roachpb.Key("q"), Value: expVal7q, PrevValue: expVal6q,
+		}},
+		{DeleteRange: &kvpb.RangeFeedDeleteRange{
+			Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}, Timestamp: ts8,
 		}},
 	}...)
 	// here


### PR DESCRIPTION
OmitInRangefeeds is a transaction attibute that, when set to true, indicates that rangefeeds should ignore all writes of the transaction. The flag is also populated on the MVCCValueHeader of any transactional write whose trasaction has it set to true. This change enforces the actual filtering on the rangefeed server side for both current rangefeed events and the rangefeed catchup iterator.

Part of: #114313

Release note: None