### PR TITLE
release-23.1: roachtest: lower default timeout

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -247,6 +248,7 @@ func registerActiveRecord(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "activerecord",
 		Owner:            registry.OwnerSQLFoundations,
+		Timeout:          5 * time.Hour,
 		Cluster:          r.MakeClusterSpec(1),
 		NativeLibs:       registry.LibGEOS,
 		CompatibleClouds: registry.AllExceptAWS,

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -31,6 +31,7 @@ import (
 func registerMultiTenantUpgrade(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:              "multitenant-upgrade",
+		Timeout:           1 * time.Hour,
 		Cluster:           r.MakeClusterSpec(2),
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -233,6 +234,7 @@ func registerRubyPG(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:             "ruby-pg",
+		Timeout:          1 * time.Hour,
 		Owner:            registry.OwnerSQLFoundations,
 		Cluster:          r.MakeClusterSpec(1, spec.UbuntuVersion(vm.FocalFossa)),
 		CompatibleClouds: registry.AllExceptAWS,

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -478,8 +478,9 @@ func registerTPCC(r registry.Registry) {
 		// node and on a mixed version cluster which runs its long-running
 		// migrations while TPCC runs. It simulates a real production
 		// deployment in the middle of the migration into a new cluster version.
-		Name:  "tpcc/mixed-headroom/" + mixedHeadroomSpec.String(),
-		Owner: registry.OwnerTestEng,
+		Name:    "tpcc/mixed-headroom/" + mixedHeadroomSpec.String(),
+		Timeout: 6 * time.Hour,
+		Owner:   registry.OwnerTestEng,
 		// TODO(tbg): add release_qualification tag once we know the test isn't
 		// buggy.
 		CompatibleClouds:  registry.AllExceptAWS,
@@ -1161,6 +1162,7 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 		Cluster:           nodes,
 		CompatibleClouds:  b.Clouds,
 		Suites:            b.Suites,
+		Timeout:           5 * time.Hour,
 		Tags:              b.Tags,
 		EncryptionSupport: encryptionSupport,
 		Leases:            leases,

--- a/pkg/cmd/roachtest/tests/version.go
+++ b/pkg/cmd/roachtest/tests/version.go
@@ -219,6 +219,7 @@ func registerVersion(r registry.Registry) {
 	for _, n := range []int{3, 5} {
 		r.Add(registry.TestSpec{
 			Name:             fmt.Sprintf("version/mixed/nodes=%d", n),
+			Timeout:          4 * time.Hour,
 			Owner:            registry.OwnerTestEng,
 			Cluster:          r.MakeClusterSpec(n + 1),
 			CompatibleClouds: registry.AllExceptAWS,


### PR DESCRIPTION
Backport 1/1 commits from #99371.

/cc @cockroachdb/release

---

The previous default of 10 hours if unnecessarily long. As a consequence, if a test has a bug that causes it to hang, it will take 10h's worth of cluster usage, even if it's a test that generally succeeds in half an hour.

This should hopefully help with the timeouts we have been seeing in roachtest nightly runs.

Epic: none

Release note: None

---

Release Justification: test only change