### PR TITLE
storage: improve mvcc benchmarks under -short

### DIFF
--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -412,40 +412,34 @@ func BenchmarkMVCCPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
 
 	type testCase struct {
-		batch     bool
 		valueSize int
 		versions  int
 	}
 	var testCases []testCase
 
-	for _, batch := range []bool{false, true} {
-		for _, valueSize := range []int{10, 100, 1000, 10000} {
-			for _, versions := range []int{1, 10} {
-				testCases = append(testCases, testCase{
-					batch:     batch,
-					valueSize: valueSize,
-					versions:  versions,
-				})
-			}
+	for _, valueSize := range []int{10, 100, 1000, 10000} {
+		for _, versions := range []int{1, 10} {
+			testCases = append(testCases, testCase{
+				valueSize: valueSize,
+				versions:  versions,
+			})
 		}
 	}
 
 	if testing.Short() {
 		// Choose a few configurations for the short version.
 		testCases = []testCase{
-			{batch: false, valueSize: 10, versions: 1},
-			{batch: true, valueSize: 1000, versions: 10},
+			{valueSize: 10, versions: 1},
+			{valueSize: 1000, versions: 10},
 		}
 	}
 
 	for _, tc := range testCases {
-		name := fmt.Sprintf(
-			"batch=%t/valueSize=%d/versions=%d",
-			tc.batch, tc.valueSize, tc.versions,
-		)
+		// We use "batch=false" so that we can compare with corresponding benchmarks in older branches.
+		name := fmt.Sprintf("batch=false/valueSize=%d/versions=%d", tc.valueSize, tc.versions)
 		b.Run(name, func(b *testing.B) {
 			ctx := context.Background()
-			runMVCCPut(ctx, b, setupMVCCInMemPebble, tc.valueSize, tc.versions, tc.batch)
+			runMVCCPut(ctx, b, setupMVCCInMemPebble, tc.valueSize, tc.versions)
 		})
 	}
 }

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -77,138 +76,231 @@ func setupPebbleInMemPebbleForLatestRelease(b testing.TB, _ string) Engine {
 }
 
 func BenchmarkMVCCScan_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		numRows      int
+		numVersions  int
+		valueSize    int
+		numRangeKeys int
+	}
+	var testCases []testCase
 	for _, numRows := range []int{1, 10, 100, 1000, 10000, 50000} {
-		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
-			for _, numVersions := range []int{1, 2, 10, 100, 1000} {
-				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
-					for _, valueSize := range []int{8, 64, 512} {
-						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-							for _, numRangeKeys := range []int{0, 1, 100} {
-								b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-									runMVCCScan(ctx, b, benchScanOptions{
-										mvccBenchData: mvccBenchData{
-											numVersions:  numVersions,
-											valueBytes:   valueSize,
-											numRangeKeys: numRangeKeys,
-										},
-										numRows: numRows,
-										reverse: false,
-									})
-								})
-							}
-						})
-					}
-				})
+		for _, numVersions := range []int{1, 2, 10, 100, 1000} {
+			for _, valueSize := range []int{8, 64, 512} {
+				for _, numRangeKeys := range []int{0, 1, 100} {
+					testCases = append(testCases, testCase{
+						numRows:      numRows,
+						numVersions:  numVersions,
+						valueSize:    valueSize,
+						numRangeKeys: numRangeKeys,
+					})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{numRows: 1, numVersions: 1, valueSize: 8, numRangeKeys: 0},
+			{numRows: 100, numVersions: 2, valueSize: 64, numRangeKeys: 1},
+			{numRows: 1000, numVersions: 10, valueSize: 64, numRangeKeys: 100},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"rows=%d/versions=%d/valueSize=%d/numRangeKeys=%d",
+			tc.numRows, tc.numVersions, tc.valueSize, tc.numRangeKeys,
+		)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCScan(ctx, b, benchScanOptions{
+				mvccBenchData: mvccBenchData{
+					numVersions:  tc.numVersions,
+					valueBytes:   tc.valueSize,
+					numRangeKeys: tc.numRangeKeys,
+				},
+				numRows: tc.numRows,
+				reverse: false,
+			})
 		})
 	}
 }
 
 func BenchmarkMVCCScanGarbage_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		numRows      int
+		numVersions  int
+		numRangeKeys int
+		tombstones   bool
+	}
+	var testCases []testCase
 	for _, numRows := range []int{1, 10, 100, 1000, 10000, 50000} {
-		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
-			for _, numVersions := range []int{1, 2, 10, 100, 1000} {
-				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
-					for _, numRangeKeys := range []int{0, 1, 100} {
-						b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-							for _, tombstones := range []bool{false, true} {
-								b.Run(fmt.Sprintf("tombstones=%t", tombstones), func(b *testing.B) {
-									runMVCCScan(ctx, b, benchScanOptions{
-										mvccBenchData: mvccBenchData{
-											numVersions:  numVersions,
-											numRangeKeys: numRangeKeys,
-											garbage:      true,
-										},
-										numRows:    numRows,
-										tombstones: tombstones,
-										reverse:    false,
-									})
-								})
-							}
-						})
-					}
-				})
+		for _, numVersions := range []int{1, 2, 10, 100, 1000} {
+			for _, numRangeKeys := range []int{0, 1, 100} {
+				for _, tombstones := range []bool{false, true} {
+					testCases = append(testCases, testCase{
+						numRows:      numRows,
+						numVersions:  numVersions,
+						numRangeKeys: numRangeKeys,
+						tombstones:   tombstones,
+					})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{numRows: 1, numVersions: 1, numRangeKeys: 0, tombstones: false},
+			{numRows: 10, numVersions: 2, numRangeKeys: 1, tombstones: true},
+			{numRows: 1000, numVersions: 10, numRangeKeys: 100, tombstones: true},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"rows=%d/versions=%d/numRangeKeys=%d/tombstones=%t",
+			tc.numRows, tc.numVersions, tc.numRangeKeys, tc.tombstones,
+		)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCScan(ctx, b, benchScanOptions{
+				mvccBenchData: mvccBenchData{
+					numVersions:  tc.numVersions,
+					numRangeKeys: tc.numRangeKeys,
+					garbage:      true,
+				},
+				numRows:    tc.numRows,
+				tombstones: tc.tombstones,
+				reverse:    false,
+			})
 		})
 	}
 }
 
 func BenchmarkMVCCScanSQLRows_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		numRows           int
+		numColumnFamilies int
+		numVersions       int
+		valueSize         int
+		wholeRows         bool
+	}
+	var testCases []testCase
 	for _, numRows := range []int{1, 10, 100, 1000, 10000} {
-		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
-			for _, numColumnFamilies := range []int{1, 3, 10} {
-				b.Run(fmt.Sprintf("columnFamilies=%d", numColumnFamilies), func(b *testing.B) {
-					for _, numVersions := range []int{1} {
-						b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
-							for _, valueSize := range []int{8, 64, 512} {
-								b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-									for _, wholeRows := range []bool{false, true} {
-										b.Run(fmt.Sprintf("wholeRows=%t", wholeRows), func(b *testing.B) {
-											runMVCCScan(ctx, b, benchScanOptions{
-												mvccBenchData: mvccBenchData{
-													numColumnFamilies: numColumnFamilies,
-													numVersions:       numVersions,
-													valueBytes:        valueSize,
-												},
-												numRows:   numRows,
-												reverse:   false,
-												wholeRows: wholeRows,
-											})
-										})
-									}
-								})
-							}
+		for _, numColumnFamilies := range []int{1, 3, 10} {
+			for _, numVersions := range []int{1} {
+				for _, valueSize := range []int{8, 64, 512} {
+					for _, wholeRows := range []bool{false, true} {
+						testCases = append(testCases, testCase{
+							numRows:           numRows,
+							numColumnFamilies: numColumnFamilies,
+							numVersions:       numVersions,
+							valueSize:         valueSize,
+							wholeRows:         wholeRows,
 						})
 					}
-				})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{numRows: 1, numColumnFamilies: 1, numVersions: 1, valueSize: 8, wholeRows: false},
+			{numRows: 100, numColumnFamilies: 10, numVersions: 1, valueSize: 8, wholeRows: true},
+			{numRows: 1000, numColumnFamilies: 3, numVersions: 1, valueSize: 64, wholeRows: true},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"rows=%d/columnFamillies=%d/versions=%d/valueSize=%d/wholeRows=%t",
+			tc.numRows, tc.numColumnFamilies, tc.numVersions, tc.valueSize, tc.wholeRows,
+		)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCScan(ctx, b, benchScanOptions{
+				mvccBenchData: mvccBenchData{
+					numColumnFamilies: tc.numColumnFamilies,
+					numVersions:       tc.numVersions,
+					valueBytes:        tc.valueSize,
+				},
+				numRows:   tc.numRows,
+				reverse:   false,
+				wholeRows: tc.wholeRows,
+			})
 		})
 	}
 }
 
 func BenchmarkMVCCReverseScan_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		numRows      int
+		numVersions  int
+		valueSize    int
+		numRangeKeys int
+	}
+	var testCases []testCase
 	for _, numRows := range []int{1, 10, 100, 1000, 10000, 50000} {
-		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
-			for _, numVersions := range []int{1, 2, 10, 100, 1000} {
-				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
-					for _, valueSize := range []int{8, 64, 512} {
-						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-							for _, numRangeKeys := range []int{0, 1, 100} {
-								b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-									runMVCCScan(ctx, b, benchScanOptions{
-										mvccBenchData: mvccBenchData{
-											numVersions:  numVersions,
-											valueBytes:   valueSize,
-											numRangeKeys: numRangeKeys,
-										},
-										numRows: numRows,
-										reverse: true,
-									})
-								})
-							}
-						})
-					}
-				})
+		for _, numVersions := range []int{1, 2, 10, 100, 1000} {
+			for _, valueSize := range []int{8, 64, 512} {
+				for _, numRangeKeys := range []int{0, 1, 100} {
+					testCases = append(testCases, testCase{
+						numRows:      numRows,
+						numVersions:  numVersions,
+						valueSize:    valueSize,
+						numRangeKeys: numRangeKeys,
+					})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{numRows: 1, numVersions: 1, valueSize: 8, numRangeKeys: 0},
+			{numRows: 100, numVersions: 1, valueSize: 8, numRangeKeys: 1},
+			{numRows: 1000, numVersions: 2, valueSize: 64, numRangeKeys: 100},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"rows=%d/versions=%d/valueSize=%d/numRangeKeys=%d",
+			tc.numRows, tc.numVersions, tc.valueSize, tc.numRangeKeys,
+		)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCScan(ctx, b, benchScanOptions{
+				mvccBenchData: mvccBenchData{
+					numVersions:  tc.numVersions,
+					valueBytes:   tc.valueSize,
+					numRangeKeys: tc.numRangeKeys,
+				},
+				numRows: tc.numRows,
+				reverse: true,
+			})
 		})
 	}
 }
 
 func BenchmarkMVCCScanTransactionalData_Pebble(b *testing.B) {
-	ctx := context.Background()
 	defer log.Scope(b).Close(b)
+
+	ctx := context.Background()
 	runMVCCScan(ctx, b, benchScanOptions{
 		numRows: 10000,
 		mvccBenchData: mvccBenchData{
@@ -220,52 +312,97 @@ func BenchmarkMVCCScanTransactionalData_Pebble(b *testing.B) {
 }
 
 func BenchmarkMVCCGet_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		batch        bool
+		numVersions  int
+		valueSize    int
+		numRangeKeys int
+	}
+	var testCases []testCase
 	for _, batch := range []bool{false, true} {
-		b.Run(fmt.Sprintf("batch=%t", batch), func(b *testing.B) {
-			for _, numVersions := range []int{10} {
-				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
-					for _, valueSize := range []int{8} {
-						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-							for _, numRangeKeys := range []int{0} {
-								b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-									runMVCCGet(ctx, b, mvccBenchData{
-										numVersions:  numVersions,
-										valueBytes:   valueSize,
-										numRangeKeys: numRangeKeys,
-									}, batch)
-								})
-							}
-						})
-					}
-				})
+		for _, numVersions := range []int{1, 10, 100} {
+			for _, valueSize := range []int{8} {
+				for _, numRangeKeys := range []int{0, 1, 100} {
+					testCases = append(testCases, testCase{
+						batch:        batch,
+						numVersions:  numVersions,
+						valueSize:    valueSize,
+						numRangeKeys: numRangeKeys,
+					})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{batch: false, numVersions: 1, valueSize: 8, numRangeKeys: 0},
+			{batch: true, numVersions: 10, valueSize: 8, numRangeKeys: 0},
+			{batch: true, numVersions: 10, valueSize: 8, numRangeKeys: 10},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"batch=%t/versions=%d/valueSize=%d/numRangeKeys=%d",
+			tc.batch, tc.numVersions, tc.valueSize, tc.numRangeKeys,
+		)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCGet(ctx, b, mvccBenchData{
+				numVersions:  tc.numVersions,
+				valueBytes:   tc.valueSize,
+				numRangeKeys: tc.numRangeKeys,
+			}, tc.batch)
 		})
 	}
 }
 
 func BenchmarkMVCCComputeStats_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		valueSize    int
+		numRangeKeys int
+	}
+	var testCases []testCase
 	for _, valueSize := range []int{8, 32, 256} {
-		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-			for _, numRangeKeys := range []int{0, 1, 100} {
-				b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-					runMVCCComputeStats(ctx, b, valueSize, numRangeKeys)
-				})
-			}
+		for _, numRangeKeys := range []int{0, 1, 100} {
+			testCases = append(testCases, testCase{
+				valueSize:    valueSize,
+				numRangeKeys: numRangeKeys,
+			})
+		}
+	}
+
+	if testing.Short() {
+		// Choose a configuration for the short version.
+		testCases = []testCase{
+			{valueSize: 8, numRangeKeys: 1},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"valueSize=%d/numRangeKeys=%d",
+			tc.valueSize, tc.numRangeKeys,
+		)
+
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCComputeStats(ctx, b, tc.valueSize, tc.numRangeKeys)
 		})
 	}
 }
 
 func BenchmarkMVCCFindSplitKey_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
 	for _, valueSize := range []int{32} {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			ctx := context.Background()
 			runMVCCFindSplitKey(ctx, b, valueSize)
 		})
 	}
@@ -273,27 +410,57 @@ func BenchmarkMVCCFindSplitKey_Pebble(b *testing.B) {
 
 func BenchmarkMVCCPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		batch     bool
+		valueSize int
+		versions  int
+	}
+	var testCases []testCase
+
 	for _, batch := range []bool{false, true} {
-		b.Run(fmt.Sprintf("batch=%t", batch), func(b *testing.B) {
-			for _, valueSize := range []int{10, 100, 1000, 10000} {
-				b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-					for _, versions := range []int{1, 10} {
-						b.Run(fmt.Sprintf("versions=%d", versions), func(b *testing.B) {
-							runMVCCPut(ctx, b, setupMVCCInMemPebble, valueSize, versions, batch)
-						})
-					}
+		for _, valueSize := range []int{10, 100, 1000, 10000} {
+			for _, versions := range []int{1, 10} {
+				testCases = append(testCases, testCase{
+					batch:     batch,
+					valueSize: valueSize,
+					versions:  versions,
 				})
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{batch: false, valueSize: 10, versions: 1},
+			{batch: true, valueSize: 1000, versions: 10},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"batch=%t/valueSize=%d/versions=%d",
+			tc.batch, tc.valueSize, tc.versions,
+		)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCPut(ctx, b, setupMVCCInMemPebble, tc.valueSize, tc.versions, tc.batch)
 		})
 	}
 }
 
 func BenchmarkMVCCBlindPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
-	for _, valueSize := range []int{10, 100, 1000, 10000} {
+
+	valueSizes := []int{10, 100, 1000, 10000}
+	if testing.Short() {
+		valueSizes = []int{10, 10000}
+	}
+
+	for _, valueSize := range valueSizes {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			ctx := context.Background()
 			runMVCCBlindPut(ctx, b, setupMVCCInMemPebble, valueSize)
 		})
 	}
@@ -301,15 +468,21 @@ func BenchmarkMVCCBlindPut_Pebble(b *testing.B) {
 
 func BenchmarkMVCCConditionalPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	valueSizes := []int{10, 100, 1000, 10000}
+	if testing.Short() {
+		valueSizes = []int{10, 10000}
+	}
+
 	for _, createFirst := range []bool{false, true} {
 		prefix := "Create"
 		if createFirst {
 			prefix = "Replace"
 		}
 		b.Run(prefix, func(b *testing.B) {
-			for _, valueSize := range []int{10, 100, 1000, 10000} {
+			for _, valueSize := range valueSizes {
 				b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+					ctx := context.Background()
 					runMVCCConditionalPut(ctx, b, setupMVCCInMemPebble, valueSize, createFirst)
 				})
 			}
@@ -319,9 +492,15 @@ func BenchmarkMVCCConditionalPut_Pebble(b *testing.B) {
 
 func BenchmarkMVCCBlindConditionalPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
-	for _, valueSize := range []int{10, 100, 1000, 10000} {
+
+	valueSizes := []int{10, 100, 1000, 10000}
+	if testing.Short() {
+		valueSizes = []int{10, 10000}
+	}
+
+	for _, valueSize := range valueSizes {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			ctx := context.Background()
 			runMVCCBlindConditionalPut(ctx, b, setupMVCCInMemPebble, valueSize)
 		})
 	}
@@ -329,9 +508,15 @@ func BenchmarkMVCCBlindConditionalPut_Pebble(b *testing.B) {
 
 func BenchmarkMVCCInitPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
-	for _, valueSize := range []int{10, 100, 1000, 10000} {
+
+	valueSizes := []int{10, 100, 1000, 10000}
+	if testing.Short() {
+		valueSizes = []int{10, 10000}
+	}
+
+	for _, valueSize := range valueSizes {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			ctx := context.Background()
 			runMVCCInitPut(ctx, b, setupMVCCInMemPebble, valueSize)
 		})
 	}
@@ -339,9 +524,15 @@ func BenchmarkMVCCInitPut_Pebble(b *testing.B) {
 
 func BenchmarkMVCCBlindInitPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
-	for _, valueSize := range []int{10, 100, 1000, 10000} {
+
+	valueSizes := []int{10, 100, 1000, 10000}
+	if testing.Short() {
+		valueSizes = []int{10, 10000}
+	}
+
+	for _, valueSize := range valueSizes {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			ctx := context.Background()
 			runMVCCBlindInitPut(ctx, b, setupMVCCInMemPebble, valueSize)
 		})
 	}
@@ -374,11 +565,17 @@ func BenchmarkMVCCPutDelete_Pebble(b *testing.B) {
 
 func BenchmarkMVCCBatchPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	batchSizes := []int{10, 100, 1000, 10000}
+	if testing.Short() {
+		batchSizes = []int{10, 10000}
+	}
+
 	for _, valueSize := range []int{10} {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-			for _, batchSize := range []int{1, 100, 10000, 100000} {
+			for _, batchSize := range batchSizes {
 				b.Run(fmt.Sprintf("batchSize=%d", batchSize), func(b *testing.B) {
+					ctx := context.Background()
 					runMVCCBatchPut(ctx, b, setupMVCCInMemPebble, valueSize, batchSize)
 				})
 			}
@@ -399,16 +596,34 @@ func BenchmarkMVCCBatchTimeSeries_Pebble(b *testing.B) {
 // BenchmarkMVCCGetMergedTimeSeries computes performance of reading merged
 // time series data using `MVCCGet()`. Uses an in-memory engine.
 func BenchmarkMVCCGetMergedTimeSeries_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		numKeys      int
+		mergesPerKey int
+	}
+	var testCases []testCase
 	for _, numKeys := range []int{1, 16, 256} {
-		b.Run(fmt.Sprintf("numKeys=%d", numKeys), func(b *testing.B) {
-			for _, mergesPerKey := range []int{1, 16, 256} {
-				b.Run(fmt.Sprintf("mergesPerKey=%d", mergesPerKey), func(b *testing.B) {
-					runMVCCGetMergedValue(ctx, b, setupMVCCInMemPebble, numKeys, mergesPerKey)
-				})
-			}
+		for _, mergesPerKey := range []int{1, 16, 256} {
+			testCases = append(testCases, testCase{
+				numKeys:      numKeys,
+				mergesPerKey: mergesPerKey,
+			})
+		}
+	}
+
+	if testing.Short() {
+		// Choose a configuration for the short version.
+		testCases = []testCase{
+			{numKeys: 16, mergesPerKey: 16},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf("numKeys=%d/mergesPerKey=%d", tc.numKeys, tc.mergesPerKey)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCGetMergedValue(ctx, b, setupMVCCInMemPebble, tc.numKeys, tc.mergesPerKey)
 		})
 	}
 }
@@ -421,6 +636,8 @@ func BenchmarkMVCCGetMergedTimeSeries_Pebble(b *testing.B) {
 // what these benchmarks are trying to measure, and fix them.
 
 func BenchmarkMVCCDeleteRange_Pebble(b *testing.B) {
+	// TODO(radu): run one configuration under Short once the above TODO is
+	// resolved.
 	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ctx := context.Background()
@@ -432,6 +649,8 @@ func BenchmarkMVCCDeleteRange_Pebble(b *testing.B) {
 }
 
 func BenchmarkMVCCDeleteRangeUsingTombstone_Pebble(b *testing.B) {
+	// TODO(radu): run one configuration under Short once the above TODO is
+	// resolved.
 	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ctx := context.Background()
@@ -455,6 +674,8 @@ func BenchmarkMVCCDeleteRangeUsingTombstone_Pebble(b *testing.B) {
 // imports with more interspersed keys, leading to fewer range tombstones and
 // more point tombstones.
 func BenchmarkMVCCDeleteRangeWithPredicate_Pebble(b *testing.B) {
+	// TODO(radu): run one configuration under Short once the above TODO is
+	// resolved.
 	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ctx := context.Background()
@@ -476,6 +697,8 @@ func BenchmarkMVCCDeleteRangeWithPredicate_Pebble(b *testing.B) {
 }
 
 func BenchmarkClearMVCCVersions_Pebble(b *testing.B) {
+	// TODO(radu): run one configuration under Short once the above TODO is
+	// resolved.
 	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ctx := context.Background()
@@ -493,63 +716,108 @@ func BenchmarkClearMVCCIteratorRange_Pebble(b *testing.B) {
 }
 
 func BenchmarkBatchApplyBatchRepr_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		indexed    bool
+		sequential bool
+		valueSize  int
+		batchSize  int
+	}
+	var testCases []testCase
+
 	for _, indexed := range []bool{false, true} {
-		b.Run(fmt.Sprintf("indexed=%t", indexed), func(b *testing.B) {
-			for _, sequential := range []bool{false, true} {
-				b.Run(fmt.Sprintf("seq=%t", sequential), func(b *testing.B) {
-					for _, valueSize := range []int{10} {
-						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-							for _, batchSize := range []int{10000} {
-								b.Run(fmt.Sprintf("batchSize=%d", batchSize), func(b *testing.B) {
-									runBatchApplyBatchRepr(ctx, b, setupMVCCInMemPebble,
-										indexed, sequential, valueSize, batchSize)
-								})
-							}
-						})
-					}
-				})
+		for _, sequential := range []bool{false, true} {
+			for _, valueSize := range []int{10} {
+				for _, batchSize := range []int{10000} {
+					testCases = append(testCases, testCase{
+						indexed:    indexed,
+						sequential: sequential,
+						valueSize:  valueSize,
+						batchSize:  batchSize,
+					})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a configuration for the short version.
+		testCases = []testCase{
+			{indexed: true, sequential: false, valueSize: 10, batchSize: 8},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"indexed=%t/seq=%t/valueSize=%d/batchSize=%d",
+			tc.indexed, tc.sequential, tc.valueSize, tc.batchSize,
+		)
+
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runBatchApplyBatchRepr(ctx, b, setupMVCCInMemPebble,
+				tc.indexed, tc.sequential, tc.valueSize, tc.batchSize)
 		})
 	}
 }
 
+type acquireLockTestCase struct {
+	batch        bool
+	heldOtherTxn bool
+	heldSameTxn  bool
+	strength     lock.Strength
+}
+
+func (tc acquireLockTestCase) name() string {
+	return fmt.Sprintf(
+		"batch=%t/heldOtherTxn=%t/heldSameTxn=%t/strength=%s",
+		tc.batch, tc.heldOtherTxn, tc.heldSameTxn, tc.strength,
+	)
+}
+
+func acquireLockTestCases() []acquireLockTestCase {
+	var res []acquireLockTestCase
+	for _, batch := range []bool{false, true} {
+		for _, heldOtherTxn := range []bool{false, true} {
+			for _, heldSameTxn := range []bool{false, true} {
+				if heldOtherTxn && heldSameTxn {
+					continue // not possible
+				}
+				for _, strength := range []lock.Strength{lock.Shared, lock.Exclusive} {
+					res = append(res, acquireLockTestCase{
+						batch:        batch,
+						heldOtherTxn: heldOtherTxn,
+						heldSameTxn:  heldSameTxn,
+						strength:     strength,
+					})
+				}
+			}
+		}
+	}
+	return res
+}
+
 func BenchmarkMVCCCheckForAcquireLock_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
-	testutils.RunTrueAndFalse(b, "batch", func(b *testing.B, batch bool) {
-		testutils.RunTrueAndFalse(b, "heldOtherTxn", func(b *testing.B, heldOtherTxn bool) {
-			testutils.RunTrueAndFalse(b, "heldSameTxn", func(b *testing.B, heldSameTxn bool) {
-				if heldOtherTxn && heldSameTxn {
-					return // not possible
-				}
-				strs := []lock.Strength{lock.Shared, lock.Exclusive}
-				testutils.RunValues(b, "strength", strs, func(b *testing.B, strength lock.Strength) {
-					runMVCCCheckForAcquireLock(ctx, b, setupMVCCInMemPebble, batch, heldOtherTxn, heldSameTxn, strength)
-				})
-			})
+
+	for _, tc := range acquireLockTestCases() {
+		b.Run(tc.name(), func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCCheckForAcquireLock(ctx, b, setupMVCCInMemPebble, tc.batch, tc.heldOtherTxn, tc.heldSameTxn, tc.strength)
 		})
-	})
+	}
 }
 
 func BenchmarkMVCCAcquireLock_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
-	testutils.RunTrueAndFalse(b, "batch", func(b *testing.B, batch bool) {
-		testutils.RunTrueAndFalse(b, "heldOtherTxn", func(b *testing.B, heldOtherTxn bool) {
-			testutils.RunTrueAndFalse(b, "heldSameTxn", func(b *testing.B, heldSameTxn bool) {
-				if heldOtherTxn && heldSameTxn {
-					return // not possible
-				}
-				strs := []lock.Strength{lock.Shared, lock.Exclusive}
-				testutils.RunValues(b, "strength", strs, func(b *testing.B, strength lock.Strength) {
-					runMVCCAcquireLock(ctx, b, setupMVCCInMemPebble, batch, heldOtherTxn, heldSameTxn, strength)
-				})
-			})
+
+	for _, tc := range acquireLockTestCases() {
+		b.Run(tc.name(), func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCAcquireLock(ctx, b, setupMVCCInMemPebble, tc.batch, tc.heldOtherTxn, tc.heldSameTxn, tc.strength)
 		})
-	})
+	}
 }
 
 func BenchmarkBatchBuilderPut(b *testing.B) {
@@ -583,27 +851,52 @@ func BenchmarkBatchBuilderPut(b *testing.B) {
 
 func BenchmarkCheckSSTConflicts(b *testing.B) {
 	defer log.Scope(b).Close(b)
+
+	type testCase struct {
+		numKeys       int
+		numSSTKeys    int
+		overlap       bool
+		usePrefixSeek bool
+	}
+	var testCases []testCase
+
 	for _, numKeys := range []int{1000, 10000, 100000} {
-		b.Run(fmt.Sprintf("keys=%d", numKeys), func(b *testing.B) {
-			for _, numSstKeys := range []int{10, 100, 1000, 10000, 100000} {
-				b.Run(fmt.Sprintf("sstKeys=%d", numSstKeys), func(b *testing.B) {
-					for _, overlap := range []bool{false, true} {
-						b.Run(fmt.Sprintf("overlap=%t", overlap), func(b *testing.B) {
-							for _, usePrefixSeek := range []bool{false, true} {
-								b.Run(fmt.Sprintf("prefixSeek=%t", usePrefixSeek), func(b *testing.B) {
-									runCheckSSTConflicts(b, numKeys, 1 /* numVersions */, numSstKeys, overlap, usePrefixSeek)
-								})
-							}
-						})
-					}
-				})
+		for _, numSSTKeys := range []int{10, 100, 1000, 10000, 100000} {
+			for _, overlap := range []bool{false, true} {
+				for _, usePrefixSeek := range []bool{false, true} {
+					testCases = append(testCases, testCase{
+						numKeys:       numKeys,
+						numSSTKeys:    numSSTKeys,
+						overlap:       overlap,
+						usePrefixSeek: usePrefixSeek,
+					})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{numKeys: 10000, numSSTKeys: 100, overlap: false, usePrefixSeek: false},
+			{numKeys: 10000, numSSTKeys: 1000, overlap: true, usePrefixSeek: true},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"keys=%d/sstKeys=%d/overlap=%t/usePrefixSeek=%v",
+			tc.numKeys, tc.numSSTKeys, tc.overlap, tc.usePrefixSeek,
+		)
+		b.Run(name, func(b *testing.B) {
+			runCheckSSTConflicts(b, tc.numKeys, 1 /* numVersions */, tc.numSSTKeys, tc.overlap, tc.usePrefixSeek)
 		})
 	}
 }
 
 func BenchmarkSSTIterator(b *testing.B) {
 	defer log.Scope(b).Close(b)
+
 	for _, numKeys := range []int{1, 100, 10000} {
 		b.Run(fmt.Sprintf("keys=%d", numKeys), func(b *testing.B) {
 			for _, verify := range []bool{false, true} {

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -876,9 +876,7 @@ func runMVCCGet(ctx context.Context, b *testing.B, opts mvccBenchData, useBatch 
 	b.StopTimer()
 }
 
-func runMVCCPut(
-	ctx context.Context, b *testing.B, emk engineMaker, valueSize, versions int, useBatch bool,
-) {
+func runMVCCPut(ctx context.Context, b *testing.B, emk engineMaker, valueSize, versions int) {
 	rng, _ := randutil.NewTestRand()
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
@@ -887,11 +885,6 @@ func runMVCCPut(
 	defer eng.Close()
 
 	rw := ReadWriter(eng)
-	if useBatch {
-		batch := eng.NewBatch()
-		defer batch.Close()
-		rw = batch
-	}
 
 	b.SetBytes(int64(valueSize))
 	b.ResetTimer()

--- a/pkg/storage/mvcc_key_test.go
+++ b/pkg/storage/mvcc_key_test.go
@@ -361,6 +361,11 @@ func BenchmarkEncodeMVCCKey(b *testing.B) {
 		"walltime":         {WallTime: 1643550788737652545},
 		"walltime+logical": {WallTime: 1643550788737652545, Logical: 4096},
 	}
+	if testing.Short() {
+		// Reduce the number of configurations under -short.
+		delete(keys, "empty")
+		delete(timestamps, "walltime")
+	}
 	buf := make([]byte, 0, 65536)
 	for keyDesc, key := range keys {
 		for tsDesc, ts := range timestamps {
@@ -387,6 +392,11 @@ func BenchmarkDecodeMVCCKey(b *testing.B) {
 		"empty":            {},
 		"walltime":         {WallTime: 1643550788737652545},
 		"walltime+logical": {WallTime: 1643550788737652545, Logical: 4096},
+	}
+	if testing.Short() {
+		// Reduce the number of configurations under -short.
+		delete(keys, "empty")
+		delete(timestamps, "walltime")
 	}
 	var mvccKey MVCCKey
 	var err error
@@ -967,27 +977,51 @@ func BenchmarkMVCCRangeKeyStack_Clone(b *testing.B) {
 		return stack
 	}
 
+	type testCase struct {
+		keySize     int
+		numVersions int
+		withValues  int
+	}
+	var testCases []testCase
+
 	for _, keySize := range []int{16} {
-		b.Run(fmt.Sprintf("keySize=%d", keySize), func(b *testing.B) {
-			for _, numVersions := range []int{1, 3, 10, 100} {
-				b.Run(fmt.Sprintf("numVersions=%d", numVersions), func(b *testing.B) {
-					for _, withValues := range []int{0, 1} {
-						b.Run(fmt.Sprintf("withValues=%d", withValues), func(b *testing.B) {
-							stack := makeStack(keySize, numVersions, withValues)
-							b.Run("Clone", func(b *testing.B) {
-								for i := 0; i < b.N; i++ {
-									mvccRangeKeyStackClone = stack.Clone()
-								}
-							})
-							b.Run("CloneInto", func(b *testing.B) {
-								for i := 0; i < b.N; i++ {
-									stack.CloneInto(&mvccRangeKeyStackClone)
-								}
-							})
-						})
-					}
+		for _, numVersions := range []int{1, 3, 10, 100} {
+			for _, withValues := range []int{0, 1} {
+				testCases = append(testCases, testCase{
+					keySize:     keySize,
+					numVersions: numVersions,
+					withValues:  withValues,
 				})
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{keySize: 16, numVersions: 1, withValues: 0},
+			{keySize: 16, numVersions: 3, withValues: 1},
+			{keySize: 16, numVersions: 100, withValues: 1},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"keySize=%d/numVersions=%d/withValues=%d",
+			tc.keySize, tc.numVersions, tc.withValues,
+		)
+		b.Run(name, func(b *testing.B) {
+			stack := makeStack(tc.keySize, tc.numVersions, tc.withValues)
+			b.Run("Clone", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					mvccRangeKeyStackClone = stack.Clone()
+				}
+			})
+			b.Run("CloneInto", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					stack.CloneInto(&mvccRangeKeyStackClone)
+				}
+			})
 		})
 	}
 }

--- a/pkg/storage/mvcc_value_test.go
+++ b/pkg/storage/mvcc_value_test.go
@@ -178,27 +178,34 @@ func TestDecodeMVCCValueErrors(t *testing.T) {
 	}
 }
 
-var mvccValueBenchmarkConfigs = struct {
-	headers map[string]enginepb.MVCCValueHeader
-	values  map[string]roachpb.Value
-}{
-	headers: map[string]enginepb.MVCCValueHeader{
+func mvccValueBenchmarkConfigs() (
+	headers map[string]enginepb.MVCCValueHeader,
+	values map[string]roachpb.Value,
+) {
+	headers = map[string]enginepb.MVCCValueHeader{
 		"empty":                  {},
 		"local walltime":         {LocalTimestamp: hlc.ClockTimestamp{WallTime: 1643550788737652545}},
 		"local walltime+logical": {LocalTimestamp: hlc.ClockTimestamp{WallTime: 1643550788737652545, Logical: 4096}},
-	},
-	values: map[string]roachpb.Value{
+		"omit in rangefeeds":     {OmitInRangefeeds: true},
+	}
+	if testing.Short() {
+		// Reduce the number of configurations in short mode.
+		delete(headers, "local walltime")
+		delete(headers, "omit in rangefeeds")
+	}
+	values = map[string]roachpb.Value{
 		"tombstone": {},
 		"short":     roachpb.MakeValueFromString("foo"),
 		"long":      roachpb.MakeValueFromBytes(bytes.Repeat([]byte{1}, 4096)),
-	},
+	}
+	return headers, values
 }
 
 func BenchmarkEncodeMVCCValue(b *testing.B) {
 	DisableMetamorphicSimpleValueEncoding(b)
-	cfg := mvccValueBenchmarkConfigs
-	for hDesc, h := range cfg.headers {
-		for vDesc, v := range cfg.values {
+	headers, values := mvccValueBenchmarkConfigs()
+	for hDesc, h := range headers {
+		for vDesc, v := range values {
 			name := fmt.Sprintf("header=%s/value=%s", hDesc, vDesc)
 			mvccValue := MVCCValue{MVCCValueHeader: h, Value: v}
 			b.Run(name, func(b *testing.B) {
@@ -215,9 +222,9 @@ func BenchmarkEncodeMVCCValue(b *testing.B) {
 }
 
 func BenchmarkDecodeMVCCValue(b *testing.B) {
-	cfg := mvccValueBenchmarkConfigs
-	for hDesc, h := range cfg.headers {
-		for vDesc, v := range cfg.values {
+	headers, values := mvccValueBenchmarkConfigs()
+	for hDesc, h := range headers {
+		for vDesc, v := range values {
 			for _, inline := range []bool{false, true} {
 				name := fmt.Sprintf("header=%s/value=%s/inline=%t", hDesc, vDesc, inline)
 				mvccValue := MVCCValue{MVCCValueHeader: h, Value: v}
@@ -248,9 +255,9 @@ func BenchmarkDecodeMVCCValue(b *testing.B) {
 }
 
 func BenchmarkMVCCValueIsTombstone(b *testing.B) {
-	cfg := mvccValueBenchmarkConfigs
-	for hDesc, h := range cfg.headers {
-		for vDesc, v := range cfg.values {
+	headers, values := mvccValueBenchmarkConfigs()
+	for hDesc, h := range headers {
+		for vDesc, v := range values {
 			name := fmt.Sprintf("header=%s/value=%s", hDesc, vDesc)
 			mvccValue := MVCCValue{MVCCValueHeader: h, Value: v}
 			buf, err := EncodeMVCCValue(mvccValue)


### PR DESCRIPTION
#### storage: improve mvcc benchmarks under -short

Many of the MVCC benchmarks have too many variants and are completely
sipped when using the `-short` flag (which is used for the weekly
microbenchmarks job). Conversely, other benchmarks are not skipped but
still have quite a few variants.

In this commit we change relevant tests to run a small set of
configurations under `-short`. We also fix a few smaller issues, for
example we remove some bogus empty acquire lock benchmarks with
`heldOtherTxn=true/heldSameTxn=true`.

Fixes #115794
Release note: None

#### storage: remove batch=true variants of BenchmarkMVCCPut

This benchmark has batching variants but the batch size is `b.N` which
can hit the 4GB batch limit.

Given that we already have a separate `MVCCBatchPut` which has
reasonable batch sizes, we are removing the batched variants of
`BenchmarkMVCCPut`.

Fixes: #115811
Release note: None