### PR TITLE
sql: omit virtual tables from stmt bundles

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -490,6 +490,9 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 	}
 	buf.Reset()
 
+	// TODO(#27611): when we support stats on virtual tables, we'll need to
+	// update this logic to not include virtual tables into schema.sql but still
+	// create stats files for them.
 	var tables, sequences, views []tree.TableName
 	err := b.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		var err error
@@ -497,6 +500,7 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 			ctx, b.plan.catalog, func(ds cat.DataSource) (cat.DataSourceName, error) {
 				return b.plan.catalog.fullyQualifiedNameWithTxn(ctx, ds, txn)
 			},
+			false, /* includeVirtualTables */
 		)
 		return err
 	})

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3619,6 +3619,7 @@ func (b *Builder) getEnvData() (exec.ExplainEnvData, error) {
 		func(ds cat.DataSource) (cat.DataSourceName, error) {
 			return b.catalog.FullyQualifiedName(context.TODO(), ds)
 		},
+		true, /* includeVirtualTables */
 	)
 	return envOpts, err
 }

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -987,11 +987,13 @@ func (md *Metadata) getAllReferencedTables(
 // AllDataSourceNames returns the fully qualified names of all datasources
 // referenced by the metadata. This includes all tables, sequences, and views
 // that are directly stored in the metadata, as well as tables that are
-// recursively referenced from foreign keys.
+// recursively referenced from foreign keys. If includeVirtualTables is false,
+// then virtual tables are not returned.
 func (md *Metadata) AllDataSourceNames(
 	ctx context.Context,
 	catalog cat.Catalog,
 	fullyQualifiedName func(ds cat.DataSource) (cat.DataSourceName, error),
+	includeVirtualTables bool,
 ) (tables, sequences, views []tree.TableName, _ error) {
 	// Catalog objects can show up multiple times in our lists, so deduplicate
 	// them.
@@ -1014,6 +1016,17 @@ func (md *Metadata) AllDataSourceNames(
 	}
 	var err error
 	refTables := md.getAllReferencedTables(ctx, catalog)
+	if !includeVirtualTables {
+		// Update refTables in-place to remove all virtual tables.
+		i := 0
+		for j := 0; j < len(refTables); j++ {
+			if t, ok := refTables[j].(cat.Table); !ok || !t.IsVirtualTable() {
+				refTables[i] = refTables[j]
+				i++
+			}
+		}
+		refTables = refTables[:i]
+	}
 	tables, err = getNames(len(refTables), func(i int) cat.DataSource {
 		return refTables[i]
 	})


### PR DESCRIPTION
This commit makes it so that we do not include virtual tables into `schema.sql` file (as well as don't create the stats files for them) into the stmt bundle. This should make it easier to recreate the bundles that access virtual tables.

Note that in the future, once we support stats on virtual tables, this logic will need to be update so that only the create statements are omitted.

Fixes: #115437.

Release note: None