### PR TITLE
workload: extend kv txn qos to all supported values 

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
@@ -83,7 +83,7 @@ func registerElasticIO(r registry.Registry) {
 				url := fmt.Sprintf(" {pgurl:1-%d}", crdbNodes)
 				cmd := "./workload run kv --init --histograms=perf/stats.json --concurrency=512 " +
 					"--splits=1000 --read-percent=0 --min-block-bytes=65536 --max-block-bytes=65536 " +
-					"--background-qos=true --tolerate-errors" + dur + url
+					"--txn-qos=background --tolerate-errors" + dur + url
 				c.Run(ctx, c.Node(workAndPromNode), cmd)
 				return nil
 			})


### PR DESCRIPTION
The `kv` workload previously supported setting the session
`default_transaction_quality_of_service` to `background` via the flag
`--background-qos=true` (https://github.com/cockroachdb/cockroach/pull/109161). It is desirable to also be able to
set the default transaction QoS to `critical`.

Replace the `--background-qos` flag with `--txn-qos`, which accepts
`background`, `regular` and `critical`. The default value is `regular`.

Epic: none
Release note: None