### PR TITLE
serverccl: skip TestTenantCannotSeeNonTenantStats under stress

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -386,6 +386,7 @@ func testTenantLogs(ctx context.Context, t *testing.T, helper serverccl.TenantTe
 func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderStressWithIssue(t, 113984)
 
 	ctx := context.Background()
 	testCluster := serverutils.StartCluster(t, 3 /* numNodes */, base.TestClusterArgs{


### PR DESCRIPTION
This test has been flaky under stress for some time. Let's skip it until we figure it out.

Epic: none
Release note: None