### PR TITLE
sql: allow dropping routines with UDT-typed parameters

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -187,3 +187,66 @@ SET search_path = public
 
 statement ok
 DROP SCHEMA sc1;
+
+# Regression test for #114677 - it should be possible to drop a function with
+# a UDT parameter
+subtest udt_parameter
+
+statement ok
+CREATE TYPE t114677 AS (x INT, y INT);
+CREATE TYPE t114677_2 AS (a INT, b INT);
+
+# Create an overload with a composite type that has the same signature to verify
+# that the correct overload is dropped.
+statement ok
+CREATE FUNCTION f114677(v t114677) RETURNS INT LANGUAGE SQL AS $$ SELECT 0; $$;
+CREATE FUNCTION f114677(v t114677_2) RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+
+query T nosort
+SELECT create_statement FROM [SHOW CREATE FUNCTION f114677] ORDER BY create_statement;
+----
+CREATE FUNCTION public.f114677(IN v T114677)
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT 0;
+$$
+CREATE FUNCTION public.f114677(IN v T114677_2)
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT 1;
+$$
+
+statement error pgcode 42725 pq: function name \"f114677\" is not unique
+DROP FUNCTION f114677;
+
+statement ok
+DROP FUNCTION f114677(t114677);
+
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f114677];
+----
+CREATE FUNCTION public.f114677(IN v T114677_2)
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT 1;
+$$
+
+statement ok
+DROP FUNCTION f114677;
+
+statement error pgcode 42883 unknown function: f114677\(\)
+SHOW CREATE FUNCTION f114677;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/drop_procedure
+++ b/pkg/sql/logictest/testdata/logic_test/drop_procedure
@@ -167,3 +167,18 @@ SET search_path = public
 
 statement ok
 DROP SCHEMA sc1
+
+# Regression test for #114677 - it should be possible to drop a procedure with
+# a UDT parameter
+subtest udt_parameter
+
+statement ok
+CREATE TYPE t114677 AS (x INT, y INT);
+
+statement ok
+CREATE PROCEDURE p114677(v t114677) LANGUAGE SQL AS $$ SELECT 0; $$;
+
+statement ok
+DROP PROCEDURE p114677(t114677);
+
+subtest end

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -430,9 +430,6 @@ func (p ParamTypes) MatchAt(typ *types.T, i int) bool {
 
 // MatchAtIdentical is part of the TypeList interface.
 func (p ParamTypes) MatchAtIdentical(typ *types.T, i int) bool {
-	if typ.Family() == types.TupleFamily {
-		typ = types.AnyTuple
-	}
 	return i < len(p) && (typ.Family() == types.UnknownFamily || p[i].Typ.Identical(typ))
 }
 


### PR DESCRIPTION
Previously, it was not possible to specify UDT parameters when dropping a routine. This is because of an oversight in `MatchAtIdentical`, which was likely copied from `MatchAt`. Specifically, `MatchAt` has special handling for tuple types that take advantage of the fact that `types.Equivalent` allows `types.AnyTuple` to match with any other tuple. `MatchAtIdentical, on the other hand, uses `types.Identical`, which does not make the same allowance. This meant that overload resolution would always fail for UDT parameters in code paths that use `MatchAtIdentical`, such as DROP FUNCTION.

This patch removes the replacement logic for tuple types in `MatchAtIdentical`, so that `types.Identical` is always called with the original type. This allows statements like the following to succeed:
```
DROP PROCEDURE foo(x udt);
```

Fixes #114677

Release note (bug fix): Fixed a bug existing since v23.1 that prevented naming UDT parameters when dropping a user-defined function (or procedure).