### PR TITLE
release-23.2.0-rc: release-23.2: enginepb: add OmitInRangefeeds field to MVCCValueHeader

### DIFF
--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -143,8 +143,6 @@ message IgnoredSeqNumRange {
 // MVCCValueHeader holds MVCC-level metadata for a versioned value.
 // Used by storage.MVCCValue.
 //
-// NB: Make sure to update MVCCValueHeader.IsEmpty() when adding fields.
-//
 // NB: a shallow copy of this value has to equal a deep copy, i.e. there
 // must be (recursively) no pointers in this type. Should this need to
 // change, need to update mvccGetWithValueHeader.
@@ -195,6 +193,11 @@ message MVCCValueHeader {
   // to stale reads.
   util.hlc.Timestamp local_timestamp = 1 [(gogoproto.nullable) = false,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
+
+  // When set to true, this value will be filtered out by rangefeeds and will
+  // not be available in changefeeds. This allows higher levels of the system to
+  // control which writes are exported.
+  bool omit_in_rangefeeds = 3;
 }
 
 // MVCCValueHeaderPure is not to be used directly. It's generated only for use of
@@ -202,6 +205,8 @@ message MVCCValueHeader {
 message MVCCValueHeaderPure {
   util.hlc.Timestamp local_timestamp = 1 [(gogoproto.nullable) = false,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
+
+  bool omit_in_rangefeeds = 3;
 }
 // MVCCValueHeaderCrdbTest is not to be used directly. It's generated only for use of
 // its marshaling methods by MVCCValueHeader. See the comment there.
@@ -213,6 +218,7 @@ message MVCCValueHeaderCrdbTest {
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil.Container"];
   util.hlc.Timestamp local_timestamp = 1 [(gogoproto.nullable) = false,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
+  bool omit_in_rangefeeds = 3;
 }
 
 // MVCCStatsDelta is convertible to MVCCStats, but uses signed variable width

--- a/pkg/storage/enginepb/mvcc3_test.go
+++ b/pkg/storage/enginepb/mvcc3_test.go
@@ -29,7 +29,8 @@ func TestTxnMetaSizeOf(t *testing.T) {
 
 func populatedMVCCValueHeader() MVCCValueHeader {
 	allFieldsSet := MVCCValueHeader{
-		LocalTimestamp: hlc.ClockTimestamp{WallTime: 1, Logical: 1, Synthetic: true},
+		LocalTimestamp:   hlc.ClockTimestamp{WallTime: 1, Logical: 1, Synthetic: true},
+		OmitInRangefeeds: true,
 	}
 	allFieldsSet.KVNemesisSeq.Set(123)
 	return allFieldsSet
@@ -37,9 +38,13 @@ func populatedMVCCValueHeader() MVCCValueHeader {
 
 func TestMVCCValueHeader_IsEmpty(t *testing.T) {
 	allFieldsSet := populatedMVCCValueHeader()
-	require.NoError(t, zerofields.NoZeroField(allFieldsSet), "make sure you update the IsEmpty method")
+	require.NoError(t, zerofields.NoZeroField(allFieldsSet), "make sure you update TestMVCCValueHeader_IsEmpty for the new field")
+
 	require.True(t, MVCCValueHeader{}.IsEmpty())
+
 	require.False(t, allFieldsSet.IsEmpty())
+	require.False(t, MVCCValueHeader{LocalTimestamp: allFieldsSet.LocalTimestamp}.IsEmpty())
+	require.False(t, MVCCValueHeader{OmitInRangefeeds: allFieldsSet.OmitInRangefeeds}.IsEmpty())
 }
 
 func TestMVCCValueHeader_MarshalUnmarshal(t *testing.T) {

--- a/pkg/storage/enginepb/mvcc3_valueheader.go
+++ b/pkg/storage/enginepb/mvcc3_valueheader.go
@@ -20,7 +20,8 @@ func (h MVCCValueHeader) IsEmpty() bool {
 
 func (h *MVCCValueHeader) pure() MVCCValueHeaderPure {
 	return MVCCValueHeaderPure{
-		LocalTimestamp: h.LocalTimestamp,
+		LocalTimestamp:   h.LocalTimestamp,
+		OmitInRangefeeds: h.OmitInRangefeeds,
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #115333.

/cc @cockroachdb/release

---

Backport 1/1 commits from #115288 on behalf of @RaduBerinde.

/cc @cockroachdb/release

Release justification: this proto change is necessary for a feature we plan to add in a point release, and merging it in .0 will make things easier. The change should be functionally a no-op.

----

This commit is just the proto change that adds the field.

Informs: #113634
Epic: CRDB-13169
Release note: None

----
