### PR TITLE
roachtest: loosely match error in multitenant-upgrade

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -248,17 +248,11 @@ func runMultiTenantUpgrade(
 		"SELECT version = crdb_internal.node_executable_version() FROM [SHOW CLUSTER SETTING version]",
 		[][]string{{"true"}})
 
-	tenant11aRunner, tenant11aRunnerCloser := openDBAndMakeSQLRunner(t, tenant11a.pgURL)
-	defer tenant11aRunnerCloser()
-
-	finalVersion := tenant11aRunner.QueryStr(t, "SELECT * FROM crdb_internal.node_executable_version();")[0][0]
 	// Remove patch release from predecessorVersion.
 	predecessorVersion := fmt.Sprintf("%d.%d", predecessor.Major(), predecessor.Minor())
-
 	t.Status("migrating first tenant 11 server to the current version after system tenant is finalized which should fail because second server is still on old binary - expecting a failure here too")
 	expectErr(t, tenant11a.pgURL,
-		fmt.Sprintf(`pq: error validating the version of one or more SQL server instances: rpc error: code = Unknown desc = sql server 2 is running a binary version %s which is less than the attempted upgrade version %s
-HINT: check the binary versions of all running SQL server instances to ensure that they are compatible with the attempted upgrade version`, predecessorVersion, finalVersion),
+		fmt.Sprintf(`sql server 2 is running a binary version %s which is less than the attempted upgrade version`, predecessorVersion),
 		"SET CLUSTER SETTING version = crdb_internal.node_executable_version()")
 
 	t.Status("verify that the first tenant 11 server can now query the storage cluster")


### PR DESCRIPTION
In #115223 we improved the string representation of internal versions. This test, however, gets an error generated from a node on an older version that uses the older string format.

Here, I change the assertion to match on only part of the error message which is enough to assert that the correct node is reporting it is on an older version.

Fixes #115502

Release note: None