### PR TITLE
kvserver: additional progress logging during store initialization

### DIFF
--- a/pkg/kv/kvserver/kvstorage/testdata/init
+++ b/pkg/kv/kvserver/kvstorage/testdata/init
@@ -28,8 +28,12 @@ r7/70: r7:{a-c} [(n1,s1):70, next=71, gen=0]
 r8/80: r8:{c-f} [(n1,s1):80, next=81, gen=0]
 beginning range descriptor iteration
 range descriptor iteration done: 2 keys, 2 range descriptors (by suffix: map[rdsc:2]); scan stats: <redacted>
+loaded replica ID for 3/3 replicas
+loaded Raft state for 4/4 replicas
+loaded 4 replicas
 removed legacy uninitialized replica for r5
 backfilled replicaID for initialized replica r7/70
+verified 4/4 replicas
 
 # Idempotency.
 load-and-reconcile trace=true
@@ -39,3 +43,7 @@ r7/70: r7:{a-c} [(n1,s1):70, next=71, gen=0]
 r8/80: r8:{c-f} [(n1,s1):80, next=81, gen=0]
 beginning range descriptor iteration
 range descriptor iteration done: 2 keys, 2 range descriptors (by suffix: map[rdsc:2]); scan stats: <redacted>
+loaded replica ID for 3/3 replicas
+loaded Raft state for 3/3 replicas
+loaded 3 replicas
+verified 3/3 replicas

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2126,6 +2126,12 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	log.Infof(ctx, "loaded %d replicas, initializing", len(repls))
 	logEvery := log.Every(10 * time.Second)
 	for i, repl := range repls {
+		// Log progress regularly, but not for the first replica (we only want to
+		// log when this is slow). The last replica is logged after iteration.
+		if logEvery.ShouldLog() && i > 0 {
+			log.Infof(ctx, "initialized %d/%d replicas", i, len(repls))
+		}
+
 		if repl.Desc == nil {
 			// Uninitialized Replicas are not currently instantiated at store start.
 			continue
@@ -2173,13 +2179,6 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		// also check Sequence > 0 to omit ranges that haven't seen a lease yet.
 		if l, _ := rep.GetLease(); l.Type() == roachpb.LeaseExpiration && l.Sequence > 0 {
 			rep.maybeUnquiesce(true /* wakeLeader */, true /* mayCampaign */)
-		}
-
-		// Log progress regularly, but not for the first replica (we only want to
-		// log when this is slow) and the last replica (which is always logged after
-		// we're done).
-		if logEvery.ShouldLog() && i > 0 && i+1 < len(repls) {
-			log.Infof(ctx, "initialized %d/%d replicas", i+1, len(repls))
 		}
 	}
 	log.Infof(ctx, "initialized %d/%d replicas", len(repls), len(repls))

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2123,7 +2123,6 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	if err != nil {
 		return err
 	}
-	log.Infof(ctx, "loaded %d replicas, initializing", len(repls))
 	logEvery := log.Every(10 * time.Second)
 	for i, repl := range repls {
 		// Log progress regularly, but not for the first replica (we only want to


### PR DESCRIPTION
Follows #115760.
Epic: none
Release note: None