### PR TITLE
kvserver: remove ReplicaID migration

### DIFF
--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -414,20 +413,9 @@ func loadReplicas(ctx context.Context, eng storage.Engine) ([]Replica, error) {
 		}
 	}
 
+	// Load replicas from disk based on their RaftReplicaID and HardState.
+	//
 	// INVARIANT: all replicas have a persisted full ReplicaID (i.e. a "ReplicaID from disk").
-	//
-	// This invariant is true for replicas created in 22.1. Without further action, it
-	// would be violated for clusters that originated before 22.1. In this method, we
-	// backfill the ReplicaID (for initialized replicas) and we remove uninitialized
-	// replicas lacking a ReplicaID (see below for rationale).
-	//
-	// The migration can be removed when the KV host cluster MinSupportedVersion
-	// matches or exceeds 23.1 (i.e. once we know that a store has definitely
-	// started up on >=23.1 at least once).
-
-	// Collect all the RangeIDs that either have a RaftReplicaID or HardState. For
-	// unmigrated replicas we see only the HardState - that is how we detect
-	// replicas that still need to be migrated.
 	//
 	// TODO(tbg): tighten up the case where we see a RaftReplicaID but no HardState.
 	// This leads to the general desire to validate the internal consistency of the
@@ -496,9 +484,8 @@ func LoadAndReconcileReplicas(ctx context.Context, eng storage.Engine) ([]Replic
 
 	// Check invariants.
 	//
-	// Migrate into RaftReplicaID for all replicas that need it.
+	// TODO(erikgrinaker): consider moving this logic into loadReplicas.
 	logEvery := log.Every(10 * time.Second)
-	var newIdx int
 	for i, repl := range sl {
 		// Log progress regularly, but not for the first replica (we only want to
 		// log when this is slow). The last replica is logged after iteration.
@@ -506,7 +493,11 @@ func LoadAndReconcileReplicas(ctx context.Context, eng storage.Engine) ([]Replic
 			log.Infof(ctx, "verified %d/%d replicas", i, len(sl))
 		}
 
-		var descReplicaID roachpb.ReplicaID
+		// INVARIANT: a Replica always has a replica ID.
+		if repl.ReplicaID == 0 {
+			return nil, errors.AssertionFailedf("no RaftReplicaID for %s", repl.Desc)
+		}
+
 		if repl.Desc != nil {
 			// INVARIANT: a Replica's RangeDescriptor always contains the local Store,
 			// i.e. a Store is a member of all of its local initialized Replicas.
@@ -514,52 +505,15 @@ func LoadAndReconcileReplicas(ctx context.Context, eng storage.Engine) ([]Replic
 			if !found {
 				return nil, errors.AssertionFailedf("s%d not found in %s", ident.StoreID, repl.Desc)
 			}
-			if repl.ReplicaID != 0 && replDesc.ReplicaID != repl.ReplicaID {
+			// INVARIANT: a Replica's ID always matches the descriptor.
+			if replDesc.ReplicaID != repl.ReplicaID {
 				return nil, errors.AssertionFailedf("conflicting RaftReplicaID %d for %s", repl.ReplicaID, repl.Desc)
 			}
-			descReplicaID = replDesc.ReplicaID
-		}
-
-		if repl.ReplicaID != 0 {
-			sl[newIdx] = repl
-			newIdx++
-			// RaftReplicaID present, no need to migrate.
-			continue
-		}
-
-		// Migrate into RaftReplicaID. This migration can be removed once the
-		// MinSupportedVersion is >= 23.1, and we can assert that
-		// repl.ReplicaID != 0 always holds.
-
-		if descReplicaID != 0 {
-			// Backfill RaftReplicaID for an initialized Replica.
-			if err := logstore.NewStateLoader(repl.RangeID).SetRaftReplicaID(ctx, eng, descReplicaID); err != nil {
-				return nil, errors.Wrapf(err, "backfilling ReplicaID for r%d", repl.RangeID)
-			}
-			repl.ReplicaID = descReplicaID
-			sl[newIdx] = repl
-			newIdx++
-			log.Eventf(ctx, "backfilled replicaID for initialized replica %s", repl.ID())
-		} else {
-			// We found an uninitialized replica that did not have a persisted
-			// ReplicaID. We can't determine the ReplicaID now, so we migrate by
-			// removing this uninitialized replica. This technically violates raft
-			// invariants if this replica has cast a vote, but the conditions under
-			// which this matters are extremely unlikely.
-			//
-			// TODO(tbg): if clearRangeData were in this package we could destroy more
-			// effectively even if for some reason we had in the past written state
-			// other than the HardState here (not supposed to happen, but still).
-			if err := eng.ClearUnversioned(logstore.NewStateLoader(repl.RangeID).RaftHardStateKey(), storage.ClearOptions{}); err != nil {
-				return nil, errors.Wrapf(err, "removing HardState for r%d", repl.RangeID)
-			}
-			log.Eventf(ctx, "removed legacy uninitialized replica for r%s", repl.RangeID)
-			// NB: removed from `sl` since we're not incrementing `newIdx`.
 		}
 	}
 	log.Infof(ctx, "verified %d/%d replicas", len(sl), len(sl))
 
-	return sl[:newIdx], nil
+	return sl, nil
 }
 
 // A NotBootstrappedError indicates that an engine has not yet been

--- a/pkg/kv/kvserver/kvstorage/replica_state.go
+++ b/pkg/kv/kvserver/kvstorage/replica_state.go
@@ -137,20 +137,6 @@ func CreateUninitializedReplica(
 	//   the Term and Vote values for that older replica in the context of
 	//   this newer replica is harmless since it just limits the votes for
 	//   this replica.
-	//
-	// Compatibility:
-	// - v21.2 and v22.1: v22.1 unilaterally introduces RaftReplicaID (an
-	//   unreplicated range-id local key). If a v22.1 binary is rolled back at
-	//   a node, the fact that RaftReplicaID was written is harmless to a
-	//   v21.2 node since it does not read it. When a v21.2 drops an
-	//   initialized range, the RaftReplicaID will also be deleted because the
-	//   whole range-ID local key space is deleted.
-	// - v22.2: no changes: RaftReplicaID is written, but old Replicas may not
-	//   have it yet.
-	// - v23.1: at startup, we remove any uninitialized replicas that have a
-	//   HardState but no RaftReplicaID, see kvstorage.LoadAndReconcileReplicas.
-	//   So after first call to this method we have the invariant that all replicas
-	//   have a RaftReplicaID persisted.
 	sl := stateloader.Make(rangeID)
 	if err := sl.SetRaftReplicaID(ctx, eng, replicaID); err != nil {
 		return err

--- a/pkg/kv/kvserver/kvstorage/testdata/assert_replicaid
+++ b/pkg/kv/kvserver/kvstorage/testdata/assert_replicaid
@@ -1,0 +1,13 @@
+# Initialized replica without a RaftReplicaID should error.
+new-replica range-id=5 replica-id=50 k=a ek=c skip-raft-replica-id=true
+----
+r5:{a-c} [(n1,s1):50, next=51, gen=0]
+
+load-and-reconcile trace=true
+----
+no RaftReplicaID for r5:{a-c} [(n1,s1):50, next=51, gen=0]
+beginning range descriptor iteration
+range descriptor iteration done: 1 keys, 1 range descriptors (by suffix: map[rdsc:1]); scan stats: <redacted>
+loaded replica ID for 1/1 replicas
+loaded Raft state for 1/1 replicas
+loaded 1 replicas

--- a/pkg/kv/kvserver/kvstorage/testdata/assert_replicaid_uninitialized
+++ b/pkg/kv/kvserver/kvstorage/testdata/assert_replicaid_uninitialized
@@ -1,0 +1,13 @@
+# Uninitialized replica without a RaftReplicaID should error.
+new-replica range-id=5
+----
+ok
+
+load-and-reconcile trace=true
+----
+no RaftReplicaID for <nil>
+beginning range descriptor iteration
+range descriptor iteration done: 0 keys, 0 range descriptors (by suffix: map[]); scan stats: <redacted>
+loaded replica ID for 0/0 replicas
+loaded Raft state for 1/1 replicas
+loaded 1 replicas

--- a/pkg/kv/kvserver/kvstorage/testdata/init
+++ b/pkg/kv/kvserver/kvstorage/testdata/init
@@ -1,49 +1,33 @@
-# Uninitialized deprecated replica: doesn't have a RaftReplicaID, it's just a
-# HardState. We expect this to be removed by load-and-reconcile.
-new-replica range-id=5
-----
-ok
-
 # Uninitialized replica. Expect this to stay around and be returned as such.
 new-replica range-id=6 replica-id=60
 ----
 ok
 
-# Initialized deprecated replica: no RaftReplicaID. Expect ID to be backfilled.
-new-replica range-id=7 replica-id=70 k=a ek=c skip-raft-replica-id=true
-----
-r7:{a-c} [(n1,s1):70, next=71, gen=0]
-
-# Initialized replica without a need for a backfill.
+# Initialized replica with a replica ID.
 new-replica range-id=8 replica-id=80 k=c ek=f
 ----
 r8:{c-f} [(n1,s1):80, next=81, gen=0]
 
-# Loading the replicas returns only the ones that
-# had a ReplicaID.
+# Load the replicas.
 load-and-reconcile trace=true
 ----
 r6/60: uninitialized
-r7/70: r7:{a-c} [(n1,s1):70, next=71, gen=0]
 r8/80: r8:{c-f} [(n1,s1):80, next=81, gen=0]
 beginning range descriptor iteration
-range descriptor iteration done: 2 keys, 2 range descriptors (by suffix: map[rdsc:2]); scan stats: <redacted>
-loaded replica ID for 3/3 replicas
-loaded Raft state for 4/4 replicas
-loaded 4 replicas
-removed legacy uninitialized replica for r5
-backfilled replicaID for initialized replica r7/70
-verified 4/4 replicas
+range descriptor iteration done: 1 keys, 1 range descriptors (by suffix: map[rdsc:1]); scan stats: <redacted>
+loaded replica ID for 2/2 replicas
+loaded Raft state for 2/2 replicas
+loaded 2 replicas
+verified 2/2 replicas
 
 # Idempotency.
 load-and-reconcile trace=true
 ----
 r6/60: uninitialized
-r7/70: r7:{a-c} [(n1,s1):70, next=71, gen=0]
 r8/80: r8:{c-f} [(n1,s1):80, next=81, gen=0]
 beginning range descriptor iteration
-range descriptor iteration done: 2 keys, 2 range descriptors (by suffix: map[rdsc:2]); scan stats: <redacted>
-loaded replica ID for 3/3 replicas
-loaded Raft state for 3/3 replicas
-loaded 3 replicas
-verified 3/3 replicas
+range descriptor iteration done: 1 keys, 1 range descriptors (by suffix: map[rdsc:1]); scan stats: <redacted>
+loaded replica ID for 2/2 replicas
+loaded Raft state for 2/2 replicas
+loaded 2 replicas
+verified 2/2 replicas


### PR DESCRIPTION
This migration ensured every replica had a persisted replica ID. It is no longer needed after `MinSupportedVersion` >= 23.1, since the migration has been applied on every finalized 23.1 node. Instead, we assert during startup that all replicas have a replica ID.

Resolves #115869.
Touches #95513.
Epic: none
Release note: None