### PR TITLE
sql/stats: skip `TestCreateStatsControlJob` under `race`

### DIFF
--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -49,6 +49,7 @@ func TestCreateStatsControlJob(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderDeadlock(t, "possible OOM")
+	skip.UnderRace(t, "possible OOM")
 
 	// Test with 3 nodes and rowexec.SamplerProgressInterval=100 to ensure
 	// that progress metadata is sent correctly after every 100 input rows.


### PR DESCRIPTION
This is prone to OOM'ing.

Epic: CRDB-8308
Release note: None