### PR TITLE
physicalplan: skip TestFakeSpanResolver only under race

### DIFF
--- a/pkg/sql/physicalplan/fake_span_resolver_test.go
+++ b/pkg/sql/physicalplan/fake_span_resolver_test.go
@@ -34,7 +34,7 @@ func TestFakeSpanResolver(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderRemoteExecutionWithIssue(t, 115619, "probable OOM")
+	skip.UnderRaceWithIssue(t, 115619, "probable OOM")
 
 	ctx := context.Background()
 	tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{})


### PR DESCRIPTION
Skipping under all remote execution runs seems unnecessary as the test
only seems to OOM under `race`.

Epic: CRDB-8308
Release note: None