### PR TITLE
backupccl: skip mvcc stats during online restore stats polling

### DIFF
--- a/pkg/ccl/backupccl/restore_online.go
+++ b/pkg/ccl/backupccl/restore_online.go
@@ -345,7 +345,8 @@ func (r *restoreResumer) waitForDownloadToComplete(
 		var remaining uint64
 		for _, span := range details.DownloadSpans {
 			resp, err := execCtx.ExecCfg().TenantStatusServer.SpanStats(ctx, &roachpb.SpanStatsRequest{
-				Spans: []roachpb.Span{span},
+				Spans:         []roachpb.Span{span},
+				SkipMvccStats: true,
 			})
 			if err != nil {
 				return err

--- a/pkg/roachpb/span_stats.proto
+++ b/pkg/roachpb/span_stats.proto
@@ -33,6 +33,8 @@ message SpanStatsRequest {
   bytes end_key = 3 [(gogoproto.casttype) = "RKey"];
 
   repeated Span spans = 4 [(gogoproto.nullable) = false];
+
+  bool skip_mvcc_stats = 5;
 }
 
 message SpanStats {

--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -281,6 +281,9 @@ func (s *systemStatusServer) statsForSpan(
 			if descSpan.EndKey.Compare(rSpan.EndKey) == -1 {
 				scanEnd = descSpan.EndKey
 			}
+			log.VEventf(ctx, 1, "Range %v exceeds span %v, calculating stats for subspan %v",
+				descSpan, rSpan, roachpb.RSpan{Key: scanStart, EndKey: scanEnd},
+			)
 			err = s.stores.VisitStores(func(s *kvserver.Store) error {
 				stats, err := storage.ComputeStats(
 					ctx,

--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -188,7 +188,7 @@ func (s *systemStatusServer) getLocalStats(
 ) (*roachpb.SpanStatsResponse, error) {
 	var res = &roachpb.SpanStatsResponse{SpanToStats: make(map[string]*roachpb.SpanStats)}
 	for _, span := range req.Spans {
-		spanStats, err := s.statsForSpan(ctx, span)
+		spanStats, err := s.statsForSpan(ctx, span, req.SkipMvccStats)
 		if err != nil {
 			return nil, err
 		}
@@ -198,7 +198,7 @@ func (s *systemStatusServer) getLocalStats(
 }
 
 func (s *systemStatusServer) statsForSpan(
-	ctx context.Context, span roachpb.Span,
+	ctx context.Context, span roachpb.Span, skipMVCCStats bool,
 ) (*roachpb.SpanStats, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "systemStatusServer.statsForSpan")
 	defer sp.Finish()
@@ -220,11 +220,32 @@ func (s *systemStatusServer) statsForSpan(
 	}
 
 	spanStats := &roachpb.SpanStats{}
-	var fullyContainedKeysBatch []roachpb.Key
 	rSpan, err := keys.SpanAddr(span)
 	if err != nil {
 		return nil, err
 	}
+
+	// First, get the approximate disk bytes from each store.
+	err = s.stores.VisitStores(func(store *kvserver.Store) error {
+		approxDiskBytes, remoteBytes, externalBytes, err := store.TODOEngine().ApproximateDiskBytes(rSpan.Key.AsRawKey(), rSpan.EndKey.AsRawKey())
+		if err != nil {
+			return err
+		}
+		spanStats.ApproximateDiskBytes += approxDiskBytes
+		spanStats.RemoteFileBytes += remoteBytes
+		spanStats.ExternalFileBytes += externalBytes
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if skipMVCCStats {
+		return spanStats, nil
+	}
+
+	var fullyContainedKeysBatch []roachpb.Key
 	// Iterate through the span's ranges.
 	for _, desc := range descriptors {
 
@@ -292,21 +313,7 @@ func (s *systemStatusServer) statsForSpan(
 		// Nil the batch.
 		fullyContainedKeysBatch = nil
 	}
-	// Finally, get the approximate disk bytes from each store.
-	err = s.stores.VisitStores(func(store *kvserver.Store) error {
-		approxDiskBytes, remoteBytes, externalBytes, err := store.TODOEngine().ApproximateDiskBytes(rSpan.Key.AsRawKey(), rSpan.EndKey.AsRawKey())
-		if err != nil {
-			return err
-		}
-		spanStats.ApproximateDiskBytes += approxDiskBytes
-		spanStats.RemoteFileBytes += remoteBytes
-		spanStats.ExternalFileBytes += externalBytes
-		return nil
-	})
 
-	if err != nil {
-		return nil, err
-	}
 	return spanStats, nil
 }
 


### PR DESCRIPTION
We poll SpanStats to see the estimated disk usage by type of file (remote vs local) shift over time to report progress during an online restore. Previously this call also always included MVCC stats, which are unused by the online restore call. However these MVCC stats can be expensive to include especially in cases where a range exceeds the request bounds, as these require iterating and computing stats from scratch. This CL makes the stats skippable and skips them during online restore polling.

Release note: none.
Epic: none.