### PR TITLE
kvserver: don't covert ctx errors to ReplicaCorruptionError

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -783,7 +783,7 @@ func RunCommitTrigger(
 			ctx, rec, batch, *ms, ct.SplitTrigger, txn.WriteTimestamp,
 		)
 		if err != nil {
-			return result.Result{}, kvpb.NewReplicaCorruptionError(err)
+			return result.Result{}, kvpb.MaybeWrapReplicaCorruptionError(ctx, err)
 		}
 		*ms = newMS
 		return res, nil
@@ -791,7 +791,7 @@ func RunCommitTrigger(
 	if mt := ct.GetMergeTrigger(); mt != nil {
 		res, err := mergeTrigger(ctx, rec, batch, ms, mt, txn.WriteTimestamp)
 		if err != nil {
-			return result.Result{}, kvpb.NewReplicaCorruptionError(err)
+			return result.Result{}, kvpb.MaybeWrapReplicaCorruptionError(ctx, err)
 		}
 		return res, nil
 	}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2322,7 +2322,7 @@ func checkIfTxnAborted(
 	var entry roachpb.AbortSpanEntry
 	aborted, err := rec.AbortSpan().Get(ctx, reader, txn.ID, &entry)
 	if err != nil {
-		return kvpb.NewError(kvpb.NewReplicaCorruptionError(
+		return kvpb.NewError(kvpb.MaybeWrapReplicaCorruptionError(ctx,
 			errors.Wrap(err, "could not read from AbortSpan")))
 	}
 	if aborted {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7770,6 +7770,17 @@ func TestNewReplicaCorruptionError(t *testing.T) {
 			t.Errorf("%d: expected '%s' but got '%s'", i, tc.expErr, errStr)
 		}
 	}
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	if !errors.HasType(kvpb.MaybeWrapReplicaCorruptionError(ctx, errors.New("foo")), &kvpb.ReplicaCorruptionError{}) {
+		t.Fatal("MaybeWrapReplicaCorruptionError should wrap a non-ctx err")
+	}
+
+	cancel(errors.New("we're done here"))
+	if errors.HasType(kvpb.MaybeWrapReplicaCorruptionError(ctx, ctx.Err()), &kvpb.ReplicaCorruptionError{}) {
+		t.Fatal("MaybeWrapReplicaCorruptionError should not wrap a ctx err")
+	}
 }
 
 func TestSyncSnapshot(t *testing.T) {


### PR DESCRIPTION
Release note: none.
Epic: none.

Fixes #114442.