### PR TITLE
roachtest: add option to skip uploading to last node

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1759,17 +1759,21 @@ func (c *clusterImpl) PutE(
 // runtime assertions enabled. Note that we upload to all nodes even if they
 // don't use the binary, so that the test runner can always fetch logs.
 func (c *clusterImpl) PutCockroach(ctx context.Context, l *logger.Logger, t *testImpl) error {
+	nodes := c.All()
+	if t.spec.SkipCockroachBinaryOnLastNode {
+		nodes = nodes[:len(nodes)-1]
+	}
 	switch t.spec.CockroachBinary {
 	case registry.RandomizedCockroach:
 		if tests.UsingRuntimeAssertions(t) {
 			t.l.Printf("To reproduce the same set of metamorphic constants, run this test with %s=%d", test.EnvAssertionsEnabledSeed, c.cockroachRandomSeed())
 		}
-		return c.PutE(ctx, l, t.Cockroach(), test.DefaultCockroachPath, c.All())
+		return c.PutE(ctx, l, t.Cockroach(), test.DefaultCockroachPath, nodes)
 	case registry.StandardCockroach:
-		return c.PutE(ctx, l, t.StandardCockroach(), test.DefaultCockroachPath, c.All())
+		return c.PutE(ctx, l, t.StandardCockroach(), test.DefaultCockroachPath, nodes)
 	case registry.RuntimeAssertionsCockroach:
 		t.l.Printf("To reproduce the same set of metamorphic constants, run this test with %s=%d", test.EnvAssertionsEnabledSeed, c.cockroachRandomSeed())
-		return c.PutE(ctx, l, t.RuntimeAssertionsCockroach(), test.DefaultCockroachPath, c.All())
+		return c.PutE(ctx, l, t.RuntimeAssertionsCockroach(), test.DefaultCockroachPath, nodes)
 	default:
 		return errors.Errorf("Specified cockroach binary does not exist.")
 	}

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -139,6 +139,11 @@ type TestSpec struct {
 	// If one is not specified, the default behavior is to upload
 	// a binary with the crdb_test flag randomly enabled or disabled.
 	CockroachBinary ClusterCockroachBinary
+
+	// SkipCockroachBinaryOnLastNode skips putting the crdb binary on the last
+	// node when PutCockroach is called which can avoid the extra upload if that
+	// last node is only in use as a workload node.
+	SkipCockroachBinaryOnLastNode bool
 }
 
 // PostValidation is a type of post-validation that runs after a test completes.

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -86,11 +86,12 @@ func registerOnlineRestore(r registry.Registry) {
 					Timeout:   sp.timeout,
 					// These tests measure performance. To ensure consistent perf,
 					// disable metamorphic encryption.
-					EncryptionSupport: registry.EncryptionAlwaysDisabled,
-					CompatibleClouds:  sp.clouds,
-					Suites:            sp.suites,
-					Tags:              sp.tags,
-					Skip:              sp.skip,
+					EncryptionSupport:             registry.EncryptionAlwaysDisabled,
+					SkipCockroachBinaryOnLastNode: sp.hardware.workloadNode,
+					CompatibleClouds:              sp.clouds,
+					Suites:                        sp.suites,
+					Tags:                          sp.tags,
+					Skip:                          sp.skip,
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 						testStartTime := timeutil.Now()


### PR DESCRIPTION
Often the last node is used to execute the workload. If that is done without using the whole CRDB binary such as when we use the standalone tpce load generator, then we can skip uploading the extra CRDB binary.

Release note: none.
Epic: none.