### PR TITLE
roachtest: use backup cloud to set CompatibleClouds

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -239,6 +239,9 @@ var AllExceptLocal = AllClouds.NoLocal()
 // AllExceptAWS contains all clouds except AWS.
 var AllExceptAWS = AllClouds.NoAWS()
 
+// OnlyAWS contains only the AWS cloud.
+var OnlyAWS = Clouds(spec.AWS)
+
 // OnlyGCE contains only the GCE cloud.
 var OnlyGCE = Clouds(spec.GCE)
 

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -372,7 +372,7 @@ func (t *TestSpec) CrossCheckTags() {
 	actual.weeklyAWS = t.Suites.Contains(Weekly) && t.CompatibleClouds.Contains(spec.AWS)
 
 	if actual != expected {
-		panic(fmt.Sprintf("CompatibleClouds/Suites inconsistent with Tags\nexpected: %#v\nactual:   %#v\nclouds: %s  suites:%s  tags:%v\n", expected, actual, t.CompatibleClouds, t.Suites, t.Tags))
+		panic(fmt.Sprintf("%q CompatibleClouds/Suites inconsistent with Tags\nexpected: %#v\nactual:   %#v\nclouds: %s  suites:%s  tags:%v\n", t.Name, expected, actual, t.CompatibleClouds, t.Suites, t.Tags))
 	}
 
 	otherSuiteTags := fmt.Sprintf("%v", removeFromSet(t.Tags, "default", "weekly", "aws-weekly", "aws", "owner-"+string(t.Owner)))

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -366,7 +366,11 @@ func (t *TestSpec) CrossCheckTags() {
 	expected.nightlyAWS = matchesAll(t.Tags, []string{"aws"})
 	expected.weeklyAWS = matchesAll(t.Tags, []string{"aws-weekly"})
 
-	actual.nightlyGCE = t.Suites.Contains(Nightly) && t.CompatibleClouds.Contains(spec.GCE)
+	// Unfortunately lots of tests that are are aws only hae tag AWS but use the
+	// AllClouds filter and then skip themselves, so they so they are technically
+	// considered "nightly GCE" even though they will internally skip.
+	// This goes away when we get rid of tags entirely so for now ignore them.
+	actual.nightlyGCE = t.Suites.Contains(Nightly) && (t.CompatibleClouds.Contains(spec.GCE) || t.CompatibleClouds.Contains(spec.AWS))
 	actual.weeklyGCE = t.Suites.Contains(Weekly) && t.CompatibleClouds.Contains(spec.GCE)
 	actual.nightlyAWS = t.Suites.Contains(Nightly) && t.CompatibleClouds.Contains(spec.AWS)
 	actual.weeklyAWS = t.Suites.Contains(Weekly) && t.CompatibleClouds.Contains(spec.AWS)

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -111,11 +111,7 @@ func (r *testRegistryImpl) prepareSpec(spec *registry.TestSpec) error {
 	// weekly tag.
 	const maxTimeout = 18 * time.Hour
 	if spec.Timeout > maxTimeout {
-		var weekly bool
-		if _, ok := spec.Tags["weekly"]; ok {
-			weekly = true
-		}
-		if !weekly {
+		if !spec.Suites.Contains(registry.Weekly) {
 			return fmt.Errorf(
 				"%s: timeout %s exceeds the maximum allowed of %s", spec.Name, spec.Timeout, maxTimeout,
 			)

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -538,7 +538,7 @@ func registerBackup(r registry.Registry) {
 		tags        map[string]struct{}
 	}{
 		{kmsProvider: "GCS", machine: spec.GCE, clouds: registry.AllExceptAWS},
-		{kmsProvider: "AWS", machine: spec.AWS, clouds: registry.AllClouds, tags: registry.Tags("aws")},
+		{kmsProvider: "AWS", machine: spec.AWS, clouds: registry.OnlyAWS, tags: registry.Tags("aws")},
 	} {
 		item := item
 		r.Add(registry.TestSpec{

--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -30,7 +29,7 @@ func registerDisaggRebalance(r registry.Registry) {
 	disaggRebalanceSpec := r.MakeClusterSpec(4)
 	r.Add(registry.TestSpec{
 		Name:              fmt.Sprintf("disagg-rebalance/aws/%s", disaggRebalanceSpec),
-		CompatibleClouds:  registry.AllClouds,
+		CompatibleClouds:  registry.OnlyAWS,
 		Suites:            registry.Suites(registry.Nightly),
 		Tags:              registry.Tags("aws"),
 		Owner:             registry.OwnerStorage,
@@ -39,9 +38,6 @@ func registerDisaggRebalance(r registry.Registry) {
 		EncryptionSupport: registry.EncryptionAlwaysDisabled,
 		Timeout:           1 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Cloud() != spec.AWS {
-				t.Skip("disagg-rebalance is only configured to run on AWS")
-			}
 			s3dir := fmt.Sprintf("s3://%s/disagg-rebalance/%s?AUTH=implicit", testutils.BackupTestingBucketLongTTL(), c.Name())
 			startOpts := option.DefaultStartOptsNoBackups()
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, fmt.Sprintf("--experimental-shared-storage=%s", s3dir))

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -41,9 +41,7 @@ func registerOnlineRestore(r registry.Registry) {
 			hardware:               makeHardwareSpecs(hardwareSpecs{ebsThroughput: 250 /* MB/s */, workloadNode: true}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{nonRevisionHistory: true, version: "v23.1.11"}),
 			timeout:                5 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: 1,
 			skip:                   "used for ad hoc experiments",
 		},
@@ -56,9 +54,7 @@ func registerOnlineRestore(r registry.Registry) {
 				version:            "v23.1.11",
 				workload:           tpceRestore{customers: 500000}}),
 			timeout:                5 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: 1,
 			skip:                   "used for ad hoc experiments",
 		},
@@ -87,9 +83,9 @@ func registerOnlineRestore(r registry.Registry) {
 					// These tests measure performance. To ensure consistent perf,
 					// disable metamorphic encryption.
 					EncryptionSupport: registry.EncryptionAlwaysDisabled,
-					CompatibleClouds:  sp.clouds,
+					CompatibleClouds:  registry.Clouds(sp.backup.cloud),
 					Suites:            sp.suites,
-					Tags:              sp.tags,
+					Tags:              tagsFromSuiteAndCloud(sp.backup.cloud, sp.suites),
 					Skip:              sp.skip,
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -133,9 +133,9 @@ func registerRestore(r registry.Registry) {
 		Benchmark:        true,
 		Cluster:          withPauseSpecs.hardware.makeClusterSpecs(r, withPauseSpecs.backup.cloud),
 		Timeout:          withPauseSpecs.timeout,
-		CompatibleClouds: registry.AllClouds,
+		CompatibleClouds: registry.Clouds(withPauseSpecs.backup.cloud),
 		Suites:           registry.Suites(registry.Nightly),
-		Tags:             registry.Tags("aws"),
+		Tags:             registry.Tags(withPauseSpecs.backup.cloud),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 			rd := makeRestoreDriver(t, c, withPauseSpecs)
@@ -279,9 +279,7 @@ func registerRestore(r registry.Registry) {
 			hardware:               makeHardwareSpecs(hardwareSpecs{ebsThroughput: 250 /* MB/s */}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
 			timeout:                1 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
 		{
@@ -290,7 +288,6 @@ func registerRestore(r registry.Registry) {
 			hardware:               makeHardwareSpecs(hardwareSpecs{}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{cloud: spec.GCE}),
 			timeout:                1 * time.Hour,
-			clouds:                 registry.AllExceptAWS,
 			suites:                 registry.Suites(registry.Nightly),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
@@ -300,7 +297,6 @@ func registerRestore(r registry.Registry) {
 			hardware:               makeHardwareSpecs(hardwareSpecs{mem: spec.Low}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{cloud: spec.GCE}),
 			timeout:                1 * time.Hour,
-			clouds:                 registry.AllExceptAWS,
 			suites:                 registry.Suites(registry.Nightly),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
@@ -310,9 +306,7 @@ func registerRestore(r registry.Registry) {
 			hardware:               makeHardwareSpecs(hardwareSpecs{nodes: 8, ebsThroughput: 250 /* MB/s */}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
 			timeout:                1 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
 		{
@@ -323,9 +317,7 @@ func registerRestore(r registry.Registry) {
 				zones: []string{"us-east-2b", "us-west-2b", "eu-west-1b"}}), // These zones are AWS-specific.
 			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
 			timeout:                90 * time.Minute,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
 		{
@@ -334,9 +326,7 @@ func registerRestore(r registry.Registry) {
 			hardware:               makeHardwareSpecs(hardwareSpecs{cpus: 16, ebsThroughput: 250 /* MB/s */}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
 			timeout:                1 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
 		{
@@ -345,9 +335,7 @@ func registerRestore(r registry.Registry) {
 			hardware:               makeHardwareSpecs(hardwareSpecs{ebsThroughput: 250 /* MB/s */}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
 			timeout:                1 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: 48,
 		},
 		{
@@ -360,9 +348,7 @@ func registerRestore(r registry.Registry) {
 				version:  "v22.2.1",
 				workload: tpceRestore{customers: 500000}}),
 			timeout:                5 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
 		{
@@ -373,9 +359,7 @@ func registerRestore(r registry.Registry) {
 				version:  "v22.2.1",
 				workload: tpceRestore{customers: 2000000}}),
 			timeout:                24 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Weekly),
-			tags:                   registry.Tags("weekly", "aws-weekly"),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
 		{
@@ -395,9 +379,7 @@ func registerRestore(r registry.Registry) {
 				numBackupsInChain: 400,
 			}),
 			timeout: 30 * time.Hour,
-			clouds:  registry.AllClouds,
 			suites:  registry.Suites(registry.Weekly),
-			tags:    registry.Tags("weekly", "aws-weekly"),
 			setUpStmts: []string{
 				`SET CLUSTER SETTING backup.restore_span.target_size = '0'`,
 			},
@@ -413,9 +395,7 @@ func registerRestore(r registry.Registry) {
 				numBackupsInChain: 400,
 			}),
 			timeout: 30 * time.Hour,
-			clouds:  registry.AllExceptAWS,
 			suites:  registry.Suites(registry.Weekly),
-			tags:    registry.Tags("weekly"),
 			setUpStmts: []string{
 				`SET CLUSTER SETTING backup.restore_span.target_size = '0'`,
 			},
@@ -429,9 +409,7 @@ func registerRestore(r registry.Registry) {
 				backupSpecs{workload: tpceRestore{customers: 1000},
 					version: "v22.2.1"}),
 			timeout:                3 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			fingerprint:            8445446819555404274,
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
@@ -442,6 +420,7 @@ func registerRestore(r registry.Registry) {
 	} {
 		sp := sp
 		sp.initTestName()
+
 		r.Add(registry.TestSpec{
 			Name:      sp.testName,
 			Owner:     registry.OwnerDisasterRecovery,
@@ -451,9 +430,9 @@ func registerRestore(r registry.Registry) {
 			// These tests measure performance. To ensure consistent perf,
 			// disable metamorphic encryption.
 			EncryptionSupport: registry.EncryptionAlwaysDisabled,
-			CompatibleClouds:  sp.clouds,
+			CompatibleClouds:  registry.Clouds(sp.backup.cloud),
 			Suites:            sp.suites,
-			Tags:              sp.tags,
+			Tags:              tagsFromSuiteAndCloud(sp.backup.cloud, sp.suites),
 			Skip:              sp.skip,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 
@@ -826,9 +805,7 @@ type restoreSpecs struct {
 	// backup describes the backup fixture from which we will restore.
 	backup  backupSpecs
 	timeout time.Duration
-	clouds  registry.CloudSet
 	suites  registry.SuiteSet
-	tags    map[string]struct{}
 
 	// restoreUptoIncremental specifies the number of incremental backups in the
 	// chain to restore up to.
@@ -906,10 +883,6 @@ func makeRestoreDriver(t test.Test, c cluster.Cluster, sp restoreSpecs) restoreD
 }
 
 func (rd *restoreDriver) prepareCluster(ctx context.Context) {
-	if rd.c.Cloud() != rd.sp.backup.cloud {
-		// For now, only run the test on the cloud provider that also stores the backup.
-		rd.t.Skipf("test configured to run on %s", rd.sp.backup.cloud)
-	}
 	rd.c.Start(ctx, rd.t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), rd.sp.hardware.getCRDBNodes())
 	rd.getAOST(ctx)
 }
@@ -992,6 +965,22 @@ func (rd *restoreDriver) initRestorePerfMetrics(
 			throughput)
 		exportToRoachperf(ctx, rd.t, rd.c, rd.sp.testName, int64(throughput))
 	}
+}
+
+func tagsFromSuiteAndCloud(cloud string, suites registry.SuiteSet) map[string]struct{} {
+	tags := registry.Tags()
+	if cloud == spec.AWS {
+		if suites.Contains(registry.Weekly) {
+			tags = registry.Tags("aws-weekly")
+		} else {
+			tags = registry.Tags("aws")
+		}
+	} else {
+		if suites.Contains(registry.Weekly) {
+			tags = registry.Tags("weekly")
+		}
+	}
+	return tags
 }
 
 // checkFingerprint runs a stripped fingerprint on all user tables in the cluster if the restore


### PR DESCRIPTION
Release note: none.
Epic: none.