### PR TITLE
logictest: add regression test for UDFs with composite types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -736,3 +736,55 @@ statement error unknown function: public.LOWERCASE_HINT_ERROR_EXPLICIT_SCHEMA_FN
 SELECT public."LOWERCASE_HINT_ERROR_EXPLICIT_SCHEMA_FN"();
 
 subtest end
+
+# Regression test for #102227 - it should be possible to use a UDF with a
+# composite type parameter after the type is updated.
+subtest udt_parameter
+
+statement ok
+CREATE TYPE amount AS ("value" INT, "currency" STRING, "minor_units" INT)
+
+statement ok
+CREATE TABLE "purchase" (
+    "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "amount" amount NOT NULL,
+    "timestamp" TIMESTAMP NOT NULL DEFAULT now()
+)
+
+statement ok
+INSERT INTO "purchase" (amount) VALUES
+    ((1000,  'GBP', 100)),
+    ((10,    'YEN', 1)),
+    ((10000, 'BHD', 1000))
+
+statement ok
+CREATE FUNCTION decimal_amount(a amount) RETURNS DECIMAL(10, 2) IMMUTABLE LANGUAGE SQL AS $$
+    SELECT (a)."value" / (a)."minor_units";
+$$
+
+query RT rowsort
+SELECT
+    decimal_amount(amount) AS amount,
+    (amount).currency
+FROM purchase
+----
+10.00  YEN
+10.00  BHD
+10.00  GBP
+
+statement ok
+UPDATE purchase
+SET amount = ((amount).value, (amount).currency, 10000)
+WHERE (amount).currency = 'BHD'
+
+query RT rowsort
+SELECT
+    decimal_amount(amount) AS amount,
+    (amount).currency
+FROM purchase
+----
+10.00  YEN
+1.00   BHD
+10.00  GBP
+
+subtest end


### PR DESCRIPTION
The change in defd7463b9797453d22b519b12e691bac005f3af also fixed another (possibly more prominent) issue, where a UDF couldn't be used in some cases.

fixes https://github.com/cockroachdb/cockroach/issues/102227
Release note: None