### PR TITLE
sql,opt: add hint for STRAIGHT join

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1430,6 +1430,7 @@ unreserved_keyword ::=
 	| 'STORE'
 	| 'STORED'
 	| 'STORING'
+	| 'STRAIGHT'
 	| 'STREAM'
 	| 'STRICT'
 	| 'SUBSCRIPTION'
@@ -4057,6 +4058,7 @@ bare_label_keywords ::=
 	| 'STORE'
 	| 'STORED'
 	| 'STORING'
+	| 'STRAIGHT'
 	| 'STREAM'
 	| 'STRICT'
 	| 'STRING'
@@ -4167,6 +4169,7 @@ opt_join_hint ::=
 	| 'MERGE'
 	| 'LOOKUP'
 	| 'INVERTED'
+	| 'STRAIGHT'
 	| 
 
 join_type ::=

--- a/pkg/sql/opt/exec/execbuilder/testdata/straight_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/straight_join
@@ -1,0 +1,273 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE t1 (x INT, PRIMARY KEY (x))
+
+statement ok
+CREATE TABLE t2 (x INT, y INT, z INT, PRIMARY KEY (x), INDEX idx_y (y))
+
+# Set up the statistics as if t1 is much smaller than t2.
+statement ok
+ALTER TABLE t1 INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 100,
+    "distinct_count": 100,
+    "null_count": 0
+  }
+]'
+
+statement ok
+ALTER TABLE t2 INJECT STATISTICS '[
+  {
+    "columns": ["y"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000,
+    "null_count": 0
+  },
+  {
+    "columns": ["z"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000,
+    "null_count": 0
+  }
+]'
+
+# --------------------------------------------------
+# INNER JOIN
+# --------------------------------------------------
+
+# The best plan should be a lookup join into t2 (right).
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t1 INNER JOIN t2 ON t1.x = t2.y
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (x, x, y, z)
+│ estimated row count: 100
+│ table: t2@t2_pkey
+│ equality: (x) = (x)
+│ equality cols are key
+│
+└── • lookup join (inner)
+    │ columns: (x, x, y)
+    │ estimated row count: 100
+    │ table: t2@idx_y
+    │ equality: (x) = (y)
+    │
+    └── • scan
+          columns: (x)
+          estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+          table: t1@t1_pkey
+          spans: FULL SCAN
+
+# Should not change the plan, as the table on the right side of the join is still t2.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t1 INNER STRAIGHT JOIN t2 ON t1.x = t2.y
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (x, x, y, z)
+│ estimated row count: 100
+│ table: t2@t2_pkey
+│ equality: (x) = (x)
+│ equality cols are key
+│
+└── • lookup join (inner)
+    │ columns: (x, x, y)
+    │ estimated row count: 100
+    │ table: t2@idx_y
+    │ equality: (x) = (y)
+    │
+    └── • scan
+          columns: (x)
+          estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+          table: t1@t1_pkey
+          spans: FULL SCAN
+
+# Now, the best plan (lookup join into t2) should no longer be picked as t1 is now on the right.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t2 INNER STRAIGHT JOIN t1 ON t1.x = t2.y
+----
+distribution: local
+vectorized: true
+·
+• hash join (inner)
+│ columns: (x, y, z, x)
+│ estimated row count: 100
+│ equality: (y) = (x)
+│ right cols are key
+│
+├── • scan
+│     columns: (x, y, z)
+│     estimated row count: 10,000 (100% of the table; stats collected <hidden> ago)
+│     table: t2@t2_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (x)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: t1@t1_pkey
+      spans: FULL SCAN
+
+
+# The best plan should be a hash join into t1 (smaller table).
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t1 INNER JOIN t2 ON t1.x = t2.z
+----
+distribution: local
+vectorized: true
+·
+• hash join (inner)
+│ columns: (x, x, y, z)
+│ estimated row count: 100
+│ equality: (z) = (x)
+│ right cols are key
+│
+├── • scan
+│     columns: (x, y, z)
+│     estimated row count: 10,000 (100% of the table; stats collected <hidden> ago)
+│     table: t2@t2_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (x)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: t1@t1_pkey
+      spans: FULL SCAN
+
+# Should not change the plan, as the table on the right side of the join is t1.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t2 INNER STRAIGHT JOIN t1 ON t1.x = t2.z
+----
+distribution: local
+vectorized: true
+·
+• hash join (inner)
+│ columns: (x, y, z, x)
+│ estimated row count: 100
+│ equality: (z) = (x)
+│ right cols are key
+│
+├── • scan
+│     columns: (x, y, z)
+│     estimated row count: 10,000 (100% of the table; stats collected <hidden> ago)
+│     table: t2@t2_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (x)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: t1@t1_pkey
+      spans: FULL SCAN
+
+# Now, the best plan (hash join into t1) should no longer be picked as t2 is now on the right.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t1 INNER STRAIGHT JOIN t2 ON t1.x = t2.z
+----
+distribution: local
+vectorized: true
+·
+• hash join (inner)
+│ columns: (x, x, y, z)
+│ estimated row count: 100
+│ equality: (x) = (z)
+│ left cols are key
+│
+├── • scan
+│     columns: (x)
+│     estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+│     table: t1@t1_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (x, y, z)
+      estimated row count: 10,000 (100% of the table; stats collected <hidden> ago)
+      table: t2@t2_pkey
+      spans: FULL SCAN
+
+# --------------------------------------------------
+# LEFT JOIN
+# --------------------------------------------------
+
+# The best plan should be a (commuted) right outer hash join into t1.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t1 LEFT JOIN t2 ON t1.x = t2.z
+----
+distribution: local
+vectorized: true
+·
+• hash join (right outer)
+│ columns: (x, x, y, z)
+│ estimated row count: 100
+│ equality: (z) = (x)
+│ right cols are key
+│
+├── • scan
+│     columns: (x, y, z)
+│     estimated row count: 10,000 (100% of the table; stats collected <hidden> ago)
+│     table: t2@t2_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (x)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: t1@t1_pkey
+      spans: FULL SCAN
+
+# Now, the best plan should no longer be picked, as we're forcing the join order.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t1 LEFT STRAIGHT JOIN t2 ON t1.x = t2.z
+----
+distribution: local
+vectorized: true
+·
+• hash join (left outer)
+│ columns: (x, x, y, z)
+│ estimated row count: 100
+│ equality: (x) = (z)
+│ left cols are key
+│
+├── • scan
+│     columns: (x)
+│     estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+│     table: t1@t1_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (x, y, z)
+      estimated row count: 10,000 (100% of the table; stats collected <hidden> ago)
+      table: t2@t2_pkey
+      spans: FULL SCAN
+
+# Should produce the same plan except with a right outer hash join.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t1 RIGHT STRAIGHT JOIN t2 ON t1.x = t2.z
+----
+distribution: local
+vectorized: true
+·
+• hash join (right outer)
+│ columns: (x, x, y, z)
+│ estimated row count: 10,000
+│ equality: (x) = (z)
+│ left cols are key
+│
+├── • scan
+│     columns: (x)
+│     estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+│     table: t1@t1_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      columns: (x, y, z)
+      estimated row count: 10,000 (100% of the table; stats collected <hidden> ago)
+      table: t2@t2_pkey
+      spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -587,6 +587,13 @@ func TestExecBuild_srfs(
 	runExecBuildLogicTest(t, "srfs")
 }
 
+func TestExecBuild_straight_join(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "straight_join")
+}
+
 func TestExecBuild_subquery(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -518,6 +518,11 @@ const (
 
 	// AllowOnlyMergeJoin has all "disallow" flags set except DisallowMergeJoin.
 	AllowOnlyMergeJoin = disallowAll ^ DisallowMergeJoin
+
+	// AllowAllJoinsIntoRight has all "disallow" flags set except
+	// DisallowHashJoinStoreRight, DisallowLookupJoinIntoRight,
+	// DisallowInvertedJoinIntoRight, and DisallowMergeJoin.
+	AllowAllJoinsIntoRight = disallowAll ^ DisallowHashJoinStoreRight ^ DisallowLookupJoinIntoRight ^ DisallowInvertedJoinIntoRight ^ DisallowMergeJoin
 )
 
 var joinFlagStr = map[JoinFlags]string{

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -94,6 +94,10 @@ func (b *Builder) buildJoin(
 		telemetry.Inc(sqltelemetry.MergeJoinHintUseCounter)
 		flags = memo.AllowOnlyMergeJoin
 
+	case tree.AstStraight:
+		telemetry.Inc(sqltelemetry.StraightJoinHintUseCounter)
+		flags = memo.AllowAllJoinsIntoRight
+
 	default:
 		panic(pgerror.Newf(
 			pgcode.FeatureNotSupported, "join hint %s not supported", join.Hint,

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -2437,6 +2437,21 @@ project
            └── x:1 = y:5
 
 build
+SELECT * FROM onecolumn AS a(x) INNER STRAIGHT JOIN onecolumn AS b(y) ON a.x = b.y
+----
+project
+ ├── columns: x:1!null y:5!null
+ └── inner-join (hash)
+      ├── columns: x:1!null a.rowid:2!null a.crdb_internal_mvcc_timestamp:3 a.tableoid:4 y:5!null b.rowid:6!null b.crdb_internal_mvcc_timestamp:7 b.tableoid:8
+      ├── flags: disallow hash join (store left side) and lookup join (into left side) and inverted join (into left side)
+      ├── scan onecolumn [as=a]
+      │    └── columns: x:1 a.rowid:2!null a.crdb_internal_mvcc_timestamp:3 a.tableoid:4
+      ├── scan onecolumn [as=b]
+      │    └── columns: y:5 b.rowid:6!null b.crdb_internal_mvcc_timestamp:7 b.tableoid:8
+      └── filters
+           └── x:1 = y:5
+
+build
 SELECT * FROM onecolumn AS a NATURAL LEFT LOOKUP JOIN onecolumn as b USING(x)
 ----
 error (42601): at or near "using": syntax error

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -121,6 +121,75 @@ inner-join (hash)
  └── filters
       └── k:1 = x:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
 
+# Verify that if we specify a straight join, huge cost is given to 
+# commuted joins so that non-commuted joins are picked as 
+# the best plan by the optimizer.
+exploretrace rule=CommuteLeftJoin format=(hide-all,show-cost)
+SELECT k, x FROM b LEFT STRAIGHT JOIN a ON k=x
+----
+----
+================================================================================
+CommuteLeftJoin
+================================================================================
+Source expression:
+  left-join (hash)
+   ├── flags: disallow hash join (store left side) and lookup join (into left side) and inverted join (into left side)
+   ├── cost: 2187.10625
+   ├── scan b
+   │    └── cost: 1068.42
+   ├── scan a
+   │    └── cost: 1078.52
+   └── filters
+        └── k = x
+
+New expression 1 of 1:
+  right-join (hash)
+   ├── flags: disallow hash join (store right side) and lookup join (into right side) and inverted join (into right side)
+   ├── cost: 1e+100
+   ├── scan a
+   │    └── cost: 1078.52
+   ├── scan b
+   │    └── cost: 1068.42
+   └── filters
+        └── k = x
+----
+----
+
+# CommuteRightJoin is a normalization rule and thus does not
+# show up in the exploretrace output. But we can verify that
+# huge cost is given to commuted joins from one of the 
+# source expressions (which was commuted).
+exploretrace rule=CommuteLeftJoin format=(hide-all,show-cost)
+SELECT k, x FROM b RIGHT STRAIGHT JOIN a ON k=x
+----
+----
+================================================================================
+CommuteLeftJoin
+================================================================================
+Source expression:
+  left-join (hash)
+   ├── flags: disallow hash join (store right side) and lookup join (into right side) and inverted join (into right side)
+   ├── cost: 1e+100
+   ├── scan a
+   │    └── cost: 1078.52
+   ├── scan b
+   │    └── cost: 1068.42
+   └── filters
+        └── k = x
+
+New expression 1 of 1:
+  right-join (hash)
+   ├── flags: disallow hash join (store left side) and lookup join (into left side) and inverted join (into left side)
+   ├── cost: 2187.10625
+   ├── scan b
+   │    └── cost: 1068.42
+   ├── scan a
+   │    └── cost: 1078.52
+   └── filters
+        └── k = x
+----
+----
+
 # Verify that we pick inverted join if we force it.
 opt
 SELECT * FROM g AS g1 INNER INVERTED JOIN g AS g2 ON ST_Contains(g1.geom, g2.geom)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -3488,3 +3488,132 @@ inner-join (merge)
 exploretrace rule=ReorderJoins set=reorder_joins_limit=0
 SELECT * FROM bx INNER JOIN cy ON b = c;
 ----
+
+# Tests for straight join - join reordering should not be
+# explored when the STRAIGHT keyword is present.
+exec-ddl
+CREATE TABLE straight_join1 (x INT, PRIMARY KEY (x));
+----
+
+exec-ddl
+CREATE TABLE straight_join2 (x INT, y INT, PRIMARY KEY (x));
+----
+
+exec-ddl
+CREATE TABLE straight_join3 (x INT, z INT, PRIMARY KEY (x));
+----
+
+reorderjoins format=hide-all
+SELECT * FROM straight_join1 INNER STRAIGHT JOIN straight_join2 ON straight_join1.x = straight_join2.y
+----
+Joins Considered: 0
+================================================================================
+Final Plan
+================================================================================
+inner-join (hash)
+ ├── flags: disallow hash join (store left side) and lookup join (into left side) and inverted join (into left side)
+ ├── scan straight_join1
+ ├── scan straight_join2
+ └── filters
+      └── straight_join1.x = y
+
+reorderjoins format=hide-all
+SELECT * FROM straight_join1 LEFT STRAIGHT JOIN straight_join2 ON straight_join1.x = straight_join2.y
+----
+Joins Considered: 0
+================================================================================
+Final Plan
+================================================================================
+left-join (hash)
+ ├── flags: disallow hash join (store left side) and lookup join (into left side) and inverted join (into left side)
+ ├── scan straight_join1
+ ├── scan straight_join2
+ └── filters
+      └── straight_join1.x = y
+
+reorderjoins format=hide-all
+SELECT * FROM straight_join1 RIGHT STRAIGHT JOIN straight_join2 ON straight_join1.x = straight_join2.y
+----
+Joins Considered: 0
+================================================================================
+Final Plan
+================================================================================
+right-join (hash)
+ ├── flags: disallow hash join (store left side) and lookup join (into left side) and inverted join (into left side)
+ ├── scan straight_join1
+ ├── scan straight_join2
+ └── filters
+      └── straight_join1.x = y
+
+# Only 2 joins are considered (instead of 8) when the STRAIGHT hint is present in one join.
+reorderjoins format=hide-all
+SELECT * 
+FROM straight_join1
+INNER STRAIGHT JOIN straight_join2 ON straight_join1.x = straight_join2.y
+INNER JOIN straight_join3 ON straight_join1.x = straight_join3.z
+----
+--------------------------------------------------------------------------------
+Join Tree #1
+--------------------------------------------------------------------------------
+  inner-join (hash)
+   ├── inner-join (hash)
+   │    ├── flags: disallow hash join (store left side) and lookup join (into left side) and inverted join (into left side)
+   │    ├── scan straight_join1
+   │    ├── scan straight_join2
+   │    └── filters
+   │         └── straight_join1.x = y
+   ├── scan straight_join3
+   └── filters
+        └── straight_join1.x = z
+Vertexes
+  A:
+    inner-join (hash)
+     ├── flags: disallow hash join (store left side) and lookup join (into left side) and inverted join (into left side)
+     ├── scan straight_join1
+     ├── scan straight_join2
+     └── filters
+          └── straight_join1.x = y
+  B:
+    scan straight_join3
+Edges
+  straight_join1.x = z [inner, ses=AB, tes=AB, rules=()]
+Joining AB
+  A B [inner, refs=AB]
+  B A [inner, refs=AB]
+Joins Considered: 2
+================================================================================
+Final Plan
+================================================================================
+inner-join (hash)
+ ├── scan straight_join3
+ ├── inner-join (hash)
+ │    ├── flags: disallow hash join (store left side) and lookup join (into left side) and inverted join (into left side)
+ │    ├── scan straight_join1
+ │    ├── scan straight_join2
+ │    └── filters
+ │         └── straight_join1.x = y
+ └── filters
+      └── straight_join1.x = z
+
+# No joins are considered when the STRAIGHT hint is present in both joins.
+reorderjoins format=hide-all
+SELECT * 
+FROM straight_join1
+INNER STRAIGHT JOIN straight_join2 ON straight_join1.x = straight_join2.y
+INNER STRAIGHT JOIN straight_join3 ON straight_join1.x = straight_join3.z
+----
+Joins Considered: 0
+================================================================================
+Final Plan
+================================================================================
+inner-join (hash)
+ ├── flags: disallow hash join (store left side) and lookup join (into left side) and inverted join (into left side)
+ ├── inner-join (hash)
+ │    ├── flags: disallow hash join (store left side) and lookup join (into left side) and inverted join (into left side)
+ │    ├── scan straight_join1
+ │    ├── scan straight_join2
+ │    └── filters
+ │         └── straight_join1.x = y
+ ├── scan straight_join3
+ └── filters
+      └── straight_join1.x = z

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1000,7 +1000,7 @@ func (u *sqlSymUnion) showFingerprintOptions() *tree.ShowFingerprintOptions {
 %token <str> SHARE SHARED SHOW SIMILAR SIMPLE SIZE SKIP SKIP_LOCALITIES_CHECK SKIP_MISSING_FOREIGN_KEYS
 %token <str> SKIP_MISSING_SEQUENCES SKIP_MISSING_SEQUENCE_OWNERS SKIP_MISSING_VIEWS SKIP_MISSING_UDFS SMALLINT SMALLSERIAL
 %token <str> SNAPSHOT SOME SPLIT SQL SQLLOGIN
-%token <str> STABLE START STATE STATISTICS STATUS STDIN STDOUT STOP STREAM STRICT STRING STORAGE STORE STORED STORING SUBSTRING SUPER
+%token <str> STABLE START STATE STATISTICS STATUS STDIN STDOUT STOP STRAIGHT STREAM STRICT STRING STORAGE STORE STORED STORING SUBSTRING SUPER
 %token <str> SUPPORT SURVIVE SURVIVAL SYMMETRIC SYNTAX SYSTEM SQRT SUBSCRIPTION STATEMENTS
 
 %token <str> TABLE TABLES TABLESPACE TEMP TEMPLATE TEMPORARY TENANT TENANT_NAME TENANTS TESTING_RELOCATE TEXT THEN
@@ -13466,7 +13466,7 @@ opt_index_flags:
 //   '{' FORCE_ZIGZAG = <idxname> [, ...]  '}'
 //
 // Join types:
-//   { INNER | { LEFT | RIGHT | FULL } [OUTER] } [ { HASH | MERGE | LOOKUP | INVERTED } ]
+//   { INNER | { LEFT | RIGHT | FULL } [OUTER] } [ { HASH | MERGE | LOOKUP | INVERTED | STRAIGHT } ]
 //
 // %SeeAlso: WEBDOCS/table-expressions.html
 table_ref:
@@ -13790,6 +13790,7 @@ join_outer:
 //  - INVERTED forces an inverted join into the right side; the right side must
 //    be a table with a suitable inverted index. `INVERTED` can only be used
 //    with INNER and LEFT joins (though this is not enforced by the syntax).
+//  - STRAIGHT forces the join order, but not the algorithm.
 //  - If it is not possible to use the algorithm in the hint, an error is
 //    returned.
 //  - When a join hint is specified, the two tables will not be reordered
@@ -13810,6 +13811,10 @@ opt_join_hint:
 | INVERTED
   {
     $$ = tree.AstInverted
+  }
+| STRAIGHT
+  {
+    $$ = tree.AstStraight
   }
 | /* EMPTY */
   {
@@ -17284,6 +17289,7 @@ unreserved_keyword:
 | STORE
 | STORED
 | STORING
+| STRAIGHT
 | STREAM
 | STRICT
 | SUBSCRIPTION
@@ -17848,6 +17854,7 @@ bare_label_keywords:
 | STORE
 | STORED
 | STORING
+| STRAIGHT
 | STREAM
 | STRICT
 | STRING

--- a/pkg/sql/parser/testdata/select_clauses
+++ b/pkg/sql/parser/testdata/select_clauses
@@ -2588,6 +2588,14 @@ SELECT a FROM t1 INNER JOIN t2 ON a = b -- literals removed
 SELECT _ FROM _ INNER JOIN _ ON _ = _ -- identifiers removed
 
 parse
+SELECT a FROM t1 INNER STRAIGHT JOIN t2 ON a = b
+----
+SELECT a FROM t1 INNER STRAIGHT JOIN t2 ON a = b
+SELECT (a) FROM t1 INNER STRAIGHT JOIN t2 ON ((a) = (b)) -- fully parenthesized
+SELECT a FROM t1 INNER STRAIGHT JOIN t2 ON a = b -- literals removed
+SELECT _ FROM _ INNER STRAIGHT JOIN _ ON _ = _ -- identifiers removed
+
+parse
 SELECT a FROM t1 INNER HASH JOIN t2 ON a = b
 ----
 SELECT a FROM t1 INNER HASH JOIN t2 ON a = b
@@ -2642,6 +2650,14 @@ SELECT a FROM t1 INNER JOIN t2 USING (a)
 SELECT (a) FROM t1 INNER JOIN t2 USING (a) -- fully parenthesized
 SELECT a FROM t1 INNER JOIN t2 USING (a) -- literals removed
 SELECT _ FROM _ INNER JOIN _ USING (_) -- identifiers removed
+
+parse
+SELECT a FROM t1 INNER STRAIGHT JOIN t2 USING (a)
+----
+SELECT a FROM t1 INNER STRAIGHT JOIN t2 USING (a)
+SELECT (a) FROM t1 INNER STRAIGHT JOIN t2 USING (a) -- fully parenthesized
+SELECT a FROM t1 INNER STRAIGHT JOIN t2 USING (a) -- literals removed
+SELECT _ FROM _ INNER STRAIGHT JOIN _ USING (_) -- identifiers removed
 
 parse
 SELECT a FROM t1 FULL JOIN t2 USING (a)

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -637,6 +637,7 @@ const (
 	AstLookup   = "LOOKUP"
 	AstMerge    = "MERGE"
 	AstInverted = "INVERTED"
+	AstStraight = "STRAIGHT"
 )
 
 // Format implements the NodeFormatter interface.

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -65,6 +65,10 @@ var LookupJoinHintUseCounter = telemetry.GetCounterOnce("sql.plan.hints.lookup-j
 // inverted join via a query hint.
 var InvertedJoinHintUseCounter = telemetry.GetCounterOnce("sql.plan.hints.inverted-join")
 
+// StraightJoinHintUseCounter is to be incremented whenever a query specifies a
+// straight join via a query hint.
+var StraightJoinHintUseCounter = telemetry.GetCounterOnce("sql.plan.hints.straight-join")
+
 // IndexHintUseCounter is to be incremented whenever a query specifies an index
 // hint. Incremented whenever one of the more specific variants below is
 // incremented.

--- a/pkg/sql/testdata/telemetry/planning
+++ b/pkg/sql/testdata/telemetry/planning
@@ -80,6 +80,11 @@ SELECT a FROM (VALUES ('{"a": "b"}'::jsonb)) AS a(z) INNER INVERTED JOIN y ON b 
 sql.plan.hints.inverted-join
 
 feature-usage
+SELECT x FROM (VALUES (1)) AS a(x) INNER STRAIGHT JOIN (VALUES (1)) AS b(y) ON x = y
+----
+sql.plan.hints.straight-join
+
+feature-usage
 SELECT * FROM x@x_pkey
 ----
 sql.plan.hints.index


### PR DESCRIPTION
Our current join hints (a INNER HASH JOIN b, a LEFT LOOKUP JOIN b, etc) fixes both the join order and the join algorithm. This commit adds the syntax and support for hinting the join order without hinting the join algorithm. This will be useful for the (few) cases where the optimizer processes the tables in a suboptimal order.

Resolves: #115308

Release note (sql change): It is now possible to hint to the optimizer that it should plan a straight join by using the syntax `... INNER STRAIGHT JOIN ...`. If the hint is provided, the optimizer will now fix the join order as given in the query, even if it estimates that a different plan using join reordering would have a lower cost.