### PR TITLE
kvserver: filter rangefeed events based on OmitInRangefeeds flag

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -140,7 +140,7 @@ func TestKVFeed(t *testing.T) {
 		tf := newRawTableFeed(tc.descs, tc.initialHighWater)
 		f := newKVFeed(buf, tc.spans, tc.checkpoint, hlc.Timestamp{},
 			tc.schemaChangeEvents, tc.schemaChangePolicy,
-			tc.needsInitialScan, tc.withDiff,
+			tc.needsInitialScan, tc.withDiff, true, /* withFiltering */
 			tc.initialHighWater, tc.endTime,
 			codec,
 			tf, sf, rangefeedFactory(ref.run), bufferFactory,

--- a/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
@@ -30,6 +30,7 @@ type rangeFeedConfig struct {
 	Frontier      hlc.Timestamp
 	Spans         []kvcoord.SpanTimePair
 	WithDiff      bool
+	WithFiltering bool
 	RangeObserver func(fn kvcoord.ForEachRangeFn)
 	Knobs         TestingKnobs
 	UseMux        bool
@@ -81,6 +82,9 @@ func (p rangefeedFactory) Run(ctx context.Context, sink kvevent.Writer, cfg rang
 	}
 	if cfg.WithDiff {
 		rfOpts = append(rfOpts, kvcoord.WithDiff())
+	}
+	if cfg.WithFiltering {
+		rfOpts = append(rfOpts, kvcoord.WithFiltering())
 	}
 	if cfg.RangeObserver != nil {
 		rfOpts = append(rfOpts, kvcoord.WithRangeObserver(cfg.RangeObserver))

--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -275,7 +275,7 @@ func (s *activeMuxRangeFeed) start(ctx context.Context, m *rangefeedMuxer) error
 
 		for !s.transport.IsExhausted() {
 			args := makeRangeFeedRequest(
-				s.Span, s.token.Desc().RangeID, m.cfg.overSystemTable, s.startAfter, m.cfg.withDiff)
+				s.Span, s.token.Desc().RangeID, m.cfg.overSystemTable, s.startAfter, m.cfg.withDiff, m.cfg.withFiltering)
 			args.Replica = s.transport.NextReplica()
 			args.StreamID = streamID
 			s.ReplicaDescriptor = args.Replica

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -96,6 +96,7 @@ type rangeFeedConfig struct {
 	useMuxRangeFeed bool
 	overSystemTable bool
 	withDiff        bool
+	withFiltering   bool
 	rangeObserver   func(ForEachRangeFn)
 
 	knobs struct {
@@ -142,6 +143,14 @@ func WithSystemTablePriority() RangeFeedOption {
 func WithDiff() RangeFeedOption {
 	return optionFunc(func(c *rangeFeedConfig) {
 		c.withDiff = true
+	})
+}
+
+// WithFiltering opts into rangefeed filtering. When rangefeed filtering is on,
+// any transactional write with OmitInRangefeeds = true will be dropped.
+func WithFiltering() RangeFeedOption {
+	return optionFunc(func(c *rangeFeedConfig) {
+		c.withFiltering = true
 	})
 }
 
@@ -770,6 +779,7 @@ func makeRangeFeedRequest(
 	isSystemRange bool,
 	startAfter hlc.Timestamp,
 	withDiff bool,
+	withFiltering bool,
 ) kvpb.RangeFeedRequest {
 	admissionPri := admissionpb.BulkNormalPri
 	if isSystemRange {
@@ -781,7 +791,8 @@ func makeRangeFeedRequest(
 			Timestamp: startAfter,
 			RangeID:   rangeID,
 		},
-		WithDiff: withDiff,
+		WithDiff:      withDiff,
+		WithFiltering: withFiltering,
 		AdmissionHeader: kvpb.AdmissionHeader{
 			// NB: AdmissionHeader is used only at the start of the range feed
 			// stream since the initial catch-up scan is expensive.
@@ -839,7 +850,7 @@ func (ds *DistSender) singleRangeFeed(
 		cancelFeed()
 	}()
 
-	args := makeRangeFeedRequest(span, desc.RangeID, cfg.overSystemTable, startAfter, cfg.withDiff)
+	args := makeRangeFeedRequest(span, desc.RangeID, cfg.overSystemTable, startAfter, cfg.withDiff, cfg.withFiltering)
 	transport, err := newTransportForRange(ctx, desc, ds)
 	if err != nil {
 		return args.Timestamp, err

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3113,6 +3113,11 @@ message RangeFeedRequest {
   // When CloseStream is set, only the StreamID must be set, and
   // other fields (such as Span) are ignored.
   bool close_stream = 6;
+  // WithFiltering specifies if the rangefeed server should respect the
+  // OmitInRangefeeds flag of a transactional write. If WithFiltering = true and
+  // OmitInRangefeeds = true, the write will not be emitted on the rangefeed.
+  // WithFiltering should NOT be set for system-table rangefeeds.
+  bool with_filtering = 7;
 }
 
 // RangeFeedValue is a variant of RangeFeedEvent that represents an update to

--- a/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
@@ -64,6 +64,7 @@ func ConditionalPut(
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		Category:                       storage.BatchEvalReadCategory,
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_delete.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete.go
@@ -37,6 +37,7 @@ func Delete(
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		Category:                       storage.BatchEvalReadCategory,
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -255,6 +255,7 @@ func DeleteRange(
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		Category:                       storage.BatchEvalReadCategory,
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_increment.go
+++ b/pkg/kv/kvserver/batcheval/cmd_increment.go
@@ -38,6 +38,7 @@ func Increment(
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		Category:                       storage.BatchEvalReadCategory,
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_init_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_init_put.go
@@ -39,6 +39,7 @@ func InitPut(
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		Category:                       storage.BatchEvalReadCategory,
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_put.go
@@ -60,6 +60,7 @@ func Put(
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		Category:                       storage.BatchEvalReadCategory,
 	}

--- a/pkg/kv/kvserver/batcheval/declare.go
+++ b/pkg/kv/kvserver/batcheval/declare.go
@@ -216,4 +216,5 @@ type CommandArgs struct {
 	Concurrency           *concurrency.Guard
 	Uncertainty           uncertainty.Interval
 	DontInterleaveIntents bool
+	OmitInRangefeeds      bool
 }

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -103,6 +103,16 @@ func incrementArgs(key roachpb.Key, inc int64) *kvpb.IncrementRequest {
 	}
 }
 
+// delRangeArgs returns a DeleteRangeRequest for the specified span.
+func delRangeArgs(
+	key roachpb.Key, endKey roachpb.Key, useRangeTombstone bool,
+) *kvpb.DeleteRangeRequest {
+	return &kvpb.DeleteRangeRequest{
+		RequestHeader:     kvpb.RequestHeader{Key: key, EndKey: endKey},
+		UseRangeTombstone: useRangeTombstone,
+	}
+}
+
 func truncateLogArgs(index kvpb.RaftIndex, rangeID roachpb.RangeID) *kvpb.TruncateLogRequest {
 	return &kvpb.TruncateLogRequest{
 		Index:   index,

--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -140,7 +140,7 @@ type outputEventFn func(e *kvpb.RangeFeedEvent) error
 // TODO(sumeer): ctx is not used for SeekGE and Next. Fix by adding a method
 // to SimpleMVCCIterator to replace the context.
 func (i *CatchUpIterator) CatchUpScan(
-	ctx context.Context, outputFn outputEventFn, withDiff bool,
+	ctx context.Context, outputFn outputEventFn, withDiff bool, withFiltering bool,
 ) error {
 	var a bufalloc.ByteAllocator
 	// MVCCIterator will encounter historical values for each key in
@@ -320,20 +320,30 @@ func (i *CatchUpIterator) CatchUpScan(
 			if withDiff {
 				// Update the last version with its previous value (this version).
 				if l := len(reorderBuf) - 1; l >= 0 {
-					if reorderBuf[l].Val.PrevValue.IsPresent() {
-						return errors.AssertionFailedf("unexpected previous value %s for key %s",
-							reorderBuf[l].Val.PrevValue, key)
-					}
-					// However, don't emit a value if an MVCC range tombstone existed
-					// between this value and the next one. The RangeKeysIgnoringTime()
-					// call is cheap, no need for caching.
-					rangeKeys := i.RangeKeysIgnoringTime()
-					if rangeKeys.IsEmpty() || !rangeKeys.HasBetween(ts, reorderBuf[l].Val.Value.Timestamp) {
-						// TODO(sumeer): find out if it is deliberate that we are not populating
-						// PrevValue.Timestamp.
-						reorderBuf[l].Val.PrevValue.RawBytes = val
+					// The previous value may have already been set by an event with
+					// OmitInRangefeeds = true (and withFiltering = true). That event
+					// is not in reorderBuf because we want to filter it out of the
+					// rangefeed, but we still want to keep it as a previous value.
+					if !reorderBuf[l].Val.PrevValue.IsPresent() {
+						// However, don't emit a value if an MVCC range tombstone existed
+						// between this value and the next one. The RangeKeysIgnoringTime()
+						// call is cheap, no need for caching.
+						rangeKeys := i.RangeKeysIgnoringTime()
+						if rangeKeys.IsEmpty() || !rangeKeys.HasBetween(ts, reorderBuf[l].Val.Value.Timestamp) {
+							// TODO(sumeer): find out if it is deliberate that we are not populating
+							// PrevValue.Timestamp.
+							reorderBuf[l].Val.PrevValue.RawBytes = val
+						}
 					}
 				}
+			}
+
+			// If this value has the flag to omit from rangefeeds, and if the consumer
+			// has opted into filtering, move to the next version for this the key
+			// (which may or may not have OmitInRangefeeds = true).
+			if mvccVal.OmitInRangefeeds && withFiltering {
+				i.Next()
+				continue
 			}
 
 			if !ignore {

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -59,7 +59,7 @@ func runCatchUpBenchmark(b *testing.B, emk engineMaker, opts benchOptions) (numE
 			err = iter.CatchUpScan(ctx, func(*kvpb.RangeFeedEvent) error {
 				counter++
 				return nil
-			}, opts.withDiff)
+			}, opts.withDiff, false /* withFiltering */)
 			if err != nil {
 				b.Fatalf("failed catchUp scan: %+v", err)
 			}

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
@@ -58,12 +58,17 @@ func TestCatchupScan(t *testing.T) {
 		testValue2 = roachpb.MakeValueFromString("val2")
 		testValue3 = roachpb.MakeValueFromString("val3")
 		testValue4 = roachpb.MakeValueFromString("val4")
+		testValue5 = roachpb.MakeValueFromString("val5")
+		testValue6 = roachpb.MakeValueFromString("val6")
 
 		ts1 = hlc.Timestamp{WallTime: 1, Logical: 0}
 		ts2 = hlc.Timestamp{WallTime: 2, Logical: 0}
 		ts3 = hlc.Timestamp{WallTime: 3, Logical: 0}
 		ts4 = hlc.Timestamp{WallTime: 4, Logical: 0}
 		ts5 = hlc.Timestamp{WallTime: 4, Logical: 0}
+		ts6 = hlc.Timestamp{WallTime: 5, Logical: 0}
+		ts7 = hlc.Timestamp{WallTime: 6, Logical: 0}
+		ts8 = hlc.Timestamp{WallTime: 7, Logical: 0}
 	)
 
 	makeTxn := func(key roachpb.Key, val roachpb.Value, ts hlc.Timestamp,
@@ -86,65 +91,112 @@ func TestCatchupScan(t *testing.T) {
 	makeKTV := func(key roachpb.Key, ts hlc.Timestamp, value roachpb.Value) storage.MVCCKeyValue {
 		return storage.MVCCKeyValue{Key: storage.MVCCKey{Key: key, Timestamp: ts}, Value: value.RawBytes}
 	}
-	// testKey1 has an intent and provisional value that will be skipped. Both
-	// testKey1 and testKey2 have a value that is older than what we need with
-	// the catchup scan, but will be read if a diff is desired.
-	kv1_1_1 := makeKTV(testKey1, ts1, testValue1)
-	kv1_2_2 := makeKTV(testKey1, ts2, testValue2)
-	kv1_3_3 := makeKTV(testKey1, ts3, testValue3)
-	kv1_4_4 := makeKTV(testKey1, ts4, testValue4)
-	txn, val := makeTxn(testKey1, testValue4, ts4)
-	kv2_1_1 := makeKTV(testKey2, ts1, testValue1)
-	kv2_2_2 := makeKTV(testKey2, ts2, testValue2)
-	kv2_5_3 := makeKTV(testKey2, ts5, testValue3)
+	testutils.RunTrueAndFalse(t, "omitInRangefeeds", func(t *testing.T, omitInRangefeeds bool) {
+		// testKey1 has an intent and provisional value that will be skipped. Both
+		// testKey1 and testKey2 have a value that is older than what we need with
+		// the catchup scan, but will be read if a diff is desired.
+		kv1_1_1 := makeKTV(testKey1, ts1, testValue1)
+		kv1_2_2 := makeKTV(testKey1, ts2, testValue2)
+		kv1_3_3 := makeKTV(testKey1, ts3, testValue3)
+		kv1_4_4 := makeKTV(testKey1, ts4, testValue4)
+		txn, val := makeTxn(testKey1, testValue4, ts4)
+		kv2_1_1 := makeKTV(testKey2, ts1, testValue1)
+		kv2_2_2 := makeKTV(testKey2, ts2, testValue2)
+		kv2_5_3 := makeKTV(testKey2, ts5, testValue3)
+		kv2_6_4 := makeKTV(testKey2, ts6, testValue4)
+		txn2, val2 := makeTxn(testKey2, testValue4, ts6)
+		txn2.OmitInRangefeeds = omitInRangefeeds
+		kv2_7_5 := makeKTV(testKey2, ts7, testValue5)
+		kv2_8_6 := makeKTV(testKey2, ts8, testValue6)
 
-	eng := storage.NewDefaultInMemForTesting(storage.If(smallEngineBlocks, storage.BlockSize(1)))
-	defer eng.Close()
-	// Put with no intent.
-	for _, kv := range []storage.MVCCKeyValue{kv1_1_1, kv1_2_2, kv1_3_3, kv2_1_1, kv2_2_2, kv2_5_3} {
-		v := roachpb.Value{RawBytes: kv.Value}
+		eng := storage.NewDefaultInMemForTesting(storage.If(smallEngineBlocks, storage.BlockSize(1)))
+		defer eng.Close()
+		// Put with no intent.
+		for _, kv := range []storage.MVCCKeyValue{kv1_1_1, kv1_2_2, kv1_3_3, kv2_1_1, kv2_2_2, kv2_5_3} {
+			v := roachpb.Value{RawBytes: kv.Value}
+			if _, err := storage.MVCCPut(
+				ctx, eng, kv.Key.Key, kv.Key.Timestamp, v, storage.MVCCWriteOptions{},
+			); err != nil {
+				t.Fatal(err)
+			}
+		}
+		// Put with an intent.
 		if _, err := storage.MVCCPut(
-			ctx, eng, kv.Key.Key, kv.Key.Timestamp, v, storage.MVCCWriteOptions{},
+			ctx, eng, kv1_4_4.Key.Key, txn.ReadTimestamp, val, storage.MVCCWriteOptions{Txn: &txn},
 		); err != nil {
 			t.Fatal(err)
 		}
-	}
-	// Put with an intent.
-	if _, err := storage.MVCCPut(
-		ctx, eng, kv1_4_4.Key.Key, txn.ReadTimestamp, val, storage.MVCCWriteOptions{Txn: &txn},
-	); err != nil {
-		t.Fatal(err)
-	}
-	testutils.RunTrueAndFalse(t, "withDiff", func(t *testing.T, withDiff bool) {
-		span := roachpb.Span{Key: testKey1, EndKey: roachpb.KeyMax}
-		iter, err := NewCatchUpIterator(ctx, eng, span, ts1, nil, nil)
-		require.NoError(t, err)
-		defer iter.Close()
-		var events []kvpb.RangeFeedValue
-		// ts1 here is exclusive, so we do not want the versions at ts1.
-		require.NoError(t, iter.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
-			events = append(events, *e.Val)
-			return nil
-		}, withDiff))
-		require.Equal(t, 4, len(events))
-		checkEquality := func(
-			kv storage.MVCCKeyValue, prevKV storage.MVCCKeyValue, event kvpb.RangeFeedValue) {
-			require.Equal(t, string(kv.Key.Key), string(event.Key))
-			require.Equal(t, kv.Key.Timestamp, event.Value.Timestamp)
-			require.Equal(t, string(kv.Value), string(event.Value.RawBytes))
-			if withDiff {
-				// TODO(sumeer): uncomment after clarifying CatchUpScan behavior.
-				// require.Equal(t, prevKV.Key.Timestamp, event.PrevValue.Timestamp)
-				require.Equal(t, string(prevKV.Value), string(event.PrevValue.RawBytes))
-			} else {
-				require.Equal(t, hlc.Timestamp{}, event.PrevValue.Timestamp)
-				require.Equal(t, 0, len(event.PrevValue.RawBytes))
-			}
+		// Transactional put with OmitInRangefeeds.
+		if _, err := storage.MVCCPut(
+			ctx, eng, kv2_6_4.Key.Key, txn2.ReadTimestamp, val2,
+			storage.MVCCWriteOptions{Txn: &txn2, OmitInRangefeeds: omitInRangefeeds},
+		); err != nil {
+			t.Fatal(err)
 		}
-		checkEquality(kv1_2_2, kv1_1_1, events[0])
-		checkEquality(kv1_3_3, kv1_2_2, events[1])
-		checkEquality(kv2_2_2, kv2_1_1, events[2])
-		checkEquality(kv2_5_3, kv2_2_2, events[3])
+		// Resolve the intent.
+		intent := roachpb.LockUpdate{Txn: txn2.TxnMeta, Span: roachpb.Span{Key: kv2_6_4.Key.Key}, Status: roachpb.COMMITTED}
+		if ok, _, _, _, err := storage.MVCCResolveWriteIntent(
+			ctx, eng, nil, intent, storage.MVCCResolveWriteIntentOptions{}); err != nil || !ok {
+			t.Fatal(err)
+		}
+		// Non-transactional put with OmitInRangefeeds (e.g. 1PC write).
+		if _, err := storage.MVCCPut(
+			ctx, eng, kv2_7_5.Key.Key, kv2_7_5.Key.Timestamp, roachpb.Value{RawBytes: kv2_7_5.Value},
+			storage.MVCCWriteOptions{OmitInRangefeeds: omitInRangefeeds},
+		); err != nil {
+			t.Fatal(err)
+		}
+		// Write a new value for testKey2.
+		if _, err := storage.MVCCPut(
+			ctx, eng, kv2_8_6.Key.Key, kv2_8_6.Key.Timestamp, roachpb.Value{RawBytes: kv2_8_6.Value},
+			storage.MVCCWriteOptions{},
+		); err != nil {
+			t.Fatal(err)
+		}
+		testutils.RunTrueAndFalse(t, "withDiff", func(t *testing.T, withDiff bool) {
+			testutils.RunTrueAndFalse(t, "withFiltering", func(t *testing.T, withFiltering bool) {
+				span := roachpb.Span{Key: testKey1, EndKey: roachpb.KeyMax}
+				iter, err := NewCatchUpIterator(ctx, eng, span, ts1, nil, nil)
+				require.NoError(t, err)
+				defer iter.Close()
+				var events []kvpb.RangeFeedValue
+				// ts1 here is exclusive, so we do not want the versions at ts1.
+				require.NoError(t, iter.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
+					events = append(events, *e.Val)
+					return nil
+				}, withDiff, withFiltering))
+				if !(withFiltering && omitInRangefeeds) {
+					require.Equal(t, 7, len(events))
+				} else {
+					require.Equal(t, 5, len(events))
+				}
+				checkEquality := func(
+					kv storage.MVCCKeyValue, prevKV storage.MVCCKeyValue, event kvpb.RangeFeedValue) {
+					require.Equal(t, string(kv.Key.Key), string(event.Key))
+					require.Equal(t, kv.Key.Timestamp, event.Value.Timestamp)
+					require.Equal(t, string(kv.Value), string(event.Value.RawBytes))
+					if withDiff {
+						// TODO(sumeer): uncomment after clarifying CatchUpScan behavior.
+						// require.Equal(t, prevKV.Key.Timestamp, event.PrevValue.Timestamp)
+						require.Equal(t, string(prevKV.Value), string(event.PrevValue.RawBytes))
+					} else {
+						require.Equal(t, hlc.Timestamp{}, event.PrevValue.Timestamp)
+						require.Equal(t, 0, len(event.PrevValue.RawBytes))
+					}
+				}
+				checkEquality(kv1_2_2, kv1_1_1, events[0])
+				checkEquality(kv1_3_3, kv1_2_2, events[1])
+				checkEquality(kv2_2_2, kv2_1_1, events[2])
+				checkEquality(kv2_5_3, kv2_2_2, events[3])
+				if !(withFiltering && omitInRangefeeds) {
+					checkEquality(kv2_6_4, kv2_5_3, events[4])
+					checkEquality(kv2_7_5, kv2_6_4, events[5])
+					checkEquality(kv2_8_6, kv2_7_5, events[6])
+				} else {
+					checkEquality(kv2_8_6, kv2_7_5, events[4])
+				}
+			})
+		})
 	})
 }
 
@@ -166,7 +218,7 @@ func TestCatchupScanInlineError(t *testing.T) {
 	require.NoError(t, err)
 	defer iter.Close()
 
-	err = iter.CatchUpScan(ctx, nil, false)
+	err = iter.CatchUpScan(ctx, nil, false /* withDiff */, false /* withFiltering */)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected inline value")
 }
@@ -214,7 +266,7 @@ func TestCatchupScanSeesOldIntent(t *testing.T) {
 	require.NoError(t, iter.CatchUpScan(ctx, func(e *kvpb.RangeFeedEvent) error {
 		keys[string(e.Val.Key)] = struct{}{}
 		return nil
-	}, true /* withDiff */))
+	}, true /* withDiff */, false /* withFiltering */))
 	require.Equal(t, map[string]struct{}{
 		"b": {},
 		"e": {},

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -191,6 +191,7 @@ type Processor interface {
 		startTS hlc.Timestamp, // exclusive
 		catchUpIter *CatchUpIterator,
 		withDiff bool,
+		withFiltering bool,
 		stream Stream,
 		disconnectFn func(),
 		done *future.ErrorFuture,
@@ -568,6 +569,7 @@ func (p *LegacyProcessor) Register(
 	startTS hlc.Timestamp,
 	catchUpIter *CatchUpIterator,
 	withDiff bool,
+	withFiltering bool,
 	stream Stream,
 	disconnectFn func(),
 	done *future.ErrorFuture,
@@ -579,7 +581,7 @@ func (p *LegacyProcessor) Register(
 
 	blockWhenFull := p.Config.EventChanTimeout == 0 // for testing
 	r := newRegistration(
-		span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff,
+		span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering,
 		p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn, done,
 	)
 	select {
@@ -799,9 +801,12 @@ func (p *LegacyProcessor) consumeLogicalOps(
 	for _, op := range ops {
 		// Publish RangeFeedValue updates, if necessary.
 		switch t := op.GetValue().(type) {
+		// OmitInRangefeeds is relevant only for transactional writes, so it's
+		// propagated only in the case of a MVCCCommitIntentOp and
+		// MVCCWriteValueOp (could be the result of a 1PC write).
 		case *enginepb.MVCCWriteValueOp:
 			// Publish the new value directly.
-			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, alloc)
+			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, t.OmitInRangefeeds, alloc)
 
 		case *enginepb.MVCCDeleteRangeOp:
 			// Publish the range deletion directly.
@@ -815,7 +820,7 @@ func (p *LegacyProcessor) consumeLogicalOps(
 
 		case *enginepb.MVCCCommitIntentOp:
 			// Publish the newly committed value.
-			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, alloc)
+			p.publishValue(ctx, t.Key, t.Timestamp, t.Value, t.PrevValue, t.OmitInRangefeeds, alloc)
 
 		case *enginepb.MVCCAbortIntentOp:
 			// No updates to publish.
@@ -862,6 +867,7 @@ func (p *LegacyProcessor) publishValue(
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
 	value, prevValue []byte,
+	omitInRangefeeds bool,
 	alloc *SharedBudgetAllocation,
 ) {
 	if !p.Span.ContainsKey(roachpb.RKey(key)) {
@@ -881,7 +887,7 @@ func (p *LegacyProcessor) publishValue(
 		},
 		PrevValue: prevVal,
 	})
-	p.reg.PublishToOverlapping(ctx, roachpb.Span{Key: key}, &event, alloc)
+	p.reg.PublishToOverlapping(ctx, roachpb.Span{Key: key}, &event, omitInRangefeeds, alloc)
 }
 
 func (p *LegacyProcessor) publishDeleteRange(
@@ -900,7 +906,7 @@ func (p *LegacyProcessor) publishDeleteRange(
 		Span:      span,
 		Timestamp: timestamp,
 	})
-	p.reg.PublishToOverlapping(ctx, span, &event, alloc)
+	p.reg.PublishToOverlapping(ctx, span, &event, false /* omitInRangefeeds */, alloc)
 }
 
 func (p *LegacyProcessor) publishSSTable(
@@ -922,7 +928,7 @@ func (p *LegacyProcessor) publishSSTable(
 			Span:    sstSpan,
 			WriteTS: sstWTS,
 		},
-	}, alloc)
+	}, false /* omitInRangefeeds */, alloc)
 }
 
 func (p *LegacyProcessor) publishCheckpoint(ctx context.Context) {
@@ -930,7 +936,7 @@ func (p *LegacyProcessor) publishCheckpoint(ctx context.Context) {
 	// TODO(nvanbenschoten): rate limit these? send them periodically?
 
 	event := p.newCheckpointEvent()
-	p.reg.PublishToOverlapping(ctx, all, event, nil)
+	p.reg.PublishToOverlapping(ctx, all, event, false /* omitInRangefeeds */, nil)
 }
 
 func (p *LegacyProcessor) newCheckpointEvent() *kvpb.RangeFeedEvent {

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -95,18 +95,19 @@ func updateIntentOp(txnID uuid.UUID, ts hlc.Timestamp) enginepb.MVCCLogicalOp {
 }
 
 func commitIntentOpWithKV(
-	txnID uuid.UUID, key roachpb.Key, ts hlc.Timestamp, val []byte,
+	txnID uuid.UUID, key roachpb.Key, ts hlc.Timestamp, val []byte, omitInRangefeeds bool,
 ) enginepb.MVCCLogicalOp {
 	return makeLogicalOp(&enginepb.MVCCCommitIntentOp{
-		TxnID:     txnID,
-		Key:       key,
-		Timestamp: ts,
-		Value:     val,
+		TxnID:            txnID,
+		Key:              key,
+		Timestamp:        ts,
+		Value:            val,
+		OmitInRangefeeds: omitInRangefeeds,
 	})
 }
 
 func commitIntentOp(txnID uuid.UUID, ts hlc.Timestamp) enginepb.MVCCLogicalOp {
-	return commitIntentOpWithKV(txnID, roachpb.Key("a"), ts, nil /* val */)
+	return commitIntentOpWithKV(txnID, roachpb.Key("a"), ts, nil /* val */, false /* omitInRangefeeds */)
 }
 
 func abortIntentOp(txnID uuid.UUID) enginepb.MVCCLogicalOp {
@@ -462,6 +463,7 @@ func TestProcessorBasic(t *testing.T) {
 			hlc.Timestamp{WallTime: 1},
 			nil,   /* catchUpIter */
 			false, /* withDiff */
+			false, /* withFiltering */
 			r1Stream,
 			func() {},
 			&r1Done,
@@ -568,7 +570,8 @@ func TestProcessorBasic(t *testing.T) {
 		)
 		// Commit intent. Should forward resolved timestamp to closed timestamp.
 		p.ConsumeLogicalOps(ctx,
-			commitIntentOpWithKV(txn2, roachpb.Key("e"), hlc.Timestamp{WallTime: 13}, []byte("ival")))
+			commitIntentOpWithKV(txn2, roachpb.Key("e"), hlc.Timestamp{WallTime: 13},
+				[]byte("ival"), false /* omitInRangefeeds */))
 		h.syncEventAndRegistrations()
 		require.Equal(t,
 			[]*kvpb.RangeFeedEvent{
@@ -587,7 +590,7 @@ func TestProcessorBasic(t *testing.T) {
 			r1Stream.Events(),
 		)
 
-		// Add another registration with withDiff = true.
+		// Add another registration with withDiff = true and withFiltering = true.
 		r2Stream := newTestStream()
 		var r2Done future.ErrorFuture
 		r2OK, r1And2Filter := p.Register(
@@ -595,6 +598,7 @@ func TestProcessorBasic(t *testing.T) {
 			hlc.Timestamp{WallTime: 1},
 			nil,  /* catchUpIter */
 			true, /* withDiff */
+			true, /* withFiltering */
 			r2Stream,
 			func() {},
 			&r2Done,
@@ -674,6 +678,24 @@ func TestProcessorBasic(t *testing.T) {
 		require.Equal(t, []*kvpb.RangeFeedEvent(nil), r1Stream.Events())
 		require.Equal(t, valEvent2, r2Stream.Events())
 
+		// Test committing intent with OmitInRangefeeds that overlaps two
+		// registration (one withFiltering = true and one withFiltering = false).
+		p.ConsumeLogicalOps(ctx,
+			commitIntentOpWithKV(txn2, roachpb.Key("k"), hlc.Timestamp{WallTime: 22},
+				[]byte("val3"), true /* omitInRangefeeds */))
+		h.syncEventAndRegistrations()
+		valEvent3 := []*kvpb.RangeFeedEvent{
+			rangeFeedValue(
+				roachpb.Key("k"),
+				roachpb.Value{
+					RawBytes:  []byte("val3"),
+					Timestamp: hlc.Timestamp{WallTime: 22},
+				},
+			),
+		}
+		require.Equal(t, valEvent3, r1Stream.Events())
+		// r2Stream should not see the event.
+
 		// Cancel the first registration.
 		r1Stream.Cancel()
 		require.NotNil(t, waitErrorFuture(&r1Done))
@@ -691,6 +713,7 @@ func TestProcessorBasic(t *testing.T) {
 			hlc.Timestamp{WallTime: 1},
 			nil,   /* catchUpIter */
 			false, /* withDiff */
+			false, /* withFiltering */
 			r3Stream,
 			func() {},
 			&r3Done,
@@ -714,6 +737,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 			hlc.Timestamp{WallTime: 1},
 			nil,   /* catchUpIter */
 			false, /* withDiff */
+			false, /* withFiltering */
 			r1Stream,
 			func() {},
 			&r1Done,
@@ -725,6 +749,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 			hlc.Timestamp{WallTime: 1},
 			nil,   /* catchUpIter */
 			false, /* withDiff */
+			false, /* withFiltering */
 			r2Stream,
 			func() {},
 			&r2Done,
@@ -821,6 +846,7 @@ func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 			hlc.Timestamp{WallTime: 1},
 			nil,   /* catchUpIter */
 			false, /* withDiff */
+			false, /* withFiltering */
 			r1Stream,
 			func() {},
 			&r1Done,
@@ -876,6 +902,7 @@ func TestProcessorMemoryBudgetReleased(t *testing.T) {
 			hlc.Timestamp{WallTime: 1},
 			nil,   /* catchUpIter */
 			false, /* withDiff */
+			false, /* withFiltering */
 			r1Stream,
 			func() {},
 			&r1Done,
@@ -957,6 +984,7 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 			hlc.Timestamp{WallTime: 1},
 			nil,   /* catchUpIter */
 			false, /* withDiff */
+			false, /* withFiltering */
 			r1Stream,
 			func() {},
 			&r1Done,
@@ -1264,8 +1292,8 @@ func TestProcessorConcurrentStop(t *testing.T) {
 				runtime.Gosched()
 				s := newTestStream()
 				var done future.ErrorFuture
-				p.Register(h.span, hlc.Timestamp{}, nil, false, s,
-					func() {}, &done)
+				p.Register(h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+					false /* withDiff */, false /* withFiltering */, s, func() {}, &done)
 			}()
 			go func() {
 				defer wg.Done()
@@ -1337,8 +1365,8 @@ func TestProcessorRegistrationObservesOnlyNewEvents(t *testing.T) {
 				s := newTestStream()
 				regs[s] = firstIdx
 				var done future.ErrorFuture
-				p.Register(h.span, hlc.Timestamp{}, nil, false,
-					s, func() {}, &done)
+				p.Register(h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+					false /* withDiff */, false /* withFiltering */, s, func() {}, &done)
 				regDone <- struct{}{}
 			}
 		}()
@@ -1399,6 +1427,7 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 			hlc.Timestamp{WallTime: 1},
 			nil,   /* catchUpIter */
 			false, /* withDiff */
+			false, /* withFiltering */
 			rStream,
 			func() {},
 			&done,
@@ -1480,6 +1509,7 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 			hlc.Timestamp{WallTime: 1},
 			nil,   /* catchUpIter */
 			false, /* withDiff */
+			false, /* withFiltering */
 			rStream,
 			func() {},
 			&done,
@@ -1551,6 +1581,7 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 			hlc.Timestamp{WallTime: 1},
 			nil,   /* catchUpIter */
 			false, /* withDiff */
+			false, /* withFiltering */
 			r1Stream,
 			func() {},
 			&r1Done,
@@ -1565,6 +1596,7 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 			hlc.Timestamp{WallTime: 1},
 			nil,   /* catchUpIter */
 			false, /* withDiff */
+			false, /* withFiltering */
 			r2Stream,
 			func() {},
 			&r2Done,
@@ -1715,7 +1747,8 @@ func TestProcessorBackpressure(t *testing.T) {
 	// Add a registration.
 	stream := newTestStream()
 	done := &future.ErrorFuture{}
-	ok, _ := p.Register(span, hlc.MinTimestamp, nil, false, stream, nil, done)
+	ok, _ := p.Register(span, hlc.MinTimestamp, nil, /* catchUpIter */
+		false /* withDiff */, false /* withFiltering */, stream, nil, done)
 	require.True(t, ok)
 
 	// Wait for the initial checkpoint.

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/future"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -114,7 +116,11 @@ func makeCatchUpIterator(
 }
 
 func newTestRegistration(
-	span roachpb.Span, ts hlc.Timestamp, catchup storage.SimpleMVCCIterator, withDiff bool,
+	span roachpb.Span,
+	ts hlc.Timestamp,
+	catchup storage.SimpleMVCCIterator,
+	withDiff bool,
+	withFiltering bool,
 ) *testRegistration {
 	s := newTestStream()
 	r := newRegistration(
@@ -122,6 +128,7 @@ func newTestRegistration(
 		ts,
 		makeCatchUpIterator(catchup, span, ts),
 		withDiff,
+		withFiltering,
 		5,
 		false, /* blockWhenFull */
 		NewMetrics(),
@@ -158,7 +165,8 @@ func TestRegistrationBasic(t *testing.T) {
 	ev2.MustSetValue(&kvpb.RangeFeedValue{Key: keyB, Value: val})
 
 	// Registration with no catchup scan specified.
-	noCatchupReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, false)
+	noCatchupReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
+		false /* withDiff */, false /* withFiltering */)
 	noCatchupReg.publish(ctx, ev1, nil /* alloc */)
 	noCatchupReg.publish(ctx, ev2, nil /* alloc */)
 	require.Equal(t, len(noCatchupReg.buf), 2)
@@ -173,7 +181,8 @@ func TestRegistrationBasic(t *testing.T) {
 			makeKV("b", "val1", 10),
 			makeKV("bc", "val3", 11),
 			makeKV("bd", "val4", 9),
-		}, nil), false)
+		}, nil),
+		false /* withDiff */, false /* withFiltering */)
 	catchupReg.publish(ctx, ev1, nil /* alloc */)
 	catchupReg.publish(ctx, ev2, nil /* alloc */)
 	require.Equal(t, len(catchupReg.buf), 2)
@@ -186,7 +195,8 @@ func TestRegistrationBasic(t *testing.T) {
 
 	// EXIT CONDITIONS
 	// External Disconnect.
-	disconnectReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, false)
+	disconnectReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
+		false /* withDiff */, false /* withFiltering */)
 	disconnectReg.publish(ctx, ev1, nil /* alloc */)
 	disconnectReg.publish(ctx, ev2, nil /* alloc */)
 	go disconnectReg.runOutputLoop(context.Background(), 0)
@@ -197,7 +207,8 @@ func TestRegistrationBasic(t *testing.T) {
 	require.Equal(t, 2, len(disconnectReg.stream.Events()))
 
 	// External Disconnect before output loop.
-	disconnectEarlyReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, false)
+	disconnectEarlyReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
+		false /* withDiff */, false /* withFiltering */)
 	disconnectEarlyReg.publish(ctx, ev1, nil /* alloc */)
 	disconnectEarlyReg.publish(ctx, ev2, nil /* alloc */)
 	disconnectEarlyReg.disconnect(discErr)
@@ -206,7 +217,8 @@ func TestRegistrationBasic(t *testing.T) {
 	require.Equal(t, 0, len(disconnectEarlyReg.stream.Events()))
 
 	// Overflow.
-	overflowReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, false)
+	overflowReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
+		false /* withDiff */, false /* withFiltering */)
 	for i := 0; i < cap(overflowReg.buf)+3; i++ {
 		overflowReg.publish(ctx, ev1, nil /* alloc */)
 	}
@@ -215,7 +227,8 @@ func TestRegistrationBasic(t *testing.T) {
 	require.Equal(t, cap(overflowReg.buf), len(overflowReg.Events()))
 
 	// Stream Error.
-	streamErrReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, false)
+	streamErrReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
+		false /* withDiff */, false /* withFiltering */)
 	streamErr := fmt.Errorf("stream error")
 	streamErrReg.stream.SetSendErr(streamErr)
 	go streamErrReg.runOutputLoop(context.Background(), 0)
@@ -223,7 +236,8 @@ func TestRegistrationBasic(t *testing.T) {
 	require.Equal(t, streamErr.Error(), streamErrReg.Err().Error())
 
 	// Stream Context Canceled.
-	streamCancelReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, false)
+	streamCancelReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
+		false /* withDiff */, false /* withFiltering */)
 	streamCancelReg.stream.Cancel()
 	go streamCancelReg.runOutputLoop(context.Background(), 0)
 	require.NoError(t, streamCancelReg.waitForCaughtUp())
@@ -233,98 +247,123 @@ func TestRegistrationBasic(t *testing.T) {
 func TestRegistrationCatchUpScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// Run a catch-up scan for a registration over a test
-	// iterator with the following keys.
-	txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
-	iter := newTestIterator([]storage.MVCCKeyValue{
-		makeKV("a", "valA1", 10),
-		makeIntent("c", txn1, "txnKeyC", 15),
-		makeProvisionalKV("c", "txnKeyC", 15),
-		makeKV("c", "valC2", 11),
-		makeKV("c", "valC1", 9),
-		makeIntent("d", txn2, "txnKeyD", 21),
-		makeProvisionalKV("d", "txnKeyD", 21),
-		makeKV("d", "valD5", 20),
-		makeKV("d", "valD4", 19),
-		makeKV("d", "valD3", 16),
-		makeKV("d", "valD2", 3),
-		makeKV("d", "valD1", 1),
-		makeKV("e", "valE3", 6),
-		makeKV("e", "valE2", 5),
-		makeKV("e", "valE1", 4),
-		makeKV("f", "valF3", 7),
-		makeKV("f", "valF2", 6),
-		makeKV("f", "valF1", 5),
-		makeKV("h", "valH1", 15),
-		makeKV("m", "valM1", 1),
-		makeIntent("n", txn1, "txnKeyN", 12),
-		makeProvisionalKV("n", "txnKeyN", 12),
-		makeIntent("r", txn1, "txnKeyR", 19),
-		makeProvisionalKV("r", "txnKeyR", 19),
-		makeKV("r", "valR1", 4),
-		makeIntent("w", txn1, "txnKeyW", 3),
-		makeProvisionalKV("w", "txnKeyW", 3),
-		makeIntent("z", txn2, "txnKeyZ", 21),
-		makeProvisionalKV("z", "txnKeyZ", 21),
-		makeKV("z", "valZ1", 4),
-	}, roachpb.Key("w"))
-	r := newTestRegistration(roachpb.Span{
-		Key:    roachpb.Key("d"),
-		EndKey: roachpb.Key("w"),
-	}, hlc.Timestamp{WallTime: 4}, iter, true /* withDiff */)
+	testutils.RunTrueAndFalse(t, "withFiltering", func(t *testing.T, withFiltering bool) {
+		// Run a catch-up scan for a registration over a test
+		// iterator with the following keys.
+		txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
+		iter := newTestIterator([]storage.MVCCKeyValue{
+			makeKV("a", "valA1", 10),
+			makeIntent("c", txn1, "txnKeyC", 15),
+			makeProvisionalKV("c", "txnKeyC", 15),
+			makeKV("c", "valC2", 11),
+			makeKV("c", "valC1", 9),
+			makeIntent("d", txn2, "txnKeyD", 21),
+			makeProvisionalKV("d", "txnKeyD", 21),
+			makeKV("d", "valD5", 20),
+			makeKV("d", "valD4", 19),
+			makeKV("d", "valD3", 16),
+			makeKV("d", "valD2", 3),
+			makeKV("d", "valD1", 1),
+			makeKV("e", "valE3", 6),
+			makeKV("e", "valE2", 5),
+			makeKV("e", "valE1", 4),
+			makeKV("f", "valF3", 7),
+			makeKV("f", "valF2", 6),
+			makeKV("f", "valF1", 5),
+			makeKV("h", "valH1", 15),
+			makeKV("m", "valM1", 1),
+			makeIntent("n", txn1, "txnKeyN", 12),
+			makeProvisionalKV("n", "txnKeyN", 12),
+			makeIntent("r", txn1, "txnKeyR", 19),
+			makeProvisionalKV("r", "txnKeyR", 19),
+			makeKV("r", "valR1", 4),
+			makeKV("s", "valS3", 21),
+			makeKVWithHeader("s", "valS2", 20, enginepb.MVCCValueHeader{OmitInRangefeeds: true}),
+			makeKV("s", "valS1", 19),
+			makeIntent("w", txn1, "txnKeyW", 3),
+			makeProvisionalKV("w", "txnKeyW", 3),
+			makeIntent("z", txn2, "txnKeyZ", 21),
+			makeProvisionalKV("z", "txnKeyZ", 21),
+			makeKV("z", "valZ1", 4),
+		}, roachpb.Key("w"))
 
-	require.Zero(t, r.metrics.RangeFeedCatchUpScanNanos.Count())
-	require.NoError(t, r.maybeRunCatchUpScan(context.Background()))
-	require.True(t, iter.closed)
-	require.NotZero(t, r.metrics.RangeFeedCatchUpScanNanos.Count())
+		r := newTestRegistration(roachpb.Span{
+			Key:    roachpb.Key("d"),
+			EndKey: roachpb.Key("w"),
+		}, hlc.Timestamp{WallTime: 4}, iter, true /* withDiff */, withFiltering)
 
-	// Compare the events sent on the registration's Stream to the expected events.
-	expEvents := []*kvpb.RangeFeedEvent{
-		rangeFeedValueWithPrev(
-			roachpb.Key("d"),
-			makeValWithTs("valD3", 16),
-			makeVal("valD2"),
-		),
-		rangeFeedValueWithPrev(
-			roachpb.Key("d"),
-			makeValWithTs("valD4", 19),
-			makeVal("valD3"),
-		),
-		rangeFeedValueWithPrev(
-			roachpb.Key("d"),
-			makeValWithTs("valD5", 20),
-			makeVal("valD4"),
-		),
-		rangeFeedValueWithPrev(
-			roachpb.Key("e"),
-			makeValWithTs("valE2", 5),
-			makeVal("valE1"),
-		),
-		rangeFeedValueWithPrev(
-			roachpb.Key("e"),
-			makeValWithTs("valE3", 6),
-			makeVal("valE2"),
-		),
-		rangeFeedValue(
-			roachpb.Key("f"),
-			makeValWithTs("valF1", 5),
-		),
-		rangeFeedValueWithPrev(
-			roachpb.Key("f"),
-			makeValWithTs("valF2", 6),
-			makeVal("valF1"),
-		),
-		rangeFeedValueWithPrev(
-			roachpb.Key("f"),
-			makeValWithTs("valF3", 7),
-			makeVal("valF2"),
-		),
-		rangeFeedValue(
-			roachpb.Key("h"),
-			makeValWithTs("valH1", 15),
-		),
-	}
-	require.Equal(t, expEvents, r.Events())
+		require.Zero(t, r.metrics.RangeFeedCatchUpScanNanos.Count())
+		require.NoError(t, r.maybeRunCatchUpScan(context.Background()))
+		require.True(t, iter.closed)
+		require.NotZero(t, r.metrics.RangeFeedCatchUpScanNanos.Count())
+
+		// Compare the events sent on the registration's Stream to the expected events.
+		expEvents := []*kvpb.RangeFeedEvent{
+			rangeFeedValueWithPrev(
+				roachpb.Key("d"),
+				makeValWithTs("valD3", 16),
+				makeVal("valD2"),
+			),
+			rangeFeedValueWithPrev(
+				roachpb.Key("d"),
+				makeValWithTs("valD4", 19),
+				makeVal("valD3"),
+			),
+			rangeFeedValueWithPrev(
+				roachpb.Key("d"),
+				makeValWithTs("valD5", 20),
+				makeVal("valD4"),
+			),
+			rangeFeedValueWithPrev(
+				roachpb.Key("e"),
+				makeValWithTs("valE2", 5),
+				makeVal("valE1"),
+			),
+			rangeFeedValueWithPrev(
+				roachpb.Key("e"),
+				makeValWithTs("valE3", 6),
+				makeVal("valE2"),
+			),
+			rangeFeedValue(
+				roachpb.Key("f"),
+				makeValWithTs("valF1", 5),
+			),
+			rangeFeedValueWithPrev(
+				roachpb.Key("f"),
+				makeValWithTs("valF2", 6),
+				makeVal("valF1"),
+			),
+			rangeFeedValueWithPrev(
+				roachpb.Key("f"),
+				makeValWithTs("valF3", 7),
+				makeVal("valF2"),
+			),
+			rangeFeedValue(
+				roachpb.Key("h"),
+				makeValWithTs("valH1", 15),
+			),
+			rangeFeedValue(
+				roachpb.Key("s"),
+				makeValWithTs("valS1", 19),
+			),
+		}
+		if !withFiltering {
+			expEvents = append(expEvents,
+				rangeFeedValueWithPrev(
+					roachpb.Key("s"),
+					makeValWithTs("valS2", 20),
+					makeVal("valS1"),
+				))
+		}
+		expEvents = append(expEvents, rangeFeedValueWithPrev(
+			roachpb.Key("s"),
+			makeValWithTs("valS3", 21),
+			// Even though the event that wrote val2 is filtered out, we want to keep
+			// val2 as a previous value of the next event.
+			makeVal("valS2"),
+		))
+		require.Equal(t, expEvents, r.Events())
+	})
 }
 
 func TestRegistryBasic(t *testing.T) {
@@ -333,11 +372,12 @@ func TestRegistryBasic(t *testing.T) {
 
 	val := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
 	ev1, ev2 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
-	ev3, ev4 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
+	ev3, ev4, ev5 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
 	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val, PrevValue: val})
 	ev2.MustSetValue(&kvpb.RangeFeedValue{Key: keyB, Value: val, PrevValue: val})
 	ev3.MustSetValue(&kvpb.RangeFeedValue{Key: keyC, Value: val, PrevValue: val})
 	ev4.MustSetValue(&kvpb.RangeFeedValue{Key: keyD, Value: val, PrevValue: val})
+	ev5.MustSetValue(&kvpb.RangeFeedValue{Key: keyD, Value: val, PrevValue: val})
 	err1 := kvpb.NewErrorf("error1")
 	noPrev := func(ev *kvpb.RangeFeedEvent) *kvpb.RangeFeedEvent {
 		ev = ev.ShallowCopy()
@@ -347,22 +387,25 @@ func TestRegistryBasic(t *testing.T) {
 
 	reg := makeRegistry(NewMetrics())
 	require.Equal(t, 0, reg.Len())
-	require.NotPanics(t, func() { reg.PublishToOverlapping(ctx, spAB, ev1, nil /* alloc */) })
+	require.NotPanics(t, func() { reg.PublishToOverlapping(ctx, spAB, ev1, false /* omitInRangefeeds */, nil /* alloc */) })
 	require.NotPanics(t, func() { reg.Disconnect(spAB) })
 	require.NotPanics(t, func() { reg.DisconnectWithErr(spAB, err1) })
 
-	rAB := newTestRegistration(spAB, hlc.Timestamp{}, nil, false /* withDiff */)
-	rBC := newTestRegistration(spBC, hlc.Timestamp{}, nil, true /* withDiff */)
-	rCD := newTestRegistration(spCD, hlc.Timestamp{}, nil, true /* withDiff */)
-	rAC := newTestRegistration(spAC, hlc.Timestamp{}, nil, false /* withDiff */)
+	rAB := newTestRegistration(spAB, hlc.Timestamp{}, nil, false /* withDiff */, false /* withFiltering */)
+	rBC := newTestRegistration(spBC, hlc.Timestamp{}, nil, true /* withDiff */, false /* withFiltering */)
+	rCD := newTestRegistration(spCD, hlc.Timestamp{}, nil, true /* withDiff */, false /* withFiltering */)
+	rAC := newTestRegistration(spAC, hlc.Timestamp{}, nil, false /* withDiff */, false /* withFiltering */)
+	rACFiltering := newTestRegistration(spAC, hlc.Timestamp{}, nil, false /* withDiff */, true /* withFiltering */)
 	go rAB.runOutputLoop(context.Background(), 0)
 	go rBC.runOutputLoop(context.Background(), 0)
 	go rCD.runOutputLoop(context.Background(), 0)
 	go rAC.runOutputLoop(context.Background(), 0)
+	go rACFiltering.runOutputLoop(context.Background(), 0)
 	defer rAB.disconnect(nil)
 	defer rBC.disconnect(nil)
 	defer rCD.disconnect(nil)
 	defer rAC.disconnect(nil)
+	defer rACFiltering.disconnect(nil)
 
 	// Register 4 registrations.
 	reg.Register(&rAB.registration)
@@ -373,21 +416,28 @@ func TestRegistryBasic(t *testing.T) {
 	require.Equal(t, 3, reg.Len())
 	reg.Register(&rAC.registration)
 	require.Equal(t, 4, reg.Len())
+	reg.Register(&rACFiltering.registration)
+	require.Equal(t, 5, reg.Len())
 
 	// Publish to different spans.
-	reg.PublishToOverlapping(ctx, spAB, ev1, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spBC, ev2, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spCD, ev3, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spAC, ev4, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAB, ev1, false /* omitInRangefeeds */, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spBC, ev2, false /* omitInRangefeeds */, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spCD, ev3, false /* omitInRangefeeds */, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAC, ev4, false /* omitInRangefeeds */, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAC, ev5, true /* omitInRangefeeds */, nil /* alloc */)
 	require.NoError(t, reg.waitForCaughtUp(all))
-	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev4)}, rAB.Events())
-	require.Equal(t, []*kvpb.RangeFeedEvent{ev2, ev4}, rBC.Events())
+	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev4), noPrev(ev5)}, rAB.Events())
+	require.Equal(t, []*kvpb.RangeFeedEvent{ev2, ev4, ev5}, rBC.Events())
 	require.Equal(t, []*kvpb.RangeFeedEvent{ev3}, rCD.Events())
-	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev2), noPrev(ev4)}, rAC.Events())
+	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev2), noPrev(ev4), noPrev(ev5)}, rAC.Events())
+	// Registration rACFiltering doesn't receive ev5 because both withFiltering
+	// (for the registration) and OmitInRangefeeds (for the event) are true.
+	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev2), noPrev(ev4)}, rACFiltering.Events())
 	require.Nil(t, rAB.TryErr())
 	require.Nil(t, rBC.TryErr())
 	require.Nil(t, rCD.TryErr())
 	require.Nil(t, rAC.TryErr())
+	require.Nil(t, rACFiltering.TryErr())
 
 	// Check the registry's operation filter.
 	f := reg.NewFilter()
@@ -414,14 +464,14 @@ func TestRegistryBasic(t *testing.T) {
 
 	// Disconnect span that overlaps with rCD.
 	reg.DisconnectWithErr(spCD, err1)
-	require.Equal(t, 3, reg.Len())
+	require.Equal(t, 4, reg.Len())
 	require.Equal(t, err1.GoError(), rCD.Err())
 
 	// Can still publish to rAB.
-	reg.PublishToOverlapping(ctx, spAB, ev4, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spBC, ev3, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spCD, ev2, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spAC, ev1, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAB, ev4, false /* omitInRangefeeds */, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spBC, ev3, false /* omitInRangefeeds */, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spCD, ev2, false /* omitInRangefeeds */, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAC, ev1, false /* omitInRangefeeds */, nil /* alloc */)
 	require.NoError(t, reg.waitForCaughtUp(all))
 	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev4), noPrev(ev1)}, rAB.Events())
 
@@ -464,11 +514,11 @@ func TestRegistryPublishAssertsPopulatedInformation(t *testing.T) {
 	ctx := context.Background()
 	reg := makeRegistry(NewMetrics())
 
-	rNoDiff := newTestRegistration(spAB, hlc.Timestamp{}, nil, false /* withDiff */)
+	rNoDiff := newTestRegistration(spAB, hlc.Timestamp{}, nil, false /* withDiff */, false /* withFiltering */)
 	go rNoDiff.runOutputLoop(context.Background(), 0)
 	reg.Register(&rNoDiff.registration)
 
-	rWithDiff := newTestRegistration(spCD, hlc.Timestamp{}, nil, true /* withDiff */)
+	rWithDiff := newTestRegistration(spCD, hlc.Timestamp{}, nil, true /* withDiff */, false /* withFiltering */)
 	go rWithDiff.runOutputLoop(context.Background(), 0)
 	reg.Register(&rWithDiff.registration)
 
@@ -483,8 +533,8 @@ func TestRegistryPublishAssertsPopulatedInformation(t *testing.T) {
 		Value:     val,
 		PrevValue: val,
 	})
-	require.Panics(t, func() { reg.PublishToOverlapping(ctx, spAB, ev, nil /* alloc */) })
-	require.Panics(t, func() { reg.PublishToOverlapping(ctx, spCD, ev, nil /* alloc */) })
+	require.Panics(t, func() { reg.PublishToOverlapping(ctx, spAB, ev, false /* omitInRangefeeds */, nil /* alloc */) })
+	require.Panics(t, func() { reg.PublishToOverlapping(ctx, spCD, ev, false /* omitInRangefeeds */, nil /* alloc */) })
 	require.NoError(t, reg.waitForCaughtUp(all))
 
 	// Both registrations require RangeFeedValue events to have a Value.
@@ -493,8 +543,8 @@ func TestRegistryPublishAssertsPopulatedInformation(t *testing.T) {
 		Value:     noVal,
 		PrevValue: val,
 	})
-	require.Panics(t, func() { reg.PublishToOverlapping(ctx, spAB, ev, nil /* alloc */) })
-	require.Panics(t, func() { reg.PublishToOverlapping(ctx, spCD, ev, nil /* alloc */) })
+	require.Panics(t, func() { reg.PublishToOverlapping(ctx, spAB, ev, false /* omitInRangefeeds */, nil /* alloc */) })
+	require.Panics(t, func() { reg.PublishToOverlapping(ctx, spCD, ev, false /* omitInRangefeeds */, nil /* alloc */) })
 	require.NoError(t, reg.waitForCaughtUp(all))
 
 	// Neither registrations require RangeFeedValue events to have a PrevValue.
@@ -504,8 +554,8 @@ func TestRegistryPublishAssertsPopulatedInformation(t *testing.T) {
 		Value:     val,
 		PrevValue: roachpb.Value{},
 	})
-	require.NotPanics(t, func() { reg.PublishToOverlapping(ctx, spAB, ev, nil /* alloc */) })
-	require.NotPanics(t, func() { reg.PublishToOverlapping(ctx, spCD, ev, nil /* alloc */) })
+	require.NotPanics(t, func() { reg.PublishToOverlapping(ctx, spAB, ev, false /* omitInRangefeeds */, nil /* alloc */) })
+	require.NotPanics(t, func() { reg.PublishToOverlapping(ctx, spCD, ev, false /* omitInRangefeeds */, nil /* alloc */) })
 	require.NoError(t, reg.waitForCaughtUp(all))
 
 	rNoDiff.disconnect(nil)
@@ -517,7 +567,8 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 	ctx := context.Background()
 	reg := makeRegistry(NewMetrics())
 
-	r := newTestRegistration(spAB, hlc.Timestamp{WallTime: 10}, nil, false)
+	r := newTestRegistration(spAB, hlc.Timestamp{WallTime: 10}, nil, /* catchup */
+		false /* withDiff */, false /* withFiltering */)
 	go r.runOutputLoop(context.Background(), 0)
 	reg.Register(&r.registration)
 
@@ -527,7 +578,7 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 	ev.MustSetValue(&kvpb.RangeFeedValue{
 		Value: roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 5}},
 	})
-	reg.PublishToOverlapping(ctx, spAB, ev, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAB, ev, false /* omitInRangefeeds */, nil /* alloc */)
 	require.NoError(t, reg.waitForCaughtUp(all))
 	require.Nil(t, r.Events())
 
@@ -536,7 +587,7 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 	ev.MustSetValue(&kvpb.RangeFeedValue{
 		Value: roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 10}},
 	})
-	reg.PublishToOverlapping(ctx, spAB, ev, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAB, ev, false /* omitInRangefeeds */, nil /* alloc */)
 	require.NoError(t, reg.waitForCaughtUp(all))
 	require.Nil(t, r.Events())
 
@@ -545,7 +596,7 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 	ev.MustSetValue(&kvpb.RangeFeedCheckpoint{
 		Span: spAB, ResolvedTS: hlc.Timestamp{WallTime: 5},
 	})
-	reg.PublishToOverlapping(ctx, spAB, ev, nil /* alloc */)
+	reg.PublishToOverlapping(ctx, spAB, ev, false /* omitInRangefeeds */, nil /* alloc */)
 	require.NoError(t, reg.waitForCaughtUp(all))
 	require.Equal(t, []*kvpb.RangeFeedEvent{ev}, r.Events())
 
@@ -597,7 +648,8 @@ func TestRegistryShutdownMetrics(t *testing.T) {
 	reg := makeRegistry(NewMetrics())
 
 	regDoneC := make(chan interface{})
-	r := newTestRegistration(spAB, hlc.Timestamp{WallTime: 10}, nil, false)
+	r := newTestRegistration(spAB, hlc.Timestamp{WallTime: 10}, nil, /*catchup */
+		false /* withDiff */, false /* withFiltering */)
 	go func() {
 		r.runOutputLoop(context.Background(), 0)
 		close(regDoneC)

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -32,6 +32,13 @@ func makeVal(val string) roachpb.Value {
 	return roachpb.MakeValueFromString(val)
 }
 
+func makeMVCCVal(val string, header enginepb.MVCCValueHeader) storage.MVCCValue {
+	return storage.MVCCValue{
+		MVCCValueHeader: header,
+		Value:           roachpb.MakeValueFromString(val),
+	}
+}
+
 func makeValWithTs(val string, ts int64) roachpb.Value {
 	v := makeVal(val)
 	v.Timestamp = hlc.Timestamp{WallTime: ts}
@@ -45,6 +52,19 @@ func makeKV(key, val string, ts int64) storage.MVCCKeyValue {
 			Timestamp: hlc.Timestamp{WallTime: ts},
 		},
 		Value: makeVal(val).RawBytes,
+	}
+}
+
+func makeKVWithHeader(
+	key, val string, ts int64, header enginepb.MVCCValueHeader,
+) storage.MVCCKeyValue {
+	v, _ := storage.EncodeMVCCValue(makeMVCCVal(val, header))
+	return storage.MVCCKeyValue{
+		Key: storage.MVCCKey{
+			Key:       roachpb.Key(key),
+			Timestamp: hlc.Timestamp{WallTime: ts},
+		},
+		Value: v,
 	}
 }
 

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -167,6 +167,7 @@ func evaluateBatch(
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 	evalPath batchEvalPath,
+	omitInRangefeeds bool, // only relevant for transactional writes
 ) (_ *kvpb.BatchResponse, _ result.Result, retErr *kvpb.Error) {
 	defer func() {
 		// Ensure that errors don't carry the WriteTooOld flag set. The client
@@ -302,7 +303,7 @@ func evaluateBatch(
 		// may carry a response transaction and in the case of WriteTooOldError
 		// (which is sometimes deferred) it is fully populated.
 		curResult, err := evaluateCommand(
-			ctx, readWriter, rec, ms, ss, baHeader, args, reply, g, st, ui, evalPath,
+			ctx, readWriter, rec, ms, ss, baHeader, args, reply, g, st, ui, evalPath, omitInRangefeeds,
 		)
 
 		if filter := rec.EvalKnobs().TestingPostEvalFilter; filter != nil {
@@ -460,6 +461,7 @@ func evaluateCommand(
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 	evalPath batchEvalPath,
+	omitInRangefeeds bool,
 ) (result.Result, error) {
 	var err error
 	var pd result.Result
@@ -479,6 +481,7 @@ func evaluateCommand(
 			Concurrency:           g,
 			Uncertainty:           ui,
 			DontInterleaveIntents: evalPath == readOnlyWithoutInterleavedIntents,
+			OmitInRangefeeds:      omitInRangefeeds,
 		}
 
 		if cmd.EvalRW != nil {

--- a/pkg/kv/kvserver/replica_evaluate_test.go
+++ b/pkg/kv/kvserver/replica_evaluate_test.go
@@ -949,6 +949,7 @@ func TestEvaluateBatch(t *testing.T) {
 				nil,
 				uncertainty.Interval{},
 				evalPath,
+				false, /* omitInRangefeeds */
 			)
 
 			tc.check(t, r)

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -101,7 +101,7 @@ func (r *Replica) MaybeGossipNodeLivenessRaftMuLocked(
 	br, result, pErr :=
 		evaluateBatch(
 			ctx, kvserverbase.CmdIDKey(""), rw, rec, nil /* ms */, &ba,
-			nil /* g */, nil /* st */, uncertainty.Interval{}, readOnlyDefault,
+			nil /* g */, nil /* st */, uncertainty.Interval{}, readOnlyDefault, false, /* omitInRangefeeds */
 		)
 	if pErr != nil {
 		return errors.Wrapf(pErr.GoError(), "couldn't scan node liveness records in span %s", span)

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -289,7 +289,7 @@ func (r *Replica) RangeFeed(
 	}
 	var done future.ErrorFuture
 	p := r.registerWithRangefeedRaftMuLocked(
-		ctx, rSpan, args.Timestamp, catchUpIter, args.WithDiff, lockedStream, &done,
+		ctx, rSpan, args.Timestamp, catchUpIter, args.WithDiff, args.WithFiltering, lockedStream, &done,
 	)
 	r.raftMu.Unlock()
 
@@ -385,6 +385,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	startTS hlc.Timestamp, // exclusive
 	catchUpIter *rangefeed.CatchUpIterator,
 	withDiff bool,
+	withFiltering bool,
 	stream rangefeed.Stream,
 	done *future.ErrorFuture,
 ) rangefeed.Processor {
@@ -406,7 +407,8 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	p := r.rangefeedMu.proc
 
 	if p != nil {
-		reg, filter := p.Register(span, startTS, catchUpIter, withDiff, stream, func() { r.maybeDisconnectEmptyRangefeed(p) }, done)
+		reg, filter := p.Register(span, startTS, catchUpIter, withDiff, withFiltering,
+			stream, func() { r.maybeDisconnectEmptyRangefeed(p) }, done)
 		if reg {
 			// Registered successfully with an existing processor.
 			// Update the rangefeed filter to avoid filtering ops
@@ -493,7 +495,8 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	// any other goroutines are able to stop the processor. In other words,
 	// this ensures that the only time the registration fails is during
 	// server shutdown.
-	reg, filter := p.Register(span, startTS, catchUpIter, withDiff, stream, func() { r.maybeDisconnectEmptyRangefeed(p) }, done)
+	reg, filter := p.Register(span, startTS, catchUpIter, withDiff,
+		withFiltering, stream, func() { r.maybeDisconnectEmptyRangefeed(p) }, done)
 	if !reg {
 		select {
 		case <-r.store.Stopper().ShouldQuiesce():
@@ -660,6 +663,16 @@ func (r *Replica) handleLogicalOpLogRaftMuLocked(
 		return
 	}
 
+	// The RangefeedValueHeaderFilter function is supposed to be applied for all
+	// emitted events to enable kvnemesis to match rangefeed events to kvnemesis
+	// operations. Applying the function here could mean we apply it to a
+	// rangefeed event that is later filtered out and not actually emitted; this
+	// filtering happens in the registry's PublishToOverlapping if the event has
+	// OmitInRangefeeds = true and the registration has WithFiltering = true.
+	//
+	// The above is not an issue because (a) for all emitted events, the
+	// RangefeedValueHeaderFilter will be called, and (b) the kvnemesis rangefeed
+	// is an internal rangefeed and should always have WithFiltering = false.
 	vhf := r.store.TestingKnobs().RangefeedValueHeaderFilter
 
 	// When reading straight from the Raft log, some logical ops will not be
@@ -668,10 +681,11 @@ func (r *Replica) handleLogicalOpLogRaftMuLocked(
 		var key []byte
 		var ts hlc.Timestamp
 		var valPtr *[]byte
+		var omitInRangefeedsPtr *bool
 		valueInBatch := false
 		switch t := op.GetValue().(type) {
 		case *enginepb.MVCCWriteValueOp:
-			key, ts, valPtr = t.Key, t.Timestamp, &t.Value
+			key, ts, valPtr, omitInRangefeedsPtr = t.Key, t.Timestamp, &t.Value, &t.OmitInRangefeeds
 			if !ts.IsEmpty() {
 				// 1PC transaction commit, and no intent was written, so the value
 				// must be in the batch.
@@ -683,7 +697,7 @@ func (r *Replica) handleLogicalOpLogRaftMuLocked(
 			// involve merging with state in the engine. So, valueInBatch remains
 			// false.
 		case *enginepb.MVCCCommitIntentOp:
-			key, ts, valPtr = t.Key, t.Timestamp, &t.Value
+			key, ts, valPtr, omitInRangefeedsPtr = t.Key, t.Timestamp, &t.Value, &t.OmitInRangefeeds
 			// Intent was committed. The now committed provisional value may be in
 			// the engine, so valueInBatch remains false.
 		case *enginepb.MVCCWriteIntentOp,
@@ -739,6 +753,7 @@ func (r *Replica) handleLogicalOpLogRaftMuLocked(
 			vhf(key, nil, ts, vh)
 		}
 		*valPtr = val.RawBytes
+		*omitInRangefeedsPtr = vh.OmitInRangefeeds
 	}
 
 	// Pass the ops to the rangefeed processor.

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -471,7 +471,8 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 		}
 		now := timeutil.Now()
 		br, res, pErr = evaluateBatch(
-			ctx, kvserverbase.CmdIDKey(""), rw, rec, nil /* ms */, ba, g, st, ui, evalPath,
+			ctx, kvserverbase.CmdIDKey(""), rw, rec, nil /* ms */, ba, g,
+			st, ui, evalPath, false, /* omitInRangefeeds */
 		)
 		r.store.metrics.ReplicaReadBatchEvaluationLatency.RecordValue(timeutil.Since(now).Nanoseconds())
 		// Allow only one retry.

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -452,8 +452,11 @@ func (r *Replica) evaluateWriteBatch(
 	rec := NewReplicaEvalContext(
 		ctx, r, g.LatchSpans(), ba.RequiresClosedTSOlderThanStorageSnapshot(), ba.AdmissionHeader)
 	defer rec.Release()
+	// For non-transactional writes, omitInRangefeeds should always be false.
+	// For transactional writes, we propagate the flag from the txn.
+	omitInRangefeeds := ba.Txn != nil && ba.Txn.OmitInRangefeeds
 	batch, br, res, pErr := r.evaluateWriteBatchWithServersideRefreshes(
-		ctx, idKey, rec, ms, ba, g, st, ui, hlc.Timestamp{} /* deadline */)
+		ctx, idKey, rec, ms, ba, g, st, ui, hlc.Timestamp{} /* deadline */, omitInRangefeeds)
 	return batch, *ms, br, res, pErr
 }
 
@@ -538,10 +541,10 @@ func (r *Replica) evaluate1PC(
 	defer releaseMVCCStats(ms)
 	if ba.CanForwardReadTimestamp {
 		batch, br, res, pErr = r.evaluateWriteBatchWithServersideRefreshes(
-			ctx, idKey, rec, ms, &strippedBa, g, st, ui, etArg.Deadline)
+			ctx, idKey, rec, ms, &strippedBa, g, st, ui, etArg.Deadline, ba.Txn.OmitInRangefeeds)
 	} else {
 		batch, br, res, pErr = r.evaluateWriteBatchWrapper(
-			ctx, idKey, rec, ms, &strippedBa, g, st, ui)
+			ctx, idKey, rec, ms, &strippedBa, g, st, ui, ba.Txn.OmitInRangefeeds)
 	}
 
 	if pErr != nil || (!ba.CanForwardReadTimestamp && ba.Timestamp != br.Timestamp) {
@@ -670,6 +673,7 @@ func (r *Replica) evaluateWriteBatchWithServersideRefreshes(
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
 	deadline hlc.Timestamp,
+	omitInRangefeeds bool,
 ) (batch storage.Batch, br *kvpb.BatchResponse, res result.Result, pErr *kvpb.Error) {
 	goldenMS := *ms
 	for retries := 0; ; retries++ {
@@ -682,7 +686,7 @@ func (r *Replica) evaluateWriteBatchWithServersideRefreshes(
 			batch.Close()
 		}
 
-		batch, br, res, pErr = r.evaluateWriteBatchWrapper(ctx, idKey, rec, ms, ba, g, st, ui)
+		batch, br, res, pErr = r.evaluateWriteBatchWrapper(ctx, idKey, rec, ms, ba, g, st, ui, omitInRangefeeds)
 
 		// Allow one retry only; a non-txn batch containing overlapping
 		// spans will always experience WriteTooOldError.
@@ -711,10 +715,11 @@ func (r *Replica) evaluateWriteBatchWrapper(
 	g *concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
+	omitInRangefeeds bool,
 ) (storage.Batch, *kvpb.BatchResponse, result.Result, *kvpb.Error) {
 	batch, opLogger := r.newBatchedEngine(ba, g)
 	now := timeutil.Now()
-	br, res, pErr := evaluateBatch(ctx, idKey, batch, rec, ms, ba, g, st, ui, readWrite)
+	br, res, pErr := evaluateBatch(ctx, idKey, batch, rec, ms, ba, g, st, ui, readWrite, omitInRangefeeds)
 	r.store.metrics.ReplicaWriteBatchEvaluationLatency.RecordValue(timeutil.Since(now).Nanoseconds())
 	if pErr == nil {
 		if opLogger != nil {

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -256,11 +256,17 @@ message MVCCStatsDelta {
 
 // MVCCWriteValueOp corresponds to a value being written outside of a
 // transaction. Inline values (without timestamp) are not logged.
+// Note that 1PC writes are included here.
 message MVCCWriteValueOp {
   bytes key = 1;
   util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable) = false];
   bytes value = 3;
   bytes prev_value = 4;
+  // When set to true, this value will be filtered out by rangefeeds and will
+  // not be available in changefeeds. OmitInRangefeeds is populated from the
+  // MVCCValueHeader of the corresponding write. It is only relevant for
+  // transactional writes, which in the case of MVCCWriteValueOp are 1PC writes.
+  bool omit_in_rangefeeds = 6;
 }
 
 // MVCCUpdateIntentOp corresponds to an intent being written for a given
@@ -297,6 +303,11 @@ message MVCCCommitIntentOp {
   util.hlc.Timestamp timestamp = 3 [(gogoproto.nullable) = false];
   bytes value = 4;
   bytes prev_value = 5;
+  // When set to true, this value will be filtered out by rangefeeds and will
+  // not be available in changefeeds. OmitInRangefeeds is populated from the
+  // MVCCValueHeader of the corresponding write. It is only relevant for
+  // transactional writes.
+  bool omit_in_rangefeeds = 6;
 }
 
 // MVCCAbortIntentOp corresponds to an intent being aborted for a given

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2649,9 +2649,7 @@ func mvccPutInternal(
 	versionValue := MVCCValue{}
 	versionValue.Value = value
 	versionValue.LocalTimestamp = opts.LocalTimestamp
-	if opts.Txn != nil {
-		versionValue.OmitInRangefeeds = opts.Txn.OmitInRangefeeds
-	}
+	versionValue.OmitInRangefeeds = opts.OmitInRangefeeds
 
 	if buildutil.CrdbTestBuild {
 		if seq, seqOK := kvnemesisutil.FromContext(ctx); seqOK {
@@ -4553,6 +4551,7 @@ type MVCCWriteOptions struct {
 	LocalTimestamp                 hlc.ClockTimestamp
 	Stats                          *enginepb.MVCCStats
 	ReplayWriteTimestampProtection bool
+	OmitInRangefeeds               bool
 	// MaxLockConflicts is a maximum number of conflicting locks collected before
 	// returning LockConflictError. Even single-key writes can encounter multiple
 	// conflicting shared locks, so the limit is important to bound the number of


### PR DESCRIPTION
OmitInRangefeeds is a transaction attibute that, when set to true, indicates that rangefeeds should ignore all writes of the transaction. It is set on all transactions for sessions that have the session variable `disable_changefeed_replication`. The flag is also populated on the MVCCValueHeader of any transactional write whose trasaction has it set to true. This change enforces the actual filtering on the rangefeed server side for both current rangefeed events and the rangefeed catchup iterator.

If a user sets the `disable_changefeed_replication` session variable and also runs statements that write to system tables (e.g. set a cluster setting), the rangefeed events corresponding to those writes will be dropped because the use transaction is used for the writes; this is undesirable because many internal system components depend on these events (e.g. the cluster settings rangefeed cache). To prevent this, we also add a flag on the rangefeed consumer side to explicitly opt into filtering. All changefeeds will set this flag to true to utilize the `disable_changefeed_replication` feature, and all internal rangefeeds will not set the flag to ensure they receive all rangefeed events.

Part of: #114313

Release note: None