### PR TITLE
cli: skip TestDebugCheckStore under deadlock and race

### DIFF
--- a/pkg/cli/debug_check_store_test.go
+++ b/pkg/cli/debug_check_store_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -33,6 +34,11 @@ import (
 func TestDebugCheckStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// This test is prone to timing out when run using remote execution under the
+	// {deadlock,race} detector.
+	skip.UnderDeadlock(t)
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Addresses #115938

Release note: None