### PR TITLE
roachtest: deduplicate descriptor validation check

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1437,18 +1437,6 @@ func (c *clusterImpl) HealthStatus(
 	return results, nil
 }
 
-// assertValidDescriptors fails the test if there exists any descriptors in
-// the crdb_internal.invalid_objects virtual table.
-func (c *clusterImpl) assertValidDescriptors(ctx context.Context, db *gosql.DB, t *testImpl) error {
-	t.L().Printf("checking for invalid descriptors")
-	return timeutil.RunWithTimeout(
-		ctx, "invalid descriptors check", 1*time.Minute,
-		func(ctx context.Context) error {
-			return roachtestutil.CheckInvalidDescriptors(ctx, db)
-		},
-	)
-}
-
 // assertConsistentReplicas fails the test if
 // crdb_internal.check_consistency(true, ”, ”) indicates that any ranges'
 // replicas are inconsistent with each other.

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
@@ -1262,7 +1263,7 @@ func (r *testRunner) postTestAssertions(
 			// If this validation fails due to a timeout, it is very likely that
 			// the replica divergence check below will also fail.
 			if t.spec.SkipPostValidations&registry.PostValidationInvalidDescriptors == 0 {
-				if err := c.assertValidDescriptors(ctx, db, t); err != nil {
+				if err := roachtestutil.CheckInvalidDescriptors(ctx, db); err != nil {
 					postAssertionErr(errors.WithDetail(err, "invalid descriptors check failed"))
 				}
 			}


### PR DESCRIPTION
Epic: none

Release note: none