### PR TITLE
release-23.2: sql: prevent creating indexes on arrays of non-indexable types

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/refcursor
+++ b/pkg/ccl/logictestccl/testdata/logic_test/refcursor
@@ -596,6 +596,49 @@ CREATE INDEX ON t112099_no_index (r);
 statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
 CREATE INDEX ON t112099_no_index (x, r, y);
 
+# Regression test for #115701 - REFCURSOR[] is not a valid index column.
+subtest refcursor[]_array_index
+
+statement ok
+CREATE TABLE t115701_no_index (x INT NOT NULL, y TEXT NOT NULL, r REFCURSOR[] NOT NULL);
+
+# REFCURSOR[] is not allowed in a primary key.
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+CREATE TABLE t115701 (r REFCURSOR[] PRIMARY KEY);
+
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+CREATE TABLE t115701 (x INT, y TEXT, r REFCURSOR[], PRIMARY KEY (x, r, y));
+
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+ALTER TABLE t115701_no_index ADD PRIMARY KEY (r);
+
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+ALTER TABLE t115701_no_index ADD PRIMARY KEY (x, r, y);
+
+# REFCURSOR[] is not allowed in a secondary index.
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+CREATE TABLE t115701 (r REFCURSOR[], INDEX (r));
+
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+CREATE TABLE t115701 (x INT, y TEXT, r REFCURSOR[], INDEX (x, r, y));
+
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+CREATE INDEX ON t115701_no_index (r);
+
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+CREATE INDEX ON t115701_no_index (x, r, y);
+
+statement error pgcode 0A000 pq: column r of type refcursor\[\] is not allowed as the last column in an inverted index
+CREATE INDEX ON t115701_no_index USING GIN (r)
+
+skipif config local-legacy-schema-changer
+statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+CREATE INDEX ON t115701_no_index USING GIN (x, r, y gin_trgm_ops)
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 0A000  pq: column r of type refcursor\[\] is only allowed as the last column in an inverted index
+CREATE INDEX ON t115701_no_index USING GIN (x, r, y gin_trgm_ops)
+
 # REFCURSOR is allowed as a STORING column.
 statement ok
 CREATE TABLE t112099 (x INT, r REFCURSOR, INDEX (x) STORING (r));


### PR DESCRIPTION
Backport 1/1 commits from #115707.

/cc @cockroachdb/release

---

#### ae7fbfbe95493939fc28ef6d83bbcc6b03c46f58 sql: prevent creating indexes on arrays of non-indexable types

Previously, it was possible to circumvent the check performed by
`ColumnTypeIsIndexable` and `ColumnTypeIsInvertedIndexable` by wrapping
a type in an array. Doing so would violate some invariants across the
system and lead to undefined behavior.

This commit updates both `ColumnTypeIsIndexable` and
`ColumnTypeIsInvertedIndexable` to unwrap array types, as necessary, to
prevent invalid indexes from being created.

Fixes: #115701
Epic: none
Release note (bug fix): Standard and inverted indexes may no longer be
created on REFCURSOR[]s columns. REFCURSOR columns themselves are not
indexable.
Release justification: Prevents users from creating invalid indexes and is otherwise minimally invasive.