### PR TITLE
pgwirecancel: deflake TestCancelCopyTo

### DIFF
--- a/pkg/sql/pgwire/pgwirecancel/cancel_test.go
+++ b/pkg/sql/pgwire/pgwirecancel/cancel_test.go
@@ -190,7 +190,7 @@ func TestCancelCopyTo(t *testing.T) {
 
 	g := ctxgroup.WithContext(ctx)
 	g.GoCtx(func(ctx context.Context) error {
-		_, err = conn.Exec(ctx, "COPY (SELECT pg_sleep(1) FROM ROWS FROM (generate_series(1, 60)) AS i) TO STDOUT")
+		_, err := conn.Exec(ctx, "COPY (SELECT pg_sleep(1) FROM ROWS FROM (generate_series(1, 60)) AS i) TO STDOUT")
 		return err
 	})
 


### PR DESCRIPTION
This test had a race condition since it used the same err variable in different goroutines.

fixes https://github.com/cockroachdb/cockroach/issues/116032
Release note: None