### PR TITLE
cluster-ui: use feature flag for useObsService

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
@@ -20,12 +20,15 @@ import {
   selectStmtInsightDetails,
   selectStmtInsightsError,
 } from "src/store/insights/statementInsights";
-import { selectHasAdminRole, selectIsTenant } from "src/store/uiConfig";
+import {
+  selectHasAdminRole,
+  selectIsTenant,
+  selectUseObsService,
+} from "src/store/uiConfig";
 import { TimeScale } from "../../timeScaleDropdown";
 import { actions as sqlStatsActions } from "../../store/sqlStats";
 import { selectTimeScale } from "../../store/utils/selectors";
 import { actions as analyticsActions } from "../../store/analytics";
-import { selectUseObsService } from "src/store/clusterSettings/clusterSettings.selectors";
 
 const mapStateToProps = (
   state: AppState,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
@@ -50,8 +50,7 @@ import { TimeScale } from "../../timeScaleDropdown";
 import { StmtInsightsReq, TxnInsightsRequest } from "src/api";
 import { selectTimeScale } from "../../store/utils/selectors";
 import { actions as analyticsActions } from "../../store/analytics";
-import { selectIsTenant } from "../../store/uiConfig";
-import { selectUseObsService } from "src/store/clusterSettings/clusterSettings.selectors";
+import { selectIsTenant, selectUseObsService } from "../../store/uiConfig";
 
 const transactionMapStateToProps = (
   state: AppState,

--- a/pkg/ui/workspaces/cluster-ui/src/store/clusterSettings/clusterSettings.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/clusterSettings/clusterSettings.selectors.ts
@@ -9,11 +9,7 @@
 // licenses/APL.txt.
 
 import { AppState } from "../reducers";
-import {
-  exportInsights,
-  greaterOrEqualThanVersion,
-  indexUnusedDuration,
-} from "../../util";
+import { greaterOrEqualThanVersion, indexUnusedDuration } from "../../util";
 
 export const selectAutomaticStatsCollectionEnabled = (
   state: AppState,
@@ -53,19 +49,4 @@ export const selectDropUnusedIndexDuration = (state: AppState): string => {
     settings["sql.index_recommendation.drop_unused_duration"]?.value ||
     indexUnusedDuration
   );
-};
-
-export const selectUseObsService = (state: AppState): boolean => {
-  const settings = state.adminUI?.clusterSettings.data?.key_values;
-  if (!settings) {
-    return exportInsights;
-  }
-  if (settings["sql.insights.export.enabled"]) {
-    if (settings["sql.insights.export.enabled"]?.value === "false") {
-      return false;
-    }
-    return true;
-  } else {
-    return exportInsights;
-  }
 };

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
@@ -19,6 +19,7 @@ export type UIConfigState = {
   userSQLRoles: string[];
   hasViewActivityRedactedRole: boolean;
   hasAdminRole: boolean;
+  useObsService: boolean;
   pages: {
     statementDetails: {
       showStatementDiagnosticsLink: boolean;
@@ -34,6 +35,7 @@ const initialState: UIConfigState = {
   userSQLRoles: [],
   hasViewActivityRedactedRole: false,
   hasAdminRole: false,
+  useObsService: false,
   pages: {
     statementDetails: {
       showStatementDiagnosticsLink: true,

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
@@ -29,3 +29,7 @@ export const selectHasViewActivityRedactedRole = createSelector(
 export const selectHasAdminRole = createSelector(selectUIConfig, uiConfig =>
   uiConfig?.userSQLRoles.includes("ADMIN"),
 );
+
+export const selectUseObsService = createSelector(selectUIConfig, uiConfig => {
+  return uiConfig?.useObsService;
+});

--- a/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
@@ -38,7 +38,6 @@ export const idAttr = "id";
 
 // Default value for cluster settings
 export const indexUnusedDuration = "168h";
-export const exportInsights = false;
 
 export const REMOTE_DEBUGGING_ERROR_TEXT =
   "This information is not available due to the current value of the 'server.remote_debugging.mode' setting.";

--- a/pkg/ui/workspaces/db-console/src/util/constants.ts
+++ b/pkg/ui/workspaces/db-console/src/util/constants.ts
@@ -37,5 +37,4 @@ export const {
   REMOTE_DEBUGGING_ERROR_TEXT,
   idAttr,
   indexUnusedDuration,
-  exportInsights,
 } = util;


### PR DESCRIPTION
Get feature flag for useObsService and use it on
Insights API selector for CC Console.
The DB Console will never use Observability Service,
so the value can be set to `false`
and no need to check for feature flags.

Epic: [CC-26619](https://cockroachlabs.atlassian.net/browse/CC-26619)

Release note: None