### PR TITLE
sql: skip TestShowLastQueryStatistics under race

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/pgtest"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
@@ -1325,6 +1326,8 @@ CREATE TABLE t1.test (k INT PRIMARY KEY, v TEXT);
 func TestShowLastQueryStatistics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "measure planning latency which is slower than usual under race")
 
 	ctx := context.Background()
 	params := base.TestServerArgs{}


### PR DESCRIPTION
This commit skips TestShowLastQueryStatistics under the `race` test flag
because the added overhead of the race detector makes latency checks in
the test fail.

Fixes #115934

Release note: None
