### PR TITLE
sql: disable write pipelining for implicit txns used by COPY

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3031,6 +3031,12 @@ func (ex *connExecutor) execCopyIn(
 		},
 	}
 
+	if ex.implicitTxn() && !ex.planner.SessionData().CopyWritePipeliningEnabled {
+		if err := txnOpt.txn.DisablePipelining(); err != nil {
+			return ex.makeErrEvent(err, cmd.ParsedStmt.AST)
+		}
+	}
+
 	ex.setCopyLoggingFields(cmd.ParsedStmt)
 
 	var cm copyMachineInterface

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -1037,6 +1037,11 @@ func (p *planner) preparePlannerForCopy(
 			// Start the implicit txn for the next batch.
 			nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID()
 			txnOpt.txn = kv.NewTxnWithSteppingEnabled(ctx, p.execCfg.DB, nodeID, p.SessionData().CopyTxnQualityOfService)
+			if !p.SessionData().CopyWritePipeliningEnabled {
+				if err = txnOpt.txn.DisablePipelining(); err != nil {
+					return err
+				}
+			}
 			txnOpt.txnTimestamp = p.execCfg.Clock.PhysicalTime()
 			txnOpt.stmtTimestamp = txnOpt.txnTimestamp
 		}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3404,6 +3404,10 @@ func (m *sessionDataMutator) SetCopyQualityOfService(val sessiondatapb.QoSLevel)
 	m.data.CopyTxnQualityOfService = val.Validate()
 }
 
+func (m *sessionDataMutator) SetCopyWritePipeliningEnabled(val bool) {
+	m.data.CopyWritePipeliningEnabled = val
+}
+
 func (m *sessionDataMutator) SetOptSplitScanLimit(val int32) {
 	m.data.OptSplitScanLimit = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5489,6 +5489,7 @@ client_min_messages                                        notice
 copy_from_atomic_enabled                                   on
 copy_from_retries_enabled                                  on
 copy_transaction_quality_of_service                        background
+copy_write_pipelining_enabled                              off
 cost_scans_with_default_col_size                           off
 database                                                   test
 datestyle                                                  ISO, MDY

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2802,6 +2802,7 @@ client_min_messages                                        notice              N
 copy_from_atomic_enabled                                   on                  NULL      NULL        NULL        string
 copy_from_retries_enabled                                  on                  NULL      NULL        NULL        string
 copy_transaction_quality_of_service                        background          NULL      NULL        NULL        string
+copy_write_pipelining_enabled                              off                 NULL      NULL        NULL        string
 cost_scans_with_default_col_size                           off                 NULL      NULL        NULL        string
 database                                                   test                NULL      NULL        NULL        string
 datestyle                                                  ISO, MDY            NULL      NULL        NULL        string
@@ -2973,6 +2974,7 @@ client_min_messages                                        notice              N
 copy_from_atomic_enabled                                   on                  NULL  user     NULL      on                  on
 copy_from_retries_enabled                                  on                  NULL  user     NULL      on                  on
 copy_transaction_quality_of_service                        background          NULL  user     NULL      background          background
+copy_write_pipelining_enabled                              off                 NULL  user     NULL      off                 off
 cost_scans_with_default_col_size                           off                 NULL  user     NULL      off                 off
 database                                                   test                NULL  user     NULL      ·                   test
 datestyle                                                  ISO, MDY            NULL  user     NULL      ISO, MDY            ISO, MDY
@@ -3138,6 +3140,7 @@ copy_fast_path_enabled                                     NULL    NULL     NULL
 copy_from_atomic_enabled                                   NULL    NULL     NULL     NULL        NULL
 copy_from_retries_enabled                                  NULL    NULL     NULL     NULL        NULL
 copy_transaction_quality_of_service                        NULL    NULL     NULL     NULL        NULL
+copy_write_pipelining_enabled                              NULL    NULL     NULL     NULL        NULL
 cost_scans_with_default_col_size                           NULL    NULL     NULL     NULL        NULL
 crdb_version                                               NULL    NULL     NULL     NULL        NULL
 database                                                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -40,6 +40,7 @@ client_min_messages                                        notice
 copy_from_atomic_enabled                                   on
 copy_from_retries_enabled                                  on
 copy_transaction_quality_of_service                        background
+copy_write_pipelining_enabled                              off
 cost_scans_with_default_col_size                           off
 database                                                   test
 datestyle                                                  ISO, MDY

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -469,6 +469,9 @@ message LocalOnlySessionData {
   // CopyTxnQualityOfService indicates the default QoSLevel/WorkPriority of the
   // transactions used to evaluate COPY commands.
   int32 copy_txn_quality_of_service = 117 [(gogoproto.casttype)="QoSLevel"];
+  // CopyWritePipeliningEnabled indicates whether the write pipelining is
+  // enabled for implicit txns used by COPY.
+  bool copy_write_pipelining_enabled = 118;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2258,6 +2258,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`copy_write_pipelining_enabled`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`copy_write_pipelining_enabled`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("copy_write_pipelining_enabled", s)
+			if err != nil {
+				return err
+			}
+			m.SetCopyWritePipeliningEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().CopyWritePipeliningEnabled), nil
+		},
+		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
 	`opt_split_scan_limit`: {
 		GetStringVal: makeIntGetStringValFn(`opt_split_scan_limit`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {


### PR DESCRIPTION
This commit makes it so that we disable write pipelining on implicit txns used by COPY. The rationale for that is that these are throughput-oriented txns which build large batches and shouldn’t be getting much benefit from write pipelining. It also introduces a session variable to be able to go back to the old behavior should we need to.

Note that there are two places where we deal with txns in COPY:
- the initial txn is created by the connExecutor state machine. It also might be explicit. In this case disabling the write pipelining is done only for the implicit txn.
- for implicit txns with non-atomic COPY, we create a fresh txn after each batch.

Epic: None

Release note: None