### PR TITLE
sql: don't redact already-redacted statement in logs

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/lib/pq/oid"
 )
 
@@ -285,7 +286,7 @@ func (ex *connExecutor) prepare(
 		} else {
 			f := tree.NewFmtCtx(tree.FmtMarkRedactionNode | tree.FmtSimple)
 			f.FormatNode(stmt.AST)
-			redactableStmt := f.CloseAndGetString()
+			redactableStmt := redact.SafeString(f.CloseAndGetString())
 			log.Warningf(ctx, "could not prepare statement during session migration (%s): %v", redactableStmt, err)
 		}
 	}


### PR DESCRIPTION
This log message uses the FmtMarkRedactionNode option to redact the statement. But since the redacted statement was a raw string, the whole statement was getting redacted anyway. This patch fixes that.

Epic: None
Release note: None