### PR TITLE
backupccl: flush at end of online restore span entry

### DIFF
--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -61,7 +61,7 @@ var targetOnlineRestoreSpanSize = settings.RegisterByteSizeSetting(
 	settings.ApplicationLevel,
 	"backup.restore_span.online_target_size",
 	"target size to which base spans of an online restore are merged to produce a restore span (0 disables)",
-	8<<30,
+	16<<30,
 )
 
 // backupManifestFileIterator exposes methods that can be used to iterate over


### PR DESCRIPTION
This patch adds a flush call at the end of processing a restoreSpanEntry during
the linking phase. Previously, we'd flush the leftover data at the beginning of
processing the next restore span entry. But in a multi worker world, in which
workers grab restore span entries off a single channel, this "leftover" flush
could link data to a nonempty range that another worker was linking data into,
causing that range to overfill and splits to retry.

Epic: none

Release note: none