### PR TITLE
stress: Revert "enable github issue posting on deadlock, race nightlies"

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
@@ -8,4 +8,6 @@ export EXTRA_ISSUE_PARAMS=deadlock=true
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 
+unset GITHUB_API_TOKEN
+
 $THIS_DIR/stress_engflow_impl.sh

--- a/build/teamcity/cockroach/nightlies/stress_engflow_race.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_race.sh
@@ -8,4 +8,6 @@ export EXTRA_ISSUE_PARAMS=race=true
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 
+unset GITHUB_API_TOKEN
+
 $THIS_DIR/stress_engflow_impl.sh

--- a/build/teamcity/cockroach/nightlies/stress_trigger.sh
+++ b/build/teamcity/cockroach/nightlies/stress_trigger.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run stress trigger"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e TC_API_USER -e TC_API_PASSWORD -e TC_SERVER_URL -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH" \
+  run_bazel build/teamcity/cockroach/nightlies/stress_trigger_impl.sh "$@"
+tc_end_block "Run stress trigger"

--- a/build/teamcity/cockroach/nightlies/stress_trigger_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_trigger_impl.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+bazel build //pkg/cmd/teamcity-trigger --config=ci
+BAZEL_BIN=$(bazel info bazel-bin --config=ci)
+$BAZEL_BIN/pkg/cmd/teamcity-trigger/teamcity-trigger_/teamcity-trigger "$@"


### PR DESCRIPTION
This reverts commit 11901418b3e84c89dd690365dd529b32428af1c2.

This is not quite fully baked and could use a little more time in the oven. Eng teams are also fully booked with release-related concerns. I plan to re-enable this later this week or next week.

Epic: CRDB-8308

Release note: None