### PR TITLE
release-23.1: cluster-ui: allow multiple transaction details to show multiple apps

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/testUtils.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/api/testUtils.tsx
@@ -13,7 +13,7 @@ import Long from "long";
 
 export type Stmt =
   cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
-type Txn =
+export type Txn =
   cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
 type ILatencyInfo = cockroach.sql.ILatencyInfo;
 
@@ -27,6 +27,7 @@ const latencyInfo: Required<ILatencyInfo> = {
 
 const baseStmt: Partial<Stmt> = {
   id: Long.fromInt(11871906682067483964),
+  txn_fingerprint_ids: [Long.fromInt(1)],
   key: {
     key_data: {
       query: "SELECT node_id FROM system.statement_statistics",
@@ -193,13 +194,18 @@ const assignObjectPropsIfExists = <T extends { [key: string]: unknown }>(
   overrides: Partial<T>,
 ): T => {
   const copiedObj: T = { ...baseObj };
+
   for (const prop in baseObj) {
     if (overrides[prop] === undefined) {
       continue;
     }
 
     const val = copiedObj[prop];
-    if (typeof val === "object") {
+    if (
+      typeof val === "object" &&
+      !Array.isArray(val) &&
+      overrides[prop] != null
+    ) {
       copiedObj[prop] = assignObjectPropsIfExists(
         val as Record<string, unknown>,
         overrides[prop] as Record<string, unknown>,

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
@@ -49,11 +49,11 @@ import {
   getMatchParamByName,
   queryByName,
   appNamesAttr,
-  unset,
 } from "../util";
 import { TimeScale } from "../timeScaleDropdown";
 import { actions as analyticsActions } from "../store/analytics";
 import { selectRequestTime } from "src/transactionsPage/transactionsPage.selectors";
+import { getTxnFromSqlStatsTxns } from "../transactionsPage/utils";
 
 export const selectTransaction = createSelector(
   (state: AppState) => state.adminUI?.transactions,
@@ -68,7 +68,9 @@ export const selectTransaction = createSelector(
       };
     }
 
-    const apps = queryByName(props.location, appNamesAttr)
+    // We convert the empty string to null here so that ?appNames= is treated as
+    // selecting all apps.
+    const apps = (queryByName(props.location, appNamesAttr) || null)
       ?.split(",")
       .map(s => s.trim());
 
@@ -77,11 +79,10 @@ export const selectTransaction = createSelector(
       txnFingerprintIdAttr,
     );
 
-    const transaction = transactions.find(
-      txn =>
-        txn.stats_data.transaction_fingerprint_id.toString() ===
-          txnFingerprintId &&
-        (apps?.length ? apps.includes(txn.stats_data.app ?? unset) : true),
+    const transaction = getTxnFromSqlStatsTxns(
+      transactions,
+      txnFingerprintId,
+      apps,
     );
 
     return {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/index.ts
@@ -12,3 +12,4 @@ export * from "./transactionsPage";
 export * from "./transactionsPageConnected";
 export * from "./recentTransactionsView";
 export * from "./transactionsPageRoot";
+export { getTxnFromSqlStatsTxns } from "./utils";

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.spec.ts
@@ -14,16 +14,16 @@ import {
   generateRegion,
   getStatementsByFingerprintId,
   statementFingerprintIdsToText,
+  getTxnFromSqlStatsTxns,
+  getTxnQueryString,
+  getStatementsForTransaction,
 } from "./utils";
 import { Filters } from "../queryFilter";
 import { data, nodeRegions } from "./transactions.fixture";
 import Long from "long";
-import * as protos from "@cockroachlabs/crdb-protobuf-client";
-
-type Statement =
-  protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
-type Transaction =
-  protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
+import { mockTxnStats, Txn, Stmt, mockStmtStats } from "../api/testUtils";
+import { shuffle } from "lodash";
+import { unset } from "src/util/constants";
 
 describe("getStatementsByFingerprintId", () => {
   it("filters statements by fingerprint id", () => {
@@ -41,7 +41,7 @@ describe("getStatementsByFingerprintId", () => {
   });
 });
 
-const txData = data.transactions as Transaction[];
+const txData = data.transactions as Txn[];
 
 describe("Filter transactions", () => {
   it("show internal if no filters applied", () => {
@@ -293,7 +293,7 @@ SELECT _`,
 });
 
 describe("generateRegion", () => {
-  function transaction(...ids: number[]): Transaction {
+  function transaction(...ids: number[]): Txn {
     return {
       stats_data: {
         statement_fingerprint_ids: ids.map(id => Long.fromInt(id)),
@@ -301,7 +301,7 @@ describe("generateRegion", () => {
     };
   }
 
-  function statement(id: number, ...regions: string[]): Statement {
+  function statement(id: number, ...regions: string[]): Stmt {
     return { id: Long.fromInt(id), stats: { regions } };
   }
 
@@ -315,4 +315,327 @@ describe("generateRegion", () => {
       ["gcp-us-central1", "gcp-us-east1", "gcp-us-west1"],
     );
   });
+});
+
+describe("getTxnFromSqlStatsTxns", () => {
+  // Each transaction will be mocked with an exec count of 1.
+  // We will verify that we aggregated the expected number of transactions.
+  it.each([
+    [
+      [
+        { id: 1, app: "hello_world" },
+        { id: 2, app: "cockroach" },
+        { id: 3, app: "" },
+        { id: 3, app: "cockroach" },
+        { id: 3, app: "cockroach" },
+        { id: 3, app: "my_app" },
+        { id: 4, app: "my_app" },
+      ],
+      "3", // fingerprint id
+      ["cockroach", "my_app"], // app name
+      3, // Expected count
+    ],
+    [
+      [
+        { id: 1, app: "hello_world" },
+        { id: 2, app: "cockroach_app" },
+        { id: 3, app: "" },
+        { id: 3, app: "cockroach" },
+        { id: 3, app: "my_app" },
+        { id: 4, app: "my_app" },
+      ],
+      "3", // fingerprint id
+      ["cockroach", "my_app"], // app name
+      2, // Expected count.
+    ],
+    [
+      [
+        { id: 1, app: "hello_world" },
+        { id: 2, app: "cockroach" },
+        { id: 2, app: "cockrooch" },
+        { id: 3, app: "cockroach" },
+        { id: 4, app: "my_app" },
+      ],
+      "2", // fingerprint id
+      null, // app names
+      2, // Expected idx.
+    ],
+    [
+      [
+        { id: 1, app: "aaaaaa" },
+        { id: 2, app: "bbbbbb" },
+        { id: 2, app: "cccccc" },
+        { id: 3, app: "dddddd" },
+        { id: 4, app: "dddddd" },
+      ],
+      "3", // fingerprint id
+      ["dddddd"], // app names
+      1, // Expected idx.
+    ],
+    // Test unset app name. The '(unset)' app name should be explicitly
+    // provided to the function instead of the empty string.
+    [
+      [
+        { id: 1, app: "aaaaaa" },
+        { id: 3, app: "cccccc" },
+        { id: 4, app: "" },
+        { id: 4, app: "" },
+        { id: 5, app: "" },
+      ],
+      "4", // fingerprint id
+      [unset], // app names
+      2, // Expected idx.
+    ],
+  ])(
+    "should return the txn aggregated by fingerprint ID and app names",
+    (
+      txnsToMock,
+      fingerprintID: string,
+      apps: string[] | null,
+      expectedCount: number,
+    ) => {
+      const txns = txnsToMock.map((txn: { id: number; app: string }) =>
+        mockTxnStats({
+          stats_data: {
+            transaction_fingerprint_id: Long.fromInt(txn.id),
+            app: txn.app,
+            stats: {
+              count: Long.fromNumber(1),
+            },
+          },
+        }),
+      );
+
+      const txn = getTxnFromSqlStatsTxns(txns, fingerprintID, apps);
+      expect(txn.stats_data.transaction_fingerprint_id.toString()).toEqual(
+        fingerprintID,
+      );
+      expect(txn.stats_data.stats.count.toNumber()).toEqual(expectedCount);
+    },
+  );
+
+  it("should return null if no txn can be found", () => {
+    const txns = [1, 2, 3, 4, 5, 6].map(txn =>
+      mockTxnStats({
+        stats_data: {
+          transaction_fingerprint_id: Long.fromInt(txn),
+          app: "uncool_app",
+        },
+      }),
+    );
+
+    const txn = getTxnFromSqlStatsTxns(txns, "1", ["cool_app"]);
+    expect(txn == null).toBe(true);
+  });
+
+  it.each([
+    [null, null, null],
+    [null, "123", null],
+    [null, null, ["app"]],
+    [[mockTxnStats()], null, null],
+    [[mockTxnStats()], "123", []],
+    [[mockTxnStats()], null, ["app"]],
+    [[mockTxnStats()], "", ["app"]],
+    [null, "123", ["app"]],
+  ])(
+    "should return null when given invalid parameters: (%p, %p, %p)",
+    (
+      txns: Txn[] | null,
+      fingerprintID: string | null,
+      apps: string[] | null,
+    ) => {
+      const txn = getTxnFromSqlStatsTxns(txns, fingerprintID, apps);
+      expect(txn == null).toBe(true);
+    },
+  );
+});
+
+describe("getTxnQueryString", () => {
+  const extraStmts = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(i =>
+    mockStmtStats({
+      id: Long.fromInt(i + 100),
+      txn_fingerprint_ids: [Long.fromInt(9999999999)],
+    }),
+  );
+
+  const queryStrTestCases = [
+    {
+      txnID: 1,
+      stmtIDs: [4, 5, 6],
+      queries: ["SELECT 1", "SELECT 2", "SELECT 3"],
+    },
+    {
+      txnID: 2,
+      stmtIDs: [2, 11],
+      queries: ["INSERT INTO foo VALUES (1, 2), (3, 4)", "SELECT * FROM foo"],
+    },
+    {
+      txnID: 3,
+      stmtIDs: [8],
+      queries: ["SELECT * FROM foo"],
+    },
+    {
+      txnID: 4,
+      stmtIDs: [3, 5, 7, 9],
+      queries: ["a", "b", "c", "d"],
+    },
+  ].map(tc => {
+    const txnID = Long.fromInt(tc.txnID);
+
+    const txn = mockTxnStats({
+      stats_data: {
+        transaction_fingerprint_id: txnID,
+        statement_fingerprint_ids: tc.stmtIDs.map(id => Long.fromInt(id)),
+      },
+    });
+
+    // Stub statements to have the test case txn id and appropriate query strings.
+    const stmts = tc.queries.map((query, i) =>
+      mockStmtStats({
+        id: Long.fromInt(tc.stmtIDs[i]),
+        key: { key_data: { query, transaction_fingerprint_id: txnID } },
+      }),
+    );
+
+    return [txn, stmts, tc.queries.join("\n")];
+  });
+
+  it.each(queryStrTestCases)(
+    "should build the full txn query string from the provided txn and stmt list",
+    (txn: Txn, stmts: Stmt[], expected: string) => {
+      const txnStr = getTxnQueryString(txn, shuffle([...extraStmts, ...stmts]));
+      expect(txnStr).toEqual(expected);
+    },
+  );
+
+  it("builds partial query when there is a stmt missing from the provided list", () => {
+    const txn = mockTxnStats({
+      stats_data: {
+        transaction_fingerprint_id: Long.fromInt(1),
+        statement_fingerprint_ids: [Long.fromInt(1), Long.fromInt(2)],
+      },
+    });
+    const stmts = [
+      mockStmtStats({
+        id: Long.fromInt(2),
+        key: { key_data: { query: "HELLO" } },
+      }),
+    ];
+
+    const txnStr = getTxnQueryString(txn, stmts);
+    expect(txnStr).toEqual("\nHELLO");
+  });
+
+  it.each([
+    [null, null],
+    [null, extraStmts],
+    [mockTxnStats(), null],
+    [mockTxnStats(), []],
+  ])(
+    "should return the empty string when given invalid params",
+    (txn: Txn, stmts: Stmt[] | null) => {
+      const txnStr = getTxnQueryString(txn, stmts);
+      expect(txnStr).toEqual("");
+    },
+  );
+});
+
+describe("getStatementsForTransaction", () => {
+  // These are the statements we'll throw in with the expected statements
+  // that should be filtered out.
+  // We'll use txn ids in the range [1,10] when testing this function.
+  // Although some of the mocked statements below will have ids in that range,
+  // the app name will never match the given transactions.
+  const extraStmts = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(i =>
+    mockStmtStats({
+      id: Long.fromInt(i),
+      key: {
+        key_data: {
+          transaction_fingerprint_id: Long.fromInt(i),
+          app: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
+      },
+      txn_fingerprint_ids: [Long.fromInt(i)],
+    }),
+  );
+
+  // The statements specified in each test case will be assigned the txn id in the test
+  //  and also be randomly be assigned one of the app names in the provided apps list.
+  const testCases = [
+    {
+      txnID: 1,
+      apps: ["cockroach", "myApp"],
+      stmtIDs: [2, 4, 6, 8, 10, 12],
+    },
+    {
+      txnID: 2,
+      apps: ["myApp"],
+      stmtIDs: [1],
+    },
+    {
+      txnID: 3,
+      apps: ["hello-world"],
+      stmtIDs: [],
+    },
+    {
+      txnID: 3,
+      apps: ["$ internal-my-app"],
+      stmtIDs: [4, 5, 6],
+      useArrayProp: true,
+    },
+  ].map(tc => {
+    const txnID = Long.fromInt(tc.txnID);
+
+    const txn = mockTxnStats({
+      stats_data: { transaction_fingerprint_id: txnID, app: tc.apps[0] },
+    });
+
+    const randomApp = tc.apps?.[Math.floor(Math.random() * tc.apps.length)];
+    const stmts = tc.stmtIDs.map(id =>
+      mockStmtStats({
+        id: Long.fromInt(id),
+        txn_fingerprint_ids: tc.useArrayProp ? [txnID] : null,
+        key: {
+          key_data: {
+            transaction_fingerprint_id: !tc.useArrayProp ? txnID : null,
+            app: randomApp,
+          },
+        },
+      }),
+    );
+
+    return [txn, tc.apps, stmts];
+  });
+
+  it.each(testCases)(
+    "should return the list of stmts that have txn ids matching the provided txn and one of the app names",
+    (txn: Txn, apps: string[], expectedStmts: Stmt[]) => {
+      const stmtsRes = getStatementsForTransaction(
+        txn?.stats_data?.transaction_fingerprint_id?.toString(),
+        apps,
+        shuffle([...extraStmts, ...expectedStmts]),
+      );
+
+      expect(stmtsRes.length).toEqual(expectedStmts.length);
+      const expectedStmtIDs = new Set(expectedStmts.map(s => s.id.toString()));
+      stmtsRes.forEach(s => expect(expectedStmtIDs.has(s.id.toString())));
+    },
+  );
+
+  it.each([
+    [null, null],
+    [mockTxnStats(), null],
+    [null, []],
+  ])(
+    "should return empty array when given invalid params",
+    (txn: Txn | null, stmts: Stmt[] | null) => {
+      expect(
+        getStatementsForTransaction(
+          txn?.stats_data.transaction_fingerprint_id.toString(),
+          [txn?.stats_data.app],
+          stmts,
+        ),
+      ).toEqual([]);
+    },
+  );
 });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -22,13 +22,18 @@ import {
   flattenStatementStats,
   computeOrUseStmtSummary,
   transactionScopedStatementKey,
+  addExecStats,
+  aggregateNumericStats,
+  FixLong,
   unset,
 } from "../util";
+import { cloneDeep } from "lodash";
 
 type Statement =
   protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 type Transaction =
   protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
+type TransactionStats = protos.cockroach.sql.ITransactionStatistics;
 
 export const getTrxAppFilterOptions = (
   transactions: Transaction[],
@@ -307,4 +312,147 @@ export const generateRegionNode = (
     );
   });
   return regionNodes;
+};
+
+/**
+ * getStatementsForTransaction returns the list of stmts with transaction ids
+ * matching and app name matching that of the provided txn.
+ * @param txnFingerprintIDString Txn fingerprint id for which we will find matching stmts.
+ * @param apps List of app names to filter stmts by.
+ * @param stmts List of available stmts.
+ */
+export const getStatementsForTransaction = (
+  txnFingerprintIDString: string,
+  apps: string[],
+  stmts: Statement[] | null,
+): Statement[] => {
+  if (!txnFingerprintIDString || !stmts?.length) return [];
+
+  return stmts.filter(
+    s =>
+      (s.key.key_data?.transaction_fingerprint_id?.toString() ===
+        txnFingerprintIDString ||
+        s.txn_fingerprint_ids
+          ?.map(t => t.toString())
+          .includes(txnFingerprintIDString)) &&
+      (!apps?.length ||
+        apps.includes(s.key.key_data.app ? s.key.key_data.app : unset)),
+  );
+};
+
+/**
+ * getTxnQueryString returns the transaction query built from the provided stmt list
+ * @param txn Transaction to build query for.
+ * @param stmts List of stmts from which to get query strings.
+ */
+export const getTxnQueryString = (
+  txn: Transaction | null,
+  stmts: Statement[],
+): string => {
+  if (!txn || !stmts?.length) return "";
+
+  const statementFingerprintIds = txn?.stats_data?.statement_fingerprint_ids;
+
+  return (
+    (statementFingerprintIds &&
+      statementFingerprintIdsToText(statementFingerprintIds, stmts)) ??
+    ""
+  );
+};
+
+// addTransactionStats adds together two stat objects into one using their counts to compute a new
+// average for the numeric statistics. It's modeled after the similar `addStatementStats` function
+function addTransactionStats(
+  a: TransactionStats,
+  b: TransactionStats,
+): Required<TransactionStats> {
+  const countA = FixLong(a.count).toInt();
+  const countB = FixLong(b.count).toInt();
+  return {
+    count: a.count.add(b.count),
+    max_retries: a.max_retries.greaterThan(b.max_retries)
+      ? a.max_retries
+      : b.max_retries,
+    num_rows: aggregateNumericStats(a.num_rows, b.num_rows, countA, countB),
+    service_lat: aggregateNumericStats(
+      a.service_lat,
+      b.service_lat,
+      countA,
+      countB,
+    ),
+    retry_lat: aggregateNumericStats(a.retry_lat, b.retry_lat, countA, countB),
+    commit_lat: aggregateNumericStats(
+      a.commit_lat,
+      b.commit_lat,
+      countA,
+      countB,
+    ),
+    idle_lat: aggregateNumericStats(a.idle_lat, b.idle_lat, countA, countB),
+    rows_read: aggregateNumericStats(a.rows_read, b.rows_read, countA, countB),
+    rows_written: aggregateNumericStats(
+      a.rows_written,
+      b.rows_written,
+      countA,
+      countB,
+    ),
+    bytes_read: aggregateNumericStats(
+      a.bytes_read,
+      b.bytes_read,
+      countA,
+      countB,
+    ),
+    exec_stats: addExecStats(a.exec_stats, b.exec_stats),
+  };
+}
+
+// mergeTransactionStats takes a list of transactions (assuming they're all for the same fingerprint)
+// and returns a copy of the first element with its `stats_data.stats` object replaced with a
+// merged stats object that aggregates statistics from every copy of the fingerprint in the list
+// provided. This function SHOULD NOT mutate any objects in the provided txns array.
+const mergeTransactionStats = function (txns: Transaction[]): Transaction {
+  if (txns.length === 0) {
+    return null;
+  }
+
+  if (txns.length === 1) {
+    return txns[0];
+  }
+
+  const txn = cloneDeep(txns[0]);
+
+  txn.stats_data.stats = txns
+    .map(t => t.stats_data.stats)
+    .reduce(addTransactionStats);
+
+  return txn;
+};
+
+/*
+ * getTxnFromSqlStatsTxns aggregates txn stats from the provided list which match the
+ * specified txn fingerprint ID and contains one of the provided app names.
+ * Note that the returned txn will have other properties matching the first txn
+ * in the list matching the provided criteria, but its stats_data.stats will be
+ * aggregated from all matching txns.
+ *
+ * @param txns List of txns to search through.
+ * @param txnFingerprintID Txn fingerprint ID to search for.
+ * @param apps list of app names to filter by.
+ */
+export const getTxnFromSqlStatsTxns = (
+  txns: Transaction[] | null,
+  txnFingerprintID: string | null,
+  apps: string[] | null,
+): Transaction | null => {
+  if (!txns?.length || !txnFingerprintID) {
+    return null;
+  }
+
+  return mergeTransactionStats(
+    txns.filter(
+      txn =>
+        txn.stats_data.transaction_fingerprint_id.toString() ===
+          txnFingerprintID &&
+        (!apps?.length || apps.includes(txn.stats_data.app || unset)),
+    ),
+  );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -154,7 +154,7 @@ export function makeTransactionsColumns(
               item.stats_data.statement_fingerprint_ids,
               statements,
             ) || "Transaction query unavailable.",
-          appName: item.stats_data.app,
+          appName: item.stats_data.app ? item.stats_data.app : unset,
           transactionFingerprintId:
             item.stats_data.transaction_fingerprint_id.toString(),
           search,

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -318,7 +318,7 @@ export function statementKey(stmt: ExecutionStatistics): string {
 export function transactionScopedStatementKey(
   stmt: ExecutionStatistics,
 ): string {
-  return statementKey(stmt) + stmt.txn_fingerprint_ids?.toString();
+  return statementKey(stmt) + stmt.txn_fingerprint_ids?.toString() + stmt.app;
 }
 
 export const generateStmtDetailsToID = (


### PR DESCRIPTION
Backport 1/1 commits from #114991.

/cc @cockroachdb/release

Release justification: bug fix

---

This patch fixes a bug in the transaction details page where we could
only show a transaction fingerprint id from a single application at a
time. In the statements page, specifying multiple app names in the
URL search params (or none for all apps) would show statement fingerprint
ids from all of those applications. This behaviour did not exist for
the transaction details page. In fact, the aggregation functions we
previously had for transactions was only being used on the transaction
overview page (which no longer aggregates transactions with the same
app name). This patch allows viewing a transaction fingerprint id from
multiple applications. The user can specify which applications to view
using the `appNames` URL search param containing a comma separated list
of application names. Not specifying any applications will result in
viewing all applications containing the requested fingerprint.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/114254

Release note (bug fix): In the SQL Activity Transaction Details page,
users can now view a transaction fingerprint id across  multiple
applications. To do so, they can specify the app name in the
`appNames` URL search param using a comma separated encoded string  of
transaction fingerprint ids.


Before
---------------------------
Note the differing application names of the statement and transaction when looking at transaction details. This indicates that a statement with a different app name was included in the aggregation.
https://www.loom.com/share/a2a7ddda922d435a8172fc31d2df6762

After
--------------------------
https://www.loom.com/share/259471bc959141ac9624c6baf05bb8dd
