### PR TITLE
sql: skip a couple of tests under deadlock

### DIFF
--- a/pkg/ccl/testccl/sqlccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlccl/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//pkg/sql/tests",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",

--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -32,6 +33,8 @@ import (
 func TestExplainRedactDDL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderDeadlock(t, "the test is too slow")
 
 	const numStatements = 10
 

--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -509,6 +509,8 @@ func TestExplainRedact(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderDeadlock(t, "the test is too slow")
+
 	const numStatements = 10
 
 	ctx := context.Background()


### PR DESCRIPTION
`TestExplainRedact` and `TestExplainRedactDDL` are quite long, making that some KV level deadlock mechanism fires incorrectly. We've skipped other tests due to this, so this commit skips these two as well.

Fixes: #115861.
Fixes: #115998.

Release note: None