### PR TITLE
batcheval: remove modification of InitPutRequest

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_init_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_init_put.go
@@ -33,10 +33,7 @@ func InitPut(
 	args := cArgs.Args.(*kvpb.InitPutRequest)
 	h := cArgs.Header
 
-	if args.FailOnTombstones && cArgs.EvalCtx.EvalKnobs().DisableInitPutFailOnTombstones {
-		args.FailOnTombstones = false
-	}
-
+	failOnTombstones := args.FailOnTombstones && !cArgs.EvalCtx.EvalKnobs().DisableInitPutFailOnTombstones
 	opts := storage.MVCCWriteOptions{
 		Txn:                            h.Txn,
 		LocalTimestamp:                 cArgs.Now,
@@ -50,10 +47,10 @@ func InitPut(
 	var acq roachpb.LockAcquisition
 	if args.Blind {
 		acq, err = storage.MVCCBlindInitPut(
-			ctx, readWriter, args.Key, h.Timestamp, args.Value, args.FailOnTombstones, opts)
+			ctx, readWriter, args.Key, h.Timestamp, args.Value, failOnTombstones, opts)
 	} else {
 		acq, err = storage.MVCCInitPut(
-			ctx, readWriter, args.Key, h.Timestamp, args.Value, args.FailOnTombstones, opts)
+			ctx, readWriter, args.Key, h.Timestamp, args.Value, failOnTombstones, opts)
 	}
 	if err != nil {
 		return result.Result{}, err


### PR DESCRIPTION
This commit removes the modification of InitPutRequest (that is done due to a testing knob) since modifications of anything that comes from BatchRequest is not allowed (currently, both on the server and the client side). In this case we can just modify the local variable to appease the grpc transport.

Fixes: #115958.

Release note: None