### PR TITLE
opt: optimize ReorderJoins for a small join order limit

### DIFF
--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1117,13 +1117,17 @@ func (c *CustomFuncs) constructJoinWithConstants(
 }
 
 // ShouldReorderJoins returns whether the optimizer should attempt to find
-// a better ordering of inner joins. This is the case if the given expression is
-// the first expression of its group, and the join tree rooted at the expression
-// has not previously been reordered. This is to avoid duplicate work. In
-// addition, a join cannot be reordered if it has join hints.
+// a better ordering for a join tree. This is the case if the given expression
+// is the first expression of its group, and the join tree rooted at the
+// expression has not previously been reordered. This is to avoid duplicate
+// work. In addition, a join cannot be reordered if it has join hints.
 func (c *CustomFuncs) ShouldReorderJoins(root memo.RelExpr) bool {
-	// Only match the first expression of a group to avoid duplicate work.
 	if root != root.FirstExpr() {
+		// Only match the first expression of a group to avoid duplicate work.
+		return false
+	}
+	if c.e.evalCtx.SessionData().ReorderJoinsLimit == 0 {
+		// Join reordering has been disabled.
 		return false
 	}
 

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -3010,8 +3010,7 @@ project
       │    │    │    └── filters
       │    │    │         └── tab_171969.col1_3 = tab_171969.tableoid
       │    │    └── filters
-      │    │         ├── tab_171968.col1_3 = tab_171969.col1_3
-      │    │         └── tab_171968.tableoid = tab_171969.col1_3
+      │    │         └── tab_171968.col1_3 = tab_171969.col1_3
       │    └── projections
       │         └── true
       └── filters (true)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -1111,7 +1111,6 @@ Vertexes
     scan dz
 Edges
   y = z [inner, ses=AB, tes=AB, rules=()]
-  x = z [inner, ses=AB, tes=AB, rules=()]
 Joining AB
   A B [inner, refs=AB]
   B A [inner, refs=AB]
@@ -3483,3 +3482,9 @@ inner-join (merge)
  │    ├── fd: (5)-->(6)
  │    └── ordering: +5
  └── filters (true)
+
+# Regression test for #116131 - don't match ReorderJoins when the join order
+# limit is zero.
+exploretrace rule=ReorderJoins set=reorder_joins_limit=0
+SELECT * FROM bx INNER JOIN cy ON b = c;
+----


### PR DESCRIPTION
This patch adds some checks to avoid unnecessary work when the join order limit is zero or one. When the limit is zero, `ReorderJoins` shouldn't be matched at all. When the limit is one, we should not calculate the transitive closure of the filter equalities, since it does not affect commutation.

Fixes #116131

Release note: None