### PR TITLE
server: unredact health alerts

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -122,6 +123,9 @@ func TestHealthCheck(t *testing.T) {
 		}
 		if !reflect.DeepEqual(expAlerts, result.Alerts) {
 			t.Fatalf("expected %+v, got %+v", expAlerts, result.Alerts)
+		}
+		if redact.Sprintf("%s", result.Alerts) != redact.Sprintf("%s", result.Alerts).Redact() {
+			t.Fatalf("expected %+v, got %+v", redact.Sprintf("%s", result.Alerts), redact.Sprintf("%s", result.Alerts).Redact())
 		}
 	}
 }

--- a/pkg/server/status/statuspb/BUILD.bazel
+++ b/pkg/server/status/statuspb/BUILD.bazel
@@ -29,7 +29,9 @@ go_proto_library(
 
 go_library(
     name = "statuspb",
+    srcs = ["status.go"],
     embed = [":statuspb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/server/status/statuspb",
     visibility = ["//visibility:public"],
+    deps = ["@com_github_cockroachdb_redact//:redact"],
 )

--- a/pkg/server/status/statuspb/status.go
+++ b/pkg/server/status/statuspb/status.go
@@ -1,0 +1,30 @@
+
+
+package statuspb
+
+import (
+	"github.com/cockroachdb/redact"
+)
+
+func (h HealthAlert) String() string {
+	return redact.StringWithoutMarkers(h)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (h HealthAlert) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("{StoreID:%d Category:%d Description:%s Value:%f}",
+		h.StoreID, redact.Safe(h.Category), redact.Safe(h.Description), h.Value)
+}
+
+func (h HealthCheckResult) String() string {
+	return redact.StringWithoutMarkers(h)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (h HealthCheckResult) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("{Alerts:[")
+	for _, alert := range h.Alerts {
+		w.Printf("%s,", alert)
+	}
+	w.Printf("]}")
+}

--- a/pkg/server/status/statuspb/status.proto
+++ b/pkg/server/status/statuspb/status.proto
@@ -97,6 +97,7 @@ message NodeStatus {
 // A HealthAlert is an undesired condition detected by a server which should be
 // exposed to the operators.
 message HealthAlert {
+  option (gogoproto.goproto_stringer) = false;
   // store_id is zero for alerts not specific to a store (i.e. apply at the node level).
   int32 store_id = 1 [
     // NB: trying to make this nullable does not work with the custom type. You need a
@@ -116,5 +117,6 @@ message HealthAlert {
 
 // HealthCheckResult holds a number of HealthAlerts.
 message HealthCheckResult{
+  option (gogoproto.goproto_stringer) = false;
   repeated HealthAlert alerts = 1 [(gogoproto.nullable) = false];
 }


### PR DESCRIPTION
Unredacts the `Category` and `Description` fields of health alert logs using custom `String()` and `SafeFormat()` methods.

Added a test case to confirm `redact.Sprint(healthCheckResult).Redact()` and `redact.Sprint(healthCheckResult)` are the same value.

Resolves #103839

Release note: None