### PR TITLE
opt: lock all column families for new SELECT FOR UPDATE

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
@@ -3113,7 +3114,13 @@ func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 		return nil, err
 	}
 
-	splitter := span.MakeSplitter(n.table.desc, n.table.index, fetchOrdinals)
+	var splitter span.Splitter
+	if joinReaderSpec.LockingStrength != descpb.ScanLockingStrength_FOR_NONE &&
+		planCtx.ExtendedEvalCtx.TxnIsoLevel != isolation.Serializable {
+		splitter = span.MakeSplitterForSideEffect(n.table.desc, n.table.index, fetchOrdinals)
+	} else {
+		splitter = span.MakeSplitter(n.table.desc, n.table.index, fetchOrdinals)
+	}
 	joinReaderSpec.SplitFamilyIDs = splitter.FamilyIDs()
 
 	joinReaderSpec.LookupColumns = make([]uint32, len(n.eqCols))

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
@@ -391,3 +391,178 @@ user root
 awaitquery q12
 
 awaitquery q13
+
+subtest lock_column_family
+
+# Check that we lock all column families.
+
+statement ok
+CREATE TABLE abcde (
+  a INT NOT NULL,
+  b INT NOT NULL,
+  c INT NOT NULL,
+  d INT NULL,
+  e INT NOT NULL,
+  PRIMARY KEY (a, b),
+  FAMILY (a),
+  FAMILY (b),
+  FAMILY (c),
+  FAMILY (d),
+  FAMILY (e)
+)
+
+statement ok
+GRANT ALL on abcde TO testuser
+
+statement ok
+INSERT INTO abcde VALUES (5, 6, 7, 8, 9)
+
+user testuser
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+# Only read one column family in the initial scan, but lock all of them.
+query I rowsort
+SELECT e FROM abcde WHERE a = 5 AND b = 6 FOR UPDATE
+----
+9
+
+user root
+
+# Updating the same column family should block and then retry.
+query I async,rowsort q14
+BEGIN ISOLATION LEVEL READ COMMITTED;
+UPDATE abcde SET e = e + 10 WHERE a = 5 AND b = 6 RETURNING e;
+COMMIT;
+----
+29
+
+# Updating a different column family should also block.
+query I async,rowsort q15
+BEGIN ISOLATION LEVEL READ COMMITTED;
+UPDATE abcde SET c = c + 10 WHERE a = 5 AND b = 6 RETURNING c;
+COMMIT;
+----
+17
+
+user testuser
+
+query II rowsort
+SELECT c, e FROM abcde WHERE a = 5 AND b = 6
+----
+7  9
+
+statement ok
+UPDATE abcde SET e = e + 10 WHERE a = 5 AND b = 6
+
+statement ok
+COMMIT
+
+user root
+
+awaitquery q14
+
+awaitquery q15
+
+# Now try again, but lock a nullable column. Again, we should be locking all
+# column families.
+
+statement ok
+INSERT INTO abcde VALUES (45, 46, 47, NULL, 49)
+
+user testuser
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+# Only read one nullable column in the initial scan, which requires also reading
+# the first column family, but lock all of them.
+query I rowsort
+SELECT d FROM abcde WHERE a = 45 AND b = 46 FOR UPDATE
+----
+NULL
+
+user root
+
+# Locked-reading from the same column family should block on the lock.
+query I async,rowsort q16
+BEGIN ISOLATION LEVEL READ COMMITTED;
+SELECT d FROM abcde WHERE a = 45 AND b = 46 FOR UPDATE;
+COMMIT;
+----
+68
+
+# Locked-reading from a different column family should also block.
+query I async,rowsort q17
+BEGIN ISOLATION LEVEL READ COMMITTED;
+SELECT c FROM abcde WHERE a = 45 AND b = 46 FOR UPDATE;
+INSERT INTO abcde VALUES (45, 66, 67, 68, 69);
+COMMIT;
+----
+47
+
+user testuser
+
+query I rowsort
+SELECT d FROM abcde WHERE a = 45
+----
+NULL
+
+statement ok
+UPDATE abcde SET d = 68 WHERE a = 45 AND b = 46
+
+statement ok
+COMMIT
+
+user root
+
+awaitquery q16
+
+awaitquery q17
+
+# Now try again, but lock one of the PK columns. Again, we should be locking all
+# column families.
+
+statement ok
+INSERT INTO abcde VALUES (85, 86, 87, 88, 89)
+
+user testuser
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+statement ok
+SET tracing = kv
+
+# Only read one of the PK column in the initial scan, which might only require
+# reading the first column family but should still lock all column families.
+query I rowsort
+SELECT b FROM abcde WHERE a = 85 AND b = 86 FOR UPDATE
+----
+86
+
+user root
+
+# Locked-reading from the same column family should block on the lock.
+query I async,rowsort q18
+BEGIN ISOLATION LEVEL READ COMMITTED;
+SELECT b FROM abcde WHERE a = 85 AND b = 86 FOR UPDATE;
+INSERT INTO abcde VALUES (85, 96, 97, 98, 99);
+COMMIT;
+----
+86
+
+user testuser
+
+query I rowsort
+SELECT b FROM abcde WHERE a = 85
+----
+86
+
+statement ok
+COMMIT
+
+user root
+
+awaitquery q18

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -2668,6 +2668,10 @@ project
 statement ok
 RESET enable_durable_locking_for_serializable
 
+# ------------------------------------------------------------------------------
+# Tests with optimizer_use_lock_op_for_serializable.
+# ------------------------------------------------------------------------------
+
 subtest lock_op_optimizations
 
 statement ok
@@ -2924,6 +2928,93 @@ vectorized: true
       estimated row count: 1 (missing stats)
       table: t@t_pkey
       spans: /5/0
+
+# Table with multiple column families. Cannot push down locking.
+statement ok
+CREATE TABLE xyz (
+  x INT PRIMARY KEY,
+  y INT NOT NULL,
+  z INT,
+  INDEX (z),
+  FAMILY (x, y),
+  FAMILY (z)
+)
+
+query T
+EXPLAIN (VERBOSE) SELECT y FROM xyz WHERE x = 1 FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (y)
+│
+└── • lookup join (semi)
+    │ columns: (x, y)
+    │ estimated row count: 1 (missing stats)
+    │ table: xyz@xyz_pkey
+    │ equality: (x) = (x)
+    │ equality cols are key
+    │ locking strength: for update
+    │
+    └── • scan
+          columns: (x, y)
+          estimated row count: 1 (missing stats)
+          table: xyz@xyz_pkey
+          spans: /1/0
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM xyz WHERE z = 2 FOR SHARE
+----
+distribution: local
+vectorized: true
+·
+• lookup join (semi)
+│ columns: (x, y, z)
+│ estimated row count: 10 (missing stats)
+│ table: xyz@xyz_pkey
+│ equality: (x) = (x)
+│ equality cols are key
+│ locking strength: for share
+│
+└── • index join
+    │ columns: (x, y, z)
+    │ estimated row count: 10 (missing stats)
+    │ table: xyz@xyz_pkey
+    │ key columns: x
+    │
+    └── • scan
+          columns: (x, z)
+          estimated row count: 10 (missing stats)
+          table: xyz@xyz_z_idx
+          spans: /2-/3
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t INNER LOOKUP JOIN xyz ON x = b WHERE a = 5 FOR UPDATE OF xyz
+----
+distribution: local
+vectorized: true
+·
+• lookup join (semi)
+│ columns: (a, b, x, y, z)
+│ estimated row count: 1 (missing stats)
+│ table: xyz@xyz_pkey
+│ equality: (x) = (x)
+│ equality cols are key
+│ locking strength: for update
+│
+└── • lookup join (inner)
+    │ columns: (a, b, x, y, z)
+    │ estimated row count: 1 (missing stats)
+    │ table: xyz@xyz_pkey
+    │ equality: (b) = (x)
+    │ equality cols are key
+    │
+    └── • scan
+          columns: (a, b)
+          estimated row count: 1 (missing stats)
+          table: t@t_pkey
+          spans: /5/0
 
 statement ok
 RESET optimizer_use_lock_op_for_serializable

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -374,11 +374,57 @@ define Lock {
     _ LockPrivate
 }
 
+# LockPrivate contains the state describing a lock operation. For example,
+# consider the following SELECT FOR UPDATE statement under read committed
+# isolation:
+#
+#   CREATE TABLE ab (a INT NOT NULL PRIMARY KEY, b INT);
+#
+#   SELECT x.a, y.b
+#   FROM ab AS x
+#   JOIN ab AS y ON y.a = x.b
+#   WHERE x.a = 5
+#   FOR UPDATE OF x;
+#
+# After optbuild the plan will look like:
+#
+#   lock ab [as=x]
+#    ├── columns: a:1 b:6
+#    ├── locking: for-update,durability-guaranteed
+#    ├── volatile, mutations
+#    └── project
+#         ├── columns: x.a:1 y.b:6
+#         └── inner-join (lookup ab [as=y])
+#              ├── columns: x.a:1 x.b:2 y.a:5 y.b:6
+#              ├── key columns: [2] = [5]
+#              ├── lookup columns are key
+#              ├── scan ab [as=x]
+#              │    ├── columns: x.a:1 x.b:2
+#              │    ├── constraint: /1: [/5 - /5]
+#              │    └── prune: (2)
+#              └── filters (true)
+#
+# In this case the LockPrivate will look like:
+#
+#   {
+#     Table:     a fresh table ID for ab (separate from x and y),
+#     KeySource: the table ID of x,
+#     Locking:   {Strength: FOR UPDATE, Durability: GUARANTEED},
+#     KeyCols:   [a:1 of x],
+#     LockCols:  {a and b of the new Table},
+#     Cols:      {a:1 of x and b:6 of y},
+#   }
+#
+# Many of these fields are needed to produce the locking LookupJoin in execbuild
+# that is the current implementation of locking.
 [Private]
 define LockPrivate {
     # Table identifies the table to lock. Currently only the primary index of
     # the table is locked.
     Table TableID
+
+    # KeySource identifies the source of the key columns.
+    KeySource TableID
 
     # Locking represents the row-level locking mode to use when locking the
     # primary index.
@@ -389,7 +435,14 @@ define LockPrivate {
     # primary key columns of the table.
     KeyCols ColList
 
+    # LockCols is the set of columns to lock. LockCols determines which column
+    # families will be locked. None of the LockCols are included in the output
+    # of the lock operation. If LockCols is empty we will only lock the first
+    # column family.
+    LockCols ColSet
+
     # Cols is the set of columns from the input expression returned by the Lock
-    # operator. Cols contains all of the KeyCols.
+    # operator, which are passed through. Cols contains all of the KeyCols and
+    # none of the LockCols.
     Cols ColSet
 }

--- a/pkg/sql/opt/optbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/optbuilder/testdata/select_for_update
@@ -746,11 +746,11 @@ build set=optimizer_use_lock_op_for_serializable=true
 SELECT (SELECT a FROM t FOR UPDATE)
 ----
 project
- ├── columns: a:5
+ ├── columns: a:9
  ├── values
  │    └── ()
  └── projections
-      └── subquery [as=a:5]
+      └── subquery [as=a:9]
            └── max1-row
                 ├── columns: t.a:1!null
                 └── lock t
@@ -792,11 +792,11 @@ build set=optimizer_use_lock_op_for_serializable=true
 SELECT (SELECT a FROM t FOR UPDATE OF t)
 ----
 project
- ├── columns: a:5
+ ├── columns: a:9
  ├── values
  │    └── ()
  └── projections
-      └── subquery [as=a:5]
+      └── subquery [as=a:9]
            └── max1-row
                 ├── columns: t.a:1!null
                 └── lock t
@@ -860,11 +860,11 @@ build set=optimizer_use_lock_op_for_serializable=true
 SELECT (SELECT a FROM t FOR UPDATE) AS r
 ----
 project
- ├── columns: r:5
+ ├── columns: r:9
  ├── values
  │    └── ()
  └── projections
-      └── subquery [as=r:5]
+      └── subquery [as=r:9]
            └── max1-row
                 ├── columns: a:1!null
                 └── lock t
@@ -906,11 +906,11 @@ build set=optimizer_use_lock_op_for_serializable=true
 SELECT (SELECT a FROM t FOR UPDATE OF t) AS r
 ----
 project
- ├── columns: r:5
+ ├── columns: r:9
  ├── values
  │    └── ()
  └── projections
-      └── subquery [as=r:5]
+      └── subquery [as=r:9]
            └── max1-row
                 ├── columns: a:1!null
                 └── lock t
@@ -1312,7 +1312,7 @@ build set=optimizer_use_lock_op_for_serializable=true
 SELECT * FROM [SELECT a FROM t FOR UPDATE]
 ----
 with &1
- ├── columns: a:5!null
+ ├── columns: a:9!null
  ├── lock t
  │    ├── columns: t.a:1!null
  │    ├── locking: for-update
@@ -1321,9 +1321,9 @@ with &1
  │         └── scan t
  │              └── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
  └── with-scan &1
-      ├── columns: a:5!null
+      ├── columns: a:9!null
       └── mapping:
-           └──  t.a:1 => a:5
+           └──  t.a:1 => a:9
 
 build
 WITH cte AS (SELECT a FROM t FOR UPDATE) SELECT * FROM cte
@@ -1344,7 +1344,7 @@ build set=optimizer_use_lock_op_for_serializable=true
 WITH cte AS (SELECT a FROM t FOR UPDATE) SELECT * FROM cte
 ----
 with &1 (cte)
- ├── columns: a:5!null
+ ├── columns: a:9!null
  ├── lock t
  │    ├── columns: t.a:1!null
  │    ├── locking: for-update
@@ -1353,9 +1353,9 @@ with &1 (cte)
  │         └── scan t
  │              └── columns: t.a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
  └── with-scan &1 (cte)
-      ├── columns: a:5!null
+      ├── columns: a:9!null
       └── mapping:
-           └──  t.a:1 => a:5
+           └──  t.a:1 => a:9
 
 # ------------------------------------------------------------------------------
 # Tests with joins.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1791,9 +1791,7 @@ func (ef *execFactory) ConstructDeleteRange(
 	var sb span.Builder
 	sb.Init(ef.planner.EvalContext(), ef.planner.ExecCfg().Codec, tabDesc, tabDesc.GetPrimaryIndex())
 
-	splitter := span.MakeSplitterForDelete(
-		tabDesc, tabDesc.GetPrimaryIndex(), needed, true, /* forDelete */
-	)
+	splitter := span.MakeSplitterForDelete(tabDesc, tabDesc.GetPrimaryIndex(), needed)
 	spans, err := sb.SpansFromConstraint(indexConstraint, splitter)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/span/BUILD.bazel
+++ b/pkg/sql/span/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/catalog/systemschema",
         "//pkg/testutils/serverutils",
@@ -50,5 +51,6 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/span/span_splitter_test.go
+++ b/pkg/sql/span/span_splitter_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/span"
@@ -24,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSpanSplitterDoesNotSplitSystemTableFamilySpans(t *testing.T) {
@@ -136,6 +138,134 @@ func TestSpanSplitterCanSplitSpan(t *testing.T) {
 			if res := splitter.CanSplitSpanIntoFamilySpans(tc.prefixLen, tc.containsNull); res != tc.canSplit {
 				t.Errorf("expected result to be %v, but found %v", tc.canSplit, res)
 			}
+		})
+	}
+}
+
+func TestSpanSplitterFamilyIDs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	codec := srv.ApplicationLayer().Codec()
+	tcs := []struct {
+		sql           string
+		index         string
+		neededColumns intsets.Fast
+		forDelete     bool
+		forSideEffect bool
+		familyIDs     []descpb.FamilyID
+	}{
+		{
+			sql:           "a INT NOT NULL, PRIMARY KEY (a)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(0),
+			familyIDs:     []descpb.FamilyID{0},
+		},
+		{
+			sql:           "a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a), FAMILY (a), FAMILY (b)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(1),
+			familyIDs:     []descpb.FamilyID{1},
+		},
+		{
+			sql:           "a INT NOT NULL, b INT NULL, PRIMARY KEY (a), FAMILY (a), FAMILY (b)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(1),
+			familyIDs:     []descpb.FamilyID(nil),
+		},
+		{
+			sql:           "a INT NOT NULL, b INT NULL, c INT NULL, PRIMARY KEY (a), FAMILY (a, b, c)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(2),
+			familyIDs:     []descpb.FamilyID{0},
+		},
+		{
+			sql:           "a INT, b INT, c INT, d INT, PRIMARY KEY (a, b), FAMILY (a, b), FAMILY (c, d)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(2, 3),
+			familyIDs:     []descpb.FamilyID(nil),
+		},
+		{
+			sql:           "a INT NOT NULL, b INT NOT NULL, c INT NOT NULL, PRIMARY KEY (a, b), FAMILY (a, b), FAMILY (c)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(0, 1),
+			familyIDs:     []descpb.FamilyID{0},
+		},
+		{
+			sql:           "a INT NOT NULL, b INT NULL, c INT NOT NULL, PRIMARY KEY (a, b), FAMILY (a), FAMILY (b, c)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(0, 2),
+			familyIDs:     []descpb.FamilyID{1},
+		},
+		{
+			sql:           "a INT NOT NULL, b INT NULL, c INT NOT NULL, PRIMARY KEY (a, b), FAMILY (a, c), FAMILY (b)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(0, 2),
+			familyIDs:     []descpb.FamilyID{0},
+		},
+		{
+			sql:           "a INT NOT NULL, b INT NULL, c INT NOT NULL, d INT NOT NULL, PRIMARY KEY (a, b), FAMILY (a, b), FAMILY (c, d)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(0, 1, 2, 3),
+			familyIDs:     []descpb.FamilyID{1},
+		},
+		{
+			sql:           "a INT NOT NULL, b INT NULL, c INT NOT NULL, d INT NOT NULL, PRIMARY KEY (a, b), FAMILY (a, b), FAMILY (c, d)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(0, 1, 2, 3),
+			forDelete:     true,
+			familyIDs:     []descpb.FamilyID(nil),
+		},
+		{
+			sql:           "a INT NOT NULL, b INT NULL, c INT NOT NULL, d INT NOT NULL, PRIMARY KEY (a, b), FAMILY (a, b), FAMILY (c, d)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(0, 1, 2, 3),
+			forSideEffect: true,
+			familyIDs:     []descpb.FamilyID(nil),
+		},
+		{
+			sql:           "a INT NOT NULL, b INT NULL, c INT NOT NULL, d INT NOT NULL, e INT NULL, PRIMARY KEY (a, b), FAMILY (a, c), FAMILY (b, d), FAMILY (e)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(0, 3),
+			familyIDs:     []descpb.FamilyID{1},
+		},
+		{
+			sql:           "a INT NOT NULL, b INT NULL, c INT NOT NULL, d INT NOT NULL, e INT NULL, PRIMARY KEY (a, b), FAMILY (a, c), FAMILY (b, d), FAMILY (e)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(0, 3),
+			forDelete:     true,
+			familyIDs:     []descpb.FamilyID(nil),
+		},
+		{
+			sql:           "a INT NOT NULL, b INT NULL, c INT NOT NULL, d INT NOT NULL, e INT NULL, PRIMARY KEY (a, b), FAMILY (a, c), FAMILY (b, d), FAMILY (e)",
+			index:         "t_pkey",
+			neededColumns: intsets.MakeFast(0, 3),
+			forSideEffect: true,
+			familyIDs:     []descpb.FamilyID{0, 1},
+		},
+	}
+	if _, err := sqlDB.Exec("CREATE DATABASE t"); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range tcs {
+		t.Run(tc.sql, func(t *testing.T) {
+			if _, err := sqlDB.Exec("DROP TABLE IF EXISTS t.t"); err != nil {
+				t.Fatal(err)
+			}
+			sql := fmt.Sprintf("CREATE TABLE t.t (%s)", tc.sql)
+			if _, err := sqlDB.Exec(sql); err != nil {
+				t.Fatal(err)
+			}
+			desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "t")
+			idx, err := catalog.MustFindIndexByName(desc, tc.index)
+			if err != nil {
+				t.Fatal(err)
+			}
+			splitter := span.MakeSplitterBase(desc, idx, tc.neededColumns, tc.forDelete, tc.forSideEffect)
+			require.Equal(t, tc.familyIDs, splitter.FamilyIDs())
 		})
 	}
 }


### PR DESCRIPTION
**opt: lock all column families for new SELECT FOR UPDATE**

The new implementation of SELECT FOR UPDATE used for Read Committed isolation starts as a lock operator built from a table scan, which becomes a lookup join during execbuild. This lock operator was re-using the same table and column references as the original table scan, which caused the resulting lookup join to only lock the first column family of the table.

Instead, we need to use fresh table and column references for the lock operator, so that the resulting lookup join is able to control which column families it locks.

For now we choose to lock all column families, even if some column family would not normally be read by the select statement. We do this to more closely match Postgres behavior for statements like:

```
SELECT 1 FROM foo FOR UPDATE
```

Fixes: https://github.com/cockroachdb/cockroach/issues/115014

Release note (sql change): The new SELECT FOR UPDATE implementation used under Read Committed isolation (and under Serializable isolation when optimizer_use_lock_op_for_serializable is true) now locks all column families instead of only the first column family.

---

**sql: do not skip key col families when performing a locked read**

When determining which column families to read from an index for a set of requested columns, the span splitter has an optimization: it skips over the families for requested columns that are completely encoded in the index key, because these columns can be decoded from the key of *any* column family. For example, for the following query we do not need to read column families foo and bar:

```
CREATE TABLE abc (
  a INT NOT NULL,
  b INT NOT NULL,
  c INT NOT NULL,
  PRIMARY KEY (a, b),
  FAMILY foo (a),
  FAMILY bar (b),
  FAMILY baz (c)
);
SELECT * FROM abc WHERE a = 5 AND b = 6;
```

When the read has a side-effect, however (e.g. SELECT FOR UPDATE) we need to lock all of the requested column families. To do so, this commit adds a variant of `span.MakeSplitter` for locked reads, called `span.MakeSplitterForSideEffect`, which does not use this optimization.

Fixes: #115014

Release note (sql change): Fix a bug where SELECT FOR UPDATE under Read Committed isolation on multi-column-family tables was not locking column families containing only key columns.