### PR TITLE
Revert "cloud/gcp: use cloud http client for gcs"

### DIFF
--- a/pkg/cloud/gcp/gcs_storage.go
+++ b/pkg/cloud/gcp/gcs_storage.go
@@ -174,13 +174,7 @@ func makeGCSStorage(
 		}
 	}
 
-	httpClient, err := cloud.MakeHTTPClient(args.Settings)
-	if err != nil {
-		return nil, err
-	}
-
-	opts := []option.ClientOption{option.WithScopes(scope), option.WithHTTPClient(httpClient)}
-
+	opts := []option.ClientOption{option.WithScopes(scope)}
 	// Once credentials have been obtained via implicit or specified params, we
 	// then check if we should use the credentials directly or whether they should
 	// be used to assume another role.


### PR DESCRIPTION
This reverts commit cc39e777d0b3c81aa72168d202ba180c8f8260bd.

Fixes #116186

Unfortunately, setting WithHTTPClient overrides other options that control our
credentials. I'm still looking into the API, but from the looks of it, in order to
set WithHTTPClient we may have to build the client using the SDK to set the
credential options.