### PR TITLE
cloud: use custom HTTP client for gcs

### DIFF
--- a/pkg/cloud/gcp/BUILD.bazel
+++ b/pkg/cloud/gcp/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "@org_golang_google_api//impersonate",
         "@org_golang_google_api//iterator",
         "@org_golang_google_api//option",
+        "@org_golang_google_api//transport/http",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//types/known/wrapperspb",


### PR DESCRIPTION
Unfortunately, the WithHTTPClient option overrides all other options when constructing a GCS client. As a result, it appears we can not both set credentials options and set an HTTP client with custom configs via the primary API.

Here, we construct a transport using the SDK which allows us to attach the relevant credential options to the transport directly before making the HTTP client.

The downside here is that the SDK's NewTransport's documentation says that it is not intended for end-user use -- so we may expect breakage in the future.

Epic: none

Release note: None