### PR TITLE
kvserver: skip swap voters with non-voters under deadlock

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1434,6 +1434,7 @@ func TestReplicateQueueSwapVotersWithNonVoters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes a long time or times out under race")
+	skip.UnderDeadlock(t, "takes a long time or times out under deadlock")
 
 	ctx := context.Background()
 	serverArgs := make(map[int]base.TestServerArgs)


### PR DESCRIPTION
Liveness heartbeats may fail under deadlock builds with large test clusters, causing the test to time out waiting for suspect stores to become eligible targets.

Skip `TestReplicateQueueSwapVotersWithNonVoters` under deadlock builds.

Release note: None
Resolves: #116225