### PR TITLE
roachtest: enable ingest splits, disable stats in OR tests

### DIFF
--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -104,6 +104,9 @@ func registerOnlineRestore(r registry.Registry) {
 							if _, err := db.Exec("SET CLUSTER SETTING kv.queue.process.guaranteed_time_budget='1h'"); err != nil {
 								return err
 							}
+							if _, err := db.Exec("SET CLUSTER SETTING kv.snapshot_receiver.excise.enabled=true"); err != nil {
+								return err
+							}
 							opts := ""
 							if runOnline {
 								opts = "WITH EXPERIMENTAL DEFERRED COPY"

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -107,6 +107,9 @@ func registerOnlineRestore(r registry.Registry) {
 							if _, err := db.Exec("SET CLUSTER SETTING kv.snapshot_receiver.excise.enabled=true"); err != nil {
 								return err
 							}
+							if _, err := db.Exec("SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false"); err != nil {
+								return err
+							}
 							opts := ""
 							if runOnline {
 								opts = "WITH EXPERIMENTAL DEFERRED COPY"


### PR DESCRIPTION
Release note: none.
Epic: none.