### PR TITLE
memo: remove Memo() method from RelExpr interface

### DIFF
--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -112,7 +112,7 @@ func PlanCDCExpression(
 		return cdcPlan, err
 	}
 	if log.V(2) {
-		log.Infof(ctx, "Optimized CDC expression: %s", memo.RootExpr().String())
+		log.Infof(ctx, "Optimized CDC expression: %s", memo)
 	}
 
 	const allowAutoCommit = false

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -864,7 +864,7 @@ func newHarness(tb testing.TB, query benchQuery, schemas []string) *harness {
 			tb.Fatalf("%v", err)
 		}
 	} else {
-		if _, _, err := h.optimizer.TryPlaceholderFastPath(); err != nil {
+		if _, err := h.optimizer.TryPlaceholderFastPath(); err != nil {
 			tb.Fatalf("%v", err)
 		}
 	}

--- a/pkg/sql/opt/distribution/distribution.go
+++ b/pkg/sql/opt/distribution/distribution.go
@@ -20,7 +20,11 @@ import (
 // CanProvide returns true if the given operator returns rows that can
 // satisfy the given required distribution.
 func CanProvide(
-	ctx context.Context, evalCtx *eval.Context, expr memo.RelExpr, required *physical.Distribution,
+	ctx context.Context,
+	evalCtx *eval.Context,
+	mem *memo.Memo,
+	expr memo.RelExpr,
+	required *physical.Distribution,
 ) bool {
 	if required.Any() {
 		return true
@@ -38,7 +42,7 @@ func CanProvide(
 		provided.FromLocality(evalCtx.Locality)
 
 	case *memo.ScanExpr:
-		tabMeta := t.Memo().Metadata().TableMeta(t.Table)
+		tabMeta := mem.Metadata().TableMeta(t.Table)
 		if t.Distribution.Regions != nil {
 			provided = t.Distribution
 		} else {
@@ -89,7 +93,11 @@ func BuildChildRequired(
 // This function assumes that the provided distributions have already been set in
 // the children of the expression.
 func BuildProvided(
-	ctx context.Context, evalCtx *eval.Context, expr memo.RelExpr, required *physical.Distribution,
+	ctx context.Context,
+	evalCtx *eval.Context,
+	mem *memo.Memo,
+	expr memo.RelExpr,
+	required *physical.Distribution,
 ) physical.Distribution {
 	var provided physical.Distribution
 	switch t := expr.(type) {
@@ -100,7 +108,7 @@ func BuildProvided(
 		provided.FromLocality(evalCtx.Locality)
 
 	case *memo.ScanExpr:
-		tabMeta := t.Memo().Metadata().TableMeta(t.Table)
+		tabMeta := mem.Metadata().TableMeta(t.Table)
 		if t.Distribution.Regions != nil {
 			provided = t.Distribution
 		} else {
@@ -153,6 +161,7 @@ func GetDEnumAsStringFromConstantExpr(expr opt.Expr) (enumAsString string, ok bo
 func getCRBDRegionColSetFromInput(
 	ctx context.Context,
 	evalCtx *eval.Context,
+	mem *memo.Memo,
 	join *memo.LookupJoinExpr,
 	required *physical.Required,
 	maybeGetBestCostRelation func(grp memo.RelExpr, required *physical.Required) (best memo.RelExpr, ok bool),
@@ -184,7 +193,7 @@ func getCRBDRegionColSetFromInput(
 		if lookupJoinExpr, ok := maybeScan.(*memo.LookupJoinExpr); ok {
 			crdbRegionColSet, inputDistribution =
 				BuildLookupJoinLookupTableDistribution(
-					ctx, evalCtx, lookupJoinExpr, required, maybeGetBestCostRelation)
+					ctx, evalCtx, mem, lookupJoinExpr, required, maybeGetBestCostRelation)
 			return crdbRegionColSet, inputDistribution
 		}
 		if localityOptimizedScan, ok := maybeScan.(*memo.LocalityOptimizedSearchExpr); ok {
@@ -196,12 +205,12 @@ func getCRBDRegionColSetFromInput(
 		if !ok {
 			return crdbRegionColSet, physical.Distribution{}
 		}
-		tab := maybeScan.Memo().Metadata().Table(scanExpr.Table)
+		tab := mem.Metadata().Table(scanExpr.Table)
 		if !tab.IsRegionalByRow() {
 			return crdbRegionColSet, physical.Distribution{}
 		}
 		inputDistribution =
-			BuildProvided(ctx, evalCtx, scanExpr, &required.Distribution)
+			BuildProvided(ctx, evalCtx, mem, scanExpr, &required.Distribution)
 		index := tab.Index(scanExpr.Index)
 		crdbRegionColID := scanExpr.Table.IndexColumnID(index, 0)
 		if needRemap {
@@ -242,14 +251,15 @@ func getCRBDRegionColSetFromInput(
 func BuildLookupJoinLookupTableDistribution(
 	ctx context.Context,
 	evalCtx *eval.Context,
+	mem *memo.Memo,
 	lookupJoin *memo.LookupJoinExpr,
 	required *physical.Required,
 	maybeGetBestCostRelation func(grp memo.RelExpr, required *physical.Required) (best memo.RelExpr, ok bool),
 ) (crdbRegionColSet opt.ColSet, provided physical.Distribution) {
 	localCrdbRegionColSet, inputDistribution :=
-		getCRBDRegionColSetFromInput(ctx, evalCtx, lookupJoin, required, maybeGetBestCostRelation)
+		getCRBDRegionColSetFromInput(ctx, evalCtx, mem, lookupJoin, required, maybeGetBestCostRelation)
 
-	lookupTableMeta := lookupJoin.Memo().Metadata().TableMeta(lookupJoin.Table)
+	lookupTableMeta := mem.Metadata().TableMeta(lookupJoin.Table)
 	lookupTable := lookupTableMeta.Table
 
 	idx := lookupTable.Index(lookupJoin.Index)
@@ -299,7 +309,7 @@ func BuildLookupJoinLookupTableDistribution(
 				return crdbRegionColSet, provided
 			}
 		} else if len(lookupJoin.LookupJoinPrivate.LookupExpr) > 0 {
-			if filterIdx, ok := lookupJoin.GetConstPrefixFilter(lookupJoin.Memo().Metadata()); ok {
+			if filterIdx, ok := lookupJoin.GetConstPrefixFilter(mem.Metadata()); ok {
 				firstIndexColEqExpr := lookupJoin.LookupJoinPrivate.LookupExpr[filterIdx].Condition
 				if firstIndexColEqExpr.Op() == opt.EqOp {
 					if regionName, ok := GetDEnumAsStringFromConstantExpr(firstIndexColEqExpr.Child(1)); ok {
@@ -309,7 +319,7 @@ func BuildLookupJoinLookupTableDistribution(
 						return crdbRegionColSet, provided
 					}
 				}
-			} else if lookupJoin.LookupIndexPrefixIsEquatedWithColInColSet(lookupJoin.Memo().Metadata(), localCrdbRegionColSet) {
+			} else if lookupJoin.LookupIndexPrefixIsEquatedWithColInColSet(mem.Metadata(), localCrdbRegionColSet) {
 				// We have a `crdb_region = crdb_region` term in `LookupJoinPrivate.LookupExpr`.
 				provided.FromIndexScan(ctx, evalCtx, lookupTableMeta, lookupJoin.Index, nil)
 				if !inputDistribution.Any() &&
@@ -330,9 +340,9 @@ func BuildLookupJoinLookupTableDistribution(
 // from performing lookups of an inverted join, if that distribution can be
 // statically determined.
 func BuildInvertedJoinLookupTableDistribution(
-	ctx context.Context, evalCtx *eval.Context, invertedJoin *memo.InvertedJoinExpr,
+	ctx context.Context, evalCtx *eval.Context, mem *memo.Memo, invertedJoin *memo.InvertedJoinExpr,
 ) (provided physical.Distribution) {
-	lookupTableMeta := invertedJoin.Memo().Metadata().TableMeta(invertedJoin.Table)
+	lookupTableMeta := mem.Metadata().TableMeta(invertedJoin.Table)
 	lookupTable := lookupTableMeta.Table
 
 	if lookupTable.IsGlobalTable() {

--- a/pkg/sql/opt/distribution/distribution_test.go
+++ b/pkg/sql/opt/distribution/distribution_test.go
@@ -95,7 +95,7 @@ func TestBuildProvided(t *testing.T) {
 				)
 			}
 
-			res := BuildProvided(context.Background(), evalCtx, expr, &physical.Distribution{})
+			res := BuildProvided(context.Background(), evalCtx, f.Memo(), expr, &physical.Distribution{})
 			if res.String() != expected.String() {
 				t.Errorf("expected '%s', got '%s'", expected, res)
 			}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2550,7 +2550,7 @@ func (b *Builder) handleRemoteLookupJoinError(join *memo.LookupJoinExpr) (err er
 	// more.
 	if homeRegion == "" && b.optimizer != nil && b.optimizer.Coster() != nil {
 		_, physicalDistribution := distribution.BuildLookupJoinLookupTableDistribution(
-			b.ctx, b.evalCtx, join, join.RequiredPhysical(), b.optimizer.MaybeGetBestCostRelation,
+			b.ctx, b.evalCtx, b.mem, join, join.RequiredPhysical(), b.optimizer.MaybeGetBestCostRelation,
 		)
 		if len(physicalDistribution.Regions) == 1 {
 			homeRegion = physicalDistribution.Regions[0]

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3790,7 +3790,7 @@ func (b *Builder) applySaveTable(
 	// opttester.
 	outputCols := e.Relational().OutputCols
 	colNames := make([]string, outputCols.Len())
-	colNameGen := memo.NewColumnNameGenerator(e)
+	colNameGen := memo.NewColumnNameGenerator(b.mem, e)
 	for col, ok := outputCols.Next(0); ok; col, ok = outputCols.Next(col + 1) {
 		ord, _ := inputCols.Get(col)
 		colNames[ord] = colNameGen.GenerateName(col)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1169,6 +1169,7 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (_ execPlan, outputCols colO
 	//
 	// Note: we put o outside of the function so we allocate it only once.
 	var o xform.Optimizer
+	fromMemo := b.mem
 	planRightSideFn := func(ctx context.Context, ef exec.Factory, leftRow tree.Datums) (_ exec.Plan, err error) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -1233,7 +1234,7 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (_ execPlan, outputCols colO
 			}
 			return f.CopyAndReplaceDefault(e, replaceFn)
 		}
-		f.CopyAndReplace(rightExpr, &rightRequiredProps, replaceFn)
+		f.CopyAndReplace(fromMemo, rightExpr, &rightRequiredProps, replaceFn)
 
 		newRightSide, err := o.Optimize()
 		if err != nil {
@@ -2175,7 +2176,7 @@ func (b *Builder) enforceScanWithHomeRegion(skipID cat.StableID) error {
 		}
 	}
 	if len(moreThanOneRegionScans) > 0 {
-		md := moreThanOneRegionScans[0].Memo().Metadata()
+		md := b.mem.Metadata()
 		tabMeta := md.TableMeta(moreThanOneRegionScans[0].Table)
 		if len(moreThanOneRegionScans) == 1 {
 			return b.filterSuggestionError(tabMeta, moreThanOneRegionScans[0].Index, nil /* table2Meta */, 0 /* indexOrdinal2 */)
@@ -2194,7 +2195,7 @@ func (b *Builder) enforceScanWithHomeRegion(skipID cat.StableID) error {
 			sqlerrors.EnforceHomeRegionFurtherInfo)
 	}
 	for i, scan := range b.builtScans {
-		inputTableMeta := scan.Memo().Metadata().TableMeta(scan.Table)
+		inputTableMeta := b.mem.Metadata().TableMeta(scan.Table)
 		inputTable := inputTableMeta.Table
 		// Mutation DML errors out with additional information via a call to
 		// `filterSuggestionError`, handled by the caller, so skip the target of
@@ -2233,7 +2234,7 @@ func (b *Builder) enforceScanWithHomeRegion(skipID cat.StableID) error {
 			var inputIndexOrdinal2 cat.IndexOrdinal
 			if len(b.builtScans) > 1 && i == 0 {
 				scan2 := b.builtScans[1]
-				inputTableMeta2 = scan2.Memo().Metadata().TableMeta(scan2.Table)
+				inputTableMeta2 = b.mem.Metadata().TableMeta(scan2.Table)
 				inputIndexOrdinal2 = scan2.Index
 			}
 			return b.filterSuggestionError(inputTableMeta, inputIndexOrdinal, inputTableMeta2, inputIndexOrdinal2)
@@ -2468,7 +2469,7 @@ func (b *Builder) handleRemoteLookupJoinError(join *memo.LookupJoinExpr) (err er
 		// the query can't be answered by executing the first branch of the LOS.
 		return nil
 	}
-	lookupTableMeta := join.Memo().Metadata().TableMeta(join.Table)
+	lookupTableMeta := b.mem.Metadata().TableMeta(join.Table)
 	lookupTable := lookupTableMeta.Table
 
 	var input opt.Expr
@@ -2499,7 +2500,7 @@ func (b *Builder) handleRemoteLookupJoinError(join *memo.LookupJoinExpr) (err er
 	var inputIndexOrdinal cat.IndexOrdinal
 	switch t := input.(type) {
 	case *memo.ScanExpr:
-		inputTableMeta = join.Memo().Metadata().TableMeta(t.Table)
+		inputTableMeta = b.mem.Metadata().TableMeta(t.Table)
 		inputTable = inputTableMeta.Table
 		inputTableName = string(inputTable.Name())
 		inputIndexOrdinal = t.Index
@@ -2531,7 +2532,7 @@ func (b *Builder) handleRemoteLookupJoinError(join *memo.LookupJoinExpr) (err er
 				}
 			} else if join.LookupColsAreTableKey &&
 				len(join.LookupExpr) > 0 {
-				if filterIdx, ok := join.GetConstPrefixFilter(join.Memo().Metadata()); ok {
+				if filterIdx, ok := join.GetConstPrefixFilter(b.mem.Metadata()); ok {
 					firstIndexColEqExpr := join.LookupJoinPrivate.LookupExpr[filterIdx].Condition
 					if firstIndexColEqExpr.Op() == opt.EqOp {
 						if regionName, ok := distribution.GetDEnumAsStringFromConstantExpr(firstIndexColEqExpr.Child(1)); ok {
@@ -2792,7 +2793,7 @@ func (b *Builder) buildLookupJoin(
 }
 
 func (b *Builder) handleRemoteInvertedJoinError(join *memo.InvertedJoinExpr) (err error) {
-	lookupTableMeta := join.Memo().Metadata().TableMeta(join.Table)
+	lookupTableMeta := b.mem.Metadata().TableMeta(join.Table)
 	lookupTable := lookupTableMeta.Table
 
 	var input opt.Expr
@@ -2810,7 +2811,7 @@ func (b *Builder) handleRemoteInvertedJoinError(join *memo.InvertedJoinExpr) (er
 	var inputIndexOrdinal cat.IndexOrdinal
 	switch t := input.(type) {
 	case *memo.ScanExpr:
-		inputTableMeta = join.Memo().Metadata().TableMeta(t.Table)
+		inputTableMeta = b.mem.Metadata().TableMeta(t.Table)
 		inputTable = inputTableMeta.Table
 		inputTableName = string(inputTable.Name())
 		inputIndexOrdinal = t.Index

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -1131,6 +1131,7 @@ func (b *Builder) buildRoutinePlanGenerator(
 	//
 	// Note: we put o outside of the function so we allocate it only once.
 	var o xform.Optimizer
+	originalMemo := b.mem
 	planGen := func(
 		ctx context.Context, ref tree.RoutineExecFactory, args tree.Datums, fn tree.RoutinePlanGeneratedFunc,
 	) (err error) {
@@ -1203,7 +1204,7 @@ func (b *Builder) buildRoutinePlanGenerator(
 
 				return f.CopyAndReplaceDefault(e, replaceFn)
 			}
-			f.CopyAndReplace(stmt, props, replaceFn)
+			f.CopyAndReplace(originalMemo, stmt, props, replaceFn)
 
 			if wrapRootExpr != nil {
 				wrapped := wrapRootExpr(f, f.Memo().RootExpr().(memo.RelExpr)).(memo.RelExpr)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -678,7 +678,7 @@ upsert bc
 query T
 EXPLAIN (OPT, MEMO, REDACT) INSERT INTO bc SELECT a::float + 1 FROM a ON CONFLICT (b) DO UPDATE SET b = bc.b + 100
 ----
-memo (optimized, ~37KB, required=[presentation: info:25] [distribution: test])
+memo (optimized, ~36KB, required=[presentation: info:25] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:25] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -1117,7 +1117,7 @@ update ab
 query T
 EXPLAIN (OPT, MEMO, REDACT) UPDATE ab SET a = a || 'ab' WHERE a > 'a'
 ----
-memo (optimized, ~15KB, required=[presentation: info:15] [distribution: test])
+memo (optimized, ~14KB, required=[presentation: info:15] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:15] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -1355,7 +1355,7 @@ update e
 query T
 EXPLAIN (OPT, MEMO, REDACT) UPDATE e SET e = 'eee' WHERE e > 'a'
 ----
-memo (optimized, ~18KB, required=[presentation: info:17] [distribution: test])
+memo (optimized, ~17KB, required=[presentation: info:17] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:17] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -1686,7 +1686,7 @@ project
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT * FROM bc WHERE b >= 1.0 AND b < 2.0
 ----
-memo (optimized, ~13KB, required=[presentation: info:7] [distribution: test])
+memo (optimized, ~12KB, required=[presentation: info:7] [distribution: test])
  ├── G1: (explain G2 [presentation: b:1,c:2] [distribution: test])
  │    └── [presentation: info:7] [distribution: test]
  │         ├── best: (explain G2="[presentation: b:1,c:2] [distribution: test]" [presentation: b:1,c:2] [distribution: test])
@@ -2435,7 +2435,7 @@ project
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT * FROM bc JOIN f ON b = f + 1
 ----
-memo (optimized, ~29KB, required=[presentation: info:14] [distribution: test])
+memo (optimized, ~28KB, required=[presentation: info:14] [distribution: test])
  ├── G1: (explain G2 [presentation: b:1,c:2,f:7] [distribution: test])
  │    └── [presentation: info:14] [distribution: test]
  │         ├── best: (explain G2="[presentation: b:1,c:2,f:7] [distribution: test]" [presentation: b:1,c:2,f:7] [distribution: test])

--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -71,7 +71,6 @@ go_test(
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/exec",
-        "//pkg/sql/opt/memo",
         "//pkg/sql/opt/testutils/opttester",
         "//pkg/sql/opt/testutils/testcat",
         "//pkg/sql/sem/eval",

--- a/pkg/sql/opt/exec/explain/plan_gist_test.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/opttester"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -29,11 +28,7 @@ func makeGist(ot *opttester.OptTester, t *testing.T) explain.PlanGist {
 	if err != nil {
 		t.Error(err)
 	}
-	var mem *memo.Memo
-	if rel, ok := expr.(memo.RelExpr); ok {
-		mem = rel.Memo()
-	}
-	_, err = ot.ExecBuild(&f, mem, expr)
+	_, err = ot.ExecBuild(&f, ot.GetMemo(), expr)
 	if err != nil {
 		t.Error(err)
 	}
@@ -63,11 +58,7 @@ func plan(ot *opttester.OptTester, t *testing.T) string {
 	if expr == nil {
 		t.Error("Optimize failed, use a logictest instead?")
 	}
-	var mem *memo.Memo
-	if rel, ok := expr.(memo.RelExpr); ok {
-		mem = rel.Memo()
-	}
-	explainPlan, err := ot.ExecBuild(f, mem, expr)
+	explainPlan, err := ot.ExecBuild(f, ot.GetMemo(), expr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -597,19 +597,19 @@ func (jf JoinFlags) String() string {
 }
 
 func (ij *InnerJoinExpr) initUnexportedFields(mem *Memo) {
-	initJoinMultiplicity(ij)
+	initJoinMultiplicity(mem, ij)
 }
 
 func (lj *LeftJoinExpr) initUnexportedFields(mem *Memo) {
-	initJoinMultiplicity(lj)
+	initJoinMultiplicity(mem, lj)
 }
 
 func (fj *FullJoinExpr) initUnexportedFields(mem *Memo) {
-	initJoinMultiplicity(fj)
+	initJoinMultiplicity(mem, fj)
 }
 
 func (sj *SemiJoinExpr) initUnexportedFields(mem *Memo) {
-	initJoinMultiplicity(sj)
+	initJoinMultiplicity(mem, sj)
 }
 
 func (lj *LookupJoinExpr) initUnexportedFields(mem *Memo) {

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -48,9 +48,6 @@ import (
 type RelExpr interface {
 	opt.Expr
 
-	// Memo is the memo which contains this relational expression.
-	Memo() *Memo
-
 	// Relational is the set of logical properties that describe the content and
 	// characteristics of this expression's behavior and results.
 	Relational() *props.Relational

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -152,7 +152,9 @@ type ExprFmtCtx struct {
 	// data from the formatted expression with redaction markers, including spans.
 	RedactableValues bool
 
-	// Memo must contain any expression that is formatted.
+	// Memo must contain any expression that is formatted. It is not used for
+	// scalar expressions. If it is nil for relational expressions, formatting may
+	// result in a nil-pointer panic.
 	Memo *Memo
 
 	// Catalog must be set unless the ExprFmtHideQualifications flag is set.

--- a/pkg/sql/opt/memo/expr_name_gen.go
+++ b/pkg/sql/opt/memo/expr_name_gen.go
@@ -54,16 +54,16 @@ func (g *ExprNameGenerator) GenerateName(op opt.Operator) string {
 // ColumnNameGenerator is used to generate a unique name for each column of a
 // relational expression. See GenerateName for details.
 type ColumnNameGenerator struct {
-	e    RelExpr
+	mem  *Memo
 	pres physical.Presentation
 	seen map[string]int
 }
 
 // NewColumnNameGenerator creates a new instance of ColumnNameGenerator,
 // initialized with the given relational expression.
-func NewColumnNameGenerator(e RelExpr) *ColumnNameGenerator {
+func NewColumnNameGenerator(mem *Memo, e RelExpr) *ColumnNameGenerator {
 	return &ColumnNameGenerator{
-		e:    e,
+		mem:  mem,
 		pres: e.RequiredPhysical().Presentation,
 		seen: make(map[string]int, e.Relational().OutputCols.Len()),
 	}
@@ -74,7 +74,7 @@ func NewColumnNameGenerator(e RelExpr) *ColumnNameGenerator {
 // for the columns in the table that will be created if the session
 // variable `save_tables_prefix` is non-empty.
 func (g *ColumnNameGenerator) GenerateName(col opt.ColumnID) string {
-	colMeta := g.e.Memo().Metadata().ColumnMeta(col)
+	colMeta := g.mem.Metadata().ColumnMeta(col)
 	colName := colMeta.Alias
 
 	// Check whether the presentation has a different name for this column, and

--- a/pkg/sql/opt/memo/group.go
+++ b/pkg/sql/opt/memo/group.go
@@ -19,9 +19,6 @@ import (
 //
 // See comments for Memo, RelExpr, Relational, and Physical for more details.
 type exprGroup interface {
-	// memo is the memo which contains the group.
-	memo() *Memo
-
 	// firstExpr points to the first member expression in the group. Other members
 	// of the group can be accessed via calls to RelExpr.NextExpr.
 	firstExpr() RelExpr

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -644,11 +644,6 @@ func (m *Memo) DisableCheckExpr() {
 	m.disableCheckExpr = true
 }
 
-// EvalContext returns the eval.Context of the current SQL request.
-func (m *Memo) EvalContext() *eval.Context {
-	return m.logPropsBuilder.evalCtx
-}
-
 // String prints the current expression tree stored in the memo. It should only
 // be used for testing and debugging.
 func (m *Memo) String() string {

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -7,6 +7,7 @@
 package memo
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
@@ -646,6 +647,29 @@ func (m *Memo) DisableCheckExpr() {
 // EvalContext returns the eval.Context of the current SQL request.
 func (m *Memo) EvalContext() *eval.Context {
 	return m.logPropsBuilder.evalCtx
+}
+
+// String prints the current expression tree stored in the memo. It should only
+// be used for testing and debugging.
+func (m *Memo) String() string {
+	return m.FormatExpr(m.rootExpr)
+}
+
+// FormatExpr prints the given expression for testing and debugging.
+func (m *Memo) FormatExpr(expr opt.Expr) string {
+	if expr == nil {
+		return ""
+	}
+	f := MakeExprFmtCtxBuffer(
+		context.Background(),
+		&bytes.Buffer{},
+		ExprFmtHideQualifications,
+		false, /* redactableValues */
+		m,
+		nil, /* catalog */
+	)
+	f.FormatExpr(expr)
+	return f.Buffer.String()
 }
 
 // ValuesContainer lets ValuesExpr and LiteralValuesExpr share code.

--- a/pkg/sql/opt/memo/multiplicity_builder.go
+++ b/pkg/sql/opt/memo/multiplicity_builder.go
@@ -18,14 +18,14 @@ import (
 // only be called during construction of the join by the initUnexportedFields
 // methods. Panics if called on an operator that does not support
 // JoinMultiplicity.
-func initJoinMultiplicity(in RelExpr) {
+func initJoinMultiplicity(mem *Memo, in RelExpr) {
 	switch t := in.(type) {
 	case *InnerJoinExpr, *LeftJoinExpr, *FullJoinExpr, *SemiJoinExpr:
 		// Calculate JoinMultiplicity and set the multiplicity field of the join.
 		left := t.Child(0).(RelExpr)
 		right := t.Child(1).(RelExpr)
 		filters := *t.Child(2).(*FiltersExpr)
-		multiplicity := DeriveJoinMultiplicityFromInputs(left, right, filters)
+		multiplicity := DeriveJoinMultiplicityFromInputs(mem, left, right, filters)
 		t.(joinWithMultiplicity).setMultiplicity(multiplicity)
 
 	default:
@@ -55,10 +55,10 @@ func GetJoinMultiplicity(in RelExpr) props.JoinMultiplicity {
 // property is used in calculating the JoinMultiplicity, and is lazily derived
 // by a call to deriveUnfilteredCols.
 func DeriveJoinMultiplicityFromInputs(
-	left, right RelExpr, filters FiltersExpr,
+	mem *Memo, left, right RelExpr, filters FiltersExpr,
 ) props.JoinMultiplicity {
-	leftMultiplicity := getJoinLeftMultiplicityVal(left, right, filters)
-	rightMultiplicity := getJoinLeftMultiplicityVal(right, left, filters)
+	leftMultiplicity := getJoinLeftMultiplicityVal(mem, left, right, filters)
+	rightMultiplicity := getJoinLeftMultiplicityVal(mem, right, left, filters)
 
 	return props.JoinMultiplicity{
 		LeftMultiplicity:  leftMultiplicity,
@@ -69,7 +69,7 @@ func DeriveJoinMultiplicityFromInputs(
 // deriveUnfilteredCols recursively derives the UnfilteredCols field and
 // populates the props.Relational.Rule.UnfilteredCols field as it goes to
 // make future calls faster.
-func deriveUnfilteredCols(in RelExpr) opt.ColSet {
+func deriveUnfilteredCols(mem *Memo, in RelExpr) opt.ColSet {
 	// If the UnfilteredCols property has already been derived, return it
 	// immediately.
 	relational := in.Relational()
@@ -99,7 +99,7 @@ func deriveUnfilteredCols(in RelExpr) opt.ColSet {
 		// non-null foreign key relation - rows in kr imply rows in xy. However,
 		// the columns from xy are not output columns, so in order to see that this
 		// is the case we must bubble up non-output columns.
-		md := t.Memo().Metadata()
+		md := mem.Metadata()
 		baseTable := md.Table(t.Table)
 		if t.IsUnfiltered(md) {
 			for i, cnt := 0, baseTable.ColumnCount(); i < cnt; i++ {
@@ -110,7 +110,7 @@ func deriveUnfilteredCols(in RelExpr) opt.ColSet {
 	case *ProjectExpr:
 		// Project never filters rows, so it passes through unfiltered columns.
 		// Include non-output columns for the same reasons as for the Scan operator.
-		unfilteredCols.UnionWith(deriveUnfilteredCols(t.Input))
+		unfilteredCols.UnionWith(deriveUnfilteredCols(mem, t.Input))
 
 	case *InnerJoinExpr, *LeftJoinExpr, *FullJoinExpr:
 		left := t.Child(0).(RelExpr)
@@ -120,16 +120,16 @@ func deriveUnfilteredCols(in RelExpr) opt.ColSet {
 		// Use the join's multiplicity to determine whether unfiltered columns
 		// can be passed through.
 		if multiplicity.JoinPreservesLeftRows(t.Op()) {
-			unfilteredCols.UnionWith(deriveUnfilteredCols(left))
+			unfilteredCols.UnionWith(deriveUnfilteredCols(mem, left))
 		}
 		if multiplicity.JoinPreservesRightRows(t.Op()) {
-			unfilteredCols.UnionWith(deriveUnfilteredCols(right))
+			unfilteredCols.UnionWith(deriveUnfilteredCols(mem, right))
 		}
 
 	case *SemiJoinExpr:
 		multiplicity := GetJoinMultiplicity(t)
 		if multiplicity.JoinPreservesLeftRows(t.Op()) {
-			unfilteredCols.UnionWith(deriveUnfilteredCols(t.Left))
+			unfilteredCols.UnionWith(deriveUnfilteredCols(mem, t.Left))
 		}
 
 	default:
@@ -145,12 +145,14 @@ func deriveUnfilteredCols(in RelExpr) opt.ColSet {
 //
 // The duplicated and filtered flags will be set unless it can be statically
 // proven that no rows will be duplicated or filtered respectively.
-func getJoinLeftMultiplicityVal(left, right RelExpr, filters FiltersExpr) props.MultiplicityValue {
+func getJoinLeftMultiplicityVal(
+	mem *Memo, left, right RelExpr, filters FiltersExpr,
+) props.MultiplicityValue {
 	multiplicity := props.MultiplicityIndeterminateVal
 	if filtersMatchLeftRowsAtMostOnce(left, right, filters) {
 		multiplicity |= props.MultiplicityNotDuplicatedVal
 	}
-	if filtersMatchAllLeftRows(left, right, filters) {
+	if filtersMatchAllLeftRows(mem, left, right, filters) {
 		multiplicity |= props.MultiplicityPreservedVal
 	}
 	return multiplicity
@@ -263,7 +265,7 @@ func filtersMatchLeftRowsAtMostOnce(left, right RelExpr, filters FiltersExpr) bo
 // Note: in the foreign key case, if the key's match method is match simple, all
 // columns in the foreign key must be not-null in order to guarantee that all
 // rows will have a match in the referenced table.
-func filtersMatchAllLeftRows(left, right RelExpr, filters FiltersExpr) bool {
+func filtersMatchAllLeftRows(mem *Memo, left, right RelExpr, filters FiltersExpr) bool {
 	if filters.IsTrue() {
 		// Cross join case.
 		if !right.Relational().Cardinality.CanBeZero() {
@@ -273,23 +275,23 @@ func filtersMatchAllLeftRows(left, right RelExpr, filters FiltersExpr) bool {
 		// Case 1b. We don't have to check verifyFiltersAreValidEqualities because
 		// there are no filters.
 		return checkForeignKeyCase(
-			left.Memo().Metadata(),
+			mem.Metadata(),
 			left.Relational().NotNullCols,
-			deriveUnfilteredCols(right),
+			deriveUnfilteredCols(mem, right),
 			filters,
 		)
 	}
-	rightEqualityCols, ok := verifyFiltersAreValidEqualities(left, right, filters)
+	rightEqualityCols, ok := verifyFiltersAreValidEqualities(mem, left, right, filters)
 	if !ok {
 		return false
 	}
-	if checkSelfJoinCase(left.Memo().Metadata(), filters) {
+	if checkSelfJoinCase(mem.Metadata(), filters) {
 		// Case 2a.
 		return true
 	}
 	// Case 2b.
 	return checkForeignKeyCase(
-		left.Memo().Metadata(),
+		mem.Metadata(),
 		left.Relational().NotNullCols,
 		rightEqualityCols,
 		filters,
@@ -313,13 +315,13 @@ func filtersMatchAllLeftRows(left, right RelExpr, filters FiltersExpr) bool {
 //
 // Returns ok=false if any of these conditions are unsatisfied.
 func verifyFiltersAreValidEqualities(
-	left, right RelExpr, filters FiltersExpr,
+	mem *Memo, left, right RelExpr, filters FiltersExpr,
 ) (rightEqualityCols opt.ColSet, ok bool) {
-	md := left.Memo().Metadata()
+	md := mem.Metadata()
 
 	var leftTab, rightTab opt.TableID
 	leftNotNullCols := left.Relational().NotNullCols
-	rightUnfilteredCols := deriveUnfilteredCols(right)
+	rightUnfilteredCols := deriveUnfilteredCols(mem, right)
 
 	for i := range filters {
 		eq, _ := filters[i].Condition.(*EqExpr)
@@ -350,7 +352,7 @@ func verifyFiltersAreValidEqualities(
 		switch {
 		case rightUnfilteredCols.Contains(rightColID):
 		// Condition #3a: the right column is unfiltered.
-		case rightHasSingleFilterThatMatchesLeft(left, right, leftColID, rightColID):
+		case rightHasSingleFilterThatMatchesLeft(mem, left, right, leftColID, rightColID):
 		// Condition #3b: The left and right are Selects where the left filters
 		// imply the right filters when replacing the left column with the right
 		// column, and the right column is unfiltered in the right Select's
@@ -398,7 +400,9 @@ func verifyFiltersAreValidEqualities(
 // equal by the join filters. This may be a good opportunity to reuse
 // partialidx.Implicator. Be aware that it might not be possible to simply
 // replace columns in a filter when one of the columns has a composite type.
-func rightHasSingleFilterThatMatchesLeft(left, right RelExpr, leftCol, rightCol opt.ColumnID) bool {
+func rightHasSingleFilterThatMatchesLeft(
+	mem *Memo, left, right RelExpr, leftCol, rightCol opt.ColumnID,
+) bool {
 	leftSelect, ok := left.(*SelectExpr)
 	if !ok {
 		return false
@@ -410,7 +414,7 @@ func rightHasSingleFilterThatMatchesLeft(left, right RelExpr, leftCol, rightCol 
 
 	// Return false if the right column has been filtered in the input to
 	// rightSelect.
-	rightUnfilteredCols := deriveUnfilteredCols(rightSelect.Input)
+	rightUnfilteredCols := deriveUnfilteredCols(mem, rightSelect.Input)
 	if !rightUnfilteredCols.Contains(rightCol) {
 		return false
 	}

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -5067,9 +5067,11 @@ func (sb *statisticsBuilder) numConjunctsInConstraint(
 
 // RequestColStat causes a column statistic to be calculated on the relational
 // expression. This is used for testing.
-func RequestColStat(ctx context.Context, evalCtx *eval.Context, e RelExpr, cols opt.ColSet) {
+func RequestColStat(
+	ctx context.Context, evalCtx *eval.Context, mem *Memo, e RelExpr, cols opt.ColSet,
+) {
 	var sb statisticsBuilder
-	sb.init(ctx, evalCtx, e.Memo().Metadata())
+	sb.init(ctx, evalCtx, mem.Metadata())
 	sb.colStat(cols, e)
 }
 

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -231,18 +231,20 @@ const (
 type statisticsBuilder struct {
 	ctx                   context.Context
 	evalCtx               *eval.Context
+	mem                   *Memo
 	md                    *opt.Metadata
 	checkInputMinRowCount float64
 	minRowCount           float64
 }
 
-func (sb *statisticsBuilder) init(ctx context.Context, evalCtx *eval.Context, md *opt.Metadata) {
+func (sb *statisticsBuilder) init(ctx context.Context, evalCtx *eval.Context, mem *Memo) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
 	*sb = statisticsBuilder{
 		ctx:                   ctx,
 		evalCtx:               evalCtx,
-		md:                    md,
+		mem:                   mem,
+		md:                    mem.Metadata(),
 		checkInputMinRowCount: evalCtx.SessionData().OptimizerCheckInputMinRowCount,
 		minRowCount:           evalCtx.SessionData().OptimizerMinRowCount,
 	}
@@ -1173,10 +1175,10 @@ func (sb *statisticsBuilder) colStatProject(
 				if sb.evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats &&
 					!s.VirtualCols.Empty() {
 					element := sb.factorOutVirtualCols(
-						item.Element, &item.scalar.Shared, s.VirtualCols, prj.Memo(),
+						item.Element, &item.scalar.Shared, s.VirtualCols, sb.mem,
 					).(opt.ScalarExpr)
 					if element != item.Element {
-						newItem := constructProjectionsItem(element, item.Col, prj.Memo())
+						newItem := constructProjectionsItem(element, item.Col, sb.mem)
 						item = &newItem
 					}
 				}
@@ -3219,7 +3221,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 
 		// We need to determine the row count of the join before the
 		// ON conditions are applied.
-		withoutOn := e.Memo().MemoizeLookupJoin(t.Input, nil /* on */, lookupJoinPrivate)
+		withoutOn := sb.mem.MemoizeLookupJoin(t.Input, nil /* on */, lookupJoinPrivate)
 		return withoutOn.Relational().Statistics().RowCount
 
 	case *InvertedJoinExpr:
@@ -3243,7 +3245,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 
 		// We need to determine the row count of the join before the
 		// ON conditions are applied.
-		withoutOn := e.Memo().MemoizeInvertedJoin(t.Input, nil /* on */, invertedJoinPrivate)
+		withoutOn := sb.mem.MemoizeInvertedJoin(t.Input, nil /* on */, invertedJoinPrivate)
 		return withoutOn.Relational().Statistics().RowCount
 
 	case *MergeJoinExpr:
@@ -3267,7 +3269,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 
 		// We need to determine the row count of the join before the
 		// ON conditions are applied.
-		withoutOn := e.Memo().MemoizeMergeJoin(t.Left, t.Right, nil /* on */, mergeJoinPrivate)
+		withoutOn := sb.mem.MemoizeMergeJoin(t.Left, t.Right, nil /* on */, mergeJoinPrivate)
 		return withoutOn.Relational().Statistics().RowCount
 
 	default:
@@ -3286,13 +3288,13 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 		// The number of rows processed for semi and anti joins is closer to the
 		// number of output rows for an equivalent inner join.
 		case *SemiJoinExpr:
-			e = e.Memo().MemoizeInnerJoin(t.Left, t.Right, on, &t.JoinPrivate)
+			e = sb.mem.MemoizeInnerJoin(t.Left, t.Right, on, &t.JoinPrivate)
 		case *SemiJoinApplyExpr:
-			e = e.Memo().MemoizeInnerJoinApply(t.Left, t.Right, on, &t.JoinPrivate)
+			e = sb.mem.MemoizeInnerJoinApply(t.Left, t.Right, on, &t.JoinPrivate)
 		case *AntiJoinExpr:
-			e = e.Memo().MemoizeInnerJoin(t.Left, t.Right, on, &t.JoinPrivate)
+			e = sb.mem.MemoizeInnerJoin(t.Left, t.Right, on, &t.JoinPrivate)
 		case *AntiJoinApplyExpr:
-			e = e.Memo().MemoizeInnerJoinApply(t.Left, t.Right, on, &t.JoinPrivate)
+			e = sb.mem.MemoizeInnerJoinApply(t.Left, t.Right, on, &t.JoinPrivate)
 
 		default:
 			if len(on) == len(*filters) {
@@ -3302,17 +3304,17 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 
 			switch t := e.(type) {
 			case *InnerJoinExpr:
-				e = e.Memo().MemoizeInnerJoin(t.Left, t.Right, on, &t.JoinPrivate)
+				e = sb.mem.MemoizeInnerJoin(t.Left, t.Right, on, &t.JoinPrivate)
 			case *InnerJoinApplyExpr:
-				e = e.Memo().MemoizeInnerJoinApply(t.Left, t.Right, on, &t.JoinPrivate)
+				e = sb.mem.MemoizeInnerJoinApply(t.Left, t.Right, on, &t.JoinPrivate)
 			case *LeftJoinExpr:
-				e = e.Memo().MemoizeLeftJoin(t.Left, t.Right, on, &t.JoinPrivate)
+				e = sb.mem.MemoizeLeftJoin(t.Left, t.Right, on, &t.JoinPrivate)
 			case *LeftJoinApplyExpr:
-				e = e.Memo().MemoizeLeftJoinApply(t.Left, t.Right, on, &t.JoinPrivate)
+				e = sb.mem.MemoizeLeftJoinApply(t.Left, t.Right, on, &t.JoinPrivate)
 			case *RightJoinExpr:
-				e = e.Memo().MemoizeRightJoin(t.Left, t.Right, on, &t.JoinPrivate)
+				e = sb.mem.MemoizeRightJoin(t.Left, t.Right, on, &t.JoinPrivate)
 			case *FullJoinExpr:
-				e = e.Memo().MemoizeFullJoin(t.Left, t.Right, on, &t.JoinPrivate)
+				e = sb.mem.MemoizeFullJoin(t.Left, t.Right, on, &t.JoinPrivate)
 			default:
 				panic(errors.AssertionFailedf("join type %v not handled", redact.Safe(e.Op())))
 			}
@@ -3488,10 +3490,10 @@ func (sb *statisticsBuilder) applyFiltersItem(
 	if sb.evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats &&
 		!relProps.Statistics().VirtualCols.Empty() {
 		cond := sb.factorOutVirtualCols(
-			filter.Condition, &filter.scalar.Shared, relProps.Statistics().VirtualCols, e.Memo(),
+			filter.Condition, &filter.scalar.Shared, relProps.Statistics().VirtualCols, sb.mem,
 		).(opt.ScalarExpr)
 		if cond != filter.Condition {
-			newFilter := constructFiltersItem(cond, e.Memo())
+			newFilter := constructFiltersItem(cond, sb.mem)
 			filter = &newFilter
 		}
 	}
@@ -4673,11 +4675,11 @@ func (sb *statisticsBuilder) selectivityFromOredEquivalencies(
 			// is able to build column equivalencies.
 			switch disjuncts[i].(type) {
 			case *EqExpr, *AndExpr:
-				if andFilters, ok = addEqExprConjuncts(disjuncts[i], andFilters, e.Memo()); !ok {
+				if andFilters, ok = addEqExprConjuncts(disjuncts[i], andFilters, sb.mem); !ok {
 					unapplied.unknown++
 					continue
 				}
-				e.Memo().logPropsBuilder.addFiltersToFuncDep(andFilters, &filtersFD)
+				sb.mem.logPropsBuilder.addFiltersToFuncDep(andFilters, &filtersFD)
 			default:
 				unapplied.unknown++
 				ok = false
@@ -5071,7 +5073,7 @@ func RequestColStat(
 	ctx context.Context, evalCtx *eval.Context, mem *Memo, e RelExpr, cols opt.ColSet,
 ) {
 	var sb statisticsBuilder
-	sb.init(ctx, evalCtx, mem.Metadata())
+	sb.init(ctx, evalCtx, mem)
 	sb.colStat(cols, e)
 }
 

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -251,8 +251,7 @@ func (sb *statisticsBuilder) init(ctx context.Context, evalCtx *eval.Context, me
 }
 
 func (sb *statisticsBuilder) clear() {
-	sb.evalCtx = nil
-	sb.md = nil
+	*sb = statisticsBuilder{}
 }
 
 // colStatCols returns the set of columns which may be looked up in

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -101,7 +101,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		}
 
 		sb := &statisticsBuilder{}
-		sb.init(context.Background(), &evalCtx, mem.Metadata())
+		sb.init(context.Background(), &evalCtx, &mem)
 
 		// Make the scan.
 		scan := mem.MemoizeScan(&ScanPrivate{Table: tabID, Cols: cols})

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -317,7 +317,7 @@ memo (optimized, ~6KB, required=[presentation: array_agg:6])
 memo
 SELECT array_agg(x) FROM (SELECT * FROM a) GROUP BY y
 ----
-memo (optimized, ~8KB, required=[presentation: array_agg:6])
+memo (optimized, ~7KB, required=[presentation: array_agg:6])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:6]
  │         ├── best: (project G2 G3 array_agg)
@@ -373,7 +373,7 @@ memo (optimized, ~6KB, required=[presentation: array_cat_agg:6])
 memo
 SELECT array_cat_agg(arr) FROM (SELECT * FROM a) GROUP BY y
 ----
-memo (optimized, ~8KB, required=[presentation: array_cat_agg:6])
+memo (optimized, ~7KB, required=[presentation: array_cat_agg:6])
  ├── G1: (project G2 G3 array_cat_agg)
  │    └── [presentation: array_cat_agg:6]
  │         ├── best: (project G2 G3 array_cat_agg)

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -262,10 +262,10 @@ func (f *Factory) EvalContext() *eval.Context {
 }
 
 // CopyAndReplace builds this factory's memo by constructing a copy of a subtree
-// that is part of another memo. That memo's metadata is copied to this
-// factory's memo so that tables and columns referenced by the copied memo can
-// keep the same ids. The copied subtree becomes the root of the destination
-// memo, having the given physical properties.
+// that is part of another memo. fromMemo's metadata is copied to this factory's
+// memo so that tables and columns referenced by the copied memo can keep the
+// same ids. The copied subtree becomes the root of the destination memo, having
+// the given physical properties.
 //
 // The "replace" callback function allows the caller to override the default
 // traversal and cloning behavior with custom logic. It is called for each node
@@ -288,18 +288,18 @@ func (f *Factory) EvalContext() *eval.Context {
 //	  return f.CopyAndReplaceDefault(e, replaceFn)
 //	}
 //
-//	f.CopyAndReplace(from, fromProps, replaceFn)
+//	f.CopyAndReplace(fromMemo, from, fromProps, replaceFn)
 //
 // NOTE: Callers must take care to always create brand new copies of non-
 // singleton source nodes rather than referencing existing nodes. The source
 // memo should always be treated as immutable, and the destination memo must be
 // completely independent of it once CopyAndReplace has completed.
 func (f *Factory) CopyAndReplace(
-	from memo.RelExpr, fromProps *physical.Required, replace ReplaceFunc,
+	fromMemo *memo.Memo, from memo.RelExpr, fromProps *physical.Required, replace ReplaceFunc,
 ) {
 	opt.MaybeInjectOptimizerTestingPanic(f.ctx, f.evalCtx)
 
-	f.CopyMetadataFrom(from.Memo())
+	f.CopyMetadataFrom(fromMemo)
 
 	// Perform copy and replacement, and store result as the root of this
 	// factory's memo.
@@ -394,7 +394,7 @@ func (f *Factory) AssignPlaceholders(from *memo.Memo) (err error) {
 		}
 		return f.CopyAndReplaceDefault(e, replaceFn)
 	}
-	f.CopyAndReplace(from.RootExpr().(memo.RelExpr), from.RootProps(), replaceFn)
+	f.CopyAndReplace(from, from.RootExpr().(memo.RelExpr), from.RootProps(), replaceFn)
 
 	return nil
 }

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -102,7 +102,7 @@ func TestCopyAndReplace(t *testing.T) {
 		}
 		return o.Factory().CopyAndReplaceDefault(e, replaceFn)
 	}
-	o.Factory().CopyAndReplace(m.RootExpr().(memo.RelExpr), m.RootProps(), replaceFn)
+	o.Factory().CopyAndReplace(m, m.RootExpr().(memo.RelExpr), m.RootProps(), replaceFn)
 
 	if e, err := o.Optimize(); err != nil {
 		t.Fatal(err)
@@ -147,7 +147,7 @@ func TestCopyAndReplaceWithScan(t *testing.T) {
 			replaceFn = func(e opt.Expr) opt.Expr {
 				return o.Factory().CopyAndReplaceDefault(e, replaceFn)
 			}
-			o.Factory().CopyAndReplace(m.RootExpr().(memo.RelExpr), m.RootProps(), replaceFn)
+			o.Factory().CopyAndReplace(m, m.RootExpr().(memo.RelExpr), m.RootProps(), replaceFn)
 
 			if _, err := o.Optimize(); err != nil {
 				t.Fatal(err)

--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -490,7 +490,7 @@ func (c *CustomFuncs) GetEquivGroups(
 func (c *CustomFuncs) JoinFiltersMatchAllLeftRows(
 	left, right memo.RelExpr, on memo.FiltersExpr,
 ) bool {
-	multiplicity := memo.DeriveJoinMultiplicityFromInputs(left, right, on)
+	multiplicity := memo.DeriveJoinMultiplicityFromInputs(c.mem, left, right, on)
 	return multiplicity.JoinFiltersMatchAllLeftRows()
 }
 

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -73,10 +73,6 @@ type Expr interface {
 	// For example, an operator may choose to return one of its fields, or perhaps
 	// a pointer to itself, or nil if there is nothing useful to return.
 	Private() interface{}
-
-	// String returns a human-readable string representation for the expression
-	// that can be used for debugging and testing.
-	String() string
 }
 
 // ScalarRank is the type of the sort order given to every scalar
@@ -95,6 +91,11 @@ type ScalarExpr interface {
 
 	// DataType is the SQL type of the expression.
 	DataType() *types.T
+
+	// String returns a human-readable string representation for the expression
+	// that can be used for debugging and testing. It is only implemented for
+	// scalar expressions because relational expressions need access to the memo.
+	String() string
 }
 
 // MutableExpr is implemented by expressions that allow their children to be

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -98,17 +98,11 @@ func (g *exprsGen) genExprGroupDef(define *lang.DefineExpr) {
 
 	// Generate the type definition.
 	fmt.Fprintf(g.w, "type %s struct {\n", groupStructType)
-	fmt.Fprintf(g.w, "  mem *Memo\n")
 	fmt.Fprintf(g.w, "  rel props.Relational\n")
 	fmt.Fprintf(g.w, "  first %s\n", structType)
 	fmt.Fprintf(g.w, "  best bestProps\n")
 	fmt.Fprintf(g.w, "}\n\n")
 	fmt.Fprintf(g.w, "var _ exprGroup = &%s{}\n\n", groupStructType)
-
-	// Generate the memo method.
-	fmt.Fprintf(g.w, "func (g *%s) memo() *Memo {\n", groupStructType)
-	fmt.Fprintf(g.w, "  return g.mem\n")
-	fmt.Fprintf(g.w, "}\n\n")
 
 	// Generate the relational method.
 	fmt.Fprintf(g.w, "func (g *%s) relational() *props.Relational {\n", groupStructType)
@@ -332,11 +326,6 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 			fmt.Fprintf(g.w, "}\n\n")
 		}
 	} else {
-		// Generate the Memo method.
-		fmt.Fprintf(g.w, "func (e *%s) Memo() *Memo {\n", opTyp.name)
-		fmt.Fprintf(g.w, "  return e.grp.memo()\n")
-		fmt.Fprintf(g.w, "}\n\n")
-
 		// Generate the Relational method.
 		fmt.Fprintf(g.w, "func (e *%s) Relational() *props.Relational {\n", opTyp.name)
 		fmt.Fprintf(g.w, "  return e.grp.relational()\n")
@@ -431,11 +420,6 @@ func (g *exprsGen) genEnforcerFuncs(define *lang.DefineExpr) {
 	fmt.Fprintf(g.w, "    return\n")
 	fmt.Fprintf(g.w, "  }\n")
 	fmt.Fprintf(g.w, "  panic(errors.AssertionFailedf(\"child index out of range\"))\n")
-	fmt.Fprintf(g.w, "}\n\n")
-
-	// Generate the Memo method.
-	fmt.Fprintf(g.w, "func (e *%s) Memo() *Memo {\n", opTyp.name)
-	fmt.Fprintf(g.w, "  return e.Input.Memo()\n")
 	fmt.Fprintf(g.w, "}\n\n")
 
 	// Generate the Relational method.
@@ -587,7 +571,7 @@ func (g *exprsGen) genMemoizeFuncs() {
 		} else {
 			groupName := fmt.Sprintf("%sGroup", unTitle(string(define.Name)))
 			fmt.Fprintf(g.w, "  const size = int64(unsafe.Sizeof(%s{}))\n", groupName)
-			fmt.Fprintf(g.w, "  grp := &%s{mem: m, first: %s{\n", groupName, opTyp.name)
+			fmt.Fprintf(g.w, "  grp := &%s{first: %s{\n", groupName, opTyp.name)
 		}
 
 		for _, field := range fields {

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -280,17 +280,6 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 	}
 	fmt.Fprintf(g.w, "}\n\n")
 
-	// Generate the String method.
-	fmt.Fprintf(g.w, "func (e *%s) String() string {\n", opTyp.name)
-	if define.Tags.Contains("Scalar") {
-		fmt.Fprintf(g.w, "  f := makeExprFmtCtxForString(ExprFmtHideQualifications, nil, nil)\n")
-	} else {
-		fmt.Fprintf(g.w, "  f := makeExprFmtCtxForString(ExprFmtHideQualifications, e.Memo(), nil)\n")
-	}
-	fmt.Fprintf(g.w, "  f.FormatExpr(e)\n")
-	fmt.Fprintf(g.w, "  return f.Buffer.String()\n")
-	fmt.Fprintf(g.w, "}\n\n")
-
 	// Generate the SetChild method.
 	fmt.Fprintf(g.w, "func (e *%s) SetChild(nth int, child opt.Expr) {\n", opTyp.name)
 	if len(childFields) > 0 {
@@ -315,6 +304,13 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 	fmt.Fprintf(g.w, "}\n\n")
 
 	if define.Tags.Contains("Scalar") {
+		// Generate the String method.
+		fmt.Fprintf(g.w, "func (e *%s) String() string {\n", opTyp.name)
+		fmt.Fprintf(g.w, "  f := makeExprFmtCtxForString(ExprFmtHideQualifications, nil, nil)\n")
+		fmt.Fprintf(g.w, "  f.FormatExpr(e)\n")
+		fmt.Fprintf(g.w, "  return f.Buffer.String()\n")
+		fmt.Fprintf(g.w, "}\n\n")
+
 		// Generate the DataType method.
 		fmt.Fprintf(g.w, "func (e *%s) DataType() *types.T {\n", opTyp.name)
 		if dataType, ok := g.constDataType(define); ok {
@@ -384,7 +380,7 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 		// Generate the setNext method.
 		fmt.Fprintf(g.w, "func (e *%s) setNext(member RelExpr) {\n", opTyp.name)
 		fmt.Fprintf(g.w, "  if e.next != nil {\n")
-		fmt.Fprintf(g.w, "    panic(errors.AssertionFailedf(\"expression already has its next defined: %%s\", e))\n")
+		fmt.Fprintf(g.w, "    panic(errors.AssertionFailedf(\"expression already has its next defined: %%s\", errors.Safe(e.Op())))\n")
 		fmt.Fprintf(g.w, "  }\n")
 		fmt.Fprintf(g.w, "  e.next = member\n")
 		fmt.Fprintf(g.w, "}\n\n")
@@ -392,7 +388,7 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 		// Generate the setGroup method.
 		fmt.Fprintf(g.w, "func (e *%s) setGroup(member RelExpr) {\n", opTyp.name)
 		fmt.Fprintf(g.w, "  if e.grp != nil {\n")
-		fmt.Fprintf(g.w, "    panic(errors.AssertionFailedf(\"expression is already in a group: %%s\", e))\n")
+		fmt.Fprintf(g.w, "    panic(errors.AssertionFailedf(\"expression is already in a group: %%s\", errors.Safe(e.Op())))\n")
 		fmt.Fprintf(g.w, "  }\n")
 		fmt.Fprintf(g.w, "  e.grp = member.group()\n")
 		fmt.Fprintf(g.w, "  LastGroupMember(member).setNext(e)\n")
@@ -426,13 +422,6 @@ func (g *exprsGen) genEnforcerFuncs(define *lang.DefineExpr) {
 	// Generate the Private method.
 	fmt.Fprintf(g.w, "func (e *%s) Private() interface{} {\n", opTyp.name)
 	fmt.Fprintf(g.w, "  return nil\n")
-	fmt.Fprintf(g.w, "}\n\n")
-
-	// Generate the String method.
-	fmt.Fprintf(g.w, "func (e *%s) String() string {\n", opTyp.name)
-	fmt.Fprintf(g.w, "  f := makeExprFmtCtxForString(ExprFmtHideQualifications, e.Memo(), nil)\n")
-	fmt.Fprintf(g.w, "  f.FormatExpr(e)\n")
-	fmt.Fprintf(g.w, "  return f.Buffer.String()\n")
 	fmt.Fprintf(g.w, "}\n\n")
 
 	// Generate the SetChild method.
@@ -716,7 +705,7 @@ func (g *exprsGen) genInternFuncs() {
 		fmt.Fprintf(g.w, "    return in.Intern%s(t)\n", define.Name)
 	}
 	fmt.Fprintf(g.w, "  default:\n")
-	fmt.Fprintf(g.w, "    panic(errors.AssertionFailedf(\"unhandled op: %%s\", e.Op()))\n")
+	fmt.Fprintf(g.w, "    panic(errors.AssertionFailedf(\"unhandled op: %%s\", errors.Safe(e.Op())))\n")
 	fmt.Fprintf(g.w, "  }\n")
 	fmt.Fprintf(g.w, "}\n\n")
 
@@ -814,7 +803,7 @@ func (g *exprsGen) genBuildPropsFunc() {
 		fmt.Fprintf(g.w, "    b.build%sProps(t, rel)\n", define.Name)
 	}
 	fmt.Fprintf(g.w, "  default:\n")
-	fmt.Fprintf(g.w, "    panic(errors.AssertionFailedf(\"unhandled type: %%s\", t.Op()))\n")
+	fmt.Fprintf(g.w, "    panic(errors.AssertionFailedf(\"unhandled type: %%s\", errors.Safe(e.Op())))\n")
 
 	fmt.Fprintf(g.w, "  }\n")
 	fmt.Fprintf(g.w, "}\n\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -111,10 +111,6 @@ func (e *ProjectExpr) SetChild(nth int, child opt.Expr) {
 	panic(errors.AssertionFailedf("child index out of range"))
 }
 
-func (e *ProjectExpr) Memo() *Memo {
-	return e.grp.memo()
-}
-
 func (e *ProjectExpr) Relational() *props.Relational {
 	return e.grp.relational()
 }
@@ -163,17 +159,12 @@ func (e *ProjectExpr) setGroup(member RelExpr) {
 }
 
 type projectGroup struct {
-	mem   *Memo
 	rel   props.Relational
 	first ProjectExpr
 	best  bestProps
 }
 
 var _ exprGroup = &projectGroup{}
-
-func (g *projectGroup) memo() *Memo {
-	return g.mem
-}
 
 func (g *projectGroup) relational() *props.Relational {
 	return &g.rel
@@ -319,10 +310,6 @@ func (e *SortExpr) SetChild(nth int, child opt.Expr) {
 	panic(errors.AssertionFailedf("child index out of range"))
 }
 
-func (e *SortExpr) Memo() *Memo {
-	return e.Input.Memo()
-}
-
 func (e *SortExpr) Relational() *props.Relational {
 	return e.Input.Relational()
 }
@@ -369,7 +356,7 @@ func (m *Memo) MemoizeProject(
 	passthrough opt.ColSet,
 ) RelExpr {
 	const size = int64(unsafe.Sizeof(projectGroup{}))
-	grp := &projectGroup{mem: m, first: ProjectExpr{
+	grp := &projectGroup{first: ProjectExpr{
 		Input:       input,
 		Projections: projections,
 		Passthrough: passthrough,

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -99,12 +99,6 @@ func (e *ProjectExpr) Private() interface{} {
 	return &e.Passthrough
 }
 
-func (e *ProjectExpr) String() string {
-	f := makeExprFmtCtxForString(ExprFmtHideQualifications, e.Memo(), nil)
-	f.FormatExpr(e)
-	return f.Buffer.String()
-}
-
 func (e *ProjectExpr) SetChild(nth int, child opt.Expr) {
 	switch nth {
 	case 0:
@@ -155,14 +149,14 @@ func (e *ProjectExpr) bestProps() *bestProps {
 
 func (e *ProjectExpr) setNext(member RelExpr) {
 	if e.next != nil {
-		panic(errors.AssertionFailedf("expression already has its next defined: %s", e))
+		panic(errors.AssertionFailedf("expression already has its next defined: %s", errors.Safe(e.Op())))
 	}
 	e.next = member
 }
 
 func (e *ProjectExpr) setGroup(member RelExpr) {
 	if e.grp != nil {
-		panic(errors.AssertionFailedf("expression is already in a group: %s", e))
+		panic(errors.AssertionFailedf("expression is already in a group: %s", errors.Safe(e.Op())))
 	}
 	e.grp = member.group()
 	LastGroupMember(member).setNext(e)
@@ -266,12 +260,6 @@ func (e *ProjectionsItem) Private() interface{} {
 	return &e.ColPrivate
 }
 
-func (e *ProjectionsItem) String() string {
-	f := makeExprFmtCtxForString(ExprFmtHideQualifications, nil, nil)
-	f.FormatExpr(e)
-	return f.Buffer.String()
-}
-
 func (e *ProjectionsItem) SetChild(nth int, child opt.Expr) {
 	switch nth {
 	case 0:
@@ -279,6 +267,12 @@ func (e *ProjectionsItem) SetChild(nth int, child opt.Expr) {
 		return
 	}
 	panic(errors.AssertionFailedf("child index out of range"))
+}
+
+func (e *ProjectionsItem) String() string {
+	f := makeExprFmtCtxForString(ExprFmtHideQualifications, nil, nil)
+	f.FormatExpr(e)
+	return f.Buffer.String()
 }
 
 func (e *ProjectionsItem) DataType() *types.T {
@@ -315,12 +309,6 @@ func (e *SortExpr) Child(nth int) opt.Expr {
 
 func (e *SortExpr) Private() interface{} {
 	return nil
-}
-
-func (e *SortExpr) String() string {
-	f := makeExprFmtCtxForString(ExprFmtHideQualifications, e.Memo(), nil)
-	f.FormatExpr(e)
-	return f.Buffer.String()
 }
 
 func (e *SortExpr) SetChild(nth int, child opt.Expr) {
@@ -426,7 +414,7 @@ func (in *interner) InternExpr(e opt.Expr) opt.Expr {
 	case *ProjectionsItem:
 		return in.InternProjectionsItem(t)
 	default:
-		panic(errors.AssertionFailedf("unhandled op: %s", e.Op()))
+		panic(errors.AssertionFailedf("unhandled op: %s", errors.Safe(e.Op())))
 	}
 }
 
@@ -495,7 +483,7 @@ func (b *logicalPropsBuilder) buildProps(e RelExpr, rel *props.Relational) {
 	case *ProjectExpr:
 		b.buildProjectProps(t, rel)
 	default:
-		panic(errors.AssertionFailedf("unhandled type: %s", t.Op()))
+		panic(errors.AssertionFailedf("unhandled type: %s", errors.Safe(e.Op())))
 	}
 }
 ----
@@ -565,14 +553,14 @@ func (e *VariableExpr) Private() interface{} {
 	return &e.Col
 }
 
+func (e *VariableExpr) SetChild(nth int, child opt.Expr) {
+	panic(errors.AssertionFailedf("child index out of range"))
+}
+
 func (e *VariableExpr) String() string {
 	f := makeExprFmtCtxForString(ExprFmtHideQualifications, nil, nil)
 	f.FormatExpr(e)
 	return f.Buffer.String()
-}
-
-func (e *VariableExpr) SetChild(nth int, child opt.Expr) {
-	panic(errors.AssertionFailedf("child index out of range"))
 }
 
 func (e *VariableExpr) DataType() *types.T {
@@ -612,12 +600,6 @@ func (e *MaxExpr) Private() interface{} {
 	return nil
 }
 
-func (e *MaxExpr) String() string {
-	f := makeExprFmtCtxForString(ExprFmtHideQualifications, nil, nil)
-	f.FormatExpr(e)
-	return f.Buffer.String()
-}
-
 func (e *MaxExpr) SetChild(nth int, child opt.Expr) {
 	switch nth {
 	case 0:
@@ -625,6 +607,12 @@ func (e *MaxExpr) SetChild(nth int, child opt.Expr) {
 		return
 	}
 	panic(errors.AssertionFailedf("child index out of range"))
+}
+
+func (e *MaxExpr) String() string {
+	f := makeExprFmtCtxForString(ExprFmtHideQualifications, nil, nil)
+	f.FormatExpr(e)
+	return f.Buffer.String()
 }
 
 func (e *MaxExpr) DataType() *types.T {
@@ -678,7 +666,7 @@ func (in *interner) InternExpr(e opt.Expr) opt.Expr {
 	case *MaxExpr:
 		return in.InternMax(t)
 	default:
-		panic(errors.AssertionFailedf("unhandled op: %s", e.Op()))
+		panic(errors.AssertionFailedf("unhandled op: %s", errors.Safe(e.Op())))
 	}
 }
 
@@ -721,7 +709,7 @@ func (in *interner) InternMax(val *MaxExpr) *MaxExpr {
 func (b *logicalPropsBuilder) buildProps(e RelExpr, rel *props.Relational) {
 	switch t := e.(type) {
 	default:
-		panic(errors.AssertionFailedf("unhandled type: %s", t.Op()))
+		panic(errors.AssertionFailedf("unhandled type: %s", errors.Safe(e.Op())))
 	}
 }
 ----

--- a/pkg/sql/opt/optgen/exprgen/expr_gen.go
+++ b/pkg/sql/opt/optgen/exprgen/expr_gen.go
@@ -389,7 +389,7 @@ func (eg *exprGen) populateBestProps(
 ) memo.Cost {
 	rel, _ := expr.(memo.RelExpr)
 	if rel != nil {
-		if !xform.CanProvidePhysicalProps(ctx, eg.f.EvalContext(), rel, required) {
+		if !xform.CanProvidePhysicalProps(ctx, eg.f.EvalContext(), eg.mem, rel, required) {
 			panic(errorf("operator %s cannot provide required props %s", rel.Op(), required))
 		}
 	}
@@ -409,8 +409,10 @@ func (eg *exprGen) populateBestProps(
 		provided := &physical.Provided{}
 		// BuildProvided relies on ProvidedPhysical() being set in the children, so
 		// it must run after the recursive calls on the children.
-		provided.Ordering = ordering.BuildProvided(eg.f.EvalContext(), rel, &required.Ordering)
-		provided.Distribution = distribution.BuildProvided(ctx, eg.f.EvalContext(), rel, &required.Distribution)
+		provided.Ordering = ordering.BuildProvided(eg.f.EvalContext(), eg.mem, rel, &required.Ordering)
+		provided.Distribution = distribution.BuildProvided(
+			ctx, eg.f.EvalContext(), eg.mem, rel, &required.Distribution,
+		)
 
 		cost.Add(eg.coster.ComputeCost(rel, required))
 		eg.mem.SetBestProps(rel, required, provided, cost)

--- a/pkg/sql/opt/ordering/lookup_join_test.go
+++ b/pkg/sql/opt/ordering/lookup_join_test.go
@@ -174,7 +174,7 @@ func TestLookupJoinProvided(t *testing.T) {
 				},
 			)
 			req := props.ParseOrderingChoice(tc.required)
-			res := lookupJoinBuildProvided(lookupJoin, &req).String()
+			res := lookupJoinBuildProvided(f.Memo(), lookupJoin, &req).String()
 			if res != tc.provided {
 				t.Errorf("expected '%s', got '%s'", tc.provided, res)
 			}
@@ -358,7 +358,7 @@ func TestLookupJoinCanProvide(t *testing.T) {
 				},
 			)
 			req := props.ParseOrderingChoice(tc.required)
-			canProvide := lookupJoinCanProvideOrdering(lookupJoin, &req)
+			canProvide := lookupJoinCanProvideOrdering(f.Memo(), lookupJoin, &req)
 			if canProvide != tc.canProvide {
 				t.Errorf(errorString(tc.canProvide), req)
 			}

--- a/pkg/sql/opt/ordering/mutation.go
+++ b/pkg/sql/opt/ordering/mutation.go
@@ -38,7 +38,7 @@ func mutationBuildChildReqOrdering(
 	return props.OrderingChoice{Optional: optional, Columns: columns}
 }
 
-func mutationBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) opt.Ordering {
+func mutationBuildProvided(mem *memo.Memo, expr memo.RelExpr) opt.Ordering {
 	private := expr.Private().(*memo.MutationPrivate)
 	input := expr.Child(0).(memo.RelExpr)
 	provided := input.ProvidedPhysical().Ordering
@@ -47,7 +47,7 @@ func mutationBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) op
 	// be used by remapProvided.
 	var fdset props.FuncDepSet
 	fdset.CopyFrom(&input.Relational().FuncDeps)
-	private.AddEquivTableCols(expr.Memo().Metadata(), &fdset)
+	private.AddEquivTableCols(mem.Metadata(), &fdset)
 
 	// Ensure that provided ordering only uses projected columns.
 	return remapProvided(provided, &fdset, expr.Relational().OutputCols)

--- a/pkg/sql/opt/ordering/scan_test.go
+++ b/pkg/sql/opt/ordering/scan_test.go
@@ -185,7 +185,7 @@ func TestScan(t *testing.T) {
 					}
 					if ok {
 						scan := f.ConstructScan(&g.p)
-						prov := scanBuildProvided(scan, &req).String()
+						prov := scanBuildProvided(f.Memo(), scan, &req).String()
 						if prov != tc.prov {
 							t.Errorf("expected provided '%s', got '%s'", tc.prov, prov)
 						}

--- a/pkg/sql/opt/ordering/select.go
+++ b/pkg/sql/opt/ordering/select.go
@@ -17,7 +17,7 @@ func selectCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice)
 }
 
 func selectBuildChildReqOrdering(
-	parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
+	mem *memo.Memo, parent memo.RelExpr, required *props.OrderingChoice, childIdx int,
 ) props.OrderingChoice {
 	if childIdx != 0 {
 		return props.OrderingChoice{}
@@ -42,7 +42,7 @@ func selectBuildChildReqOrdering(
 	// down +1,+2,+3 as the required ordering to avoid an unnecessary sort.
 	//
 	// See #33023 for more details.
-	orders := DeriveInterestingOrderings(child)
+	orders := DeriveInterestingOrderings(mem, child)
 	for i := range orders {
 		if orders[i].Implies(required) {
 			// Get the common prefix of this ordering and the required ordering to

--- a/pkg/sql/opt/testutils/opttester/opt_steps.go
+++ b/pkg/sql/opt/testutils/opttester/opt_steps.go
@@ -111,7 +111,7 @@ func (os *optSteps) Next() error {
 
 	os.fo = fo
 	os.expr = fo.Optimize()
-	text := os.expr.String()
+	text := fo.o.Memo().String()
 
 	// If the expression text changes, then it must have gotten better.
 	os.better = text != os.best

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -959,7 +959,7 @@ func (ot *OptTester) fillInLazyProps(mem *memo.Memo, e opt.Expr) {
 		norm.DeriveRejectNullCols(mem, rel, intsets.Fast{} /* disabledRules */)
 
 		// Make sure the interesting orderings are calculated.
-		ordering.DeriveInterestingOrderings(rel)
+		ordering.DeriveInterestingOrderings(mem, rel)
 	}
 
 	for i, n := 0, e.ChildCount(); i < n; i++ {

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -2153,8 +2153,8 @@ func (ot *OptTester) createTableAs(name tree.TableName, rel memo.RelExpr) (*test
 
 	relProps := rel.Relational()
 	outputCols := relProps.OutputCols
-	colNameGen := memo.NewColumnNameGenerator(rel)
 	mem := ot.f.Memo()
+	colNameGen := memo.NewColumnNameGenerator(mem, rel)
 
 	// Create each of the columns and their estimated stats for the test catalog
 	// table.

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -935,9 +935,9 @@ func (ot *OptTester) checkExpectedRules(tb testing.TB, d *datadriven.TestData) {
 }
 
 func (ot *OptTester) postProcess(tb testing.TB, d *datadriven.TestData, e opt.Expr) {
-	ot.fillInLazyProps(e)
-
 	mem := ot.f.Memo()
+	ot.fillInLazyProps(mem, e)
+
 	if rel, ok := e.(memo.RelExpr); ok {
 		for _, cols := range ot.Flags.ColStats {
 			memo.RequestColStat(ot.ctx, &ot.evalCtx, mem, rel, cols)
@@ -947,7 +947,7 @@ func (ot *OptTester) postProcess(tb testing.TB, d *datadriven.TestData, e opt.Ex
 }
 
 // Fills in lazily-derived properties (for display).
-func (ot *OptTester) fillInLazyProps(e opt.Expr) {
+func (ot *OptTester) fillInLazyProps(mem *memo.Memo, e opt.Expr) {
 	if rel, ok := e.(memo.RelExpr); ok {
 		// These properties are derived from the normalized expression.
 		rel = rel.FirstExpr()
@@ -956,14 +956,14 @@ func (ot *OptTester) fillInLazyProps(e opt.Expr) {
 		ot.f.CustomFuncs().DerivePruneCols(rel, intsets.Fast{} /* disabledRules */)
 
 		// Derive columns that are candidates for null rejection.
-		norm.DeriveRejectNullCols(rel, intsets.Fast{} /* disabledRules */)
+		norm.DeriveRejectNullCols(mem, rel, intsets.Fast{} /* disabledRules */)
 
 		// Make sure the interesting orderings are calculated.
 		ordering.DeriveInterestingOrderings(rel)
 	}
 
 	for i, n := 0, e.ChildCount(); i < n; i++ {
-		ot.fillInLazyProps(e.Child(i))
+		ot.fillInLazyProps(mem, e.Child(i))
 	}
 }
 

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -892,12 +892,17 @@ func (ot *OptTester) runCommandInternal(tb testing.TB, d *datadriven.TestData) s
 	}
 }
 
+// GetMemo returns the memo for the current command, if any.
+func (ot *OptTester) GetMemo() *memo.Memo {
+	if ot.f == nil {
+		return nil
+	}
+	return ot.f.Memo()
+}
+
 // FormatExpr is a convenience wrapper for memo.FormatExpr.
 func (ot *OptTester) FormatExpr(e opt.Expr) string {
-	var mem *memo.Memo
-	if rel, ok := e.(memo.RelExpr); ok {
-		mem = rel.Memo()
-	}
+	mem := ot.f.Memo()
 	return memo.FormatExpr(
 		ot.ctx, e, ot.Flags.ExprFormat, false /* redactableValues */, mem, ot.catalog,
 	)
@@ -932,9 +937,10 @@ func (ot *OptTester) checkExpectedRules(tb testing.TB, d *datadriven.TestData) {
 func (ot *OptTester) postProcess(tb testing.TB, d *datadriven.TestData, e opt.Expr) {
 	ot.fillInLazyProps(e)
 
+	mem := ot.f.Memo()
 	if rel, ok := e.(memo.RelExpr); ok {
 		for _, cols := range ot.Flags.ColStats {
-			memo.RequestColStat(ot.ctx, &ot.evalCtx, rel, cols)
+			memo.RequestColStat(ot.ctx, &ot.evalCtx, mem, rel, cols)
 		}
 	}
 	ot.checkExpectedRules(tb, d)
@@ -1345,7 +1351,7 @@ func (ot *OptTester) AssignPlaceholders(
 	o.NotifyOnMatchedRule(maybeDisableRule)
 
 	o.Factory().FoldingControl().AllowStableFolds()
-	if err := o.Factory().AssignPlaceholders(prepMemo); err != nil {
+	if err = o.Factory().AssignPlaceholders(prepMemo); err != nil {
 		return nil, err
 	}
 	return o.Optimize()
@@ -1363,7 +1369,11 @@ func (ot *OptTester) PlaceholderFastPath() (_ opt.Expr, ok bool, _ error) {
 	if err != nil {
 		return nil, false, err
 	}
-	return o.TryPlaceholderFastPath()
+	ok, err = o.TryPlaceholderFastPath()
+	if err != nil {
+		return nil, false, err
+	}
+	return ot.f.Memo().RootExpr(), ok, nil
 }
 
 // Memo returns a string that shows the memo data structure that is constructed
@@ -2144,6 +2154,7 @@ func (ot *OptTester) createTableAs(name tree.TableName, rel memo.RelExpr) (*test
 	relProps := rel.Relational()
 	outputCols := relProps.OutputCols
 	colNameGen := memo.NewColumnNameGenerator(rel)
+	mem := ot.f.Memo()
 
 	// Create each of the columns and their estimated stats for the test catalog
 	// table.
@@ -2151,7 +2162,7 @@ func (ot *OptTester) createTableAs(name tree.TableName, rel memo.RelExpr) (*test
 	jsonStats := make([]stats.JSONStatistic, outputCols.Len())
 	i := 0
 	for col, ok := outputCols.Next(0); ok; col, ok = outputCols.Next(col + 1) {
-		colMeta := rel.Memo().Metadata().ColumnMeta(col)
+		colMeta := mem.Metadata().ColumnMeta(col)
 		colName := colNameGen.GenerateName(col)
 
 		columns[i].Init(
@@ -2171,7 +2182,7 @@ func (ot *OptTester) createTableAs(name tree.TableName, rel memo.RelExpr) (*test
 
 		// Make sure we have estimated stats for this column.
 		colSet := opt.MakeColSet(col)
-		memo.RequestColStat(ot.ctx, &ot.evalCtx, rel, colSet)
+		memo.RequestColStat(ot.ctx, &ot.evalCtx, mem, rel, colSet)
 		stat, ok := relProps.Statistics().ColStats.Lookup(colSet)
 		if !ok {
 			return nil, fmt.Errorf("could not find statistic for column %s", colName)
@@ -2270,7 +2281,7 @@ func (ot *OptTester) IndexCandidates() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	indexCandidates := indexrec.FindIndexCandidateSet(expr, expr.(memo.RelExpr).Memo().Metadata())
+	indexCandidates := indexrec.FindIndexCandidateSet(expr, ot.f.Memo().Metadata())
 
 	// Build a formatted string to output from the map of indexCandidates.
 	tablesOutput := make([]string, 0, len(indexCandidates))
@@ -2312,7 +2323,7 @@ func (ot *OptTester) IndexRecommendations() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	md := normExpr.(memo.RelExpr).Memo().Metadata()
+	md := ot.f.Memo().Metadata()
 	indexCandidates := indexrec.FindIndexCandidateSet(normExpr, md)
 	_, hypTables := indexrec.BuildOptAndHypTableMaps(ot.catalog, indexCandidates)
 
@@ -2320,7 +2331,7 @@ func (ot *OptTester) IndexRecommendations() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	md = optExpr.(memo.RelExpr).Memo().Metadata()
+	md = ot.f.Memo().Metadata()
 	recs, err := indexrec.FindRecs(ot.ctx, optExpr, md)
 	if err != nil {
 		return "", err

--- a/pkg/sql/opt/testutils/testexpr/test_expr.go
+++ b/pkg/sql/opt/testutils/testexpr/test_expr.go
@@ -62,9 +62,6 @@ func (e *Instance) ChildCount() int { panic("not implemented") }
 // Child is part of the RelExpr interface.
 func (e *Instance) Child(nth int) opt.Expr { panic("not implemented") }
 
-// String is part of the RelExpr interface.
-func (e *Instance) String() string { panic("not implemented") }
-
 // SetChild is part of the RelExpr interface.
 func (e *Instance) SetChild(nth int, child opt.Expr) { panic("not implemented") }
 

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -881,7 +881,7 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 	if scan.Distribution.Regions != nil {
 		regionsAccessed = scan.Distribution
 	} else {
-		tabMeta := scan.Memo().Metadata().TableMeta(scan.Table)
+		tabMeta := c.mem.Metadata().TableMeta(scan.Table)
 		regionsAccessed.FromIndexScan(c.ctx, c.evalCtx, tabMeta, scan.Index, scan.Constraint)
 	}
 	if scan.LocalityOptimized {

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -837,7 +837,7 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 	// choose a reverse scan over a sort, add the reverse scan cost before we
 	// alter the row count for unbounded scan penalties below. This cost must also
 	// be added before adjusting the row count for the limit hint.
-	if ordering.ScanIsReverse(scan, &required.Ordering) {
+	if ordering.ScanIsReverse(c.mem, scan, &required.Ordering) {
 		if rowCount > 1 {
 			// Need to do binary search to seek to the previous row.
 			perRowCost.C += math.Log2(rowCount) * cpuCostFactor
@@ -1107,7 +1107,7 @@ func (c *coster) computeLookupJoinCost(
 		join.LocalityOptimized,
 	)
 	_, provided := distribution.BuildLookupJoinLookupTableDistribution(
-		c.ctx, c.evalCtx, join, required, c.MaybeGetBestCostRelation)
+		c.ctx, c.evalCtx, c.mem, join, required, c.MaybeGetBestCostRelation)
 	extraCost := c.distributionCost(provided)
 	cost.Add(extraCost)
 	return cost
@@ -1265,7 +1265,7 @@ func (c *coster) computeInvertedJoinCost(
 
 	cost.C += rowsProcessed * perRowCost.C
 
-	provided := distribution.BuildInvertedJoinLookupTableDistribution(c.ctx, c.evalCtx, join)
+	provided := distribution.BuildInvertedJoinLookupTableDistribution(c.ctx, c.evalCtx, c.mem, join)
 	extraCost := c.distributionCost(provided)
 	cost.Add(extraCost)
 	return cost

--- a/pkg/sql/opt/xform/groupby_funcs.go
+++ b/pkg/sql/opt/xform/groupby_funcs.go
@@ -302,7 +302,7 @@ func (c *CustomFuncs) GenerateStreamingGroupByLimitOrderingHint(
 			Limit:    limitExpr.Limit,
 			Ordering: limitExpr.Ordering,
 		}
-	grp.Memo().AddLimitToGroup(newLimitExpr, grp)
+	c.e.mem.AddLimitToGroup(newLimitExpr, grp)
 }
 
 // GenerateStreamingGroupBy generates variants of a GroupBy, DistinctOn,
@@ -604,6 +604,8 @@ func (c *CustomFuncs) GenerateLimitedGroupByScans(
 		// Reconstruct the GroupBy and Limit so the new expression in the memo is
 		// equivalent.
 		input = c.e.f.ConstructGroupBy(input, aggs, gp)
-		grp.Memo().AddLimitToGroup(&memo.LimitExpr{Limit: limit, Ordering: requiredOrdering, Input: input}, grp)
+		c.e.mem.AddLimitToGroup(
+			&memo.LimitExpr{Limit: limit, Ordering: requiredOrdering, Input: input}, grp,
+		)
 	})
 }

--- a/pkg/sql/opt/xform/groupby_funcs.go
+++ b/pkg/sql/opt/xform/groupby_funcs.go
@@ -317,7 +317,7 @@ func (c *CustomFuncs) GenerateStreamingGroupBy(
 	aggs memo.AggregationsExpr,
 	private *memo.GroupingPrivate,
 ) {
-	orders := ordering.DeriveInterestingOrderings(input)
+	orders := ordering.DeriveInterestingOrderings(c.e.mem, input)
 	intraOrd := private.Ordering
 	for _, ord := range orders {
 		newOrd, fullPrefix, found := getPrefixFromOrdering(ord.ToOrdering(), intraOrd, input,

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -56,7 +56,7 @@ func (c *CustomFuncs) GenerateMergeJoins(
 	leftCols := leftEq.ToSet()
 	// NOTE: leftCols cannot be mutated after this point because it is used as a
 	// key to cache the restricted orderings in left's logical properties.
-	orders := ordering.DeriveRestrictedInterestingOrderings(left, leftCols).Copy()
+	orders := ordering.DeriveRestrictedInterestingOrderings(c.e.mem, left, leftCols).Copy()
 
 	var mustGenerateMergeJoin bool
 	leftFDs := &left.Relational().FuncDeps
@@ -69,7 +69,7 @@ func (c *CustomFuncs) GenerateMergeJoins(
 	if !c.NoJoinHints(joinPrivate) || c.e.evalCtx.SessionData().ReorderJoinsLimit == 0 {
 		// If we are using a hint, or the join limit is set to zero, the join won't
 		// be commuted. Add the orderings from the right side.
-		rightOrders := ordering.DeriveInterestingOrderings(right).Copy()
+		rightOrders := ordering.DeriveInterestingOrderings(c.e.mem, right).Copy()
 		rightOrders.RestrictToCols(rightEq.ToSet(), &right.Relational().FuncDeps)
 		orders = append(orders, rightOrders...)
 
@@ -1908,7 +1908,9 @@ func (c *CustomFuncs) CanMaybeGenerateLocalityOptimizedSearchOfLookupJoins(
 func (c *CustomFuncs) LookupsAreLocal(
 	lookupJoinExpr *memo.LookupJoinExpr, required *physical.Required,
 ) bool {
-	_, provided := distribution.BuildLookupJoinLookupTableDistribution(c.e.ctx, c.e.f.EvalContext(), lookupJoinExpr, required, c.e.o.MaybeGetBestCostRelation)
+	_, provided := distribution.BuildLookupJoinLookupTableDistribution(
+		c.e.ctx, c.e.f.EvalContext(), c.e.mem, lookupJoinExpr, required, c.e.o.MaybeGetBestCostRelation,
+	)
 	if provided.Any() || len(provided.Regions) != 1 {
 		return false
 	}

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -368,7 +368,7 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 	c.cb.Init(
 		c.e.ctx,
 		c.e.f,
-		c.e.mem.Metadata(),
+		md,
 		c.e.evalCtx,
 		scanPrivate.Table,
 		inputProps.OutputCols,
@@ -396,8 +396,8 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 			scanPrivate2 = &scanExpr.ScanPrivate
 			// The scan should already exist in the memo. We need to look it up so we
 			// have a `ScanExpr` with properties fully populated.
-			input2 = scanExpr.Memo().MemoizeScan(scanPrivate)
-			tabMeta := c.e.mem.Metadata().TableMeta(scanPrivate2.Table)
+			input2 = c.e.mem.MemoizeScan(scanPrivate)
+			tabMeta := md.TableMeta(scanPrivate2.Table)
 			indexCols2 = tabMeta.IndexColumns(scanPrivate2.Index)
 			onClauseLookupRelStrictKeyCols, lookupRelEquijoinCols, inputRelJoinCols, lookupIsKey2 =
 				c.GetEquijoinStrictKeyCols(on, scanPrivate2, input2)

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -406,7 +406,7 @@ func getPrefixFromOrdering(
 func (c *CustomFuncs) GeneratePartialOrderTopK(
 	grp memo.RelExpr, required *physical.Required, input memo.RelExpr, private *memo.TopKPrivate,
 ) {
-	orders := ordering.DeriveInterestingOrderings(input)
+	orders := ordering.DeriveInterestingOrderings(c.e.mem, input)
 	intraOrd := private.Ordering
 	for _, ord := range orders {
 		newOrd, fullPrefix, found := getPrefixFromOrdering(ord.ToOrdering(), intraOrd, input, func(id opt.ColumnID) bool {

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -347,7 +347,7 @@ func (c *CustomFuncs) GenerateLimitedTopKScans(
 		input := sb.BuildNewExpr()
 		// Use the overlapping indexes and requiredOrdering ordering.
 		newPrivate := *tp
-		grp.Memo().AddTopKToGroup(&memo.TopKExpr{Input: input, TopKPrivate: newPrivate}, grp)
+		c.e.mem.AddTopKToGroup(&memo.TopKExpr{Input: input, TopKPrivate: newPrivate}, grp)
 	})
 }
 
@@ -422,7 +422,7 @@ func (c *CustomFuncs) GeneratePartialOrderTopK(
 		newPrivate := *private
 		newPrivate.PartialOrdering = newOrd
 
-		grp.Memo().AddTopKToGroup(&memo.TopKExpr{Input: input, TopKPrivate: newPrivate}, grp)
+		c.e.mem.AddTopKToGroup(&memo.TopKExpr{Input: input, TopKPrivate: newPrivate}, grp)
 	}
 }
 

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -525,7 +525,7 @@ func (o *Optimizer) optimizeGroup(grp memo.RelExpr, required *physical.Required)
 		if cachedLCP.exists {
 			return cachedLCP.lcp, cachedLCP.ok
 		}
-		interestingOrderings := ordering.DeriveInterestingOrderings(grp)
+		interestingOrderings := ordering.DeriveInterestingOrderings(o.mem, grp)
 		cachedLCP.lcp, cachedLCP.ok = interestingOrderings.LongestCommonPrefix(&required.Ordering)
 		cachedLCP.exists = true
 		return cachedLCP.lcp, cachedLCP.ok
@@ -593,7 +593,7 @@ func (o *Optimizer) optimizeGroupMember(
 	// properties? That case is taken care of by enforceProps, which will
 	// recursively optimize the group with property subsets and then add
 	// enforcers to provide the remainder.
-	if CanProvidePhysicalProps(o.ctx, o.evalCtx, member, required) {
+	if CanProvidePhysicalProps(o.ctx, o.evalCtx, o.mem, member, required) {
 		var cost memo.Cost
 		for i, n := 0, member.ChildCount(); i < n; i++ {
 			// Given required parent properties, get the properties required from
@@ -843,8 +843,10 @@ func (o *Optimizer) setLowestCostTree(parent opt.Expr, parentProps *physical.Req
 		var provided physical.Provided
 		// BuildProvided relies on ProvidedPhysical() being set in the children, so
 		// it must run after the recursive calls on the children.
-		provided.Ordering = ordering.BuildProvided(o.evalCtx, relParent, &parentProps.Ordering)
-		provided.Distribution = distribution.BuildProvided(o.ctx, o.evalCtx, relParent, &parentProps.Distribution)
+		provided.Ordering = ordering.BuildProvided(o.evalCtx, o.mem, relParent, &parentProps.Ordering)
+		provided.Distribution = distribution.BuildProvided(
+			o.ctx, o.evalCtx, o.mem, relParent, &parentProps.Distribution,
+		)
 		o.mem.SetBestProps(relParent, parentProps, &provided, relCost)
 	}
 

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -58,16 +58,8 @@ func TestDetachMemo(t *testing.T) {
 		t.Error("after memo did not contain expected operator")
 	}
 
-	if after.RootExpr().(memo.RelExpr).Memo() != after {
-		t.Error("after memo expression does not reference the after memo")
-	}
-
 	if before == o.Memo() {
 		t.Error("detached memo should not be reused")
-	}
-
-	if before.RootExpr().(memo.RelExpr).Memo() != before {
-		t.Error("detached memo expression does not reference the detached memo")
 	}
 
 	if !strings.Contains(before.String(), "variable: c:3 [type=string]") {

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -121,7 +121,7 @@ func TestDetachMemoRace(t *testing.T) {
 			// Rewrite the filter to use a different column, which will trigger creation
 			// of new table statistics. If the statistics object is aliased, this will
 			// be racy.
-			f.CopyAndReplace(mem.RootExpr().(memo.RelExpr), mem.RootProps(), replaceFn)
+			f.CopyAndReplace(mem, mem.RootExpr().(memo.RelExpr), mem.RootProps(), replaceFn)
 			wg.Done()
 		}()
 	}

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -54,7 +54,7 @@ func TestDetachMemo(t *testing.T) {
 		t.Error("after memo cannot be the same as the detached memo")
 	}
 
-	if !strings.Contains(after.RootExpr().String(), "variable: a:1 [type=int]") {
+	if !strings.Contains(after.String(), "variable: a:1 [type=int]") {
 		t.Error("after memo did not contain expected operator")
 	}
 
@@ -70,7 +70,7 @@ func TestDetachMemo(t *testing.T) {
 		t.Error("detached memo expression does not reference the detached memo")
 	}
 
-	if !strings.Contains(before.RootExpr().String(), "variable: c:3 [type=string]") {
+	if !strings.Contains(before.String(), "variable: c:3 [type=string]") {
 		t.Error("detached memo did not contain expected operator")
 	}
 }

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -307,7 +307,7 @@ func init() {
 			return physicalDistribution
 		}
 		o, ok := optimizer.(*Optimizer)
-		if !ok {
+		if !ok || o.mem == nil || !o.mem.IsOptimized() {
 			return physicalDistribution
 		}
 		if o.evalCtx == nil {

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -307,20 +307,20 @@ func init() {
 		lookupJoin *memo.LookupJoinExpr,
 		required *physical.Required,
 		optimizer interface{},
-	) (physicalDistribution physical.Distribution) {
+	) physical.Distribution {
 		if optimizer == nil {
-			return physicalDistribution
+			return physical.Distribution{}
 		}
 		o, ok := optimizer.(*Optimizer)
 		if !ok || o.mem == nil || !o.mem.IsOptimized() {
-			return physicalDistribution
+			return physical.Distribution{}
 		}
 		if o.evalCtx == nil {
-			return physicalDistribution
+			return physical.Distribution{}
 		}
-		_, physicalDistribution = distribution.BuildLookupJoinLookupTableDistribution(
+		_, d := distribution.BuildLookupJoinLookupTableDistribution(
 			o.ctx, o.evalCtx, o.mem, lookupJoin, required, o.MaybeGetBestCostRelation,
 		)
-		return physicalDistribution
+		return d
 	}
 }

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -30,12 +30,17 @@ import (
 // method and then pass through that property in the buildChildPhysicalProps
 // method.
 func CanProvidePhysicalProps(
-	ctx context.Context, evalCtx *eval.Context, e memo.RelExpr, required *physical.Required,
+	ctx context.Context,
+	evalCtx *eval.Context,
+	mem *memo.Memo,
+	e memo.RelExpr,
+	required *physical.Required,
 ) bool {
 	// All operators can provide the Presentation and LimitHint properties, so no
 	// need to check for that.
-	canProvideOrdering := e.Op() == opt.SortOp || ordering.CanProvide(e, &required.Ordering)
-	canProvideDistribution := e.Op() == opt.DistributeOp || distribution.CanProvide(ctx, evalCtx, e, &required.Distribution)
+	canProvideOrdering := e.Op() == opt.SortOp || ordering.CanProvide(mem, e, &required.Ordering)
+	canProvideDistribution := e.Op() == opt.DistributeOp ||
+		distribution.CanProvide(ctx, evalCtx, mem, e, &required.Distribution)
 	return canProvideOrdering && canProvideDistribution
 }
 
@@ -81,7 +86,7 @@ func BuildChildPhysicalProps(
 		childProps.Presentation = parent.(*memo.ExportExpr).Props.Presentation
 	}
 
-	childProps.Ordering = ordering.BuildChildRequired(parent, &parentProps.Ordering, nth)
+	childProps.Ordering = ordering.BuildChildRequired(mem, parent, &parentProps.Ordering, nth)
 	childProps.Distribution = distribution.BuildChildRequired(parent, &parentProps.Distribution, nth)
 
 	switch parent.Op() {
@@ -314,7 +319,7 @@ func init() {
 			return physicalDistribution
 		}
 		_, physicalDistribution = distribution.BuildLookupJoinLookupTableDistribution(
-			o.ctx, o.evalCtx, lookupJoin, required, o.MaybeGetBestCostRelation,
+			o.ctx, o.evalCtx, o.mem, lookupJoin, required, o.MaybeGetBestCostRelation,
 		)
 		return physicalDistribution
 	}

--- a/pkg/sql/opt/xform/scan_funcs.go
+++ b/pkg/sql/opt/xform/scan_funcs.go
@@ -505,7 +505,7 @@ func (c *CustomFuncs) IsRegionalByRowTableScanOrSelect(input memo.RelExpr) bool 
 	if !ok {
 		return false
 	}
-	table := scanExpr.Memo().Metadata().Table(scanExpr.Table)
+	table := c.e.mem.Metadata().Table(scanExpr.Table)
 	return table.IsRegionalByRow()
 }
 
@@ -524,7 +524,7 @@ func (c *CustomFuncs) IsSelectFromRemoteTableRowsOnly(input memo.RelExpr) bool {
 	if c.e.evalCtx.BoundedStaleness() {
 		return false
 	}
-	table := scanExpr.Memo().Metadata().Table(scanExpr.Table)
+	table := c.e.mem.Metadata().Table(scanExpr.Table)
 	if table.IsRegionalByRow() {
 		tabMeta := c.e.mem.Metadata().TableMeta(scanExpr.Table)
 		index := table.Index(scanExpr.Index)

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -920,7 +920,7 @@ func (c *CustomFuncs) generateInvertedIndexScansImpl(
 			return
 		}
 		if minimizeSpans {
-			newSpanExpr, ok := reduceInvertedSpans(c.e.ctx, input, scanPrivate.Table, index, spanExpr)
+			newSpanExpr, ok := reduceInvertedSpans(c.e.ctx, c.e.mem, input, scanPrivate.Table, index, spanExpr)
 			if !ok {
 				// The span expression could not be reduced, so skip this index.
 				// An inverted index scan may still be generated for it when
@@ -1007,6 +1007,7 @@ func (c *CustomFuncs) generateInvertedIndexScansImpl(
 // span expression cannot be reduced, ok=false is returned.
 func reduceInvertedSpans(
 	ctx context.Context,
+	mem *memo.Memo,
 	grp memo.RelExpr,
 	tabID opt.TableID,
 	index cat.Index,
@@ -1018,7 +1019,7 @@ func reduceInvertedSpans(
 	}
 
 	colID := tabID.ColumnID(index.InvertedColumn().Ordinal())
-	colStat, ok := grp.Memo().RequestColStat(grp, opt.MakeColSet(colID))
+	colStat, ok := mem.RequestColStat(grp, opt.MakeColSet(colID))
 	if !ok || colStat.Histogram == nil {
 		// Only attempt to reduce spans if we have histogram statistics.
 		// TODO(mgartner): We could blindly reduce the spans without a

--- a/pkg/sql/opt/xform/set_funcs.go
+++ b/pkg/sql/opt/xform/set_funcs.go
@@ -32,7 +32,7 @@ func (c *CustomFuncs) GenerateStreamingSetOp(
 	right memo.RelExpr,
 	private *memo.SetPrivate,
 ) {
-	orders := ordering.DeriveInterestingOrderings(grp)
+	orders := ordering.DeriveInterestingOrderings(c.e.mem, grp)
 	for _, order := range orders {
 		// A streaming set operation must have an ordering that includes all output
 		// columns. If the interesting ordering includes some columns but not all,

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -686,7 +686,7 @@ memo (optimized, ~4KB, required=[presentation: info:7])
 memo
 SELECT y FROM a WITH ORDINALITY ORDER BY ordinality
 ----
-memo (optimized, ~6KB, required=[presentation: y:2] [ordering: +7])
+memo (optimized, ~5KB, required=[presentation: y:2] [ordering: +7])
  ├── G1: (ordinality G2)
  │    ├── [presentation: y:2] [ordering: +7]
  │    │    ├── best: (ordinality G2)
@@ -725,7 +725,7 @@ memo (optimized, ~7KB, required=[presentation: y:2] [ordering: +8])
 memo
 SELECT y FROM a WITH ORDINALITY ORDER BY ordinality, x
 ----
-memo (optimized, ~9KB, required=[presentation: y:2] [ordering: +7])
+memo (optimized, ~8KB, required=[presentation: y:2] [ordering: +7])
  ├── G1: (ordinality G2)
  │    ├── [presentation: y:2] [ordering: +7]
  │    │    ├── best: (ordinality G2)
@@ -779,7 +779,7 @@ memo (optimized, ~7KB, required=[presentation: y:2] [ordering: +7])
 memo
 SELECT y FROM a WITH ORDINALITY ORDER BY ordinality DESC
 ----
-memo (optimized, ~6KB, required=[presentation: y:2] [ordering: -7])
+memo (optimized, ~5KB, required=[presentation: y:2] [ordering: -7])
  ├── G1: (ordinality G2)
  │    ├── [presentation: y:2] [ordering: -7]
  │    │    ├── best: (sort G1)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -2298,7 +2298,7 @@ memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
 memo
 SELECT (SELECT w FROM kuvw WHERE v=1 AND x=u) FROM xyz ORDER BY x+1, x
 ----
-memo (optimized, ~28KB, required=[presentation: w:12] [ordering: +13,+1])
+memo (optimized, ~27KB, required=[presentation: w:12] [ordering: +13,+1])
  ├── G1: (project G2 G3 x)
  │    ├── [presentation: w:12] [ordering: +13,+1]
  │    │    ├── best: (sort G1)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -235,7 +235,7 @@ inner-join (merge)
 memo expect=ReorderJoins
 SELECT * FROM abc, stu, xyz WHERE abc.a=stu.s AND stu.s=xyz.x
 ----
-memo (optimized, ~48KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
+memo (optimized, ~47KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (merge-join G2 G3 G10 inner-join,+1,+7) (merge-join G3 G2 G10 inner-join,+7,+1) (lookup-join G3 G10 abc@ab,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G5 G6 G10 inner-join,+7,+12) (merge-join G6 G5 G10 inner-join,+12,+7) (lookup-join G6 G10 stu,keyCols=[12],outCols=(1-3,7-9,12-14)) (merge-join G8 G9 G10 inner-join,+7,+12) (lookup-join G8 G10 xyz@xy,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G9 G8 G10 inner-join,+12,+7)
  │    └── [presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14]
  │         ├── best: (merge-join G5="[ordering: +7]" G6="[ordering: +(1|12)]" G10 inner-join,+7,+12)
@@ -343,7 +343,7 @@ SELECT *
 FROM stu, abc, xyz, pqr
 WHERE u = a AND a = x AND x = p
 ----
-memo (optimized, ~42KB, required=[presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
+memo (optimized, ~41KB, required=[presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+3,+6) (merge-join G3 G2 G5 inner-join,+6,+3) (lookup-join G3 G5 stu@uts,keyCols=[6],outCols=(1-3,6-8,12-14,18-22))
  │    └── [presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22]
  │         ├── best: (merge-join G2="[ordering: +3]" G3="[ordering: +(6|12|18)]" G5 inner-join,+3,+6)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -521,7 +521,7 @@ inner-join (cross)
 memo set=reorder_joins_limit=0
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
-memo (optimized, ~33KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
+memo (optimized, ~32KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
  ├── G1: (inner-join G2 G3 G4) (merge-join G2 G3 G5 inner-join,+2,+6)
  │    └── [presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16]
  │         ├── best: (inner-join G2 G3 G4)
@@ -2774,7 +2774,7 @@ SELECT (
 )
   FROM table80901_1 AS tab_42921;
 ----
-memo (optimized, ~74KB, required=[presentation: ?column?:50])
+memo (optimized, ~73KB, required=[presentation: ?column?:50])
  ├── G1: (project G2 G3)
  │    └── [presentation: ?column?:50]
  │         ├── best: (project G2 G3)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -281,7 +281,7 @@ CREATE INDEX idx2 ON p (s) WHERE i > 0
 memo expect=GeneratePartialIndexScans
 SELECT * FROM p WHERE i > 0 AND s = 'foo'
 ----
-memo (optimized, ~20KB, required=[presentation: k:1,i:2,f:3,s:4,b:5])
+memo (optimized, ~19KB, required=[presentation: k:1,i:2,f:3,s:4,b:5])
  ├── G1: (select G2 G3) (index-join G4 p,cols=(1-5)) (index-join G5 p,cols=(1-5)) (index-join G6 p,cols=(1-5)) (index-join G7 p,cols=(1-5))
  │    └── [presentation: k:1,i:2,f:3,s:4,b:5]
  │         ├── best: (index-join G4 p,cols=(1-5))
@@ -1091,7 +1091,7 @@ select
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k+u = 1 AND k > 5
 ----
-memo (optimized, ~13KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~12KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7)
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (select G6 G7)
@@ -11928,7 +11928,7 @@ JOIN t61795 AS t2 ON t1.c = t1.b AND t1.b = t2.b
 WHERE t1.a = 10 OR t2.b != abs(t2.b)
 ORDER BY t1.b ASC
 ----
-memo (optimized, ~38KB, required=[presentation: a:1] [ordering: +2])
+memo (optimized, ~37KB, required=[presentation: a:1] [ordering: +2])
  ├── G1: (project G2 G3 a b)
  │    ├── [presentation: a:1] [ordering: +2]
  │    │    ├── best: (sort G1)

--- a/pkg/sql/opt/xform/testdata/rules/set
+++ b/pkg/sql/opt/xform/testdata/rules/set
@@ -263,7 +263,7 @@ memo (optimized, ~12KB, required=[presentation: k:1,u:2,v:3,w:4])
 memo expect-not=GenerateStreamingSetOp
 SELECT * FROM kuvw UNION ALL SELECT * FROM kuvw
 ----
-memo (optimized, ~11KB, required=[presentation: k:13,u:14,v:15,w:16])
+memo (optimized, ~10KB, required=[presentation: k:13,u:14,v:15,w:16])
  ├── G1: (union-all G2 G3)
  │    └── [presentation: k:13,u:14,v:15,w:16]
  │         ├── best: (union-all G2 G3)

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -1031,6 +1031,7 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(
 	f := opc.optimizer.Factory()
 	f.FoldingControl().AllowStableFolds()
 	f.CopyAndReplace(
+		savedMemo,
 		savedMemo.RootExpr().(memo.RelExpr),
 		savedMemo.RootProps(),
 		f.CopyWithoutAssigningPlaceholders,
@@ -1051,6 +1052,7 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(
 	// optimal plan to determine index recommendations.
 	opc.optimizer.Init(ctx, f.EvalContext(), opc.catalog)
 	f.CopyAndReplace(
+		savedMemo,
 		savedMemo.RootExpr().(memo.RelExpr),
 		savedMemo.RootProps(),
 		f.CopyWithoutAssigningPlaceholders,
@@ -1075,6 +1077,7 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(
 	opc.optimizer.Init(origCtx, f.EvalContext(), opc.catalog)
 	savedMemo.Metadata().UpdateTableMeta(origCtx, f.EvalContext(), optTables)
 	f.CopyAndReplace(
+		savedMemo,
 		savedMemo.RootExpr().(memo.RelExpr),
 		savedMemo.RootProps(),
 		f.CopyWithoutAssigningPlaceholders,

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -527,7 +527,7 @@ func (opc *optPlanningCtx) buildReusableMemo(
 	}
 
 	// If the memo has placeholders, first try the placeholder fast path.
-	_, ok, err := opc.optimizer.TryPlaceholderFastPath()
+	ok, err := opc.optimizer.TryPlaceholderFastPath()
 	if err != nil {
 		return nil, memoTypeUnknown, err
 	}


### PR DESCRIPTION
#### xform: check the memo before calling BuildLookupJoinLookupTableDistribution

This commit adds a check for nil and unoptimized memo to the implementation
of `GetLookupJoinLookupTableDistribution`. This is necessary because this
code path can be reached after the planner's optimizer has been reset during
formatting of a plan.

Informs #104009

Release note: None

#### opt: remove String() method from RelExpr

This patch removes the `String` method from the `RelExpr` interface.
This prepares to remove references to the memo from relational expressions.
For convenience, the memo now has the convenience methods `String()` and
`FormatExpr(expr)` for testing and debugging.

Informs #104009

Release note: None

#### opt: remove opttester references to RelExpr.Memo()

This patch removes references in the opttester framework to the `Memo`
method of `RelExpr`. This prepares for the removal of `Memo()`.

Informs #104009

Release note: None

#### opt/memo: remove references to RelExpr Memo() method

This patch removes various references to `RelExpr.Memo()` in the `memo`
package in preparation to remove the method entirely.

Informs #104009

Release note: None

#### opt: remove references to RelExpr Memo() method in optimizer and execbuilder

This patch removes various references to the `RelExpr.Memo()` method
throughout the optimizer and execbuilder logic.

Informs #104009

Release note: None

#### opt/props: remove references to RelExpr Memo() method

This commit removes references to the `RelExpr.Memo()` method throughout
the ordering and distribution props logic.

Informs #104009

Release note: None

#### memo: remove the RelExpr Memo() method

Since previous commits removed all references to the `RelExpr.Memo()`
method, it can now be removed entirely, and the reference to the memo
can be removed from `RelExpr` implementations.

Informs #104009

Release note: None

#### opt/memo: fix `(*statisticsBuilder).clear`

Release note: None

#### opt/memo: remove `(*Memo).EvalContext()`

Release note: None

#### opt/xform: clean up init

Release note: None
