### PR TITLE
cloud/amazon: skip tests if cloud creds are not present

### DIFF
--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -67,7 +67,6 @@ go_test(
         "//pkg/util/leaktest",
         "@com_github_aws_aws_sdk_go//aws/awserr",
         "@com_github_aws_aws_sdk_go//aws/credentials",
-        "@com_github_aws_aws_sdk_go//aws/session",
         "@com_github_aws_aws_sdk_go//service/s3",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",


### PR DESCRIPTION
Previously, a few amazon cloud tests would fail instead of skip if credentials were not present. This patch fixes this.

Fixes #109051

Release note: none