### PR TITLE
release-23.2: sql: make CALL statements explainable

### DIFF
--- a/docs/generated/sql/bnf/explainable_stmt.bnf
+++ b/docs/generated/sql/bnf/explainable_stmt.bnf
@@ -2,3 +2,4 @@ explainable_stmt ::=
 	preparable_stmt
 	| comment_stmt
 	| execute_stmt
+	| call_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -671,6 +671,7 @@ explainable_stmt ::=
 	preparable_stmt
 	| comment_stmt
 	| execute_stmt
+	| call_stmt
 
 explain_option_list ::=
 	( explain_option_name ) ( ( ',' explain_option_name ) )*

--- a/pkg/ccl/logictestccl/testdata/logic_test/explain_call_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/explain_call_plpgsql
@@ -1,0 +1,174 @@
+# LogicTest: local
+
+statement ok
+CREATE PROCEDURE foo(x INT) LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE 'foo: %', x;
+  END
+$$
+
+query T
+EXPLAIN CALL foo(0);
+----
+distribution: local
+vectorized: true
+·
+• call
+  procedure: foo(0)
+
+query T
+EXPLAIN (VERBOSE) CALL foo(1);
+----
+distribution: local
+vectorized: true
+·
+• call
+  columns: ()
+  estimated row count: 10 (missing stats)
+  procedure: foo(1)
+
+query T
+EXPLAIN (OPT) CALL foo(3);
+----
+call
+ └── procedure: foo
+      ├── args
+      │    └── 3
+      ├── params: x
+      └── body
+           └── values
+                └── (_stmt_raise_1(x),)
+
+query T
+EXPLAIN (OPT, VERBOSE) CALL foo(3);
+----
+call
+ ├── volatile
+ ├── stats: [rows=10]
+ ├── cost: 0.02
+ ├── distribution: test
+ └── procedure: foo
+      ├── args
+      │    └── 3
+      ├── params: x:1
+      └── body
+           └── values
+                ├── columns: "_stmt_raise_1":5
+                ├── outer: (1)
+                ├── cardinality: [1 - 1]
+                ├── volatile
+                ├── stats: [rows=1]
+                ├── key: ()
+                ├── fd: ()-->(5)
+                └── (_stmt_raise_1(x:1),)
+
+query T
+EXPLAIN (OPT, TYPES) CALL foo(3);
+----
+call
+ ├── volatile
+ ├── stats: [rows=10]
+ ├── cost: 0.02
+ ├── distribution: test
+ └── procedure: foo [type=void]
+      ├── args
+      │    └── const: 3 [type=int]
+      ├── params: x:1(int)
+      └── body
+           └── values
+                ├── columns: "_stmt_raise_1":5(void)
+                ├── outer: (1)
+                ├── cardinality: [1 - 1]
+                ├── volatile
+                ├── stats: [rows=1]
+                ├── key: ()
+                ├── fd: ()-->(5)
+                └── tuple [type=tuple{void}]
+                     └── udf: _stmt_raise_1 [type=void]
+                          ├── args
+                          │    └── variable: x:1 [type=int]
+                          ├── params: x:2(int)
+                          └── body
+                               ├── values
+                               │    ├── columns: stmt_raise_2:3(int)
+                               │    ├── outer: (2)
+                               │    ├── cardinality: [1 - 1]
+                               │    ├── volatile
+                               │    ├── stats: [rows=1]
+                               │    ├── key: ()
+                               │    ├── fd: ()-->(3)
+                               │    └── tuple [type=tuple{int}]
+                               │         └── function: crdb_internal.plpgsql_raise [type=int]
+                               │              ├── const: 'NOTICE' [type=string]
+                               │              ├── concat [type=string]
+                               │              │    ├── concat [type=string]
+                               │              │    │    ├── const: 'foo: ' [type=string]
+                               │              │    │    └── coalesce [type=string]
+                               │              │    │         ├── cast: STRING [type=string]
+                               │              │    │         │    └── variable: x:2 [type=int]
+                               │              │    │         └── const: '<NULL>' [type=string]
+                               │              │    └── const: '' [type=string]
+                               │              ├── const: '' [type=string]
+                               │              ├── const: '' [type=string]
+                               │              └── const: '00000' [type=string]
+                               └── values
+                                    ├── columns: stmt_return_3:4(void)
+                                    ├── cardinality: [1 - 1]
+                                    ├── stats: [rows=1]
+                                    ├── key: ()
+                                    ├── fd: ()-->(4)
+                                    └── tuple [type=tuple{void}]
+                                         └── null [type=void]
+
+query T
+EXPLAIN (DISTSQL) CALL foo(3);
+----
+distribution: local
+vectorized: true
+·
+• call
+  procedure: foo(3)
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyMj0FL-0AQxe__TxHeqYXt3wRveyvWQyDWansQJMi6mdbFbSbubKhS8t0liUURD53DwLx5M7-ZI-TNQ-P6YVXM82UyWeTrzfqumCZX86JImvbZO_t_yzy5nEKh5oqWZk8C_YgMpUIT2JIIh146Doa8eodOFVzdtLGXSwXLgaCPiC56goZna3xijfdJepFCoaJonB_cnQK38XtWotkRdPYDli-g006dz7snabgWOouU_iLNsq5UoGpH45PCbbC0CmwH71jeDosGoSKJYzcbi7w-tSQGMvvx_FJh6_nw5CpopF8x-yOdAv2A2Un_2PqFD8PazUfTn7U1XkjhxrzSgiKFvaudRGehY2ip6_59BgAA__9oSZu_
+
+query T
+EXPLAIN ANALYZE CALL foo(3);
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• call
+  nodes: <hidden>
+  regions: <hidden>
+  actual row count: 0
+  procedure: foo(3)
+
+query T
+EXPLAIN ANALYZE (DISTSQL) CALL foo(3);
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• call
+  nodes: <hidden>
+  regions: <hidden>
+  actual row count: 0
+  procedure: foo(3)
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyMUMtq40AQvO9XiDrtwnhXYm9zW9YXg_MgyS2IMB617SEjtTLdwg5Gn5UfyJcFSTY4IYH0YaCqu6tq-gB5irD4_2-5zNpuFYP_vWb--fcXDBqu6NLVJLD3KFAatIk9iXAaqMM4sKj2sLlBaNpOB7o08JwI9gANGgkWkb2LmXcxZvmfHAYVqQtx1KU9-U4DN5mGmmyWv74IDFZO_ZYk407bTm02bCXenRNlbzCho62o2xBscZZzMYfNe_P9qDckLTdC70J-5ZR_cJoVfWlA1Yam-wh3ydN1Yj_OTvBqFBqJikSnbjGBRXNqiSZy9RS_NFhH3j2EChb5sWafPKfCsOA2Mnzsdsu7UfbuuR1irV0UMrhwjzQnpVSHJogGD6upo77_8RYAAP__9m6rjw==

--- a/pkg/ccl/logictestccl/tests/local/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local/BUILD.bazel
@@ -13,7 +13,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"Pool": "large"},
-    shard_count = 30,
+    shard_count = 31,
     tags = [
         "ccl_test",
         "cpu:1",

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -113,6 +113,13 @@ func TestCCLLogic_crdb_internal(
 	runCCLLogicTest(t, "crdb_internal")
 }
 
+func TestCCLLogic_explain_call_plpgsql(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "explain_call_plpgsql")
+}
+
 func TestCCLLogic_explain_redact(
 	t *testing.T,
 ) {

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -553,8 +553,26 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 	if mem.Metadata().HasUserDefinedFunctions() {
 		// Get all relevant user-defined functions.
 		blankLine()
-		if err := c.PrintRelevantCreateUdf(&buf, strings.ToLower(b.stmt), b.flags.RedactValues, &b.errorStrings); err != nil {
+		err = c.PrintRelevantCreateRoutine(
+			&buf, strings.ToLower(b.stmt), b.flags.RedactValues, &b.errorStrings, false, /* procedure */
+		)
+		if err != nil {
 			b.printError(fmt.Sprintf("-- error getting schema for udfs: %v", err), &buf)
+		}
+	}
+	if call, ok := mem.RootExpr().(*memo.CallExpr); ok {
+		// Currently, a stored procedure can only be called from a CALL statement,
+		// which can only be the root expression.
+		if proc, ok := call.Proc.(*memo.UDFCallExpr); ok {
+			blankLine()
+			err = c.PrintRelevantCreateRoutine(
+				&buf, strings.ToLower(proc.Def.Name), b.flags.RedactValues, &b.errorStrings, true, /* procedure */
+			)
+			if err != nil {
+				b.printError(fmt.Sprintf("-- error getting schema for procedure: %v", err), &buf)
+			}
+		} else {
+			b.printError("-- unexpected input expression for CALL statement", &buf)
 		}
 	}
 	for i := range tables {
@@ -917,30 +935,43 @@ func (c *stmtEnvCollector) PrintCreateEnum(w io.Writer, redactValues bool) error
 	return nil
 }
 
-func (c *stmtEnvCollector) PrintRelevantCreateUdf(
-	w io.Writer, stmt string, redactValues bool, errorStrings *[]string,
+func (c *stmtEnvCollector) PrintRelevantCreateRoutine(
+	w io.Writer, stmt string, redactValues bool, errorStrings *[]string, procedure bool,
 ) error {
 	// The select function_name returns a DOidWrapper,
 	// we need to cast it to string for queryRows function to process.
-	// TODO: consider getting the udf sql body statements from the memo metadata.
-	functionNameQuery := "SELECT function_name::STRING as function_name_str FROM [SHOW FUNCTIONS]"
-	udfNames, err := c.queryRows(functionNameQuery)
+	// TODO(#104976): consider getting the udf sql body statements from the memo metadata.
+	var routineTypeName, routineNameQuery string
+	if procedure {
+		routineTypeName = "PROCEDURE"
+		routineNameQuery = "SELECT procedure_name::STRING as procedure_name_str FROM [SHOW PROCEDURES]"
+	} else {
+		routineTypeName = "FUNCTION"
+		routineNameQuery = "SELECT function_name::STRING as function_name_str FROM [SHOW FUNCTIONS]"
+	}
+	routineNames, err := c.queryRows(routineNameQuery)
 	if err != nil {
 		return err
 	}
-	for _, name := range udfNames {
+	for _, name := range routineNames {
 		if strings.Contains(stmt, name) {
-			createFunctionQuery := fmt.Sprintf(
-				"SELECT create_statement FROM [ SHOW CREATE FUNCTION \"%s\" ]", name,
+			createRoutineQuery := fmt.Sprintf(
+				"SELECT create_statement FROM [ SHOW CREATE %s \"%s\" ]", routineTypeName, name,
 			)
 			if redactValues {
-				createFunctionQuery = fmt.Sprintf(
-					"SELECT crdb_internal.redact(crdb_internal.redactable_sql_constants(create_statement)) FROM [ SHOW CREATE FUNCTION \"%s\" ]", name,
+				createRoutineQuery = fmt.Sprintf(
+					"SELECT crdb_internal.redact(crdb_internal.redactable_sql_constants(create_statement)) FROM [ SHOW CREATE %s \"%s\" ]",
+					routineTypeName, name,
 				)
 			}
-			createStatement, err := c.query(createFunctionQuery)
+			createStatement, err := c.query(createRoutineQuery)
 			if err != nil {
-				errString := fmt.Sprintf("-- error getting user defined function %s: %s", name, err)
+				var errString string
+				if procedure {
+					errString = fmt.Sprintf("-- error getting stored procedure %s: %s", name, err)
+				} else {
+					errString = fmt.Sprintf("-- error getting user defined function %s: %s", name, err)
+				}
 				fmt.Fprint(w, errString+"\n")
 				*errorStrings = append(*errorStrings, errString)
 				continue

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1694,4 +1694,19 @@ SELECT colors FROM test_114867
 ----
 {red}
 
+subtest prepare_call
+
+# CALL statements cannot be prepared.
+statement ok
+CREATE PROCEDURE foo(x INT) LANGUAGE SQL AS $$
+  SELECT 1;
+  SELECT 2;
+$$;
+
+statement error pgcode 42601 syntax error
+PREPARE bar AS CALL foo(0);
+
+statement error pgcode 42601 syntax error
+PREPARE bar AS CALL foo($1);
+
 subtest end

--- a/pkg/sql/opt/exec/execbuilder/testdata/call
+++ b/pkg/sql/opt/exec/execbuilder/testdata/call
@@ -1,0 +1,169 @@
+# LogicTest: local
+
+statement ok
+CREATE PROCEDURE foo(x INT) LANGUAGE SQL AS $$
+  SELECT 1;
+  SELECT 2;
+$$
+
+query T
+EXPLAIN CALL foo(0);
+----
+distribution: local
+vectorized: true
+·
+• call
+  procedure: foo(0)
+
+query T
+EXPLAIN (VERBOSE) CALL foo(1);
+----
+distribution: local
+vectorized: true
+·
+• call
+  columns: ()
+  estimated row count: 10 (missing stats)
+  procedure: foo(1)
+
+query T
+EXPLAIN (OPT) CALL foo(3);
+----
+call
+ └── procedure: foo
+      ├── args
+      │    └── 3
+      ├── params: x
+      └── body
+           ├── values
+           │    └── (1,)
+           ├── values
+           │    └── (2,)
+           └── values
+                └── (NULL,)
+
+query T
+EXPLAIN (OPT, VERBOSE) CALL foo(3);
+----
+call
+ ├── volatile
+ ├── stats: [rows=10]
+ ├── cost: 0.02
+ ├── distribution: test
+ └── procedure: foo
+      ├── args
+      │    └── 3
+      ├── params: x:1
+      └── body
+           ├── values
+           │    ├── columns: "?column?":2
+           │    ├── cardinality: [1 - 1]
+           │    ├── stats: [rows=1]
+           │    ├── key: ()
+           │    ├── fd: ()-->(2)
+           │    └── (1,)
+           ├── values
+           │    ├── columns: "?column?":3
+           │    ├── cardinality: [1 - 1]
+           │    ├── stats: [rows=1]
+           │    ├── key: ()
+           │    ├── fd: ()-->(3)
+           │    └── (2,)
+           └── values
+                ├── columns: column5:5
+                ├── cardinality: [1 - 1]
+                ├── stats: [rows=1]
+                ├── key: ()
+                ├── fd: ()-->(5)
+                └── (NULL,)
+
+query T
+EXPLAIN (OPT, TYPES) CALL foo(3);
+----
+call
+ ├── volatile
+ ├── stats: [rows=10]
+ ├── cost: 0.02
+ ├── distribution: test
+ └── procedure: foo [type=void]
+      ├── args
+      │    └── const: 3 [type=int]
+      ├── params: x:1(int)
+      └── body
+           ├── values
+           │    ├── columns: "?column?":2(int!null)
+           │    ├── cardinality: [1 - 1]
+           │    ├── stats: [rows=1]
+           │    ├── key: ()
+           │    ├── fd: ()-->(2)
+           │    └── tuple [type=tuple{int}]
+           │         └── const: 1 [type=int]
+           ├── values
+           │    ├── columns: "?column?":3(int!null)
+           │    ├── cardinality: [1 - 1]
+           │    ├── stats: [rows=1]
+           │    ├── key: ()
+           │    ├── fd: ()-->(3)
+           │    └── tuple [type=tuple{int}]
+           │         └── const: 2 [type=int]
+           └── values
+                ├── columns: column5:5(void)
+                ├── cardinality: [1 - 1]
+                ├── stats: [rows=1]
+                ├── key: ()
+                ├── fd: ()-->(5)
+                └── tuple [type=tuple{void}]
+                     └── null [type=void]
+
+query T
+EXPLAIN (DISTSQL) CALL foo(3);
+----
+distribution: local
+vectorized: true
+·
+• call
+  procedure: foo(3)
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyMj0FL-0AQxe__TxHeqYXt3wRveyvWQyDWansQJMi6mdbFbSbubKhS8t0liUURD53DwLx5M7-ZI-TNQ-P6YVXM82UyWeTrzfqumCZX86JImvbZO_t_yzy5nEKh5oqWZk8C_YgMpUIT2JIIh146Doa8eodOFVzdtLGXSwXLgaCPiC56goZna3xijfdJepFCoaJonB_cnQK38XtWotkRdPYDli-g006dz7snabgWOouU_iLNsq5UoGpH45PCbbC0CmwH71jeDosGoSKJYzcbi7w-tSQGMvvx_FJh6_nw5CpopF8x-yOdAv2A2Un_2PqFD8PazUfTn7U1XkjhxrzSgiKFvaudRGehY2ip6_59BgAA__9oSZu_
+
+query T
+EXPLAIN ANALYZE CALL foo(3);
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• call
+  nodes: <hidden>
+  regions: <hidden>
+  actual row count: 0
+  procedure: foo(3)
+
+query T
+EXPLAIN ANALYZE (DISTSQL) CALL foo(3);
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• call
+  nodes: <hidden>
+  regions: <hidden>
+  actual row count: 0
+  procedure: foo(3)
+·
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyMUMtq40AQvO9XiDrtwnhXYm9zW9YXg_MgyS2IMB617SEjtTLdwg5Gn5UfyJcFSTY4IYH0YaCqu6tq-gB5irD4_2-5zNpuFYP_vWb--fcXDBqu6NLVJLD3KFAatIk9iXAaqMM4sKj2sLlBaNpOB7o08JwI9gANGgkWkb2LmXcxZvmfHAYVqQtx1KU9-U4DN5mGmmyWv74IDFZO_ZYk407bTm02bCXenRNlbzCho62o2xBscZZzMYfNe_P9qDckLTdC70J-5ZR_cJoVfWlA1Yam-wh3ydN1Yj_OTvBqFBqJikSnbjGBRXNqiSZy9RS_NFhH3j2EChb5sWafPKfCsOA2Mnzsdsu7UfbuuR1irV0UMrhwjzQnpVSHJogGD6upo77_8RYAAP__9m6rjw==

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -111,6 +111,13 @@ func TestExecBuild_autocommit(
 	runExecBuildLogicTest(t, "autocommit")
 }
 
+func TestExecBuild_call(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "call")
+}
+
 func TestExecBuild_cascade(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -294,6 +294,7 @@ var nodeNames = [...]string{
 	alterTableUnsplitOp:    "unsplit",
 	applyJoinOp:            "", // This node does not have a fixed name.
 	bufferOp:               "buffer",
+	callOp:                 "call",
 	cancelQueriesOp:        "cancel queries",
 	cancelSessionsOp:       "cancel sessions",
 	controlJobsOp:          "control jobs",
@@ -979,6 +980,10 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		if a.subjectReplicas != tree.RelocateLease {
 			ob.Expr("from", a.fromStoreID, nil /* columns */)
 		}
+
+	case callOp:
+		a := n.args.(*callArgs)
+		ob.Expr("procedure", a.Proc, nil /* columns */)
 
 	case simpleProjectOp,
 		serializingProjectOp,

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -707,6 +707,10 @@ type UDFDefinition struct {
 	// applies to direct as well as indirect recursive calls (mutual recursion).
 	IsRecursive bool
 
+	// RoutineType indicates whether this routine is a UDF, stored procedure, or
+	// builtin function.
+	RoutineType tree.RoutineType
+
 	// Params is the list of columns representing parameters of the function. The
 	// i-th column in the list corresponds to the i-th parameter of the function.
 	// During execution of the UDF, these columns are replaced with the arguments

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1053,7 +1053,7 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 
 	case opt.UDFCallOp:
 		udf := scalar.(*UDFCallExpr)
-		fmt.Fprintf(f.Buffer, "udf: %s", udf.Def.Name)
+		fmt.Fprintf(f.Buffer, "%s: %s", udf.Def.RoutineType, udf.Def.Name)
 		f.FormatScalarProps(scalar)
 		tp = tp.Child(f.Buffer.String())
 		formatUDFInputAndBody(udf, tp)

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -1304,6 +1304,7 @@ func (b *plpgsqlBuilder) makeContinuation(name string) continuation {
 			Typ:               b.returnType,
 			CalledOnNullInput: true,
 			BlockState:        b.blockState,
+			RoutineType:       tree.UDFRoutine,
 		},
 		s: s,
 	}

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -321,6 +321,7 @@ func (b *Builder) buildRoutine(
 				SetReturning:       isSetReturning,
 				CalledOnNullInput:  o.CalledOnNullInput,
 				MultiColDataSource: isMultiColDataSource,
+				RoutineType:        o.Type,
 				Body:               body,
 				BodyProps:          bodyProps,
 				Params:             params,

--- a/pkg/sql/opt/optbuilder/testdata/procedure
+++ b/pkg/sql/opt/optbuilder/testdata/procedure
@@ -24,7 +24,7 @@ build format=show-scalars
 CALL p()
 ----
 call
- └── udf: p
+ └── procedure: p
       └── body
            ├── insert abc
            │    ├── columns: <none>
@@ -62,7 +62,7 @@ build format=show-scalars
 CALL p()
 ----
 call
- └── udf: p
+ └── procedure: p
       └── body
            ├── insert abc
            │    ├── columns: <none>
@@ -116,7 +116,7 @@ build format=show-scalars
 CALL p(10, 20, 30.3)
 ----
 call
- └── udf: p
+ └── procedure: p
       ├── args
       │    ├── const: 10
       │    ├── const: 20

--- a/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
@@ -25,7 +25,7 @@ build format=show-scalars
 CALL my_upsert(1, 10, 'foo')
 ----
 call
- └── udf: my_upsert
+ └── procedure: my_upsert
       ├── args
       │    ├── const: 1
       │    ├── const: 10

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5910,6 +5910,7 @@ explainable_stmt:
   preparable_stmt
 | comment_stmt
 | execute_stmt
+| call_stmt
 
 preparable_stmt:
   alter_stmt     // help texts in sub-rule

--- a/pkg/sql/parser/testdata/explain
+++ b/pkg/sql/parser/testdata/explain
@@ -94,6 +94,14 @@ EXPLAIN (OPT, VERBOSE) SELECT (1) -- fully parenthesized
 EXPLAIN (OPT, VERBOSE) SELECT _ -- literals removed
 EXPLAIN (OPT, VERBOSE) SELECT 1 -- identifiers removed
 
+parse
+EXPLAIN (OPT) CALL foo(1, 'bar')
+----
+EXPLAIN (OPT) CALL foo(1, 'bar')
+EXPLAIN (OPT) CALL foo((1), ('bar')) -- fully parenthesized
+EXPLAIN (OPT) CALL foo(_, '_') -- literals removed
+EXPLAIN (OPT) CALL _(1, 'bar') -- identifiers removed
+
 error
 EXPLAIN (ANALYZE, PLAN) SELECT 1
 ----

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -142,6 +142,20 @@ const (
 	ProcedureRoutine
 )
 
+// String returns the string representation of the routine type.
+func (t RoutineType) String() string {
+	switch t {
+	case BuiltinRoutine:
+		return "builtin"
+	case UDFRoutine:
+		return "udf"
+	case ProcedureRoutine:
+		return "procedure"
+	default:
+		panic(errors.AssertionFailedf("unexpected routine type %d", t))
+	}
+}
+
 // Overload is one of the overloads of a built-in function.
 // Each FunctionDefinition may contain one or more overloads.
 type Overload struct {


### PR DESCRIPTION
Backport 2/2 commits from #115468.

/cc @cockroachdb/release

---

This patch makes it possible to run CALL statements with EXPLAIN. Currently, most explain variants only display the name and arguments of the procedure. The `OPT` explain variants additionally show the SQL/PLpgSQL body statements of the procedure. This commit also changes the name displayed for a procedure in the output of `EXPLAIN (OPT)` from `udf` to `procedure`.

Fixes #114674

Release note (sql change): It is now possible to run CALL statements with EXPLAIN. The `EXPLAIN (OPT)` variant will show the body of the procedure, while other variants will only show the procedure name and arguments.

Release justification: observability improvement for new feature in 23.2