### PR TITLE
multiregionccl: skip region liveness tests under race / deadlock modes

### DIFF
--- a/pkg/ccl/multiregionccl/regionliveness_test.go
+++ b/pkg/ccl/multiregionccl/regionliveness_test.go
@@ -46,7 +46,13 @@ import (
 func TestRegionLivenessProber(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t)
+	// This test forces the SQL liveness TTL be a small number,
+	// which makes the heartbeats even more critical. Under stress and
+	// race environments this test becomes even more sensitive, if
+	// we can't send heartbeats within 10 seconds.
+	skip.UnderStress(t)
+	skip.UnderRace(t)
+	skip.UnderDeadlock(t)
 
 	ctx := context.Background()
 
@@ -182,8 +188,13 @@ func TestRegionLivenessProber(t *testing.T) {
 func TestRegionLivenessProberForLeases(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStressRace(t)
+	// This test forces the SQL liveness TTL be a small number,
+	// which makes the heartbeats even more critical. Under stress and
+	// race environments this test becomes even more sensitive, if
+	// we can't send heartbeats within 10 seconds.
 	skip.UnderStress(t)
+	skip.UnderRace(t)
+	skip.UnderDeadlock(t)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Previously, the region liveness tests intentionally simulated node failures with small sqlliveness TTLs and region timeouts to get reasonable execution times. These values were acceptable in regular executions of the tests and sufficiently large enough, but in the race/deadlock modes of the test, we are seeing flakes because this timing is too small. As a result, we observed sqlliveness failures or regions timing out. To address this, this patch will skip regionliveness tests in race/deadlock modes.

Fixes: #116057
fixes #115909

Release note: None