### PR TITLE
kv,admission: add missing admission headers

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
@@ -525,6 +525,13 @@ func (h *txnHeartbeater) abortTxnAsyncLocked(ctx context.Context) {
 		// concurrent requests from failing to notice the transaction was aborted.
 		Poison: true,
 	})
+	// NB: Setting `Source: kvpb.AdmissionHeader_OTHER` means this request will
+	// bypass AC.
+	ba.AdmissionHeader = kvpb.AdmissionHeader{
+		Priority:   txn.AdmissionPriority,
+		CreateTime: timeutil.Now().UnixNano(),
+		Source:     kvpb.AdmissionHeader_OTHER,
+	}
 
 	const taskName = "txnHeartbeater: aborting txn"
 	log.VEventf(ctx, 2, "async abort for txn: %s", txn)


### PR DESCRIPTION
This patch adds missing admission headers in a couple of places: `txn_interceptor_heartbeater` and `replica_range_lease`. Batch requests coming from these code paths are expected to bypass AC. Empty admission headers were accomplishing the same goal but this makes it more clear at what the intention is.

Informs #112680

Release note: None