### PR TITLE
roachtest: improve sqlsmith for an elusive setup error

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -125,6 +125,19 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 		for _, stmt := range setup {
 			logStmt(stmt)
 			if _, err := conn.Exec(stmt); err != nil {
+				if strings.Contains(err.Error(), "does not exist") {
+					// This is likely to be an elusive 'pq: column
+					// "crdb_internal_idx_expr" does not exist' error that we
+					// cannot reproduce. The current hypothesis is that the
+					// CREATE TABLE statement contains some non-visible
+					// characters that get lost when printing as a string, so we
+					// will log this statement as a sequence of integers so that
+					// later we can reconstruct the stmt precisely.
+					for _, char := range stmt {
+						fmt.Fprintf(smithLog, "%d ", char)
+					}
+					fmt.Fprint(smithLog, "\n\n")
+				}
 				t.Fatalf("error: %s\nstatement: %s", err.Error(), stmt)
 			}
 		}

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -123,10 +123,9 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 		t.Status("executing setup")
 		t.L().Printf("setup:\n%s", strings.Join(setup, "\n"))
 		for _, stmt := range setup {
+			logStmt(stmt)
 			if _, err := conn.Exec(stmt); err != nil {
 				t.Fatalf("error: %s\nstatement: %s", err.Error(), stmt)
-			} else {
-				logStmt(stmt)
 			}
 		}
 


### PR DESCRIPTION
**roachtest: log erroneous stmt in sqlsmith.log**

Previously, if we hit an error when executing a setup query, we would only include it into the error message (so it would only be seen in the test.log file). This commit makes it so that the erroneous setup query is included into sqlsmith.log as well.

Informs: #116160.
Informs: #116307.

**roachtest/sqlsmith: print a setup query as integers**

This commit adjusts the sqlsmith logging so that if it encounters an error during the setup that contains "does not exist" substring, then we will also log the failed stmt as space-separated integers. This change is made in hopes of being able to reproduce the elusive 'pq: column "crdb_internal_idx_expr" does not exist' error we've seen a few times. My hypothesis is that there is some non-visible character that gets lost when stringified.

Epic: None

Release note: None