### PR TITLE
roachtest: unskip restore/online/tpce/400GB/aws/inc-count=1/nodes=4/cpus=8

### DIFF
--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -43,7 +43,6 @@ func registerOnlineRestore(r registry.Registry) {
 			timeout:                5 * time.Hour,
 			suites:                 registry.Suites(registry.Nightly),
 			restoreUptoIncremental: 1,
-			skip:                   "used for ad hoc experiments",
 		},
 		{
 			// 8TB tpce Online Restore


### PR DESCRIPTION
Epic: none

Release note: none