### PR TITLE
backupccl: fix codec selection during restore

### DIFF
--- a/pkg/ccl/backupccl/backupinfo/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupinfo/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//pkg/ccl/backupccl/backuppb",
         "//pkg/ccl/backupccl/backuptestutils",
         "//pkg/cloud",
+        "//pkg/keys",
         "//pkg/multitenant/mtinfopb",
         "//pkg/roachpb",
         "//pkg/security/securityassets",

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1644,7 +1644,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	defer func() {
 		mem.Shrink(ctx, memSize)
 	}()
-	backupCodec, err := backupinfo.MakeBackupCodec(latestBackupManifest)
+	backupCodec, err := backupinfo.MakeBackupCodec(backupManifests)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously, the codec selection logic only looked at a single manifest to determine whether the backup data requires a system or tenant codec to be read. In older release branches if the full backup was empty (but a subsequent incremental was not) then we could incorrectly use a system codec for a backup that actually required a tenant codec.

To fix this we now process all the manifests in the backup chain and use the first non-empty manifest.

Fixes: #115773
Release note(bug fix): an empty full backup, followed by non-empty incrementals taken inside an application tenant may be unrestoreable because of the use of an incorrect SQL codec