### PR TITLE
roachtest: explicitly close monitor reader after closing session

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1023,6 +1023,9 @@ wait
 			go func() {
 				<-monitorCtx.Done()
 				sess.Close()
+				if pc, ok := p.(io.ReadCloser); ok {
+					_ = pc.Close()
+				}
 			}()
 
 			readerWg.Wait()


### PR DESCRIPTION
Previously the reader did not close, even though the session is closed. This change ensures the reader is closed by closing it after the session has been closed. This seems to have only been a problem with local clusters.

Fixes: #116314

Epic: None
Release Note: None