### PR TITLE
util/span: increase test timeout

### DIFF
--- a/pkg/util/span/BUILD.bazel
+++ b/pkg/util/span/BUILD.bazel
@@ -24,7 +24,7 @@ go_library(
 
 go_test(
     name = "span_test",
-    size = "small",
+    size = "large",
     srcs = [
         "frontier_test.go",
         "frontierentry_interval_btree_test.go",  #keep


### PR DESCRIPTION
Fixes #115600.
Fixes #115835.

With all of the new tests added in c7264978e, the tests in this package are now "large", which is the size used by all other packages which use the generated btree library.

Release note: None