### PR TITLE
streamingccl: skip TestStreamingReplanOnLag under duress

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -758,6 +758,8 @@ func TestStreamingReplanOnLag(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderDuressWithIssue(t, 115850, "time to scatter ranges takes too long under duress")
+
 	ctx := context.Background()
 	args := replicationtestutils.DefaultTenantStreamingClustersArgs
 	args.MultitenantSingleClusterNumNodes = 3


### PR DESCRIPTION
Fixes: #115850

Release note: none