### PR TITLE
opt, sql: disallow multi-column-family checks in updates under read committed

### DIFF
--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -182,15 +182,25 @@ type Table interface {
 	IsHypothetical() bool
 }
 
-// CheckConstraint contains the SQL text and the validity status for a check
-// constraint on a table. Check constraints are user-defined restrictions
-// on the content of each row in a table. For example, this check constraint
-// ensures that only values greater than zero can be inserted into the table:
+// CheckConstraint represents a check constraint on a table. Check constraints
+// are user-defined restrictions on the content of each row in a table. For
+// example, this check constraint ensures that only values greater than zero can
+// be inserted into the table:
 //
 //	CREATE TABLE a (a INT CHECK (a > 0))
-type CheckConstraint struct {
-	Constraint string
-	Validated  bool
+type CheckConstraint interface {
+	// Constraint contains the SQL text of this check constraint.
+	Constraint() string
+
+	// Validated returns true if this check constraint has been validated.
+	Validated() bool
+
+	// ColumnCount returns the number of columns in this constraint.
+	ColumnCount() int
+
+	// ColumnOrdinal returns the table column ordinal of the ith column in this
+	// constraint.
+	ColumnOrdinal(i int) int
 }
 
 // TableStatistic is an interface to a table statistic. Each statistic is

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -82,7 +82,7 @@ func FormatTable(cat Catalog, tab Table, tp treeprinter.Node, redactableValues b
 	}
 
 	for i := 0; i < tab.CheckCount(); i++ {
-		child.Childf("CHECK (%s)", MaybeMarkRedactable(tab.Check(i).Constraint, redactableValues))
+		child.Childf("CHECK (%s)", MaybeMarkRedactable(tab.Check(i).Constraint(), redactableValues))
 	}
 
 	for i := 0; i < tab.DeletableIndexCount(); i++ {

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_read_committed
@@ -1,0 +1,118 @@
+# LogicTest: local
+
+statement ok
+SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true
+
+# Test multi-column-family checks under read committed. If a check constraint
+# contains multiple column families but only some of them are updated, the
+# query should fail under read committed.
+
+statement ok
+CREATE TABLE multi_col_fam_checks (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  e INT,
+  FAMILY (a),
+  FAMILY (b, d),
+  FAMILY (c, e),
+  CHECK (a < b),
+  CHECK (c != d)
+)
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+# Only a is updated, but b must be read to check the constraint. Should fail
+# under read committed.
+query error pq: unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+EXPLAIN UPDATE multi_col_fam_checks SET a = 5
+
+# Only a is updated, but b is read. Should fail under read committed.
+query error pq: unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+EXPLAIN UPDATE multi_col_fam_checks SET a = 5 WHERE b = 6 AND c = 3
+
+# Both a and b are updated, so this should succeed.
+query T
+EXPLAIN UPDATE multi_col_fam_checks SET a = 5, b = 6
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: multi_col_fam_checks
+│ set: a, b
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: multi_col_fam_checks@multi_col_fam_checks_pkey
+          spans: FULL SCAN
+          locking strength: for update
+
+# Both a and b are updated, so this should succeed.
+query T
+EXPLAIN UPDATE multi_col_fam_checks SET a = 5, b = 6, e = 3
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: multi_col_fam_checks
+│ set: a, b, e
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: multi_col_fam_checks@multi_col_fam_checks_pkey
+          spans: FULL SCAN
+          locking strength: for update
+
+# Neither a nor b is updated, so this should succeed.
+query T
+EXPLAIN UPDATE multi_col_fam_checks SET e = 3 WHERE a = 5
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: multi_col_fam_checks
+│ set: e
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: multi_col_fam_checks@multi_col_fam_checks_pkey
+          spans: [/5 - /5]
+          locking strength: for update
+
+# Neither a nor b is updated, so this should succeed.
+query T
+EXPLAIN UPDATE multi_col_fam_checks SET e = 3
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: multi_col_fam_checks
+│ set: e
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: multi_col_fam_checks@multi_col_fam_checks_pkey
+          spans: FULL SCAN
+          locking strength: for update
+
+# Test failure due to a different constraint on c and d.
+query error pq: unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+EXPLAIN UPDATE multi_col_fam_checks SET d = 4, e = 5

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert_read_committed
@@ -1,0 +1,231 @@
+# LogicTest: local
+
+statement ok
+SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true
+
+# Test multi-column-family checks under read committed. If a check constraint
+# contains multiple column families but only some of them are updated, the
+# query should fail under read committed.
+
+statement ok
+CREATE TABLE multi_col_fam_checks (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT UNIQUE,
+  UNIQUE (a, b),
+  UNIQUE (b, c),
+  FAMILY (a),
+  FAMILY (b, d),
+  FAMILY (c),
+  CHECK (b < c)
+)
+
+statement ok
+CREATE TABLE multi_col_fam_checks_simple (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  FAMILY (a),
+  FAMILY (b),
+  FAMILY (c),
+  FAMILY (d),
+  CHECK (b < c)
+)
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+# Both b and c are updated (c is given the default value), so this should
+# succeed.
+query T
+EXPLAIN UPSERT INTO multi_col_fam_checks VALUES (5, 6)
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ into: multi_col_fam_checks(a, b, c, d)
+│ auto commit
+│ arbiter indexes: multi_col_fam_checks_pkey
+│
+└── • render
+    │
+    └── • cross join (left outer)
+        │
+        ├── • values
+        │     size: 3 columns, 1 row
+        │
+        └── • scan
+              missing stats
+              table: multi_col_fam_checks@multi_col_fam_checks_pkey
+              spans: [/5 - /5]
+              locking strength: for update
+
+# Fast upsert case. Both b and c are updated (c is given the default value), so
+# this should succeed.
+query T
+EXPLAIN UPSERT INTO multi_col_fam_checks_simple VALUES (1, 2)
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ into: multi_col_fam_checks_simple(a, b, c, d)
+│ auto commit
+│
+└── • values
+      size: 4 columns, 1 row
+
+# Only b is updated, but c must be read to check the constraint. Should fail
+# under read committed.
+query error pq: unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+EXPLAIN UPSERT INTO multi_col_fam_checks (a, b) VALUES (5, 6)
+
+# Neither b nor c is updated, so this should succeed.
+query T
+EXPLAIN UPSERT INTO multi_col_fam_checks (a, d) VALUES (3, 5)
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ into: multi_col_fam_checks(a, b, c, d)
+│ auto commit
+│ arbiter indexes: multi_col_fam_checks_pkey
+│
+└── • render
+    │
+    └── • cross join (left outer)
+        │
+        ├── • values
+        │     size: 3 columns, 1 row
+        │
+        └── • scan
+              missing stats
+              table: multi_col_fam_checks@multi_col_fam_checks_pkey
+              spans: [/3 - /3]
+              locking strength: for update
+
+# Only b is updated, but c must be read to check the constraint. Should fail
+# under read committed.
+query error pq: unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+EXPLAIN INSERT INTO multi_col_fam_checks VALUES (5) ON CONFLICT (a) DO UPDATE SET b = 5
+
+# Only c is updated, but b is read. Should fail under read committed.
+query error pq: unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+EXPLAIN INSERT INTO multi_col_fam_checks SELECT a FROM multi_col_fam_checks WHERE b = 5
+ON CONFLICT (d) DO UPDATE SET c = 3
+
+# Both b and c are updated, so this should succeed.
+query T
+EXPLAIN INSERT INTO multi_col_fam_checks VALUES (1, 2, 3)
+ON CONFLICT (a, b) DO UPDATE SET b = 3, c = 4
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ into: multi_col_fam_checks(a, b, c, d)
+│ auto commit
+│ arbiter indexes: multi_col_fam_checks_a_b_key
+│
+└── • render
+    │
+    └── • render
+        │
+        └── • cross join (left outer)
+            │
+            ├── • values
+            │     size: 4 columns, 1 row
+            │
+            └── • filter
+                │ filter: b = 2
+                │
+                └── • scan
+                      missing stats
+                      table: multi_col_fam_checks@multi_col_fam_checks_pkey
+                      spans: [/1 - /1]
+
+# Both b and c are updated, so this should succeed.
+query T
+EXPLAIN INSERT INTO multi_col_fam_checks (a) VALUES (1)
+ON CONFLICT (a) DO UPDATE SET b = 3, c = 4, d = 5
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ into: multi_col_fam_checks(a, b, c, d)
+│ auto commit
+│ arbiter indexes: multi_col_fam_checks_pkey
+│
+└── • render
+    │
+    └── • render
+        │
+        └── • cross join (left outer)
+            │
+            ├── • values
+            │     size: 2 columns, 1 row
+            │
+            └── • scan
+                  missing stats
+                  table: multi_col_fam_checks@multi_col_fam_checks_pkey
+                  spans: [/1 - /1]
+                  locking strength: for update
+
+# Neither b nor c is updated, so this should succeed.
+query T
+EXPLAIN INSERT INTO multi_col_fam_checks (a, b, c, d) VALUES (1, 2, 3, 4)
+ON CONFLICT (b, c) DO UPDATE SET a = 5
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ into: multi_col_fam_checks(a, b, c, d)
+│ auto commit
+│ arbiter indexes: multi_col_fam_checks_b_c_key
+│
+└── • render
+    │
+    └── • cross join (left outer)
+        │
+        ├── • values
+        │     size: 4 columns, 1 row
+        │
+        └── • index join
+            │ table: multi_col_fam_checks@multi_col_fam_checks_pkey
+            │
+            └── • scan
+                  missing stats
+                  table: multi_col_fam_checks@multi_col_fam_checks_b_c_key
+                  spans: [/2/3 - /2/3]
+
+# Neither b nor c is updated, so this should succeed.
+query T
+EXPLAIN INSERT INTO multi_col_fam_checks (a) VALUES (1)
+ON CONFLICT (a) DO UPDATE SET d = 5
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ into: multi_col_fam_checks(a, b, c, d)
+│ auto commit
+│ arbiter indexes: multi_col_fam_checks_pkey
+│
+└── • render
+    │
+    └── • cross join (left outer)
+        │
+        ├── • values
+        │     size: 2 columns, 1 row
+        │
+        └── • scan
+              missing stats
+              table: multi_col_fam_checks@multi_col_fam_checks_pkey
+              spans: [/1 - /1]
+              locking strength: for update

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -671,11 +671,25 @@ func TestExecBuild_update_from(
 	runExecBuildLogicTest(t, "update_from")
 }
 
+func TestExecBuild_update_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "update_read_committed")
+}
+
 func TestExecBuild_upsert(
 	t *testing.T,
 ) {
 	defer leaktest.AfterTest(t)()
 	runExecBuildLogicTest(t, "upsert")
+}
+
+func TestExecBuild_upsert_read_committed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "upsert_read_committed")
 }
 
 func TestExecBuild_values(

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -800,7 +800,8 @@ func (mb *mutationBuilder) addCheckConstraintCols(isUpdate bool) {
 		mutationCols := mb.mutationColumnIDs()
 
 		for i, n := 0, mb.tab.CheckCount(); i < n; i++ {
-			expr, err := parser.ParseExpr(mb.tab.Check(i).Constraint)
+			check := mb.tab.Check(i)
+			expr, err := parser.ParseExpr(check.Constraint())
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -825,7 +825,7 @@ func (b *Builder) addCheckConstraintsForTable(tabMeta *opt.TableMeta) {
 	numChecks := tab.CheckCount()
 	chkIdx := 0
 	for ; chkIdx < numChecks; chkIdx++ {
-		if tab.Check(chkIdx).Validated {
+		if tab.Check(chkIdx).Validated() {
 			break
 		}
 	}
@@ -852,10 +852,10 @@ func (b *Builder) addCheckConstraintsForTable(tabMeta *opt.TableMeta) {
 		checkConstraint := tab.Check(chkIdx)
 
 		// Only add validated check constraints to the table's metadata.
-		if !checkConstraint.Validated {
+		if !checkConstraint.Validated() {
 			continue
 		}
-		expr, err := parser.ParseExpr(checkConstraint.Constraint)
+		expr, err := parser.ParseExpr(checkConstraint.Constraint())
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1703,6 +1703,188 @@ update checks
            ├── abcde.b:14 < checks.d:10 [as=check1:22]
            └── abcde.a:13 > 0 [as=check2:23]
 
+# Test multi-column-family checks under read committed. If a check constraint
+# contains multiple column families but only some of them are updated, the
+# query should fail under read committed.
+
+exec-ddl
+CREATE TABLE multi_col_fam_checks (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  e INT,
+  FAMILY (a),
+  FAMILY (b, d),
+  FAMILY (c, e),
+  CHECK (a < b),
+  CHECK (c != d)
+)
+----
+
+# Only a is updated, but b must be read to check the constraint. Should fail
+# under read committed.
+build isolation=ReadCommitted
+UPDATE multi_col_fam_checks SET a = 5
+----
+error (0A000): unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+
+# The same query should succeed under serializable isolation.
+build isolation=Serializable
+UPDATE multi_col_fam_checks SET a = 5
+----
+update multi_col_fam_checks
+ ├── columns: <none>
+ ├── fetch columns: a:8 b:9 c:10 d:11 e:12
+ ├── update-mapping:
+ │    └── a_new:15 => a:1
+ ├── check columns: check1:16
+ └── project
+      ├── columns: check1:16 check2:17 a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14 a_new:15!null
+      ├── project
+      │    ├── columns: a_new:15!null a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    ├── scan multi_col_fam_checks
+      │    │    └── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    └── projections
+      │         └── 5 [as=a_new:15]
+      └── projections
+           ├── a_new:15 < b:9 [as=check1:16]
+           └── c:10 != d:11 [as=check2:17]
+
+# Only a is updated, but b is read. Should fail under read committed.
+build isolation=ReadCommitted
+UPDATE multi_col_fam_checks SET a = 5 WHERE b = 6 AND c = 3
+----
+error (0A000): unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+
+# The same query should succeed under serializable isolation.
+build isolation=Serializable
+UPDATE multi_col_fam_checks SET a = 5 WHERE b = 6 AND c = 3
+----
+update multi_col_fam_checks
+ ├── columns: <none>
+ ├── fetch columns: a:8 b:9 c:10 d:11 e:12
+ ├── update-mapping:
+ │    └── a_new:15 => a:1
+ ├── check columns: check1:16
+ └── project
+      ├── columns: check1:16!null check2:17 a:8!null b:9!null c:10!null d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14 a_new:15!null
+      ├── project
+      │    ├── columns: a_new:15!null a:8!null b:9!null c:10!null d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    ├── select
+      │    │    ├── columns: a:8!null b:9!null c:10!null d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── scan multi_col_fam_checks
+      │    │    │    └── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    └── filters
+      │    │         └── (b:9 = 6) AND (c:10 = 3)
+      │    └── projections
+      │         └── 5 [as=a_new:15]
+      └── projections
+           ├── a_new:15 < b:9 [as=check1:16]
+           └── c:10 != d:11 [as=check2:17]
+
+# Both a and b are updated, so this should succeed.
+build isolation=ReadCommitted
+UPDATE multi_col_fam_checks SET a = 5, b = 6
+----
+update multi_col_fam_checks
+ ├── columns: <none>
+ ├── fetch columns: a:8 b:9 c:10 d:11 e:12
+ ├── update-mapping:
+ │    ├── a_new:15 => a:1
+ │    └── b_new:16 => b:2
+ ├── check columns: check1:17
+ └── project
+      ├── columns: check1:17!null check2:18 a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14 a_new:15!null b_new:16!null
+      ├── project
+      │    ├── columns: a_new:15!null b_new:16!null a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    ├── scan multi_col_fam_checks
+      │    │    └── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    └── projections
+      │         ├── 5 [as=a_new:15]
+      │         └── 6 [as=b_new:16]
+      └── projections
+           ├── a_new:15 < b_new:16 [as=check1:17]
+           └── c:10 != d:11 [as=check2:18]
+
+# Both a and b are updated, so this should succeed.
+build isolation=ReadCommitted
+UPDATE multi_col_fam_checks SET a = 5, b = 6, e = 3
+----
+update multi_col_fam_checks
+ ├── columns: <none>
+ ├── fetch columns: a:8 b:9 c:10 d:11 e:12
+ ├── update-mapping:
+ │    ├── a_new:15 => a:1
+ │    ├── b_new:16 => b:2
+ │    └── e_new:17 => e:5
+ ├── check columns: check1:18
+ └── project
+      ├── columns: check1:18!null check2:19 a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14 a_new:15!null b_new:16!null e_new:17!null
+      ├── project
+      │    ├── columns: a_new:15!null b_new:16!null e_new:17!null a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    ├── scan multi_col_fam_checks
+      │    │    └── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    └── projections
+      │         ├── 5 [as=a_new:15]
+      │         ├── 6 [as=b_new:16]
+      │         └── 3 [as=e_new:17]
+      └── projections
+           ├── a_new:15 < b_new:16 [as=check1:18]
+           └── c:10 != d:11 [as=check2:19]
+
+# Neither a nor b is updated, so this should succeed.
+build isolation=ReadCommitted
+UPDATE multi_col_fam_checks SET e = 3 WHERE a = 5
+----
+update multi_col_fam_checks
+ ├── columns: <none>
+ ├── fetch columns: a:8 b:9 c:10 d:11 e:12
+ ├── update-mapping:
+ │    └── e_new:15 => e:5
+ └── project
+      ├── columns: check1:16 check2:17 a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14 e_new:15!null
+      ├── project
+      │    ├── columns: e_new:15!null a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    ├── select
+      │    │    ├── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── scan multi_col_fam_checks
+      │    │    │    └── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    └── filters
+      │    │         └── a:8 = 5
+      │    └── projections
+      │         └── 3 [as=e_new:15]
+      └── projections
+           ├── a:8 < b:9 [as=check1:16]
+           └── c:10 != d:11 [as=check2:17]
+
+# Neither a nor b is updated, so this should succeed.
+build isolation=ReadCommitted
+UPDATE multi_col_fam_checks SET e = 3
+----
+update multi_col_fam_checks
+ ├── columns: <none>
+ ├── fetch columns: a:8 b:9 c:10 d:11 e:12
+ ├── update-mapping:
+ │    └── e_new:15 => e:5
+ └── project
+      ├── columns: check1:16 check2:17 a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14 e_new:15!null
+      ├── project
+      │    ├── columns: e_new:15!null a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    ├── scan multi_col_fam_checks
+      │    │    └── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    └── projections
+      │         └── 3 [as=e_new:15]
+      └── projections
+           ├── a:8 < b:9 [as=check1:16]
+           └── c:10 != d:11 [as=check2:17]
+
+# Test failure due to a different constraint on c and d.
+build isolation=ReadCommitted
+UPDATE multi_col_fam_checks SET d = 4, e = 5
+----
+error (0A000): unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+
 # ------------------------------------------------------------------------------
 # Test assignment casts.
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -1815,6 +1815,572 @@ upsert xyz
            ├── CASE WHEN x:12 IS NULL THEN b:7 ELSE y_new:17 END [as=upsert_y:19]
            └── CASE WHEN x:12 IS NULL THEN c:8 ELSE z:14 END [as=upsert_z:20]
 
+# Test multi-column-family checks under read committed. If a check constraint
+# contains multiple column families but only some of them are updated, the
+# query should fail under read committed.
+
+exec-ddl
+CREATE TABLE multi_col_fam_checks (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT UNIQUE,
+  UNIQUE (a, b),
+  UNIQUE (b, c),
+  FAMILY (a),
+  FAMILY (b, d),
+  FAMILY (c),
+  CHECK (b < c)
+)
+----
+
+exec-ddl
+CREATE TABLE multi_col_fam_checks_simple (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  FAMILY (a),
+  FAMILY (b),
+  FAMILY (c),
+  FAMILY (d),
+  CHECK (b < c)
+)
+----
+
+# Both b and c are updated (c is given the default value), so this should
+# succeed.
+build isolation=ReadCommitted
+UPSERT INTO multi_col_fam_checks VALUES (5, 6)
+----
+upsert multi_col_fam_checks
+ ├── arbiter indexes: multi_col_fam_checks_pkey
+ ├── columns: <none>
+ ├── canary column: a:10
+ ├── fetch columns: a:10 b:11 c:12 d:13
+ ├── insert-mapping:
+ │    ├── column1:7 => a:1
+ │    ├── column2:8 => b:2
+ │    ├── c_default:9 => c:3
+ │    └── c_default:9 => d:4
+ ├── update-mapping:
+ │    ├── column2:8 => b:2
+ │    ├── c_default:9 => c:3
+ │    └── c_default:9 => d:4
+ ├── check columns: check1:17
+ └── project
+      ├── columns: check1:17 column1:7!null column2:8!null c_default:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_a:16
+      ├── project
+      │    ├── columns: upsert_a:16 column1:7!null column2:8!null c_default:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+      │    ├── left-join (hash)
+      │    │    ├── columns: column1:7!null column2:8!null c_default:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+      │    │    ├── ensure-upsert-distinct-on
+      │    │    │    ├── columns: column1:7!null column2:8!null c_default:9
+      │    │    │    ├── grouping columns: column1:7!null
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: c_default:9 column1:7!null column2:8!null
+      │    │    │    │    ├── values
+      │    │    │    │    │    ├── columns: column1:7!null column2:8!null
+      │    │    │    │    │    └── (5, 6)
+      │    │    │    │    └── projections
+      │    │    │    │         └── NULL::INT8 [as=c_default:9]
+      │    │    │    └── aggregations
+      │    │    │         ├── first-agg [as=column2:8]
+      │    │    │         │    └── column2:8
+      │    │    │         └── first-agg [as=c_default:9]
+      │    │    │              └── c_default:9
+      │    │    ├── scan multi_col_fam_checks
+      │    │    │    ├── columns: a:10!null b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+      │    │    │    └── flags: disabled not visible index feature
+      │    │    └── filters
+      │    │         └── column1:7 = a:10
+      │    └── projections
+      │         └── CASE WHEN a:10 IS NULL THEN column1:7 ELSE a:10 END [as=upsert_a:16]
+      └── projections
+           └── column2:8 < c_default:9 [as=check1:17]
+
+# Fast upsert case. Both b and c are updated (c is given the default value), so
+# this should succeed.
+build isolation=ReadCommitted
+UPSERT INTO multi_col_fam_checks_simple VALUES (1, 2)
+----
+upsert multi_col_fam_checks_simple
+ ├── columns: <none>
+ ├── upsert-mapping:
+ │    ├── column1:7 => a:1
+ │    ├── column2:8 => b:2
+ │    ├── c_default:9 => c:3
+ │    └── c_default:9 => d:4
+ ├── check columns: check1:10
+ └── project
+      ├── columns: check1:10 column1:7!null column2:8!null c_default:9
+      ├── project
+      │    ├── columns: c_default:9 column1:7!null column2:8!null
+      │    ├── values
+      │    │    ├── columns: column1:7!null column2:8!null
+      │    │    └── (1, 2)
+      │    └── projections
+      │         └── NULL::INT8 [as=c_default:9]
+      └── projections
+           └── column2:8 < c_default:9 [as=check1:10]
+
+# Only b is updated, but c must be read to check the constraint. Should fail
+# under read committed.
+build isolation=ReadCommitted
+UPSERT INTO multi_col_fam_checks (a, b) VALUES (5, 6)
+----
+error (0A000): unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+
+# The same query should succeed under serializable isolation.
+build isolation=Serializable
+UPSERT INTO multi_col_fam_checks (a, b) VALUES (5, 6)
+----
+upsert multi_col_fam_checks
+ ├── arbiter indexes: multi_col_fam_checks_pkey
+ ├── columns: <none>
+ ├── canary column: a:10
+ ├── fetch columns: a:10 b:11 c:12 d:13
+ ├── insert-mapping:
+ │    ├── column1:7 => a:1
+ │    ├── column2:8 => b:2
+ │    ├── c_default:9 => c:3
+ │    └── c_default:9 => d:4
+ ├── update-mapping:
+ │    └── column2:8 => b:2
+ ├── check columns: check1:19
+ └── project
+      ├── columns: check1:19 column1:7!null column2:8!null c_default:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_a:16 upsert_c:17 upsert_d:18
+      ├── project
+      │    ├── columns: upsert_a:16 upsert_c:17 upsert_d:18 column1:7!null column2:8!null c_default:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+      │    ├── left-join (hash)
+      │    │    ├── columns: column1:7!null column2:8!null c_default:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+      │    │    ├── ensure-upsert-distinct-on
+      │    │    │    ├── columns: column1:7!null column2:8!null c_default:9
+      │    │    │    ├── grouping columns: column1:7!null
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: c_default:9 column1:7!null column2:8!null
+      │    │    │    │    ├── values
+      │    │    │    │    │    ├── columns: column1:7!null column2:8!null
+      │    │    │    │    │    └── (5, 6)
+      │    │    │    │    └── projections
+      │    │    │    │         └── NULL::INT8 [as=c_default:9]
+      │    │    │    └── aggregations
+      │    │    │         ├── first-agg [as=column2:8]
+      │    │    │         │    └── column2:8
+      │    │    │         └── first-agg [as=c_default:9]
+      │    │    │              └── c_default:9
+      │    │    ├── scan multi_col_fam_checks
+      │    │    │    ├── columns: a:10!null b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+      │    │    │    └── flags: disabled not visible index feature
+      │    │    └── filters
+      │    │         └── column1:7 = a:10
+      │    └── projections
+      │         ├── CASE WHEN a:10 IS NULL THEN column1:7 ELSE a:10 END [as=upsert_a:16]
+      │         ├── CASE WHEN a:10 IS NULL THEN c_default:9 ELSE c:12 END [as=upsert_c:17]
+      │         └── CASE WHEN a:10 IS NULL THEN c_default:9 ELSE d:13 END [as=upsert_d:18]
+      └── projections
+           └── column2:8 < upsert_c:17 [as=check1:19]
+
+# Neither b nor c is updated, so this should succeed.
+build isolation=ReadCommitted
+UPSERT INTO multi_col_fam_checks (a, d) VALUES (3, 5)
+----
+upsert multi_col_fam_checks
+ ├── arbiter indexes: multi_col_fam_checks_pkey
+ ├── columns: <none>
+ ├── canary column: a:10
+ ├── fetch columns: a:10 b:11 c:12 d:13
+ ├── insert-mapping:
+ │    ├── column1:7 => a:1
+ │    ├── b_default:9 => b:2
+ │    ├── b_default:9 => c:3
+ │    └── column2:8 => d:4
+ ├── update-mapping:
+ │    └── column2:8 => d:4
+ ├── check columns: check1:19
+ └── project
+      ├── columns: check1:19 column1:7!null column2:8!null b_default:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_a:16 upsert_b:17 upsert_c:18
+      ├── project
+      │    ├── columns: upsert_a:16 upsert_b:17 upsert_c:18 column1:7!null column2:8!null b_default:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+      │    ├── left-join (hash)
+      │    │    ├── columns: column1:7!null column2:8!null b_default:9 a:10 b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+      │    │    ├── ensure-upsert-distinct-on
+      │    │    │    ├── columns: column1:7!null column2:8!null b_default:9
+      │    │    │    ├── grouping columns: column1:7!null
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: b_default:9 column1:7!null column2:8!null
+      │    │    │    │    ├── values
+      │    │    │    │    │    ├── columns: column1:7!null column2:8!null
+      │    │    │    │    │    └── (3, 5)
+      │    │    │    │    └── projections
+      │    │    │    │         └── NULL::INT8 [as=b_default:9]
+      │    │    │    └── aggregations
+      │    │    │         ├── first-agg [as=column2:8]
+      │    │    │         │    └── column2:8
+      │    │    │         └── first-agg [as=b_default:9]
+      │    │    │              └── b_default:9
+      │    │    ├── scan multi_col_fam_checks
+      │    │    │    ├── columns: a:10!null b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+      │    │    │    └── flags: disabled not visible index feature
+      │    │    └── filters
+      │    │         └── column1:7 = a:10
+      │    └── projections
+      │         ├── CASE WHEN a:10 IS NULL THEN column1:7 ELSE a:10 END [as=upsert_a:16]
+      │         ├── CASE WHEN a:10 IS NULL THEN b_default:9 ELSE b:11 END [as=upsert_b:17]
+      │         └── CASE WHEN a:10 IS NULL THEN b_default:9 ELSE c:12 END [as=upsert_c:18]
+      └── projections
+           └── upsert_b:17 < upsert_c:18 [as=check1:19]
+
+# Only b is updated, but c must be read to check the constraint. Should fail
+# under read committed.
+build isolation=ReadCommitted
+INSERT INTO multi_col_fam_checks VALUES (5) ON CONFLICT (a) DO UPDATE SET b = 5
+----
+error (0A000): unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+
+# The same query should succeed under serializable isolation.
+build isolation=Serializable
+INSERT INTO multi_col_fam_checks VALUES (5) ON CONFLICT (a) DO UPDATE SET b = 5
+----
+upsert multi_col_fam_checks
+ ├── arbiter indexes: multi_col_fam_checks_pkey
+ ├── columns: <none>
+ ├── canary column: a:9
+ ├── fetch columns: a:9 b:10 c:11 d:12
+ ├── insert-mapping:
+ │    ├── column1:7 => a:1
+ │    ├── b_default:8 => b:2
+ │    ├── b_default:8 => c:3
+ │    └── b_default:8 => d:4
+ ├── update-mapping:
+ │    └── upsert_b:17 => b:2
+ ├── check columns: check1:20
+ └── project
+      ├── columns: check1:20 column1:7!null b_default:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14 b_new:15!null upsert_a:16 upsert_b:17 upsert_c:18 upsert_d:19
+      ├── project
+      │    ├── columns: upsert_a:16 upsert_b:17 upsert_c:18 upsert_d:19 column1:7!null b_default:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14 b_new:15!null
+      │    ├── project
+      │    │    ├── columns: b_new:15!null column1:7!null b_default:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:7!null b_default:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: column1:7!null b_default:8
+      │    │    │    │    ├── grouping columns: column1:7!null
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: b_default:8 column1:7!null
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:7!null
+      │    │    │    │    │    │    └── (5,)
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── NULL::INT8 [as=b_default:8]
+      │    │    │    │    └── aggregations
+      │    │    │    │         └── first-agg [as=b_default:8]
+      │    │    │    │              └── b_default:8
+      │    │    │    ├── scan multi_col_fam_checks
+      │    │    │    │    ├── columns: a:9!null b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── filters
+      │    │    │         └── column1:7 = a:9
+      │    │    └── projections
+      │    │         └── 5 [as=b_new:15]
+      │    └── projections
+      │         ├── CASE WHEN a:9 IS NULL THEN column1:7 ELSE a:9 END [as=upsert_a:16]
+      │         ├── CASE WHEN a:9 IS NULL THEN b_default:8 ELSE b_new:15 END [as=upsert_b:17]
+      │         ├── CASE WHEN a:9 IS NULL THEN b_default:8 ELSE c:11 END [as=upsert_c:18]
+      │         └── CASE WHEN a:9 IS NULL THEN b_default:8 ELSE d:12 END [as=upsert_d:19]
+      └── projections
+           └── upsert_b:17 < upsert_c:18 [as=check1:20]
+
+# Only c is updated, but b is read. Should fail under read committed.
+build isolation=ReadCommitted
+INSERT INTO multi_col_fam_checks SELECT a FROM multi_col_fam_checks WHERE b = 5
+ON CONFLICT (d) DO UPDATE SET c = 3
+----
+error (0A000): unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+
+# The same query should succeed under serializable isolation.
+build isolation=Serializable
+INSERT INTO multi_col_fam_checks SELECT a FROM multi_col_fam_checks WHERE b = 5
+ON CONFLICT (d) DO UPDATE SET c = 3
+----
+upsert multi_col_fam_checks
+ ├── arbiter indexes: multi_col_fam_checks_d_key
+ ├── columns: <none>
+ ├── canary column: a:14
+ ├── fetch columns: a:14 b:15 c:16 d:17
+ ├── insert-mapping:
+ │    ├── a:7 => a:1
+ │    ├── b_default:13 => b:2
+ │    ├── b_default:13 => c:3
+ │    └── b_default:13 => d:4
+ ├── update-mapping:
+ │    └── upsert_c:23 => c:3
+ ├── check columns: check1:25
+ └── project
+      ├── columns: check1:25 a:7!null b_default:13 a:14 b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 tableoid:19 c_new:20!null upsert_a:21 upsert_b:22 upsert_c:23 upsert_d:24
+      ├── project
+      │    ├── columns: upsert_a:21 upsert_b:22 upsert_c:23 upsert_d:24 a:7!null b_default:13 a:14 b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 tableoid:19 c_new:20!null
+      │    ├── project
+      │    │    ├── columns: c_new:20!null a:7!null b_default:13 a:14 b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: a:7!null b_default:13 a:14 b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: a:7!null b_default:13
+      │    │    │    │    ├── grouping columns: b_default:13
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: b_default:13 a:7!null
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: a:7!null
+      │    │    │    │    │    │    └── select
+      │    │    │    │    │    │         ├── columns: a:7!null b:8!null c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    │    │    │         ├── scan multi_col_fam_checks
+      │    │    │    │    │    │         │    └── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    │    │    │         └── filters
+      │    │    │    │    │    │              └── b:8 = 5
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── NULL::INT8 [as=b_default:13]
+      │    │    │    │    └── aggregations
+      │    │    │    │         └── first-agg [as=a:7]
+      │    │    │    │              └── a:7
+      │    │    │    ├── scan multi_col_fam_checks
+      │    │    │    │    ├── columns: a:14!null b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 tableoid:19
+      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── filters
+      │    │    │         └── b_default:13 = d:17
+      │    │    └── projections
+      │    │         └── 3 [as=c_new:20]
+      │    └── projections
+      │         ├── CASE WHEN a:14 IS NULL THEN a:7 ELSE a:14 END [as=upsert_a:21]
+      │         ├── CASE WHEN a:14 IS NULL THEN b_default:13 ELSE b:15 END [as=upsert_b:22]
+      │         ├── CASE WHEN a:14 IS NULL THEN b_default:13 ELSE c_new:20 END [as=upsert_c:23]
+      │         └── CASE WHEN a:14 IS NULL THEN b_default:13 ELSE d:17 END [as=upsert_d:24]
+      └── projections
+           └── upsert_b:22 < upsert_c:23 [as=check1:25]
+
+# Both b and c are updated, so this should succeed.
+build isolation=ReadCommitted
+INSERT INTO multi_col_fam_checks VALUES (1, 2, 3)
+ON CONFLICT (a, b) DO UPDATE SET b = 3, c = 4
+----
+upsert multi_col_fam_checks
+ ├── arbiter indexes: multi_col_fam_checks_a_b_key
+ ├── columns: <none>
+ ├── canary column: a:11
+ ├── fetch columns: a:11 b:12 c:13 d:14
+ ├── insert-mapping:
+ │    ├── column1:7 => a:1
+ │    ├── column2:8 => b:2
+ │    ├── column3:9 => c:3
+ │    └── d_default:10 => d:4
+ ├── update-mapping:
+ │    ├── upsert_b:20 => b:2
+ │    └── upsert_c:21 => c:3
+ ├── check columns: check1:23
+ └── project
+      ├── columns: check1:23!null column1:7!null column2:8!null column3:9!null d_default:10 a:11 b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16 b_new:17!null c_new:18!null upsert_a:19 upsert_b:20!null upsert_c:21!null upsert_d:22
+      ├── project
+      │    ├── columns: upsert_a:19 upsert_b:20!null upsert_c:21!null upsert_d:22 column1:7!null column2:8!null column3:9!null d_default:10 a:11 b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16 b_new:17!null c_new:18!null
+      │    ├── project
+      │    │    ├── columns: b_new:17!null c_new:18!null column1:7!null column2:8!null column3:9!null d_default:10 a:11 b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_default:10 a:11 b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null d_default:10
+      │    │    │    │    ├── grouping columns: column1:7!null column2:8!null
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: d_default:10 column1:7!null column2:8!null column3:9!null
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
+      │    │    │    │    │    │    └── (1, 2, 3)
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── NULL::INT8 [as=d_default:10]
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── first-agg [as=column3:9]
+      │    │    │    │         │    └── column3:9
+      │    │    │    │         └── first-agg [as=d_default:10]
+      │    │    │    │              └── d_default:10
+      │    │    │    ├── scan multi_col_fam_checks
+      │    │    │    │    ├── columns: a:11!null b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── filters
+      │    │    │         ├── column1:7 = a:11
+      │    │    │         └── column2:8 = b:12
+      │    │    └── projections
+      │    │         ├── 3 [as=b_new:17]
+      │    │         └── 4 [as=c_new:18]
+      │    └── projections
+      │         ├── CASE WHEN a:11 IS NULL THEN column1:7 ELSE a:11 END [as=upsert_a:19]
+      │         ├── CASE WHEN a:11 IS NULL THEN column2:8 ELSE b_new:17 END [as=upsert_b:20]
+      │         ├── CASE WHEN a:11 IS NULL THEN column3:9 ELSE c_new:18 END [as=upsert_c:21]
+      │         └── CASE WHEN a:11 IS NULL THEN d_default:10 ELSE d:14 END [as=upsert_d:22]
+      └── projections
+           └── upsert_b:20 < upsert_c:21 [as=check1:23]
+
+# Both b and c are updated, so this should succeed.
+build isolation=ReadCommitted
+INSERT INTO multi_col_fam_checks (a) VALUES (1)
+ON CONFLICT (a) DO UPDATE SET b = 3, c = 4, d = 5
+----
+upsert multi_col_fam_checks
+ ├── arbiter indexes: multi_col_fam_checks_pkey
+ ├── columns: <none>
+ ├── canary column: a:9
+ ├── fetch columns: a:9 b:10 c:11 d:12
+ ├── insert-mapping:
+ │    ├── column1:7 => a:1
+ │    ├── b_default:8 => b:2
+ │    ├── b_default:8 => c:3
+ │    └── b_default:8 => d:4
+ ├── update-mapping:
+ │    ├── upsert_b:19 => b:2
+ │    ├── upsert_c:20 => c:3
+ │    └── upsert_d:21 => d:4
+ ├── check columns: check1:22
+ └── project
+      ├── columns: check1:22 column1:7!null b_default:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14 b_new:15!null c_new:16!null d_new:17!null upsert_a:18 upsert_b:19 upsert_c:20 upsert_d:21
+      ├── project
+      │    ├── columns: upsert_a:18 upsert_b:19 upsert_c:20 upsert_d:21 column1:7!null b_default:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14 b_new:15!null c_new:16!null d_new:17!null
+      │    ├── project
+      │    │    ├── columns: b_new:15!null c_new:16!null d_new:17!null column1:7!null b_default:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:7!null b_default:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: column1:7!null b_default:8
+      │    │    │    │    ├── grouping columns: column1:7!null
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: b_default:8 column1:7!null
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:7!null
+      │    │    │    │    │    │    └── (1,)
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── NULL::INT8 [as=b_default:8]
+      │    │    │    │    └── aggregations
+      │    │    │    │         └── first-agg [as=b_default:8]
+      │    │    │    │              └── b_default:8
+      │    │    │    ├── scan multi_col_fam_checks
+      │    │    │    │    ├── columns: a:9!null b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── filters
+      │    │    │         └── column1:7 = a:9
+      │    │    └── projections
+      │    │         ├── 3 [as=b_new:15]
+      │    │         ├── 4 [as=c_new:16]
+      │    │         └── 5 [as=d_new:17]
+      │    └── projections
+      │         ├── CASE WHEN a:9 IS NULL THEN column1:7 ELSE a:9 END [as=upsert_a:18]
+      │         ├── CASE WHEN a:9 IS NULL THEN b_default:8 ELSE b_new:15 END [as=upsert_b:19]
+      │         ├── CASE WHEN a:9 IS NULL THEN b_default:8 ELSE c_new:16 END [as=upsert_c:20]
+      │         └── CASE WHEN a:9 IS NULL THEN b_default:8 ELSE d_new:17 END [as=upsert_d:21]
+      └── projections
+           └── upsert_b:19 < upsert_c:20 [as=check1:22]
+
+# Neither b nor c is updated, so this should succeed.
+build isolation=ReadCommitted
+INSERT INTO multi_col_fam_checks (a, b, c, d) VALUES (1, 2, 3, 4)
+ON CONFLICT (b, c) DO UPDATE SET a = 5
+----
+upsert multi_col_fam_checks
+ ├── arbiter indexes: multi_col_fam_checks_b_c_key
+ ├── columns: <none>
+ ├── canary column: a:11
+ ├── fetch columns: a:11 b:12 c:13 d:14
+ ├── insert-mapping:
+ │    ├── column1:7 => a:1
+ │    ├── column2:8 => b:2
+ │    ├── column3:9 => c:3
+ │    └── column4:10 => d:4
+ ├── update-mapping:
+ │    └── upsert_a:18 => a:1
+ ├── check columns: check1:22
+ └── project
+      ├── columns: check1:22 column1:7!null column2:8!null column3:9!null column4:10!null a:11 b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17!null upsert_a:18!null upsert_b:19 upsert_c:20 upsert_d:21
+      ├── project
+      │    ├── columns: upsert_a:18!null upsert_b:19 upsert_c:20 upsert_d:21 column1:7!null column2:8!null column3:9!null column4:10!null a:11 b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17!null
+      │    ├── project
+      │    │    ├── columns: a_new:17!null column1:7!null column2:8!null column3:9!null column4:10!null a:11 b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null a:11 b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
+      │    │    │    │    ├── grouping columns: column2:8!null column3:9!null
+      │    │    │    │    ├── values
+      │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
+      │    │    │    │    │    └── (1, 2, 3, 4)
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── first-agg [as=column1:7]
+      │    │    │    │         │    └── column1:7
+      │    │    │    │         └── first-agg [as=column4:10]
+      │    │    │    │              └── column4:10
+      │    │    │    ├── scan multi_col_fam_checks
+      │    │    │    │    ├── columns: a:11!null b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── filters
+      │    │    │         ├── column2:8 = b:12
+      │    │    │         └── column3:9 = c:13
+      │    │    └── projections
+      │    │         └── 5 [as=a_new:17]
+      │    └── projections
+      │         ├── CASE WHEN a:11 IS NULL THEN column1:7 ELSE a_new:17 END [as=upsert_a:18]
+      │         ├── CASE WHEN a:11 IS NULL THEN column2:8 ELSE b:12 END [as=upsert_b:19]
+      │         ├── CASE WHEN a:11 IS NULL THEN column3:9 ELSE c:13 END [as=upsert_c:20]
+      │         └── CASE WHEN a:11 IS NULL THEN column4:10 ELSE d:14 END [as=upsert_d:21]
+      └── projections
+           └── upsert_b:19 < upsert_c:20 [as=check1:22]
+
+# Neither b nor c is updated, so this should succeed.
+build isolation=ReadCommitted
+INSERT INTO multi_col_fam_checks (a) VALUES (1)
+ON CONFLICT (a) DO UPDATE SET d = 5
+----
+upsert multi_col_fam_checks
+ ├── arbiter indexes: multi_col_fam_checks_pkey
+ ├── columns: <none>
+ ├── canary column: a:9
+ ├── fetch columns: a:9 b:10 c:11 d:12
+ ├── insert-mapping:
+ │    ├── column1:7 => a:1
+ │    ├── b_default:8 => b:2
+ │    ├── b_default:8 => c:3
+ │    └── b_default:8 => d:4
+ ├── update-mapping:
+ │    └── upsert_d:19 => d:4
+ ├── check columns: check1:20
+ └── project
+      ├── columns: check1:20 column1:7!null b_default:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14 d_new:15!null upsert_a:16 upsert_b:17 upsert_c:18 upsert_d:19
+      ├── project
+      │    ├── columns: upsert_a:16 upsert_b:17 upsert_c:18 upsert_d:19 column1:7!null b_default:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14 d_new:15!null
+      │    ├── project
+      │    │    ├── columns: d_new:15!null column1:7!null b_default:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:7!null b_default:8 a:9 b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: column1:7!null b_default:8
+      │    │    │    │    ├── grouping columns: column1:7!null
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: b_default:8 column1:7!null
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:7!null
+      │    │    │    │    │    │    └── (1,)
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── NULL::INT8 [as=b_default:8]
+      │    │    │    │    └── aggregations
+      │    │    │    │         └── first-agg [as=b_default:8]
+      │    │    │    │              └── b_default:8
+      │    │    │    ├── scan multi_col_fam_checks
+      │    │    │    │    ├── columns: a:9!null b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── filters
+      │    │    │         └── column1:7 = a:9
+      │    │    └── projections
+      │    │         └── 5 [as=d_new:15]
+      │    └── projections
+      │         ├── CASE WHEN a:9 IS NULL THEN column1:7 ELSE a:9 END [as=upsert_a:16]
+      │         ├── CASE WHEN a:9 IS NULL THEN b_default:8 ELSE b:10 END [as=upsert_b:17]
+      │         ├── CASE WHEN a:9 IS NULL THEN b_default:8 ELSE c:11 END [as=upsert_c:18]
+      │         └── CASE WHEN a:9 IS NULL THEN b_default:8 ELSE d_new:15 END [as=upsert_d:19]
+      └── projections
+           └── upsert_b:17 < upsert_c:18 [as=check1:20]
+
 # ------------------------------------------------------------------------------
 # Test assignment casts.
 # ------------------------------------------------------------------------------

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -1245,6 +1245,36 @@ func (p *Partition) SetDatums(datums []tree.Datums) {
 	p.datums = datums
 }
 
+// CheckConstraint implements cat.CheckConstraint. See that interface
+// for more information on the fields.
+type CheckConstraint struct {
+	constraint     string
+	validated      bool
+	columnOrdinals []int
+}
+
+var _ cat.CheckConstraint = &CheckConstraint{}
+
+// Constraint is part of the cat.CheckConstraint interface.
+func (c *CheckConstraint) Constraint() string {
+	return c.constraint
+}
+
+// Validated is part of the cat.CheckConstraint interface.
+func (c *CheckConstraint) Validated() bool {
+	return c.validated
+}
+
+// ColumnCount is part of the cat.CheckConstraint interface.
+func (c *CheckConstraint) ColumnCount() int {
+	return len(c.columnOrdinals)
+}
+
+// ColumnOrdinal is part of the cat.CheckConstraint interface.
+func (c *CheckConstraint) ColumnOrdinal(i int) int {
+	return c.columnOrdinals[i]
+}
+
 // TableStat implements the cat.TableStatistic interface for testing purposes.
 type TableStat struct {
 	js            stats.JSONStatistic

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -772,7 +772,7 @@ type optTable struct {
 	// checkConstraints is the set of check constraints for this table. It
 	// can be different from desc's constraints because of synthesized
 	// constraints for user defined types.
-	checkConstraints []cat.CheckConstraint
+	checkConstraints []optCheckConstraint
 
 	// colMap is a mapping from unique ColumnID to column ordinal within the
 	// table. This is a common lookup that needs to be fast.
@@ -1040,7 +1040,7 @@ func newOptTable(
 	}
 
 	// Synthesize any check constraints for user defined types.
-	var synthesizedChecks []cat.CheckConstraint
+	var synthesizedChecks []optCheckConstraint
 	for i := 0; i < ot.ColumnCount(); i++ {
 		col := ot.Column(i)
 		if col.IsMutation() {
@@ -1057,20 +1057,29 @@ func newOptTable(
 					Left:     &tree.ColumnItem{ColumnName: col.ColName()},
 					Right:    tree.NewDTuple(colType, tree.MakeAllDEnumsInType(colType)...),
 				}
-				synthesizedChecks = append(synthesizedChecks, cat.CheckConstraint{
-					Constraint: tree.Serialize(expr),
-					Validated:  true,
+				synthesizedChecks = append(synthesizedChecks, optCheckConstraint{
+					constraint:  tree.Serialize(expr),
+					validated:   true,
+					columnCount: 1,
+					lookupColumnOrdinal: func(i int) (int, error) {
+						return col.Ordinal(), nil
+					},
 				})
 			}
 		}
 	}
 	// Move all existing and synthesized checks into the opt table.
 	activeChecks := desc.EnforcedCheckConstraints()
-	ot.checkConstraints = make([]cat.CheckConstraint, 0, len(activeChecks)+len(synthesizedChecks))
+	ot.checkConstraints = make([]optCheckConstraint, 0, len(activeChecks)+len(synthesizedChecks))
 	for i := range activeChecks {
-		ot.checkConstraints = append(ot.checkConstraints, cat.CheckConstraint{
-			Constraint: activeChecks[i].GetExpr(),
-			Validated:  activeChecks[i].GetConstraintValidity() == descpb.ConstraintValidity_Validated,
+		check := activeChecks[i]
+		ot.checkConstraints = append(ot.checkConstraints, optCheckConstraint{
+			constraint:  check.GetExpr(),
+			validated:   check.GetConstraintValidity() == descpb.ConstraintValidity_Validated,
+			columnCount: len(check.CheckDesc().ColumnIDs),
+			lookupColumnOrdinal: func(j int) (int, error) {
+				return ot.lookupColumnOrdinal(check.CheckDesc().ColumnIDs[j])
+			},
 		})
 	}
 	ot.checkConstraints = append(ot.checkConstraints, synthesizedChecks...)
@@ -1254,7 +1263,7 @@ func (ot *optTable) CheckCount() int {
 
 // Check is part of the cat.Table interface.
 func (ot *optTable) Check(i int) cat.CheckConstraint {
-	return ot.checkConstraints[i]
+	return &ot.checkConstraints[i]
 }
 
 // FamilyCount is part of the cat.Table interface.
@@ -1734,6 +1743,44 @@ func (op *optPartition) Zone() cat.Zone {
 // PartitionByListPrefixes is part of the cat.Partition interface.
 func (op *optPartition) PartitionByListPrefixes() []tree.Datums {
 	return op.datums
+}
+
+// optCheckConstraint implements cat.CheckConstraint. See that interface
+// for more information on the fields.
+type optCheckConstraint struct {
+	constraint  string
+	validated   bool
+	columnCount int
+
+	// lookupColumnOrdinal returns the table column ordinal of the ith column in
+	// this constraint.
+	lookupColumnOrdinal func(i int) (int, error)
+}
+
+var _ cat.CheckConstraint = &optCheckConstraint{}
+
+// Constraint is part of the cat.CheckConstraint interface.
+func (oc *optCheckConstraint) Constraint() string {
+	return oc.constraint
+}
+
+// Validated is part of the cat.CheckConstraint interface.
+func (oc *optCheckConstraint) Validated() bool {
+	return oc.validated
+}
+
+// ColumnCount is part of the cat.CheckConstraint interface.
+func (oc *optCheckConstraint) ColumnCount() int {
+	return oc.columnCount
+}
+
+// ColumnOrdinal is part of the cat.CheckConstraint interface.
+func (oc *optCheckConstraint) ColumnOrdinal(i int) int {
+	ord, err := oc.lookupColumnOrdinal(i)
+	if err != nil {
+		panic(err)
+	}
+	return ord
 }
 
 type optTableStat struct {
@@ -2288,9 +2335,13 @@ func (ot *optVirtualTable) CheckCount() int {
 // Check is part of the cat.Table interface.
 func (ot *optVirtualTable) Check(i int) cat.CheckConstraint {
 	check := ot.desc.EnforcedCheckConstraints()[i]
-	return cat.CheckConstraint{
-		Constraint: check.GetExpr(),
-		Validated:  check.GetConstraintValidity() == descpb.ConstraintValidity_Validated,
+	return &optCheckConstraint{
+		constraint:  check.GetExpr(),
+		validated:   check.GetConstraintValidity() == descpb.ConstraintValidity_Validated,
+		columnCount: len(check.CheckDesc().ColumnIDs),
+		lookupColumnOrdinal: func(j int) (int, error) {
+			return ot.lookupColumnOrdinal(check.CheckDesc().ColumnIDs[j])
+		},
 	}
 }
 


### PR DESCRIPTION
**opt, sql: add support for getting columns from cat.CheckConstraint**

This commit adds support for getting the columns referenced by a
`cat.CheckConstraint`. In order to make this possible, the struct has
been converted to an interface, and implementations have been added to
the `optCatalog` as well as the test catalog.

This feature will be needed in a following commit.

Release note: None

**opt: disallow multi-column-family checks in updates under read committed**

This commit adds logic to disallow `UPDATE`, `UPSERT`, and `INSERT ON CONFLICT`
queries in some cases when the mutated table has a check constraint with
columns from multiple column families. This is needed until we add logic
to take shared locks on unmodified column families in the constraint.

Specifically, these queries are disallowed when:
 - The check constraint involves a column family that is updated
   (otherwise we don't need to do anything to maintain this constraint)
 - And the check constraint involves a column family that is *not*
   updated, but *is* read. In this case we don't have an intent, so
   we need a lock. But we're not currently taking that lock.

Fixes https://github.com/cockroachdb/cockroach/issues/114605
Informs https://github.com/cockroachdb/cockroach/issues/112488

Release note (bug fix): `UPDATE`, `UPSERT`, and `INSERT ON CONFLICT` queries
are now disallowed under read committed isolation when the table contains
a check constraint involving a column family that is updated, and the
check constraint also involves a column family that is *not* updated,
but *is* read. This is a temporary fix to prevent possible violation of
the check constraint, and the restriction will be lifted in the future.

Co-authored-by: Michael Erickson <michae2@cockroachlabs.com>
