### PR TITLE
sql/catalog: remove egregious allocation

### DIFF
--- a/pkg/sql/catalog/descs/getters.go
+++ b/pkg/sql/catalog/descs/getters.go
@@ -402,34 +402,26 @@ func (g MutableByNameGetter) Type(
 
 func makeGetterBase(txn *kv.Txn, col *Collection, flags getterFlags) getterBase {
 	return getterBase{
-		txn:   &txnWrapper{Txn: txn, Collection: col},
-		flags: flags,
+		txnWrapper: txnWrapper{Txn: txn, Collection: col},
+		flags:      flags,
 	}
 }
 
 type getterBase struct {
-	txn
+	txnWrapper
 	flags getterFlags
 }
 
-type (
-	txn interface {
-		KV() *kv.Txn
-		Descriptors() *Collection
-	}
-	txnWrapper struct {
-		*kv.Txn
-		*Collection
-	}
-)
+type txnWrapper struct {
+	*kv.Txn
+	*Collection
+}
 
-var _ txn = &txnWrapper{}
-
-func (w *txnWrapper) KV() *kv.Txn {
+func (w txnWrapper) KV() *kv.Txn {
 	return w.Txn
 }
 
-func (w *txnWrapper) Descriptors() *Collection {
+func (w txnWrapper) Descriptors() *Collection {
 	return w.Collection
 }
 


### PR DESCRIPTION
We were shoving a struct into an interface that only had one implementation -- not even testing was using it. I happened to be looking at a cockroach profile for other reasons and I noticed this. There's some other low hanging fruit, but none as low as this.

```
name                  old time/op    new time/op    delta
KV/Scan/SQL/rows=1-3     179µs ± 6%     178µs ± 9%    ~     (p=0.518 n=25+30)

name                  old alloc/op   new alloc/op   delta
KV/Scan/SQL/rows=1-3    30.9kB ± 2%    30.7kB ± 1%  -0.40%  (p=0.028 n=28+29)

name                  old allocs/op  new allocs/op  delta
KV/Scan/SQL/rows=1-3       357 ± 3%       351 ± 2%  -1.78%  (p=0.000 n=30+27)
```

Epic: none

Release note: None