### PR TITLE
release-23.2.0-rc: importer: support arrays of UDT in some cases

### DIFF
--- a/pkg/cli/statement_bundle.go
+++ b/pkg/cli/statement_bundle.go
@@ -329,7 +329,7 @@ func getExplainCombinations(
 				}
 				upperBound := bucket["upper_bound"].(string)
 				bucketMap[key] = []string{upperBound}
-				datum, err := rowenc.ParseDatumStringAs(ctx, colType, upperBound, &evalCtx)
+				datum, err := rowenc.ParseDatumStringAs(ctx, colType, upperBound, &evalCtx, nil /* semaCtx */)
 				if err != nil {
 					panic("failed parsing datum string as " + datum.String() + " " + err.Error())
 				}

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -93,6 +93,7 @@ go_library(
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sqlerrors",
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/stats",
         "//pkg/sql/types",

--- a/pkg/sql/importer/import_type_resolver.go
+++ b/pkg/sql/importer/import_type_resolver.go
@@ -16,7 +16,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
@@ -24,36 +27,64 @@ import (
 
 type importTypeResolver struct {
 	typeIDToDesc   map[descpb.ID]*descpb.TypeDescriptor
-	typeNameToDesc map[string]*descpb.TypeDescriptor
+	typeNameToDesc map[string][]*descpb.TypeDescriptor
 }
 
-func newImportTypeResolver(typeDescs []*descpb.TypeDescriptor) importTypeResolver {
+var _ tree.TypeReferenceResolver = importTypeResolver{}
+var _ catalog.TypeDescriptorResolver = importTypeResolver{}
+
+func makeImportTypeResolver(typeDescs []*descpb.TypeDescriptor) importTypeResolver {
 	itr := importTypeResolver{
 		typeIDToDesc:   make(map[descpb.ID]*descpb.TypeDescriptor),
-		typeNameToDesc: make(map[string]*descpb.TypeDescriptor),
+		typeNameToDesc: make(map[string][]*descpb.TypeDescriptor),
 	}
 	for _, typeDesc := range typeDescs {
 		itr.typeIDToDesc[typeDesc.GetID()] = typeDesc
-		itr.typeNameToDesc[typeDesc.GetName()] = typeDesc
+		name := typeDesc.GetName()
+		itr.typeNameToDesc[name] = append(itr.typeNameToDesc[name], typeDesc)
 	}
 	return itr
 }
 
-var _ tree.TypeReferenceResolver = &importTypeResolver{}
-
+// ResolveType implements the tree.TypeReferenceResolver interface.
+//
+// We currently have an incomplete implementation of this method - namely, it
+// works whenever typeDescs are provided in makeImportTypeResolver (which is the
+// case when we're importing into exactly one table). In such a case, the type
+// resolution can be simplified to only look up into the provided types based on
+// the type's name (meaning we can avoid resolving the db and the schema names).
+//
+// Note that if a table happens to have multiple types with the same name (but
+// different schemas), this implementation will return a "feature unsupported"
+// error.
 func (i importTypeResolver) ResolveType(
-	_ context.Context, _ *tree.UnresolvedObjectName,
+	ctx context.Context, name *tree.UnresolvedObjectName,
 ) (*types.T, error) {
-	return nil, errors.New("importTypeResolver does not implement ResolveType")
+	var descs []*descpb.TypeDescriptor
+	var ok bool
+	if descs, ok = i.typeNameToDesc[name.Parts[0]]; !ok || len(descs) == 0 {
+		return nil, sqlerrors.NewUndefinedTypeError(name)
+	}
+	if len(descs) > 1 {
+		return nil, pgerror.New(
+			pgcode.FeatureNotSupported,
+			"tables with multiple user-defined types with the same name are currently unsupported",
+		)
+	}
+	typeDesc := typedesc.NewBuilder(descs[0]).BuildImmutableType()
+	t := typeDesc.AsTypesT()
+	if err := typedesc.EnsureTypeIsHydrated(ctx, t, i); err != nil {
+		return nil, err
+	}
+	return t, nil
 }
 
+// ResolveTypeByOID implements the tree.TypeReferenceResolver interface.
 func (i importTypeResolver) ResolveTypeByOID(ctx context.Context, oid oid.Oid) (*types.T, error) {
 	return typedesc.ResolveHydratedTByOID(ctx, oid, i)
 }
 
-var _ catalog.TypeDescriptorResolver = &importTypeResolver{}
-
-// GetTypeDescriptor implements the sqlbase.TypeDescriptorResolver interface.
+// GetTypeDescriptor implements the catalog.TypeDescriptorResolver interface.
 func (i importTypeResolver) GetTypeDescriptor(
 	_ context.Context, id descpb.ID,
 ) (tree.TypeName, catalog.TypeDescriptor, error) {

--- a/pkg/sql/importer/read_import_avro.go
+++ b/pkg/sql/importer/read_import_avro.go
@@ -73,7 +73,12 @@ func nativeTimeToDatum(t time.Time, targetT *types.T) (tree.Datum, error) {
 // the key is a primitive or logical Avro type name ("string",
 // "long.time-millis", etc).
 func nativeToDatum(
-	ctx context.Context, x interface{}, targetT *types.T, avroT []string, evalCtx *eval.Context,
+	ctx context.Context,
+	x interface{},
+	targetT *types.T,
+	avroT []string,
+	evalCtx *eval.Context,
+	semaCtx *tree.SemaContext,
 ) (tree.Datum, error) {
 	var d tree.Datum
 
@@ -111,19 +116,19 @@ func nativeToDatum(
 			// []byte arrays are hard.  Sometimes we want []bytes, sometimes
 			// we want StringFamily.  So, instead of creating DBytes datum,
 			// parse this data to "cast" it to our expected type.
-			return rowenc.ParseDatumStringAs(ctx, targetT, string(v), evalCtx)
+			return rowenc.ParseDatumStringAs(ctx, targetT, string(v), evalCtx, semaCtx)
 		}
 	case string:
 		// We allow strings to be specified for any column, as
 		// long as we can convert the string value to the target type.
-		return rowenc.ParseDatumStringAs(ctx, targetT, v, evalCtx)
+		return rowenc.ParseDatumStringAs(ctx, targetT, v, evalCtx, semaCtx)
 	case map[string]interface{}:
 		for _, aT := range avroT {
 			// The value passed in is an avro schema.  Extract
 			// possible primitive types from the dictionary and
 			// attempt to convert those values to our target type.
 			if val, ok := v[aT]; ok {
-				return nativeToDatum(ctx, val, targetT, avroT, evalCtx)
+				return nativeToDatum(ctx, val, targetT, avroT, evalCtx, semaCtx)
 			}
 		}
 	case []interface{}:
@@ -139,7 +144,7 @@ func nativeToDatum(
 		// Convert each element.
 		arr := tree.NewDArray(targetT.ArrayContents())
 		for _, elt := range v {
-			eltDatum, err := nativeToDatum(ctx, elt, targetT.ArrayContents(), eltAvroT, evalCtx)
+			eltDatum, err := nativeToDatum(ctx, elt, targetT.ArrayContents(), eltAvroT, evalCtx, semaCtx)
 			if err == nil {
 				err = arr.Append(eltDatum)
 			}
@@ -230,7 +235,7 @@ func (a *avroConsumer) convertNative(
 		if !ok {
 			return fmt.Errorf("cannot convert avro value %v to col %s", v, conv.VisibleCols[idx].GetType().Name())
 		}
-		datum, err := nativeToDatum(ctx, v, typ, avroT, conv.EvalCtx)
+		datum, err := nativeToDatum(ctx, v, typ, avroT, conv.EvalCtx, conv.SemaCtx)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -60,7 +60,7 @@ func runImport(
 
 	// Install type metadata in all of the import tables.
 	spec = protoutil.Clone(spec).(*execinfrapb.ReadImportDataSpec)
-	importResolver := newImportTypeResolver(spec.Types)
+	importResolver := makeImportTypeResolver(spec.Types)
 	for _, table := range spec.Tables {
 		cpy := tabledesc.NewBuilder(table.Desc).BuildCreatedMutableTable()
 		if err := typedesc.HydrateTypesInDescriptor(ctx, cpy, importResolver); err != nil {
@@ -493,7 +493,8 @@ func makeDatumConverter(
 ) (*row.DatumRowConverter, error) {
 	conv, err := row.NewDatumRowConverter(
 		ctx, importCtx.semaCtx, importCtx.tableDesc, importCtx.targetCols, importCtx.evalCtx,
-		importCtx.kvCh, importCtx.seqChunkProvider, nil /* metrics */, db)
+		importCtx.kvCh, importCtx.seqChunkProvider, nil /* metrics */, db,
+	)
 	if err == nil {
 		conv.KvBatch.Source = fileCtx.source
 	}

--- a/pkg/sql/importer/read_import_csv.go
+++ b/pkg/sql/importer/read_import_csv.go
@@ -219,7 +219,7 @@ func (c *csvRowConsumer) FillDatums(
 			conv.Datums[datumIdx] = tree.DNull
 		} else {
 			var err error
-			conv.Datums[datumIdx], err = rowenc.ParseDatumStringAs(ctx, conv.VisibleColTypes[i], field.Val, conv.EvalCtx)
+			conv.Datums[datumIdx], err = rowenc.ParseDatumStringAs(ctx, conv.VisibleColTypes[i], field.Val, conv.EvalCtx, conv.SemaCtx)
 			if err != nil {
 				// Fallback to parsing as a string literal. This allows us to support
 				// both array expressions (like `ARRAY[1, 2, 3]`) and literals (like

--- a/pkg/sql/importer/read_import_mysql_test.go
+++ b/pkg/sql/importer/read_import_mysql_test.go
@@ -374,7 +374,7 @@ func TestMysqlValueToDatum(t *testing.T) {
 	evalContext := eval.NewTestingEvalContext(st)
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("%v", tc.raw), func(t *testing.T) {
-			got, err := mysqlValueToDatum(context.Background(), tc.raw, tc.typ, evalContext)
+			got, err := mysqlValueToDatum(context.Background(), tc.raw, tc.typ, evalContext, nil /* semaCtx */)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/importer/read_import_pgcopy.go
+++ b/pkg/sql/importer/read_import_pgcopy.go
@@ -336,7 +336,7 @@ func (p *pgCopyConsumer) FillDatums(
 		if s == nil {
 			conv.Datums[i] = tree.DNull
 		} else {
-			conv.Datums[i], err = rowenc.ParseDatumStringAs(ctx, conv.VisibleColTypes[i], *s, conv.EvalCtx)
+			conv.Datums[i], err = rowenc.ParseDatumStringAs(ctx, conv.VisibleColTypes[i], *s, conv.EvalCtx, conv.SemaCtx)
 			if err != nil {
 				col := conv.VisibleCols[i]
 				return newImportRowError(errors.Wrapf(

--- a/pkg/sql/importer/read_import_pgdump.go
+++ b/pkg/sql/importer/read_import_pgdump.go
@@ -999,8 +999,10 @@ func newPgDumpReader(
 			for i, col := range tableDesc.VisibleColumns() {
 				colSubMap[col.GetName()] = i
 			}
-			conv, err := row.NewDatumRowConverter(ctx, semaCtx, tableDesc, targetCols, evalCtx, kvCh,
-				nil /* seqChunkProvider */, nil /* metrics */, db)
+			conv, err := row.NewDatumRowConverter(
+				ctx, semaCtx, tableDesc, targetCols, evalCtx, kvCh,
+				nil /* seqChunkProvider */, nil /* metrics */, db,
+			)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -1323,7 +1323,7 @@ func (ts *TableStat) Histogram() []cat.HistogramBucket {
 
 	for i := offset; i < len(ts.histogram); i++ {
 		bucket := &ts.js.HistogramBuckets[i-offset]
-		datum, err := rowenc.ParseDatumStringAs(context.Background(), colType, bucket.UpperBound, evalCtx)
+		datum, err := rowenc.ParseDatumStringAs(context.Background(), colType, bucket.UpperBound, evalCtx, nil /* semaCtx */)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sql/rowenc/roundtrip_format.go
+++ b/pkg/sql/rowenc/roundtrip_format.go
@@ -20,15 +20,19 @@ import (
 )
 
 // ParseDatumStringAs parses s as type t. This function is guaranteed to
-// round-trip when printing a Datum with FmtExport.
+// round-trip when printing a Datum with FmtExport. semaCtx is optional.
 func ParseDatumStringAs(
-	ctx context.Context, t *types.T, s string, evalCtx *eval.Context,
+	ctx context.Context, t *types.T, s string, evalCtx *eval.Context, semaCtx *tree.SemaContext,
 ) (tree.Datum, error) {
 	switch t.Family() {
-	// We use a different parser for array types because ParseAndRequireString only parses
-	// the internal postgres string representation of arrays.
+	// We use a different parser for array types because ParseAndRequireString
+	// only parses the internal postgres string representation of arrays.
 	case types.ArrayFamily, types.CollatedStringFamily:
-		return parseAsTyp(ctx, evalCtx, t, s)
+		if semaCtx == nil {
+			sema := tree.MakeSemaContext()
+			semaCtx = &sema
+		}
+		return parseAsTyp(ctx, evalCtx, semaCtx, t, s)
 	default:
 		res, _, err := tree.ParseAndRequireString(t, s, evalCtx)
 		return res, err
@@ -36,14 +40,13 @@ func ParseDatumStringAs(
 }
 
 func parseAsTyp(
-	ctx context.Context, evalCtx *eval.Context, typ *types.T, s string,
+	ctx context.Context, evalCtx *eval.Context, semaCtx *tree.SemaContext, typ *types.T, s string,
 ) (tree.Datum, error) {
 	expr, err := parser.ParseExpr(s)
 	if err != nil {
 		return nil, err
 	}
-	semaCtx := tree.MakeSemaContext()
-	typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, typ)
+	typedExpr, err := tree.TypeCheck(ctx, expr, semaCtx, typ)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rowenc/roundtrip_format_test.go
+++ b/pkg/sql/rowenc/roundtrip_format_test.go
@@ -98,7 +98,7 @@ func TestRandParseDatumStringAs(t *testing.T) {
 					t.Fatal(ds, err)
 				}
 
-				parsed, err := rowenc.ParseDatumStringAs(context.Background(), typ, ds, evalCtx)
+				parsed, err := rowenc.ParseDatumStringAs(context.Background(), typ, ds, evalCtx, nil /* semaCtx */)
 				if err != nil {
 					t.Fatal(ds, err)
 				}
@@ -294,7 +294,7 @@ func TestParseDatumStringAs(t *testing.T) {
 		t.Run(typ.String(), func(t *testing.T) {
 			for _, s := range exprs {
 				t.Run(fmt.Sprintf("%q", s), func(t *testing.T) {
-					d, err := rowenc.ParseDatumStringAs(context.Background(), typ, s, evalCtx)
+					d, err := rowenc.ParseDatumStringAs(context.Background(), typ, s, evalCtx, nil /* semaCtx */)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -302,7 +302,7 @@ func TestParseDatumStringAs(t *testing.T) {
 						t.Fatalf("unexpected type: %s", d.ResolvedType())
 					}
 					ds := tree.AsStringWithFlags(d, tree.FmtExport)
-					parsed, err := rowenc.ParseDatumStringAs(context.Background(), typ, ds, evalCtx)
+					parsed, err := rowenc.ParseDatumStringAs(context.Background(), typ, ds, evalCtx, nil /* semaCtx */)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/sql/stats/json.go
+++ b/pkg/sql/stats/json.go
@@ -150,7 +150,7 @@ func (js *JSONStatistic) GetHistogram(
 	h.Buckets = make([]HistogramData_Bucket, len(js.HistogramBuckets))
 	for i := range h.Buckets {
 		hb := &js.HistogramBuckets[i]
-		upperVal, err := rowenc.ParseDatumStringAs(ctx, colType, hb.UpperBound, evalCtx)
+		upperVal, err := rowenc.ParseDatumStringAs(ctx, colType, hb.UpperBound, evalCtx, semaCtx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Backport 1/1 commits from #115146.

/cc @cockroachdb/release

---

This commit adjusts the import code to support IMPORT INTO tables with columns typed as arrays of UDTs. This required a couple of minor changes:
- propagating the `SemaCtx` into `ParseDatumStringAs`. Previously, we would always create a fresh one, but now all callers of this method have been adjusted to provide the one they have in scope. This allows us to parse expressions of the form `'Monday'::db.sc.enum_name` where `'Monday'` is a member of an enum.
- implement `importTypeResolver.ResolveType` in the "happy" case. This is used to resolve casts from above to a concrete type.

Note that `ResolveType` implementation is incomplete in the general case. In particular, whenever an import job is created, we _might_ have a set of types available (it appears that this is the case when we're importing into one table - for example, we have logic for importing the whole pgdump, there we can have multiple tables, and set of types won't be available). Whenever we do have a set of types, we can simplify the type resolution to simply match on the name of the type.

However, if we happen to have a table that uses two UDTs with the same name but different schemas, this simplistic resolution won't work, so we still return an error in this case.

Fixes: #112100.

Release note (sql change): CockroachDB now supports IMPORT INTO a table that has columns typed as arrays of user-defined types (like enums). Tables that uses multiple user-defined types with the same name but different schemas are still unsupported.

Release justification: low-risk improvement.