### PR TITLE
testserver: set defaults on shared-process tenant before starting it

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1368,6 +1368,10 @@ func (ts *testServer) StartSharedProcessTenant(
 		}
 	}
 
+	if err = ts.grantDefaultTenantCapabilities(ctx, tenantID, args.SkipTenantCheck); err != nil {
+		return nil, nil, err
+	}
+
 	// Also mark it for shared-process execution.
 	err = execSQL(
 		"start-tenant-shared-service",
@@ -1408,10 +1412,6 @@ func (ts *testServer) StartSharedProcessTenant(
 		pgL:            sqlServerWrapper.loopbackPgL,
 		httpTestServer: hts,
 		drain:          sqlServerWrapper.drainServer,
-	}
-
-	if err = ts.grantDefaultTenantCapabilities(ctx, tenantID, args.SkipTenantCheck); err != nil {
-		return nil, nil, err
 	}
 
 	sqlDB, err := ts.SQLConnE(serverutils.DBName("cluster:" + string(args.TenantName) + "/" + args.UseDatabase))


### PR DESCRIPTION
This commit makes it so that we grant the default tenant capabilities (which includes overriding some cluster settings) _before_ we start the shared-process tenant server. This makes it more similar to what we do in the external-process mode and should - hopefully - prevent a race between the cluster setting update picked up by the tenant setting watcher and the test relying on the updated cluster setting value.

Fixes: #116260.

Release note: None