### PR TITLE
regionliveness: detect if the region enum is not public

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -214,7 +214,7 @@ SELECT enum_last('c'::build)
 ----
 f
 
-statement error pq: enum value \"g\" is not yet public
+statement error  pq: cannot use enum value \"g\": enum value is not yet public
 INSERT INTO new_enum_values VALUES ('g')
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1733,7 +1733,7 @@ statement ok
 ALTER TYPE greeting ADD VALUE 'salud' AFTER 'hello'
 
 # The insert should fail but with awareness that 'salud' is an enum type.
-statement error pq: enum value "salud" is not yet public
+statement error pq: cannot use enum value \"salud\": enum value is not yet public
 INSERT INTO tab2 VALUES ('salud')
 
 statement ok

--- a/pkg/sql/regionliveness/BUILD.bazel
+++ b/pkg/sql/regionliveness/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlliveness/slinstance",
+        "//pkg/sql/types",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/sql/regionliveness/prober.go
+++ b/pkg/sql/regionliveness/prober.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
@@ -218,5 +219,6 @@ func IsQueryTimeoutErr(err error) bool {
 // IsMissingRegionEnumErr determines if a query hit an error because of a missing
 // because of the region enum.
 func IsMissingRegionEnumErr(err error) bool {
-	return pgerror.GetPGCode(err) == pgcode.InvalidTextRepresentation
+	return pgerror.GetPGCode(err) == pgcode.InvalidTextRepresentation ||
+		errors.Is(err, types.EnumValueNotYetPublicError)
 }

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2705,6 +2705,9 @@ func (t *T) EnumGetIdxOfPhysical(phys []byte) (int, error) {
 	return 0, err
 }
 
+// EnumValueNotYetPublicError enum value is not public yet.
+var EnumValueNotYetPublicError = errors.New("enum value is not yet public")
+
 // EnumGetIdxOfLogical returns the index within the TypeMeta's slice of
 // enum logical representations that matches the input string.
 func (t *T) EnumGetIdxOfLogical(logical string) (int, error) {
@@ -2717,7 +2720,7 @@ func (t *T) EnumGetIdxOfLogical(logical string) (int, error) {
 			// written until all nodes in the cluster are able to decode the
 			// physical representation.
 			if t.TypeMeta.EnumData.IsMemberReadOnly[i] {
-				return 0, errors.Newf("enum value %q is not yet public", logical)
+				return 0, errors.WithMessagef(EnumValueNotYetPublicError, "cannot use enum value %q", logical)
 			}
 			return i, nil
 		}


### PR DESCRIPTION
Previously, the regionlivneess used a cached set of region descriptor
that could be stale for a given txn time. This works fine in most cases,
but if the region is going through a mutation we can either have queries
with a syntax error or an error for the enum value not being public,
where the second error was not handled. This patch will address this by
ignoring errors related to an enum not being public.

Fixes: #116309

Release note: None