### PR TITLE
ui: default to descending hot ranges order

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/hotRanges.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/hotRanges.ts
@@ -49,5 +49,5 @@ export const isLoadingSelector = createSelector(
 export const sortSettingLocalSetting = new LocalSetting(
   "sortSetting/hotRanges",
   localSettingsSelector,
-  { ascending: true, columnTitle: "qps" },
+  { ascending: false, columnTitle: "qps" },
 );


### PR DESCRIPTION
The hot ranges page default sort setting changed from descending to ascending in b06b6f0a. Change it back to descending, so that the hottest ranges appear first by default.

Epic: none
Release note: None