### PR TITLE
roachtest: report failures to extend cluster as infra flakes

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2695,9 +2695,9 @@ func (c *clusterImpl) DestroyDNS(ctx context.Context, l *logger.Logger) error {
 // test plus enough headroom after the test finishes so that the next test
 // can be selected. If it doesn't, extend it.
 func (c *clusterImpl) MaybeExtendCluster(
-	ctx context.Context, l *logger.Logger, testSpec registry.TestSpec,
+	ctx context.Context, l *logger.Logger, testSpec *registry.TestSpec,
 ) error {
-	timeout := testTimeout(&testSpec)
+	timeout := testTimeout(testSpec)
 	minExp := timeutil.Now().Add(timeout + time.Hour)
 	if c.expiration.Before(minExp) {
 		extend := minExp.Sub(c.expiration)

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -574,16 +574,11 @@ func (r *testRunner) runWorker(
 			// Try to reuse cluster.
 			testToRun = work.selectTestForCluster(ctx, c.spec, r.cr)
 			if !testToRun.noWork {
-				var err error
 				// We found a test to run on this cluster. Wipe the cluster.
-				if err = c.WipeForReuse(ctx, l, testToRun.spec.Cluster); err == nil {
-					// Extend the lifetime of the cluster if needed.
-					err = c.MaybeExtendCluster(ctx, l, testToRun.spec)
-				}
-				// We do not count reuse attempt error toward clusterCreateErr. If
-				// either the Wipe or Extend failed, then destroy the cluster and attempt
-				// to create a fresh cluster for the selected test.
-				if err != nil {
+				if err := c.WipeForReuse(ctx, l, testToRun.spec.Cluster); err != nil {
+					// We do not count reuse attempt error toward clusterCreateErr. If
+					// either the Wipe or Extend failed, then destroy the cluster and attempt
+					// to create a fresh cluster for the selected test.
 					shout(ctx, l, stdout, "Unable to reuse cluster: %s due to: %s. Will attempt to create a fresh one",
 						c.Name(), err)
 					// We don't release the quota allocation - the new cluster will be
@@ -809,32 +804,20 @@ func (r *testRunner) runWorker(
 				wStatus.SetTest(t, testToRun)
 				wStatus.SetStatus("running test")
 
-				err = r.runTest(ctx, t, testToRun.runNum, testToRun.runCount, c, stdout, testL, github)
+				r.runTest(ctx, t, testToRun.runNum, testToRun.runCount, c, stdout, testL, github)
 			}
 		}
 
-		if err != nil {
-			shout(ctx, l, stdout, "test returned error: %s: %s", t.Name(), err)
-			// Mark the test as failed if it isn't already.
-			if !t.Failed() {
-				t.Error(err)
-			}
-		} else {
-			msg := "test passed: %s (run %d)"
-			if t.Failed() {
-				msg = "test failed: %s (run %d)"
-			}
-			msg = fmt.Sprintf(msg, t.Name(), testToRun.runNum)
-			l.PrintfCtx(ctx, msg)
+		msg := "test passed: %s (run %d)"
+		if t.Failed() {
+			msg = "test failed: %s (run %d)"
 		}
+		msg = fmt.Sprintf(msg, t.Name(), testToRun.runNum)
+		l.PrintfCtx(ctx, msg)
+
 		testL.Close()
-		if err != nil || t.Failed() {
-			failureMsg := fmt.Sprintf("%s (%d) - ", testToRun.spec.Name, testToRun.runNum)
-			if err != nil {
-				failureMsg += fmt.Sprintf("%+v", err)
-			} else {
-				failureMsg += t.failureMsg()
-			}
+		if t.Failed() {
+			failureMsg := fmt.Sprintf("%s (%d) - %s", testToRun.spec.Name, testToRun.runNum, t.failureMsg())
 			if c != nil {
 				switch clustersOpt.debugMode {
 				case DebugKeepAlways, DebugKeepOnFailure:
@@ -850,10 +833,6 @@ func (r *testRunner) runWorker(
 					c.Destroy(context.Background(), closeLogger, l)
 					c = nil
 				}
-			}
-			if err != nil {
-				// N.B. bail out iff runTest exits exceptionally.
-				return err
 			}
 		} else {
 			// Upon success fetch the perf artifacts from the remote hosts.
@@ -948,8 +927,7 @@ func (r *testRunner) runTest(
 	stdout io.Writer,
 	l *logger.Logger,
 	github *githubIssues,
-) error {
-
+) {
 	testRunID := t.Name()
 	if runCount > 1 {
 		testRunID += fmt.Sprintf("#%d", runNum)
@@ -1086,6 +1064,12 @@ func (r *testRunner) runTest(
 
 	t.start = timeutil.Now()
 
+	// Extend the lifetime of the cluster if needed.
+	if err := c.MaybeExtendCluster(ctx, l, t.spec); err != nil {
+		t.Error(errors.Mark(err, errClusterProvisioningFailed))
+		return
+	}
+
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	t.mu.Lock()
@@ -1177,7 +1161,6 @@ func (r *testRunner) runTest(
 	if err := r.teardownTest(ctx, t, c, timedOut); err != nil {
 		l.Printf("error during test teardown: %v; see test-teardown.log for details", err)
 	}
-	return nil
 }
 
 // getPreemptedVMNames returns a comma separated list of preempted VM names - if any.


### PR DESCRIPTION
This commit introduces two main changes:

* always verify if we need to extend a cluster's lifetime before running a test, whether the cluster is being reused or not;
* if we fail to extend the cluster's lifetime, report the error as an infrastructure flake (cluster creation error). Crucially, don't return an error to the worker (which would halt the entire run), and don't notify teams about the failure.

Fixes: #115950.

Release note: None