### PR TITLE
release-23.2.0-rc: ccl: dev gen bazel to update BUILD.bazel

### DIFF
--- a/pkg/ccl/logictestccl/tests/local/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local/BUILD.bazel
@@ -13,7 +13,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"Pool": "large"},
-    shard_count = 29,
+    shard_count = 30,
     tags = [
         "ccl_test",
         "cpu:1",


### PR DESCRIPTION
Fixes tip of release-23.2.0-rc (currently at 51fbd81, from https://github.com/cockroachdb/cockroach/pull/116343)

Epic: None
Release note: Note
Release justification: test-only fix