### PR TITLE
opt: add session setting for disabling merge joins

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3248,6 +3248,10 @@ func (m *sessionDataMutator) SetOptimizerUseNotVisibleIndexes(val bool) {
 	m.data.OptimizerUseNotVisibleIndexes = val
 }
 
+func (m *sessionDataMutator) SetOptimizerMergeJoinsEnabled(val bool) {
+	m.data.OptimizerMergeJoinsEnabled = val
+}
+
 func (m *sessionDataMutator) SetLocalityOptimizedSearch(val bool) {
 	m.data.LocalityOptimizedSearch = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5570,6 +5570,7 @@ opt_split_scan_limit                                       2048
 optimizer                                                  on
 optimizer_always_use_histograms                            on
 optimizer_hoist_uncorrelated_equality_subqueries           on
+optimizer_merge_joins_enabled                              on
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2883,6 +2883,7 @@ on_update_rehome_row_enabled                               on                  N
 opt_split_scan_limit                                       2048                NULL      NULL        NULL        string
 optimizer_always_use_histograms                            on                  NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL      NULL        NULL        string
+optimizer_merge_joins_enabled                              on                  NULL      NULL        NULL        string
 optimizer_use_forecasts                                    on                  NULL      NULL        NULL        string
 optimizer_use_histograms                                   on                  NULL      NULL        NULL        string
 optimizer_use_improved_computed_column_filters_derivation  on                  NULL      NULL        NULL        string
@@ -3055,6 +3056,7 @@ on_update_rehome_row_enabled                               on                  N
 opt_split_scan_limit                                       2048                NULL  user     NULL      2048                2048
 optimizer_always_use_histograms                            on                  NULL  user     NULL      on                  on
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL  user     NULL      on                  on
+optimizer_merge_joins_enabled                              on                  NULL  user     NULL      on                  on
 optimizer_use_forecasts                                    on                  NULL  user     NULL      on                  on
 optimizer_use_histograms                                   on                  NULL  user     NULL      on                  on
 optimizer_use_improved_computed_column_filters_derivation  on                  NULL  user     NULL      on                  on
@@ -3226,6 +3228,7 @@ opt_split_scan_limit                                       NULL    NULL     NULL
 optimizer                                                  NULL    NULL     NULL     NULL        NULL
 optimizer_always_use_histograms                            NULL    NULL     NULL     NULL        NULL
 optimizer_hoist_uncorrelated_equality_subqueries           NULL    NULL     NULL     NULL        NULL
+optimizer_merge_joins_enabled                              NULL    NULL     NULL     NULL        NULL
 optimizer_use_forecasts                                    NULL    NULL     NULL     NULL        NULL
 optimizer_use_histograms                                   NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_computed_column_filters_derivation  NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -121,6 +121,7 @@ on_update_rehome_row_enabled                               on
 opt_split_scan_limit                                       2048
 optimizer_always_use_histograms                            on
 optimizer_hoist_uncorrelated_equality_subqueries           on
+optimizer_merge_joins_enabled                              on
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  on

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -174,6 +174,7 @@ type Memo struct {
 	sharedLockingForSerializable               bool
 	useLockOpForSerializable                   bool
 	useProvidedOrderingFix                     bool
+	mergeJoinsEnabled                          bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -246,6 +247,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		sharedLockingForSerializable:               evalCtx.SessionData().SharedLockingForSerializable,
 		useLockOpForSerializable:                   evalCtx.SessionData().OptimizerUseLockOpForSerializable,
 		useProvidedOrderingFix:                     evalCtx.SessionData().OptimizerUseProvidedOrderingFix,
+		mergeJoinsEnabled:                          evalCtx.SessionData().OptimizerMergeJoinsEnabled,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -392,6 +394,7 @@ func (m *Memo) IsStale(
 		m.sharedLockingForSerializable != evalCtx.SessionData().SharedLockingForSerializable ||
 		m.useLockOpForSerializable != evalCtx.SessionData().OptimizerUseLockOpForSerializable ||
 		m.useProvidedOrderingFix != evalCtx.SessionData().OptimizerUseProvidedOrderingFix ||
+		m.mergeJoinsEnabled != evalCtx.SessionData().OptimizerMergeJoinsEnabled ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -424,6 +424,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerUseProvidedOrderingFix = false
 	notStale()
 
+	// Stale optimizer_merge_joins_enabled.
+	evalCtx.SessionData().OptimizerMergeJoinsEnabled = true
+	stale()
+	evalCtx.SessionData().OptimizerMergeJoinsEnabled = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -87,6 +87,7 @@ func TestCopyAndReplace(t *testing.T) {
 	}
 
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	evalCtx.SessionData().OptimizerMergeJoinsEnabled = true
 
 	var o xform.Optimizer
 	testutils.BuildQuery(t, &o, cat, &evalCtx, "SELECT * FROM cde INNER JOIN ab ON a=c AND d=$1")

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -308,6 +308,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	ot.evalCtx.SessionData().OptimizerUseImprovedComputedColumnFiltersDerivation = true
 	ot.evalCtx.SessionData().OptimizerUseImprovedJoinElimination = true
 	ot.evalCtx.SessionData().OptimizerUseProvidedOrderingFix = true
+	ot.evalCtx.SessionData().OptimizerMergeJoinsEnabled = true
 
 	return ot
 }

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -39,7 +39,8 @@ func (c *CustomFuncs) GenerateMergeJoins(
 	on memo.FiltersExpr,
 	joinPrivate *memo.JoinPrivate,
 ) {
-	if joinPrivate.Flags.Has(memo.DisallowMergeJoin) {
+	if joinPrivate.Flags.Has(memo.DisallowMergeJoin) ||
+		!c.e.evalCtx.SessionData().OptimizerMergeJoinsEnabled {
 		return
 	}
 

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1862,6 +1862,29 @@ memo (optimized, ~11KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G6: (variable a)
  └── G7: (variable x)
 
+# Do not generate merge joins if optimizer_merge_joins_enabled is false.
+memo set=(optimizer_merge_joins_enabled=false) expect-not=GenerateMergeJoins
+SELECT * FROM abc JOIN xyz ON a=x
+----
+memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+ ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,7-9)) (lookup-join G3 G5 abc@ab,keyCols=[7],outCols=(1-3,7-9))
+ │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
+ │         ├── best: (inner-join G3 G2 G4)
+ │         └── cost: 1249.71
+ ├── G2: (scan abc,cols=(1-3)) (scan abc@ab,cols=(1-3)) (scan abc@bc,cols=(1-3))
+ │    └── []
+ │         ├── best: (scan abc,cols=(1-3))
+ │         └── cost: 135.72
+ ├── G3: (scan xyz,cols=(7-9)) (scan xyz@xy,cols=(7-9)) (scan xyz@yz,cols=(7-9))
+ │    └── []
+ │         ├── best: (scan xyz,cols=(7-9))
+ │         └── cost: 1098.72
+ ├── G4: (filters G6)
+ ├── G5: (filters)
+ ├── G6: (eq G7 G8)
+ ├── G7: (variable a)
+ └── G8: (variable x)
+
 opt
 SELECT * FROM abc JOIN xyz ON x=a
 ----

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -472,6 +472,10 @@ message LocalOnlySessionData {
   // CopyWritePipeliningEnabled indicates whether the write pipelining is
   // enabled for implicit txns used by COPY.
   bool copy_write_pipelining_enabled = 118;
+  // OptimizerMergeJoinsEnabled, when true, instructs the optimizer to explore
+  // query plans with merge joins. When false, the optimizer does not attempt
+  // to plan merge joins.
+  bool optimizer_merge_joins_enabled = 119;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -861,6 +861,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`optimizer_merge_joins_enabled`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_merge_joins_enabled`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_merge_joins_enabled", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerMergeJoinsEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerMergeJoinsEnabled), nil
+		},
+		GlobalDefault: globalTrue,
+	},
+
+	// CockroachDB extension.
 	`locality_optimized_partitioned_index_scan`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`locality_optimized_partitioned_index_scan`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {


### PR DESCRIPTION
Fixes #116085

Release note (sql change): A new session setting,
`optimizer_merge_joins_enabled`, has been added that, when true,
instructs the optimizer to explore query plans with merge joins. The
setting defaults to true.
