### PR TITLE
release-23.1: storage: improve mvcc benchmarks under -short

### DIFF
--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -75,138 +75,231 @@ func setupPebbleInMemPebbleForLatestRelease(b testing.TB, _ string) Engine {
 }
 
 func BenchmarkMVCCScan_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		numRows      int
+		numVersions  int
+		valueSize    int
+		numRangeKeys int
+	}
+	var testCases []testCase
 	for _, numRows := range []int{1, 10, 100, 1000, 10000, 50000} {
-		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
-			for _, numVersions := range []int{1, 2, 10, 100, 1000} {
-				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
-					for _, valueSize := range []int{8, 64, 512} {
-						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-							for _, numRangeKeys := range []int{0, 1, 100} {
-								b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-									runMVCCScan(ctx, b, benchScanOptions{
-										mvccBenchData: mvccBenchData{
-											numVersions:  numVersions,
-											valueBytes:   valueSize,
-											numRangeKeys: numRangeKeys,
-										},
-										numRows: numRows,
-										reverse: false,
-									})
-								})
-							}
-						})
-					}
-				})
+		for _, numVersions := range []int{1, 2, 10, 100, 1000} {
+			for _, valueSize := range []int{8, 64, 512} {
+				for _, numRangeKeys := range []int{0, 1, 100} {
+					testCases = append(testCases, testCase{
+						numRows:      numRows,
+						numVersions:  numVersions,
+						valueSize:    valueSize,
+						numRangeKeys: numRangeKeys,
+					})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{numRows: 1, numVersions: 1, valueSize: 8, numRangeKeys: 0},
+			{numRows: 100, numVersions: 2, valueSize: 64, numRangeKeys: 1},
+			{numRows: 1000, numVersions: 10, valueSize: 64, numRangeKeys: 100},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"rows=%d/versions=%d/valueSize=%d/numRangeKeys=%d",
+			tc.numRows, tc.numVersions, tc.valueSize, tc.numRangeKeys,
+		)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCScan(ctx, b, benchScanOptions{
+				mvccBenchData: mvccBenchData{
+					numVersions:  tc.numVersions,
+					valueBytes:   tc.valueSize,
+					numRangeKeys: tc.numRangeKeys,
+				},
+				numRows: tc.numRows,
+				reverse: false,
+			})
 		})
 	}
 }
 
 func BenchmarkMVCCScanGarbage_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		numRows      int
+		numVersions  int
+		numRangeKeys int
+		tombstones   bool
+	}
+	var testCases []testCase
 	for _, numRows := range []int{1, 10, 100, 1000, 10000, 50000} {
-		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
-			for _, numVersions := range []int{1, 2, 10, 100, 1000} {
-				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
-					for _, numRangeKeys := range []int{0, 1, 100} {
-						b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-							for _, tombstones := range []bool{false, true} {
-								b.Run(fmt.Sprintf("tombstones=%t", tombstones), func(b *testing.B) {
-									runMVCCScan(ctx, b, benchScanOptions{
-										mvccBenchData: mvccBenchData{
-											numVersions:  numVersions,
-											numRangeKeys: numRangeKeys,
-											garbage:      true,
-										},
-										numRows:    numRows,
-										tombstones: tombstones,
-										reverse:    false,
-									})
-								})
-							}
-						})
-					}
-				})
+		for _, numVersions := range []int{1, 2, 10, 100, 1000} {
+			for _, numRangeKeys := range []int{0, 1, 100} {
+				for _, tombstones := range []bool{false, true} {
+					testCases = append(testCases, testCase{
+						numRows:      numRows,
+						numVersions:  numVersions,
+						numRangeKeys: numRangeKeys,
+						tombstones:   tombstones,
+					})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{numRows: 1, numVersions: 1, numRangeKeys: 0, tombstones: false},
+			{numRows: 10, numVersions: 2, numRangeKeys: 1, tombstones: true},
+			{numRows: 1000, numVersions: 10, numRangeKeys: 100, tombstones: true},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"rows=%d/versions=%d/numRangeKeys=%d/tombstones=%t",
+			tc.numRows, tc.numVersions, tc.numRangeKeys, tc.tombstones,
+		)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCScan(ctx, b, benchScanOptions{
+				mvccBenchData: mvccBenchData{
+					numVersions:  tc.numVersions,
+					numRangeKeys: tc.numRangeKeys,
+					garbage:      true,
+				},
+				numRows:    tc.numRows,
+				tombstones: tc.tombstones,
+				reverse:    false,
+			})
 		})
 	}
 }
 
 func BenchmarkMVCCScanSQLRows_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		numRows           int
+		numColumnFamilies int
+		numVersions       int
+		valueSize         int
+		wholeRows         bool
+	}
+	var testCases []testCase
 	for _, numRows := range []int{1, 10, 100, 1000, 10000} {
-		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
-			for _, numColumnFamilies := range []int{1, 3, 10} {
-				b.Run(fmt.Sprintf("columnFamilies=%d", numColumnFamilies), func(b *testing.B) {
-					for _, numVersions := range []int{1} {
-						b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
-							for _, valueSize := range []int{8, 64, 512} {
-								b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-									for _, wholeRows := range []bool{false, true} {
-										b.Run(fmt.Sprintf("wholeRows=%t", wholeRows), func(b *testing.B) {
-											runMVCCScan(ctx, b, benchScanOptions{
-												mvccBenchData: mvccBenchData{
-													numColumnFamilies: numColumnFamilies,
-													numVersions:       numVersions,
-													valueBytes:        valueSize,
-												},
-												numRows:   numRows,
-												reverse:   false,
-												wholeRows: wholeRows,
-											})
-										})
-									}
-								})
-							}
+		for _, numColumnFamilies := range []int{1, 3, 10} {
+			for _, numVersions := range []int{1} {
+				for _, valueSize := range []int{8, 64, 512} {
+					for _, wholeRows := range []bool{false, true} {
+						testCases = append(testCases, testCase{
+							numRows:           numRows,
+							numColumnFamilies: numColumnFamilies,
+							numVersions:       numVersions,
+							valueSize:         valueSize,
+							wholeRows:         wholeRows,
 						})
 					}
-				})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{numRows: 1, numColumnFamilies: 1, numVersions: 1, valueSize: 8, wholeRows: false},
+			{numRows: 100, numColumnFamilies: 10, numVersions: 1, valueSize: 8, wholeRows: true},
+			{numRows: 1000, numColumnFamilies: 3, numVersions: 1, valueSize: 64, wholeRows: true},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"rows=%d/columnFamillies=%d/versions=%d/valueSize=%d/wholeRows=%t",
+			tc.numRows, tc.numColumnFamilies, tc.numVersions, tc.valueSize, tc.wholeRows,
+		)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCScan(ctx, b, benchScanOptions{
+				mvccBenchData: mvccBenchData{
+					numColumnFamilies: tc.numColumnFamilies,
+					numVersions:       tc.numVersions,
+					valueBytes:        tc.valueSize,
+				},
+				numRows:   tc.numRows,
+				reverse:   false,
+				wholeRows: tc.wholeRows,
+			})
 		})
 	}
 }
 
 func BenchmarkMVCCReverseScan_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		numRows      int
+		numVersions  int
+		valueSize    int
+		numRangeKeys int
+	}
+	var testCases []testCase
 	for _, numRows := range []int{1, 10, 100, 1000, 10000, 50000} {
-		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
-			for _, numVersions := range []int{1, 2, 10, 100, 1000} {
-				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
-					for _, valueSize := range []int{8, 64, 512} {
-						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-							for _, numRangeKeys := range []int{0, 1, 100} {
-								b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-									runMVCCScan(ctx, b, benchScanOptions{
-										mvccBenchData: mvccBenchData{
-											numVersions:  numVersions,
-											valueBytes:   valueSize,
-											numRangeKeys: numRangeKeys,
-										},
-										numRows: numRows,
-										reverse: true,
-									})
-								})
-							}
-						})
-					}
-				})
+		for _, numVersions := range []int{1, 2, 10, 100, 1000} {
+			for _, valueSize := range []int{8, 64, 512} {
+				for _, numRangeKeys := range []int{0, 1, 100} {
+					testCases = append(testCases, testCase{
+						numRows:      numRows,
+						numVersions:  numVersions,
+						valueSize:    valueSize,
+						numRangeKeys: numRangeKeys,
+					})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{numRows: 1, numVersions: 1, valueSize: 8, numRangeKeys: 0},
+			{numRows: 100, numVersions: 1, valueSize: 8, numRangeKeys: 1},
+			{numRows: 1000, numVersions: 2, valueSize: 64, numRangeKeys: 100},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"rows=%d/versions=%d/valueSize=%d/numRangeKeys=%d",
+			tc.numRows, tc.numVersions, tc.valueSize, tc.numRangeKeys,
+		)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCScan(ctx, b, benchScanOptions{
+				mvccBenchData: mvccBenchData{
+					numVersions:  tc.numVersions,
+					valueBytes:   tc.valueSize,
+					numRangeKeys: tc.numRangeKeys,
+				},
+				numRows: tc.numRows,
+				reverse: true,
+			})
 		})
 	}
 }
 
 func BenchmarkMVCCScanTransactionalData_Pebble(b *testing.B) {
-	ctx := context.Background()
 	defer log.Scope(b).Close(b)
+
+	ctx := context.Background()
 	runMVCCScan(ctx, b, benchScanOptions{
 		numRows: 10000,
 		mvccBenchData: mvccBenchData{
@@ -218,52 +311,97 @@ func BenchmarkMVCCScanTransactionalData_Pebble(b *testing.B) {
 }
 
 func BenchmarkMVCCGet_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		batch        bool
+		numVersions  int
+		valueSize    int
+		numRangeKeys int
+	}
+	var testCases []testCase
 	for _, batch := range []bool{false, true} {
-		b.Run(fmt.Sprintf("batch=%t", batch), func(b *testing.B) {
-			for _, numVersions := range []int{10} {
-				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
-					for _, valueSize := range []int{8} {
-						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-							for _, numRangeKeys := range []int{0} {
-								b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-									runMVCCGet(ctx, b, mvccBenchData{
-										numVersions:  numVersions,
-										valueBytes:   valueSize,
-										numRangeKeys: numRangeKeys,
-									}, batch)
-								})
-							}
-						})
-					}
-				})
+		for _, numVersions := range []int{1, 10, 100} {
+			for _, valueSize := range []int{8} {
+				for _, numRangeKeys := range []int{0, 1, 100} {
+					testCases = append(testCases, testCase{
+						batch:        batch,
+						numVersions:  numVersions,
+						valueSize:    valueSize,
+						numRangeKeys: numRangeKeys,
+					})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{batch: false, numVersions: 1, valueSize: 8, numRangeKeys: 0},
+			{batch: true, numVersions: 10, valueSize: 8, numRangeKeys: 0},
+			{batch: true, numVersions: 10, valueSize: 8, numRangeKeys: 10},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"batch=%t/versions=%d/valueSize=%d/numRangeKeys=%d",
+			tc.batch, tc.numVersions, tc.valueSize, tc.numRangeKeys,
+		)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCGet(ctx, b, mvccBenchData{
+				numVersions:  tc.numVersions,
+				valueBytes:   tc.valueSize,
+				numRangeKeys: tc.numRangeKeys,
+			}, tc.batch)
 		})
 	}
 }
 
 func BenchmarkMVCCComputeStats_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		valueSize    int
+		numRangeKeys int
+	}
+	var testCases []testCase
 	for _, valueSize := range []int{8, 32, 256} {
-		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-			for _, numRangeKeys := range []int{0, 1, 100} {
-				b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-					runMVCCComputeStats(ctx, b, valueSize, numRangeKeys)
-				})
-			}
+		for _, numRangeKeys := range []int{0, 1, 100} {
+			testCases = append(testCases, testCase{
+				valueSize:    valueSize,
+				numRangeKeys: numRangeKeys,
+			})
+		}
+	}
+
+	if testing.Short() {
+		// Choose a configuration for the short version.
+		testCases = []testCase{
+			{valueSize: 8, numRangeKeys: 1},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"valueSize=%d/numRangeKeys=%d",
+			tc.valueSize, tc.numRangeKeys,
+		)
+
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCComputeStats(ctx, b, tc.valueSize, tc.numRangeKeys)
 		})
 	}
 }
 
 func BenchmarkMVCCFindSplitKey_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
 	for _, valueSize := range []int{32} {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			ctx := context.Background()
 			runMVCCFindSplitKey(ctx, b, valueSize)
 		})
 	}
@@ -271,27 +409,57 @@ func BenchmarkMVCCFindSplitKey_Pebble(b *testing.B) {
 
 func BenchmarkMVCCPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		batch     bool
+		valueSize int
+		versions  int
+	}
+	var testCases []testCase
+
 	for _, batch := range []bool{false, true} {
-		b.Run(fmt.Sprintf("batch=%t", batch), func(b *testing.B) {
-			for _, valueSize := range []int{10, 100, 1000, 10000} {
-				b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-					for _, versions := range []int{1, 10} {
-						b.Run(fmt.Sprintf("versions=%d", versions), func(b *testing.B) {
-							runMVCCPut(ctx, b, setupMVCCInMemPebble, valueSize, versions, batch)
-						})
-					}
+		for _, valueSize := range []int{10, 100, 1000, 10000} {
+			for _, versions := range []int{1, 10} {
+				testCases = append(testCases, testCase{
+					batch:     batch,
+					valueSize: valueSize,
+					versions:  versions,
 				})
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{batch: false, valueSize: 10, versions: 1},
+			{batch: true, valueSize: 1000, versions: 10},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"batch=%t/valueSize=%d/versions=%d",
+			tc.batch, tc.valueSize, tc.versions,
+		)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCPut(ctx, b, setupMVCCInMemPebble, tc.valueSize, tc.versions, tc.batch)
 		})
 	}
 }
 
 func BenchmarkMVCCBlindPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
-	for _, valueSize := range []int{10, 100, 1000, 10000} {
+
+	valueSizes := []int{10, 100, 1000, 10000}
+	if testing.Short() {
+		valueSizes = []int{10, 10000}
+	}
+
+	for _, valueSize := range valueSizes {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			ctx := context.Background()
 			runMVCCBlindPut(ctx, b, setupMVCCInMemPebble, valueSize)
 		})
 	}
@@ -299,15 +467,21 @@ func BenchmarkMVCCBlindPut_Pebble(b *testing.B) {
 
 func BenchmarkMVCCConditionalPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	valueSizes := []int{10, 100, 1000, 10000}
+	if testing.Short() {
+		valueSizes = []int{10, 10000}
+	}
+
 	for _, createFirst := range []bool{false, true} {
 		prefix := "Create"
 		if createFirst {
 			prefix = "Replace"
 		}
 		b.Run(prefix, func(b *testing.B) {
-			for _, valueSize := range []int{10, 100, 1000, 10000} {
+			for _, valueSize := range valueSizes {
 				b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+					ctx := context.Background()
 					runMVCCConditionalPut(ctx, b, setupMVCCInMemPebble, valueSize, createFirst)
 				})
 			}
@@ -317,9 +491,15 @@ func BenchmarkMVCCConditionalPut_Pebble(b *testing.B) {
 
 func BenchmarkMVCCBlindConditionalPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
-	for _, valueSize := range []int{10, 100, 1000, 10000} {
+
+	valueSizes := []int{10, 100, 1000, 10000}
+	if testing.Short() {
+		valueSizes = []int{10, 10000}
+	}
+
+	for _, valueSize := range valueSizes {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			ctx := context.Background()
 			runMVCCBlindConditionalPut(ctx, b, setupMVCCInMemPebble, valueSize)
 		})
 	}
@@ -327,9 +507,15 @@ func BenchmarkMVCCBlindConditionalPut_Pebble(b *testing.B) {
 
 func BenchmarkMVCCInitPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
-	for _, valueSize := range []int{10, 100, 1000, 10000} {
+
+	valueSizes := []int{10, 100, 1000, 10000}
+	if testing.Short() {
+		valueSizes = []int{10, 10000}
+	}
+
+	for _, valueSize := range valueSizes {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			ctx := context.Background()
 			runMVCCInitPut(ctx, b, setupMVCCInMemPebble, valueSize)
 		})
 	}
@@ -337,9 +523,15 @@ func BenchmarkMVCCInitPut_Pebble(b *testing.B) {
 
 func BenchmarkMVCCBlindInitPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
-	for _, valueSize := range []int{10, 100, 1000, 10000} {
+
+	valueSizes := []int{10, 100, 1000, 10000}
+	if testing.Short() {
+		valueSizes = []int{10, 10000}
+	}
+
+	for _, valueSize := range valueSizes {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			ctx := context.Background()
 			runMVCCBlindInitPut(ctx, b, setupMVCCInMemPebble, valueSize)
 		})
 	}
@@ -372,11 +564,17 @@ func BenchmarkMVCCPutDelete_Pebble(b *testing.B) {
 
 func BenchmarkMVCCBatchPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	batchSizes := []int{10, 100, 1000, 10000}
+	if testing.Short() {
+		batchSizes = []int{10, 10000}
+	}
+
 	for _, valueSize := range []int{10} {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-			for _, batchSize := range []int{1, 100, 10000, 100000} {
+			for _, batchSize := range batchSizes {
 				b.Run(fmt.Sprintf("batchSize=%d", batchSize), func(b *testing.B) {
+					ctx := context.Background()
 					runMVCCBatchPut(ctx, b, setupMVCCInMemPebble, valueSize, batchSize)
 				})
 			}
@@ -397,16 +595,34 @@ func BenchmarkMVCCBatchTimeSeries_Pebble(b *testing.B) {
 // BenchmarkMVCCGetMergedTimeSeries computes performance of reading merged
 // time series data using `MVCCGet()`. Uses an in-memory engine.
 func BenchmarkMVCCGetMergedTimeSeries_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		numKeys      int
+		mergesPerKey int
+	}
+	var testCases []testCase
 	for _, numKeys := range []int{1, 16, 256} {
-		b.Run(fmt.Sprintf("numKeys=%d", numKeys), func(b *testing.B) {
-			for _, mergesPerKey := range []int{1, 16, 256} {
-				b.Run(fmt.Sprintf("mergesPerKey=%d", mergesPerKey), func(b *testing.B) {
-					runMVCCGetMergedValue(ctx, b, setupMVCCInMemPebble, numKeys, mergesPerKey)
-				})
-			}
+		for _, mergesPerKey := range []int{1, 16, 256} {
+			testCases = append(testCases, testCase{
+				numKeys:      numKeys,
+				mergesPerKey: mergesPerKey,
+			})
+		}
+	}
+
+	if testing.Short() {
+		// Choose a configuration for the short version.
+		testCases = []testCase{
+			{numKeys: 16, mergesPerKey: 16},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf("numKeys=%d/mergesPerKey=%d", tc.numKeys, tc.mergesPerKey)
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runMVCCGetMergedValue(ctx, b, setupMVCCInMemPebble, tc.numKeys, tc.mergesPerKey)
 		})
 	}
 }
@@ -419,6 +635,8 @@ func BenchmarkMVCCGetMergedTimeSeries_Pebble(b *testing.B) {
 // what these benchmarks are trying to measure, and fix them.
 
 func BenchmarkMVCCDeleteRange_Pebble(b *testing.B) {
+	// TODO(radu): run one configuration under Short once the above TODO is
+	// resolved.
 	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ctx := context.Background()
@@ -430,6 +648,8 @@ func BenchmarkMVCCDeleteRange_Pebble(b *testing.B) {
 }
 
 func BenchmarkMVCCDeleteRangeUsingTombstone_Pebble(b *testing.B) {
+	// TODO(radu): run one configuration under Short once the above TODO is
+	// resolved.
 	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ctx := context.Background()
@@ -449,6 +669,8 @@ func BenchmarkMVCCDeleteRangeUsingTombstone_Pebble(b *testing.B) {
 }
 
 func BenchmarkClearMVCCVersions_Pebble(b *testing.B) {
+	// TODO(radu): run one configuration under Short once the above TODO is
+	// resolved.
 	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ctx := context.Background()
@@ -466,25 +688,48 @@ func BenchmarkClearMVCCIteratorRange_Pebble(b *testing.B) {
 }
 
 func BenchmarkBatchApplyBatchRepr_Pebble(b *testing.B) {
-	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
-	ctx := context.Background()
+
+	type testCase struct {
+		indexed    bool
+		sequential bool
+		valueSize  int
+		batchSize  int
+	}
+	var testCases []testCase
+
 	for _, indexed := range []bool{false, true} {
-		b.Run(fmt.Sprintf("indexed=%t", indexed), func(b *testing.B) {
-			for _, sequential := range []bool{false, true} {
-				b.Run(fmt.Sprintf("seq=%t", sequential), func(b *testing.B) {
-					for _, valueSize := range []int{10} {
-						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-							for _, batchSize := range []int{10000} {
-								b.Run(fmt.Sprintf("batchSize=%d", batchSize), func(b *testing.B) {
-									runBatchApplyBatchRepr(ctx, b, setupMVCCInMemPebble,
-										indexed, sequential, valueSize, batchSize)
-								})
-							}
-						})
-					}
-				})
+		for _, sequential := range []bool{false, true} {
+			for _, valueSize := range []int{10} {
+				for _, batchSize := range []int{10000} {
+					testCases = append(testCases, testCase{
+						indexed:    indexed,
+						sequential: sequential,
+						valueSize:  valueSize,
+						batchSize:  batchSize,
+					})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a configuration for the short version.
+		testCases = []testCase{
+			{indexed: true, sequential: false, valueSize: 10, batchSize: 8},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"indexed=%t/seq=%t/valueSize=%d/batchSize=%d",
+			tc.indexed, tc.sequential, tc.valueSize, tc.batchSize,
+		)
+
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			runBatchApplyBatchRepr(ctx, b, setupMVCCInMemPebble,
+				tc.indexed, tc.sequential, tc.valueSize, tc.batchSize)
 		})
 	}
 }
@@ -520,27 +765,52 @@ func BenchmarkBatchBuilderPut(b *testing.B) {
 
 func BenchmarkCheckSSTConflicts(b *testing.B) {
 	defer log.Scope(b).Close(b)
+
+	type testCase struct {
+		numKeys       int
+		numSSTKeys    int
+		overlap       bool
+		usePrefixSeek bool
+	}
+	var testCases []testCase
+
 	for _, numKeys := range []int{1000, 10000, 100000} {
-		b.Run(fmt.Sprintf("keys=%d", numKeys), func(b *testing.B) {
-			for _, numSstKeys := range []int{10, 100, 1000, 10000, 100000} {
-				b.Run(fmt.Sprintf("sstKeys=%d", numSstKeys), func(b *testing.B) {
-					for _, overlap := range []bool{false, true} {
-						b.Run(fmt.Sprintf("overlap=%t", overlap), func(b *testing.B) {
-							for _, usePrefixSeek := range []bool{false, true} {
-								b.Run(fmt.Sprintf("prefixSeek=%t", usePrefixSeek), func(b *testing.B) {
-									runCheckSSTConflicts(b, numKeys, 1 /* numVersions */, numSstKeys, overlap, usePrefixSeek)
-								})
-							}
-						})
-					}
-				})
+		for _, numSSTKeys := range []int{10, 100, 1000, 10000, 100000} {
+			for _, overlap := range []bool{false, true} {
+				for _, usePrefixSeek := range []bool{false, true} {
+					testCases = append(testCases, testCase{
+						numKeys:       numKeys,
+						numSSTKeys:    numSSTKeys,
+						overlap:       overlap,
+						usePrefixSeek: usePrefixSeek,
+					})
+				}
 			}
+		}
+	}
+
+	if testing.Short() {
+		// Choose a few configurations for the short version.
+		testCases = []testCase{
+			{numKeys: 10000, numSSTKeys: 100, overlap: false, usePrefixSeek: false},
+			{numKeys: 10000, numSSTKeys: 1000, overlap: true, usePrefixSeek: true},
+		}
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf(
+			"keys=%d/sstKeys=%d/overlap=%t/usePrefixSeek=%v",
+			tc.numKeys, tc.numSSTKeys, tc.overlap, tc.usePrefixSeek,
+		)
+		b.Run(name, func(b *testing.B) {
+			runCheckSSTConflicts(b, tc.numKeys, 1 /* numVersions */, tc.numSSTKeys, tc.overlap, tc.usePrefixSeek)
 		})
 	}
 }
 
 func BenchmarkSSTIterator(b *testing.B) {
 	defer log.Scope(b).Close(b)
+
 	for _, numKeys := range []int{1, 100, 10000} {
 		b.Run(fmt.Sprintf("keys=%d", numKeys), func(b *testing.B) {
 			for _, verify := range []bool{false, true} {

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -411,40 +411,34 @@ func BenchmarkMVCCPut_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
 
 	type testCase struct {
-		batch     bool
 		valueSize int
 		versions  int
 	}
 	var testCases []testCase
 
-	for _, batch := range []bool{false, true} {
-		for _, valueSize := range []int{10, 100, 1000, 10000} {
-			for _, versions := range []int{1, 10} {
-				testCases = append(testCases, testCase{
-					batch:     batch,
-					valueSize: valueSize,
-					versions:  versions,
-				})
-			}
+	for _, valueSize := range []int{10, 100, 1000, 10000} {
+		for _, versions := range []int{1, 10} {
+			testCases = append(testCases, testCase{
+				valueSize: valueSize,
+				versions:  versions,
+			})
 		}
 	}
 
 	if testing.Short() {
 		// Choose a few configurations for the short version.
 		testCases = []testCase{
-			{batch: false, valueSize: 10, versions: 1},
-			{batch: true, valueSize: 1000, versions: 10},
+			{valueSize: 10, versions: 1},
+			{valueSize: 1000, versions: 10},
 		}
 	}
 
 	for _, tc := range testCases {
-		name := fmt.Sprintf(
-			"batch=%t/valueSize=%d/versions=%d",
-			tc.batch, tc.valueSize, tc.versions,
-		)
+		// We use "batch=false" so that we can compare with corresponding benchmarks in older branches.
+		name := fmt.Sprintf("batch=false/valueSize=%d/versions=%d", tc.valueSize, tc.versions)
 		b.Run(name, func(b *testing.B) {
 			ctx := context.Background()
-			runMVCCPut(ctx, b, setupMVCCInMemPebble, tc.valueSize, tc.versions, tc.batch)
+			runMVCCPut(ctx, b, setupMVCCInMemPebble, tc.valueSize, tc.versions)
 		})
 	}
 }

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -865,9 +865,7 @@ func runMVCCGet(ctx context.Context, b *testing.B, opts mvccBenchData, useBatch 
 	b.StopTimer()
 }
 
-func runMVCCPut(
-	ctx context.Context, b *testing.B, emk engineMaker, valueSize, versions int, useBatch bool,
-) {
+func runMVCCPut(ctx context.Context, b *testing.B, emk engineMaker, valueSize, versions int) {
 	rng, _ := randutil.NewTestRand()
 	value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueSize))
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
@@ -876,11 +874,6 @@ func runMVCCPut(
 	defer eng.Close()
 
 	rw := ReadWriter(eng)
-	if useBatch {
-		batch := eng.NewBatch()
-		defer batch.Close()
-		rw = batch
-	}
 
 	b.SetBytes(int64(valueSize))
 	b.ResetTimer()

--- a/pkg/storage/mvcc_value_test.go
+++ b/pkg/storage/mvcc_value_test.go
@@ -180,27 +180,32 @@ func TestDecodeMVCCValueErrors(t *testing.T) {
 	}
 }
 
-var mvccValueBenchmarkConfigs = struct {
-	headers map[string]enginepb.MVCCValueHeader
-	values  map[string]roachpb.Value
-}{
-	headers: map[string]enginepb.MVCCValueHeader{
+func mvccValueBenchmarkConfigs() (
+	headers map[string]enginepb.MVCCValueHeader,
+	values map[string]roachpb.Value,
+) {
+	headers = map[string]enginepb.MVCCValueHeader{
 		"empty":                  {},
 		"local walltime":         {LocalTimestamp: hlc.ClockTimestamp{WallTime: 1643550788737652545}},
 		"local walltime+logical": {LocalTimestamp: hlc.ClockTimestamp{WallTime: 1643550788737652545, Logical: 4096}},
-	},
-	values: map[string]roachpb.Value{
+	}
+	if testing.Short() {
+		// Reduce the number of configurations in short mode.
+		delete(headers, "local walltime")
+	}
+	values = map[string]roachpb.Value{
 		"tombstone": {},
 		"short":     roachpb.MakeValueFromString("foo"),
 		"long":      roachpb.MakeValueFromBytes(bytes.Repeat([]byte{1}, 4096)),
-	},
+	}
+	return headers, values
 }
 
 func BenchmarkEncodeMVCCValue(b *testing.B) {
 	DisableMetamorphicSimpleValueEncoding(b)
-	cfg := mvccValueBenchmarkConfigs
-	for hDesc, h := range cfg.headers {
-		for vDesc, v := range cfg.values {
+	headers, values := mvccValueBenchmarkConfigs()
+	for hDesc, h := range headers {
+		for vDesc, v := range values {
 			name := fmt.Sprintf("header=%s/value=%s", hDesc, vDesc)
 			mvccValue := MVCCValue{MVCCValueHeader: h, Value: v}
 			b.Run(name, func(b *testing.B) {
@@ -217,9 +222,9 @@ func BenchmarkEncodeMVCCValue(b *testing.B) {
 }
 
 func BenchmarkDecodeMVCCValue(b *testing.B) {
-	cfg := mvccValueBenchmarkConfigs
-	for hDesc, h := range cfg.headers {
-		for vDesc, v := range cfg.values {
+	headers, values := mvccValueBenchmarkConfigs()
+	for hDesc, h := range headers {
+		for vDesc, v := range values {
 			for _, inline := range []bool{false, true} {
 				name := fmt.Sprintf("header=%s/value=%s/inline=%t", hDesc, vDesc, inline)
 				mvccValue := MVCCValue{MVCCValueHeader: h, Value: v}
@@ -250,9 +255,9 @@ func BenchmarkDecodeMVCCValue(b *testing.B) {
 }
 
 func BenchmarkMVCCValueIsTombstone(b *testing.B) {
-	cfg := mvccValueBenchmarkConfigs
-	for hDesc, h := range cfg.headers {
-		for vDesc, v := range cfg.values {
+	headers, values := mvccValueBenchmarkConfigs()
+	for hDesc, h := range headers {
+		for vDesc, v := range values {
 			name := fmt.Sprintf("header=%s/value=%s", hDesc, vDesc)
 			mvccValue := MVCCValue{MVCCValueHeader: h, Value: v}
 			buf, err := EncodeMVCCValue(mvccValue)


### PR DESCRIPTION
Backport 2/2 commits from #115810.

/cc @cockroachdb/release

Release justification: test only change

---

#### storage: improve mvcc benchmarks under -short

Many of the MVCC benchmarks have too many variants and are completely
sipped when using the `-short` flag (which is used for the weekly
microbenchmarks job). Conversely, other benchmarks are not skipped but
still have quite a few variants.

In this commit we change relevant tests to run a small set of
configurations under `-short`. We also fix a few smaller issues, for
example we remove some bogus empty acquire lock benchmarks with
`heldOtherTxn=true/heldSameTxn=true`.

Fixes #115794
Release note: None

#### storage: remove batch=true variants of BenchmarkMVCCPut

This benchmark has batching variants but the batch size is `b.N` which
can hit the 4GB batch limit.

Given that we already have a separate `MVCCBatchPut` which has
reasonable batch sizes, we are removing the batched variants of
`BenchmarkMVCCPut`.

Fixes: #115811
Release note: None

