### PR TITLE
cli: skip TestNodeStatus under race and deadlock

### DIFF
--- a/pkg/cli/node_test.go
+++ b/pkg/cli/node_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -65,6 +66,11 @@ func Example_node() {
 func TestNodeStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// This test is prone to timing out when run using remote execution under the
+	// {deadlock,race} detector.
+	skip.UnderDeadlock(t)
+	skip.UnderRace(t)
 
 	start := timeutil.Now()
 	c := NewCLITest(TestCLIParams{})


### PR DESCRIPTION
Closes #115936

Release note: None