### PR TITLE
kvnemesis: properly encode range keys

### DIFF
--- a/pkg/kv/kvnemesis/engine.go
+++ b/pkg/kv/kvnemesis/engine.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -119,7 +120,9 @@ func (e *Engine) Put(key storage.MVCCKey, value []byte) {
 
 func (e *Engine) DeleteRange(from, to roachpb.Key, ts hlc.Timestamp, val []byte) {
 	suffix := storage.EncodeMVCCTimestampSuffix(ts)
-	if err := e.kvs.RangeKeySet(from, to, suffix, val, nil); err != nil {
+	err := e.kvs.RangeKeySet(
+		storage.EngineKey{Key: from}.Encode(), storage.EngineKey{Key: to}.Encode(), suffix, val, nil)
+	if err != nil {
 		panic(err)
 	}
 }
@@ -153,18 +156,27 @@ func (e *Engine) Iterate(
 			}
 		}
 		if iter.RangeKeyChanged() {
-			key, endKey := iter.RangeBounds()
-			e.b, key = e.b.Copy(key, 0 /* extraCap */)
-			e.b, endKey = e.b.Copy(endKey, 0 /* extraCap */)
+			keyCopy, endKeyCopy := iter.RangeBounds()
+			e.b, keyCopy = e.b.Copy(keyCopy, 0 /* extraCap */)
+			e.b, endKeyCopy = e.b.Copy(endKeyCopy, 0 /* extraCap */)
 			for _, rk := range iter.RangeKeys() {
 				ts, err := storage.DecodeMVCCTimestampSuffix(rk.Suffix)
 				if err != nil {
 					fn(nil, nil, hlc.Timestamp{}, nil, err)
 					continue
 				}
+				engineKey, ok := storage.DecodeEngineKey(keyCopy)
+				if !ok || len(engineKey.Version) > 0 {
+					fn(nil, nil, hlc.Timestamp{}, nil, errors.Errorf("invalid key %q", keyCopy))
+				}
+				engineEndKey, ok := storage.DecodeEngineKey(endKeyCopy)
+				if !ok || len(engineEndKey.Version) > 0 {
+					fn(nil, nil, hlc.Timestamp{}, nil, errors.Errorf("invalid key %q", endKeyCopy))
+				}
 
 				e.b, rk.Value = e.b.Copy(rk.Value, 0)
-				fn(key, endKey, ts, rk.Value, nil)
+
+				fn(engineKey.Key, engineEndKey.Key, ts, rk.Value, nil)
 			}
 		}
 	}

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -1058,8 +1058,10 @@ func (v *validator) checkAtomicCommitted(
 					panic(err)
 				}
 			} else { // ranged write
+				key := storage.EngineKey{Key: o.Key}.Encode()
+				endKey := storage.EngineKey{Key: o.EndKey}.Encode()
 				suffix := storage.EncodeMVCCTimestampSuffix(o.Timestamp)
-				if err := batch.RangeKeyUnset(o.Key, o.EndKey, suffix, nil); err != nil {
+				if err := batch.RangeKeyUnset(key, endKey, suffix, nil); err != nil {
 					panic(err)
 				}
 			}
@@ -1103,8 +1105,10 @@ func (v *validator) checkAtomicCommitted(
 					panic(err)
 				}
 			} else {
+				key := storage.EngineKey{Key: o.Key}.Encode()
+				endKey := storage.EngineKey{Key: o.EndKey}.Encode()
 				suffix := storage.EncodeMVCCTimestampSuffix(writeTS)
-				if err := batch.RangeKeySet(o.Key, o.EndKey, suffix, o.Value.RawBytes, nil); err != nil {
+				if err := batch.RangeKeySet(key, endKey, suffix, o.Value.RawBytes, nil); err != nil {
 					panic(err)
 				}
 			}


### PR DESCRIPTION
Previously, kvnemesis did not properly encode range keys with a trailing `0` separator, instead using the user key directly. This trips Pebble assertions.

Resolves #116438.
Epic: none
Release note: None