### PR TITLE
roachtest: port multitenant/shared-process/basic to new APIs

### DIFF
--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -66,6 +66,15 @@ func DefaultStartVirtualClusterOpts(tenantName string, sqlInstance int) StartOpt
 	return startOpts
 }
 
+// DefaultStartSharedVirtualClusterOpts returns StartOpts for starting a shared
+// process virtual cluster with the given tenant name.
+func DefaultStartSharedVirtualClusterOpts(tenantName string) StartOpts {
+	startOpts := StartOpts{RoachprodOpts: roachprod.DefaultStartOpts()}
+	startOpts.RoachprodOpts.Target = install.StartSharedProcessForVirtualCluster
+	startOpts.RoachprodOpts.VirtualClusterName = tenantName
+	return startOpts
+}
+
 // StopOpts is a type that combines the stop options needed by roachprod and roachtest.
 type StopOpts struct {
 	// TODO(radu): we should use a higher-level abstraction instead of

--- a/pkg/cmd/roachtest/tests/multitenant_shared_process.go
+++ b/pkg/cmd/roachtest/tests/multitenant_shared_process.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 )
 
 func registerMultiTenantSharedProcess(r registry.Registry) {
@@ -48,12 +47,8 @@ func registerMultiTenantSharedProcess(r registry.Registry) {
 			clusterSettings := install.MakeClusterSettings(install.SecureOption(true))
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), clusterSettings, crdbNodes)
 
-			sysConn := c.Conn(ctx, t.L(), crdbNodes.RandNode()[0])
-			sysSQL := sqlutils.MakeSQLRunner(sysConn)
-
-			createTenantAdminRole(t, "system", sysSQL)
-
-			createInMemoryTenant(ctx, t, c, appTenantName, crdbNodes, true)
+			startOpts := option.DefaultStartSharedVirtualClusterOpts(appTenantName)
+			c.StartServiceForVirtualCluster(ctx, t.L(), crdbNodes, startOpts, clusterSettings, crdbNodes)
 
 			t.Status(`initialize tpcc workload`)
 			initCmd := fmt.Sprintf(`./workload init tpcc --data-loader import --warehouses %d {pgurl%s:%s}`,


### PR DESCRIPTION
Converts multitenant/shared-process/basic to use the new roachprod multitenant APIs.

Fixes: #115868

Epic: CRDB-31933
Release Note: None