### PR TITLE
release-23.2.0-rc: ui: update label "CPU" to "SQL CPU"

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -123,8 +123,8 @@ export const StatementInsightDetailsOverviewTab: React.FC<
               value={Duration(insightDetails.elapsedTimeMillis * 1e6)}
             />
             <SummaryCardItem
-              label={"CPU Time"}
-              value={Duration(insightDetails.cpuSQLNanos)}
+              label={"SQL CPU Time"}
+              value={Duration(insightDetails?.cpuSQLNanos)}
             />
             <SummaryCardItem
               label="Rows Read"

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
@@ -178,7 +178,7 @@ the maximum number of statements was reached in the console.`;
                       value={Duration(txnDetails.elapsedTimeMillis * 1e6)}
                     />
                     <SummaryCardItem
-                      label="CPU Time"
+                      label="SQL CPU Time"
                       value={Duration(txnDetails.cpuSQLNanos)}
                     />
                     <SummaryCardItem

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -38,7 +38,7 @@ export const insightsColumnLabels = {
   databaseName: "Database Name",
   tableName: "Table Name",
   indexName: "Index Name",
-  cpu: "CPU Time",
+  cpu: "SQL CPU Time",
 };
 
 export type InsightsTableColumnKeys = keyof typeof insightsColumnLabels;
@@ -238,7 +238,8 @@ export const insightsTableTitles: InsightsTableTitleType = {
   },
   cpu: (_: InsightExecEnum) => {
     return makeToolTip(
-      <p>{`CPU Time spent executing within the specified time interval.`}</p>,
+      <p>{`SQL CPU Time spent executing within the specified time interval. It
+      does not include SQL planning time nor KV execution time.`}</p>,
       "cpu",
     );
   },

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -665,8 +665,8 @@ export class StatementDetails extends React.Component<
     const cpuTimeseries: AlignedData =
       generateCPUTimeseries(statsPerAggregatedTs);
     const cpuOps: Partial<Options> = {
-      axes: [{}, { label: "CPU Time" }],
-      series: [{}, { label: "CPU Time" }],
+      axes: [{}, { label: "SQL CPU Time" }],
+      series: [{}, { label: "SQL CPU Time" }],
       legend: { show: false },
       width: cardWidth,
     };
@@ -831,7 +831,7 @@ export class StatementDetails extends React.Component<
                   )}
                 />
                 <SummaryCardItem
-                  label="CPU Time"
+                  label="SQL CPU Time"
                   value={formatNumberForDisplay(
                     stats?.exec_stats?.cpu_sql_nanos.mean,
                     Duration,
@@ -909,7 +909,7 @@ export class StatementDetails extends React.Component<
             </Col>
             <Col className="gutter-row" span={12}>
               <BarGraphTimeSeries
-                title={`CPU Time${noSamples}`}
+                title={`SQL CPU Time${noSamples}`}
                 alignedData={cpuTimeseries}
                 uPlotOptions={cpuOps}
                 tooltip={unavailableTooltip}

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -31,7 +31,7 @@ export const statisticsColumnLabels = {
   bytesRead: "Bytes Read",
   clientAddress: "Client IP Address",
   contention: "Contention Time",
-  cpu: "CPU Time",
+  cpu: "SQL CPU Time",
   database: "Database",
   diagnostics: "Diagnostics",
   executionCount: "Execution Count",
@@ -650,8 +650,9 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         content={
           <>
             <p>
-              Average CPU time spent executing within the specified time
-              interval. The gray bar indicates mean CPU time. The blue bar
+              Average SQL CPU time spent executing within the specified time
+              interval. It does not include SQL planning time nor KV execution
+              time. The gray bar indicates mean SQL CPU time. The blue bar
               indicates one standard deviation from the mean.
             </p>
           </>

--- a/pkg/ui/workspaces/cluster-ui/src/util/sqlActivityConstants.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/util/sqlActivityConstants.tsx
@@ -72,7 +72,7 @@ export function getSortLabel(
     case SqlStatsSortOptions.EXECUTION_COUNT:
       return "Execution Count";
     case SqlStatsSortOptions.CPU_TIME:
-      return "CPU Time";
+      return "SQL CPU Time";
     case SqlStatsSortOptions.P99_STMTS_ONLY:
       return "P99 Latency";
     case SqlStatsSortOptions.CONTENTION_TIME:


### PR DESCRIPTION
Backport 1/1 commits from #116411.

/cc @cockroachdb/release

---

Previosuly, we were using the label "CPU Time" in the Console, which could be confusing since it was only SQL CPU Time.

This commit updates the title and tooltips to clarify that.

Fixes #116409

Updates on Insights and SQL Activity pages (Overview, Details, Search Criteria)
<img width="1513" alt="Screenshot 2023-12-13 at 7 36 06 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/775801a5-352f-4672-b713-b57a791b6e25">


<img width="1395" alt="Screenshot 2023-12-13 at 7 36 24 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/ce7f32d2-a818-4339-a9d6-4342f496140c">


<img width="801" alt="Screenshot 2023-12-13 at 6 39 51 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/f96d2fa7-0b4d-497c-941a-204665fbce2c">


Release note (ui change): Update "CPU Time" label to "SQL CPU Time" on the Console and add clarification to its tooltip.

---

Release justification: UX improvement
