### PR TITLE
roachtest: pass startopts to SetDefaultPort helpers by reference

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils.go
@@ -42,7 +42,7 @@ func DefaultPGUrl(
 
 // SetDefaultSQLPort sets the SQL port to the default of 26257 if it is
 // a non-local cluster. Local clusters don't support changing the port.
-func SetDefaultSQLPort(c cluster.Cluster, opts install.StartOpts) {
+func SetDefaultSQLPort(c cluster.Cluster, opts *install.StartOpts) {
 	if !c.IsLocal() {
 		opts.SQLPort = config.DefaultSQLPort
 	}
@@ -50,7 +50,7 @@ func SetDefaultSQLPort(c cluster.Cluster, opts install.StartOpts) {
 
 // SetDefaultAdminUIPort sets the AdminUI port to the default of 26258 if it is
 // a non-local cluster. Local clusters don't support changing the port.
-func SetDefaultAdminUIPort(c cluster.Cluster, opts install.StartOpts) {
+func SetDefaultAdminUIPort(c cluster.Cluster, opts *install.StartOpts) {
 	if !c.IsLocal() {
 		opts.AdminUIPort = config.DefaultAdminUIPort
 	}

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -96,7 +96,7 @@ func registerDatabaseDrop(r registry.Registry) {
 					start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
 						startOpts := option.DefaultStartOptsNoBackups()
-						roachtestutil.SetDefaultSQLPort(c, startOpts.RoachprodOpts)
+						roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
 						if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
 							t.Fatal(err)
 						}
@@ -199,8 +199,8 @@ func registerDatabaseDrop(r registry.Registry) {
 			runTPCE(ctx, t, c, tpceOptions{
 				start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					startOpts := option.DefaultStartOptsNoBackups()
-					roachtestutil.SetDefaultSQLPort(c, startOpts.RoachprodOpts)
-					roachtestutil.SetDefaultAdminUIPort(c, startOpts.RoachprodOpts)
+					roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
+					roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
 					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
 					if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
 						t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
@@ -71,7 +71,7 @@ func registerElasticIO(r registry.Registry) {
 
 			c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(workAndPromNode))
 			startOpts := option.DefaultStartOptsNoBackups()
-			roachtestutil.SetDefaultAdminUIPort(c, startOpts.RoachprodOpts)
+			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
 				"--vmodule=io_load_listener=2")
 			settings := install.MakeClusterSettings()

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -95,7 +95,7 @@ func registerIndexBackfill(r registry.Registry) {
 						c.Run(ctx, c.All(), fmt.Sprintf("cp %s ./cockroach", path))
 						settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
 						startOpts := option.DefaultStartOptsNoBackups()
-						roachtestutil.SetDefaultSQLPort(c, startOpts.RoachprodOpts)
+						roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
 						if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
 							t.Fatal(err)
 						}
@@ -153,8 +153,8 @@ func registerIndexBackfill(r registry.Registry) {
 			runTPCE(ctx, t, c, tpceOptions{
 				start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					startOpts := option.DefaultStartOptsNoBackups()
-					roachtestutil.SetDefaultSQLPort(c, startOpts.RoachprodOpts)
-					roachtestutil.SetDefaultAdminUIPort(c, startOpts.RoachprodOpts)
+					roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
+					roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
 					settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
 					if err := c.StartE(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes)); err != nil {
 						t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
+++ b/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
@@ -71,8 +71,8 @@ func registerIntentResolutionOverload(r registry.Registry) {
 			startOpts := option.DefaultStartOptsNoBackups()
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
 				"--vmodule=io_load_listener=2")
-			roachtestutil.SetDefaultSQLPort(c, startOpts.RoachprodOpts)
-			roachtestutil.SetDefaultAdminUIPort(c, startOpts.RoachprodOpts)
+			roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
+			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
 			settings := install.MakeClusterSettings()
 			c.Start(ctx, t.L(), startOpts, settings, c.Range(1, crdbNodes))
 			setAdmissionControl(ctx, t, c, true)

--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -211,7 +211,7 @@ func makeCDCBenchOptions(c cluster.Cluster) (option.StartOpts, install.ClusterSe
 	opts.RoachprodOpts.ScheduleBackups = false
 
 	// Prom helpers assume AdminUIPort is at 26258
-	roachtestutil.SetDefaultAdminUIPort(c, opts.RoachprodOpts)
+	roachtestutil.SetDefaultAdminUIPort(c, &opts.RoachprodOpts)
 
 	// Backpressure writers when rangefeed clients can't keep up. This gives more
 	// reliable results, since we can otherwise randomly hit timeouts and incur

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -500,14 +500,14 @@ func (rd *replicationDriver) setupC2C(
 	srcStartOps := option.DefaultStartOptsNoBackups()
 	srcStartOps.RoachprodOpts.InitTarget = 1
 
-	roachtestutil.SetDefaultAdminUIPort(c, srcStartOps.RoachprodOpts)
+	roachtestutil.SetDefaultAdminUIPort(c, &srcStartOps.RoachprodOpts)
 	srcClusterSetting := install.MakeClusterSettings(install.SecureOption(true))
 	c.Start(ctx, t.L(), srcStartOps, srcClusterSetting, srcCluster)
 
 	// TODO(msbutler): allow for backups once this test stabilizes a bit more.
 	dstStartOps := option.DefaultStartOptsNoBackups()
 	dstStartOps.RoachprodOpts.InitTarget = rd.rs.srcNodes + 1
-	roachtestutil.SetDefaultAdminUIPort(c, dstStartOps.RoachprodOpts)
+	roachtestutil.SetDefaultAdminUIPort(c, &dstStartOps.RoachprodOpts)
 	dstClusterSetting := install.MakeClusterSettings(install.SecureOption(true))
 	c.Start(ctx, t.L(), dstStartOps, dstClusterSetting, dstCluster)
 

--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -147,7 +147,7 @@ func runTPCE(ctx context.Context, t test.Test, c cluster.Cluster, opts tpceOptio
 			t.Status("installing cockroach")
 			startOpts := option.DefaultStartOpts()
 			startOpts.RoachprodOpts.StoreCount = opts.ssds
-			roachtestutil.SetDefaultSQLPort(c, startOpts.RoachprodOpts)
+			roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
 			settings := install.MakeClusterSettings(install.NumRacksOption(racks))
 			c.Start(ctx, t.L(), startOpts, settings, crdbNodes)
 		}


### PR DESCRIPTION
Startopts was being passed by value, effectively making the helpers noops.

Release note: none
Epic: none
Fixes: #116432 
Fixes: #116433 
Fixes: #116485