### PR TITLE
server, backupccl: pass multiple spans to DownloadSpan

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3427,7 +3427,7 @@ Support status: [reserved](#support-status)
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | node_id | [string](#cockroach.server.serverpb.DownloadSpanRequest-string) |  |  | [reserved](#support-status) |
-| span | [cockroach.roachpb.Span](#cockroach.server.serverpb.DownloadSpanRequest-cockroach.roachpb.Span) |  |  | [reserved](#support-status) |
+| spans | [cockroach.roachpb.Span](#cockroach.server.serverpb.DownloadSpanRequest-cockroach.roachpb.Span) | repeated |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -303,6 +303,7 @@ go_library(
         "//pkg/util/admission/admissionpb",
         "//pkg/util/allstacks",
         "//pkg/util/buildutil",
+        "//pkg/util/ctxgroup",
         "//pkg/util/envutil",
         "//pkg/util/future",
         "//pkg/util/goschedstats",

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -601,7 +601,7 @@ message EngineStatsResponse {
 
 message DownloadSpanRequest {
   string node_id = 1 [(gogoproto.customname) = "NodeID"];
-  roachpb.Span span = 2 [(gogoproto.nullable) = false];
+  repeated roachpb.Span spans = 2 [(gogoproto.nullable) = false];
 }
 
 message DownloadSpanResponse {


### PR DESCRIPTION
Release note: none.
Epic: none.