### PR TITLE
kv: disallow use of skip locked in conjunction with replicated locks 

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -92,7 +92,7 @@ func Get(
 		acq, err := acquireLockOnKey(ctx, readWriter, h.Txn, args.KeyLockingStrength,
 			args.KeyLockingDurability, args.Key, cArgs.Stats, cArgs.EvalCtx.ClusterSettings())
 		if err != nil {
-			return result.Result{}, err
+			return result.Result{}, maybeInterceptDisallowedSkipLockedUsage(h, err)
 		}
 		res.Local.AcquiredLocks = []roachpb.LockAcquisition{acq}
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -120,7 +120,7 @@ func ReverseScan(
 			ctx, readWriter, h.Txn, args.KeyLockingStrength, args.KeyLockingDurability,
 			args.ScanFormat, &scanRes, cArgs.Stats, cArgs.EvalCtx.ClusterSettings())
 		if err != nil {
-			return result.Result{}, err
+			return result.Result{}, maybeInterceptDisallowedSkipLockedUsage(h, err)
 		}
 		res.Local.AcquiredLocks = acquiredLocks
 	}

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -628,3 +628,51 @@ SELECT * FROM t94290 WHERE b = 2 FOR UPDATE;
 
 statement ok
 RESET statement_timeout;
+
+# Ensure when SKIP LOCKED is used in conjunction with replicated locks we return
+# appropriate errors.
+
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t(a INT PRIMARY KEY);
+INSERT INTO t VALUES(1);
+GRANT ALL ON t TO testuser;
+GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser;
+
+user testuser
+
+statement ok
+SET enable_durable_locking_for_serializable = true;
+
+statement ok
+BEGIN
+
+query I
+SELECT * FROM t WHERE a = 1 FOR UPDATE;
+----
+1
+
+user root
+
+skipif config local-mixed-23.1
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+----
+database_name  schema_name  table_name  lock_key_pretty  lock_strength  durability  isolation_level  granted  contended
+
+skipif config local-mixed-23.1
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+
+# Ensure the replicated lock isn't pulled into the in-memory lock table, even
+# after the skip locked statement has run.
+skipif config local-mixed-23.1
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+----
+database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
+
+user testuser
+
+statement ok
+COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
@@ -66,19 +66,19 @@ COMMIT;
 
 # SKIP LOCKED reads do not block.
 
-query III rowsort
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM abc FOR UPDATE SKIP LOCKED;
-COMMIT;
-----
-3  30  300
 
-query III rowsort
+statement ok
+ROLLBACK;
+
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM bcd FOR UPDATE SKIP LOCKED;
-COMMIT;
-----
-20  200  2000
+
+statement ok
+ROLLBACK
 
 # Shared reads block on exclusive locks but not on shared locks.
 
@@ -238,19 +238,19 @@ SELECT * FROM bcd WHERE b = 7 FOR UPDATE
 
 user root
 
-query III rowsort
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM abc WHERE a > 4 FOR UPDATE SKIP LOCKED;
-COMMIT;
-----
-6  1  7
 
-query III rowsort
+statement ok
+ROLLBACK
+
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM bcd WHERE b < 8 FOR UPDATE SKIP LOCKED;
-COMMIT;
-----
-6  1  5
+
+statement ok
+ROLLBACK
 
 query III async,rowsort q10
 BEGIN ISOLATION LEVEL READ COMMITTED;
@@ -327,19 +327,19 @@ SELECT * FROM bcd WHERE b = 7 FOR UPDATE
 
 user root
 
-query III rowsort
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM abc WHERE a > 4 FOR UPDATE SKIP LOCKED;
-COMMIT;
-----
-6  1  7
 
-query III rowsort
+statement ok
+ROLLBACK
+
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM bcd WHERE b < 8 FOR UPDATE SKIP LOCKED;
-COMMIT;
-----
-6  1  5
+
+statement ok
+ROLLBACK;
 
 query III async,rowsort q12
 BEGIN ISOLATION LEVEL READ COMMITTED;


### PR DESCRIPTION
Currently, requests running with the skip locked wait policy only have
a handle into the in-memory lock table during evaluation, which excludes
uncontended replicated locks. As such, any conflicting replicated locks
may result in a `LockConflictError` after evaluation instead of getting
skipped over -- this breaks expectations about the skip locked wait
policy.

The linked issue talks about fixing this behaviour. Until fixed, we
disallow interactions between the skip locked wait policy and replicated
locks by transforming `LockConflictErrors` returned by evaluation of
skip locked requests into unimplemented errors.

Informs https://github.com/cockroachdb/cockroach/issues/115057

Release note: None