### PR TITLE
release-23.2: scripts/bump-pebble.sh: use current branch, don't use pebble repo

### DIFF
--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -1,104 +1,95 @@
 #!/usr/bin/env bash
 
-# This script may be used to produce a branch bumping the Pebble
-# version. The storage team bumps CockroachDB's Pebble dependency
-# frequently, and this script automates some of that work.
-#
-# To bump the Pebble dependency to the corresponding pebble branch HEAD, run:
-#
-#   ./scripts/bump-pebble.sh
-#
-# Note that this script has different behaviour based on the branch on which it
-# is run.
-
-set -euo pipefail
-
-echoerr() { printf "%s\n" "$*" >&2; }
-pushd() { builtin pushd "$@" > /dev/null; }
-popd() { builtin popd "$@" > /dev/null; }
-
+# NOTE: After a new release has been cut, update this to the appropriate
+# Cockroach branch name (i.e. release-23.2, etc.), and corresponding Pebble
+# branch name (e.g. crl-release-23.2, etc.).
 BRANCH=release-23.2
 PEBBLE_BRANCH=crl-release-23.2
 
-# The script can only be run from a specific branch.
-if [ "$(git rev-parse --abbrev-ref HEAD)" != "$BRANCH" ]; then
-  echo "This script must be run from the $BRANCH branch."
-  exit 1
-fi
+# This script may be used to produce a branch bumping the Pebble version. The
+# storage team bumps CockroachDB's Pebble dependency frequently, and this script
+# automates some of that work.
+#
+# To bump the Pebble dependency to the corresponding pebble branch HEAD, run:
+#
+#   ./scripts/bump-pebble.sh [<pebble-sha>]
+#
+# If <pebble-sha> is not provided, the latest sha on $PEBBLE_BRANCH is used.
+#
+# The script must be run from the cockroach repo root, and the repo should be up
+# to date. If $BRANCH is checked out, the script first creates a new branch and
+# checks it out. Otherwise, the current branch is used.
 
-COCKROACH_DIR="$(go env GOPATH)/src/github.com/cockroachdb/cockroach"
-UPSTREAM="upstream"
+set -euo pipefail
 
-# Using count since error code is ignored
-MATCHING_UPSTREAMS=$(git remote | grep -c ${UPSTREAM} || true )
-if [ $MATCHING_UPSTREAMS = 0 ]; then
-  echo This script expects the upstream to point to github.com/cockroachdb/cockroach.
-  echo However no remote matches \"$UPSTREAM\".
-  echo The available remotes are:
-  git remote
-  read -p "Please enter a remote to use: " UPSTREAM
-fi
+pushd() { builtin pushd "$@" > /dev/null; }
+popd() { builtin popd "$@" > /dev/null; }
 
-# Make sure that the cockroachdb remotes match what we expect. The
-# `upstream` remote must point to github.com/cockroachdb/cockroach.
-pushd "$COCKROACH_DIR"
+# Grab the current Pebble SHA.
+OLD_SHA=$(grep 'github.com/cockroachdb/pebble' go.mod | grep -o -E '[a-f0-9]{12}$')
+echo "Current pebble SHA: $OLD_SHA"
+
 git submodule update --init --recursive
-popd
 
-COCKROACH_UPSTREAM_URL="https://github.com/cockroachdb/cockroach.git"
 PEBBLE_UPSTREAM_URL="https://github.com/cockroachdb/pebble.git"
 
-# Ensure the local CockroachDB release branch is up-to-date with
-# upstream and grab the current Pebble SHA.
-pushd "$COCKROACH_DIR"
-git fetch "$COCKROACH_UPSTREAM_URL" "$BRANCH"
-git checkout "$BRANCH"
-git rebase "$UPSTREAM/$BRANCH"
-OLD_SHA=$(grep 'github.com/cockroachdb/pebble' go.mod | grep -o -E '[a-f0-9]{12}$')
-popd
-
-# Ensure the local Pebble release branch is up-to-date with upstream,
-# and grab the desired Pebble SHA.
+# Check out the pebble repo in a temporary directory.
 PEBBLE_DIR=$(mktemp -d)
 trap "rm -rf $PEBBLE_DIR" EXIT
 
+echo
 git clone --no-checkout "$PEBBLE_UPSTREAM_URL" "$PEBBLE_DIR"
+echo
 
 pushd "$PEBBLE_DIR"
-NEW_SHA="${1-}"
-if [ -z "$NEW_SHA" ]; then
+if [ -z "${1-}" ]; then
+  # Use the latest commit in the correct branch.
   NEW_SHA=$(git rev-parse "origin/$PEBBLE_BRANCH")
-  echo "Using latest pebble $PEBBLE_BRANCH sha $NEW_SHA."
+  echo "Using latest pebble $PEBBLE_BRANCH SHA $NEW_SHA"
 else
+  NEW_SHA=$(git rev-parse "$1")
   # Verify that the given commit is in the correct pebble branch.
   if ! git merge-base --is-ancestor $NEW_SHA "origin/$PEBBLE_BRANCH"; then
     echo "Error: $NEW_SHA is not an ancestor of the pebble branch $PEBBLE_BRANCH" >&2
     exit 1
   fi
-  echo "Using provided sha $NEW_SHA."
+  echo "Using provided SHA $NEW_SHA."
+fi
+
+# Sanity check: the old SHA should be an ancestor of the new SHA.
+if ! git merge-base --is-ancestor $OLD_SHA $NEW_SHA; then
+  echo "Error: current pebble SHA $OLD_SHA is not an ancestor of $NEW_SHA (?!)" >&2
+  exit 1
 fi
 
 COMMITS=$(git log --pretty='format:%h %s' "$OLD_SHA..$NEW_SHA" |
           grep -v 'Merge pull request' |
           sed 's#^#https://github.com/cockroachdb/pebble/commit/#')
-echo "$COMMITS"
 popd
 
-COCKROACH_BRANCH="$USER/pebble-${BRANCH}-${NEW_SHA:0:12}"
+echo
+echo "$COMMITS"
+echo
+
+# If the script is run from $BRANCH, create a new local branch.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" == "$BRANCH" ]; then
+  COCKROACH_BRANCH="$USER/pebble-${BRANCH}-${NEW_SHA:0:12}"
+  echo "Creating and switching to new branch $COCKROACH_BRANCH"
+  git branch -D "$COCKROACH_BRANCH" || true
+  git checkout -b $COCKROACH_BRANCH
+else
+  echo "Using current branch $CURRENT_BRANCH."
+fi
 
 # Pull in the Pebble module at the desired SHA.
-pushd "$COCKROACH_DIR"
 ./dev generate go
 go get "github.com/cockroachdb/pebble@${NEW_SHA}"
 go mod tidy
-popd
 
 # Create the branch and commit on the CockroachDB repository.
-pushd "$COCKROACH_DIR"
 ./dev generate bazel --mirror
 git add go.mod go.sum DEPS.bzl build/bazelutil/distdir_files.bzl
-git branch -D "$COCKROACH_BRANCH" || true
-git checkout -b "$COCKROACH_BRANCH"
 git commit -m "go.mod: bump Pebble to ${NEW_SHA:0:12}
 
 $COMMITS

--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -63,7 +63,9 @@ popd
 pushd "$PEBBLE_DIR"
 git fetch "$PEBBLE_UPSTREAM_URL" "$PEBBLE_BRANCH"
 NEW_SHA=$(git rev-parse "$UPSTREAM/$PEBBLE_BRANCH")
-COMMITS=$(git log --pretty='format:%h %s' "$OLD_SHA..$NEW_SHA" | grep -v 'Merge pull request')
+COMMITS=$(git log --pretty='format:%h %s' "$OLD_SHA..$NEW_SHA" |
+          grep -v 'Merge pull request' |
+          sed 's#^#https://github.com/cockroachdb/pebble/commit/#')
 echo "$COMMITS"
 popd
 


### PR DESCRIPTION
Backport 3/3 commits from #116340.

/cc @cockroachdb/release

Release justification: dev internal tooling (no code changes)

---

#### scripts/bump-pebble.sh: add links for commits

Make the commits into links so they can easily be inspected by
reviewers.

Epic: none
Release note: None

#### scripts/bump-pebble.sh: don't use local pebble repo

Instead of assuming there is a local pebble repository, we now create
a temporary directory and clone a repository there.  Pebble is small
enough so this does not take long.

Epic: none
Release note: None

#### scripts/bump-pebble.sh: use current branch

We simplify the script to use the current branch and only create a new
branch if we are on master or the release branch. It is now the user's
responsibility to make sure the branch is up to date before running.

Epic: none
Release note: None
