### PR TITLE
release-23.1: roachtest: report failures to extend cluster as infra flakes

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2702,9 +2702,9 @@ func (c *clusterImpl) DestroyDNS(ctx context.Context, l *logger.Logger) error {
 // test plus enough headroom after the test finishes so that the next test
 // can be selected. If it doesn't, extend it.
 func (c *clusterImpl) MaybeExtendCluster(
-	ctx context.Context, l *logger.Logger, testSpec registry.TestSpec,
+	ctx context.Context, l *logger.Logger, testSpec *registry.TestSpec,
 ) error {
-	timeout := testTimeout(&testSpec)
+	timeout := testTimeout(testSpec)
 	minExp := timeutil.Now().Add(timeout + time.Hour)
 	if c.expiration.Before(minExp) {
 		extend := minExp.Sub(c.expiration)


### PR DESCRIPTION
Backport 1/1 commits from #116387.

/cc @cockroachdb/release

Release justification: test only change.

---

This commit introduces two main changes:

* always verify if we need to extend a cluster's lifetime before running a test, whether the cluster is being reused or not;
* if we fail to extend the cluster's lifetime, report the error as an infrastructure flake (cluster creation error). Crucially, don't return an error to the worker (which would halt the entire run), and don't notify teams about the failure.

Fixes: #115950.

Release note: None
