### PR TITLE
server: remove unused memory monitor

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1573,10 +1573,6 @@ func (s *SQLServer) preStart(
 	s.leaseMgr.RefreshLeases(ctx, stopper, s.execCfg.DB)
 	s.leaseMgr.PeriodicallyRefreshSomeLeases(ctx)
 
-	ieMon := sql.MakeInternalExecutorMemMonitor(sql.MemoryMetrics{}, s.execCfg.Settings)
-	ieMon.StartNoReserved(ctx, s.pgServer.SQLServer.GetBytesMonitor())
-	s.stopper.AddCloser(stop.CloserFn(func() { ieMon.Stop(ctx) }))
-
 	if err := s.jobRegistry.Start(ctx, stopper); err != nil {
 		return err
 	}


### PR DESCRIPTION
This memory monitor is not passed to anything. It was previously used
in the construction of an internal executor, but now that construction
happens elsewhere.

Epic: none

Release note: None