### PR TITLE
cli/zip: show redacted CREATE TYPE statement in debug zip

### DIFF
--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -340,8 +340,6 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 	},
 	// Ditto, for CREATE TYPE.
 	`"".crdb_internal.create_type_statements`: {
-		// `create_statement` column contains unredacted SQL statement strings
-		// containing customer-supplied enum constants.
 		// `enum_members` column contains customer-supplied enum constants.
 		nonSensitiveCols: NonSensitiveColumns{
 			"database_id",
@@ -349,6 +347,7 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 			"schema_name",
 			"descriptor_id",
 			"descriptor_name",
+			"crdb_internal.hide_sql_constants(create_statement) as create_statement",
 		},
 	},
 	"crdb_internal.default_privileges": {


### PR DESCRIPTION
The CREATE statement was not possible to view at all before, but now we use the hide_sql_constants builtin to show the redacted version.

Epic: None
Release note: None