### PR TITLE
bazel: remove spare line

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -120,7 +120,6 @@ build:engflowbase --define=EXECUTOR=remote
 build:engflowbase --disk_cache=
 build:engflowbase --experimental_inmemory_dotd_files
 build:engflowbase --experimental_inmemory_jdeps_files
-build:engflowbase --incompatible_strict_action_env=true
 build:engflowbase --remote_timeout=600
 build:engflowbase --nolegacy_important_outputs
 build:engflowbase --grpc_keepalive_time=30s


### PR DESCRIPTION
--incompatible_strict_action_env is set regardless, so we don't need to specify it again.

Epic: CRDB-8308
Release note: None