### PR TITLE
bazel: tag `integration` tests as `no-remote-exec`

### DIFF
--- a/pkg/acceptance/BUILD.bazel
+++ b/pkg/acceptance/BUILD.bazel
@@ -54,7 +54,10 @@ go_test(
     exec_properties = {"Pool": "large"},
     gotags = ["acceptance"],
     shard_count = 16,
-    tags = ["integration"],
+    tags = [
+        "integration",
+        "no-remote-exec",
+    ],
     deps = [
         "//pkg/acceptance/cluster",
         "//pkg/build/bazel",

--- a/pkg/compose/BUILD.bazel
+++ b/pkg/compose/BUILD.bazel
@@ -18,7 +18,10 @@ go_test(
     embed = [":compose"],
     exec_properties = {"Pool": "large"},
     gotags = ["compose"],
-    tags = ["integration"],
+    tags = [
+        "integration",
+        "no-remote-exec",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/util/envutil",

--- a/pkg/compose/compare/compare/BUILD.bazel
+++ b/pkg/compose/compare/compare/BUILD.bazel
@@ -12,7 +12,10 @@ go_test(
     srcs = ["compare_test.go"],
     embed = [":compare"],
     gotags = ["compose"],
-    tags = ["integration"],
+    tags = [
+        "integration",
+        "no-remote-exec",
+    ],
     visibility = ["//pkg/compose:__subpackages__"],
     deps = [
         "//pkg/cmd/cmpconn",

--- a/pkg/sql/schemachanger/corpus/BUILD.bazel
+++ b/pkg/sql/schemachanger/corpus/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "corpus",
     srcs = ["corpus.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/corpus",
-    tags = ["integration"],
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/schemachanger/scop",

--- a/pkg/testutils/docker/BUILD.bazel
+++ b/pkg/testutils/docker/BUILD.bazel
@@ -9,7 +9,10 @@ go_test(
         "//pkg/testutils/docker/docker-fsnotify",
     ],
     gotags = ["docker"],
-    tags = ["integration"],
+    tags = [
+        "integration",
+        "no-remote-exec",
+    ],
     deps = [
         "//pkg/util/ctxlog",
         "//pkg/util/log",

--- a/pkg/testutils/lint/BUILD.bazel
+++ b/pkg/testutils/lint/BUILD.bazel
@@ -25,7 +25,10 @@ go_test(
     embed = [":lint"],
     embedsrcs = ["gcassert_paths.txt"],
     gotags = ["lint"],
-    tags = ["integration"],
+    tags = [
+        "integration",
+        "no-remote-exec",
+    ],
     visibility = ["//build/bazelutil:__subpackages__"],
     deps = [
         "//pkg/build/bazel",


### PR DESCRIPTION
Epic: CRDB-8308
Release note: None