### PR TITLE
backupccl: wrap a few errors

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -2118,19 +2118,19 @@ func doRestorePlan(
 		overrideDBName = newDBName
 	}
 	if err := rewrite.TableDescs(tables, descriptorRewrites, overrideDBName); err != nil {
-		return err
+		return errors.Wrapf(err, "table descriptor rewrite failed")
 	}
 	if err := rewrite.DatabaseDescs(databases, descriptorRewrites, map[descpb.ID]struct{}{}); err != nil {
-		return err
+		return errors.Wrapf(err, "database descriptor rewrite failed")
 	}
 	if err := rewrite.SchemaDescs(schemas, descriptorRewrites); err != nil {
-		return err
+		return errors.Wrapf(err, "schema descriptor rewrite failed")
 	}
 	if err := rewrite.TypeDescs(types, descriptorRewrites); err != nil {
-		return err
+		return errors.Wrapf(err, "type descriptor rewrite failed")
 	}
 	if err := rewrite.FunctionDescs(functions, descriptorRewrites, overrideDBName); err != nil {
-		return err
+		return errors.Wrapf(err, "function descriptor rewrite failed")
 	}
 
 	encodedTables := make([]*descpb.TableDescriptor, len(tables))


### PR DESCRIPTION
Errors from the underlying parser calls used by rewrite functions can return confusing errors that make it appear as if the user's backup statement was invalid SQL.

Epic: none

Release note: None