### PR TITLE
release-23.2: streamingccl: parallelize initial splits

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -208,7 +208,7 @@ func startDistIngestion(
 	if !streamProgress.InitialSplitComplete {
 		codec := execCtx.ExtendedEvalContext().Codec
 		splitter := &dbSplitAndScatter{db: execCtx.ExecCfg().DB}
-		if err := createInitialSplits(ctx, codec, splitter, planner.initialTopology, details.DestinationTenantID); err != nil {
+		if err := createInitialSplits(ctx, codec, splitter, planner.initialTopology, len(planner.initialDestinationNodes), details.DestinationTenantID); err != nil {
 			return err
 		}
 	} else {
@@ -230,6 +230,15 @@ func startDistIngestion(
 		execCtx.ExecCfg().JobRegistry.MetricsStruct().StreamIngest.(*Metrics).ReplanCount.Inc(1)
 	}
 	return err
+}
+
+func sortSpans(partitions []streamclient.PartitionInfo) roachpb.Spans {
+	spansToSort := make(roachpb.Spans, 0)
+	for i := range partitions {
+		spansToSort = append(spansToSort, partitions[i].Spans...)
+	}
+	sort.Sort(spansToSort)
+	return spansToSort
 }
 
 // TODO(ssd): This is a duplicative with the split_and_scatter processor in
@@ -276,7 +285,8 @@ func (s *dbSplitAndScatter) now() hlc.Timestamp {
 }
 
 // createInitialSplits creates splits based on the given toplogy from the
-// source.
+// source. Parallelize splits by first sorting all the partition spans, and then
+// sending an equal number of contiguous spans to split workers.
 //
 // The idea here is to use the information from the source cluster about
 // the distribution of the data to produce split points to help prevent
@@ -287,6 +297,7 @@ func createInitialSplits(
 	codec keys.SQLCodec,
 	splitter splitAndScatterer,
 	topology streamclient.Topology,
+	destNodeCount int,
 	destTenantID roachpb.TenantID,
 ) error {
 	ctx, sp := tracing.ChildSpan(ctx, "streamingest.createInitialSplits")
@@ -302,8 +313,29 @@ func createInitialSplits(
 	if err != nil {
 		return err
 	}
-	for _, partition := range topology.Partitions {
-		for _, span := range partition.Spans {
+
+	grp := ctxgroup.WithContext(ctx)
+	sortedSpans := sortSpans(topology.Partitions)
+	splitWorkers := destNodeCount
+	spansPerWorker := len(sortedSpans) / splitWorkers
+	for i := 0; i < splitWorkers; i++ {
+		startIdx := i * spansPerWorker
+		endIdx := (i + 1) * spansPerWorker
+		workerSpans := sortedSpans[startIdx:endIdx]
+		if i == splitWorkers-1 {
+			// The last worker handles the remainder spans
+			workerSpans = sortedSpans[startIdx:]
+		}
+		grp.GoCtx(splitAndScatterWorker(workerSpans, rekeyer, splitter))
+	}
+	return grp.Wait()
+}
+
+func splitAndScatterWorker(
+	spans []roachpb.Span, rekeyer *backupccl.KeyRewriter, splitter splitAndScatterer,
+) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		for _, span := range spans {
 			startKey := span.Key.Clone()
 			splitKey, _, err := rekeyer.RewriteKey(startKey, 0 /* walltimeForImportElision */)
 			if err != nil {
@@ -336,8 +368,8 @@ func createInitialSplits(
 			}
 
 		}
+		return nil
 	}
-	return nil
 }
 
 var splitAndScatterSitckyBitDuration = time.Hour
@@ -396,8 +428,9 @@ type replicationFlowPlanner struct {
 
 	initialPlanCtx *sql.PlanningCtx
 
-	initialStreamAddresses []string
-	initialTopology        streamclient.Topology
+	initialStreamAddresses  []string
+	initialTopology         streamclient.Topology
+	initialDestinationNodes []base.SQLInstanceID
 
 	srcTenantID roachpb.TenantID
 }
@@ -430,16 +463,18 @@ func (p *replicationFlowPlanner) constructPlanGenerator(
 		if err != nil {
 			return nil, nil, err
 		}
-		if !p.createdInitialPlan() {
-			p.initialTopology = topology
-			p.initialStreamAddresses = topology.StreamAddresses()
-		}
 
 		p.srcTenantID = topology.SourceTenantID
 
 		planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, execCtx.ExtendedEvalContext(), execCtx.ExecCfg())
 		if err != nil {
 			return nil, nil, err
+		}
+		if !p.createdInitialPlan() {
+			p.initialTopology = topology
+			p.initialStreamAddresses = topology.StreamAddresses()
+			p.initialDestinationNodes = sqlInstanceIDs
+
 		}
 		destNodeLocalities, err := getDestNodeLocalities(ctx, dsp, sqlInstanceIDs)
 		if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #115562.

/cc @cockroachdb/release

---

During large scale initial scans, sending the initial splits can take a significant amount of time. This patch parallelize the splits across several workers on the job coordinator. To parallelize splits, we attempt to provide each worker with a large contiguous set of spans to minimize workers from working the same key space.

Epic: none

Release note: none
