### PR TITLE
ui: remove "undefined" from events description

### DIFF
--- a/pkg/ui/workspaces/db-console/src/util/events.ts
+++ b/pkg/ui/workspaces/db-console/src/util/events.ts
@@ -16,6 +16,7 @@ import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
  */
 export function getEventDescription(e: clusterUiApi.EventColumns): string {
   const info: EventInfo = e.info ? JSON.parse(e.info) : {};
+  const withID = info.MutationID ? ` with ID ${info.MutationID}` : "";
   let privs = "";
   let comment = "";
 
@@ -69,13 +70,13 @@ export function getEventDescription(e: clusterUiApi.EventColumns): string {
     case eventTypes.TRUNCATE_TABLE:
       return `Table Truncated: User ${info.User} truncated table ${info.TableName}`;
     case eventTypes.ALTER_TABLE:
-      return `Schema Change: User ${info.User} began a schema change to alter table ${info.TableName} with ID ${info.MutationID}`;
+      return `Schema Change: User ${info.User} began a schema change to alter table ${info.TableName}${withID}`;
     case eventTypes.CREATE_INDEX:
-      return `Schema Change: User ${info.User} began a schema change to create an index ${info.IndexName} on table ${info.TableName} with ID ${info.MutationID}`;
+      return `Schema Change: User ${info.User} began a schema change to create an index ${info.IndexName} on table ${info.TableName}${withID}`;
     case eventTypes.DROP_INDEX:
-      return `Schema Change: User ${info.User} began a schema change to drop index ${info.IndexName} on table ${info.TableName} with ID ${info.MutationID}`;
+      return `Schema Change: User ${info.User} began a schema change to drop index ${info.IndexName} on table ${info.TableName}${withID}`;
     case eventTypes.ALTER_INDEX:
-      return `Schema Change: User ${info.User} began a schema change to alter index ${info.IndexName} on table ${info.TableName} with ID ${info.MutationID}`;
+      return `Schema Change: User ${info.User} began a schema change to alter index ${info.IndexName} on table ${info.TableName}${withID}`;
     case eventTypes.CREATE_VIEW:
       return `View Created: User ${info.User} created view ${info.ViewName}`;
     case eventTypes.DROP_VIEW:
@@ -97,11 +98,11 @@ export function getEventDescription(e: clusterUiApi.EventColumns): string {
     case eventTypes.DROP_SEQUENCE:
       return `Sequence Dropped: User ${info.User} dropped sequence ${info.SequenceName}`;
     case eventTypes.REVERSE_SCHEMA_CHANGE:
-      return `Schema Change Reversed: Schema change on descriptor ${info.DescriptorID} with ID ${info.MutationID} was reversed.`;
+      return `Schema Change Reversed: Schema change on descriptor ${info.DescriptorID}${withID} was reversed.`;
     case eventTypes.FINISH_SCHEMA_CHANGE:
-      return `Schema Change Completed: Schema change on descriptor ${info.DescriptorID} with ID ${info.MutationID} was completed.`;
+      return `Schema Change Completed: Schema change on descriptor ${info.DescriptorID}${withID} was completed.`;
     case eventTypes.FINISH_SCHEMA_CHANGE_ROLLBACK:
-      return `Schema Change Rollback Completed: Rollback of schema change on descriptor ${info.DescriptorID} with ID ${info.MutationID} was completed.`;
+      return `Schema Change Rollback Completed: Rollback of schema change on descriptor ${info.DescriptorID}${withID} was completed.`;
     case eventTypes.NODE_JOIN:
       return `Node Joined: Node ${info.NodeID} joined the cluster`;
     case eventTypes.NODE_DECOMMISSIONING:


### PR DESCRIPTION
Fixes #116491

Not all types of schema changes are setting the value for the mudation ID, causing the value to show as `undefined` on the UI.
This commit checks if the value exists to be displayed, otherwise don't show it.

Before
<img width="403" alt="Screenshot 2023-12-14 at 4 18 43 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/f590348c-8f92-4730-9d8a-766f4ef0c7ee">


After
<img width="387" alt="Screenshot 2023-12-14 at 4 37 06 PM" src="https://github.com/cockroachdb/cockroach/assets/1017486/3f73d4f7-1686-454c-b545-7eb1d6330417">

Release note (bug fix): Remove ID from event description when is `undefined`.