### PR TITLE
changefeedccl: Partially support CDC query in ALTER CHANGEFEED

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupresolver"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedvalidators"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -153,6 +154,14 @@ func alterChangefeedPlanHook(
 			return err
 		}
 		newChangefeedStmt.Targets = newTargets
+
+		if prevDetails.Select != "" {
+			query, err := cdceval.ParseChangefeedExpression(prevDetails.Select)
+			if err != nil {
+				return err
+			}
+			newChangefeedStmt.Select = query
+		}
 
 		for key, value := range newOptions.AsMap() {
 			opt := tree.KVOption{Key: tree.Name(key)}
@@ -465,9 +474,26 @@ func generateAndValidateNewTargets(
 		return nil, nil, hlc.Timestamp{}, nil, err
 	}
 
+	checkIfCommandAllowed := func() error {
+		if prevDetails.Select == "" {
+			return nil
+		}
+		return errors.WithIssueLink(
+			errors.New("cannot modify targets when using CDC query changefeed; consider recreating changefeed"),
+			errors.IssueLink{
+				IssueURL: "https://github.com/cockroachdb/cockroach/issues/83033",
+				Detail: "you have encountered a known bug in CockroachDB, please consider " +
+					"reporting on the Github issue or reach out via Support.",
+			})
+	}
+
 	for _, cmd := range alterCmds {
 		switch v := cmd.(type) {
 		case *tree.AlterChangefeedAddTarget:
+			if err := checkIfCommandAllowed(); err != nil {
+				return nil, nil, hlc.Timestamp{}, nil, err
+			}
+
 			targetOpts, err := exprEval.KVOptions(
 				ctx, v.Options, changefeedvalidators.AlterTargetOptionValidations,
 			)
@@ -563,6 +589,10 @@ func generateAndValidateNewTargets(
 			}
 			telemetry.CountBucketed(telemetryPath+`.added_targets`, int64(len(v.Targets)))
 		case *tree.AlterChangefeedDropTarget:
+			if err := checkIfCommandAllowed(); err != nil {
+				return nil, nil, hlc.Timestamp{}, nil, err
+			}
+
 			for _, target := range v.Targets {
 				desc, found, err := getTargetDesc(ctx, p, descResolver, target.TableName)
 				if err != nil {

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
@@ -437,6 +438,48 @@ func TestAlterChangefeedSetDiffOption(t *testing.T) {
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (0, 'initial')`)
 		assertPayloads(t, testFeed, []string{
 			`foo: [0]->{"after": {"a": 0, "b": "initial"}, "before": null}`,
+		})
+	}
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection)
+}
+
+func TestAlterChangefeedRespectsCDCQuery(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+
+		const cdcQuery = "SELECT * FROM foo WHERE a % 2 = 0"
+		testFeed := feed(t, f, "CREATE CHANGEFEED WITH format='json', envelope='wrapped' AS "+cdcQuery)
+		defer closeFeed(t, testFeed)
+
+		feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		sqlDB.Exec(t, `PAUSE JOB $1`, feed.JobID())
+		waitForJobStatus(sqlDB, t, feed.JobID(), `paused`)
+
+		sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d SET diff`, feed.JobID()))
+		registry := s.Server.JobRegistry().(*jobs.Registry)
+		job, err := registry.LoadJob(context.Background(), feed.JobID())
+		require.NoError(t, err)
+		details, ok := job.Details().(jobspb.ChangefeedDetails)
+		require.True(t, ok)
+
+		// Verify the query still intact.
+		sc, err := cdceval.ParseChangefeedExpression(cdcQuery)
+		require.NoError(t, err)
+		require.Equal(t, cdceval.AsStringUnredacted(sc), details.Select)
+
+		// Addition/Removal of the tables is not supported yet.
+		t.Run("cannot add or drop", func(t *testing.T) {
+			sqlDB.ExpectErr(t, "cannot modify targets when using CDC query changefeed",
+				fmt.Sprintf(`ALTER CHANGEFEED %d ADD blah SET DIFF`, feed.JobID()))
+			sqlDB.ExpectErr(t, "cannot modify targets when using CDC query changefeed",
+				fmt.Sprintf(`ALTER CHANGEFEED %d DROP blah SET DIFF`, feed.JobID()))
 		})
 	}
 


### PR DESCRIPTION
Ensure `ALTER CHANGEFEED` does not erase CDC query when modifying other changefeed properties.

Informs #83033

Release note (enterprise change): `ALTER CHANGEFEED` no longer removes CDC query when modifying changefeed properties.