### PR TITLE
sql_test: Use require.ErrorContains instead of require.Equal

### DIFF
--- a/pkg/sql/catalog/tabledesc/validate_version_gating_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_version_gating_test.go
@@ -116,7 +116,7 @@ func TestIndexDoesNotStorePrimaryKeyColumnMixedVersion(t *testing.T) {
 	// Assert cluster version upgrade is blocked.
 	require.Equal(t, [][]string{{"1000023.1"}}, tdb.QueryStr(t, "SHOW CLUSTER SETTING version;"))
 	_, err := sqlDB.Exec(`SET CLUSTER SETTING version = $1`, clusterversion.Latest.String())
-	require.Equal(t, `pq: internal error: verifying precondition for version 1000023.1-upgrading-to-1000023.2-step-002: "".crdb_internal.invalid_objects is not empty`, err.Error())
+	require.ErrorContains(t, err, `verifying precondition for version 1000023.1-upgrading-to-1000023.2-step-002: "".crdb_internal.invalid_objects is not empty`)
 }
 
 // mustInsertDescToDB decode a table descriptor from a hex-encoded string and insert


### PR DESCRIPTION
It's recommended that we use `require.ErrorContains` instead of `require.Equal` so that it won't crash if `err` is nil.

Informs #116447

Release note: None