### PR TITLE
plpgsql: cast RAISE format args to strings

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -2817,4 +2817,15 @@ SELECT * FROM t114826;
 1
 1
 
+# Regression test for #114678 - cast RAISE format arguments to strings.
+subtest raise_format_arg
+
+statement ok
+CREATE FUNCTION f114678() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RAISE NOTICE '% % %', now(), 1, True; RETURN 0; END $$;
+CREATE PROCEDURE p114678() LANGUAGE PLpgSQL AS $$ BEGIN RAISE NOTICE '% % %', now(), 1, True; END $$;
+
+statement ok
+SELECT f114678();
+CALL p114678();
+
 subtest end

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -1011,7 +1011,8 @@ func (b *plpgsqlBuilder) makeRaiseFormatMessage(
 					panic(pgerror.Newf(pgcode.Syntax, "too few parameters specified for RAISE"))
 				}
 				// If the argument is NULL, postgres prints "<NULL>".
-				arg := b.buildPLpgSQLExpr(args[argIdx], types.String, s)
+				expr := &tree.CastExpr{Expr: args[argIdx], Type: types.String}
+				arg := b.buildPLpgSQLExpr(expr, types.String, s)
 				arg = b.ob.factory.ConstructCoalesce(memo.ScalarListExpr{arg, makeConstStr("<NULL>")})
 				addToResult(arg)
 				argIdx++


### PR DESCRIPTION
This patch adds explicit string casts to the formatting arguments of a PLpgSQL RAISE statement. This prevents errors during type-checking when a non-string argument is supplied - for example, the `now()` builtin.

Fixes #114678

Release note (bug fix): Fixed a bug that could cause a function resolution error when attempting to use a builtin function like `now()` as a formatting argument to a PLpgSQL RAISE statement.