### PR TITLE
release-23.2: roachtest: update multitenant/distsql to use new roachprod service APIs

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1987,6 +1987,17 @@ func (c *clusterImpl) StartE(
 	return nil
 }
 
+// StartServiceForVirtualClusterE can start either external or shared process
+// virtual clusters. This can be specified in startOpts.RoachprodOpts. Set the
+// `Target` to the required virtual cluster type. Refer to the virtual cluster
+// section in the struct for more information on what fields are available for
+// virtual clusters.
+//
+// With external process virtual clusters an external process will be started on
+// each node specified in the externalNodes parameter.
+//
+// With shared process virtual clusters the required queries will be run on a
+// storage node of the cluster specified in the opts parameter.
 func (c *clusterImpl) StartServiceForVirtualClusterE(
 	ctx context.Context,
 	l *logger.Logger,

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -64,6 +64,11 @@ type Cluster interface {
 	StopCockroachGracefullyOnNode(ctx context.Context, l *logger.Logger, node int) error
 	NewMonitor(context.Context, ...option.Option) Monitor
 
+	// Starting virtual clusters.
+
+	StartServiceForVirtualClusterE(ctx context.Context, l *logger.Logger, externalNodes option.NodeListOption, startOpts option.StartOpts, settings install.ClusterSettings, opts ...option.Option) error
+	StartServiceForVirtualCluster(ctx context.Context, l *logger.Logger, externalNodes option.NodeListOption, startOpts option.StartOpts, settings install.ClusterSettings, opts ...option.Option)
+
 	// Hostnames and IP addresses of the nodes.
 
 	InternalAddr(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)

--- a/pkg/cmd/roachtest/option/connection_options.go
+++ b/pkg/cmd/roachtest/option/connection_options.go
@@ -35,6 +35,12 @@ func TenantName(tenantName string) func(*ConnOption) {
 	}
 }
 
+func SQLInstance(sqlInstance int) func(*ConnOption) {
+	return func(option *ConnOption) {
+		option.SQLInstance = sqlInstance
+	}
+}
+
 func ConnectionOption(key, value string) func(*ConnOption) {
 	return func(option *ConnOption) {
 		if len(option.Options) == 0 {

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -56,6 +56,16 @@ func DefaultStartSingleNodeOpts() StartOpts {
 	return startOpts
 }
 
+// DefaultStartVirtualClusterOpts returns StartOpts for starting an external
+// process virtual cluster with the given tenant name and SQL instance.
+func DefaultStartVirtualClusterOpts(tenantName string, sqlInstance int) StartOpts {
+	startOpts := StartOpts{RoachprodOpts: roachprod.DefaultStartOpts()}
+	startOpts.RoachprodOpts.Target = install.StartServiceForVirtualCluster
+	startOpts.RoachprodOpts.VirtualClusterName = tenantName
+	startOpts.RoachprodOpts.SQLInstance = sqlInstance
+	return startOpts
+}
+
 // StopOpts is a type that combines the stop options needed by roachprod and roachtest.
 type StopOpts struct {
 	// TODO(radu): we should use a higher-level abstraction instead of

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -778,6 +778,7 @@ func (r *testRunner) runWorker(
 
 				// Set initial cluster settings for this test.
 				c.clusterSettings = map[string]string{}
+				c.virtualClusterSettings = map[string]string{}
 
 				switch testSpec.Leases {
 				case registry.DefaultLeases:

--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -209,6 +209,7 @@ func runMultiTenantDistSQL(
 			// Open bundle and verify its contents
 			sqlConnCtx := clisqlclient.Context{}
 			pgURL, err := c.ExternalPGUrl(ctx, t.L(), c.Node(1), tenantName, 0)
+			require.NoError(t, err)
 			conn := sqlConnCtx.MakeSQLConn(io.Discard, io.Discard, pgURL[0])
 			bundles, err := clisqlclient.StmtDiagListBundles(ctx, conn)
 			require.NoError(t, err)

--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -73,17 +73,7 @@ func runMultiTenantDistSQL(
 	for i := 0; i < numInstances; i++ {
 		node := (i % c.Spec().NodeCount) + 1
 		sqlInstance := i / c.Spec().NodeCount
-		instStartOps := option.DefaultStartOpts()
-		instStartOps.RoachprodOpts.Target = install.StartServiceForVirtualCluster
-		instStartOps.RoachprodOpts.VirtualClusterName = tenantName
-		instStartOps.RoachprodOpts.SQLInstance = sqlInstance
-		// We set the ports to 0 so that ports are assigned dynamically. This is a
-		// temporary workaround until we use dynamic port assignment as the default.
-		// See: https://github.com/cockroachdb/cockroach/issues/111052
-		// TODO(herko): remove this once dynamic port assignment is the default.
-		instStartOps.RoachprodOpts.SQLPort = 0
-		instStartOps.RoachprodOpts.AdminUIPort = 0
-
+		instStartOps := option.DefaultStartVirtualClusterOpts(tenantName, sqlInstance)
 		t.L().Printf("Starting instance %d on node %d", i, node)
 		c.StartServiceForVirtualCluster(ctx, t.L(), c.Node(node), instStartOps, settings, storageNodes)
 		nodes.Add(i + 1)

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -162,7 +162,9 @@ const (
 	// StartRoutingProxy starts the SQL proxy process to route
 	// connections to multiple virtual clusters.
 	StartRoutingProxy
+)
 
+const (
 	// startSQLTimeout identifies the COCKROACH_CONNECT_TIMEOUT to use (in seconds)
 	// for sql cmds within syncedCluster.Start().
 	startSQLTimeout = 1200


### PR DESCRIPTION
Backport 6/6 commits from #115599.

/cc @cockroachdb/release

---

Previously the multitenant distsql roachtest relied on an internal util in `roachtest` to start virtual clusters. This PR updates the test to use the new official `roachtest` and `roachprod` APIs for starting virtual clusters.


Some additional changes were required to support upgrading the test. The cluster interface only exposed a method to start storage nodes, but that is insufficient to start virtual clusters that have a separate method on the `roachprod` API (for starting).

This change adds a new method `StartServiceForVirtualCluster` to the cluster interface to enable roachtests to start virtual clusters. Some refactoring was required to enable different sets of cluster settings, depending on what service
type is going to be started.

There are now two sets of cluster settings that can be utilised in `test_runner`. For virtual clusters `virtualClusterSettings` will be used, and for storage clusters `clusterSettings` will be utilised.

Fixes: #116019

Release Note: None
Epic: CRDB-31933

Release justification: Test only change.

