### PR TITLE
release-23.2: upgrades: skip TestBackfillRegionalByRow under deadlock

### DIFF
--- a/pkg/upgrade/upgrades/system_rbr_indexes_test.go
+++ b/pkg/upgrade/upgrades/system_rbr_indexes_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -41,6 +42,8 @@ import (
 func TestBackfillRegionalByRow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderDeadlock(t, "times out under deadlock")
 
 	ctx := context.Background()
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})


### PR DESCRIPTION
Closes https://github.com/cockroachdb/cockroach/issues/116418

Release note: None