### PR TITLE
sql: delete zone configuration in secondary tenant

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -107,7 +106,7 @@ func descExists(sqlDB *gosql.DB, exists bool, id descpb.ID) error {
 func TestDropDatabase(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	ctx, cancel := context.WithCancel(context.Background())
 	params.Knobs.GCJob = &sql.GCJobTestingKnobs{
 		RunBeforeResume: func(jobID jobspb.JobID) error {
@@ -115,9 +114,10 @@ func TestDropDatabase(t *testing.T) {
 			return ctx.Err()
 		},
 	}
-	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(context.Background())
+	srv, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer srv.Stopper().Stop(context.Background())
 	defer cancel()
+	s := srv.ApplicationLayer()
 
 	// Fix the column families so the key counts below don't change if the
 	// family heuristics are updated.
@@ -129,7 +129,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatal(err)
 	}
 
-	tbDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv")
+	tbDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "t", "kv")
 	var dbDesc catalog.DatabaseDescriptor
 	require.NoError(t, sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) (err error) {
 		dbDesc, err = col.ByID(txn.KV()).Get().Database(ctx, tbDesc.GetParentID())
@@ -156,7 +156,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatal(err)
 	}
 
-	tableSpan := tbDesc.TableSpan(keys.SystemSQLCodec)
+	tableSpan := tbDesc.TableSpan(s.Codec())
 	tests.CheckKeyCount(t, kvDB, tableSpan, 6)
 
 	if _, err := sqlDB.Exec(`DROP DATABASE t RESTRICT`); !testutils.IsError(err,
@@ -174,7 +174,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	if err := descExists(sqlDB, true, tbDesc.GetID()); err != nil {
 		t.Fatal(err)
 	}
-	tbNameKey := catalogkeys.EncodeNameKey(keys.SystemSQLCodec, tbDesc)
+	tbNameKey := catalogkeys.EncodeNameKey(s.Codec(), tbDesc)
 	if gr, err := kvDB.Get(ctx, tbNameKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
@@ -189,7 +189,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatal(err)
 	}
 
-	dbNameKey := catalogkeys.EncodeNameKey(keys.SystemSQLCodec, dbDesc)
+	dbNameKey := catalogkeys.EncodeNameKey(s.Codec(), dbDesc)
 	if gr, err := kvDB.Get(ctx, dbNameKey); err != nil {
 		t.Fatal(err)
 	} else if gr.Exists() {
@@ -410,47 +410,51 @@ func TestDropIndex(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	const chunkSize = 200
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			BackfillChunkSize: chunkSize,
 		},
 	}
-	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(context.Background())
+	srv, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer srv.Stopper().Stop(context.Background())
+	s := srv.ApplicationLayer()
 
-	_, err := sqlDB.Exec(`SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s';`)
+	systemDB := srv.SystemLayer().SQLConn(t)
+
+	_, err := systemDB.Exec(`SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s';`)
 	require.NoError(t, err)
 
 	// Refresh protected timestamp cache immediately to make MVCC GC queue to
 	// process GC immediately.
-	_, err = sqlDB.Exec(`SET CLUSTER SETTING kv.protectedts.poll_interval = '1s';`)
+	_, err = systemDB.Exec(`SET CLUSTER SETTING kv.protectedts.poll_interval = '1s';`)
 	require.NoError(t, err)
 
 	// Disable strict GC TTL enforcement because we're going to shove a zero-value
 	// TTL into the system with AddImmediateGCZoneConfig.
-	defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDB)()
+	defer sqltestutils.DisableGCTTLStrictEnforcement(t, systemDB)()
 
+	codec := s.Codec()
 	numRows := 2*chunkSize + 1
 	if err := tests.CreateKVTable(sqlDB, "kv", numRows); err != nil {
 		t.Fatal(err)
 	}
-	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv")
+	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "kv")
 	if _, err := sqltestutils.AddImmediateGCZoneConfig(sqlDB, tableDesc.GetID()); err != nil {
 		t.Fatal(err)
 	}
-	tests.CheckKeyCount(t, kvDB, tableDesc.TableSpan(keys.SystemSQLCodec), 3*numRows)
+	tests.CheckKeyCount(t, kvDB, tableDesc.TableSpan(codec), 3*numRows)
 	idx, err := catalog.MustFindIndexByName(tableDesc, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
-	indexSpan := tableDesc.IndexSpan(keys.SystemSQLCodec, idx.GetID())
+	indexSpan := tableDesc.IndexSpan(codec, idx.GetID())
 	tests.CheckKeyCount(t, kvDB, indexSpan, numRows)
 	if _, err := sqlDB.Exec(`DROP INDEX t.kv@foo`); err != nil {
 		t.Fatal(err)
 	}
 
-	tableDesc = desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv")
+	tableDesc = desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "kv")
 	if _, err := catalog.MustFindIndexByName(tableDesc, "foo"); err == nil {
 		t.Fatalf("table descriptor still contains index after index is dropped")
 	}
@@ -479,12 +483,12 @@ func TestDropIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tableDesc = desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv")
+	tableDesc = desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "kv")
 	newIdx, err := catalog.MustFindIndexByName(tableDesc, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
-	newIdxSpan := tableDesc.IndexSpan(keys.SystemSQLCodec, newIdx.GetID())
+	newIdxSpan := tableDesc.IndexSpan(codec, newIdx.GetID())
 
 	testutils.SucceedsSoon(t, func() error {
 		if err := jobutils.VerifyRunningSystemJob(t, sqlRun, 2, jobspb.TypeSchemaChangeGC, sql.RunningStatusWaitingForMVCCGC, jobs.Record{
@@ -501,7 +505,7 @@ func TestDropIndex(t *testing.T) {
 
 	tests.CheckKeyCount(t, kvDB, newIdxSpan, numRows)
 	tests.CheckKeyCount(t, kvDB, indexSpan, 0)
-	tests.CheckKeyCount(t, kvDB, tableDesc.TableSpan(keys.SystemSQLCodec), 3*numRows)
+	tests.CheckKeyCount(t, kvDB, tableDesc.TableSpan(codec), 3*numRows)
 }
 
 func TestDropIndexWithZoneConfigOSS(t *testing.T) {
@@ -511,24 +515,26 @@ func TestDropIndexWithZoneConfigOSS(t *testing.T) {
 	const chunkSize = 200
 	const numRows = 2*chunkSize + 1
 
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{BackfillChunkSize: chunkSize},
 	}
-	s, sqlDBRaw, kvDB := serverutils.StartServer(t, params)
+	srv, sqlDBRaw, kvDB := serverutils.StartServer(t, params)
 	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
-	defer s.Stopper().Stop(context.Background())
+	defer srv.Stopper().Stop(context.Background())
+	s := srv.ApplicationLayer()
+	codec := s.Codec()
 
 	// Create a test table with a secondary index.
 	if err := tests.CreateKVTable(sqlDBRaw, "kv", numRows); err != nil {
 		t.Fatal(err)
 	}
-	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv")
+	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "kv")
 	index, err := catalog.MustFindIndexByName(tableDesc, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
-	indexSpan := tableDesc.IndexSpan(keys.SystemSQLCodec, index.GetID())
+	indexSpan := tableDesc.IndexSpan(codec, index.GetID())
 	tests.CheckKeyCount(t, kvDB, indexSpan, numRows)
 
 	// Hack in zone configs for the primary and secondary indexes. (You need a CCL
@@ -562,7 +568,7 @@ func TestDropIndexWithZoneConfigOSS(t *testing.T) {
 	// TODO(benesch): Run scrub here. It can't currently handle the way t.kv
 	// declares column families.
 
-	tableDesc = desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv")
+	tableDesc = desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "kv")
 	if _, err := catalog.MustFindIndexByName(tableDesc, "foo"); err == nil {
 		t.Fatalf("table descriptor still contains index after index is dropped")
 	}
@@ -574,7 +580,7 @@ func TestDropTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	ctx, cancel := context.WithCancel(context.Background())
 	params.Knobs.GCJob = &sql.GCJobTestingKnobs{
 		RunBeforeResume: func(jobID jobspb.JobID) error {
@@ -582,9 +588,11 @@ func TestDropTable(t *testing.T) {
 			return ctx.Err()
 		},
 	}
-	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(context.Background())
+	srv, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer srv.Stopper().Stop(context.Background())
 	defer cancel()
+	s := srv.ApplicationLayer()
+	codec := s.Codec()
 
 	numRows := 2*row.TableTruncateChunkSize + 1
 	if err := tests.CreateKVTable(sqlDB, "kv", numRows); err != nil {
@@ -594,8 +602,8 @@ func TestDropTable(t *testing.T) {
 	parentDatabaseID := descpb.ID(sqlutils.QueryDatabaseID(t, sqlDB, "t"))
 	parentSchemaID := descpb.ID(sqlutils.QuerySchemaID(t, sqlDB, "t", "public"))
 
-	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "kv")
-	nameKey := catalogkeys.EncodeNameKey(keys.SystemSQLCodec, &descpb.NameInfo{
+	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "kv")
+	nameKey := catalogkeys.EncodeNameKey(codec, &descpb.NameInfo{
 		ParentID:       parentDatabaseID,
 		ParentSchemaID: parentSchemaID,
 		Name:           "kv",
@@ -620,7 +628,7 @@ func TestDropTable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tableSpan := tableDesc.TableSpan(keys.SystemSQLCodec)
+	tableSpan := tableDesc.TableSpan(codec)
 	tests.CheckKeyCount(t, kvDB, tableSpan, 3*numRows)
 	if _, err := sqlDB.Exec(`DROP TABLE t.kv`); err != nil {
 		t.Fatal(err)
@@ -674,7 +682,7 @@ func TestDropTable(t *testing.T) {
 func TestDropTableDeleteData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	// Speed up mvcc queue scan.
 	params.ScanMaxIdleTime = time.Millisecond
 
@@ -686,15 +694,18 @@ func TestDropTableDeleteData(t *testing.T) {
 		},
 	}
 
-	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(context.Background())
+	srv, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer srv.Stopper().Stop(context.Background())
+	s := srv.ApplicationLayer()
+	codec := s.Codec()
+	systemDB := srv.SystemLayer().SQLConn(t)
 
-	_, err := sqlDB.Exec(`SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s';`)
+	_, err := systemDB.Exec(`SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s';`)
 	require.NoError(t, err)
 
 	// Disable strict GC TTL enforcement because we're going to shove a zero-value
 	// TTL into the system with AddImmediateGCZoneConfig.
-	defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDB)()
+	defer sqltestutils.DisableGCTTLStrictEnforcement(t, systemDB)()
 
 	const numRows = 2*row.TableTruncateChunkSize + 1
 	const numKeys = 3 * numRows
@@ -706,12 +717,12 @@ func TestDropTableDeleteData(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		descs = append(descs, desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", tableName))
+		descs = append(descs, desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", tableName))
 
 		parentDatabaseID := descpb.ID(sqlutils.QueryDatabaseID(t, sqlDB, "t"))
 		parentSchemaID := descpb.ID(sqlutils.QuerySchemaID(t, sqlDB, "t", "public"))
 
-		nameKey := catalogkeys.EncodeNameKey(keys.SystemSQLCodec, &descpb.NameInfo{
+		nameKey := catalogkeys.EncodeNameKey(codec, &descpb.NameInfo{
 			ParentID:       parentDatabaseID,
 			ParentSchemaID: parentSchemaID,
 			Name:           tableName,
@@ -724,7 +735,7 @@ func TestDropTableDeleteData(t *testing.T) {
 			t.Fatalf("Name entry %q does not exist", nameKey)
 		}
 
-		tableSpan := descs[i].TableSpan(keys.SystemSQLCodec)
+		tableSpan := descs[i].TableSpan(codec)
 		tests.CheckKeyCount(t, kvDB, tableSpan, numKeys)
 
 		if _, err := sqltestutils.AddImmediateGCZoneConfig(sqlDB, descs[i].GetID()); err != nil {
@@ -744,8 +755,8 @@ func TestDropTableDeleteData(t *testing.T) {
 		if err := descExists(sqlDB, true, descs[i].GetID()); err != nil {
 			t.Fatalf("table (id=%d name=%s) was deleted. error: %v", descs[i].GetID(), descs[i].GetName(), err)
 		}
-		tableSpan := descs[i].TableSpan(keys.SystemSQLCodec)
-		tests.CheckKeyCountIncludingTombstoned(t, s, tableSpan, numKeys)
+		tableSpan := descs[i].TableSpan(codec)
+		tests.CheckKeyCountIncludingTombstoned(t, srv.StorageLayer(), tableSpan, numKeys)
 	}
 
 	close(allowGC)
@@ -763,7 +774,7 @@ func TestDropTableDeleteData(t *testing.T) {
 
 	// Refresh protected timestamp cache immediately to make MVCC GC queue to
 	// process GC immediately.
-	_, err = sqlDB.Exec(`SET CLUSTER SETTING kv.protectedts.poll_interval = '1s';`)
+	_, err = systemDB.Exec(`SET CLUSTER SETTING kv.protectedts.poll_interval = '1s';`)
 	require.NoError(t, err)
 
 	checkTableGCed := func(i int) {
@@ -774,8 +785,8 @@ func TestDropTableDeleteData(t *testing.T) {
 			return zoneExists(sqlDB, nil, descs[i].GetID())
 		})
 
-		tableSpan := descs[i].TableSpan(keys.SystemSQLCodec)
-		tests.CheckKeyCountIncludingTombstoned(t, s, tableSpan, 0)
+		tableSpan := descs[i].TableSpan(codec)
+		tests.CheckKeyCountIncludingTombstoned(t, srv.StorageLayer(), tableSpan, 0)
 
 		// Ensure that the job is marked as succeeded.
 		if err := jobutils.VerifySystemJob(t, sqlRun, numTables+i,
@@ -804,14 +815,16 @@ func TestDropTableDeleteData(t *testing.T) {
 	}
 }
 
-func writeTableDesc(ctx context.Context, db *kv.DB, tableDesc *tabledesc.Mutable) error {
+func writeTableDesc(
+	ctx context.Context, db *kv.DB, codec keys.SQLCodec, tableDesc *tabledesc.Mutable,
+) error {
 	return db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		var err error
 		tableDesc.ModificationTime, err = txn.CommitTimestamp()
 		if err != nil {
 			return err
 		}
-		return txn.Put(ctx, catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, tableDesc.ID), tableDesc.DescriptorProto())
+		return txn.Put(ctx, catalogkeys.MakeDescMetadataKey(codec, tableDesc.ID), tableDesc.DescriptorProto())
 	})
 }
 
@@ -827,36 +840,41 @@ func TestDropTableWhileUpgradingFormat(t *testing.T) {
 
 	ctx := context.Background()
 
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	params.ScanMaxIdleTime = time.Millisecond
-	s, sqlDBRaw, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(ctx)
+	srv, sqlDBRaw, kvDB := serverutils.StartServer(t, params)
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+
+	codec := s.Codec()
+	systemDBRaw := srv.SystemLayer().SQLConn(t)
+	systemDB := sqlutils.MakeSQLRunner(systemDBRaw)
 	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s';`)
+	systemDB.Exec(t, `SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s';`)
 
 	// Refresh protected timestamp cache immediately to make MVCC GC queue to
 	// process GC immediately.
-	sqlDB.Exec(t, `SET CLUSTER SETTING kv.protectedts.poll_interval = '1s';`)
+	systemDB.Exec(t, `SET CLUSTER SETTING kv.protectedts.poll_interval = '1s';`)
 
 	// Disable strict GC TTL enforcement because we're going to shove a zero-value
 	// TTL into the system with AddImmediateGCZoneConfig.
-	defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDBRaw)()
+	defer sqltestutils.DisableGCTTLStrictEnforcement(t, systemDBRaw)()
 
 	const numRows = 100
 	sqlutils.CreateTable(t, sqlDBRaw, "t", "a INT", numRows, sqlutils.ToRowFn(sqlutils.RowIdxFn))
 
 	// Give the table an old format version.
-	tableDesc := desctestutils.TestingGetMutableExistingTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "t")
+	tableDesc := desctestutils.TestingGetMutableExistingTableDescriptor(kvDB, codec, "test", "t")
 	tableDesc.FormatVersion = descpb.FamilyFormatVersion
 	tableDesc.Version++
-	if err := writeTableDesc(ctx, kvDB, tableDesc); err != nil {
+	if err := writeTableDesc(ctx, kvDB, codec, tableDesc); err != nil {
 		t.Fatal(err)
 	}
 
-	tableSpan := tableDesc.TableSpan(keys.SystemSQLCodec)
+	tableSpan := tableDesc.TableSpan(codec)
 	testutils.SucceedsSoon(t, func() error {
-		if err := tests.CheckKeyCountIncludingTombstonedE(t, s, tableSpan, numRows); err != nil {
+		if err := tests.CheckKeyCountIncludingTombstonedE(t, srv.StorageLayer(), tableSpan, numRows); err != nil {
 			return errors.Wrap(err, "failed to verify expected amount of keys")
 		}
 		return nil
@@ -881,7 +899,7 @@ func TestDropTableWhileUpgradingFormat(t *testing.T) {
 	}
 	tableDesc.FormatVersion = descpb.InterleavedFormatVersion
 	tableDesc.Version++
-	if err := writeTableDesc(ctx, kvDB, tableDesc); err != nil {
+	if err := writeTableDesc(ctx, kvDB, codec, tableDesc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -895,13 +913,13 @@ func TestDropTableWhileUpgradingFormat(t *testing.T) {
 	testutils.SucceedsSoon(t, func() error {
 		return descExists(sqlDBRaw, false, tableDesc.ID)
 	})
-	tests.CheckKeyCountIncludingTombstoned(t, s, tableSpan, 0)
+	tests.CheckKeyCountIncludingTombstoned(t, srv.StorageLayer(), tableSpan, 0)
 }
 
 func TestDropTableInTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 
@@ -938,7 +956,7 @@ CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR);
 func TestDropAndCreateTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	params.UseDatabase = "test"
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
@@ -982,7 +1000,7 @@ func TestCommandsWhileTableBeingDropped(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	// Block schema changers so that the table we're about to DROP is not
 	// actually dropped; it will be left in the "deleted" state.
 	params.Knobs = base.TestingKnobs{
@@ -1077,12 +1095,13 @@ WHERE
     name = $1 AND database_name = current_database();`,
 		"foo").Scan(&tableID)
 
+	codec := tc.ApplicationLayer(0).Codec()
 	txn, err := tc.ServerConn(0).Begin()
 	require.NoError(t, err)
 	// Let's find out our transaction ID for our transaction by running a query.
 	// We'll also use this query to install a refresh span over the table data.
 	// Inject a request filter to snag the transaction ID.
-	tablePrefix := keys.SystemSQLCodec.TablePrefix(tableID)
+	tablePrefix := codec.TablePrefix(tableID)
 	tableSpan := roachpb.Span{
 		Key:    tablePrefix,
 		EndKey: tablePrefix.PrefixEnd(),
@@ -1151,7 +1170,7 @@ WHERE
 		}
 		if getRequest, ok := request.GetArg(kvpb.Get); ok {
 			put := getRequest.(*kvpb.GetRequest)
-			if put.Key.Equal(catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, descpb.ID(tableID))) {
+			if put.Key.Equal(catalogkeys.MakeDescMetadataKey(codec, descpb.ID(tableID))) {
 				filterState.txnID = uuid.UUID{}
 				return kvpb.NewError(kvpb.NewReadWithinUncertaintyIntervalError(
 					request.Txn.ReadTimestamp, hlc.ClockTimestamp{}, request.Txn, afterInsert, hlc.ClockTimestamp{}))
@@ -1174,15 +1193,16 @@ func TestDropIndexOnHashShardedIndexWithStoredShardColumn(t *testing.T) {
 
 	// Start a test server and connect to it with notice handler (so we can get and check notices from running queries).
 	ctx := context.Background()
-	params, _ := createTestServerParams()
-	s := serverutils.StartServerOnly(t, params)
-	defer s.Stopper().Stop(ctx)
-	url, cleanup := sqlutils.PGUrl(t, s.AdvSQLAddr(), t.Name(), url.User(username.RootUser))
+	params, _ := createTestServerParamsAllowTenants()
+	srv := serverutils.StartServerOnly(t, params)
+	defer srv.Stopper().Stop(ctx)
+
+	s := srv.ApplicationLayer()
+	url, cleanup := s.PGUrl(t)
 	defer cleanup()
 	base, err := pq.NewConnector(url.String())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	actualNotices := make([]string, 0)
 	connector := pq.ConnectorWithNoticeHandler(base, func(n *pq.Error) {
 		actualNotices = append(actualNotices, n.Message)
@@ -1257,18 +1277,22 @@ func TestDropIndexOnHashShardedIndexWithStoredShardColumn(t *testing.T) {
 func TestDropDatabaseWithForeignKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	params, _ := createTestServerParams()
-	s, sqlDB, kvDB := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(context.Background())
+	params, _ := createTestServerParamsAllowTenants()
+	srv, sqlDB, kvDB := serverutils.StartServer(t, params)
+	defer srv.Stopper().Stop(context.Background())
 
-	defer sqltestutils.DisableGCTTLStrictEnforcement(t, sqlDB)()
+	s := srv.ApplicationLayer()
+	codec := s.Codec()
+	systemDB := srv.SystemLayer().SQLConn(t)
 
-	_, err := sqlDB.Exec(`SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s';`)
+	defer sqltestutils.DisableGCTTLStrictEnforcement(t, systemDB)()
+
+	_, err := systemDB.Exec(`SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s';`)
 	require.NoError(t, err)
 
 	// Refresh protected timestamp cache immediately to make MVCC GC queue to
 	// process GC immediately.
-	_, err = sqlDB.Exec(`SET CLUSTER SETTING kv.protectedts.poll_interval = '1s';`)
+	_, err = systemDB.Exec(`SET CLUSTER SETTING kv.protectedts.poll_interval = '1s';`)
 	require.NoError(t, err)
 
 	_, err = sqlDB.Exec(`
@@ -1278,8 +1302,8 @@ CREATE TABLE t.child(k INT PRIMARY KEY REFERENCES t.parent);
 `)
 	require.NoError(t, err)
 
-	parentDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "parent")
-	childDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "child")
+	parentDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "parent")
+	childDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "t", "child")
 
 	_, err = sqlDB.Exec(`DROP DATABASE t CASCADE;`)
 	require.NoError(t, err)
@@ -1304,8 +1328,8 @@ ORDER BY
 	)
 
 	// Check that the data was cleaned up.
-	tests.CheckKeyCountIncludingTombstoned(t, s, parentDesc.TableSpan(keys.SystemSQLCodec), 0)
-	tests.CheckKeyCountIncludingTombstoned(t, s, childDesc.TableSpan(keys.SystemSQLCodec), 0)
+	tests.CheckKeyCountIncludingTombstoned(t, srv.StorageLayer(), parentDesc.TableSpan(codec), 0)
+	tests.CheckKeyCountIncludingTombstoned(t, srv.StorageLayer(), childDesc.TableSpan(codec), 0)
 }
 
 // Test that non-physical table deletions like DROP VIEW are immediate instead
@@ -1313,13 +1337,14 @@ ORDER BY
 func TestDropPhysicalTableGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 	_, err := sqlDB.Exec(`CREATE DATABASE test;`)
 	require.NoError(t, err)
 	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
+	codec := s.ApplicationLayer().Codec()
 
 	type tableInstance struct {
 		name         string
@@ -1338,7 +1363,7 @@ func TestDropPhysicalTableGC(t *testing.T) {
 		_, err := sqlDB.Exec(fmt.Sprintf(`CREATE %s test.%s %s;`, table.sqlType, table.name, table.createClause))
 		require.NoError(t, err)
 		// Fetch table descriptor ID for future system table lookups.
-		tableDescriptor := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "test", table.name)
+		tableDescriptor := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "test", table.name)
 		require.NotNil(t, tableDescriptor)
 		tableDescriptorId := tableDescriptor.GetID()
 		if table.sqlType != "VIEW" {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -3097,11 +3097,9 @@ func DeleteTableDescAndZoneConfig(
 		if err := col.DeleteDescToBatch(ctx, kvTrace, tableDesc.GetID(), b); err != nil {
 			return err
 		}
-		if codec := execCfg.Codec; codec.ForSystemTenant() {
-			// Delete the zone config entry for this table, if necessary.
-			zoneKeyPrefix := config.MakeZoneKeyPrefix(codec, tableDesc.GetID())
-			b.DelRange(zoneKeyPrefix, zoneKeyPrefix.PrefixEnd(), false /* returnKeys */)
-		}
+		// Delete the zone config entry for this table.
+		zoneKeyPrefix := config.MakeZoneKeyPrefix(execCfg.Codec, tableDesc.GetID())
+		b.DelRange(zoneKeyPrefix, zoneKeyPrefix.PrefixEnd(), false /* returnKeys */)
 		return txn.KV().Run(ctx, b)
 	})
 }

--- a/pkg/sql/server_params_test.go
+++ b/pkg/sql/server_params_test.go
@@ -18,17 +18,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 )
 
-// createTestServerParams creates a set of params suitable for SQL tests. It
+// createTestServerParamsAllowTenants creates a set of params suitable for SQL tests. It
 // enables some EndTxn sanity checking and installs a flexible
 // TestingEvalFilter.
-// TODO(andrei): this function is not used consistently by SQL tests. Figure out
-// if the EndTxn checks are important.
-func createTestServerParams() (base.TestServerArgs, *tests.CommandFilters) {
+// TODO(andrei): this function is not used consistently by SQL tests.
+func createTestServerParamsAllowTenants() (base.TestServerArgs, *tests.CommandFilters) {
 	var cmdFilters tests.CommandFilters
 	params := base.TestServerArgs{}
 	// Disable the default test tenant as limits to the number of spans in a
 	// secondary tenant cause this test to fail. Tracked with #76378.
-	params.DefaultTestTenant = base.TODOTestTenantDisabled
 	params.Knobs.SQLStatsKnobs = sqlstats.CreateTestingKnobs()
 	params.Knobs.Store = &kvserver.StoreTestingKnobs{
 		EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
@@ -36,4 +34,17 @@ func createTestServerParams() (base.TestServerArgs, *tests.CommandFilters) {
 		},
 	}
 	return params, &cmdFilters
+}
+
+// createTestServerParams creates a set of params suitable for SQL
+// tests with randomized tenant testing disabled. New tests should
+// prefer createTestServerParamsAllowTenants(). See
+// createTestServerParamsAllowTenants for additional details.
+//
+// TODO(ssd): Rename this and createTestServerParamsAllowTenants once
+// disabling tenant testing is less common than enabling it.
+func createTestServerParams() (base.TestServerArgs, *tests.CommandFilters) {
+	params, cmdFilters := createTestServerParamsAllowTenants()
+	params.DefaultTestTenant = base.TODOTestTenantDisabled
+	return params, cmdFilters
 }

--- a/pkg/sql/tests/data.go
+++ b/pkg/sql/tests/data.go
@@ -37,7 +37,7 @@ func CheckKeyCount(t *testing.T, kvDB *kv.DB, span roachpb.Span, numKeys int) {
 // those whose tombstones are marked but not GC'ed yet) in the provided span
 // matches the expected number.
 func CheckKeyCountIncludingTombstoned(
-	t *testing.T, s serverutils.TestServerInterface, span roachpb.Span, expectedNum int,
+	t *testing.T, s serverutils.StorageLayerInterface, span roachpb.Span, expectedNum int,
 ) {
 	t.Helper()
 	if err := CheckKeyCountIncludingTombstonedE(t, s, span, expectedNum); err != nil {
@@ -58,7 +58,7 @@ func CheckKeyCountE(t *testing.T, kvDB *kv.DB, span roachpb.Span, numKeys int) e
 }
 
 func CheckKeyCountIncludingTombstonedE(
-	t *testing.T, s serverutils.TestServerInterface, tableSpan roachpb.Span, expectedNum int,
+	t *testing.T, s serverutils.StorageLayerInterface, tableSpan roachpb.Span, expectedNum int,
 ) error {
 	// Check key count including tombstoned ones.
 	engines := s.Engines()


### PR DESCRIPTION
In older releases, there was nothing to delete as secondary tenants
weren't allowed to set zone configurations. Now they are allowed to
set zone configurations.

Fixes https://github.com/cockroachdb/cockroach/issues/116539

Release note: None