### PR TITLE
*pb,keys: break deps, allow compiling to wasm

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -242,8 +242,10 @@
         "exclude_files": {
             "pkg/.*\\.eg\\.go$": "generated code",
             "cockroach/pkg/roachprod/logger/log\\.go$": "format argument is not a constant expression",
-            "cockroach/pkg/util/log/channels\\.go$": "format argument is not a constant expression",
-            "pkg/util/log/log_channels_generated\\.go$": "format argument is not a constant expression"
+            "pkg/util/log/channels\\.go$": "format argument is not a constant expression",
+            "pkg/util/log/log\\.go$": "format argument is not a constant expression",
+            "pkg/util/log/log_channels_generated\\.go$": "format argument is not a constant expression",
+            "pkg/util/log/logbase/log_base\\.go$": "format argument is not a constant expression"
         },
         "only_files": {
             "cockroach/pkg/.*$": "first-party code",

--- a/docs/generated/http/BUILD.bazel
+++ b/docs/generated/http/BUILD.bazel
@@ -4,7 +4,6 @@ genrule(
         "//pkg/build:build_proto",
         "//pkg/clusterversion:clusterversion_proto",
         "//pkg/config/zonepb:zonepb_proto",
-        "//pkg/geo/geoindex:geoindex_proto",
         "//pkg/geo/geopb:geopb_proto",
         "//pkg/gossip:gossip_proto",
         "//pkg/jobs/jobspb:jobspb_proto",

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2402,6 +2402,7 @@ GO_TARGETS = [
     "//pkg/util/log/eventpb:eventpb_test",
     "//pkg/util/log/gen:gen",
     "//pkg/util/log/gen:gen_library",
+    "//pkg/util/log/logbase:logbase",
     "//pkg/util/log/logconfig:gen",
     "//pkg/util/log/logconfig:logconfig",
     "//pkg/util/log/logconfig:logconfig_test",

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -189,6 +189,7 @@ ALL_TESTS = [
     "//pkg/jobs/jobsprofiler:jobsprofiler_test",
     "//pkg/jobs/jobsprotectedts:jobsprotectedts_test",
     "//pkg/jobs:jobs_test",
+    "//pkg/keys:keys_disallowed_imports_test",
     "//pkg/keys:keys_test",
     "//pkg/keyvisualizer/spanstatsconsumer:spanstatsconsumer_test",
     "//pkg/kv/bulk/bulkpb:bulkpb_test",

--- a/pkg/gen/protobuf.bzl
+++ b/pkg/gen/protobuf.bzl
@@ -21,7 +21,6 @@ PROTOBUF_SRCS = [
     "//pkg/cmd/roachprod/upgrade:upgrade_go_proto",
     "//pkg/config/zonepb:zonepb_go_proto",
     "//pkg/config:config_go_proto",
-    "//pkg/geo/geoindex:geoindex_go_proto",
     "//pkg/geo/geopb:geopb_go_proto",
     "//pkg/gossip:gossip_go_proto",
     "//pkg/inspectz/inspectzpb:inspectzpb_go_proto",

--- a/pkg/geo/geoindex/BUILD.bazel
+++ b/pkg/geo/geoindex/BUILD.bazel
@@ -1,16 +1,12 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "geoindex",
     srcs = [
-        "config.go",
         "geoindex.go",
         "s2_geography_index.go",
         "s2_geometry_index.go",
     ],
-    embed = [":geoindex_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/geo/geoindex",
     visibility = ["//visibility:public"],
     deps = [
@@ -53,21 +49,4 @@ go_test(
         "@com_github_golang_geo//s2",
         "@com_github_stretchr_testify//require",
     ],
-)
-
-proto_library(
-    name = "geoindex_proto",
-    srcs = ["config.proto"],
-    strip_import_prefix = "/pkg",
-    visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],
-)
-
-go_proto_library(
-    name = "geoindex_go_proto",
-    compilers = ["//pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_compiler"],
-    importpath = "github.com/cockroachdb/cockroach/pkg/geo/geoindex",
-    proto = ":geoindex_proto",
-    visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto"],
 )

--- a/pkg/geo/geoindex/geoindex.go
+++ b/pkg/geo/geoindex/geoindex.go
@@ -688,8 +688,8 @@ func (b *stringBuilderWithWrap) doWrap() {
 }
 
 // DefaultS2Config returns the default S2Config to initialize.
-func DefaultS2Config() *S2Config {
-	return &S2Config{
+func DefaultS2Config() *geopb.S2Config {
+	return &geopb.S2Config{
 		MinLevel: 0,
 		MaxLevel: 30,
 		LevelMod: 1,

--- a/pkg/geo/geoindex/s2_geography_index.go
+++ b/pkg/geo/geoindex/s2_geography_index.go
@@ -36,7 +36,7 @@ var _ GeographyIndex = (*s2GeographyIndex)(nil)
 // since deletes could miss some index entries. Currently, reads could use a
 // different configuration, but that is subject to change if we manage to
 // strengthen the covering invariants (see the todo in covers() in index.go).
-func NewS2GeographyIndex(cfg S2GeographyConfig) GeographyIndex {
+func NewS2GeographyIndex(cfg geopb.S2GeographyConfig) GeographyIndex {
 	// TODO(sumeer): Sanity check cfg.
 	return &s2GeographyIndex{
 		rc: &s2.RegionCoverer{
@@ -49,9 +49,9 @@ func NewS2GeographyIndex(cfg S2GeographyConfig) GeographyIndex {
 }
 
 // DefaultGeographyIndexConfig returns a default config for a geography index.
-func DefaultGeographyIndexConfig() *Config {
-	return &Config{
-		S2Geography: &S2GeographyConfig{S2Config: DefaultS2Config()},
+func DefaultGeographyIndexConfig() *geopb.Config {
+	return &geopb.Config{
+		S2Geography: &geopb.S2GeographyConfig{S2Config: DefaultS2Config()},
 	}
 }
 

--- a/pkg/geo/geoindex/s2_geometry_index.go
+++ b/pkg/geo/geoindex/s2_geometry_index.go
@@ -45,7 +45,7 @@ const clippingBoundsDelta = 0.01
 // writes on this index must use the same config. Writes must use the same
 // config to correctly process deletions. Reads must use the same config since
 // the bounds affect when a read needs to look at the exceedsBoundsCellID.
-func NewS2GeometryIndex(cfg S2GeometryConfig) GeometryIndex {
+func NewS2GeometryIndex(cfg geopb.S2GeometryConfig) GeometryIndex {
 	// TODO(sumeer): Sanity check cfg.
 	return &s2GeometryIndex{
 		rc: &s2.RegionCoverer{
@@ -67,9 +67,9 @@ func NewS2GeometryIndex(cfg S2GeometryConfig) GeometryIndex {
 // INDEX.
 
 // DefaultGeometryIndexConfig returns a default config for a geometry index.
-func DefaultGeometryIndexConfig() *Config {
-	return &Config{
-		S2Geometry: &S2GeometryConfig{
+func DefaultGeometryIndexConfig() *geopb.Config {
+	return &geopb.Config{
+		S2Geometry: &geopb.S2GeometryConfig{
 			// Bounding box similar to the circumference of the earth (~2B meters)
 			MinX:     -(1 << 31),
 			MaxX:     (1 << 31) - 1,
@@ -81,7 +81,7 @@ func DefaultGeometryIndexConfig() *Config {
 }
 
 // GeometryIndexConfigForSRID returns a geometry index config for srid.
-func GeometryIndexConfigForSRID(srid geopb.SRID) (*Config, error) {
+func GeometryIndexConfigForSRID(srid geopb.SRID) (*geopb.Config, error) {
 	if srid == 0 {
 		return DefaultGeometryIndexConfig(), nil
 	}
@@ -120,8 +120,8 @@ func GeometryIndexConfigForSRID(srid geopb.SRID) (*Config, error) {
 	boundsExpansion := 2 * clippingBoundsDelta
 	deltaX := (maxX - minX) * boundsExpansion
 	deltaY := (maxY - minY) * boundsExpansion
-	return &Config{
-		S2Geometry: &S2GeometryConfig{
+	return &geopb.Config{
+		S2Geometry: &geopb.S2GeometryConfig{
 			MinX:     minX - deltaX,
 			MaxX:     maxX + deltaX,
 			MinY:     minY - deltaY,

--- a/pkg/geo/geopb/BUILD.bazel
+++ b/pkg/geo/geopb/BUILD.bazel
@@ -5,6 +5,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "geopb",
     srcs = [
+        "config.go",
         "geopb.go",
         "types.go",
     ],
@@ -15,7 +16,10 @@ go_library(
 
 proto_library(
     name = "geopb_proto",
-    srcs = ["geopb.proto"],
+    srcs = [
+        "config.proto",
+        "geopb.proto",
+    ],
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],

--- a/pkg/geo/geopb/config.go
+++ b/pkg/geo/geopb/config.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package geoindex
+package geopb
 
 // IsEmpty returns whether the config contains a geospatial index
 // configuration.

--- a/pkg/geo/geopb/config.proto
+++ b/pkg/geo/geopb/config.proto
@@ -9,8 +9,8 @@
 // licenses/APL.txt.
 
 syntax = "proto3";
-package cockroach.geo.geoindex;
-option go_package = "github.com/cockroachdb/cockroach/pkg/geo/geoindex";
+package cockroach.geo.geopb;
+option go_package = "github.com/cockroachdb/cockroach/pkg/geo/geopb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/keys/BUILD.bazel
+++ b/pkg/keys/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg/testutils:buildutil/buildutil.bzl", "disallowed_imports_test")
 
 go_library(
     name = "keys",
@@ -47,5 +48,13 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//require",
+    ],
+)
+
+disallowed_imports_test(
+    "keys",
+    [
+        "//pkg/util/log",
+        "//pkg/geo",
     ],
 )

--- a/pkg/kv/kvpb/BUILD.bazel
+++ b/pkg/kv/kvpb/BUILD.bazel
@@ -159,5 +159,8 @@ batch_gen(
 
 disallowed_imports_test(
     "kvpb",
+    [
+        "//pkg/geo",
+    ],
     disallow_cdeps = True,
 )

--- a/pkg/kv/kvpb/BUILD.bazel
+++ b/pkg/kv/kvpb/BUILD.bazel
@@ -36,7 +36,7 @@ go_library(
         "//pkg/util/errorutil",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
-        "//pkg/util/log",
+        "//pkg/util/log/logbase",
         "//pkg/util/protoutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
@@ -59,6 +59,7 @@ go_test(
         "batch_test.go",
         "data_test.go",
         "errors_test.go",
+        "main_test.go",
         "node_decommissioned_error_test.go",
         "replica_unavailable_error_test.go",
         "string_test.go",
@@ -75,6 +76,7 @@ go_test(
         "//pkg/testutils/echotest",
         "//pkg/util/buildutil",
         "//pkg/util/hlc",
+        "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
@@ -161,6 +163,7 @@ disallowed_imports_test(
     "kvpb",
     [
         "//pkg/geo",
+        "//pkg/util/log",
     ],
     disallow_cdeps = True,
 )

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logbase"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -432,7 +432,7 @@ func (e *Error) checkTxnStatusValid() {
 		return
 	}
 	if txn.Status.IsFinalized() {
-		log.Fatalf(context.TODO(), "transaction unexpectedly finalized in (%T): %v", err, e)
+		logbase.Fatalf(context.TODO(), "transaction unexpectedly finalized in (%T): %v", err, e)
 	}
 }
 
@@ -658,7 +658,7 @@ func (e *RangeKeyMismatchError) AppendRangeInfo(ctx context.Context, ris ...roac
 	for _, ri := range ris {
 		if !ri.Lease.Empty() {
 			if _, ok := ri.Desc.GetReplicaDescriptorByID(ri.Lease.Replica.ReplicaID); !ok {
-				log.Fatalf(ctx, "lease names missing replica; lease: %s, desc: %s", ri.Lease, ri.Desc)
+				logbase.Fatalf(ctx, "lease names missing replica; lease: %s, desc: %s", ri.Lease, ri.Desc)
 			}
 		}
 		e.Ranges = append(e.Ranges, ri)
@@ -1559,10 +1559,10 @@ func NewRefreshFailedError(
 		o.apply(&options)
 	}
 	if reason == RefreshFailedError_REASON_INTENT && options.conflictingTxn == nil {
-		log.Fatal(ctx, "conflictingTxn should be set if refresh failed with REASON_INTENT")
+		logbase.Fatalf(ctx, "conflictingTxn should be set if refresh failed with REASON_INTENT")
 	}
 	if reason != RefreshFailedError_REASON_INTENT && options.conflictingTxn != nil {
-		log.Fatal(ctx, "conflictingTxn should not be set if refresh failed without REASON_INTENT")
+		logbase.Fatalf(ctx, "conflictingTxn should not be set if refresh failed without REASON_INTENT")
 	}
 	return &RefreshFailedError{
 		Reason:         reason,

--- a/pkg/kv/kvpb/main_test.go
+++ b/pkg/kv/kvpb/main_test.go
@@ -1,0 +1,23 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvpb_test
+
+import (
+	"os"
+	"testing"
+
+	// Import log so that the redaction hooks are set up correctly in the testing.
+	_ "github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/pkg/kv/kvserver/readsummary/rspb/BUILD.bazel
+++ b/pkg/kv/kvserver/readsummary/rspb/BUILD.bazel
@@ -33,6 +33,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/hlc",
-        "//pkg/util/log",
+        "//pkg/util/log/logbase",
     ],
 )

--- a/pkg/kv/kvserver/readsummary/rspb/summary.go
+++ b/pkg/kv/kvserver/readsummary/rspb/summary.go
@@ -14,7 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logbase"
 )
 
 // FromTimestamp constructs a read summary from the provided timestamp, treating
@@ -55,7 +55,7 @@ func (c *ReadSummary) AssertNoRegression(ctx context.Context, o ReadSummary) {
 
 func (c *Segment) assertNoRegression(ctx context.Context, o Segment, name string) {
 	if c.LowWater.Less(o.LowWater) {
-		log.Fatalf(ctx, "read summary regression in %s segment, was %s, now %s",
+		logbase.Fatalf(ctx, "read summary regression in %s segment, was %s, now %s",
 			name, o.LowWater, c.LowWater)
 	}
 }

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -38,7 +38,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/interval",
-        "//pkg/util/log",
+        "//pkg/util/log/logbase",
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",
         "//pkg/util/timetz",

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -40,7 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logbase"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timetz"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -1051,7 +1051,7 @@ func (t Transaction) Clone() *Transaction {
 // AssertInitialized crashes if the transaction is not initialized.
 func (t *Transaction) AssertInitialized(ctx context.Context) {
 	if t.ID == (uuid.UUID{}) || t.WriteTimestamp.IsEmpty() {
-		log.Fatalf(ctx, "uninitialized txn: %s", *t)
+		logbase.Fatalf(ctx, "uninitialized txn: %s", *t)
 	}
 }
 
@@ -1247,7 +1247,7 @@ func (t *Transaction) Update(o *Transaction) {
 		*t = *o
 		return
 	} else if t.ID != o.ID {
-		log.Fatalf(ctx, "updating txn %s with different txn %s", t.String(), o.String())
+		logbase.Fatalf(ctx, "updating txn %s with different txn %s", t.String(), o.String())
 		return
 	}
 	if len(t.Key) == 0 {
@@ -1262,7 +1262,7 @@ func (t *Transaction) Update(o *Transaction) {
 		if !t.Status.IsFinalized() {
 			t.Status = o.Status
 		} else if t.Status == COMMITTED {
-			log.Warningf(ctx, "updating COMMITTED txn %s with txn at later epoch %s", t.String(), o.String())
+			logbase.Warningf(ctx, "updating COMMITTED txn %s with txn at later epoch %s", t.String(), o.String())
 		}
 		// Replace all epoch-scoped state.
 		t.Epoch = o.Epoch
@@ -1283,7 +1283,7 @@ func (t *Transaction) Update(o *Transaction) {
 			}
 		case ABORTED:
 			if o.Status == COMMITTED {
-				log.Warningf(ctx, "updating ABORTED txn %s with COMMITTED txn %s", t.String(), o.String())
+				logbase.Warningf(ctx, "updating ABORTED txn %s with COMMITTED txn %s", t.String(), o.String())
 			}
 		case COMMITTED:
 			// Nothing to do.
@@ -1328,7 +1328,7 @@ func (t *Transaction) Update(o *Transaction) {
 			// aborted.
 			t.Status = ABORTED
 		case COMMITTED:
-			log.Warningf(ctx, "updating txn %s with COMMITTED txn at earlier epoch %s", t.String(), o.String())
+			logbase.Warningf(ctx, "updating txn %s with COMMITTED txn at earlier epoch %s", t.String(), o.String())
 		}
 	}
 

--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
     deps = [
         "//pkg/clusterversion",
         "//pkg/config/zonepb",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/sql/catalog/catformat/BUILD.bazel
+++ b/pkg/sql/catalog/catformat/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/catalog/catformat/index.go
+++ b/pkg/sql/catalog/catformat/index.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -263,7 +264,7 @@ func formatStorageConfigs(
 ) error {
 	numCustomSettings := 0
 	if index.GeoConfig.S2Geometry != nil || index.GeoConfig.S2Geography != nil {
-		var s2Config *geoindex.S2Config
+		var s2Config *geopb.S2Config
 
 		if index.GeoConfig.S2Geometry != nil {
 			s2Config = index.GeoConfig.S2Geometry.S2Config

--- a/pkg/sql/catalog/descpb/BUILD.bazel
+++ b/pkg/sql/catalog/descpb/BUILD.bazel
@@ -53,7 +53,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/zonepb:zonepb_proto",
-        "//pkg/geo/geoindex:geoindex_proto",
+        "//pkg/geo/geopb:geopb_proto",
         "//pkg/roachpb:roachpb_proto",
         "//pkg/sql/catalog/catenumpb:catenumpb_proto",
         "//pkg/sql/catalog/catpb:catpb_proto",
@@ -73,7 +73,7 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/zonepb",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/roachpb",  # keep
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/catpb",

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -23,7 +23,7 @@ import "sql/catalog/catpb/privilege.proto";
 import "sql/catalog/catpb/function.proto";
 import "sql/schemachanger/scpb/scpb.proto";
 import "sql/types/types.proto";
-import "geo/geoindex/config.proto";
+import "geo/geopb/config.proto";
 import "gogoproto/gogo.proto";
 import "roachpb/metadata.proto";
 
@@ -446,7 +446,7 @@ message IndexDescriptor {
 
   // GeoConfig, if it's not the zero value, describes configuration for
   // this geospatial inverted index.
-  optional geo.geoindex.Config geo_config = 22 [(gogoproto.nullable) = false];
+  optional geo.geopb.Config geo_config = 22 [(gogoproto.nullable) = false];
 
   // Predicate, if it's not empty, indicates that the index is a partial index
   // with Predicate as the expression. If Predicate is empty, the index is not

--- a/pkg/sql/catalog/fetchpb/BUILD.bazel
+++ b/pkg/sql/catalog/fetchpb/BUILD.bazel
@@ -24,7 +24,7 @@ proto_library(
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo/geoindex:geoindex_proto",
+        "//pkg/geo/geopb:geopb_proto",
         "//pkg/sql/catalog/catenumpb:catenumpb_proto",
         "//pkg/sql/types:types_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
@@ -38,7 +38,7 @@ go_proto_library(
     proto = ":fetchpb_proto",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/types",
         "@com_github_gogo_protobuf//gogoproto",

--- a/pkg/sql/catalog/fetchpb/index_fetch.proto
+++ b/pkg/sql/catalog/fetchpb/index_fetch.proto
@@ -16,7 +16,7 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/fetchpb";
 import "gogoproto/gogo.proto";
 import "sql/types/types.proto";
 import "sql/catalog/catenumpb/index.proto";
-import "geo/geoindex/config.proto";
+import "geo/geopb/config.proto";
 
 // IndexFetchSpec contains the subset of information (from TableDescriptor and
 // IndexDescriptor) that is necessary to decode KVs into SQL keys and values.
@@ -89,7 +89,7 @@ message IndexFetchSpec {
   optional bool is_unique_index = 7 [(gogoproto.nullable) = false];
 
   // GeoConfig is used if we are fetching an inverted geospatial index.
-  optional geo.geoindex.Config geo_config = 16 [(gogoproto.nullable) = false];
+  optional geo.geopb.Config geo_config = 16 [(gogoproto.nullable) = false];
 
   // EncodingType represents what sort of k/v encoding is used to store the
   // table data.

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -177,7 +177,7 @@ type Index interface {
 	GetInvisibility() float64
 	GetPredicate() string
 	GetType() descpb.IndexDescriptor_Type
-	GetGeoConfig() geoindex.Config
+	GetGeoConfig() geopb.Config
 	GetVersion() descpb.IndexDescriptorVersion
 	GetEncodingType() catenumpb.IndexDescriptorEncodingType
 

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -21,7 +21,7 @@ go_library(
     deps = [
         "//pkg/clusterversion",
         "//pkg/docs",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/roachpb",
@@ -88,7 +88,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/clusterversion",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -265,7 +265,7 @@ func (w index) CollectCompositeColumnIDs() catalog.TableColSet {
 }
 
 // GetGeoConfig returns the geo config in the index descriptor.
-func (w index) GetGeoConfig() geoindex.Config {
+func (w index) GetGeoConfig() geopb.Config {
 	return w.desc.GeoConfig
 }
 

--- a/pkg/sql/catalog/tabledesc/index_test.go
+++ b/pkg/sql/catalog/tabledesc/index_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -280,7 +280,7 @@ func TestIndexInterface(t *testing.T) {
 			errMsgFmt, "GetType", idx.GetName())
 		require.Equal(t, idx == s4, idx.IsSharded(),
 			errMsgFmt, "IsSharded", idx.GetName())
-		require.Equal(t, idx == s6, !(&geoindex.Config{}).Equal(idx.GetGeoConfig()),
+		require.Equal(t, idx == s6, !(&geopb.Config{}).Equal(idx.GetGeoConfig()),
 			errMsgFmt, "GetGeoConfig", idx.GetName())
 		require.Equal(t, idx == s4, idx.GetShardColumnName() != "",
 			errMsgFmt, "GetShardColumnName", idx.GetName())

--- a/pkg/sql/evalcatalog/BUILD.bazel
+++ b/pkg/sql/evalcatalog/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/evalcatalog",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/sql/evalcatalog/geo_inverted_index_entries.go
+++ b/pkg/sql/evalcatalog/geo_inverted_index_entries.go
@@ -13,7 +13,7 @@ package evalcatalog
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -74,14 +74,14 @@ func getIndexGeoConfig(
 	txn *kv.Txn,
 	tableID catid.DescID,
 	indexID catid.IndexID,
-) (geoindex.Config, error) {
+) (geopb.Config, error) {
 	tableDesc, err := dc.ByIDWithLeased(txn).WithoutNonPublic().Get().Table(ctx, tableID)
 	if err != nil {
-		return geoindex.Config{}, err
+		return geopb.Config{}, err
 	}
 	index, err := catalog.MustFindIndexByID(tableDesc, indexID)
 	if err != nil {
-		return geoindex.Config{}, err
+		return geopb.Config{}, err
 	}
 	return index.GetGeoConfig(), nil
 }

--- a/pkg/sql/opt/cat/BUILD.bazel
+++ b/pkg/sql/opt/cat/BUILD.bazel
@@ -20,7 +20,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/zonepb",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -11,7 +11,7 @@
 package cat
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -192,7 +192,7 @@ type Index interface {
 
 	// GeoConfig returns a geospatial index configuration. If not empty, it
 	// describes the configuration for this geospatial inverted index.
-	GeoConfig() geoindex.Config
+	GeoConfig() geopb.Config
 
 	// Version returns the IndexDescriptorVersion of the index.
 	Version() descpb.IndexDescriptorVersion

--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     # Pin the dependencies used in auto-generated code.
     deps = [
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/roachpb",
         "//pkg/sql/appstatspb",

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -16,7 +16,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -726,8 +726,8 @@ func (u *unknownIndex) ImplicitPartitioningColumnCount() int {
 	return 0
 }
 
-func (u *unknownIndex) GeoConfig() geoindex.Config {
-	return geoindex.Config{}
+func (u *unknownIndex) GeoConfig() geopb.Config {
+	return geopb.Config{}
 }
 
 func (u *unknownIndex) Version() descpb.IndexDescriptorVersion {

--- a/pkg/sql/opt/indexrec/BUILD.bazel
+++ b/pkg/sql/opt/indexrec/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/roachpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/opt/indexrec/hypothetical_index.go
+++ b/pkg/sql/opt/indexrec/hypothetical_index.go
@@ -12,6 +12,7 @@ package indexrec
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -214,7 +215,7 @@ func (hi *hypotheticalIndex) ImplicitPartitioningColumnCount() int {
 }
 
 // GeoConfig is part of the cat.Index interface.
-func (hi *hypotheticalIndex) GeoConfig() geoindex.Config {
+func (hi *hypotheticalIndex) GeoConfig() geopb.Config {
 	if hi.IsInverted() {
 		srcCol := hi.tab.Column(hi.InvertedColumn().InvertedSourceColumnOrdinal())
 		switch srcCol.DatumType().Family() {
@@ -224,7 +225,7 @@ func (hi *hypotheticalIndex) GeoConfig() geoindex.Config {
 			return *geoindex.DefaultGeographyIndexConfig()
 		}
 	}
-	return geoindex.Config{}
+	return geopb.Config{}
 }
 
 // Version is part of the cat.Index interface.

--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -65,7 +65,7 @@ func GetGeoIndexRelationship(expr opt.ScalarExpr) (_ geoindex.RelationshipType, 
 // geospatial relationship. It is implemented by getSpanExprForGeographyIndex
 // and getSpanExprForGeometryIndex and used in extractGeoFilterCondition.
 type getSpanExprForGeoIndexFn func(
-	context.Context, tree.Datum, []tree.Datum, geoindex.RelationshipType, geoindex.Config,
+	context.Context, tree.Datum, []tree.Datum, geoindex.RelationshipType, geopb.Config,
 ) inverted.Expression
 
 // getSpanExprForGeographyIndex gets a SpanExpression that constrains the given
@@ -75,7 +75,7 @@ func getSpanExprForGeographyIndex(
 	d tree.Datum,
 	additionalParams []tree.Datum,
 	relationship geoindex.RelationshipType,
-	indexConfig geoindex.Config,
+	indexConfig geopb.Config,
 ) inverted.Expression {
 	geogIdx := geoindex.NewS2GeographyIndex(*indexConfig.S2Geography)
 	geog := d.(*tree.DGeography).Geography
@@ -162,7 +162,7 @@ func getSpanExprForGeometryIndex(
 	d tree.Datum,
 	additionalParams []tree.Datum,
 	relationship geoindex.RelationshipType,
-	indexConfig geoindex.Config,
+	indexConfig geopb.Config,
 ) inverted.Expression {
 	geomIdx := geoindex.NewS2GeometryIndex(*indexConfig.S2Geometry)
 	geom := d.(*tree.DGeometry).Geometry
@@ -929,7 +929,7 @@ type geoDatumsToInvertedExpr struct {
 	evalCtx      *eval.Context
 	colTypes     []*types.T
 	invertedExpr tree.TypedExpr
-	indexConfig  geoindex.Config
+	indexConfig  geopb.Config
 	typ          *types.T
 	getSpanExpr  getSpanExprForGeoIndexFn
 
@@ -971,7 +971,7 @@ func NewGeoDatumsToInvertedExpr(
 	evalCtx *eval.Context,
 	colTypes []*types.T,
 	expr tree.TypedExpr,
-	config geoindex.Config,
+	config geopb.Config,
 ) (invertedexpr.DatumsToInvertedExpr, error) {
 	if config.IsEmpty() {
 		return nil, fmt.Errorf("inverted joins are currently only supported for geospatial indexes")

--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -35,7 +35,7 @@ func NewDatumsToInvertedExpr(
 	evalCtx *eval.Context,
 	colTypes []*types.T,
 	expr tree.TypedExpr,
-	geoConfig geoindex.Config,
+	geoConfig geopb.Config,
 ) (invertedexpr.DatumsToInvertedExpr, error) {
 	if !geoConfig.IsEmpty() {
 		return NewGeoDatumsToInvertedExpr(ctx, evalCtx, colTypes, expr, geoConfig)

--- a/pkg/sql/opt/testutils/testcat/BUILD.bazel
+++ b/pkg/sql/opt/testutils/testcat/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/zonepb",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/settings/cluster",

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -925,13 +925,13 @@ func (tt *Table) addIndexWithVersion(
 			switch tt.Columns[col.InvertedSourceColumnOrdinal()].DatumType().Family() {
 			case types.GeometryFamily:
 				// Don't use the default config because it creates a huge number of spans.
-				idx.geoConfig = geoindex.Config{
-					S2Geometry: &geoindex.S2GeometryConfig{
+				idx.geoConfig = geopb.Config{
+					S2Geometry: &geopb.S2GeometryConfig{
 						MinX: -5,
 						MaxX: 5,
 						MinY: -5,
 						MaxY: 5,
-						S2Config: &geoindex.S2Config{
+						S2Config: &geopb.S2Config{
 							MinLevel: 0,
 							MaxLevel: 2,
 							LevelMod: 1,
@@ -942,8 +942,8 @@ func (tt *Table) addIndexWithVersion(
 
 			case types.GeographyFamily:
 				// Don't use the default config because it creates a huge number of spans.
-				idx.geoConfig = geoindex.Config{
-					S2Geography: &geoindex.S2GeographyConfig{S2Config: &geoindex.S2Config{
+				idx.geoConfig = geopb.Config{
+					S2Geography: &geopb.S2GeographyConfig{S2Config: &geopb.S2Config{
 						MinLevel: 0,
 						MaxLevel: 2,
 						LevelMod: 1,

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -1078,7 +1078,7 @@ type Index struct {
 
 	// geoConfig is the geospatial index configuration, if this is a geospatial
 	// inverted index.
-	geoConfig geoindex.Config
+	geoConfig geopb.Config
 
 	// version is the index descriptor version of the index.
 	version descpb.IndexDescriptorVersion
@@ -1192,7 +1192,7 @@ func (ti *Index) ImplicitPartitioningColumnCount() int {
 }
 
 // GeoConfig is part of the cat.Index interface.
-func (ti *Index) GeoConfig() geoindex.Config {
+func (ti *Index) GeoConfig() geopb.Config {
 	return ti.geoConfig
 }
 

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config"
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -1701,7 +1701,7 @@ func (oi *optIndex) ImplicitPartitioningColumnCount() int {
 }
 
 // GeoConfig is part of the cat.Index interface.
-func (oi *optIndex) GeoConfig() geoindex.Config {
+func (oi *optIndex) GeoConfig() geopb.Config {
 	return oi.idx.IndexDesc().GeoConfig
 }
 
@@ -2605,8 +2605,8 @@ func (oi *optVirtualIndex) ImplicitPartitioningColumnCount() int {
 }
 
 // GeoConfig is part of the cat.Index interface.
-func (oi *optVirtualIndex) GeoConfig() geoindex.Config {
-	return geoindex.Config{}
+func (oi *optVirtualIndex) GeoConfig() geopb.Config {
+	return geopb.Config{}
 }
 
 // Version is part of the cat.Index interface.

--- a/pkg/sql/pgwire/pgerror/BUILD.bazel
+++ b/pkg/sql/pgwire/pgerror/BUILD.bazel
@@ -10,6 +10,8 @@ go_library(
         "flatten.go",
         "internal_errors.go",
         "pgcode.go",
+        "pq.go",
+        "pq_wasm.go",
         "severity.go",
         "with_candidate_code.go",
         "wrap.go",
@@ -23,8 +25,45 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//errorspb",
         "@com_github_gogo_protobuf//proto",
-        "@com_github_lib_pq//:pq",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:386": [
+            "@com_github_lib_pq//:pq",
+        ],
+        "@io_bazel_rules_go//go/platform:amd64": [
+            "@com_github_lib_pq//:pq",
+        ],
+        "@io_bazel_rules_go//go/platform:arm": [
+            "@com_github_lib_pq//:pq",
+        ],
+        "@io_bazel_rules_go//go/platform:arm64": [
+            "@com_github_lib_pq//:pq",
+        ],
+        "@io_bazel_rules_go//go/platform:mips": [
+            "@com_github_lib_pq//:pq",
+        ],
+        "@io_bazel_rules_go//go/platform:mips64": [
+            "@com_github_lib_pq//:pq",
+        ],
+        "@io_bazel_rules_go//go/platform:mips64le": [
+            "@com_github_lib_pq//:pq",
+        ],
+        "@io_bazel_rules_go//go/platform:mipsle": [
+            "@com_github_lib_pq//:pq",
+        ],
+        "@io_bazel_rules_go//go/platform:ppc64": [
+            "@com_github_lib_pq//:pq",
+        ],
+        "@io_bazel_rules_go//go/platform:ppc64le": [
+            "@com_github_lib_pq//:pq",
+        ],
+        "@io_bazel_rules_go//go/platform:riscv64": [
+            "@com_github_lib_pq//:pq",
+        ],
+        "@io_bazel_rules_go//go/platform:s390x": [
+            "@com_github_lib_pq//:pq",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_test(

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/errors"
-	"github.com/lib/pq"
 )
 
 var _ error = (*Error)(nil)
@@ -40,12 +39,11 @@ func FullError(err error) string {
 	if err == nil {
 		panic("FullError should not be called with nil input")
 	}
-	if pqErr := (*pq.Error)(nil); errors.As(err, &pqErr) {
-		errString = formatMsgHintDetail("pq", pqErr.Message, pqErr.Hint, pqErr.Detail)
-	} else {
-		pg := Flatten(err)
-		errString = formatMsgHintDetail(pg.Severity, err.Error(), pg.Hint, pg.Detail)
+	if formatted, ok := fullErrorFromPQ(err); ok {
+		return formatted
 	}
+	pg := Flatten(err)
+	errString = formatMsgHintDetail(pg.Severity, err.Error(), pg.Hint, pg.Detail)
 	return errString
 }
 

--- a/pkg/sql/pgwire/pgerror/pq.go
+++ b/pkg/sql/pgwire/pgerror/pq.go
@@ -1,0 +1,28 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//go:build !wasm
+
+package pgerror
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/lib/pq"
+)
+
+// fullErrorFromPQ detects if the error is a pq.Error and, if so, formats it
+// according to the scheme used for FullError.
+func fullErrorFromPQ(err error) (string, bool) {
+	var pqErr *pq.Error
+	if !errors.As(err, &pqErr) {
+		return "", false
+	}
+	return formatMsgHintDetail("pq", pqErr.Message, pqErr.Hint, pqErr.Detail), true
+}

--- a/pkg/sql/pgwire/pgerror/pq_wasm.go
+++ b/pkg/sql/pgwire/pgerror/pq_wasm.go
@@ -1,0 +1,19 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//go:build wasm
+
+package pgerror
+
+// fullErrorFromPQ is a shim for wasm because github.com/lib/pq does not support
+// wasm.
+func fullErrorFromPQ(err error) (string, bool) {
+	return "", false
+}

--- a/pkg/sql/protoreflect/BUILD.bazel
+++ b/pkg/sql/protoreflect/BUILD.bazel
@@ -28,7 +28,7 @@ go_test(
     ],
     embed = [":protoreflect"],
     deps = [
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/sql/catalog/catenumpb",

--- a/pkg/sql/protoreflect/utils_test.go
+++ b/pkg/sql/protoreflect/utils_test.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
@@ -70,12 +70,12 @@ func TestMessageToJSONBRoundTrip(t *testing.T) {
 				Unique:              true,
 				KeyColumnNames:      []string{"foo", "bar", "buz"},
 				KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
-				GeoConfig: geoindex.Config{
-					S2Geography: &geoindex.S2GeographyConfig{S2Config: &geoindex.S2Config{
+				GeoConfig: geopb.Config{
+					S2Geography: &geopb.S2GeographyConfig{S2Config: &geopb.S2Config{
 						MinLevel: 123,
 						MaxLevel: 321,
 					}},
-					S2Geometry: &geoindex.S2GeometryConfig{
+					S2Geometry: &geopb.S2GeometryConfig{
 						MinX: 567,
 						MaxX: 765,
 					},

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -987,7 +987,7 @@ func EncodeTrigramSpans(s string, allMustMatch bool) (inverted.Expression, error
 // EncodeGeoInvertedIndexTableKeys is the equivalent of EncodeInvertedIndexTableKeys
 // for Geography and Geometry.
 func EncodeGeoInvertedIndexTableKeys(
-	val tree.Datum, inKey []byte, indexGeoConfig geoindex.Config,
+	val tree.Datum, inKey []byte, indexGeoConfig geopb.Config,
 ) (key [][]byte, err error) {
 	if val == tree.DNull {
 		return nil, nil

--- a/pkg/sql/schemachanger/scdecomp/BUILD.bazel
+++ b/pkg/sql/schemachanger/scdecomp/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/catpb",

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -16,7 +16,7 @@ import (
 	"reflect"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -588,7 +588,7 @@ func (w *walkCtx) walkIndex(tbl catalog.TableDescriptor, idx catalog.Index) {
 			Invisibility:        idx.GetInvisibility(),
 		}
 		if geoConfig := idx.GetGeoConfig(); !geoConfig.IsEmpty() {
-			index.GeoConfig = protoutil.Clone(&geoConfig).(*geoindex.Config)
+			index.GeoConfig = protoutil.Clone(&geoConfig).(*geopb.Config)
 		}
 		for i, c := range cpy.KeyColumnIDs {
 			invertedKind := catpb.InvertedIndexColumnKind_DEFAULT

--- a/pkg/sql/schemachanger/scpb/BUILD.bazel
+++ b/pkg/sql/schemachanger/scpb/BUILD.bazel
@@ -36,7 +36,7 @@ go_proto_library(
     proto = ":scpb_proto",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/sem/catid",  # keep
@@ -55,7 +55,7 @@ proto_library(
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo/geoindex:geoindex_proto",
+        "//pkg/geo/geopb:geopb_proto",
         "//pkg/sql/catalog/catenumpb:catenumpb_proto",
         "//pkg/sql/catalog/catpb:catpb_proto",
         "//pkg/sql/sem/semenumpb:semenumpb_proto",

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -18,7 +18,7 @@ import "sql/sem/semenumpb/constraint.proto";
 import "sql/catalog/catpb/function.proto";
 import "sql/types/types.proto";
 import "gogoproto/gogo.proto";
-import "geo/geoindex/config.proto";
+import "geo/geopb/config.proto";
 
 option (gogoproto.equal_all) = true;
 
@@ -255,7 +255,7 @@ message Index {
   uint32 source_index_id = 21 [(gogoproto.customname) = "SourceIndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
   uint32 temporary_index_id = 22 [(gogoproto.customname) = "TemporaryIndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
 
-  cockroach.geo.geoindex.Config geo_config = 24 [(gogoproto.nullable) = true];
+  cockroach.geo.geopb.Config geo_config = 24 [(gogoproto.nullable) = true];
 
   // IsNotVisible specifies whether this index is not visible.
   // NOTE: THIS FIELD IS DEPRECATED in favor of invisibility.

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -7965,14 +7965,14 @@ func makeSTDWithinBuiltin(exclusivity geo.FnExclusivity) builtinDefinition {
 }
 
 func applyGeoindexConfigStorageParams(
-	ctx context.Context, evalCtx *eval.Context, cfg geoindex.Config, params string,
-) (geoindex.Config, error) {
+	ctx context.Context, evalCtx *eval.Context, cfg geopb.Config, params string,
+) (geopb.Config, error) {
 	indexDesc := &descpb.IndexDescriptor{GeoConfig: cfg}
 	stmt, err := parser.ParseOne(
 		fmt.Sprintf("CREATE INDEX t_idx ON t USING GIST(geom) WITH (%s)", params),
 	)
 	if err != nil {
-		return geoindex.Config{}, errors.Newf("invalid storage parameters specified: %s", params)
+		return geopb.Config{}, errors.Newf("invalid storage parameters specified: %s", params)
 	}
 	semaCtx := tree.MakeSemaContext()
 	if err := storageparam.Set(
@@ -7982,7 +7982,7 @@ func applyGeoindexConfigStorageParams(
 		stmt.AST.(*tree.CreateIndex).StorageParams,
 		&indexstorageparam.Setter{IndexDesc: indexDesc},
 	); err != nil {
-		return geoindex.Config{}, err
+		return geopb.Config{}, err
 	}
 	return indexDesc.GeoConfig, nil
 }

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -7805,7 +7805,7 @@ func stAsGeoJSONFromTuple(
 			if g, ok := d.(*tree.DGeometry); ok {
 				foundGeoColumn = true
 				var err error
-				geometry, err = json.FromSpatialObject(g.SpatialObject(), numDecimalDigits)
+				geometry, err = g.ToJSON()
 				if err != nil {
 					return nil, err
 				}
@@ -7814,7 +7814,7 @@ func stAsGeoJSONFromTuple(
 			if g, ok := d.(*tree.DGeography); ok {
 				foundGeoColumn = true
 				var err error
-				geometry, err = json.FromSpatialObject(g.SpatialObject(), numDecimalDigits)
+				geometry, err = g.ToJSON()
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/storageparam/indexstorageparam/BUILD.bazel
+++ b/pkg/sql/storageparam/indexstorageparam/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/storageparam/indexstorageparam",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/paramparse",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/storageparam/indexstorageparam/index_storage_param.go
+++ b/pkg/sql/storageparam/indexstorageparam/index_storage_param.go
@@ -15,7 +15,7 @@ package indexstorageparam
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -34,8 +34,8 @@ type Setter struct {
 
 var _ storageparam.Setter = (*Setter)(nil)
 
-func getS2ConfigFromIndex(indexDesc *descpb.IndexDescriptor) *geoindex.S2Config {
-	var s2Config *geoindex.S2Config
+func getS2ConfigFromIndex(indexDesc *descpb.IndexDescriptor) *geopb.S2Config {
+	var s2Config *geopb.S2Config
 	if indexDesc.GeoConfig.S2Geometry != nil {
 		s2Config = indexDesc.GeoConfig.S2Geometry.S2Config
 	}

--- a/pkg/util/hlc/BUILD.bazel
+++ b/pkg/util/hlc/BUILD.bazel
@@ -15,7 +15,7 @@ go_library(
     deps = [
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
-        "//pkg/util/log",
+        "//pkg/util/log/logbase",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logbase"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -367,13 +367,13 @@ func (c *Clock) checkPhysicalClock(ctx context.Context, oldTime, newTime int64) 
 	interval := oldTime - newTime
 	if interval > int64(c.maxOffset/10) {
 		atomic.AddInt32(&c.monotonicityErrorsCount, 1)
-		log.Warningf(ctx, "backward time jump detected (%f seconds)", float64(-interval)/1e9)
+		logbase.Warningf(ctx, "backward time jump detected (%f seconds)", float64(-interval)/1e9)
 	}
 
 	if atomic.LoadInt32(&c.forwardClockJumpCheckEnabled) != 0 {
 		toleratedForwardClockJump := c.toleratedForwardClockJump()
 		if int64(toleratedForwardClockJump) <= -interval {
-			log.Fatalf(
+			logbase.Fatalf(
 				ctx,
 				"detected forward time jump of %f seconds is not allowed with tolerance of %f seconds",
 				redact.Safe(float64(-interval)/1e9),
@@ -418,7 +418,7 @@ func (c *Clock) NowAsClockTimestamp() ClockTimestamp {
 func (c *Clock) enforceWallTimeWithinBoundLocked() {
 	// WallTime should not cross the upper bound (if WallTimeUpperBound is set)
 	if c.mu.wallTimeUpperBound != 0 && c.mu.timestamp.WallTime > c.mu.wallTimeUpperBound {
-		log.Fatalf(
+		logbase.Fatalf(
 			context.TODO(),
 			"wall time %d is not allowed to be greater than upper bound of %d.",
 			redact.Safe(c.mu.timestamp.WallTime),

--- a/pkg/util/json/BUILD.bazel
+++ b/pkg/util/json/BUILD.bazel
@@ -19,8 +19,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/json",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo",
-        "//pkg/geo/geopb",
         "//pkg/keysbase",
         "//pkg/sql/inverted",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -24,8 +24,6 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/apd/v3"
-	"github.com/cockroachdb/cockroach/pkg/geo"
-	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/keysbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -1802,15 +1800,6 @@ func (j jsonObject) allPaths() ([]JSON, error) {
 		}
 	}
 	return ret, nil
-}
-
-// FromSpatialObject transforms a SpatialObject into the json.JSON type.
-func FromSpatialObject(so geopb.SpatialObject, numDecimalDigits int) (JSON, error) {
-	j, err := geo.SpatialObjectToGeoJSON(so, numDecimalDigits, geo.SpatialObjectToGeoJSONFlagZero)
-	if err != nil {
-		return nil, err
-	}
-	return ParseJSON(string(j))
 }
 
 // FromDecimal returns a JSON value given a apd.Decimal.

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -67,6 +67,7 @@ go_library(
         "//pkg/util/httputil",
         "//pkg/util/jsonbytes",
         "//pkg/util/log/channel",
+        "//pkg/util/log/logbase",
         "//pkg/util/log/logconfig",
         "//pkg/util/log/logflags",
         "//pkg/util/log/logpb",

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -13,6 +13,7 @@ package log
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/util/log/logbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -20,6 +21,11 @@ import (
 
 func init() {
 	errors.SetWarningFn(Warningf)
+	logbase.VEventfDepth = untypedVEventfDepth
+	logbase.ExpensiveLogEnabled = untypedExpensiveLogEnabled
+	logbase.Fatalf = Fatalf
+	logbase.Warningf = Warningf
+	logbase.Infof = Infof
 }
 
 // Severity aliases a type.
@@ -65,4 +71,19 @@ func ExpensiveLogEnabled(ctx context.Context, level Level) bool {
 		return true
 	}
 	return false
+}
+
+// untypedExpensiveLogEnabled is like ExpensiveLogEnabled, but takes an untyped
+// level argument.
+func untypedExpensiveLogEnabled(ctx context.Context, level int32) bool {
+	return ExpensiveLogEnabled(ctx, Level(level))
+}
+
+// untypedVEventfDepth is like VEventfDepth, but takes an untyped level argument.
+//
+//nolint:fmtsafe
+func untypedVEventfDepth(
+	ctx context.Context, depth int, level int32, format string, args ...interface{},
+) {
+	VEventfDepth(ctx, depth+1, Level(level), format, args...)
 }

--- a/pkg/util/log/logbase/BUILD.bazel
+++ b/pkg/util/log/logbase/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "logbase",
+    srcs = ["log_base.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/log/logbase",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/util/log/logbase/log_base.go
+++ b/pkg/util/log/logbase/log_base.go
@@ -1,0 +1,51 @@
+// Package logbase is a low-dependency front-end to log.
+//
+// Libraries which do not want to pick up the overhead of importing log, perhaps
+// because they want to compile on platforms like wasm, or are at risk of
+// creating circular dependencies can use this library instead. If log is not
+// imported in the program, the functionality will be minimal.
+package logbase
+
+import (
+	"context"
+	golog "log"
+)
+
+// ExpensiveLogEnabled is injected from pkg/util/log to avoid an import cycle.
+// This also allows it to be mocked out in tests.
+//
+// See log.ExpensiveLogEnabled for more details.
+var ExpensiveLogEnabled = func(ctx context.Context, level int32) bool { return false }
+
+// VEventfDepth is injected from pkg/util/log to avoid an import cycle. This
+// also allows it to be mocked out in tests.
+//
+// See log.VEventfDepth for more details.
+var VEventfDepth = func(ctx context.Context, depth int, level int32, format string, args ...interface{}) {}
+
+// Fatalf is injected from pkg/util/log to avoid an import cycle. This also
+// allows it to be mocked out in tests.
+//
+// See log.Fatalf for more details.
+var Fatalf = func(ctx context.Context, format string, args ...interface{}) {
+	//nolint:fmtsafe
+	golog.Fatalf(format, args...)
+}
+
+// Warningf is injected from pkg/util/log to avoid an import cycle. This also
+// allows it to be mocked out in tests.
+//
+// See log.Warningf for more details.
+var Warningf = func(ctx context.Context, format string, args ...interface{}) {
+	//nolint:fmtsafe
+	golog.Printf(format, args...)
+}
+
+// Infof is injected from pkg/util/log to avoid an import cycle. This also
+// allows it to be mocked out in tests.
+//
+// See log.Infof for more details.
+var Infof = func(ctx context.Context, format string, args ...interface{}) {
+	//nolint:fmtsafe
+	golog.Printf(format, args...)
+}


### PR DESCRIPTION
This series of patches primarily breaks the `keys` package's indirect dependencies on `util/log`  and `geo`. I don't think that there was ever an intention for our protobuf libraries to depend on those complex packages. My motivation in all of this is to enable the protobuf package and key pretty-printer to be compiled to wasm. However, only the last commit is explicitly related to that -- the other commits are justifiable on their own to improve the dependency graph.

The most controversial and least mechanical change in the series is the introduction of a logbase package for use in hlc, kvpb, and roachpb. This change, however, is really a generalization of work done by @nvanbenschoten in https://github.com/cockroachdb/cockroach/pull/115521 to allow for logging in syncutil. Also, it's not very large.