### PR TITLE
backupccl,sql: failed restore can set gcttl in tenant

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -2544,14 +2544,17 @@ func (r *restoreResumer) dropDescriptors(
 		// then waits for the MVCC GC process to clear the data before removing any
 		// descriptors. To ensure that this happens quickly, we install a zone
 		// configuration for every table that we are going to drop with a small GC TTL.
-		//
-		// NB: We can't set GC TTLs for non-system tenants currently.
-		if codec.ForSystemTenant() {
+		canSetGCTTL := codec.ForSystemTenant() ||
+			(sql.SecondaryTenantZoneConfigsEnabled.Get(&r.execCfg.Settings.SV) &&
+				sql.SecondaryTenantsAllZoneConfigsEnabled.Get(&r.execCfg.Settings.SV))
+		if canSetGCTTL {
 			if err := setGCTTLForDroppingTable(
 				ctx, txn, descsCol, tableToDrop,
 			); err != nil {
 				return errors.Wrapf(err, "setting low GC TTL for table %q", tableToDrop.GetName())
 			}
+		} else {
+			log.Infof(ctx, "cannot lower GC TTL for table %q", tableToDrop.GetName())
 		}
 
 		// In the legacy GC job, setting DropTime ensures a table uses RangeClear

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-fast-drop
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-fast-drop
@@ -1,4 +1,4 @@
-new-cluster name=s1 nodes=1 disable-tenant
+new-cluster name=s1 nodes=1
 ----
 
 subtest restore-cleanup-with-range-tombstones
@@ -16,7 +16,7 @@ exec-sql
 BACKUP INTO 'nodelocal://1/cluster_backup';
 ----
 
-new-cluster name=s2 nodes=1 share-io-dir=s1 disable-tenant
+new-cluster name=s2 nodes=1 share-io-dir=s1
 ----
 
 # Restore's OnFailOrCancel deletes descriptors which requires us to wait for no
@@ -29,15 +29,23 @@ SET CLUSTER SETTING sql.catalog.descriptor_lease_duration = '1s';
 
 # The GC Job sleeps between checking if a range being empty. Lowering this
 # speeds up the test.
-exec-sql
+exec-sql vc=system
 SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '250ms';
+----
+
+exec-sql vc=system
+SET CLUSTER SETTING sql.virtual_cluster.feature_access.zone_configs.enabled = true;
+----
+
+exec-sql vc=system
+SET CLUSTER SETTING sql.virtual_cluster.feature_access.zone_configs_unrestricted.enabled = true;
 ----
 
 # The protected timestamp poll interval controls how often our cache of
 # protected timestamps is updated. The GC threshold can only advance as far as
 # the time at which the cache was updated. We set this low so our cache is
 # fresh and our range deletions are eligible for GC faster.
-exec-sql
+exec-sql vc=system
 SET CLUSTER SETTING kv.protectedts.poll_interval = '250ms';
 ----
 
@@ -67,7 +75,7 @@ job cancel=a
 sleep ms=2000
 ----
 
-exec-sql
+exec-sql vc=system
 SELECT crdb_internal.kv_enqueue_replica(range_id, 'mvccGC', true) FROM (SELECT range_id FROM crdb_internal.ranges);
 ----
 

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -1102,10 +1102,10 @@ func validateZoneAttrsAndLocalitiesForSystemTenant(
 	return nil
 }
 
-// secondaryTenantsAllZoneConfigsEnabled is an extension of
+// SecondaryTenantsAllZoneConfigsEnabled is an extension of
 // SecondaryTenantZoneConfigsEnabled that allows virtual clusters to modify all
 // type of constraints in zone configs (i.e. not only zones and regions).
-var secondaryTenantsAllZoneConfigsEnabled = settings.RegisterBoolSetting(
+var SecondaryTenantsAllZoneConfigsEnabled = settings.RegisterBoolSetting(
 	settings.SystemVisible,
 	"sql.virtual_cluster.feature_access.zone_configs_unrestricted.enabled",
 	"enable unrestricted usage of ALTER CONFIGURE ZONE in virtual clusters",
@@ -1114,7 +1114,7 @@ var secondaryTenantsAllZoneConfigsEnabled = settings.RegisterBoolSetting(
 
 // validateZoneLocalitiesForSecondaryTenants performs constraint/lease
 // preferences validation for secondary tenants. Only newly added constraints
-// are validated. Unless secondaryTenantsAllZoneConfigsEnabled is set to 'true',
+// are validated. Unless SecondaryTenantsAllZoneConfigsEnabled is set to 'true',
 // secondary tenants are only allowed to reference locality attributes as they
 // only have access to region information via the serverpb.TenantStatusServer.
 // In that case they're only allowed to reference the "region" and "zone" tiers.
@@ -1184,7 +1184,7 @@ func validateZoneLocalitiesForSecondaryTenants(
 			}
 		default:
 			if err := requireSystemTenantOrClusterSetting(
-				codec, settings, secondaryTenantsAllZoneConfigsEnabled,
+				codec, settings, SecondaryTenantsAllZoneConfigsEnabled,
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/set_zone_config_test.go
+++ b/pkg/sql/set_zone_config_test.go
@@ -150,7 +150,7 @@ func TestValidateZoneAttrsAndLocalitiesForSecondaryTenants(t *testing.T) {
 	}
 
 	for _, anyConstraintAllowed := range []bool{false, true} {
-		secondaryTenantsAllZoneConfigsEnabled.Override(ctx, &settings.SV, anyConstraintAllowed)
+		SecondaryTenantsAllZoneConfigsEnabled.Override(ctx, &settings.SV, anyConstraintAllowed)
 		for _, tc := range testCases {
 			var zone zonepb.ZoneConfig
 			err := yaml.UnmarshalStrict([]byte(tc.cfg), &zone)


### PR DESCRIPTION
Some tenants now have the capability to set GC TTLs, so we can set a low GC TTL during the cleanup of a failed restore.

Fixes #116529

Release note: None