### PR TITLE
release-23.1: sql: add `StmtPosInTxn` to CommonSQLExecDetails

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -438,6 +438,7 @@ is directly or indirectly a member of the admin role) executes a query.
 | `FullIndexScan` | Whether the query contains a full secondary index scan of a non-partial index. | no |
 | `TxnCounter` | The sequence number of the SQL transaction inside its session. | no |
 | `BulkJobId` | The job id for bulk job (IMPORT/BACKUP/RESTORE). | no |
+| `StmtPosInTxn` | The statement's index in the transaction, starting at 1. | no |
 
 ### `role_based_audit_event`
 
@@ -473,6 +474,7 @@ cluster setting.
 | `FullIndexScan` | Whether the query contains a full secondary index scan of a non-partial index. | no |
 | `TxnCounter` | The sequence number of the SQL transaction inside its session. | no |
 | `BulkJobId` | The job id for bulk job (IMPORT/BACKUP/RESTORE). | no |
+| `StmtPosInTxn` | The statement's index in the transaction, starting at 1. | no |
 
 ### `sensitive_table_access`
 
@@ -508,6 +510,7 @@ a table marked as audited.
 | `FullIndexScan` | Whether the query contains a full secondary index scan of a non-partial index. | no |
 | `TxnCounter` | The sequence number of the SQL transaction inside its session. | no |
 | `BulkJobId` | The job id for bulk job (IMPORT/BACKUP/RESTORE). | no |
+| `StmtPosInTxn` | The statement's index in the transaction, starting at 1. | no |
 
 ## SQL Execution Log
 
@@ -550,6 +553,7 @@ and the cluster setting `sql.trace.log_statement_execute` is set.
 | `FullIndexScan` | Whether the query contains a full secondary index scan of a non-partial index. | no |
 | `TxnCounter` | The sequence number of the SQL transaction inside its session. | no |
 | `BulkJobId` | The job id for bulk job (IMPORT/BACKUP/RESTORE). | no |
+| `StmtPosInTxn` | The statement's index in the transaction, starting at 1. | no |
 
 ## SQL Logical Schema Changes
 
@@ -2349,6 +2353,7 @@ set to a non-zero value, AND
 | `FullIndexScan` | Whether the query contains a full secondary index scan of a non-partial index. | no |
 | `TxnCounter` | The sequence number of the SQL transaction inside its session. | no |
 | `BulkJobId` | The job id for bulk job (IMPORT/BACKUP/RESTORE). | no |
+| `StmtPosInTxn` | The statement's index in the transaction, starting at 1. | no |
 
 ### `txn_rows_read_limit`
 
@@ -2469,6 +2474,7 @@ the "slow query" condition.
 | `FullIndexScan` | Whether the query contains a full secondary index scan of a non-partial index. | no |
 | `TxnCounter` | The sequence number of the SQL transaction inside its session. | no |
 | `BulkJobId` | The job id for bulk job (IMPORT/BACKUP/RESTORE). | no |
+| `StmtPosInTxn` | The statement's index in the transaction, starting at 1. | no |
 
 ### `txn_rows_read_limit_internal`
 
@@ -3017,6 +3023,7 @@ contains common SQL event/execution details.
 | `FullIndexScan` | Whether the query contains a full secondary index scan of a non-partial index. | no |
 | `TxnCounter` | The sequence number of the SQL transaction inside its session. | no |
 | `BulkJobId` | The job id for bulk job (IMPORT/BACKUP/RESTORE). | no |
+| `StmtPosInTxn` | The statement's index in the transaction, starting at 1. | no |
 
 ### `schema_descriptor`
 

--- a/pkg/cli/interactive_tests/test_exec_log.tcl
+++ b/pkg/cli/interactive_tests/test_exec_log.tcl
@@ -116,12 +116,12 @@ grep 'SELECT ..*550..* +' $logfile;
 exit 1;"
 
 # Two separate single-stmt txns.
-system "n=`grep 'SELECT ..*550..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\)/\\1/g' | uniq | wc -l`; if test \$n -ne 2; then echo unexpected \$n; exit 1; fi"
+system "n=`grep 'SELECT ..*550..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 2; then echo unexpected \$n; exit 1; fi"
 # Same txns.
-system "n=`grep 'SELECT ..*660..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\)/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
-system "n=`grep 'SELECT ..*770..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\)/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
-system "n=`grep 'SELECT ..*880..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\)/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
-system "n=`grep 'SELECT ..*990..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\)/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
+system "n=`grep 'SELECT ..*660..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
+system "n=`grep 'SELECT ..*770..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
+system "n=`grep 'SELECT ..*880..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
+system "n=`grep 'SELECT ..*990..* +' $logfile | sed -e 's/.*TxnCounter.:\\(\[0-9\]*\\).*/\\1/g' | uniq | wc -l`; if test \$n -ne 1; then echo unexpected \$n; exit 1; fi"
 
 end_test
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2755,6 +2755,7 @@ func (ex *connExecutor) execCopyOut(
 			int(ex.state.mu.autoRetryCounter),
 			ex.extraTxnState.txnCounter,
 			numOutputRows,
+			ex.state.mu.stmtCount,
 			0, /* bulkJobId */
 			copyErr,
 			ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
@@ -3009,7 +3010,8 @@ func (ex *connExecutor) execCopyIn(
 		var stats topLevelQueryStats
 		ex.planner.maybeLogStatement(ctx, ex.executorType,
 			int(ex.state.mu.autoRetryCounter), ex.extraTxnState.txnCounter,
-			numInsertedRows, 0, /* bulkJobId */
+			numInsertedRows, ex.state.mu.stmtCount,
+			0, /* bulkJobId */
 			copyErr,
 			ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
 			&ex.extraTxnState.hasAdminRoleCache,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -802,6 +802,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			int(ex.state.mu.autoRetryCounter),
 			ex.extraTxnState.txnCounter,
 			0, /* rowsAffected */
+			ex.state.mu.stmtCount,
 			0, /* bulkJobId */
 			execErr,
 			ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
@@ -1564,6 +1565,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 						int(ex.state.mu.autoRetryCounter),
 						ex.extraTxnState.txnCounter,
 						ppInfo.dispatchToExecutionEngine.rowsAffected,
+						ex.state.mu.stmtCount,
 						bulkJobId,
 						ppInfo.curRes.ErrAllowReleased(),
 						ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
@@ -1590,6 +1592,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 				int(ex.state.mu.autoRetryCounter),
 				ex.extraTxnState.txnCounter,
 				nonBulkJobNumRows,
+				ex.state.mu.stmtCount,
 				bulkJobId,
 				res.Err(),
 				ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
@@ -2254,6 +2257,7 @@ func (ex *connExecutor) execStmtInNoTxnState(
 			int(ex.state.mu.autoRetryCounter),
 			ex.extraTxnState.txnCounter,
 			0, /* rowsAffected */
+			ex.state.mu.stmtCount,
 			0, /* bulkJobId */
 			execErr,
 			ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -120,7 +120,7 @@ func (s executorType) logLabel() string { return logLabels[s] }
 func (p *planner) maybeLogStatement(
 	ctx context.Context,
 	execType executorType,
-	numRetries, txnCounter, rows int,
+	numRetries, txnCounter, rows, stmtCount int,
 	bulkJobId uint64,
 	err error,
 	queryReceived time.Time,
@@ -132,7 +132,7 @@ func (p *planner) maybeLogStatement(
 ) {
 	p.maybeAuditRoleBasedAuditEvent(ctx, execType)
 	p.maybeLogStatementInternal(ctx, execType, numRetries, txnCounter,
-		rows, bulkJobId, err, queryReceived, hasAdminRoleCache,
+		rows, stmtCount, bulkJobId, err, queryReceived, hasAdminRoleCache,
 		telemetryLoggingMetrics, stmtFingerprintID, queryStats, statsCollector,
 	)
 }
@@ -141,6 +141,7 @@ func (p *planner) maybeLogStatementInternal(
 	ctx context.Context,
 	execType executorType,
 	numRetries, txnCounter, rows int,
+	stmtCount int,
 	bulkJobId uint64,
 	err error,
 	startTime time.Time,
@@ -215,6 +216,7 @@ func (p *planner) maybeLogStatementInternal(
 		FullTableScan: p.curPlan.flags.IsSet(planFlagContainsFullTableScan),
 		FullIndexScan: p.curPlan.flags.IsSet(planFlagContainsFullIndexScan),
 		TxnCounter:    uint32(txnCounter),
+		StmtPosInTxn:  uint32(stmtCount),
 	}
 
 	// Note that for bulk job query (IMPORT, BACKUP and RESTORE), we don't

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"math"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -105,7 +104,7 @@ func TestTelemetryLogging(t *testing.T) {
 		execTimestampsSeconds   []float64 // Execute the query with the following timestamps.
 		expectedLogStatement    string
 		stubMaxEventFrequency   int64
-		expectedSkipped         []int // Expected skipped query count per expected log line.
+		expectedSkipped         []uint64 // Expected skipped query count per expected log line.
 		expectedUnredactedTags  []string
 		expectedApplicationName string
 		expectedFullScan        bool
@@ -130,7 +129,7 @@ func TestTelemetryLogging(t *testing.T) {
 			execTimestampsSeconds:   []float64{1, 1.1, 1.2, 2},
 			expectedLogStatement:    `TRUNCATE TABLE defaultdb.public.t`,
 			stubMaxEventFrequency:   1,
-			expectedSkipped:         []int{0, 0, 0, 0},
+			expectedSkipped:         []uint64{0, 0, 0, 0},
 			expectedUnredactedTags:  []string{"client"},
 			expectedApplicationName: "telemetry-logging-test",
 			expectedFullScan:        false,
@@ -174,7 +173,7 @@ func TestTelemetryLogging(t *testing.T) {
 			execTimestampsSeconds:   []float64{3},
 			expectedLogStatement:    `SELECT * FROM \"\".\"\".t LIMIT ‹1›`,
 			stubMaxEventFrequency:   1,
-			expectedSkipped:         []int{0},
+			expectedSkipped:         []uint64{0},
 			expectedUnredactedTags:  []string{"client"},
 			expectedApplicationName: "telemetry-logging-test",
 			expectedFullScan:        false,
@@ -197,7 +196,7 @@ func TestTelemetryLogging(t *testing.T) {
 			execTimestampsSeconds:   []float64{4, 4.1, 4.2, 5},
 			expectedLogStatement:    `SELECT * FROM \"\".\"\".u LIMIT ‹2›`,
 			stubMaxEventFrequency:   1,
-			expectedSkipped:         []int{0, 2},
+			expectedSkipped:         []uint64{0, 2},
 			expectedUnredactedTags:  []string{"client"},
 			expectedApplicationName: "telemetry-logging-test",
 			expectedFullScan:        false,
@@ -222,7 +221,7 @@ func TestTelemetryLogging(t *testing.T) {
 			execTimestampsSeconds:   []float64{6, 6.01, 6.05, 6.06, 6.1, 6.2},
 			expectedLogStatement:    `SELECT * FROM \"\".\"\".u LIMIT ‹3›`,
 			stubMaxEventFrequency:   10,
-			expectedSkipped:         []int{0, 3, 0},
+			expectedSkipped:         []uint64{0, 3, 0},
 			expectedUnredactedTags:  []string{"client"},
 			expectedApplicationName: "telemetry-logging-test",
 			expectedFullScan:        false,
@@ -250,7 +249,7 @@ func TestTelemetryLogging(t *testing.T) {
 			execTimestampsSeconds:   []float64{7},
 			expectedLogStatement:    `SELECT x FROM \"\".\"\".u`,
 			stubMaxEventFrequency:   10,
-			expectedSkipped:         []int{0},
+			expectedSkipped:         []uint64{0},
 			expectedUnredactedTags:  []string{"client"},
 			expectedApplicationName: "telemetry-logging-test",
 			expectedFullScan:        true,
@@ -277,7 +276,7 @@ func TestTelemetryLogging(t *testing.T) {
 			execTimestampsSeconds:   []float64{8},
 			expectedLogStatement:    `UPDATE \"\".\"\".u SET x = ‹5› WHERE x > ‹50› RETURNING x`,
 			stubMaxEventFrequency:   10,
-			expectedSkipped:         []int{0},
+			expectedSkipped:         []uint64{0},
 			expectedUnredactedTags:  []string{"client"},
 			expectedApplicationName: "telemetry-logging-test",
 			expectedFullScan:        true,
@@ -302,7 +301,7 @@ func TestTelemetryLogging(t *testing.T) {
 			execTimestampsSeconds:   []float64{9},
 			expectedLogStatement:    `CREATE USER root`,
 			stubMaxEventFrequency:   1,
-			expectedSkipped:         []int{0},
+			expectedSkipped:         []uint64{0},
 			expectedUnredactedTags:  []string{"client"},
 			expectedApplicationName: "telemetry-logging-test",
 			expectedFullScan:        false,
@@ -323,7 +322,7 @@ func TestTelemetryLogging(t *testing.T) {
 			execTimestampsSeconds:   []float64{10, 10.01, 10.02, 10.03, 10.04, 10.05},
 			expectedLogStatement:    `SELECT * FROM \"\".\"\".u LIMIT ‹4›`,
 			stubMaxEventFrequency:   10,
-			expectedSkipped:         []int{0, 0, 0, 0, 0, 0},
+			expectedSkipped:         []uint64{0, 0, 0, 0, 0, 0},
 			expectedUnredactedTags:  []string{"client"},
 			expectedApplicationName: "telemetry-logging-test",
 			expectedFullScan:        false,
@@ -349,7 +348,7 @@ func TestTelemetryLogging(t *testing.T) {
 			execTimestampsSeconds:   []float64{11, 11.01, 11.02, 11.03, 11.04, 11.05},
 			expectedLogStatement:    `SELECT * FROM \"\".\"\".u WHERE x > ‹10› LIMIT ‹3›`,
 			stubMaxEventFrequency:   10,
-			expectedSkipped:         []int{0},
+			expectedSkipped:         []uint64{0},
 			expectedUnredactedTags:  []string{"client"},
 			expectedApplicationName: "telemetry-logging-test",
 			expectedFullScan:        true,
@@ -369,7 +368,7 @@ func TestTelemetryLogging(t *testing.T) {
 			execTimestampsSeconds:   []float64{20},
 			expectedLogStatement:    `SELECT x FROM \"\".\"\".u ORDER BY x DESC`,
 			stubMaxEventFrequency:   1,
-			expectedSkipped:         []int{24},
+			expectedSkipped:         []uint64{24},
 			expectedUnredactedTags:  []string{"client"},
 			expectedApplicationName: "telemetry-logging-test",
 			expectedFullScan:        true,
@@ -469,17 +468,11 @@ func TestTelemetryLogging(t *testing.T) {
 					var sampledQueryFromLog eventpb.SampledQuery
 					err = json.Unmarshal([]byte(e.Message), &sampledQueryFromLog)
 					require.NoError(t, err)
-					expectedSkipped := tc.expectedSkipped[logCount]
+
+					require.Equal(t, tc.expectedSkipped[logCount], sampledQueryFromLog.SkippedQueries)
+
 					logCount++
-					if expectedSkipped == 0 {
-						if strings.Contains(e.Message, "SkippedQueries") {
-							t.Errorf("%s: expected no skipped queries, found:\n%s", tc.name, e.Message)
-						}
-					} else {
-						if expected := fmt.Sprintf(`"SkippedQueries":%d`, expectedSkipped); !strings.Contains(e.Message, expected) {
-							t.Errorf("%s: expected %s found:\n%s", tc.name, expected, e.Message)
-						}
-					}
+
 					costRe := regexp.MustCompile("\"CostEstimate\":[0-9]*\\.[0-9]*")
 					if !costRe.MatchString(e.Message) {
 						t.Errorf("expected to find CostEstimate but none was found")
@@ -511,19 +504,18 @@ func TestTelemetryLogging(t *testing.T) {
 							}
 						}
 					}
-					if !strings.Contains(e.Message, "\"ApplicationName\":\""+tc.expectedApplicationName+"\"") {
-						t.Errorf("expected to find unredacted Application Name: %s", tc.expectedApplicationName)
-					}
-					if !strings.Contains(e.Message, "\"SessionID\":\""+sessionID+"\"") {
-						t.Errorf("expected to find sessionID: %s", sessionID)
-					}
-					if !strings.Contains(e.Message, "\"Database\":\""+databaseName+"\"") {
-						t.Errorf("expected to find Database: %s", databaseName)
-					}
+
+					require.Equal(t, tc.expectedApplicationName, sampledQueryFromLog.ApplicationName)
+					require.Equal(t, sessionID, sampledQueryFromLog.SessionID)
+					require.Equal(t, databaseName, sampledQueryFromLog.Database)
+
+					// All expected logs in this test are single stmt txns.
+					require.Equal(t, uint32(1), sampledQueryFromLog.StmtPosInTxn)
+
 					stmtFingerprintID := appstatspb.ConstructStatementFingerprintID(tc.queryNoConstants, tc.expectedErr != "", true, databaseName)
-					if !strings.Contains(e.Message, "\"StatementFingerprintID\":"+strconv.FormatUint(uint64(stmtFingerprintID), 10)) {
-						t.Errorf("expected to find StatementFingerprintID: %v", stmtFingerprintID)
-					}
+
+					require.Equal(t, uint64(stmtFingerprintID), sampledQueryFromLog.StatementFingerprintID)
+
 					maxFullScanRowsRe := regexp.MustCompile("\"MaxFullScanRowsEstimate\":[0-9]*")
 					foundFullScan := maxFullScanRowsRe.MatchString(e.Message)
 					if tc.expectedFullScan && !foundFullScan {
@@ -1551,5 +1543,84 @@ $$`
 	}
 	if numLogsFound != 1 {
 		t.Errorf("expected 1 log entries, found %d", numLogsFound)
+	}
+}
+
+// TestTelemetryLoggingStmtPosInTxn verifies that StmtCount is logged correctly to
+// telemetry. The structure of the other test cases makes it difficult to verify
+// this property, so we do it explicitly here.
+func TestTelemetryLoggingStmtPosInTxn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	sc := log.ScopeWithoutShowLogs(t)
+	defer sc.Close(t)
+
+	cleanup := logtestutils.InstallLogFileSink(sc, t, logpb.Channel_TELEMETRY)
+	defer cleanup()
+
+	st := logtestutils.StubTime{}
+	sts := logtestutils.StubTracingStatus{}
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			TelemetryLoggingKnobs: &TelemetryLoggingTestingKnobs{
+				getTimeNow:       st.TimeNow,
+				getTracingStatus: sts.TracingStatus,
+			},
+		},
+	})
+
+	defer s.Stopper().Stop(context.Background())
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, `SET application_name = 'telemetry-stmt=count-logging-test'`)
+
+	db.Exec(t, `SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true;`)
+
+	st.SetTime(timeutil.FromUnixMicros(int64(1e6)))
+	db.Exec(t, `BEGIN;`)
+	st.SetTime(timeutil.FromUnixMicros(int64(2e6)))
+	db.Exec(t, `SELECT 1`)
+	st.SetTime(timeutil.FromUnixMicros(int64(2 * 3e6)))
+	db.Exec(t, `SELECT 2`)
+	st.SetTime(timeutil.FromUnixMicros(int64(3 * 4e6)))
+	db.Exec(t, `SELECT 3`)
+	db.Exec(t, `COMMIT;`)
+
+	expectedQueries := []string{
+		`SELECT ‹1›`, `SELECT ‹2›`, `SELECT ‹3›`,
+	}
+
+	log.Flush()
+
+	entries, err := log.FetchEntriesFromFiles(
+		0,
+		math.MaxInt64,
+		10000,
+		regexp.MustCompile(`"EventType":"sampled_query"`),
+		log.WithMarkedSensitiveData,
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.NotEmpty(t, entries)
+
+	// Attempt to find all expected logs.
+	for i, expected := range expectedQueries {
+		found := false
+		for _, e := range entries {
+			if strings.Contains(e.Message, expected) {
+				var sq eventpb.SampledQuery
+				require.NoError(t, json.Unmarshal([]byte(e.Message), &sq))
+				require.Equal(t, uint32(i+1), sq.StmtPosInTxn, "%s", entries)
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			t.Errorf("did not find expected query log in log entries: %s", expected)
+		}
 	}
 }

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -1953,6 +1953,15 @@ func (m *CommonSQLExecDetails) AppendJSONFields(printComma bool, b redact.Redact
 		b = strconv.AppendUint(b, uint64(m.BulkJobId), 10)
 	}
 
+	if m.StmtPosInTxn != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"StmtPosInTxn\":"...)
+		b = strconv.AppendUint(b, uint64(m.StmtPosInTxn), 10)
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/sql_audit_events.proto
+++ b/pkg/util/log/eventpb/sql_audit_events.proto
@@ -45,6 +45,8 @@ message CommonSQLExecDetails {
   uint32 txn_counter = 9 [(gogoproto.jsontag) = ",omitempty"];
   // The job id for bulk job (IMPORT/BACKUP/RESTORE).
   uint64 bulk_job_id = 10 [(gogoproto.jsontag) = ",omitempty"];
+ // The statement's index in the transaction, starting at 1.
+  uint32 stmt_pos_in_txn = 11 [(gogoproto.jsontag) = ",omitempty"];
 }
 
 


### PR DESCRIPTION
Backport 1/1 commits from #107081.

/cc @cockroachdb/release

Release justification: low risk updates

---

This commit adds the `StmtPosInTxn` field to the `CommonSQLExecDetails` event. `StmtPosInTxn` represents the stmt's index in the transaction, starting at 1.

Epic: none

Release note (sql change): In `CommonSQLExecDetails`, which is emitted as part of the sql audit logs, sql exec logs and telemetry events, there is a new field:
- `StmtPosInTxn`: represents the stmt's index in the transaction, starting at 1.
