### PR TITLE
sql,*: remove DistributionTypeSystemTenantOnly

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -368,10 +368,10 @@ func makePlan(
 		maybeCfKnobs, haveKnobs := execCtx.ExecCfg().DistSQLSrv.TestingKnobs.Changefeed.(*TestingKnobs)
 		var blankTxn *kv.Txn
 
-		distMode := sql.DistributionTypeAlways
+		distMode := sql.FullDistribution
 		if details.SinkURI == `` {
 			// Sinkless feeds get one ChangeAggregator on this node.
-			distMode = sql.DistributionTypeNone
+			distMode = sql.LocalDistribution
 		}
 
 		var locFilter roachpb.Locality
@@ -393,7 +393,7 @@ func makePlan(
 			log.Infof(ctx, "spans returned by DistSQL: %s", spanPartitions)
 		}
 		switch {
-		case distMode == sql.DistributionTypeNone || rangeDistribution == int64(defaultDistribution):
+		case distMode == sql.LocalDistribution || rangeDistribution == int64(defaultDistribution):
 		case rangeDistribution == int64(balancedSimpleDistribution):
 			if log.ExpensiveLogEnabled(ctx, 2) {
 				log.Infof(ctx, "rebalancing ranges using balanced simple distribution")

--- a/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
@@ -294,8 +294,9 @@ func buildReplicationStreamSpec(
 
 	// Partition the spans with SQLPlanner
 	dsp := jobExecCtx.DistSQLPlanner()
-	planCtx := dsp.NewPlanningCtx(ctx, jobExecCtx.ExtendedEvalContext(),
-		nil /* planner */, nil /* txn */, sql.DistributionTypeAlways)
+	planCtx := dsp.NewPlanningCtx(
+		ctx, jobExecCtx.ExtendedEvalContext(), nil /* planner */, nil /* txn */, sql.FullDistribution,
+	)
 
 	spanPartitions, err := dsp.PartitionSpans(ctx, planCtx, targetSpans)
 	if err != nil {

--- a/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
@@ -295,7 +295,7 @@ func buildReplicationStreamSpec(
 	// Partition the spans with SQLPlanner
 	dsp := jobExecCtx.DistSQLPlanner()
 	planCtx := dsp.NewPlanningCtx(ctx, jobExecCtx.ExtendedEvalContext(),
-		nil /* planner */, nil /* txn */, sql.DistributionTypeSystemTenantOnly)
+		nil /* planner */, nil /* txn */, sql.DistributionTypeAlways)
 
 	spanPartitions, err := dsp.PartitionSpans(ctx, planCtx, targetSpans)
 	if err != nil {

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -344,9 +344,9 @@ func runPlanInsidePlan(
 		ctx, plannerCopy.Descriptors().HasUncommittedTypes(),
 		plannerCopy.SessionData().DistSQLMode, plan.main,
 	)
-	distributeType := DistributionType(DistributionTypeNone)
+	distributeType := DistributionType(LocalDistribution)
 	if distributePlan.WillDistribute() {
-		distributeType = DistributionTypeAlways
+		distributeType = FullDistribution
 	}
 	evalCtx := evalCtxFactory()
 	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, &plannerCopy, plannerCopy.txn, distributeType)

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1045,7 +1045,7 @@ func (sc *SchemaChanger) distIndexBackfill(
 		sd := NewInternalSessionData(ctx, sc.execCfg.Settings, "dist-index-backfill")
 		evalCtx = createSchemaChangeEvalCtx(ctx, sc.execCfg, sd, txn.KV().ReadTimestamp(), txn.Descriptors())
 		planCtx = sc.distSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil, /* planner */
-			txn.KV(), DistributionTypeSystemTenantOnly)
+			txn.KV(), DistributionTypeAlways)
 		indexBatchSize := indexBackfillBatchSize.Get(&sc.execCfg.Settings.SV)
 		chunkSize := sc.getChunkSize(indexBatchSize)
 		spec, err := initIndexBackfillerSpec(*tableDesc.TableDesc(), writeAsOf, readAsOf, writeAtRequestTimestamp, chunkSize, addedIndexes)
@@ -1352,7 +1352,7 @@ func (sc *SchemaChanger) distColumnBackfill(
 			defer recv.Release()
 
 			planCtx := sc.distSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil /* planner */, txn.KV(),
-				DistributionTypeSystemTenantOnly)
+				DistributionTypeAlways)
 			spec, err := initColumnBackfillerSpec(tableDesc, duration, chunkSize, backfillUpdateChunkSizeThresholdBytes, readAsOf)
 			if err != nil {
 				return err

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1044,8 +1044,9 @@ func (sc *SchemaChanger) distIndexBackfill(
 		}
 		sd := NewInternalSessionData(ctx, sc.execCfg.Settings, "dist-index-backfill")
 		evalCtx = createSchemaChangeEvalCtx(ctx, sc.execCfg, sd, txn.KV().ReadTimestamp(), txn.Descriptors())
-		planCtx = sc.distSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil, /* planner */
-			txn.KV(), DistributionTypeAlways)
+		planCtx = sc.distSQLPlanner.NewPlanningCtx(
+			ctx, &evalCtx, nil /* planner */, txn.KV(), FullDistribution,
+		)
 		indexBatchSize := indexBackfillBatchSize.Get(&sc.execCfg.Settings.SV)
 		chunkSize := sc.getChunkSize(indexBatchSize)
 		spec, err := initIndexBackfillerSpec(*tableDesc.TableDesc(), writeAsOf, readAsOf, writeAtRequestTimestamp, chunkSize, addedIndexes)
@@ -1351,8 +1352,9 @@ func (sc *SchemaChanger) distColumnBackfill(
 			)
 			defer recv.Release()
 
-			planCtx := sc.distSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil /* planner */, txn.KV(),
-				DistributionTypeAlways)
+			planCtx := sc.distSQLPlanner.NewPlanningCtx(
+				ctx, &evalCtx, nil /* planner */, txn.KV(), FullDistribution,
+			)
 			spec, err := initColumnBackfillerSpec(tableDesc, duration, chunkSize, backfillUpdateChunkSizeThresholdBytes, readAsOf)
 			if err != nil {
 				return err

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3148,7 +3148,7 @@ func (ex *connExecutor) execCopyIn(
 			// execInsertPlan
 			func(ctx context.Context, p *planner, res RestrictedCommandResult) error {
 				defer p.curPlan.close(ctx)
-				_, err := ex.execWithDistSQLEngine(ctx, p, tree.RowsAffected, res, DistributionTypeNone, nil /* progressAtomic */)
+				_, err := ex.execWithDistSQLEngine(ctx, p, tree.RowsAffected, res, LocalDistribution, nil /* progressAtomic */)
 				return err
 			},
 		)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1991,9 +1991,9 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	if ex.server.cfg.TestingKnobs.OnTxnRetry != nil && ex.state.mu.autoRetryReason != nil {
 		ex.server.cfg.TestingKnobs.OnTxnRetry(ex.state.mu.autoRetryReason, planner.EvalContext())
 	}
-	distribute := DistributionType(DistributionTypeNone)
+	distribute := DistributionType(LocalDistribution)
 	if distributePlan.WillDistribute() {
-		distribute = DistributionTypeAlways
+		distribute = FullDistribution
 	}
 	ex.sessionTracing.TraceExecStart(ctx, "distributed")
 	stats, err = ex.execWithDistSQLEngine(

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -664,8 +664,7 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 			}
 		}
 
-		planCtx := dsp.NewPlanningCtx(ctx, evalCtx, nil /* planner */, txn.KV(),
-			DistributionTypeAlways)
+		planCtx := dsp.NewPlanningCtx(ctx, evalCtx, nil /* planner */, txn.KV(), FullDistribution)
 		// CREATE STATS flow doesn't produce any rows and only emits the
 		// metadata, so we can use a nil rowContainerHelper.
 		resultWriter := NewRowResultWriter(nil /* rowContainer */)

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -665,7 +665,7 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 		}
 
 		planCtx := dsp.NewPlanningCtx(ctx, evalCtx, nil /* planner */, txn.KV(),
-			DistributionTypeSystemTenantOnly)
+			DistributionTypeAlways)
 		// CREATE STATS flow doesn't produce any rows and only emits the
 		// metadata, so we can use a nil rowContainerHelper.
 		resultWriter := NewRowResultWriter(nil /* rowContainer */)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -144,11 +144,12 @@ type DistSQLPlanner struct {
 type DistributionType int
 
 const (
-	// DistributionTypeNone does not distribute a plan across multiple instances.
-	DistributionTypeNone = iota
-	// DistributionTypeAlways distributes a plan across multiple instances whether
+	// LocalDistribution does not distribute a plan across multiple SQL
+	// instances.
+	LocalDistribution = iota
+	// FullDistribution distributes a plan across multiple SQL instances whether
 	// it is a system tenant or non-system tenant.
-	DistributionTypeAlways
+	FullDistribution
 )
 
 // ReplicaOraclePolicy controls which policy the physical planner uses to choose
@@ -4837,7 +4838,7 @@ func (dsp *DistSQLPlanner) NewPlanningCtxWithOracle(
 	oracle replicaoracle.Oracle,
 	localityFiler roachpb.Locality,
 ) *PlanningCtx {
-	distribute := distributionType == DistributionTypeAlways
+	distribute := distributionType == FullDistribution
 	infra := physicalplan.NewPhysicalInfrastructure(uuid.FastMakeV4(), dsp.gatewaySQLInstanceID)
 	planCtx := &PlanningCtx{
 		ExtendedEvalCtx: evalCtx,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -149,9 +149,6 @@ const (
 	// DistributionTypeAlways distributes a plan across multiple instances whether
 	// it is a system tenant or non-system tenant.
 	DistributionTypeAlways
-	// DistributionTypeSystemTenantOnly only distributes a plan if it is for a
-	// system tenant. Plans on non-system tenants are not distributed.
-	DistributionTypeSystemTenantOnly
 )
 
 // ReplicaOraclePolicy controls which policy the physical planner uses to choose
@@ -4840,7 +4837,7 @@ func (dsp *DistSQLPlanner) NewPlanningCtxWithOracle(
 	oracle replicaoracle.Oracle,
 	localityFiler roachpb.Locality,
 ) *PlanningCtx {
-	distribute := distributionType == DistributionTypeAlways || (distributionType == DistributionTypeSystemTenantOnly && evalCtx.Codec.ForSystemTenant())
+	distribute := distributionType == DistributionTypeAlways
 	infra := physicalplan.NewPhysicalInfrastructure(uuid.FastMakeV4(), dsp.gatewaySQLInstanceID)
 	planCtx := &PlanningCtx{
 		ExtendedEvalCtx: evalCtx,

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -1198,7 +1198,7 @@ func TestPartitionSpans(t *testing.T) {
 			}
 			planCtx := dsp.NewPlanningCtxWithOracle(ctx, &extendedEvalContext{
 				Context: *evalCtx,
-			}, nil, nil, DistributionTypeSystemTenantOnly, physicalplan.DefaultReplicaChooser, locFilter)
+			}, nil, nil, DistributionTypeAlways, physicalplan.DefaultReplicaChooser, locFilter)
 			planCtx.spanPartitionState.testingOverrideRandomSelection = tc.partitionState.testingOverrideRandomSelection
 			var spans []roachpb.Span
 			for _, s := range tc.spans {
@@ -1515,7 +1515,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 	ctx := context.Background()
 	planCtx := dsp.NewPlanningCtx(ctx, &extendedEvalContext{
 		Context: eval.Context{Codec: keys.SystemSQLCodec},
-	}, nil, nil, DistributionTypeSystemTenantOnly)
+	}, nil, nil, DistributionTypeAlways)
 	partitions, err := dsp.PartitionSpans(ctx, planCtx, roachpb.Spans{span})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -1196,9 +1196,10 @@ func TestPartitionSpans(t *testing.T) {
 					},
 				}),
 			}
-			planCtx := dsp.NewPlanningCtxWithOracle(ctx, &extendedEvalContext{
-				Context: *evalCtx,
-			}, nil, nil, DistributionTypeAlways, physicalplan.DefaultReplicaChooser, locFilter)
+			planCtx := dsp.NewPlanningCtxWithOracle(
+				ctx, &extendedEvalContext{Context: *evalCtx}, nil, /* planner */
+				nil /* txn */, FullDistribution, physicalplan.DefaultReplicaChooser, locFilter,
+			)
 			planCtx.spanPartitionState.testingOverrideRandomSelection = tc.partitionState.testingOverrideRandomSelection
 			var spans []roachpb.Span
 			for _, s := range tc.spans {
@@ -1513,9 +1514,10 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	planCtx := dsp.NewPlanningCtx(ctx, &extendedEvalContext{
-		Context: eval.Context{Codec: keys.SystemSQLCodec},
-	}, nil, nil, DistributionTypeAlways)
+	planCtx := dsp.NewPlanningCtx(
+		ctx, &extendedEvalContext{Context: eval.Context{Codec: keys.SystemSQLCodec}},
+		nil /* planner */, nil /* txn */, FullDistribution,
+	)
 	partitions, err := dsp.PartitionSpans(ctx, planCtx, roachpb.Spans{span})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -61,8 +61,9 @@ func (dsp *DistSQLPlanner) setupAllNodesPlanningSystem(
 	oracle replicaoracle.Oracle,
 	localityFilter roachpb.Locality,
 ) (*PlanningCtx, []base.SQLInstanceID, error) {
-	planCtx := dsp.NewPlanningCtxWithOracle(ctx, evalCtx, nil /* planner */, nil, /* txn */
-		DistributionTypeAlways, oracle, localityFilter)
+	planCtx := dsp.NewPlanningCtxWithOracle(
+		ctx, evalCtx, nil /* planner */, nil /* txn */, FullDistribution, oracle, localityFilter,
+	)
 
 	ss, err := execCfg.NodesStatusServer.OptionalNodesStatusServer()
 	if err != nil {
@@ -99,8 +100,9 @@ func (dsp *DistSQLPlanner) setupAllNodesPlanningTenant(
 	oracle replicaoracle.Oracle,
 	localityFilter roachpb.Locality,
 ) (*PlanningCtx, []base.SQLInstanceID, error) {
-	planCtx := dsp.NewPlanningCtxWithOracle(ctx, evalCtx, nil /* planner */, nil, /* txn */
-		DistributionTypeAlways, oracle, localityFilter)
+	planCtx := dsp.NewPlanningCtxWithOracle(
+		ctx, evalCtx, nil /* planner */, nil /* txn */, FullDistribution, oracle, localityFilter,
+	)
 	pods, err := dsp.sqlAddressResolver.GetAllInstances(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -172,7 +172,7 @@ func PlanCDCExpression(
 		return cdcPlan, errors.AssertionFailedf("unexpected query structure")
 	}
 
-	planCtx := p.DistSQLPlanner().NewPlanningCtx(ctx, &p.extendedEvalCtx, p, p.txn, DistributionTypeNone)
+	planCtx := p.DistSQLPlanner().NewPlanningCtx(ctx, &p.extendedEvalCtx, p, p.txn, LocalDistribution)
 
 	return CDCExpressionPlan{
 		Plan:         p.curPlan.main,

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -31,9 +31,9 @@ func PlanAndRunCTAS(
 	out execinfrapb.ProcessorCoreUnion,
 	recv *DistSQLReceiver,
 ) {
-	distribute := DistributionType(DistributionTypeNone)
+	distribute := DistributionType(LocalDistribution)
 	if !isLocal {
-		distribute = DistributionTypeAlways
+		distribute = FullDistribution
 	}
 	planCtx := dsp.NewPlanningCtx(ctx, planner.ExtendedEvalContext(), planner,
 		txn, distribute)

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -33,7 +33,7 @@ func PlanAndRunCTAS(
 ) {
 	distribute := DistributionType(DistributionTypeNone)
 	if !isLocal {
-		distribute = DistributionTypeSystemTenantOnly
+		distribute = DistributionTypeAlways
 	}
 	planCtx := dsp.NewPlanningCtx(ctx, planner.ExtendedEvalContext(), planner,
 		txn, distribute)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1784,9 +1784,9 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 		ctx, planner.Descriptors().HasUncommittedTypes(),
 		planner.SessionData().DistSQLMode, subqueryPlan.plan,
 	).WillDistribute()
-	distribute := DistributionType(DistributionTypeNone)
+	distribute := DistributionType(LocalDistribution)
 	if distributeSubquery {
-		distribute = DistributionTypeAlways
+		distribute = FullDistribution
 	}
 	subqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distribute)
 	subqueryPlanCtx.stmtType = tree.Rows
@@ -2030,7 +2030,7 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 		// is no point in providing the locality filter since it will be ignored
 		// anyway, so we don't use NewPlanningCtxWithOracle constructor.
 		localPlanCtx := dsp.NewPlanningCtx(
-			ctx, evalCtx, planCtx.planner, evalCtx.Txn, DistributionTypeNone,
+			ctx, evalCtx, planCtx.planner, evalCtx.Txn, LocalDistribution,
 		)
 		localPlanCtx.setUpForMainQuery(ctx, planCtx.planner, recv)
 		localPhysPlan, localPhysPlanCleanup, err := dsp.createPhysPlan(ctx, localPlanCtx, plan)
@@ -2280,9 +2280,9 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 		ctx, planner.Descriptors().HasUncommittedTypes(),
 		planner.SessionData().DistSQLMode, postqueryPlan,
 	).WillDistribute()
-	distribute := DistributionType(DistributionTypeNone)
+	distribute := DistributionType(LocalDistribution)
 	if distributePostquery {
-		distribute = DistributionTypeAlways
+		distribute = FullDistribution
 	}
 	postqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distribute)
 	postqueryPlanCtx.stmtType = tree.Rows

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -182,8 +182,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		// We need distribute = true so that executing the plan involves marshaling
 		// the root txn meta to leaf txns. Local flows can start in aborted txns
 		// because they just use the root txn.
-		planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, nil,
-			DistributionTypeAlways)
+		planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, nil /* txn */, FullDistribution)
 		planCtx.stmtType = recv.stmtType
 
 		execCfg.DistSQLPlanner.PlanAndRun(
@@ -297,7 +296,7 @@ func TestDistSQLRunningParallelFKChecksAfterAbort(t *testing.T) {
 		defer p.curPlan.close(ctx)
 
 		evalCtx := p.ExtendedEvalContext()
-		planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, txn, DistributionTypeNone)
+		planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, txn, LocalDistribution)
 		planCtx.stmtType = recv.stmtType
 
 		evalCtxFactory := func(bool) *extendedEvalContext {

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -183,7 +183,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		// the root txn meta to leaf txns. Local flows can start in aborted txns
 		// because they just use the root txn.
 		planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, nil,
-			DistributionTypeSystemTenantOnly)
+			DistributionTypeAlways)
 		planCtx.stmtType = recv.stmtType
 
 		execCfg.DistSQLPlanner.PlanAndRun(

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -75,7 +75,7 @@ func newDistSQLSpecExecFactory(
 	}
 	distribute := DistributionType(DistributionTypeNone)
 	if e.planningMode != distSQLLocalOnlyPlanning {
-		distribute = DistributionTypeSystemTenantOnly
+		distribute = DistributionTypeAlways
 	}
 	evalCtx := p.ExtendedEvalContext()
 	e.planCtx = e.dsp.NewPlanningCtx(ctx, evalCtx, e.planner, e.planner.txn, distribute)

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -73,9 +73,9 @@ func newDistSQLSpecExecFactory(
 		planningMode:         planningMode,
 		gatewaySQLInstanceID: p.extendedEvalCtx.DistSQLPlanner.gatewaySQLInstanceID,
 	}
-	distribute := DistributionType(DistributionTypeNone)
+	distribute := DistributionType(LocalDistribution)
 	if e.planningMode != distSQLLocalOnlyPlanning {
-		distribute = DistributionTypeAlways
+		distribute = FullDistribution
 	}
 	evalCtx := p.ExtendedEvalContext()
 	e.planCtx = e.dsp.NewPlanningCtx(ctx, evalCtx, e.planner, e.planner.txn, distribute)

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -128,9 +128,9 @@ func newPlanningCtxForExplainPurposes(
 	subqueryPlans []subquery,
 	distribution physicalplan.PlanDistribution,
 ) *PlanningCtx {
-	distribute := DistributionType(DistributionTypeNone)
+	distribute := DistributionType(LocalDistribution)
 	if distribution.WillDistribute() {
-		distribute = DistributionTypeAlways
+		distribute = FullDistribution
 	}
 	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx,
 		params.p, params.p.txn, distribute)

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -193,7 +193,7 @@ func (ib *IndexBackfillPlanner) plan(
 		sd := NewInternalSessionData(ctx, ib.execCfg.Settings, "plan-index-backfill")
 		evalCtx = createSchemaChangeEvalCtx(ctx, ib.execCfg, sd, nowTimestamp, descriptors)
 		planCtx = ib.execCfg.DistSQLPlanner.NewPlanningCtx(ctx, &evalCtx,
-			nil /* planner */, txn.KV(), DistributionTypeSystemTenantOnly)
+			nil /* planner */, txn.KV(), DistributionTypeAlways)
 		// TODO(ajwerner): Adopt util.ConstantWithMetamorphicTestRange for the
 		// batch size. Also plumb in a testing knob.
 		chunkSize := indexBackfillBatchSize.Get(&ib.execCfg.Settings.SV)

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -192,8 +192,9 @@ func (ib *IndexBackfillPlanner) plan(
 	) error {
 		sd := NewInternalSessionData(ctx, ib.execCfg.Settings, "plan-index-backfill")
 		evalCtx = createSchemaChangeEvalCtx(ctx, ib.execCfg, sd, nowTimestamp, descriptors)
-		planCtx = ib.execCfg.DistSQLPlanner.NewPlanningCtx(ctx, &evalCtx,
-			nil /* planner */, txn.KV(), DistributionTypeAlways)
+		planCtx = ib.execCfg.DistSQLPlanner.NewPlanningCtx(
+			ctx, &evalCtx, nil /* planner */, txn.KV(), FullDistribution,
+		)
 		// TODO(ajwerner): Adopt util.ConstantWithMetamorphicTestRange for the
 		// batch size. Also plumb in a testing knob.
 		chunkSize := indexBackfillBatchSize.Get(&ib.execCfg.Settings.SV)

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -139,7 +139,7 @@ func (im *IndexBackfillerMergePlanner) plan(
 		sd := NewInternalSessionData(ctx, im.execCfg.Settings, "plan-index-backfill-merge")
 		evalCtx = createSchemaChangeEvalCtx(ctx, im.execCfg, sd, txn.KV().ReadTimestamp(), descriptors)
 		planCtx = im.execCfg.DistSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil /* planner */, txn.KV(),
-			DistributionTypeSystemTenantOnly)
+			DistributionTypeAlways)
 
 		spec, err := initIndexBackfillMergerSpec(*tableDesc.TableDesc(), addedIndexes, temporaryIndexes, mergeTimestamp)
 		if err != nil {

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -138,8 +138,9 @@ func (im *IndexBackfillerMergePlanner) plan(
 	) error {
 		sd := NewInternalSessionData(ctx, im.execCfg.Settings, "plan-index-backfill-merge")
 		evalCtx = createSchemaChangeEvalCtx(ctx, im.execCfg, sd, txn.KV().ReadTimestamp(), descriptors)
-		planCtx = im.execCfg.DistSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil /* planner */, txn.KV(),
-			DistributionTypeAlways)
+		planCtx = im.execCfg.DistSQLPlanner.NewPlanningCtx(
+			ctx, &evalCtx, nil /* planner */, txn.KV(), FullDistribution,
+		)
 
 		spec, err := initIndexBackfillMergerSpec(*tableDesc.TableDesc(), addedIndexes, temporaryIndexes, mergeTimestamp)
 		if err != nil {

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -153,7 +153,7 @@ func (dsp *DistSQLPlanner) Exec(
 
 	distributionType := DistributionType(DistributionTypeNone)
 	if distribute {
-		distributionType = DistributionTypeSystemTenantOnly
+		distributionType = DistributionTypeAlways
 	}
 	evalCtx := p.ExtendedEvalContext()
 	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, p.txn,

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -151,9 +151,9 @@ func (dsp *DistSQLPlanner) Exec(
 	)
 	defer recv.Release()
 
-	distributionType := DistributionType(DistributionTypeNone)
+	distributionType := DistributionType(LocalDistribution)
 	if distribute {
-		distributionType = DistributionTypeAlways
+		distributionType = FullDistribution
 	}
 	evalCtx := p.ExtendedEvalContext()
 	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, p.txn,
@@ -181,7 +181,7 @@ func (dsp *DistSQLPlanner) ExecLocalAll(
 	)
 	defer recv.Release()
 
-	distributionType := DistributionType(DistributionTypeNone)
+	distributionType := DistributionType(LocalDistribution)
 	evalCtx := p.ExtendedEvalContext()
 	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, p.txn,
 		distributionType)


### PR DESCRIPTION
**sql,*: remove DistributionTypeSystemTenantOnly**

Uses of DistributionTypeSystemTenantOnly represent places where UA/MT performance may not match single-tenant performance.

This replaces all uses of DistributionTypeSystemTenantOnly with DistributionTypeAlways.

Epic: none

Fixes #116534

**sql: rename two DistributionType options**

This commit does the following renaming to better represent the options:
- `DistributionTypeNone` -> `LocalDistribution`
- `DistributionTypeAlways` -> `FullDistribution`.

Release note: None