### PR TITLE
sql: make txnCounter for BEGIN logs more understandable

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3798,9 +3798,6 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		}
 	case txnStart:
 		ex.recordTransactionStart(advInfo.txnEvent.txnID)
-		// Start of the transaction, so no statements were executed earlier.
-		// Bump the txn counter for logging.
-		ex.extraTxnState.txnCounter.Add(1)
 
 		// Session is considered active when executing a transaction.
 		ex.totalActiveTimeStopWatch.Start()

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2479,6 +2479,9 @@ func (ex *connExecutor) execStmtInNoTxnState(
 		)
 	}()
 
+	// We're in the NoTxn state, so no statements were executed earlier. Bump the
+	// txn counter for logging.
+	ex.extraTxnState.txnCounter.Add(1)
 	ast := parserStmt.AST
 	switch s := ast.(type) {
 	case *tree.BeginTransaction:

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -1638,6 +1638,7 @@ func TestTelemetryLoggingStmtPosInTxn(t *testing.T) {
 
 	require.NotEmpty(t, entries)
 	var expectedTxnID string
+	var expectedTxnCounter uint32 = 4
 
 	// Attempt to find all expected logs.
 	for i, expected := range expectedQueries {
@@ -1647,6 +1648,7 @@ func TestTelemetryLoggingStmtPosInTxn(t *testing.T) {
 				var sq eventpb.SampledQuery
 				require.NoError(t, json.Unmarshal([]byte(e.Message), &sq))
 				require.Equalf(t, uint32(i), sq.StmtPosInTxn, "stmt=%s entries: %s", expected, entries)
+				require.Equalf(t, expectedTxnCounter, sq.TxnCounter, "stmt=%s entries: %s", expected, entries)
 				found = true
 
 				if expected == "BEGIN" {


### PR DESCRIPTION
Previously, the txnCounter would not be incremented until after the transaction began. This made it hard to read the logs and understand which transaction a BEGIN statement was a part of.

Now, the txnCounter is incremented just before the time of executing any statement in the NoTxn state - all implicit and explicit transactions must be started this way.

fixes https://github.com/cockroachdb/cockroach/issues/115610
Release note: None