### PR TITLE
json,tree,geopb: remove dependency from kvpb on geo

### DIFF
--- a/docs/generated/http/BUILD.bazel
+++ b/docs/generated/http/BUILD.bazel
@@ -4,7 +4,6 @@ genrule(
         "//pkg/build:build_proto",
         "//pkg/clusterversion:clusterversion_proto",
         "//pkg/config/zonepb:zonepb_proto",
-        "//pkg/geo/geoindex:geoindex_proto",
         "//pkg/geo/geopb:geopb_proto",
         "//pkg/gossip:gossip_proto",
         "//pkg/jobs/jobspb:jobspb_proto",

--- a/pkg/cmd/geoviz/BUILD.bazel
+++ b/pkg/cmd/geoviz/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/geo",
         "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/geo/geos",
         "@com_github_golang_geo//s2",
     ],

--- a/pkg/cmd/geoviz/geoviz.go
+++ b/pkg/cmd/geoviz/geoviz.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/golang/geo/s2"
 )
 
@@ -206,8 +207,8 @@ func ImageFromReader(r io.Reader) (*Image, error) {
 			if err != nil {
 				return nil, fmt.Errorf("error parsing: %s", data)
 			}
-			index := geoindex.NewS2GeographyIndex(geoindex.S2GeographyConfig{
-				S2Config: &geoindex.S2Config{
+			index := geoindex.NewS2GeographyIndex(geopb.S2GeographyConfig{
+				S2Config: &geopb.S2Config{
 					MinLevel: 4,
 					MaxLevel: 30,
 					MaxCells: 20,

--- a/pkg/gen/protobuf.bzl
+++ b/pkg/gen/protobuf.bzl
@@ -21,7 +21,6 @@ PROTOBUF_SRCS = [
     "//pkg/cmd/roachprod/upgrade:upgrade_go_proto",
     "//pkg/config/zonepb:zonepb_go_proto",
     "//pkg/config:config_go_proto",
-    "//pkg/geo/geoindex:geoindex_go_proto",
     "//pkg/geo/geopb:geopb_go_proto",
     "//pkg/gossip:gossip_go_proto",
     "//pkg/inspectz/inspectzpb:inspectzpb_go_proto",

--- a/pkg/geo/geoindex/BUILD.bazel
+++ b/pkg/geo/geoindex/BUILD.bazel
@@ -1,16 +1,12 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "geoindex",
     srcs = [
-        "config.go",
         "geoindex.go",
         "s2_geography_index.go",
         "s2_geometry_index.go",
     ],
-    embed = [":geoindex_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/geo/geoindex",
     visibility = ["//visibility:public"],
     deps = [
@@ -53,21 +49,4 @@ go_test(
         "@com_github_golang_geo//s2",
         "@com_github_stretchr_testify//require",
     ],
-)
-
-proto_library(
-    name = "geoindex_proto",
-    srcs = ["config.proto"],
-    strip_import_prefix = "/pkg",
-    visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],
-)
-
-go_proto_library(
-    name = "geoindex_go_proto",
-    compilers = ["//pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_compiler"],
-    importpath = "github.com/cockroachdb/cockroach/pkg/geo/geoindex",
-    proto = ":geoindex_proto",
-    visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto"],
 )

--- a/pkg/geo/geoindex/geoindex.go
+++ b/pkg/geo/geoindex/geoindex.go
@@ -688,8 +688,8 @@ func (b *stringBuilderWithWrap) doWrap() {
 }
 
 // DefaultS2Config returns the default S2Config to initialize.
-func DefaultS2Config() *S2Config {
-	return &S2Config{
+func DefaultS2Config() *geopb.S2Config {
+	return &geopb.S2Config{
 		MinLevel: 0,
 		MaxLevel: 30,
 		LevelMod: 1,

--- a/pkg/geo/geoindex/s2_geography_index.go
+++ b/pkg/geo/geoindex/s2_geography_index.go
@@ -36,7 +36,7 @@ var _ GeographyIndex = (*s2GeographyIndex)(nil)
 // since deletes could miss some index entries. Currently, reads could use a
 // different configuration, but that is subject to change if we manage to
 // strengthen the covering invariants (see the todo in covers() in index.go).
-func NewS2GeographyIndex(cfg S2GeographyConfig) GeographyIndex {
+func NewS2GeographyIndex(cfg geopb.S2GeographyConfig) GeographyIndex {
 	// TODO(sumeer): Sanity check cfg.
 	return &s2GeographyIndex{
 		rc: &s2.RegionCoverer{
@@ -49,9 +49,9 @@ func NewS2GeographyIndex(cfg S2GeographyConfig) GeographyIndex {
 }
 
 // DefaultGeographyIndexConfig returns a default config for a geography index.
-func DefaultGeographyIndexConfig() *Config {
-	return &Config{
-		S2Geography: &S2GeographyConfig{S2Config: DefaultS2Config()},
+func DefaultGeographyIndexConfig() *geopb.Config {
+	return &geopb.Config{
+		S2Geography: &geopb.S2GeographyConfig{S2Config: DefaultS2Config()},
 	}
 }
 

--- a/pkg/geo/geoindex/s2_geography_index_test.go
+++ b/pkg/geo/geoindex/s2_geography_index_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/geo/geogfn"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/datadriven"
@@ -38,7 +39,7 @@ func TestS2GeographyIndexBasic(t *testing.T) {
 		switch d.Cmd {
 		case "init":
 			cfg := s2Config(t, d)
-			index = NewS2GeographyIndex(S2GeographyConfig{S2Config: &cfg})
+			index = NewS2GeographyIndex(geopb.S2GeographyConfig{S2Config: &cfg})
 			return ""
 		case "geometry":
 			g, err := geo.ParseGeography(d.Input)

--- a/pkg/geo/geoindex/s2_geometry_index.go
+++ b/pkg/geo/geoindex/s2_geometry_index.go
@@ -45,7 +45,7 @@ const clippingBoundsDelta = 0.01
 // writes on this index must use the same config. Writes must use the same
 // config to correctly process deletions. Reads must use the same config since
 // the bounds affect when a read needs to look at the exceedsBoundsCellID.
-func NewS2GeometryIndex(cfg S2GeometryConfig) GeometryIndex {
+func NewS2GeometryIndex(cfg geopb.S2GeometryConfig) GeometryIndex {
 	// TODO(sumeer): Sanity check cfg.
 	return &s2GeometryIndex{
 		rc: &s2.RegionCoverer{
@@ -67,9 +67,9 @@ func NewS2GeometryIndex(cfg S2GeometryConfig) GeometryIndex {
 // INDEX.
 
 // DefaultGeometryIndexConfig returns a default config for a geometry index.
-func DefaultGeometryIndexConfig() *Config {
-	return &Config{
-		S2Geometry: &S2GeometryConfig{
+func DefaultGeometryIndexConfig() *geopb.Config {
+	return &geopb.Config{
+		S2Geometry: &geopb.S2GeometryConfig{
 			// Bounding box similar to the circumference of the earth (~2B meters)
 			MinX:     -(1 << 31),
 			MaxX:     (1 << 31) - 1,
@@ -81,7 +81,7 @@ func DefaultGeometryIndexConfig() *Config {
 }
 
 // GeometryIndexConfigForSRID returns a geometry index config for srid.
-func GeometryIndexConfigForSRID(srid geopb.SRID) (*Config, error) {
+func GeometryIndexConfigForSRID(srid geopb.SRID) (*geopb.Config, error) {
 	if srid == 0 {
 		return DefaultGeometryIndexConfig(), nil
 	}
@@ -120,8 +120,8 @@ func GeometryIndexConfigForSRID(srid geopb.SRID) (*Config, error) {
 	boundsExpansion := 2 * clippingBoundsDelta
 	deltaX := (maxX - minX) * boundsExpansion
 	deltaY := (maxY - minY) * boundsExpansion
-	return &Config{
-		S2Geometry: &S2GeometryConfig{
+	return &geopb.Config{
+		S2Geometry: &geopb.S2GeometryConfig{
 			MinX:     minX - deltaX,
 			MaxX:     maxX + deltaX,
 			MinY:     minY - deltaY,

--- a/pkg/geo/geoindex/s2_geometry_index_test.go
+++ b/pkg/geo/geoindex/s2_geometry_index_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/geo"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoprojbase"
 	"github.com/cockroachdb/cockroach/pkg/geo/geos"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
@@ -51,7 +52,7 @@ func TestS2GeometryIndexBasic(t *testing.T) {
 			d.ScanArgs(t, "miny", &minY)
 			d.ScanArgs(t, "maxx", &maxX)
 			d.ScanArgs(t, "maxy", &maxY)
-			index = NewS2GeometryIndex(S2GeometryConfig{
+			index = NewS2GeometryIndex(geopb.S2GeometryConfig{
 				MinX:     float64(minX),
 				MinY:     float64(minY),
 				MaxX:     float64(maxX),

--- a/pkg/geo/geoindex/utils_test.go
+++ b/pkg/geo/geoindex/utils_test.go
@@ -27,12 +27,12 @@ func nameArg(t *testing.T, d *datadriven.TestData) string {
 	return name
 }
 
-func s2Config(t *testing.T, d *datadriven.TestData) S2Config {
+func s2Config(t *testing.T, d *datadriven.TestData) geopb.S2Config {
 	var minLevel, maxLevel, maxCells int
 	d.ScanArgs(t, "minlevel", &minLevel)
 	d.ScanArgs(t, "maxlevel", &maxLevel)
 	d.ScanArgs(t, "maxcells", &maxCells)
-	return S2Config{
+	return geopb.S2Config{
 		MinLevel: int32(minLevel),
 		MaxLevel: int32(maxLevel),
 		LevelMod: 1,

--- a/pkg/geo/geopb/BUILD.bazel
+++ b/pkg/geo/geopb/BUILD.bazel
@@ -5,6 +5,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "geopb",
     srcs = [
+        "config.go",
         "geopb.go",
         "types.go",
     ],
@@ -15,7 +16,10 @@ go_library(
 
 proto_library(
     name = "geopb_proto",
-    srcs = ["geopb.proto"],
+    srcs = [
+        "config.proto",
+        "geopb.proto",
+    ],
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],

--- a/pkg/geo/geopb/config.go
+++ b/pkg/geo/geopb/config.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package geoindex
+package geopb
 
 // IsEmpty returns whether the config contains a geospatial index
 // configuration.

--- a/pkg/geo/geopb/config.proto
+++ b/pkg/geo/geopb/config.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.geo.geoindex;
-option go_package = "github.com/cockroachdb/cockroach/pkg/geo/geoindex";
+option go_package = "github.com/cockroachdb/cockroach/pkg/geo/geopb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/kv/kvpb/BUILD.bazel
+++ b/pkg/kv/kvpb/BUILD.bazel
@@ -159,5 +159,8 @@ batch_gen(
 
 disallowed_imports_test(
     "kvpb",
+    [
+        "//pkg/geo",
+    ],
     disallow_cdeps = True,
 )

--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
     deps = [
         "//pkg/clusterversion",
         "//pkg/config/zonepb",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/sql/catalog/catformat/BUILD.bazel
+++ b/pkg/sql/catalog/catformat/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/catalog/catformat/index.go
+++ b/pkg/sql/catalog/catformat/index.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -263,7 +264,7 @@ func formatStorageConfigs(
 ) error {
 	numCustomSettings := 0
 	if index.GeoConfig.S2Geometry != nil || index.GeoConfig.S2Geography != nil {
-		var s2Config *geoindex.S2Config
+		var s2Config *geopb.S2Config
 
 		if index.GeoConfig.S2Geometry != nil {
 			s2Config = index.GeoConfig.S2Geometry.S2Config

--- a/pkg/sql/catalog/descpb/BUILD.bazel
+++ b/pkg/sql/catalog/descpb/BUILD.bazel
@@ -53,7 +53,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/zonepb:zonepb_proto",
-        "//pkg/geo/geoindex:geoindex_proto",
+        "//pkg/geo/geopb:geopb_proto",
         "//pkg/roachpb:roachpb_proto",
         "//pkg/sql/catalog/catenumpb:catenumpb_proto",
         "//pkg/sql/catalog/catpb:catpb_proto",
@@ -73,7 +73,7 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/zonepb",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/roachpb",  # keep
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/catpb",

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -23,7 +23,7 @@ import "sql/catalog/catpb/privilege.proto";
 import "sql/catalog/catpb/function.proto";
 import "sql/schemachanger/scpb/scpb.proto";
 import "sql/types/types.proto";
-import "geo/geoindex/config.proto";
+import "geo/geopb/config.proto";
 import "gogoproto/gogo.proto";
 import "roachpb/metadata.proto";
 

--- a/pkg/sql/catalog/fetchpb/BUILD.bazel
+++ b/pkg/sql/catalog/fetchpb/BUILD.bazel
@@ -24,7 +24,7 @@ proto_library(
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo/geoindex:geoindex_proto",
+        "//pkg/geo/geopb:geopb_proto",
         "//pkg/sql/catalog/catenumpb:catenumpb_proto",
         "//pkg/sql/types:types_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
@@ -38,7 +38,7 @@ go_proto_library(
     proto = ":fetchpb_proto",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/types",
         "@com_github_gogo_protobuf//gogoproto",

--- a/pkg/sql/catalog/fetchpb/index_fetch.proto
+++ b/pkg/sql/catalog/fetchpb/index_fetch.proto
@@ -16,7 +16,7 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/fetchpb";
 import "gogoproto/gogo.proto";
 import "sql/types/types.proto";
 import "sql/catalog/catenumpb/index.proto";
-import "geo/geoindex/config.proto";
+import "geo/geopb/config.proto";
 
 // IndexFetchSpec contains the subset of information (from TableDescriptor and
 // IndexDescriptor) that is necessary to decode KVs into SQL keys and values.

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -177,7 +177,7 @@ type Index interface {
 	GetInvisibility() float64
 	GetPredicate() string
 	GetType() descpb.IndexDescriptor_Type
-	GetGeoConfig() geoindex.Config
+	GetGeoConfig() geopb.Config
 	GetVersion() descpb.IndexDescriptorVersion
 	GetEncodingType() catenumpb.IndexDescriptorEncodingType
 

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -21,7 +21,7 @@ go_library(
     deps = [
         "//pkg/clusterversion",
         "//pkg/docs",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/roachpb",
@@ -88,7 +88,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/clusterversion",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -265,7 +265,7 @@ func (w index) CollectCompositeColumnIDs() catalog.TableColSet {
 }
 
 // GetGeoConfig returns the geo config in the index descriptor.
-func (w index) GetGeoConfig() geoindex.Config {
+func (w index) GetGeoConfig() geopb.Config {
 	return w.desc.GeoConfig
 }
 

--- a/pkg/sql/catalog/tabledesc/index_test.go
+++ b/pkg/sql/catalog/tabledesc/index_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -280,7 +280,7 @@ func TestIndexInterface(t *testing.T) {
 			errMsgFmt, "GetType", idx.GetName())
 		require.Equal(t, idx == s4, idx.IsSharded(),
 			errMsgFmt, "IsSharded", idx.GetName())
-		require.Equal(t, idx == s6, !(&geoindex.Config{}).Equal(idx.GetGeoConfig()),
+		require.Equal(t, idx == s6, !(&geopb.Config{}).Equal(idx.GetGeoConfig()),
 			errMsgFmt, "GetGeoConfig", idx.GetName())
 		require.Equal(t, idx == s4, idx.GetShardColumnName() != "",
 			errMsgFmt, "GetShardColumnName", idx.GetName())

--- a/pkg/sql/evalcatalog/BUILD.bazel
+++ b/pkg/sql/evalcatalog/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/evalcatalog",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/sql/evalcatalog/geo_inverted_index_entries.go
+++ b/pkg/sql/evalcatalog/geo_inverted_index_entries.go
@@ -13,7 +13,7 @@ package evalcatalog
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -74,14 +74,14 @@ func getIndexGeoConfig(
 	txn *kv.Txn,
 	tableID catid.DescID,
 	indexID catid.IndexID,
-) (geoindex.Config, error) {
+) (geopb.Config, error) {
 	tableDesc, err := dc.ByIDWithLeased(txn).WithoutNonPublic().Get().Table(ctx, tableID)
 	if err != nil {
-		return geoindex.Config{}, err
+		return geopb.Config{}, err
 	}
 	index, err := catalog.MustFindIndexByID(tableDesc, indexID)
 	if err != nil {
-		return geoindex.Config{}, err
+		return geopb.Config{}, err
 	}
 	return index.GetGeoConfig(), nil
 }

--- a/pkg/sql/opt/cat/BUILD.bazel
+++ b/pkg/sql/opt/cat/BUILD.bazel
@@ -20,7 +20,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/zonepb",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -11,7 +11,7 @@
 package cat
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -192,7 +192,7 @@ type Index interface {
 
 	// GeoConfig returns a geospatial index configuration. If not empty, it
 	// describes the configuration for this geospatial inverted index.
-	GeoConfig() geoindex.Config
+	GeoConfig() geopb.Config
 
 	// Version returns the IndexDescriptorVersion of the index.
 	Version() descpb.IndexDescriptorVersion

--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     # Pin the dependencies used in auto-generated code.
     deps = [
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/roachpb",
         "//pkg/sql/appstatspb",

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -16,7 +16,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -726,8 +726,8 @@ func (u *unknownIndex) ImplicitPartitioningColumnCount() int {
 	return 0
 }
 
-func (u *unknownIndex) GeoConfig() geoindex.Config {
-	return geoindex.Config{}
+func (u *unknownIndex) GeoConfig() geopb.Config {
+	return geopb.Config{}
 }
 
 func (u *unknownIndex) Version() descpb.IndexDescriptorVersion {

--- a/pkg/sql/opt/indexrec/BUILD.bazel
+++ b/pkg/sql/opt/indexrec/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/roachpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/opt/indexrec/hypothetical_index.go
+++ b/pkg/sql/opt/indexrec/hypothetical_index.go
@@ -12,6 +12,7 @@ package indexrec
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -214,7 +215,7 @@ func (hi *hypotheticalIndex) ImplicitPartitioningColumnCount() int {
 }
 
 // GeoConfig is part of the cat.Index interface.
-func (hi *hypotheticalIndex) GeoConfig() geoindex.Config {
+func (hi *hypotheticalIndex) GeoConfig() geopb.Config {
 	if hi.IsInverted() {
 		srcCol := hi.tab.Column(hi.InvertedColumn().InvertedSourceColumnOrdinal())
 		switch srcCol.DatumType().Family() {
@@ -224,7 +225,7 @@ func (hi *hypotheticalIndex) GeoConfig() geoindex.Config {
 			return *geoindex.DefaultGeographyIndexConfig()
 		}
 	}
-	return geoindex.Config{}
+	return geopb.Config{}
 }
 
 // Version is part of the cat.Index interface.

--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -65,7 +65,7 @@ func GetGeoIndexRelationship(expr opt.ScalarExpr) (_ geoindex.RelationshipType, 
 // geospatial relationship. It is implemented by getSpanExprForGeographyIndex
 // and getSpanExprForGeometryIndex and used in extractGeoFilterCondition.
 type getSpanExprForGeoIndexFn func(
-	context.Context, tree.Datum, []tree.Datum, geoindex.RelationshipType, geoindex.Config,
+	context.Context, tree.Datum, []tree.Datum, geoindex.RelationshipType, geopb.Config,
 ) inverted.Expression
 
 // getSpanExprForGeographyIndex gets a SpanExpression that constrains the given
@@ -75,7 +75,7 @@ func getSpanExprForGeographyIndex(
 	d tree.Datum,
 	additionalParams []tree.Datum,
 	relationship geoindex.RelationshipType,
-	indexConfig geoindex.Config,
+	indexConfig geopb.Config,
 ) inverted.Expression {
 	geogIdx := geoindex.NewS2GeographyIndex(*indexConfig.S2Geography)
 	geog := d.(*tree.DGeography).Geography
@@ -162,7 +162,7 @@ func getSpanExprForGeometryIndex(
 	d tree.Datum,
 	additionalParams []tree.Datum,
 	relationship geoindex.RelationshipType,
-	indexConfig geoindex.Config,
+	indexConfig geopb.Config,
 ) inverted.Expression {
 	geomIdx := geoindex.NewS2GeometryIndex(*indexConfig.S2Geometry)
 	geom := d.(*tree.DGeometry).Geometry
@@ -929,7 +929,7 @@ type geoDatumsToInvertedExpr struct {
 	evalCtx      *eval.Context
 	colTypes     []*types.T
 	invertedExpr tree.TypedExpr
-	indexConfig  geoindex.Config
+	indexConfig  geopb.Config
 	typ          *types.T
 	getSpanExpr  getSpanExprForGeoIndexFn
 
@@ -971,7 +971,7 @@ func NewGeoDatumsToInvertedExpr(
 	evalCtx *eval.Context,
 	colTypes []*types.T,
 	expr tree.TypedExpr,
-	config geoindex.Config,
+	config geopb.Config,
 ) (invertedexpr.DatumsToInvertedExpr, error) {
 	if config.IsEmpty() {
 		return nil, fmt.Errorf("inverted joins are currently only supported for geospatial indexes")

--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -35,7 +35,7 @@ func NewDatumsToInvertedExpr(
 	evalCtx *eval.Context,
 	colTypes []*types.T,
 	expr tree.TypedExpr,
-	geoConfig geoindex.Config,
+	geoConfig geopb.Config,
 ) (invertedexpr.DatumsToInvertedExpr, error) {
 	if !geoConfig.IsEmpty() {
 		return NewGeoDatumsToInvertedExpr(ctx, evalCtx, colTypes, expr, geoConfig)

--- a/pkg/sql/opt/testutils/testcat/BUILD.bazel
+++ b/pkg/sql/opt/testutils/testcat/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/zonepb",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/settings/cluster",

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -925,13 +925,13 @@ func (tt *Table) addIndexWithVersion(
 			switch tt.Columns[col.InvertedSourceColumnOrdinal()].DatumType().Family() {
 			case types.GeometryFamily:
 				// Don't use the default config because it creates a huge number of spans.
-				idx.geoConfig = geoindex.Config{
-					S2Geometry: &geoindex.S2GeometryConfig{
+				idx.geoConfig = geopb.Config{
+					S2Geometry: &geopb.S2GeometryConfig{
 						MinX: -5,
 						MaxX: 5,
 						MinY: -5,
 						MaxY: 5,
-						S2Config: &geoindex.S2Config{
+						S2Config: &geopb.S2Config{
 							MinLevel: 0,
 							MaxLevel: 2,
 							LevelMod: 1,
@@ -942,8 +942,8 @@ func (tt *Table) addIndexWithVersion(
 
 			case types.GeographyFamily:
 				// Don't use the default config because it creates a huge number of spans.
-				idx.geoConfig = geoindex.Config{
-					S2Geography: &geoindex.S2GeographyConfig{S2Config: &geoindex.S2Config{
+				idx.geoConfig = geopb.Config{
+					S2Geography: &geopb.S2GeographyConfig{S2Config: &geopb.S2Config{
 						MinLevel: 0,
 						MaxLevel: 2,
 						LevelMod: 1,

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -1078,7 +1078,7 @@ type Index struct {
 
 	// geoConfig is the geospatial index configuration, if this is a geospatial
 	// inverted index.
-	geoConfig geoindex.Config
+	geoConfig geopb.Config
 
 	// version is the index descriptor version of the index.
 	version descpb.IndexDescriptorVersion
@@ -1192,7 +1192,7 @@ func (ti *Index) ImplicitPartitioningColumnCount() int {
 }
 
 // GeoConfig is part of the cat.Index interface.
-func (ti *Index) GeoConfig() geoindex.Config {
+func (ti *Index) GeoConfig() geopb.Config {
 	return ti.geoConfig
 }
 

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config"
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -1701,7 +1701,7 @@ func (oi *optIndex) ImplicitPartitioningColumnCount() int {
 }
 
 // GeoConfig is part of the cat.Index interface.
-func (oi *optIndex) GeoConfig() geoindex.Config {
+func (oi *optIndex) GeoConfig() geopb.Config {
 	return oi.idx.IndexDesc().GeoConfig
 }
 
@@ -2605,8 +2605,8 @@ func (oi *optVirtualIndex) ImplicitPartitioningColumnCount() int {
 }
 
 // GeoConfig is part of the cat.Index interface.
-func (oi *optVirtualIndex) GeoConfig() geoindex.Config {
-	return geoindex.Config{}
+func (oi *optVirtualIndex) GeoConfig() geopb.Config {
+	return geopb.Config{}
 }
 
 // Version is part of the cat.Index interface.

--- a/pkg/sql/protoreflect/BUILD.bazel
+++ b/pkg/sql/protoreflect/BUILD.bazel
@@ -28,7 +28,7 @@ go_test(
     ],
     embed = [":protoreflect"],
     deps = [
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/sql/catalog/catenumpb",

--- a/pkg/sql/protoreflect/utils_test.go
+++ b/pkg/sql/protoreflect/utils_test.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
@@ -70,12 +70,12 @@ func TestMessageToJSONBRoundTrip(t *testing.T) {
 				Unique:              true,
 				KeyColumnNames:      []string{"foo", "bar", "buz"},
 				KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
-				GeoConfig: geoindex.Config{
-					S2Geography: &geoindex.S2GeographyConfig{S2Config: &geoindex.S2Config{
+				GeoConfig: geopb.Config{
+					S2Geography: &geopb.S2GeographyConfig{S2Config: &geopb.S2Config{
 						MinLevel: 123,
 						MaxLevel: 321,
 					}},
-					S2Geometry: &geoindex.S2GeometryConfig{
+					S2Geometry: &geopb.S2GeometryConfig{
 						MinX: 567,
 						MaxX: 765,
 					},

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -987,7 +987,7 @@ func EncodeTrigramSpans(s string, allMustMatch bool) (inverted.Expression, error
 // EncodeGeoInvertedIndexTableKeys is the equivalent of EncodeInvertedIndexTableKeys
 // for Geography and Geometry.
 func EncodeGeoInvertedIndexTableKeys(
-	val tree.Datum, inKey []byte, indexGeoConfig geoindex.Config,
+	val tree.Datum, inKey []byte, indexGeoConfig geopb.Config,
 ) (key [][]byte, err error) {
 	if val == tree.DNull {
 		return nil, nil

--- a/pkg/sql/schemachanger/scdecomp/BUILD.bazel
+++ b/pkg/sql/schemachanger/scdecomp/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/catpb",

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -16,7 +16,7 @@ import (
 	"reflect"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -588,7 +588,7 @@ func (w *walkCtx) walkIndex(tbl catalog.TableDescriptor, idx catalog.Index) {
 			Invisibility:        idx.GetInvisibility(),
 		}
 		if geoConfig := idx.GetGeoConfig(); !geoConfig.IsEmpty() {
-			index.GeoConfig = protoutil.Clone(&geoConfig).(*geoindex.Config)
+			index.GeoConfig = protoutil.Clone(&geoConfig).(*geopb.Config)
 		}
 		for i, c := range cpy.KeyColumnIDs {
 			invertedKind := catpb.InvertedIndexColumnKind_DEFAULT

--- a/pkg/sql/schemachanger/scpb/BUILD.bazel
+++ b/pkg/sql/schemachanger/scpb/BUILD.bazel
@@ -36,7 +36,7 @@ go_proto_library(
     proto = ":scpb_proto",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/sem/catid",  # keep
@@ -55,7 +55,7 @@ proto_library(
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo/geoindex:geoindex_proto",
+        "//pkg/geo/geopb:geopb_proto",
         "//pkg/sql/catalog/catenumpb:catenumpb_proto",
         "//pkg/sql/catalog/catpb:catpb_proto",
         "//pkg/sql/sem/semenumpb:semenumpb_proto",

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -18,7 +18,7 @@ import "sql/sem/semenumpb/constraint.proto";
 import "sql/catalog/catpb/function.proto";
 import "sql/types/types.proto";
 import "gogoproto/gogo.proto";
-import "geo/geoindex/config.proto";
+import "geo/geopb/config.proto";
 
 option (gogoproto.equal_all) = true;
 

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -7965,14 +7965,14 @@ func makeSTDWithinBuiltin(exclusivity geo.FnExclusivity) builtinDefinition {
 }
 
 func applyGeoindexConfigStorageParams(
-	ctx context.Context, evalCtx *eval.Context, cfg geoindex.Config, params string,
-) (geoindex.Config, error) {
+	ctx context.Context, evalCtx *eval.Context, cfg geopb.Config, params string,
+) (geopb.Config, error) {
 	indexDesc := &descpb.IndexDescriptor{GeoConfig: cfg}
 	stmt, err := parser.ParseOne(
 		fmt.Sprintf("CREATE INDEX t_idx ON t USING GIST(geom) WITH (%s)", params),
 	)
 	if err != nil {
-		return geoindex.Config{}, errors.Newf("invalid storage parameters specified: %s", params)
+		return geopb.Config{}, errors.Newf("invalid storage parameters specified: %s", params)
 	}
 	semaCtx := tree.MakeSemaContext()
 	if err := storageparam.Set(
@@ -7982,7 +7982,7 @@ func applyGeoindexConfigStorageParams(
 		stmt.AST.(*tree.CreateIndex).StorageParams,
 		&indexstorageparam.Setter{IndexDesc: indexDesc},
 	); err != nil {
-		return geoindex.Config{}, err
+		return geopb.Config{}, err
 	}
 	return indexDesc.GeoConfig, nil
 }

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -7805,7 +7805,7 @@ func stAsGeoJSONFromTuple(
 			if g, ok := d.(*tree.DGeometry); ok {
 				foundGeoColumn = true
 				var err error
-				geometry, err = json.FromSpatialObject(g.SpatialObject(), numDecimalDigits)
+				geometry, err = g.ToJSON()
 				if err != nil {
 					return nil, err
 				}
@@ -7814,7 +7814,7 @@ func stAsGeoJSONFromTuple(
 			if g, ok := d.(*tree.DGeography); ok {
 				foundGeoColumn = true
 				var err error
-				geometry, err = json.FromSpatialObject(g.SpatialObject(), numDecimalDigits)
+				geometry, err = g.ToJSON()
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/storageparam/indexstorageparam/BUILD.bazel
+++ b/pkg/sql/storageparam/indexstorageparam/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/storageparam/indexstorageparam",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo/geoindex",
+        "//pkg/geo/geopb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/paramparse",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/storageparam/indexstorageparam/index_storage_param.go
+++ b/pkg/sql/storageparam/indexstorageparam/index_storage_param.go
@@ -15,7 +15,7 @@ package indexstorageparam
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -34,8 +34,8 @@ type Setter struct {
 
 var _ storageparam.Setter = (*Setter)(nil)
 
-func getS2ConfigFromIndex(indexDesc *descpb.IndexDescriptor) *geoindex.S2Config {
-	var s2Config *geoindex.S2Config
+func getS2ConfigFromIndex(indexDesc *descpb.IndexDescriptor) *geopb.S2Config {
+	var s2Config *geopb.S2Config
 	if indexDesc.GeoConfig.S2Geometry != nil {
 		s2Config = indexDesc.GeoConfig.S2Geometry.S2Config
 	}

--- a/pkg/util/json/BUILD.bazel
+++ b/pkg/util/json/BUILD.bazel
@@ -19,8 +19,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/json",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/geo",
-        "//pkg/geo/geopb",
         "//pkg/keysbase",
         "//pkg/sql/inverted",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -24,8 +24,6 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/apd/v3"
-	"github.com/cockroachdb/cockroach/pkg/geo"
-	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
 	"github.com/cockroachdb/cockroach/pkg/keysbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -1802,15 +1800,6 @@ func (j jsonObject) allPaths() ([]JSON, error) {
 		}
 	}
 	return ret, nil
-}
-
-// FromSpatialObject transforms a SpatialObject into the json.JSON type.
-func FromSpatialObject(so geopb.SpatialObject, numDecimalDigits int) (JSON, error) {
-	j, err := geo.SpatialObjectToGeoJSON(so, numDecimalDigits, geo.SpatialObjectToGeoJSONFlagZero)
-	if err != nil {
-		return nil, err
-	}
-	return ParseJSON(string(j))
 }
 
 // FromDecimal returns a JSON value given a apd.Decimal.


### PR DESCRIPTION
The `kvpb` protobuf package shouldn't depend on geospatial C dependencies. It was a mistake that they did. This PR has two commits:

1) Move `geoindex.Config` to `geopb.Config`.
2) Move the code to convert geometry and geography data to json from the low-level json package (which kvpb depends on via coldata) to tree which already depends on both types. 