### PR TITLE
roachtest: fix mininum version calculation in `UploadWorkload`

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
+        "//pkg/roachprod/vm",
         "//pkg/util/retry",
         "//pkg/util/version",
         "@com_github_cockroachdb_errors//:errors",


### PR DESCRIPTION
In ARM64 builds, the `workload` binary is only available in 23.2+.

Epic: none

Release note: None