### PR TITLE
kvclient: correctly handle node shutdown

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -623,6 +623,119 @@ func TestImmutableBatchArgs(t *testing.T) {
 	}
 }
 
+// TestErrorWithCancellationExit verifies that the DistSender never exits the
+// loop with a retriable error. These errors are not intended to escape the Send
+// and other code may not handle them correctly.
+func TestErrorWithCancellationExit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	retriableErr := kvpb.NewError(
+		&kvpb.NotLeaseHolderError{
+			Replica: testUserRangeDescriptor.InternalReplicas[0],
+		})
+	terminalErr := kvpb.NewErrorf("boom")
+
+	tests := []struct {
+		name           string
+		retriableError *kvpb.Error
+		terminalError  *kvpb.Error
+		// Note that errorFn has side effects when it is called in the test.
+		cancelFn    func(ctx context.CancelFunc, stopper *stop.Stopper)
+		expectedErr string
+	}{
+		{
+			name:        "no error",
+			expectedErr: "",
+		},
+		{
+			name:           "terminal error",
+			retriableError: retriableErr,
+			terminalError:  terminalErr,
+			expectedErr:    "boom",
+		},
+		{
+			name:           "cancel context",
+			retriableError: retriableErr,
+			cancelFn: func(cancel context.CancelFunc, _ *stop.Stopper) {
+				// Cancel the context the request was started with.
+				cancel()
+			},
+			expectedErr: "context canceled",
+		},
+		{
+			name:           "stop stopper",
+			retriableError: retriableErr,
+			cancelFn: func(_ context.CancelFunc, stopper *stop.Stopper) {
+				// Stop the stopper simulating a shutdown.
+				stopper.Stop(context.Background())
+			},
+			expectedErr: "node unavailable",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			retryCount := atomic.Int64{}
+			stopper := stop.NewStopper()
+			defer stopper.Stop(ctx)
+
+			clock := hlc.NewClockForTesting(nil)
+			rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
+			g := makeGossip(t, stopper, rpcContext)
+			var testFn simpleSendFn = func(_ context.Context, _ *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
+				reply := &kvpb.BatchResponse{}
+
+				// Set a response so we don't get an out of bounds err in the non-error case.
+				var union kvpb.ResponseUnion
+				union.MustSetInner(&kvpb.PutResponse{})
+				reply.Responses = []kvpb.ResponseUnion{union}
+
+				// Count the number of times we are running.
+				count := retryCount.Add(1)
+
+				// Return a retriable error twice before running cancellation.
+				reply.Error = tc.retriableError
+				if count == 2 {
+					if tc.cancelFn != nil {
+						tc.cancelFn(cancel, stopper)
+					}
+				}
+
+				// Return retriable a few more times as cancellation may need to propagate.
+				if count > 5 {
+					reply.Error = tc.terminalError
+				}
+				return reply, nil
+			}
+
+			cfg := DistSenderConfig{
+				AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+				Clock:      clock,
+				NodeDescs:  g,
+				Stopper:    stopper,
+				// Retry very quickly to make this test finish fast.
+				RPCRetryOptions: &retry.Options{
+					InitialBackoff: time.Millisecond,
+					MaxBackoff:     time.Millisecond,
+				},
+				TransportFactory:  adaptSimpleTransport(testFn),
+				RangeDescriptorDB: defaultMockRangeDescriptorDB,
+				Settings:          cluster.MakeTestingClusterSettings(),
+			}
+			ds := NewDistSender(cfg)
+			// Start a request that runs through distSender.
+			put := kvpb.NewPut(roachpb.Key("a"), roachpb.MakeValueFromString("value"))
+			_, pErr := kv.SendWrapped(ctx, ds, put)
+			if tc.expectedErr == "" {
+				require.Nil(t, pErr)
+			} else {
+				require.NotNil(t, pErr)
+				require.True(t, testutils.IsPError(pErr, tc.expectedErr))
+			}
+		})
+	}
+}
+
 // TestRetryOnNotLeaseHolderError verifies that the DistSender correctly updates
 // the leaseholder in the range cache and retries when receiving a
 // NotLeaseHolderError.

--- a/pkg/kv/kvclient/kvcoord/range_iter.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter.go
@@ -230,7 +230,7 @@ func (ri *RangeIterator) Seek(ctx context.Context, key roachpb.RKey, scanDir Sca
 	}
 
 	// Check for an early exit from the retry loop.
-	if deducedErr := ri.ds.deduceRetryEarlyExitError(ctx); deducedErr != nil {
+	if deducedErr := ri.ds.deduceRetryEarlyExitError(ctx, err); deducedErr != nil {
 		ri.err = deducedErr
 	} else {
 		ri.err = errors.Wrapf(err, "RangeIterator failed to seek to %s", key)

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -520,7 +520,7 @@ func TestTxnWriteReadConflict(t *testing.T) {
 		// Verify the expected blocking behavior.
 		if expBlocking {
 			require.Error(t, err)
-			require.ErrorIs(t, context.DeadlineExceeded, err)
+			require.ErrorIs(t, err, context.DeadlineExceeded)
 		} else {
 			require.NoError(t, err)
 			require.False(t, res.Exists())

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4187,7 +4187,7 @@ func TestStoreRangeMergeDuringShutdown(t *testing.T) {
 	// Send a dummy get request on the RHS to force a lease acquisition. We expect
 	// this to fail, as quiescing stores cannot acquire leases.
 	_, err = store.DB().Get(ctx, key.Next())
-	if exp := "not lease holder"; !testutils.IsError(err, exp) {
+	if exp := "node unavailable"; !testutils.IsError(err, exp) {
 		t.Fatalf("expected %q error, but got %v", exp, err)
 	}
 }


### PR DESCRIPTION
Previously when the stopper was called for DistSender it could exit the retry loop early and return a retriable error to senders. There was a check to validate this in the case of no error returned, but this didn't handle retriable errors. The new check will instead return the correct error.

Fixes: #113125
Epic: none

Release note: None