### PR TITLE
raftlog: close storage engine in test

### DIFF
--- a/pkg/kv/kvserver/raftlog/iter_test.go
+++ b/pkg/kv/kvserver/raftlog/iter_test.go
@@ -154,6 +154,7 @@ func TestIteratorEmptyLog(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	eng := storage.NewDefaultInMemForTesting()
+	defer eng.Close()
 	for _, hi := range []kvpb.RaftIndex{0, 1} {
 		it, err := NewIterator(context.Background(), rangeID, eng, IterOptions{Hi: hi})
 		require.NoError(t, err)


### PR DESCRIPTION
Epic: none
Fixes: #114642

Release note: None