### PR TITLE
build: fix roachtest stress build; move scripts

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_stress_impl.sh
@@ -4,12 +4,13 @@ set -exuo pipefail
 
 dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-source "$dir/../../../../teamcity-support.sh"
+source "$dir/../../../teamcity-support.sh"
 
 if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
   ssh-keygen -q -C "roachtest-stress $(date)" -N "" -f ~/.ssh/id_rsa
 fi
 
+os=linux
 arch=amd64
 if [[ ${FIPS_ENABLED:-0} == 1 ]]; then
   arch=amd64-fips
@@ -36,7 +37,7 @@ build/teamcity-roachtest-invoke.sh \
   --cpu-quota="${CPUQUOTA-1024}" \
   --cluster-id="${TC_BUILD_ID}" \
   --lifetime="36h" \
-  --cockroach="${PWD}/bin/cockroach" \
+  --cockroach="${PWD}/bin/cockroach.$os-$arch" \
   --artifacts="${PWD}/artifacts" \
   --disable-issue \
   "${TESTS}"

--- a/build/teamcity/cockroach/nightlies/teamcity-roachtest-stress.sh
+++ b/build/teamcity/cockroach/nightlies/teamcity-roachtest-stress.sh
@@ -2,8 +2,8 @@
 
 set -exuo pipefail
 
-source "$(dirname "${0}")/teamcity-support.sh"
-source "$(dirname "${0}")/teamcity-bazel-support.sh" # For run_bazel
+source "$(dirname "${0}")/../../../teamcity-support.sh"
+source "$(dirname "${0}")/../../../teamcity-bazel-support.sh" # For run_bazel
 
 BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e BUILD_VCS_NUMBER -e CLOUD -e COCKROACH_DEV_LICENSE -e TESTS -e COUNT -e GCE_ZONES -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e GOOGLE_CREDENTIALS -e GOOGLE_KMS_KEY_A -e GOOGLE_KMS_KEY_B -e SLACK_TOKEN -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL -e DEBUG" \
-  run_bazel build/teamcity/cockroach/ci/tests/roachtest_stress_impl.sh
+  run_bazel build/teamcity/cockroach/nightlies/roachtest_stress_impl.sh


### PR DESCRIPTION
Update the `roachtest_stress_impl.sh` script to reference the correct artifact locations (post #111410).

Move roachtest stress build scripts into their idiomatic locations.

Release note: None.

Epic: None.