### PR TITLE
exec/explain: speed up a couple of tests

### DIFF
--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -66,7 +66,6 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql/catalog/colinfo",
-        "//pkg/sql/execinfra",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/exec",
         "//pkg/sql/opt/memo",


### PR DESCRIPTION
This commit improves a couple of tests that needlessly forced the disk spilling on the whole server. In one test we can achieve the desired disk spilling by setting low `distsql_workmem` limit, another test doesn't actually care about spilling to disk, so I think it was copy-pasted from the first one.

Fixes: #116407.

Release note: None