### PR TITLE
sqlsmith: don't use crdb_internal.reset_sql_stats builtin

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -525,6 +525,7 @@ var functions = func() *functionsMu {
 			"crdb_internal.revalidate_unique_constraint",
 			"crdb_internal.request_statement_bundle",
 			"crdb_internal.set_compaction_concurrency",
+			"crdb_internal.reset_sql_stats",
 		} {
 			skip = skip || strings.Contains(def.Name, substr)
 		}


### PR DESCRIPTION
This builtin under the hood issues multiple TRUNCATE commands that can take non-trivial amount of time to execute.

Fixes: #116522.

Release note: None