### PR TITLE
release-23.2: roachtest: use backup cloud to set CompatibleClouds

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -239,6 +239,9 @@ var AllExceptLocal = AllClouds.NoLocal()
 // AllExceptAWS contains all clouds except AWS.
 var AllExceptAWS = AllClouds.NoAWS()
 
+// OnlyAWS contains only the AWS cloud.
+var OnlyAWS = Clouds(spec.AWS)
+
 // OnlyGCE contains only the GCE cloud.
 var OnlyGCE = Clouds(spec.GCE)
 

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -372,7 +372,7 @@ func (t *TestSpec) CrossCheckTags() {
 	actual.weeklyAWS = t.Suites.Contains(Weekly) && t.CompatibleClouds.Contains(spec.AWS)
 
 	if actual != expected {
-		panic(fmt.Sprintf("CompatibleClouds/Suites inconsistent with Tags\nexpected: %#v\nactual:   %#v\nclouds: %s  suites:%s  tags:%v\n", expected, actual, t.CompatibleClouds, t.Suites, t.Tags))
+		panic(fmt.Sprintf("%q CompatibleClouds/Suites inconsistent with Tags\nexpected: %#v\nactual:   %#v\nclouds: %s  suites:%s  tags:%v\n", t.Name, expected, actual, t.CompatibleClouds, t.Suites, t.Tags))
 	}
 
 	otherSuiteTags := fmt.Sprintf("%v", removeFromSet(t.Tags, "default", "weekly", "aws-weekly", "aws", "owner-"+string(t.Owner)))

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -366,7 +366,11 @@ func (t *TestSpec) CrossCheckTags() {
 	expected.nightlyAWS = matchesAll(t.Tags, []string{"aws"})
 	expected.weeklyAWS = matchesAll(t.Tags, []string{"aws-weekly"})
 
-	actual.nightlyGCE = t.Suites.Contains(Nightly) && t.CompatibleClouds.Contains(spec.GCE)
+	// Unfortunately lots of tests that are are aws only hae tag AWS but use the
+	// AllClouds filter and then skip themselves, so they so they are technically
+	// considered "nightly GCE" even though they will internally skip.
+	// This goes away when we get rid of tags entirely so for now ignore them.
+	actual.nightlyGCE = t.Suites.Contains(Nightly) && (t.CompatibleClouds.Contains(spec.GCE) || t.CompatibleClouds.Contains(spec.AWS))
 	actual.weeklyGCE = t.Suites.Contains(Weekly) && t.CompatibleClouds.Contains(spec.GCE)
 	actual.nightlyAWS = t.Suites.Contains(Nightly) && t.CompatibleClouds.Contains(spec.AWS)
 	actual.weeklyAWS = t.Suites.Contains(Weekly) && t.CompatibleClouds.Contains(spec.AWS)

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -111,11 +111,7 @@ func (r *testRegistryImpl) prepareSpec(spec *registry.TestSpec) error {
 	// weekly tag.
 	const maxTimeout = 18 * time.Hour
 	if spec.Timeout > maxTimeout {
-		var weekly bool
-		if _, ok := spec.Tags["weekly"]; ok {
-			weekly = true
-		}
-		if !weekly {
+		if !spec.Suites.Contains(registry.Weekly) {
 			return fmt.Errorf(
 				"%s: timeout %s exceeds the maximum allowed of %s", spec.Name, spec.Timeout, maxTimeout,
 			)

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -454,7 +454,7 @@ func registerBackup(r registry.Registry) {
 		tags        map[string]struct{}
 	}{
 		{kmsProvider: "GCS", machine: spec.GCE, clouds: registry.AllExceptAWS},
-		{kmsProvider: "AWS", machine: spec.AWS, clouds: registry.AllClouds, tags: registry.Tags("aws")},
+		{kmsProvider: "AWS", machine: spec.AWS, clouds: registry.OnlyAWS, tags: registry.Tags("aws")},
 	} {
 		item := item
 		r.Add(registry.TestSpec{

--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -50,7 +50,7 @@ var defaultBackupFixtureSpecs = scheduledBackupSpecs{
 	ignoreExistingBackups: false,
 
 	backupSpecs: backupSpecs{
-		version:           "v23.1.1",
+		version:           "v23.1.11",
 		cloud:             spec.AWS,
 		fullBackupDir:     "LATEST",
 		numBackupsInChain: 48,
@@ -76,26 +76,26 @@ func (sbs scheduledBackupSpecs) scheduledBackupCmd() string {
 	// backup schedules. To ensure that only one full backup chain gets created,
 	// begin the backup schedule at the beginning of the week, as a new full
 	// backup will get created on Sunday at Midnight ;)
-	var ignoreExistingBackupsOpt string
-	if sbs.ignoreExistingBackups {
-		ignoreExistingBackupsOpt = "ignore_existing_backups"
-	}
 	backupCmd := fmt.Sprintf(`BACKUP INTO %s WITH revision_history`, sbs.backupCollection())
-	cmd := fmt.Sprintf(`CREATE SCHEDULE %s FOR %s RECURRING '%s' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS first_run = 'now', %s`,
-		scheduleLabel, backupCmd, sbs.incrementalBackupCrontab, ignoreExistingBackupsOpt)
+	cmd := fmt.Sprintf(`CREATE SCHEDULE %s FOR %s RECURRING '%s' FULL BACKUP '@weekly' WITH SCHEDULE OPTIONS first_run = 'now'`,
+		scheduleLabel, backupCmd, sbs.incrementalBackupCrontab)
+	if sbs.ignoreExistingBackups {
+		cmd = cmd + ",ignore_existing_backups"
+	}
 	return cmd
 }
 
 type backupFixtureSpecs struct {
-	// hardware specifies the roachprod specs to create the backup fixture on.
+	// hardware specifies the roachprod specs to create the scheduledBackupSpecs fixture on.
 	hardware hardwareSpecs
 
-	// backup specifies the scheduled backup fixture which will be created.
-	backup scheduledBackupSpecs
+	// scheduledBackupSpecs specifies the scheduled scheduledBackupSpecs fixture which will be created.
+	scheduledBackupSpecs scheduledBackupSpecs
 
-	// initFromBackupSpecs, if specified, initializes the cluster via restore of an older fixture.
-	// The fields specified here will override any fields specified in the backup field above.
-	initFromBackupSpecs backupSpecs
+	// initWorkloadViaRestore, if specified, initializes the cluster via restore
+	// of an older fixture. The fields specified here will override any fields
+	// specified in the scheduledBackupSpecs field above.
+	initWorkloadViaRestore *restoreSpecs
 
 	timeout  time.Duration
 	clouds   registry.CloudSet
@@ -108,7 +108,7 @@ type backupFixtureSpecs struct {
 }
 
 func (bf *backupFixtureSpecs) initTestName() {
-	bf.testName = "backupFixture/" + bf.backup.workload.String() + "/" + bf.backup.cloud
+	bf.testName = "backupFixture/" + bf.scheduledBackupSpecs.workload.String() + "/" + bf.scheduledBackupSpecs.cloud
 }
 
 func makeBackupDriver(t test.Test, c cluster.Cluster, sp backupFixtureSpecs) backupDriver {
@@ -128,12 +128,12 @@ type backupDriver struct {
 
 func (bd *backupDriver) prepareCluster(ctx context.Context) {
 
-	if bd.c.Cloud() != bd.sp.backup.cloud {
+	if bd.c.Cloud() != bd.sp.scheduledBackupSpecs.cloud {
 		// For now, only run the test on the cloud provider that also stores the backup.
-		bd.t.Skip(fmt.Sprintf("test configured to run on %s", bd.sp.backup.cloud))
+		bd.t.Skip(fmt.Sprintf("test configured to run on %s", bd.sp.scheduledBackupSpecs.cloud))
 	}
 	binaryPath, err := clusterupgrade.UploadCockroach(ctx, bd.t, bd.t.L(), bd.c,
-		bd.sp.hardware.getCRDBNodes(), clusterupgrade.MustParseVersion(bd.sp.backup.version))
+		bd.sp.hardware.getCRDBNodes(), clusterupgrade.MustParseVersion(bd.sp.scheduledBackupSpecs.version))
 	require.NoError(bd.t, err)
 
 	require.NoError(bd.t, clusterupgrade.StartWithSettings(ctx, bd.t.L(), bd.c,
@@ -142,7 +142,7 @@ func (bd *backupDriver) prepareCluster(ctx context.Context) {
 		install.BinaryOption(binaryPath)))
 
 	bd.assertCorrectCockroachBinary(ctx)
-	if !bd.sp.backup.ignoreExistingBackups {
+	if !bd.sp.scheduledBackupSpecs.ignoreExistingBackups {
 		// This check allows the roachtest to fail fast, instead of when the
 		// scheduled backup cmd is issued.
 		require.False(bd.t, bd.checkForExistingBackupCollection(ctx))
@@ -152,7 +152,7 @@ func (bd *backupDriver) prepareCluster(ctx context.Context) {
 // checkForExistingBackupCollection returns true if there exists a backup in the collection path.
 func (bd *backupDriver) checkForExistingBackupCollection(ctx context.Context) bool {
 	collectionQuery := fmt.Sprintf(`SELECT count(*) FROM [SHOW BACKUPS IN %s]`,
-		bd.sp.backup.backupCollection())
+		bd.sp.scheduledBackupSpecs.backupCollection())
 	conn := bd.c.Conn(ctx, bd.t.L(), 1)
 	sql := sqlutils.MakeSQLRunner(conn)
 	var collectionCount int
@@ -166,20 +166,22 @@ func (bd *backupDriver) assertCorrectCockroachBinary(ctx context.Context) {
 	sql := sqlutils.MakeSQLRunner(conn)
 	var binaryVersion string
 	sql.QueryRow(bd.t, binaryQuery).Scan(&binaryVersion)
-	require.Equal(bd.t, bd.sp.backup.version, binaryVersion, "cluster not running on expected binary")
+	require.Equal(bd.t, bd.sp.scheduledBackupSpecs.version, binaryVersion, "cluster not running on expected binary")
 }
 
 func (bd *backupDriver) initWorkload(ctx context.Context) {
-	if bd.sp.initFromBackupSpecs.version == "" {
+	if bd.sp.initWorkloadViaRestore == nil {
 		bd.t.L().Printf(`Initializing workload`)
-		bd.sp.backup.workload.init(ctx, bd.t, bd.c, bd.sp.hardware)
+		bd.sp.scheduledBackupSpecs.workload.init(ctx, bd.t, bd.c, bd.sp.hardware)
 		return
 	}
+	computedRestoreSpecs := restoreSpecs{
+		hardware:               bd.sp.hardware,
+		backup:                 makeBackupSpecs(bd.sp.initWorkloadViaRestore.backup, bd.sp.scheduledBackupSpecs.backupSpecs),
+		restoreUptoIncremental: bd.sp.initWorkloadViaRestore.restoreUptoIncremental,
+	}
+	restoreDriver := makeRestoreDriver(bd.t, bd.c, computedRestoreSpecs)
 	bd.t.L().Printf(`Initializing workload via restore`)
-	restoreDriver := makeRestoreDriver(bd.t, bd.c, restoreSpecs{
-		hardware: bd.sp.hardware,
-		backup:   makeBackupSpecs(bd.sp.initFromBackupSpecs, bd.sp.backup.backupSpecs),
-	})
 	restoreDriver.getAOST(ctx)
 	// Only restore the database because a cluster restore will also restore the
 	// scheduled_jobs system table, which will automatically begin any backed up
@@ -189,14 +191,14 @@ func (bd *backupDriver) initWorkload(ctx context.Context) {
 }
 
 func (bd *backupDriver) runWorkload(ctx context.Context) error {
-	return bd.sp.backup.workload.run(ctx, bd.t, bd.c, bd.sp.hardware)
+	return bd.sp.scheduledBackupSpecs.workload.run(ctx, bd.t, bd.c, bd.sp.hardware)
 }
 
 // scheduleBackups begins the backup schedule.
 func (bd *backupDriver) scheduleBackups(ctx context.Context) {
 	conn := bd.c.Conn(ctx, bd.t.L(), 1)
 	sql := sqlutils.MakeSQLRunner(conn)
-	sql.Exec(bd.t, bd.sp.backup.scheduledBackupCmd())
+	sql.Exec(bd.t, bd.sp.scheduledBackupSpecs.scheduledBackupCmd())
 }
 
 // monitorBackups pauses the schedule once the target number of backups in the
@@ -214,10 +216,10 @@ func (bd *backupDriver) monitorBackups(ctx context.Context) {
 			continue
 		}
 		var backupCount int
-		backupCountQuery := fmt.Sprintf(`SELECT count(DISTINCT end_time) FROM [SHOW BACKUP FROM LATEST IN %s]`, bd.sp.backup.backupCollection())
+		backupCountQuery := fmt.Sprintf(`SELECT count(DISTINCT end_time) FROM [SHOW BACKUP FROM LATEST IN %s]`, bd.sp.scheduledBackupSpecs.backupCollection())
 		sql.QueryRow(bd.t, backupCountQuery).Scan(&backupCount)
 		bd.t.L().Printf(`%d scheduled backups taken`, backupCount)
-		if backupCount >= bd.sp.backup.numBackupsInChain {
+		if backupCount >= bd.sp.scheduledBackupSpecs.numBackupsInChain {
 			pauseSchedulesQuery := fmt.Sprintf(`PAUSE SCHEDULES WITH x AS (SHOW SCHEDULES) SELECT id FROM x WHERE label = '%s'`, scheduleLabel)
 			sql.QueryRow(bd.t, pauseSchedulesQuery)
 			break
@@ -228,23 +230,65 @@ func (bd *backupDriver) monitorBackups(ctx context.Context) {
 func registerBackupFixtures(r registry.Registry) {
 	for _, bf := range []backupFixtureSpecs{
 		{
-			// Default AWS Backup Fixture
-			hardware:            makeHardwareSpecs(hardwareSpecs{workloadNode: true}),
-			backup:              makeBackupFixtureSpecs(scheduledBackupSpecs{}),
-			timeout:             5 * time.Hour,
-			initFromBackupSpecs: backupSpecs{version: "v22.2.0"},
-			skip:                "only for fixture generation",
+			// 400GB backup fixture with 48 incremental layers. This is used by
+			// - restore/tpce/400GB/aws/inc-count=48/nodes=4/cpus=8
+			// - restore/tpce/400GB/aws/nodes=4/cpus=16
+			// - restore/tpce/400GB/aws/nodes=4/cpus=8
+			// - restore/tpce/400GB/aws/nodes=8/cpus=8
+			hardware:             makeHardwareSpecs(hardwareSpecs{workloadNode: true}),
+			scheduledBackupSpecs: makeBackupFixtureSpecs(scheduledBackupSpecs{}),
+			timeout:              5 * time.Hour,
+			initWorkloadViaRestore: &restoreSpecs{
+				backup:                 backupSpecs{version: "v22.2.0", numBackupsInChain: 48},
+				restoreUptoIncremental: 48,
+			},
+			skip: "only for fixture generation",
 			// TODO(radu): this should be only AWS.
 			clouds: registry.AllClouds,
 			suites: registry.Suites(registry.Nightly),
 			tags:   registry.Tags("aws"),
 		},
 		{
+			// 15 GB backup fixture with 48 incremental layers. This is used by
+			// restore/tpce/15GB/aws/nodes=4/cpus=8.
+			hardware: makeHardwareSpecs(hardwareSpecs{workloadNode: true, cpus: 4}),
+			scheduledBackupSpecs: makeBackupFixtureSpecs(
+				scheduledBackupSpecs{
+					incrementalBackupCrontab: "*/2 * * * *",
+					ignoreExistingBackups:    true,
+					backupSpecs: backupSpecs{
+						workload: tpceRestore{customers: 1000}}}),
+			initWorkloadViaRestore: &restoreSpecs{
+				backup:                 backupSpecs{version: "v22.2.1", numBackupsInChain: 48},
+				restoreUptoIncremental: 48,
+			},
+			timeout: 2 * time.Hour,
+			clouds:  registry.AllClouds,
+			suites:  registry.Suites(registry.Weekly),
+			tags:    registry.Tags("weekly", "aws-weekly"),
+		},
+		{
+			// 8TB Backup Fixture.
+			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 10, volumeSize: 2000, workloadNode: true}),
+			scheduledBackupSpecs: makeBackupFixtureSpecs(scheduledBackupSpecs{
+				backupSpecs: backupSpecs{
+					workload: tpceRestore{customers: 500000}}}),
+			timeout: 25 * time.Hour,
+			initWorkloadViaRestore: &restoreSpecs{
+				backup:                 backupSpecs{version: "v22.2.1", numBackupsInChain: 48},
+				restoreUptoIncremental: 48,
+			},
+			clouds: registry.AllClouds,
+			suites: registry.Suites(registry.Weekly),
+			// add the weekly tags to allow an over 24 hour timeout.
+			tags: registry.Tags("weekly", "aws-weekly"),
+			skip: "only for fixture generation",
+		},
+		{
 			// Default Fixture, Run on GCE. Initiated by the tpce --init.
 			hardware: makeHardwareSpecs(hardwareSpecs{workloadNode: true}),
-			backup: makeBackupFixtureSpecs(scheduledBackupSpecs{
-				backupSpecs: backupSpecs{
-					cloud: spec.GCE}}),
+			scheduledBackupSpecs: makeBackupFixtureSpecs(scheduledBackupSpecs{
+				backupSpecs: backupSpecs{cloud: spec.GCE}}),
 			// TODO(radu): this should be OnlyGCE.
 			clouds:  registry.AllExceptAWS,
 			suites:  registry.Suites(registry.Nightly),
@@ -252,46 +296,17 @@ func registerBackupFixtures(r registry.Registry) {
 			skip:    "only for fixture generation",
 		},
 		{
-			// 15 GB Backup Fixture. Note, this fixture is created weekly to
-			// ensure the fixture generation code works.
-			hardware: makeHardwareSpecs(hardwareSpecs{workloadNode: true, cpus: 4}),
-			backup: makeBackupFixtureSpecs(
-				scheduledBackupSpecs{
-					incrementalBackupCrontab: "*/2 * * * *",
-					ignoreExistingBackups:    true,
-					backupSpecs: backupSpecs{
-						numBackupsInChain: 4,
-						workload:          tpceRestore{customers: 1000}}}),
-			initFromBackupSpecs: backupSpecs{version: "v22.2.1", numBackupsInChain: 48},
-			timeout:             2 * time.Hour,
-			clouds:              registry.AllClouds,
-			suites:              registry.Suites(registry.Weekly),
-			tags:                registry.Tags("weekly", "aws-weekly"),
-		},
-		{
-			// 8TB Backup Fixture.
-			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 10, volumeSize: 2000, workloadNode: true}),
-			backup: makeBackupFixtureSpecs(scheduledBackupSpecs{
-				backupSpecs: backupSpecs{
-					workload: tpceRestore{customers: 500000}}}),
-			timeout:             25 * time.Hour,
-			initFromBackupSpecs: backupSpecs{version: "v22.2.1", numBackupsInChain: 48},
-			clouds:              registry.AllClouds,
-			suites:              registry.Suites(registry.Weekly),
-			// add the weekly tags to allow an over 24 hour timeout.
-			tags: registry.Tags("weekly", "aws-weekly"),
-			skip: "only for fixture generation",
-		},
-		{
 			// 32TB Backup Fixture.
 			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 15, cpus: 16, volumeSize: 5000, workloadNode: true}),
-			backup: makeBackupFixtureSpecs(scheduledBackupSpecs{
-				backupSpecs: backupSpecs{
-					workload: tpceRestore{customers: 2000000}}}),
-			initFromBackupSpecs: backupSpecs{version: "v22.2.1", numBackupsInChain: 48},
-			timeout:             48 * time.Hour,
-			clouds:              registry.AllClouds,
-			suites:              registry.Suites(registry.Weekly),
+			scheduledBackupSpecs: makeBackupFixtureSpecs(scheduledBackupSpecs{
+				backupSpecs: backupSpecs{workload: tpceRestore{customers: 2000000}}}),
+			initWorkloadViaRestore: &restoreSpecs{
+				backup:                 backupSpecs{version: "v22.2.1", numBackupsInChain: 48},
+				restoreUptoIncremental: 48,
+			},
+			timeout: 48 * time.Hour,
+			clouds:  registry.AllClouds,
+			suites:  registry.Suites(registry.Weekly),
 			// add the weekly tags to allow an over 24 hour timeout.
 			tags: registry.Tags("weekly", "aws-weekly"),
 			skip: "only for fixture generation",
@@ -302,7 +317,7 @@ func registerBackupFixtures(r registry.Registry) {
 		r.Add(registry.TestSpec{
 			Name:              bf.testName,
 			Owner:             registry.OwnerDisasterRecovery,
-			Cluster:           bf.hardware.makeClusterSpecs(r, bf.backup.cloud),
+			Cluster:           bf.hardware.makeClusterSpecs(r, bf.scheduledBackupSpecs.cloud),
 			Timeout:           bf.timeout,
 			EncryptionSupport: registry.EncryptionMetamorphic,
 			CompatibleClouds:  bf.clouds,

--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -29,7 +28,7 @@ func registerDisaggRebalance(r registry.Registry) {
 	disaggRebalanceSpec := r.MakeClusterSpec(4)
 	r.Add(registry.TestSpec{
 		Name:              fmt.Sprintf("disagg-rebalance/aws/%s", disaggRebalanceSpec),
-		CompatibleClouds:  registry.AllClouds,
+		CompatibleClouds:  registry.OnlyAWS,
 		Suites:            registry.Suites(registry.Nightly),
 		Tags:              registry.Tags("aws"),
 		Owner:             registry.OwnerStorage,
@@ -38,9 +37,6 @@ func registerDisaggRebalance(r registry.Registry) {
 		EncryptionSupport: registry.EncryptionAlwaysDisabled,
 		Timeout:           1 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Cloud() != spec.AWS {
-				t.Skip("disagg-rebalance is only configured to run on AWS")
-			}
 			s3dir := fmt.Sprintf("s3://%s/disagg-rebalance/%s?AUTH=implicit", testutils.BackupTestingBucketLongTTL(), c.Name())
 			startOpts := option.DefaultStartOptsNoBackups()
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, fmt.Sprintf("--experimental-shared-storage=%s", s3dir))

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -71,7 +71,7 @@ func registerRestoreNodeShutdown(r registry.Registry) {
 		Name:             "restore/nodeShutdown/worker",
 		Owner:            registry.OwnerDisasterRecovery,
 		Cluster:          sp.hardware.makeClusterSpecs(r, sp.backup.cloud),
-		CompatibleClouds: registry.AllClouds,
+		CompatibleClouds: registry.Clouds(sp.backup.cloud),
 		Tags:             registry.Tags("aws"),
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -92,7 +92,7 @@ func registerRestoreNodeShutdown(r registry.Registry) {
 		Name:             "restore/nodeShutdown/coordinator",
 		Owner:            registry.OwnerDisasterRecovery,
 		Cluster:          sp.hardware.makeClusterSpecs(r, sp.backup.cloud),
-		CompatibleClouds: registry.AllClouds,
+		CompatibleClouds: registry.Clouds(sp.backup.cloud),
 		Tags:             registry.Tags("aws"),
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
@@ -135,9 +135,9 @@ func registerRestore(r registry.Registry) {
 		Benchmark:        true,
 		Cluster:          withPauseSpecs.hardware.makeClusterSpecs(r, withPauseSpecs.backup.cloud),
 		Timeout:          withPauseSpecs.timeout,
-		CompatibleClouds: registry.AllClouds,
+		CompatibleClouds: registry.Clouds(withPauseSpecs.backup.cloud),
 		Suites:           registry.Suites(registry.Nightly),
-		Tags:             registry.Tags("aws"),
+		Tags:             registry.Tags(withPauseSpecs.backup.cloud),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 			rd := makeRestoreDriver(t, c, withPauseSpecs)
@@ -281,9 +281,7 @@ func registerRestore(r registry.Registry) {
 			hardware:               makeHardwareSpecs(hardwareSpecs{ebsThroughput: 250 /* MB/s */}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
 			timeout:                1 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
 		{
@@ -292,7 +290,6 @@ func registerRestore(r registry.Registry) {
 			hardware:               makeHardwareSpecs(hardwareSpecs{}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{cloud: spec.GCE}),
 			timeout:                1 * time.Hour,
-			clouds:                 registry.AllExceptAWS,
 			suites:                 registry.Suites(registry.Nightly),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
@@ -302,7 +299,6 @@ func registerRestore(r registry.Registry) {
 			hardware:               makeHardwareSpecs(hardwareSpecs{mem: spec.Low}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{cloud: spec.GCE}),
 			timeout:                1 * time.Hour,
-			clouds:                 registry.AllExceptAWS,
 			suites:                 registry.Suites(registry.Nightly),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
@@ -312,9 +308,7 @@ func registerRestore(r registry.Registry) {
 			hardware:               makeHardwareSpecs(hardwareSpecs{nodes: 8, ebsThroughput: 250 /* MB/s */}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
 			timeout:                1 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
 		{
@@ -325,9 +319,7 @@ func registerRestore(r registry.Registry) {
 				zones: []string{"us-east-2b", "us-west-2b", "eu-west-1b"}}), // These zones are AWS-specific.
 			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
 			timeout:                90 * time.Minute,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
 		{
@@ -336,9 +328,7 @@ func registerRestore(r registry.Registry) {
 			hardware:               makeHardwareSpecs(hardwareSpecs{cpus: 16, ebsThroughput: 250 /* MB/s */}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
 			timeout:                1 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
 		{
@@ -347,9 +337,7 @@ func registerRestore(r registry.Registry) {
 			hardware:               makeHardwareSpecs(hardwareSpecs{ebsThroughput: 250 /* MB/s */}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
 			timeout:                1 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: 48,
 		},
 		{
@@ -362,9 +350,7 @@ func registerRestore(r registry.Registry) {
 				version:  "v22.2.1",
 				workload: tpceRestore{customers: 500000}}),
 			timeout:                5 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
 		{
@@ -375,9 +361,7 @@ func registerRestore(r registry.Registry) {
 				version:  "v22.2.1",
 				workload: tpceRestore{customers: 2000000}}),
 			timeout:                24 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Weekly),
-			tags:                   registry.Tags("weekly", "aws-weekly"),
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
 		{
@@ -397,9 +381,7 @@ func registerRestore(r registry.Registry) {
 				numBackupsInChain: 400,
 			}),
 			timeout: 30 * time.Hour,
-			clouds:  registry.AllClouds,
 			suites:  registry.Suites(registry.Weekly),
-			tags:    registry.Tags("weekly", "aws-weekly"),
 			setUpStmts: []string{
 				`SET CLUSTER SETTING backup.restore_span.target_size = '0'`,
 			},
@@ -415,9 +397,7 @@ func registerRestore(r registry.Registry) {
 				numBackupsInChain: 400,
 			}),
 			timeout: 30 * time.Hour,
-			clouds:  registry.AllExceptAWS,
 			suites:  registry.Suites(registry.Weekly),
-			tags:    registry.Tags("weekly"),
 			setUpStmts: []string{
 				`SET CLUSTER SETTING backup.restore_span.target_size = '0'`,
 			},
@@ -430,9 +410,7 @@ func registerRestore(r registry.Registry) {
 				backupSpecs{workload: tpceRestore{customers: 1000},
 					version: "v22.2.1"}),
 			timeout:                3 * time.Hour,
-			clouds:                 registry.AllClouds,
 			suites:                 registry.Suites(registry.Nightly),
-			tags:                   registry.Tags("aws"),
 			fingerprint:            8445446819555404274,
 			restoreUptoIncremental: defaultRestoreUptoIncremental,
 		},
@@ -443,6 +421,7 @@ func registerRestore(r registry.Registry) {
 	} {
 		sp := sp
 		sp.initTestName()
+
 		r.Add(registry.TestSpec{
 			Name:      sp.testName,
 			Owner:     registry.OwnerDisasterRecovery,
@@ -452,9 +431,9 @@ func registerRestore(r registry.Registry) {
 			// These tests measure performance. To ensure consistent perf,
 			// disable metamorphic encryption.
 			EncryptionSupport: registry.EncryptionAlwaysDisabled,
-			CompatibleClouds:  sp.clouds,
+			CompatibleClouds:  registry.Clouds(sp.backup.cloud),
 			Suites:            sp.suites,
-			Tags:              sp.tags,
+			Tags:              tagsFromSuiteAndCloud(sp.backup.cloud, sp.suites),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 				rd := makeRestoreDriver(t, c, sp)
@@ -810,9 +789,7 @@ type restoreSpecs struct {
 	// backup describes the backup fixture from which we will restore.
 	backup  backupSpecs
 	timeout time.Duration
-	clouds  registry.CloudSet
 	suites  registry.SuiteSet
-	tags    map[string]struct{}
 
 	// restoreUptoIncremental specifies the number of incremental backups in the
 	// chain to restore up to.
@@ -885,10 +862,6 @@ func makeRestoreDriver(t test.Test, c cluster.Cluster, sp restoreSpecs) restoreD
 }
 
 func (rd *restoreDriver) prepareCluster(ctx context.Context) {
-	if rd.c.Cloud() != rd.sp.backup.cloud {
-		// For now, only run the test on the cloud provider that also stores the backup.
-		rd.t.Skipf("test configured to run on %s", rd.sp.backup.cloud)
-	}
 	rd.c.Start(ctx, rd.t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings())
 	rd.getAOST(ctx)
 }
@@ -971,6 +944,22 @@ func (rd *restoreDriver) initRestorePerfMetrics(
 			throughput)
 		exportToRoachperf(ctx, rd.t, rd.c, rd.sp.testName, int64(throughput))
 	}
+}
+
+func tagsFromSuiteAndCloud(cloud string, suites registry.SuiteSet) map[string]struct{} {
+	tags := registry.Tags()
+	if cloud == spec.AWS {
+		if suites.Contains(registry.Weekly) {
+			tags = registry.Tags("aws-weekly")
+		} else {
+			tags = registry.Tags("aws")
+		}
+	} else {
+		if suites.Contains(registry.Weekly) {
+			tags = registry.Tags("weekly")
+		}
+	}
+	return tags
 }
 
 // checkFingerprint runs a stripped fingerprint on all user tables in the cluster if the restore

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -904,8 +904,10 @@ func (rd *restoreDriver) getAOST(ctx context.Context) {
 }
 
 func (rd *restoreDriver) restoreCmd(target, opts string) string {
-	return fmt.Sprintf(`RESTORE %s FROM %s IN %s AS OF SYSTEM TIME '%s' %s`,
+	query := fmt.Sprintf(`RESTORE %s FROM %s IN %s AS OF SYSTEM TIME '%s' %s`,
 		target, rd.sp.backup.fullBackupDir, rd.sp.backup.backupCollection(), rd.aost, opts)
+	rd.t.L().Printf("Running restore cmd: %s", query)
+	return query
 }
 
 // run executes the restore, where target injects a restore target into the restore command.


### PR DESCRIPTION
Backport:
  * 1/1 commits from "roachtest: minor refactor to backup fixture code" (#115387)
  * 5/5 commits from "roachtest: use backup cloud to set CompatibleClouds" (#115997)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: test-only change, keeping roachtests in sync as much as possible.
