### PR TITLE
sql: add telemetry for mixed DDL/DML transactions

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1445,9 +1445,14 @@ func (ex *connExecutor) reportSessionDataChanges(fn func() error) error {
 	return nil
 }
 
-func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) error {
+func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) (retErr error) {
 	ctx, sp := tracing.EnsureChildSpan(ctx, ex.server.cfg.AmbientCtx.Tracer, "commit sql txn")
 	defer sp.Finish()
+
+	defer func() {
+		failed := retErr != nil
+		ex.recordDDLTxnTelemetry(failed)
+	}()
 
 	if err := ex.extraTxnState.sqlCursors.closeAll(true /* errorOnWithHold */); err != nil {
 		return err
@@ -1525,6 +1530,29 @@ func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) error 
 	return nil
 }
 
+// recordDDLTxnTelemetry records telemetry for explicit transactions that
+// contain DDL.
+func (ex *connExecutor) recordDDLTxnTelemetry(failed bool) {
+	numDDL, numStmts := ex.extraTxnState.numDDL, ex.state.mu.stmtCount
+	if numDDL == 0 || ex.implicitTxn() {
+		return
+	}
+	// Subtract 1 statement so the COMMIT/ROLLBACK is not counted.
+	if numDDL == numStmts-1 {
+		if failed {
+			telemetry.Inc(sqltelemetry.DDLOnlyTransactionFailureCounter)
+		} else {
+			telemetry.Inc(sqltelemetry.DDLOnlyTransactionSuccessCounter)
+		}
+	} else /* numDDL != numStmts-1 */ {
+		if failed {
+			telemetry.Inc(sqltelemetry.MixedDDLDMLTransactionFailureCounter)
+		} else {
+			telemetry.Inc(sqltelemetry.MixedDDLDMLTransactionSuccessCounter)
+		}
+	}
+}
+
 // createJobs creates jobs for the records cached in schemaChangeJobRecords
 // during this transaction.
 func (ex *connExecutor) createJobs(ctx context.Context) error {
@@ -1558,6 +1586,7 @@ func (ex *connExecutor) rollbackSQLTransaction(
 	}
 
 	ex.extraTxnState.prepStmtsNamespace.closeAllPortals(ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc)
+	ex.recordDDLTxnTelemetry(true /* failed */)
 
 	if err := ex.state.mu.txn.Rollback(ctx); err != nil {
 		log.Warningf(ctx, "txn rollback failed: %s", err)

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -203,3 +203,19 @@ var DeclarativeSchemaChangerCounter = telemetry.GetCounterOnce("sql.schema.schem
 // LegacySchemaChangerCounter is incremented whenever the legacy schema changer
 // is used.
 var LegacySchemaChangerCounter = telemetry.GetCounterOnce("sql.schema.schema_changer_mode.legacy")
+
+// MixedDDLDMLTransactionSuccessCounter is incremented whenever an explicit
+// transaction that has both DDL and DML statements succeeds.
+var MixedDDLDMLTransactionSuccessCounter = telemetry.GetCounterOnce("sql.schema.transaction.mixed_ddl_dml.success")
+
+// MixedDDLDMLTransactionFailureCounter is incremented whenever an explicit
+// transaction that has both DDL and DML statements fails.
+var MixedDDLDMLTransactionFailureCounter = telemetry.GetCounterOnce("sql.schema.transaction.mixed_ddl_dml.failure")
+
+// DDLOnlyTransactionSuccessCounter is incremented whenever an explicit
+// transaction that has only DDL statements succeeds.
+var DDLOnlyTransactionSuccessCounter = telemetry.GetCounterOnce("sql.schema.transaction.ddl_only.success")
+
+// DDLOnlyTransactionFailureCounter is incremented whenever an explicit
+// transaction that has only DDL statements fails.
+var DDLOnlyTransactionFailureCounter = telemetry.GetCounterOnce("sql.schema.transaction.ddl_only.failure")

--- a/pkg/sql/testdata/telemetry/schema
+++ b/pkg/sql/testdata/telemetry/schema
@@ -171,3 +171,47 @@ CREATE TYPE composite_typ AS (a int, b int)
 ----
 sql.schema.create_type
 sql.schema.schema_changer_mode.legacy
+
+exec
+BEGIN;
+SELECT 1;
+DROP INDEX t_b_idx;
+SELECT 1/0;
+----
+error: pq: division by zero
+
+feature-usage
+ROLLBACK;
+----
+sql.schema.transaction.mixed_ddl_dml.failure
+
+exec
+BEGIN;
+DROP INDEX t_b_idx;
+----
+
+feature-usage
+ROLLBACK;
+----
+sql.schema.transaction.ddl_only.failure
+
+feature-usage
+BEGIN;
+SELECT 1;
+DROP INDEX t_b_idx;
+COMMIT;
+----
+sql.schema.change_in_explicit_txn
+sql.schema.drop_index
+sql.schema.schema_changer_mode.legacy
+sql.schema.transaction.mixed_ddl_dml.success
+
+feature-usage
+BEGIN;
+CREATE INDEX ON t(b);
+COMMIT;
+----
+sql.schema.change_in_explicit_txn
+sql.schema.create_index
+sql.schema.schema_changer_mode.legacy
+sql.schema.transaction.ddl_only.success


### PR DESCRIPTION
This patch adds feature counter telemetry for explicit transactions that have schema changes. We track if a transaction has DDL only or a mixture of DDL and DML, and if it succeeded or failed.

fixes https://github.com/cockroachdb/cockroach/issues/115012
Release note: None