### PR TITLE
roachtest : identify any vm preemption failure as infraFlake 

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/internal/issues"
@@ -155,6 +156,11 @@ func (g *githubIssues) createPostRequest(
 	var infraFlake bool
 	// Overrides to shield eng teams from potential flakes
 	switch {
+	case strings.Contains(message, errmsgFailedDueToVmPreemption):
+		issueOwner = registry.OwnerTestEng
+		issueName = "vm_preemption"
+		messagePrefix = fmt.Sprintf("test %s failed due to ", testName)
+		infraFlake = true
 	case failureContainsError(firstFailure, errClusterProvisioningFailed):
 		issueOwner = registry.OwnerTestEng
 		issueName = "cluster_creation"

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -64,6 +64,9 @@ var (
 	// reference error for any failures during post test assertions
 	errDuringPostAssertions = fmt.Errorf("error during post test assertions")
 
+	// reference error for any failures due to VM preemption. The string is used in runTest function.
+	errmsgFailedDueToVmPreemption = "VMs preempted during the test run"
+
 	prometheusNameSpace = "roachtest"
 	// prometheusScrapeInterval should be consistent with the scrape interval defined in
 	// https://grafana.testeng.crdb.io/prometheus/config

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_10.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_10.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_11.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_11.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----


### PR DESCRIPTION
roachtest : identify any vm preemption failure as infraFlake and route to testeng.

Epic: none

Release note: None