### PR TITLE
server: dynamically increase compaction concurrency during downloads

### DIFF
--- a/pkg/server/span_download.go
+++ b/pkg/server/span_download.go
@@ -109,7 +109,9 @@ func (s *systemStatusServer) localDownloadSpan(
 			}
 			return nil
 		}
-		for i := 0; i < 4; i++ {
+
+		const downloadWaiters = 8
+		for i := 0; i < downloadWaiters; i++ {
 			grp.GoCtx(downloader)
 		}
 		return grp.Wait()

--- a/pkg/server/span_download.go
+++ b/pkg/server/span_download.go
@@ -12,6 +12,7 @@ package server
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -19,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -101,19 +103,80 @@ func (s *systemStatusServer) localDownloadSpan(
 			return nil
 		})
 
+		const downloadWaiters = 16
+		downloadersDone := make(chan struct{}, downloadWaiters)
+
 		downloader := func(ctx context.Context) error {
 			for sp := range spanCh {
 				if err := store.TODOEngine().Download(ctx, sp); err != nil {
 					return err
 				}
 			}
+			downloadersDone <- struct{}{}
 			return nil
 		}
 
-		const downloadWaiters = 8
 		for i := 0; i < downloadWaiters; i++ {
 			grp.GoCtx(downloader)
 		}
+
+		grp.GoCtx(func(ctx context.Context) error {
+			var added int64
+			// Remove any additional concurrency we've added when we exit.
+			//
+			// TODO(dt,radu): Ideally we'd adjust a separate limit that applies only
+			// to download compactions, so that this does not fight with manual calls
+			// to SetConcurrentCompactions.
+			defer func() {
+				if added != 0 {
+					adjusted := store.TODOEngine().AdjustCompactionConcurrency(-added)
+					log.Infof(ctx, "downloads complete; reset compaction concurrency to %d", adjusted)
+				}
+			}()
+
+			const maxAddedConcurrency, lowCPU, highCPU, initialIncrease = 16, 0.65, 0.8, 8
+
+			// Begin by bumping up the concurrency by 8, then start watching the CPU
+			// usage and adjusting up or down based on CPU until downloading finishes.
+			store.TODOEngine().AdjustCompactionConcurrency(initialIncrease)
+			added += initialIncrease
+
+			t := time.NewTicker(time.Second * 15)
+			defer t.Stop()
+			ctxDone := ctx.Done()
+
+			var waitersExited int
+			for {
+				select {
+				case <-ctxDone:
+					return ctx.Err()
+				case <-downloadersDone:
+					waitersExited++
+					// Return and stop managing added concurrency if the workers are done.
+					if waitersExited >= downloadWaiters {
+						return nil
+					}
+				case <-t.C:
+					cpu := s.sqlServer.cfg.RuntimeStatSampler.GetCPUCombinedPercentNorm()
+					if cpu > highCPU && added > 0 {
+						// If CPU is high and we have added any additional concurrency, we
+						// should reduce our added concurrency to make sure CPU is available
+						// for the execution of foreground traffic.
+						adjusted := store.TODOEngine().AdjustCompactionConcurrency(-1)
+						added--
+						log.Infof(ctx, "decreasing additional compaction concurrency to %d (%d total) due cpu usage %.0f%% > %.0f%%", added, adjusted, cpu*100, highCPU*100)
+					} else if cpu < lowCPU {
+						// If CPU is low, we should use it to do additional downloading.
+						if added < maxAddedConcurrency {
+							adjusted := store.TODOEngine().AdjustCompactionConcurrency(1)
+							added++
+							log.Infof(ctx, "increasing additional compaction concurrency to %d (%d total) due cpu usage %.0f%% < %.0f%%", added, adjusted, cpu*100, lowCPU*100)
+						}
+					}
+				}
+			}
+		})
+
 		return grp.Wait()
 	})
 }

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1086,9 +1086,9 @@ type Engine interface {
 	// concurrency. It returns the previous compaction concurrency.
 	SetCompactionConcurrency(n uint64) uint64
 
-	// AdjustCompactionConcurrency is used to adjust the engine's compaction
-	// concurrency.
-	AdjustCompactionConcurrency(delta int64) (uint64, error)
+	// AdjustCompactionConcurrency adjusts the compaction concurrency up or down by
+	// the passed delta, down to a minimum of 1.
+	AdjustCompactionConcurrency(delta int64) uint64
 
 	// SetStoreID informs the engine of the store ID, once it is known.
 	// Used to show the store ID in logs and to initialize the shared object

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1086,6 +1086,10 @@ type Engine interface {
 	// concurrency. It returns the previous compaction concurrency.
 	SetCompactionConcurrency(n uint64) uint64
 
+	// AdjustCompactionConcurrency is used to adjust the engine's compaction
+	// concurrency.
+	AdjustCompactionConcurrency(delta int64) (uint64, error)
+
 	// SetStoreID informs the engine of the store ID, once it is known.
 	// Used to show the store ID in logs and to initialize the shared object
 	// creator ID (if shared object storage is configured).

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -931,17 +931,16 @@ func (p *Pebble) SetCompactionConcurrency(n uint64) uint64 {
 }
 
 // AdjustCompactionConcurrency adjusts the compaction concurrency up or down by
-// the passed delta, down to a minimum of 1. Attempts to reduce it below 1 will
-// return an error.
-func (p *Pebble) AdjustCompactionConcurrency(delta int64) (uint64, error) {
+// the passed delta, down to a minimum of 1.
+func (p *Pebble) AdjustCompactionConcurrency(delta int64) uint64 {
 	for {
 		current := atomic.LoadUint64(&p.atomic.compactionConcurrency)
 		adjusted := int64(current) + delta
 		if adjusted < 1 {
-			return 0, fmt.Errorf("compaction concurrency cannot be less than 1")
+			adjusted = 1
 		}
 		if atomic.CompareAndSwapUint64(&p.atomic.compactionConcurrency, current, uint64(adjusted)) {
-			return uint64(adjusted), nil
+			return uint64(adjusted)
 		}
 	}
 }


### PR DESCRIPTION
Early in an online restore, a workload may not be able to utilize
all CPU due to the high latency of accessing still-remote data meaning
that many or most queries spend most of their time waiting rather than
executing. During this phase, increasing the compaciton concurrency can
expedite getting data downloaded, to reduce that latency and improve the
workload performance.

However later in the download phase, when more of the most accessed data
has been downloaded, the workload itself may be able to execute fast enough
that it requires the majority of available CPU. At this point, excessive
CPU usage by download compactions will actually negatively impact the workload
performance.

Thus it is desirable to maximize compaction concurrency when CPU is available
but reduce it when becomes scarce.

This change introduces an additional goroutine to the download call that
monitors CPU usage and adjusts compaction concurrency up and down based on
the CPU usage being below 70% or above 80% respectively.

Release note: none.
Epic: none.