### PR TITLE
teamcity: update pebble scripts to use master

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
@@ -36,7 +36,7 @@ chmod a+w bin/roachtest
 # against the tip of the 'master' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
 bazel build @com_github_cockroachdb_pebble//cmd/pebble --config ci -c opt

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
@@ -16,7 +16,7 @@ mkdir -p artifacts
 # against the tip of the 'master' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
 # Just dump the diff to see what, if anything, has changed.
 git diff
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race.sh
@@ -16,7 +16,7 @@ mkdir -p artifacts
 # against the tip of the 'master' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
 # Just dump the diff to see what, if anything, has changed.
 git diff
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
@@ -36,7 +36,7 @@ chmod a+w bin/roachtest
 # against the tip of the 'master' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
 bazel build @com_github_cockroachdb_pebble//cmd/pebble --config race --config ci -c opt

--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -2,7 +2,9 @@
 
 # NOTE: After a new release has been cut, update this to the appropriate
 # Cockroach branch name (i.e. release-23.2, etc.), and corresponding Pebble
-# branch name (e.g. crl-release-23.2, etc.).
+# branch name (e.g. crl-release-23.2, etc.). Also update pebble nightly scripts
+# in build/teamcity/cockroach/nightlies to use `@crl-release-xy.z` instead of
+# `@master`.
 BRANCH=master
 PEBBLE_BRANCH=master
 


### PR DESCRIPTION
Some scripts use `latest` which is no longer what we want for Pebble
(since we recently tagged a `v1.0.0` release for external users).

Epic: none
Release note: None