### PR TITLE
teamcity: use crl-release-23.2 branch for pebble tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
@@ -32,11 +32,11 @@ BAZEL_BIN=$(bazel info bazel-bin --config ci -c opt)
 cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
 chmod a+w bin/roachtest
 
-# Pull in the latest version of Pebble from upstream. The benchmarks run
-# against the tip of the 'master' branch. We do this by `go get`ting the
+# Pull in the latest version of Pebble from upstream. The benchmarks run against
+# the tip of the 'crl-release-23.2' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@crl-release-23.2
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
 bazel build @com_github_cockroachdb_pebble//cmd/pebble --config ci -c opt

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
@@ -12,11 +12,11 @@ source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 mkdir -p artifacts
 
-# Pull in the latest version of Pebble from upstream. The benchmarks run
-# against the tip of the 'master' branch. We do this by `go get`ting the
+# Pull in the latest version of Pebble from upstream. The benchmarks run against
+# the tip of the 'crl-release-23.2' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@crl-release-23.2
 # Just dump the diff to see what, if anything, has changed.
 git diff
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race.sh
@@ -12,11 +12,11 @@ source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 mkdir -p artifacts
 
-# Pull in the latest version of Pebble from upstream. The benchmarks run
-# against the tip of the 'master' branch. We do this by `go get`ting the
+# Pull in the latest version of Pebble from upstream. The benchmarks run against
+# the tip of the 'crl-release-23.2' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@crl-release-23.2
 # Just dump the diff to see what, if anything, has changed.
 git diff
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
@@ -32,11 +32,11 @@ BAZEL_BIN=$(bazel info bazel-bin --config ci -c opt)
 cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
 chmod a+w bin/roachtest
 
-# Pull in the latest version of Pebble from upstream. The benchmarks run
-# against the tip of the 'master' branch. We do this by `go get`ting the
+# Pull in the latest version of Pebble from upstream. The benchmarks run against
+# the tip of the 'crl-release-23.2' branch. We do this by `go get`ting the
 # latest version of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@latest
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@crl-release-23.2
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
 bazel build @com_github_cockroachdb_pebble//cmd/pebble --config race --config ci -c opt


### PR DESCRIPTION
These tests were using the `latest` tag, which does not correspond to this release.

Epic: none
Release note: None
Release justification: internal test fix