### PR TITLE
kvclient: remove FirstRange from kvcoord.RangeDescriptorDB

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -811,6 +811,18 @@ func (ds *DistSender) RangeDescriptorCache() *rangecache.RangeCache {
 func (ds *DistSender) RangeLookup(
 	ctx context.Context, key roachpb.RKey, rc rangecache.RangeLookupConsistency, useReverseScan bool,
 ) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
+
+	// In this case, the requested key is stored in the cluster's first
+	// range. Return the first range, which is always gossiped and not
+	// queried from the datastore.
+	if keys.RangeMetaKey(key).Equal(roachpb.RKeyMin) {
+		desc, err := ds.firstRangeProvider.GetFirstRangeDescriptor()
+		if err != nil {
+			return nil, nil, err
+		}
+		return []roachpb.RangeDescriptor{*desc}, nil, nil
+	}
+
 	ds.metrics.RangeLookups.Inc(1)
 	switch rc {
 	case kvpb.INCONSISTENT, kvpb.READ_UNCOMMITTED:
@@ -823,18 +835,6 @@ func (ds *DistSender) RangeLookup(
 	// still find it when we scan to the next range. This addresses the issue
 	// described in #18032 and #16266, allowing us to support meta2 splits.
 	return kv.RangeLookup(ctx, ds, key.AsRawKey(), rc, RangeLookupPrefetchCount, useReverseScan)
-}
-
-// FirstRange implements the RangeDescriptorDB interface.
-//
-// It returns the RangeDescriptor for the first range in the cluster using the
-// FirstRangeProvider, which is typically implemented using the gossip protocol
-// instead of the datastore.
-func (ds *DistSender) FirstRange() (*roachpb.RangeDescriptor, error) {
-	if ds.firstRangeProvider == nil {
-		panic("with `nil` firstRangeProvider, DistSender must not use itself as RangeDescriptorDB")
-	}
-	return ds.firstRangeProvider.GetFirstRangeDescriptor()
 }
 
 // CountRanges returns the number of ranges that encompass the given key span.

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache/rangecachemock"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb/kvpbmock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -114,7 +115,7 @@ func TestDistSenderRangeFeedRetryOnTransportErrors(t *testing.T) {
 
 					// Once all replicas have failed, it should try to refresh the lease using
 					// the range cache. We let this succeed once.
-					rangeDB.EXPECT().FirstRange().Return(&desc, nil)
+					rangeDB.EXPECT().RangeLookup(gomock.Any(), roachpb.RKeyMin, kvpb.INCONSISTENT, false).Return([]roachpb.RangeDescriptor{desc}, nil, nil)
 
 					// It then tries the replicas again. This time we just report the
 					// transport as exhausted immediately.
@@ -122,13 +123,13 @@ func TestDistSenderRangeFeedRetryOnTransportErrors(t *testing.T) {
 					transport.EXPECT().Release()
 
 					// This invalidates the cache yet again. This time we error.
-					rangeDB.EXPECT().FirstRange().Return(nil, grpcstatus.Error(spec.errorCode, ""))
+					rangeDB.EXPECT().RangeLookup(gomock.Any(), roachpb.RKeyMin, kvpb.INCONSISTENT, false).Return(nil, nil, grpcstatus.Error(spec.errorCode, ""))
 
 					// If we expect a range lookup retry, allow the retry to succeed by
 					// returning a range descriptor and a client that immediately
 					// cancels the context and closes the range feed stream.
 					if spec.expectRetry {
-						rangeDB.EXPECT().FirstRange().MinTimes(1).Return(&desc, nil)
+						rangeDB.EXPECT().RangeLookup(gomock.Any(), roachpb.RKeyMin, kvpb.INCONSISTENT, false).MinTimes(1).Return([]roachpb.RangeDescriptor{desc}, nil, nil) //.FirstRange().Return(&desc, nil)
 						client := kvpbmock.NewMockInternalClient(ctrl)
 
 						if useMuxRangeFeed {

--- a/pkg/kv/kvclient/kvtenant/BUILD.bazel
+++ b/pkg/kv/kvclient/kvtenant/BUILD.bazel
@@ -87,7 +87,6 @@ go_test(
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util",
-        "//pkg/util/grpcutil",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -664,11 +664,6 @@ func (c *connector) TenantRanges(
 	return
 }
 
-// FirstRange implements the kvcoord.RangeDescriptorDB interface.
-func (c *connector) FirstRange() (*roachpb.RangeDescriptor, error) {
-	return nil, status.Error(codes.Unauthenticated, "kvtenant.Proxy does not have access to FirstRange")
-}
-
 // NewIterator implements the rangedesc.IteratorFactory interface.
 func (c *connector) NewIterator(
 	ctx context.Context, span roachpb.Span,

--- a/pkg/kv/kvclient/kvtenant/connector_test.go
+++ b/pkg/kv/kvclient/kvtenant/connector_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -475,12 +474,6 @@ func TestConnectorRangeLookup(t *testing.T) {
 	require.Nil(t, resDescs)
 	require.Nil(t, resPreDescs)
 	require.Regexp(t, context.Canceled.Error(), err)
-
-	// FirstRange always returns error.
-	desc, err := c.FirstRange()
-	require.Nil(t, desc)
-	require.Regexp(t, "does not have access to FirstRange", err)
-	require.True(t, grpcutil.IsAuthError(err))
 }
 
 // TestConnectorRetriesUnreachable tests that connector iterates over each of

--- a/pkg/kv/kvclient/rangecache/range_cache.go
+++ b/pkg/kv/kvclient/rangecache/range_cache.go
@@ -119,11 +119,6 @@ type RangeDescriptorDB interface {
 		consistency RangeLookupConsistency,
 		useReverseScan bool,
 	) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error)
-
-	// FirstRange returns the descriptor for the first Range. This is the
-	// Range containing all meta1 entries.
-	// TODO(nvanbenschoten): pull this detail in DistSender.
-	FirstRange() (*roachpb.RangeDescriptor, error)
 }
 
 // RangeCache is used to retrieve range descriptors for
@@ -1026,17 +1021,6 @@ func (rc *RangeCache) performRangeLookup(
 ) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
 	// Tag inner operations.
 	ctx = logtags.AddTag(ctx, "range-lookup", key)
-
-	// In this case, the requested key is stored in the cluster's first
-	// range. Return the first range, which is always gossiped and not
-	// queried from the datastore.
-	if keys.RangeMetaKey(key).Equal(roachpb.RKeyMin) {
-		desc, err := rc.db.FirstRange()
-		if err != nil {
-			return nil, nil, err
-		}
-		return []roachpb.RangeDescriptor{*desc}, nil, nil
-	}
 
 	return rc.db.RangeLookup(ctx, key, consistency, useReverseScan)
 }

--- a/pkg/kv/kvclient/rangecache/rangecachemock/mocks_generated.go
+++ b/pkg/kv/kvclient/rangecache/rangecachemock/mocks_generated.go
@@ -36,21 +36,6 @@ func (m *MockRangeDescriptorDB) EXPECT() *MockRangeDescriptorDBMockRecorder {
 	return m.recorder
 }
 
-// FirstRange mocks base method.
-func (m *MockRangeDescriptorDB) FirstRange() (*roachpb.RangeDescriptor, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FirstRange")
-	ret0, _ := ret[0].(*roachpb.RangeDescriptor)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FirstRange indicates an expected call of FirstRange.
-func (mr *MockRangeDescriptorDBMockRecorder) FirstRange() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FirstRange", reflect.TypeOf((*MockRangeDescriptorDB)(nil).FirstRange))
-}
-
 // RangeLookup mocks base method.
 func (m *MockRangeDescriptorDB) RangeLookup(arg0 context.Context, arg1 roachpb.RKey, arg2 kvpb.ReadConsistencyType, arg3 bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This call leaked the implementation detail that the FirstRange in DistSender is implemented differently from the other lookup calls. In general the cache doesn't care about this difference.

Epic: none

Release note: None