### PR TITLE
backup: fix BackingFileSize

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -660,10 +660,11 @@ func runBackupProcessor(
 								// to store the metadata we need, but there's no actual File
 								// on-disk anywhere yet.
 								metadata: backuppb.BackupManifest_File{
-									Span:        file.Span,
-									Path:        file.Path,
-									EntryCounts: entryCounts,
-									LocalityKV:  destLocalityKV,
+									Span:            file.Span,
+									Path:            file.Path,
+									EntryCounts:     entryCounts,
+									LocalityKV:      destLocalityKV,
+									BackingFileSize: uint64(len(file.SST)),
 								},
 								dataSST:       file.SST,
 								revStart:      resp.StartTime,

--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -125,13 +125,8 @@ func (s *fileSSTSink) flushFile(ctx context.Context) error {
 		log.Warningf(ctx, "failed to close write in fileSSTSink: % #v", pretty.Formatter(err))
 		return errors.Wrap(err, "writing SST")
 	}
-	wroteSize := s.sst.Meta.Size
 	s.outName = ""
 	s.out = nil
-
-	for i := range s.flushedFiles {
-		s.flushedFiles[i].BackingFileSize = wroteSize
-	}
 
 	progDetails := backuppb.BackupManifest_Progress{
 		RevStartTime:   s.flushedRevStart,
@@ -234,6 +229,7 @@ func (s *fileSSTSink) write(ctx context.Context, resp exportedSpan) error {
 		s.flushedFiles[l].StartTime.EqOrdering(resp.metadata.StartTime) {
 		s.flushedFiles[l].Span.EndKey = span.EndKey
 		s.flushedFiles[l].EntryCounts.Add(resp.metadata.EntryCounts)
+		s.flushedFiles[l].BackingFileSize += resp.metadata.BackingFileSize
 		s.stats.spanGrows++
 	} else {
 		f := resp.metadata


### PR DESCRIPTION
The intention of this field was to indicate how many physical bytes in the underlying file correspond to each `File` span. 

Previously we used the physical size of the entire backing file to which the span was flushed, but this obviously was a dramatic over-count when one physical file contained many spans.

Instead, this change switches to using the size of the SST used to transfer the keys from KV to the backup process. This too is imperfect, and likely to overcount somewhat, particularly for large numbers of very small kv responses where the content will compress less and the overhead of the SST footers will be proportionally larger, but is still a much better representation of the physical size of the span content than the entire backing file.

Another option would be to expose `EstimatedSize` on the backing file's writer -- which looks that the sum size of flushed blocks and pending indexes -- and compare the result of calling it before and after flushing the span to the backing file and persist the delta. This however _also_ has imperfections and just using the physical size of the span's transport sst is easier.

Release note: none.
Epic: none.