### PR TITLE
backupccl: replace UDT IDs within routine bodies and views

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_procedures
+++ b/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_procedures
@@ -10,8 +10,11 @@ CREATE TABLE sc1.tbl1(a INT PRIMARY KEY);
 CREATE TYPE sc1.enum1 AS ENUM('Good');
 CREATE SEQUENCE sc1.sq1;
 CREATE PROCEDURE sc1.p1(a sc1.enum1) LANGUAGE PLpgSQL AS $$
+  DECLARE
+    foobar sc1.enum1;
   BEGIN
     SELECT a FROM sc1.tbl1;
+    SELECT 'Good'::sc1.enum1;
     SELECT nextval('sc1.sq1');
   END
 $$;
@@ -66,8 +69,11 @@ SELECT create_statement FROM [SHOW CREATE PROCEDURE sc1.p1]
 CREATE PROCEDURE sc1.p1(IN a db1.sc1.enum1)
 	LANGUAGE plpgsql
 	AS $$
+	DECLARE
+	foobar db1.sc1.enum1;
 	BEGIN
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 	END
 
@@ -107,8 +113,11 @@ SELECT create_statement FROM [SHOW CREATE PROCEDURE sc1.p1]
 CREATE PROCEDURE sc1.p1(IN a db1_new.sc1.enum1)
 	LANGUAGE plpgsql
 	AS $$
+	DECLARE
+	foobar db1_new.sc1.enum1;
 	BEGIN
 	SELECT a FROM db1_new.sc1.tbl1;
+	SELECT 'Good':::db1_new.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 	END
 
@@ -183,8 +192,11 @@ CREATE TABLE sc1.tbl1(a INT PRIMARY KEY);
 CREATE TYPE sc1.enum1 AS ENUM('Good');
 CREATE SEQUENCE sc1.sq1;
 CREATE PROCEDURE sc1.p1(a sc1.enum1) LANGUAGE PLpgSQL AS $$
+  DECLARE
+    foobar sc1.enum1;
   BEGIN
     SELECT a FROM sc1.tbl1;
+    SELECT 'Good'::sc1.enum1;
     SELECT nextval('sc1.sq1');
   END
 $$;
@@ -244,8 +256,11 @@ SELECT create_statement FROM [SHOW CREATE PROCEDURE sc1.p1]
 CREATE PROCEDURE sc1.p1(IN a db1.sc1.enum1)
 	LANGUAGE plpgsql
 	AS $$
+	DECLARE
+	foobar db1.sc1.enum1;
 	BEGIN
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 	END
 
@@ -286,8 +301,11 @@ SELECT create_statement FROM [SHOW CREATE PROCEDURE sc1.p1]
 CREATE PROCEDURE sc1.p1(IN a db1.sc1.enum1)
 	LANGUAGE plpgsql
 	AS $$
+	DECLARE
+	foobar db1.sc1.enum1;
 	BEGIN
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 	END
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_user_defined_functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_user_defined_functions
@@ -12,8 +12,10 @@ CREATE SEQUENCE sc1.sq1;
 CREATE FUNCTION sc1.f1(a sc1.enum1) RETURNS INT LANGUAGE PLpgSQL AS $$
   DECLARE
     x INT := 0;
+    foobar sc1.enum1;
   BEGIN
     SELECT a FROM sc1.tbl1;
+    SELECT 'Good'::sc1.enum1;
     RETURN nextval('sc1.sq1');
   END
 $$;
@@ -78,8 +80,10 @@ CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	AS $$
 	DECLARE
 	x INT8 := 0;
+	foobar db1.sc1.enum1;
 	BEGIN
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	RETURN nextval('sc1.sq1'::REGCLASS);
 	END
 
@@ -121,8 +125,10 @@ CREATE FUNCTION sc1.f1(IN a db1_new.sc1.enum1)
 	AS $$
 	DECLARE
 	x INT8 := 0;
+	foobar db1_new.sc1.enum1;
 	BEGIN
 	SELECT a FROM db1_new.sc1.tbl1;
+	SELECT 'Good':::db1_new.sc1.enum1;
 	RETURN nextval('sc1.sq1'::REGCLASS);
 	END
 
@@ -188,8 +194,10 @@ CREATE SEQUENCE sc1.sq1;
 CREATE FUNCTION sc1.f1(a sc1.enum1) RETURNS INT LANGUAGE PLpgSQL AS $$
   DECLARE
     x INT;
+    foobar sc1.enum1;
   BEGIN
     SELECT a FROM sc1.tbl1;
+    SELECT 'Good'::sc1.enum1;
     SELECT nextval('sc1.sq1') INTO x;
     RETURN x;
   END
@@ -257,8 +265,10 @@ CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	AS $$
 	DECLARE
 	x INT8;
+	foobar db1.sc1.enum1;
 	BEGIN
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS) INTO x;
 	RETURN x;
 	END
@@ -302,8 +312,10 @@ CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	AS $$
 	DECLARE
 	x INT8;
+	foobar db1.sc1.enum1;
 	BEGIN
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS) INTO x;
 	RETURN x;
 	END

--- a/pkg/ccl/backupccl/testdata/backup-restore/procedures
+++ b/pkg/ccl/backupccl/testdata/backup-restore/procedures
@@ -11,6 +11,7 @@ CREATE TYPE sc1.enum1 AS ENUM('Good');
 CREATE SEQUENCE sc1.sq1;
 CREATE PROCEDURE sc1.p1(a sc1.enum1) LANGUAGE SQL AS $$
   SELECT a FROM sc1.tbl1;
+  SELECT 'Good'::sc1.enum1;
   SELECT nextval('sc1.sq1');
 $$;
 CREATE SCHEMA sc2;
@@ -62,6 +63,7 @@ CREATE PROCEDURE sc1.p1(IN a db1.sc1.enum1)
 	LANGUAGE SQL
 	AS $$
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 $$
 
@@ -97,6 +99,7 @@ CREATE PROCEDURE sc1.p1(IN a db1_new.sc1.enum1)
 	LANGUAGE SQL
 	AS $$
 	SELECT a FROM db1_new.sc1.tbl1;
+	SELECT 'Good':::db1_new.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 $$
 
@@ -168,6 +171,7 @@ CREATE TYPE sc1.enum1 AS ENUM('Good');
 CREATE SEQUENCE sc1.sq1;
 CREATE PROCEDURE sc1.p1(a sc1.enum1) LANGUAGE SQL AS $$
   SELECT a FROM sc1.tbl1;
+  SELECT 'Good'::sc1.enum1;
   SELECT nextval('sc1.sq1');
 $$;
 CREATE SCHEMA sc2;
@@ -224,6 +228,7 @@ CREATE PROCEDURE sc1.p1(IN a db1.sc1.enum1)
 	LANGUAGE SQL
 	AS $$
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 $$
 
@@ -260,6 +265,7 @@ CREATE PROCEDURE sc1.p1(IN a db1.sc1.enum1)
 	LANGUAGE SQL
 	AS $$
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 $$
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
@@ -11,6 +11,7 @@ CREATE TYPE sc1.enum1 AS ENUM('Good');
 CREATE SEQUENCE sc1.sq1;
 CREATE FUNCTION sc1.f1(a sc1.enum1) RETURNS INT LANGUAGE SQL AS $$
   SELECT a FROM sc1.tbl1;
+  SELECT 'Good'::sc1.enum1;
   SELECT nextval('sc1.sq1');
 $$;
 CREATE SCHEMA sc2;
@@ -65,6 +66,7 @@ CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	LANGUAGE SQL
 	AS $$
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 $$
 
@@ -100,6 +102,7 @@ CREATE FUNCTION sc1.f1(IN a db1_new.sc1.enum1)
 	LANGUAGE SQL
 	AS $$
 	SELECT a FROM db1_new.sc1.tbl1;
+	SELECT 'Good':::db1_new.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 $$
 
@@ -160,6 +163,7 @@ CREATE TYPE sc1.enum1 AS ENUM('Good');
 CREATE SEQUENCE sc1.sq1;
 CREATE FUNCTION sc1.f1(a sc1.enum1) RETURNS INT LANGUAGE SQL AS $$
   SELECT a FROM sc1.tbl1;
+  SELECT 'Good'::sc1.enum1;
   SELECT nextval('sc1.sq1');
 $$;
 CREATE SCHEMA sc2;
@@ -219,6 +223,7 @@ CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	LANGUAGE SQL
 	AS $$
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 $$
 
@@ -255,6 +260,7 @@ CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	LANGUAGE SQL
 	AS $$
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 $$
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/views
+++ b/pkg/ccl/backupccl/testdata/backup-restore/views
@@ -6,8 +6,9 @@ exec-sql
 CREATE DATABASE db1;
 USE db1;
 CREATE SCHEMA sc1;
+CREATE TYPE sc1.enum1 AS ENUM('Good');
 CREATE TABLE sc1.tbl1(a INT PRIMARY KEY);
-CREATE VIEW sc1.v1 AS SELECT a FROM sc1.tbl1;
+CREATE VIEW sc1.v1 AS SELECT a, 'Good'::sc1.enum1 FROM sc1.tbl1;
 ----
 
 exec-sql
@@ -17,26 +18,36 @@ INSERT INTO sc1.tbl1 VALUES (123);
 query-sql
 SELECT * FROM sc1.v1;
 ----
-123
+123 Good
 
 query-sql
 SHOW CREATE VIEW sc1.v1;
 ----
 sc1.v1 CREATE VIEW sc1.v1 (
-	a
-) AS SELECT a FROM db1.sc1.tbl1
+	a,
+	enum1
+) AS SELECT a, 'Good':::db1.sc1.enum1 FROM db1.sc1.tbl1
 
 exec-sql
 BACKUP DATABASE db1 INTO 'nodelocal://1/test/'
 ----
 
 exec-sql
+DROP DATABASE db1
+----
+
+exec-sql
 RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://1/test/' WITH new_db_name = db1_new
+----
+
+exec-sql
+USE db1_new
 ----
 
 query-sql
 SHOW CREATE VIEW db1_new.sc1.v1;
 ----
 db1_new.sc1.v1 CREATE VIEW sc1.v1 (
-	a
-) AS SELECT a FROM db1_new.sc1.tbl1
+	a,
+	enum1
+) AS SELECT a, 'Good':::db1_new.sc1.enum1 FROM db1_new.sc1.tbl1

--- a/pkg/sql/catalog/rewrite/rewrite.go
+++ b/pkg/sql/catalog/rewrite/rewrite.go
@@ -117,6 +117,10 @@ func TableDescs(
 			if err != nil {
 				return err
 			}
+			viewQuery, err = rewriteTypesInView(viewQuery, descriptorRewrites)
+			if err != nil {
+				return err
+			}
 			table.ViewQuery = viewQuery
 		}
 
@@ -375,8 +379,62 @@ func rewriteTypesInExpr(expr string, rewrites jobspb.DescRewriteMap) (string, er
 	if err != nil {
 		return "", err
 	}
+	ctx := makeTypeReplaceFmtCtx(rewrites)
+	ctx.FormatNode(parsed)
+	return ctx.CloseAndGetString(), nil
+}
 
-	ctx := tree.NewFmtCtx(
+// rewriteTypesInView rewrites all explicit ID type references in the input view
+// query string according to rewrites.
+func rewriteTypesInView(viewQuery string, rewrites jobspb.DescRewriteMap) (string, error) {
+	stmt, err := parser.ParseOne(viewQuery)
+	if err != nil {
+		return "", err
+	}
+	ctx := makeTypeReplaceFmtCtx(rewrites)
+	ctx.FormatNode(stmt.AST)
+	return ctx.CloseAndGetString(), nil
+}
+
+func rewriteTypesInRoutine(
+	fnBody string, rewrites jobspb.DescRewriteMap, lang catpb.Function_Language,
+) (string, error) {
+	switch lang {
+	case catpb.Function_SQL:
+		fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
+		stmts, err := parser.Parse(fnBody)
+		if err != nil {
+			return "", err
+		}
+		for i, stmt := range stmts {
+			if i > 0 {
+				fmtCtx.WriteString("\n")
+			}
+			typeReplaceCtx := makeTypeReplaceFmtCtx(rewrites)
+			typeReplaceCtx.FormatNode(stmt.AST)
+			fmtCtx.WriteString(typeReplaceCtx.CloseAndGetString())
+			fmtCtx.WriteString(";")
+		}
+		return fmtCtx.CloseAndGetString(), nil
+
+	case catpb.Function_PLPGSQL:
+		stmt, err := plpgsqlparser.Parse(fnBody)
+		if err != nil {
+			return "", err
+		}
+		typeReplaceCtx := makeTypeReplaceFmtCtx(rewrites)
+		typeReplaceCtx.FormatNode(stmt.AST)
+		return typeReplaceCtx.CloseAndGetString(), nil
+
+	default:
+		return "", errors.AssertionFailedf("unexpected function language: %v", lang)
+	}
+}
+
+// makeTypeReplaceFmtCtx returns a FmtCtx which rewrites explicit ID references
+// according to the rewrites map.
+func makeTypeReplaceFmtCtx(rewrites jobspb.DescRewriteMap) *tree.FmtCtx {
+	return tree.NewFmtCtx(
 		tree.FmtSerializable,
 		tree.FmtIndexedTypeFormat(func(ctx *tree.FmtCtx, ref *tree.OIDTypeReference) {
 			newRef := ref
@@ -387,8 +445,6 @@ func rewriteTypesInExpr(expr string, rewrites jobspb.DescRewriteMap) (string, er
 			ctx.WriteString(newRef.SQLString())
 		}),
 	)
-	ctx.FormatNode(parsed)
-	return ctx.CloseAndGetString(), nil
 }
 
 // rewriteSequencesInExpr rewrites all sequence IDs in the input expression
@@ -959,6 +1015,10 @@ func FunctionDescs(
 			fnBody = dbNameReplaced
 		}
 		fnBody, err := rewriteSequencesInFunction(fnBody, descriptorRewrites, fnDesc.Lang)
+		if err != nil {
+			return err
+		}
+		fnBody, err = rewriteTypesInRoutine(fnBody, descriptorRewrites, fnDesc.Lang)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
  During a database RESTORE, it is necessary to replace descriptor IDs
  from the old database with those from the new. Previously, we forgot
  to do this rewrite for UDT IDs in routine bodies and views. This would
  prevent using a database RESTORE with a user-defined function, stored
  procedure, or view, that referenced a user-defined type. This patch
  adds the needed rewrite logic and expands existing tests.

  Fixes #116653

  Release note (bug fix): Fixed a bug that prevented database RESTORE when
  the database contained a view or routine that referenced a user-defined
  type in the body string. For views, this bug was introduced in v20.2, when
  UDTs were introduced. For routines, this bug was introduced in v22.2, when
  UDFs were introduced.