### PR TITLE
util/interval/generic: stop lying about live memory

### DIFF
--- a/pkg/kv/kvserver/concurrency/keylocks_interval_btree.go
+++ b/pkg/kv/kvserver/concurrency/keylocks_interval_btree.go
@@ -101,7 +101,6 @@ func upperBound(c *keyLocks) keyBound {
 type node struct {
 	ref   int32
 	count int16
-	leaf  bool
 
 	// These fields form a keyBound, but by inlining them into node we can avoid
 	// the extra word that would be needed to pad out maxInc if it were part of
@@ -109,7 +108,10 @@ type node struct {
 	maxInc bool
 	maxKey []byte
 
-	items    [maxItems]*keyLocks
+	items [maxItems]*keyLocks
+
+	// The children array pointer is only populated for interior nodes; it is nil
+	// for leaf nodes.
 	children *childrenArray
 }
 
@@ -135,7 +137,6 @@ var nodePool = sync.Pool{
 
 func newLeafNode() *node {
 	n := leafPool.Get().(*node)
-	n.leaf = true
 	n.ref = 1
 	return n
 }
@@ -172,6 +173,11 @@ func mut(n **node) *node {
 	return *n
 }
 
+// leaf returns true if this is a leaf node.
+func (n *node) leaf() bool {
+	return n.children == nil
+}
+
 // max returns the maximum keyBound in the subtree rooted at this node.
 func (n *node) max() keyBound {
 	return keyBound{
@@ -199,7 +205,7 @@ func (n *node) decRef(recursive bool) {
 		return
 	}
 	// Clear and release node into memory pool.
-	if n.leaf {
+	if n.leaf() {
 		*n = node{}
 		leafPool.Put(n)
 	} else {
@@ -218,7 +224,7 @@ func (n *node) decRef(recursive bool) {
 // clone creates a clone of the receiver with a single reference count.
 func (n *node) clone() *node {
 	var c *node
-	if n.leaf {
+	if n.leaf() {
 		c = newLeafNode()
 	} else {
 		c = newNode()
@@ -229,7 +235,7 @@ func (n *node) clone() *node {
 	c.maxKey = n.maxKey
 	c.maxInc = n.maxInc
 	c.items = n.items
-	if !c.leaf {
+	if !c.leaf() {
 		// Copy children and increase each refcount.
 		*c.children = *n.children
 		for i := int16(0); i <= c.count; i++ {
@@ -242,12 +248,12 @@ func (n *node) clone() *node {
 func (n *node) insertAt(index int, item *keyLocks, nd *node) {
 	if index < int(n.count) {
 		copy(n.items[index+1:n.count+1], n.items[index:n.count])
-		if !n.leaf {
+		if !n.leaf() {
 			copy(n.children[index+2:n.count+2], n.children[index+1:n.count+1])
 		}
 	}
 	n.items[index] = item
-	if !n.leaf {
+	if !n.leaf() {
 		n.children[index+1] = nd
 	}
 	n.count++
@@ -255,14 +261,14 @@ func (n *node) insertAt(index int, item *keyLocks, nd *node) {
 
 func (n *node) pushBack(item *keyLocks, nd *node) {
 	n.items[n.count] = item
-	if !n.leaf {
+	if !n.leaf() {
 		n.children[n.count+1] = nd
 	}
 	n.count++
 }
 
 func (n *node) pushFront(item *keyLocks, nd *node) {
-	if !n.leaf {
+	if !n.leaf() {
 		copy(n.children[1:n.count+2], n.children[:n.count+1])
 		n.children[0] = nd
 	}
@@ -275,7 +281,7 @@ func (n *node) pushFront(item *keyLocks, nd *node) {
 // back.
 func (n *node) removeAt(index int) (*keyLocks, *node) {
 	var child *node
-	if !n.leaf {
+	if !n.leaf() {
 		child = n.children[index+1]
 		copy(n.children[index+1:n.count], n.children[index+2:n.count+1])
 		n.children[n.count] = nil
@@ -292,7 +298,7 @@ func (n *node) popBack() (*keyLocks, *node) {
 	n.count--
 	out := n.items[n.count]
 	n.items[n.count] = nilT
-	if n.leaf {
+	if n.leaf() {
 		return out, nil
 	}
 	child := n.children[n.count+1]
@@ -304,7 +310,7 @@ func (n *node) popBack() (*keyLocks, *node) {
 func (n *node) popFront() (*keyLocks, *node) {
 	n.count--
 	var child *node
-	if !n.leaf {
+	if !n.leaf() {
 		child = n.children[0]
 		copy(n.children[:n.count+1], n.children[1:n.count+2])
 		n.children[n.count+1] = nil
@@ -361,7 +367,7 @@ func (n *node) find(item *keyLocks) (index int, found bool) {
 func (n *node) split(i int) (*keyLocks, *node) {
 	out := n.items[i]
 	var next *node
-	if n.leaf {
+	if n.leaf() {
 		next = newLeafNode()
 	} else {
 		next = newNode()
@@ -371,7 +377,7 @@ func (n *node) split(i int) (*keyLocks, *node) {
 	for j := int16(i); j < n.count; j++ {
 		n.items[j] = nilT
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		copy(next.children[:], n.children[i+1:n.count+1])
 		for j := int16(i + 1); j <= n.count; j++ {
 			n.children[j] = nil
@@ -401,7 +407,7 @@ func (n *node) insert(item *keyLocks) (replaced, newBound bool) {
 		n.items[i] = item
 		return true, false
 	}
-	if n.leaf {
+	if n.leaf() {
 		n.insertAt(i, item, nil)
 		return false, n.adjustUpperBoundOnInsertion(item, nil)
 	}
@@ -429,7 +435,7 @@ func (n *node) insert(item *keyLocks) (replaced, newBound bool) {
 // removeMax removes and returns the maximum item from the subtree rooted at
 // this node.
 func (n *node) removeMax() *keyLocks {
-	if n.leaf {
+	if n.leaf() {
 		n.count--
 		out := n.items[n.count]
 		n.items[n.count] = nilT
@@ -454,7 +460,7 @@ func (n *node) removeMax() *keyLocks {
 // the node's upper bound changes.
 func (n *node) remove(item *keyLocks) (out *keyLocks, newBound bool) {
 	i, found := n.find(item)
-	if n.leaf {
+	if n.leaf() {
 		if found {
 			out, _ = n.removeAt(i)
 			return out, n.adjustUpperBoundOnRemoval(out, nil)
@@ -595,7 +601,7 @@ func (n *node) rebalanceOrMerge(i int) {
 		mergeLa, mergeChild := n.removeAt(i)
 		child.items[child.count] = mergeLa
 		copy(child.items[child.count+1:], mergeChild.items[:mergeChild.count])
-		if !child.leaf {
+		if !child.leaf() {
 			copy(child.children[child.count+1:], mergeChild.children[:mergeChild.count+1])
 		}
 		child.count += mergeChild.count + 1
@@ -615,7 +621,7 @@ func (n *node) findUpperBound() keyBound {
 			max = up
 		}
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			up := n.children[i].max()
 			if max.compare(up) < 0 {
@@ -723,7 +729,7 @@ func (t *btree) Delete(item *keyLocks) {
 	}
 	if t.root.count == 0 {
 		old := t.root
-		if t.root.leaf {
+		if t.root.leaf() {
 			t.root = nil
 		} else {
 			t.root = t.root.children[0]
@@ -766,7 +772,7 @@ func (t *btree) Height() int {
 	}
 	h := 1
 	n := t.root
-	for !n.leaf {
+	for !n.leaf() {
 		n = n.children[0]
 		h++
 	}
@@ -790,7 +796,7 @@ func (t *btree) String() string {
 }
 
 func (n *node) writeString(b *strings.Builder) {
-	if n.leaf {
+	if n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			if i != 0 {
 				b.WriteString(",")
@@ -907,7 +913,7 @@ func (i *iterator) SeekGE(item *keyLocks) {
 		if found {
 			return
 		}
-		if i.n.leaf {
+		if i.n.leaf() {
 			if i.pos == i.n.count {
 				i.Next()
 			}
@@ -926,7 +932,7 @@ func (i *iterator) SeekLT(item *keyLocks) {
 	for {
 		pos, found := i.n.find(item)
 		i.pos = int16(pos)
-		if found || i.n.leaf {
+		if found || i.n.leaf() {
 			i.Prev()
 			return
 		}
@@ -940,7 +946,7 @@ func (i *iterator) First() {
 	if i.n == nil {
 		return
 	}
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, 0)
 	}
 	i.pos = 0
@@ -952,7 +958,7 @@ func (i *iterator) Last() {
 	if i.n == nil {
 		return
 	}
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, i.n.count)
 	}
 	i.pos = i.n.count - 1
@@ -965,7 +971,7 @@ func (i *iterator) Next() {
 		return
 	}
 
-	if i.n.leaf {
+	if i.n.leaf() {
 		i.pos++
 		if i.pos < i.n.count {
 			return
@@ -977,7 +983,7 @@ func (i *iterator) Next() {
 	}
 
 	i.descend(i.n, i.pos+1)
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, 0)
 	}
 	i.pos = 0
@@ -990,7 +996,7 @@ func (i *iterator) Prev() {
 		return
 	}
 
-	if i.n.leaf {
+	if i.n.leaf() {
 		i.pos--
 		if i.pos >= 0 {
 			return
@@ -1003,7 +1009,7 @@ func (i *iterator) Prev() {
 	}
 
 	i.descend(i.n, i.pos)
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, i.n.count)
 	}
 	i.pos = i.n.count - 1
@@ -1122,7 +1128,7 @@ func (i *iterator) findNextOverlap(item *keyLocks) {
 		if i.pos > i.n.count {
 			// Iterate up tree.
 			i.ascend()
-		} else if !i.n.leaf {
+		} else if !i.n.leaf() {
 			// Iterate down tree.
 			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
 				par := i.n

--- a/pkg/kv/kvserver/concurrency/keylocks_interval_btree.go
+++ b/pkg/kv/kvserver/concurrency/keylocks_interval_btree.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"unsafe"
 )
 
 // nilT is a nil instance of the Template type.
@@ -99,42 +98,37 @@ func upperBound(c *keyLocks) keyBound {
 	return keyBound{key: c.Key(), inc: true}
 }
 
-type leafNode struct {
-	ref   int32
-	count int16
-	leaf  bool
-	max   keyBound
-	items [maxItems]*keyLocks
-}
-
 type node struct {
-	leafNode
-	children [maxItems + 1]*node
+	ref      int32
+	count    int16
+	leaf     bool
+	max      keyBound
+	items    [maxItems]*keyLocks
+	children *childrenArray
 }
 
-//go:nocheckptr casts a ptr to a smaller struct to a ptr to a larger struct.
-func leafToNode(ln *leafNode) *node {
-	return (*node)(unsafe.Pointer(ln))
-}
-
-func nodeToLeaf(n *node) *leafNode {
-	return (*leafNode)(unsafe.Pointer(n))
-}
+type childrenArray = [maxItems + 1]*node
 
 var leafPool = sync.Pool{
-	New: func() interface{} {
-		return new(leafNode)
-	},
-}
-
-var nodePool = sync.Pool{
 	New: func() interface{} {
 		return new(node)
 	},
 }
 
+var nodePool = sync.Pool{
+	New: func() interface{} {
+		type interiorNode struct {
+			node
+			children childrenArray
+		}
+		n := new(interiorNode)
+		n.node.children = &n.children
+		return &n.node
+	},
+}
+
 func newLeafNode() *node {
-	n := leafToNode(leafPool.Get().(*leafNode))
+	n := leafPool.Get().(*node)
 	n.leaf = true
 	n.ref = 1
 	return n
@@ -186,9 +180,8 @@ func (n *node) decRef(recursive bool) {
 	}
 	// Clear and release node into memory pool.
 	if n.leaf {
-		ln := nodeToLeaf(n)
-		*ln = leafNode{}
-		leafPool.Put(ln)
+		*n = node{}
+		leafPool.Put(n)
 	} else {
 		// Release child references first, if requested.
 		if recursive {
@@ -196,7 +189,8 @@ func (n *node) decRef(recursive bool) {
 				n.children[i].decRef(true /* recursive */)
 			}
 		}
-		*n = node{}
+		*n = node{children: n.children}
+		*n.children = childrenArray{}
 		nodePool.Put(n)
 	}
 }
@@ -216,7 +210,7 @@ func (n *node) clone() *node {
 	c.items = n.items
 	if !c.leaf {
 		// Copy children and increase each refcount.
-		c.children = n.children
+		*c.children = *n.children
 		for i := int16(0); i <= c.count; i++ {
 			c.children[i].incRef()
 		}

--- a/pkg/kv/kvserver/concurrency/keylocks_interval_btree.go
+++ b/pkg/kv/kvserver/concurrency/keylocks_interval_btree.go
@@ -99,10 +99,16 @@ func upperBound(c *keyLocks) keyBound {
 }
 
 type node struct {
-	ref      int32
-	count    int16
-	leaf     bool
-	max      keyBound
+	ref   int32
+	count int16
+	leaf  bool
+
+	// These fields form a keyBound, but by inlining them into node we can avoid
+	// the extra word that would be needed to pad out maxInc if it were part of
+	// its own struct.
+	maxInc bool
+	maxKey []byte
+
 	items    [maxItems]*keyLocks
 	children *childrenArray
 }
@@ -166,6 +172,20 @@ func mut(n **node) *node {
 	return *n
 }
 
+// max returns the maximum keyBound in the subtree rooted at this node.
+func (n *node) max() keyBound {
+	return keyBound{
+		key: n.maxKey,
+		inc: n.maxInc,
+	}
+}
+
+// setMax sets the maximum keyBound for the subtree rooted at this node.
+func (n *node) setMax(k keyBound) {
+	n.maxKey = k.key
+	n.maxInc = k.inc
+}
+
 // incRef acquires a reference to the node.
 func (n *node) incRef() {
 	atomic.AddInt32(&n.ref, 1)
@@ -206,7 +226,8 @@ func (n *node) clone() *node {
 	// NB: copy field-by-field without touching n.ref to avoid
 	// triggering the race detector and looking like a data race.
 	c.count = n.count
-	c.max = n.max
+	c.maxKey = n.maxKey
+	c.maxInc = n.maxInc
 	c.items = n.items
 	if !c.leaf {
 		// Copy children and increase each refcount.
@@ -358,12 +379,14 @@ func (n *node) split(i int) (*keyLocks, *node) {
 	}
 	n.count = int16(i)
 
-	next.max = next.findUpperBound()
-	if n.max.compare(next.max) != 0 && n.max.compare(upperBound(out)) != 0 {
+	nextMax := next.findUpperBound()
+	next.setMax(nextMax)
+	nMax := n.max()
+	if nMax.compare(nextMax) != 0 && nMax.compare(upperBound(out)) != 0 {
 		// If upper bound wasn't from new node or item
 		// at index i, it must still be from old node.
 	} else {
-		n.max = n.findUpperBound()
+		n.setMax(n.findUpperBound())
 	}
 	return out, next
 }
@@ -594,7 +617,7 @@ func (n *node) findUpperBound() keyBound {
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
-			up := n.children[i].max
+			up := n.children[i].max()
 			if max.compare(up) < 0 {
 				max = up
 			}
@@ -609,12 +632,12 @@ func (n *node) findUpperBound() keyBound {
 func (n *node) adjustUpperBoundOnInsertion(item *keyLocks, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
-		if up.compare(child.max) < 0 {
-			up = child.max
+		if childMax := child.max(); up.compare(childMax) < 0 {
+			up = childMax
 		}
 	}
-	if n.max.compare(up) < 0 {
-		n.max = up
+	if n.max().compare(up) < 0 {
+		n.setMax(up)
 		return true
 	}
 	return false
@@ -626,14 +649,15 @@ func (n *node) adjustUpperBoundOnInsertion(item *keyLocks, child *node) bool {
 func (n *node) adjustUpperBoundOnRemoval(item *keyLocks, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
-		if up.compare(child.max) < 0 {
-			up = child.max
+		if childMax := child.max(); up.compare(childMax) < 0 {
+			up = childMax
 		}
 	}
-	if n.max.compare(up) == 0 {
+	if n.max().compare(up) == 0 {
 		// up was previous upper bound of n.
-		n.max = n.findUpperBound()
-		return n.max.compare(up) != 0
+		max := n.findUpperBound()
+		n.setMax(max)
+		return max.compare(up) != 0
 	}
 	return false
 }
@@ -720,7 +744,7 @@ func (t *btree) Set(item *keyLocks) {
 		newRoot.items[0] = splitLa
 		newRoot.children[0] = t.root
 		newRoot.children[1] = splitNode
-		newRoot.max = newRoot.findUpperBound()
+		newRoot.setMax(newRoot.findUpperBound())
 		t.root = newRoot
 	}
 	if replaced, _ := mut(&t.root).insert(item); !replaced {
@@ -1100,7 +1124,7 @@ func (i *iterator) findNextOverlap(item *keyLocks) {
 			i.ascend()
 		} else if !i.n.leaf {
 			// Iterate down tree.
-			if i.o.constrMinReached || i.n.children[i.pos].max.contains(item) {
+			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
 				par := i.n
 				pos := i.pos
 				i.descend(par, pos)

--- a/pkg/kv/kvserver/concurrency/keylocks_interval_btree_test.go
+++ b/pkg/kv/kvserver/concurrency/keylocks_interval_btree_test.go
@@ -124,14 +124,14 @@ func (t *btree) isUpperBoundCorrect(tt *testing.T) {
 }
 
 func (n *node) isUpperBoundCorrect(t *testing.T) {
-	require.Equal(t, 0, n.findUpperBound().compare(n.max))
+	require.Equal(t, 0, n.findUpperBound().compare(n.max()))
 	for i := int16(1); i < n.count; i++ {
-		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max), 0)
+		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max()), 0)
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
 			child := n.children[i]
-			require.LessOrEqual(t, child.max.compare(n.max), 0)
+			require.LessOrEqual(t, child.max().compare(n.max()), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {

--- a/pkg/kv/kvserver/concurrency/keylocks_interval_btree_test.go
+++ b/pkg/kv/kvserver/concurrency/keylocks_interval_btree_test.go
@@ -59,7 +59,7 @@ func (t *btree) verifyLeafSameDepth(tt *testing.T) {
 }
 
 func (n *node) verifyDepthEqualToHeight(t *testing.T, depth, height int) {
-	if n.leaf {
+	if n.leaf() {
 		require.Equal(t, height, depth, "all leaves should have the same depth as the tree height")
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -83,7 +83,7 @@ func (n *node) verifyCountAllowed(t *testing.T, root bool) {
 			require.Nil(t, item, "latch above count")
 		}
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i, child := range n.children {
 			if i <= int(n.count) {
 				require.NotNil(t, child, "node below count")
@@ -105,7 +105,7 @@ func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
 		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
@@ -128,7 +128,7 @@ func (n *node) isUpperBoundCorrect(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
 		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max()), 0)
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			child := n.children[i]
 			require.LessOrEqual(t, child.max().compare(n.max()), 0)
@@ -140,7 +140,7 @@ func (n *node) isUpperBoundCorrect(t *testing.T) {
 }
 
 func (n *node) recurse(f func(child *node, pos int16)) {
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			f(n.children[i], i)
 		}

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
@@ -99,10 +99,16 @@ func upperBound(c *latch) keyBound {
 }
 
 type node struct {
-	ref      int32
-	count    int16
-	leaf     bool
-	max      keyBound
+	ref   int32
+	count int16
+	leaf  bool
+
+	// These fields form a keyBound, but by inlining them into node we can avoid
+	// the extra word that would be needed to pad out maxInc if it were part of
+	// its own struct.
+	maxInc bool
+	maxKey []byte
+
 	items    [maxItems]*latch
 	children *childrenArray
 }
@@ -166,6 +172,20 @@ func mut(n **node) *node {
 	return *n
 }
 
+// max returns the maximum keyBound in the subtree rooted at this node.
+func (n *node) max() keyBound {
+	return keyBound{
+		key: n.maxKey,
+		inc: n.maxInc,
+	}
+}
+
+// setMax sets the maximum keyBound for the subtree rooted at this node.
+func (n *node) setMax(k keyBound) {
+	n.maxKey = k.key
+	n.maxInc = k.inc
+}
+
 // incRef acquires a reference to the node.
 func (n *node) incRef() {
 	atomic.AddInt32(&n.ref, 1)
@@ -206,7 +226,8 @@ func (n *node) clone() *node {
 	// NB: copy field-by-field without touching n.ref to avoid
 	// triggering the race detector and looking like a data race.
 	c.count = n.count
-	c.max = n.max
+	c.maxKey = n.maxKey
+	c.maxInc = n.maxInc
 	c.items = n.items
 	if !c.leaf {
 		// Copy children and increase each refcount.
@@ -358,12 +379,14 @@ func (n *node) split(i int) (*latch, *node) {
 	}
 	n.count = int16(i)
 
-	next.max = next.findUpperBound()
-	if n.max.compare(next.max) != 0 && n.max.compare(upperBound(out)) != 0 {
+	nextMax := next.findUpperBound()
+	next.setMax(nextMax)
+	nMax := n.max()
+	if nMax.compare(nextMax) != 0 && nMax.compare(upperBound(out)) != 0 {
 		// If upper bound wasn't from new node or item
 		// at index i, it must still be from old node.
 	} else {
-		n.max = n.findUpperBound()
+		n.setMax(n.findUpperBound())
 	}
 	return out, next
 }
@@ -594,7 +617,7 @@ func (n *node) findUpperBound() keyBound {
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
-			up := n.children[i].max
+			up := n.children[i].max()
 			if max.compare(up) < 0 {
 				max = up
 			}
@@ -609,12 +632,12 @@ func (n *node) findUpperBound() keyBound {
 func (n *node) adjustUpperBoundOnInsertion(item *latch, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
-		if up.compare(child.max) < 0 {
-			up = child.max
+		if childMax := child.max(); up.compare(childMax) < 0 {
+			up = childMax
 		}
 	}
-	if n.max.compare(up) < 0 {
-		n.max = up
+	if n.max().compare(up) < 0 {
+		n.setMax(up)
 		return true
 	}
 	return false
@@ -626,14 +649,15 @@ func (n *node) adjustUpperBoundOnInsertion(item *latch, child *node) bool {
 func (n *node) adjustUpperBoundOnRemoval(item *latch, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
-		if up.compare(child.max) < 0 {
-			up = child.max
+		if childMax := child.max(); up.compare(childMax) < 0 {
+			up = childMax
 		}
 	}
-	if n.max.compare(up) == 0 {
+	if n.max().compare(up) == 0 {
 		// up was previous upper bound of n.
-		n.max = n.findUpperBound()
-		return n.max.compare(up) != 0
+		max := n.findUpperBound()
+		n.setMax(max)
+		return max.compare(up) != 0
 	}
 	return false
 }
@@ -720,7 +744,7 @@ func (t *btree) Set(item *latch) {
 		newRoot.items[0] = splitLa
 		newRoot.children[0] = t.root
 		newRoot.children[1] = splitNode
-		newRoot.max = newRoot.findUpperBound()
+		newRoot.setMax(newRoot.findUpperBound())
 		t.root = newRoot
 	}
 	if replaced, _ := mut(&t.root).insert(item); !replaced {
@@ -1100,7 +1124,7 @@ func (i *iterator) findNextOverlap(item *latch) {
 			i.ascend()
 		} else if !i.n.leaf {
 			// Iterate down tree.
-			if i.o.constrMinReached || i.n.children[i.pos].max.contains(item) {
+			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
 				par := i.n
 				pos := i.pos
 				i.descend(par, pos)

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
@@ -101,7 +101,6 @@ func upperBound(c *latch) keyBound {
 type node struct {
 	ref   int32
 	count int16
-	leaf  bool
 
 	// These fields form a keyBound, but by inlining them into node we can avoid
 	// the extra word that would be needed to pad out maxInc if it were part of
@@ -109,7 +108,10 @@ type node struct {
 	maxInc bool
 	maxKey []byte
 
-	items    [maxItems]*latch
+	items [maxItems]*latch
+
+	// The children array pointer is only populated for interior nodes; it is nil
+	// for leaf nodes.
 	children *childrenArray
 }
 
@@ -135,7 +137,6 @@ var nodePool = sync.Pool{
 
 func newLeafNode() *node {
 	n := leafPool.Get().(*node)
-	n.leaf = true
 	n.ref = 1
 	return n
 }
@@ -172,6 +173,11 @@ func mut(n **node) *node {
 	return *n
 }
 
+// leaf returns true if this is a leaf node.
+func (n *node) leaf() bool {
+	return n.children == nil
+}
+
 // max returns the maximum keyBound in the subtree rooted at this node.
 func (n *node) max() keyBound {
 	return keyBound{
@@ -199,7 +205,7 @@ func (n *node) decRef(recursive bool) {
 		return
 	}
 	// Clear and release node into memory pool.
-	if n.leaf {
+	if n.leaf() {
 		*n = node{}
 		leafPool.Put(n)
 	} else {
@@ -218,7 +224,7 @@ func (n *node) decRef(recursive bool) {
 // clone creates a clone of the receiver with a single reference count.
 func (n *node) clone() *node {
 	var c *node
-	if n.leaf {
+	if n.leaf() {
 		c = newLeafNode()
 	} else {
 		c = newNode()
@@ -229,7 +235,7 @@ func (n *node) clone() *node {
 	c.maxKey = n.maxKey
 	c.maxInc = n.maxInc
 	c.items = n.items
-	if !c.leaf {
+	if !c.leaf() {
 		// Copy children and increase each refcount.
 		*c.children = *n.children
 		for i := int16(0); i <= c.count; i++ {
@@ -242,12 +248,12 @@ func (n *node) clone() *node {
 func (n *node) insertAt(index int, item *latch, nd *node) {
 	if index < int(n.count) {
 		copy(n.items[index+1:n.count+1], n.items[index:n.count])
-		if !n.leaf {
+		if !n.leaf() {
 			copy(n.children[index+2:n.count+2], n.children[index+1:n.count+1])
 		}
 	}
 	n.items[index] = item
-	if !n.leaf {
+	if !n.leaf() {
 		n.children[index+1] = nd
 	}
 	n.count++
@@ -255,14 +261,14 @@ func (n *node) insertAt(index int, item *latch, nd *node) {
 
 func (n *node) pushBack(item *latch, nd *node) {
 	n.items[n.count] = item
-	if !n.leaf {
+	if !n.leaf() {
 		n.children[n.count+1] = nd
 	}
 	n.count++
 }
 
 func (n *node) pushFront(item *latch, nd *node) {
-	if !n.leaf {
+	if !n.leaf() {
 		copy(n.children[1:n.count+2], n.children[:n.count+1])
 		n.children[0] = nd
 	}
@@ -275,7 +281,7 @@ func (n *node) pushFront(item *latch, nd *node) {
 // back.
 func (n *node) removeAt(index int) (*latch, *node) {
 	var child *node
-	if !n.leaf {
+	if !n.leaf() {
 		child = n.children[index+1]
 		copy(n.children[index+1:n.count], n.children[index+2:n.count+1])
 		n.children[n.count] = nil
@@ -292,7 +298,7 @@ func (n *node) popBack() (*latch, *node) {
 	n.count--
 	out := n.items[n.count]
 	n.items[n.count] = nilT
-	if n.leaf {
+	if n.leaf() {
 		return out, nil
 	}
 	child := n.children[n.count+1]
@@ -304,7 +310,7 @@ func (n *node) popBack() (*latch, *node) {
 func (n *node) popFront() (*latch, *node) {
 	n.count--
 	var child *node
-	if !n.leaf {
+	if !n.leaf() {
 		child = n.children[0]
 		copy(n.children[:n.count+1], n.children[1:n.count+2])
 		n.children[n.count+1] = nil
@@ -361,7 +367,7 @@ func (n *node) find(item *latch) (index int, found bool) {
 func (n *node) split(i int) (*latch, *node) {
 	out := n.items[i]
 	var next *node
-	if n.leaf {
+	if n.leaf() {
 		next = newLeafNode()
 	} else {
 		next = newNode()
@@ -371,7 +377,7 @@ func (n *node) split(i int) (*latch, *node) {
 	for j := int16(i); j < n.count; j++ {
 		n.items[j] = nilT
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		copy(next.children[:], n.children[i+1:n.count+1])
 		for j := int16(i + 1); j <= n.count; j++ {
 			n.children[j] = nil
@@ -401,7 +407,7 @@ func (n *node) insert(item *latch) (replaced, newBound bool) {
 		n.items[i] = item
 		return true, false
 	}
-	if n.leaf {
+	if n.leaf() {
 		n.insertAt(i, item, nil)
 		return false, n.adjustUpperBoundOnInsertion(item, nil)
 	}
@@ -429,7 +435,7 @@ func (n *node) insert(item *latch) (replaced, newBound bool) {
 // removeMax removes and returns the maximum item from the subtree rooted at
 // this node.
 func (n *node) removeMax() *latch {
-	if n.leaf {
+	if n.leaf() {
 		n.count--
 		out := n.items[n.count]
 		n.items[n.count] = nilT
@@ -454,7 +460,7 @@ func (n *node) removeMax() *latch {
 // the node's upper bound changes.
 func (n *node) remove(item *latch) (out *latch, newBound bool) {
 	i, found := n.find(item)
-	if n.leaf {
+	if n.leaf() {
 		if found {
 			out, _ = n.removeAt(i)
 			return out, n.adjustUpperBoundOnRemoval(out, nil)
@@ -595,7 +601,7 @@ func (n *node) rebalanceOrMerge(i int) {
 		mergeLa, mergeChild := n.removeAt(i)
 		child.items[child.count] = mergeLa
 		copy(child.items[child.count+1:], mergeChild.items[:mergeChild.count])
-		if !child.leaf {
+		if !child.leaf() {
 			copy(child.children[child.count+1:], mergeChild.children[:mergeChild.count+1])
 		}
 		child.count += mergeChild.count + 1
@@ -615,7 +621,7 @@ func (n *node) findUpperBound() keyBound {
 			max = up
 		}
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			up := n.children[i].max()
 			if max.compare(up) < 0 {
@@ -723,7 +729,7 @@ func (t *btree) Delete(item *latch) {
 	}
 	if t.root.count == 0 {
 		old := t.root
-		if t.root.leaf {
+		if t.root.leaf() {
 			t.root = nil
 		} else {
 			t.root = t.root.children[0]
@@ -766,7 +772,7 @@ func (t *btree) Height() int {
 	}
 	h := 1
 	n := t.root
-	for !n.leaf {
+	for !n.leaf() {
 		n = n.children[0]
 		h++
 	}
@@ -790,7 +796,7 @@ func (t *btree) String() string {
 }
 
 func (n *node) writeString(b *strings.Builder) {
-	if n.leaf {
+	if n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			if i != 0 {
 				b.WriteString(",")
@@ -907,7 +913,7 @@ func (i *iterator) SeekGE(item *latch) {
 		if found {
 			return
 		}
-		if i.n.leaf {
+		if i.n.leaf() {
 			if i.pos == i.n.count {
 				i.Next()
 			}
@@ -926,7 +932,7 @@ func (i *iterator) SeekLT(item *latch) {
 	for {
 		pos, found := i.n.find(item)
 		i.pos = int16(pos)
-		if found || i.n.leaf {
+		if found || i.n.leaf() {
 			i.Prev()
 			return
 		}
@@ -940,7 +946,7 @@ func (i *iterator) First() {
 	if i.n == nil {
 		return
 	}
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, 0)
 	}
 	i.pos = 0
@@ -952,7 +958,7 @@ func (i *iterator) Last() {
 	if i.n == nil {
 		return
 	}
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, i.n.count)
 	}
 	i.pos = i.n.count - 1
@@ -965,7 +971,7 @@ func (i *iterator) Next() {
 		return
 	}
 
-	if i.n.leaf {
+	if i.n.leaf() {
 		i.pos++
 		if i.pos < i.n.count {
 			return
@@ -977,7 +983,7 @@ func (i *iterator) Next() {
 	}
 
 	i.descend(i.n, i.pos+1)
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, 0)
 	}
 	i.pos = 0
@@ -990,7 +996,7 @@ func (i *iterator) Prev() {
 		return
 	}
 
-	if i.n.leaf {
+	if i.n.leaf() {
 		i.pos--
 		if i.pos >= 0 {
 			return
@@ -1003,7 +1009,7 @@ func (i *iterator) Prev() {
 	}
 
 	i.descend(i.n, i.pos)
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, i.n.count)
 	}
 	i.pos = i.n.count - 1
@@ -1122,7 +1128,7 @@ func (i *iterator) findNextOverlap(item *latch) {
 		if i.pos > i.n.count {
 			// Iterate up tree.
 			i.ascend()
-		} else if !i.n.leaf {
+		} else if !i.n.leaf() {
 			// Iterate down tree.
 			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
 				par := i.n

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"unsafe"
 )
 
 // nilT is a nil instance of the Template type.
@@ -99,42 +98,37 @@ func upperBound(c *latch) keyBound {
 	return keyBound{key: c.Key(), inc: true}
 }
 
-type leafNode struct {
-	ref   int32
-	count int16
-	leaf  bool
-	max   keyBound
-	items [maxItems]*latch
-}
-
 type node struct {
-	leafNode
-	children [maxItems + 1]*node
+	ref      int32
+	count    int16
+	leaf     bool
+	max      keyBound
+	items    [maxItems]*latch
+	children *childrenArray
 }
 
-//go:nocheckptr casts a ptr to a smaller struct to a ptr to a larger struct.
-func leafToNode(ln *leafNode) *node {
-	return (*node)(unsafe.Pointer(ln))
-}
-
-func nodeToLeaf(n *node) *leafNode {
-	return (*leafNode)(unsafe.Pointer(n))
-}
+type childrenArray = [maxItems + 1]*node
 
 var leafPool = sync.Pool{
-	New: func() interface{} {
-		return new(leafNode)
-	},
-}
-
-var nodePool = sync.Pool{
 	New: func() interface{} {
 		return new(node)
 	},
 }
 
+var nodePool = sync.Pool{
+	New: func() interface{} {
+		type interiorNode struct {
+			node
+			children childrenArray
+		}
+		n := new(interiorNode)
+		n.node.children = &n.children
+		return &n.node
+	},
+}
+
 func newLeafNode() *node {
-	n := leafToNode(leafPool.Get().(*leafNode))
+	n := leafPool.Get().(*node)
 	n.leaf = true
 	n.ref = 1
 	return n
@@ -186,9 +180,8 @@ func (n *node) decRef(recursive bool) {
 	}
 	// Clear and release node into memory pool.
 	if n.leaf {
-		ln := nodeToLeaf(n)
-		*ln = leafNode{}
-		leafPool.Put(ln)
+		*n = node{}
+		leafPool.Put(n)
 	} else {
 		// Release child references first, if requested.
 		if recursive {
@@ -196,7 +189,8 @@ func (n *node) decRef(recursive bool) {
 				n.children[i].decRef(true /* recursive */)
 			}
 		}
-		*n = node{}
+		*n = node{children: n.children}
+		*n.children = childrenArray{}
 		nodePool.Put(n)
 	}
 }
@@ -216,7 +210,7 @@ func (n *node) clone() *node {
 	c.items = n.items
 	if !c.leaf {
 		// Copy children and increase each refcount.
-		c.children = n.children
+		*c.children = *n.children
 		for i := int16(0); i <= c.count; i++ {
 			c.children[i].incRef()
 		}

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
@@ -124,14 +124,14 @@ func (t *btree) isUpperBoundCorrect(tt *testing.T) {
 }
 
 func (n *node) isUpperBoundCorrect(t *testing.T) {
-	require.Equal(t, 0, n.findUpperBound().compare(n.max))
+	require.Equal(t, 0, n.findUpperBound().compare(n.max()))
 	for i := int16(1); i < n.count; i++ {
-		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max), 0)
+		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max()), 0)
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
 			child := n.children[i]
-			require.LessOrEqual(t, child.max.compare(n.max), 0)
+			require.LessOrEqual(t, child.max().compare(n.max()), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
@@ -59,7 +59,7 @@ func (t *btree) verifyLeafSameDepth(tt *testing.T) {
 }
 
 func (n *node) verifyDepthEqualToHeight(t *testing.T, depth, height int) {
-	if n.leaf {
+	if n.leaf() {
 		require.Equal(t, height, depth, "all leaves should have the same depth as the tree height")
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -83,7 +83,7 @@ func (n *node) verifyCountAllowed(t *testing.T, root bool) {
 			require.Nil(t, item, "latch above count")
 		}
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i, child := range n.children {
 			if i <= int(n.count) {
 				require.NotNil(t, child, "node below count")
@@ -105,7 +105,7 @@ func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
 		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
@@ -128,7 +128,7 @@ func (n *node) isUpperBoundCorrect(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
 		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max()), 0)
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			child := n.children[i]
 			require.LessOrEqual(t, child.max().compare(n.max()), 0)
@@ -140,7 +140,7 @@ func (n *node) isUpperBoundCorrect(t *testing.T) {
 }
 
 func (n *node) recurse(f func(child *node, pos int16)) {
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			f(n.children[i], i)
 		}

--- a/pkg/spanconfig/spanconfigstore/entry_interval_btree.go
+++ b/pkg/spanconfig/spanconfigstore/entry_interval_btree.go
@@ -99,10 +99,16 @@ func upperBound(c *entry) keyBound {
 }
 
 type node struct {
-	ref      int32
-	count    int16
-	leaf     bool
-	max      keyBound
+	ref   int32
+	count int16
+	leaf  bool
+
+	// These fields form a keyBound, but by inlining them into node we can avoid
+	// the extra word that would be needed to pad out maxInc if it were part of
+	// its own struct.
+	maxInc bool
+	maxKey []byte
+
 	items    [maxItems]*entry
 	children *childrenArray
 }
@@ -166,6 +172,20 @@ func mut(n **node) *node {
 	return *n
 }
 
+// max returns the maximum keyBound in the subtree rooted at this node.
+func (n *node) max() keyBound {
+	return keyBound{
+		key: n.maxKey,
+		inc: n.maxInc,
+	}
+}
+
+// setMax sets the maximum keyBound for the subtree rooted at this node.
+func (n *node) setMax(k keyBound) {
+	n.maxKey = k.key
+	n.maxInc = k.inc
+}
+
 // incRef acquires a reference to the node.
 func (n *node) incRef() {
 	atomic.AddInt32(&n.ref, 1)
@@ -206,7 +226,8 @@ func (n *node) clone() *node {
 	// NB: copy field-by-field without touching n.ref to avoid
 	// triggering the race detector and looking like a data race.
 	c.count = n.count
-	c.max = n.max
+	c.maxKey = n.maxKey
+	c.maxInc = n.maxInc
 	c.items = n.items
 	if !c.leaf {
 		// Copy children and increase each refcount.
@@ -358,12 +379,14 @@ func (n *node) split(i int) (*entry, *node) {
 	}
 	n.count = int16(i)
 
-	next.max = next.findUpperBound()
-	if n.max.compare(next.max) != 0 && n.max.compare(upperBound(out)) != 0 {
+	nextMax := next.findUpperBound()
+	next.setMax(nextMax)
+	nMax := n.max()
+	if nMax.compare(nextMax) != 0 && nMax.compare(upperBound(out)) != 0 {
 		// If upper bound wasn't from new node or item
 		// at index i, it must still be from old node.
 	} else {
-		n.max = n.findUpperBound()
+		n.setMax(n.findUpperBound())
 	}
 	return out, next
 }
@@ -594,7 +617,7 @@ func (n *node) findUpperBound() keyBound {
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
-			up := n.children[i].max
+			up := n.children[i].max()
 			if max.compare(up) < 0 {
 				max = up
 			}
@@ -609,12 +632,12 @@ func (n *node) findUpperBound() keyBound {
 func (n *node) adjustUpperBoundOnInsertion(item *entry, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
-		if up.compare(child.max) < 0 {
-			up = child.max
+		if childMax := child.max(); up.compare(childMax) < 0 {
+			up = childMax
 		}
 	}
-	if n.max.compare(up) < 0 {
-		n.max = up
+	if n.max().compare(up) < 0 {
+		n.setMax(up)
 		return true
 	}
 	return false
@@ -626,14 +649,15 @@ func (n *node) adjustUpperBoundOnInsertion(item *entry, child *node) bool {
 func (n *node) adjustUpperBoundOnRemoval(item *entry, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
-		if up.compare(child.max) < 0 {
-			up = child.max
+		if childMax := child.max(); up.compare(childMax) < 0 {
+			up = childMax
 		}
 	}
-	if n.max.compare(up) == 0 {
+	if n.max().compare(up) == 0 {
 		// up was previous upper bound of n.
-		n.max = n.findUpperBound()
-		return n.max.compare(up) != 0
+		max := n.findUpperBound()
+		n.setMax(max)
+		return max.compare(up) != 0
 	}
 	return false
 }
@@ -720,7 +744,7 @@ func (t *btree) Set(item *entry) {
 		newRoot.items[0] = splitLa
 		newRoot.children[0] = t.root
 		newRoot.children[1] = splitNode
-		newRoot.max = newRoot.findUpperBound()
+		newRoot.setMax(newRoot.findUpperBound())
 		t.root = newRoot
 	}
 	if replaced, _ := mut(&t.root).insert(item); !replaced {
@@ -1100,7 +1124,7 @@ func (i *iterator) findNextOverlap(item *entry) {
 			i.ascend()
 		} else if !i.n.leaf {
 			// Iterate down tree.
-			if i.o.constrMinReached || i.n.children[i.pos].max.contains(item) {
+			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
 				par := i.n
 				pos := i.pos
 				i.descend(par, pos)

--- a/pkg/spanconfig/spanconfigstore/entry_interval_btree.go
+++ b/pkg/spanconfig/spanconfigstore/entry_interval_btree.go
@@ -101,7 +101,6 @@ func upperBound(c *entry) keyBound {
 type node struct {
 	ref   int32
 	count int16
-	leaf  bool
 
 	// These fields form a keyBound, but by inlining them into node we can avoid
 	// the extra word that would be needed to pad out maxInc if it were part of
@@ -109,7 +108,10 @@ type node struct {
 	maxInc bool
 	maxKey []byte
 
-	items    [maxItems]*entry
+	items [maxItems]*entry
+
+	// The children array pointer is only populated for interior nodes; it is nil
+	// for leaf nodes.
 	children *childrenArray
 }
 
@@ -135,7 +137,6 @@ var nodePool = sync.Pool{
 
 func newLeafNode() *node {
 	n := leafPool.Get().(*node)
-	n.leaf = true
 	n.ref = 1
 	return n
 }
@@ -172,6 +173,11 @@ func mut(n **node) *node {
 	return *n
 }
 
+// leaf returns true if this is a leaf node.
+func (n *node) leaf() bool {
+	return n.children == nil
+}
+
 // max returns the maximum keyBound in the subtree rooted at this node.
 func (n *node) max() keyBound {
 	return keyBound{
@@ -199,7 +205,7 @@ func (n *node) decRef(recursive bool) {
 		return
 	}
 	// Clear and release node into memory pool.
-	if n.leaf {
+	if n.leaf() {
 		*n = node{}
 		leafPool.Put(n)
 	} else {
@@ -218,7 +224,7 @@ func (n *node) decRef(recursive bool) {
 // clone creates a clone of the receiver with a single reference count.
 func (n *node) clone() *node {
 	var c *node
-	if n.leaf {
+	if n.leaf() {
 		c = newLeafNode()
 	} else {
 		c = newNode()
@@ -229,7 +235,7 @@ func (n *node) clone() *node {
 	c.maxKey = n.maxKey
 	c.maxInc = n.maxInc
 	c.items = n.items
-	if !c.leaf {
+	if !c.leaf() {
 		// Copy children and increase each refcount.
 		*c.children = *n.children
 		for i := int16(0); i <= c.count; i++ {
@@ -242,12 +248,12 @@ func (n *node) clone() *node {
 func (n *node) insertAt(index int, item *entry, nd *node) {
 	if index < int(n.count) {
 		copy(n.items[index+1:n.count+1], n.items[index:n.count])
-		if !n.leaf {
+		if !n.leaf() {
 			copy(n.children[index+2:n.count+2], n.children[index+1:n.count+1])
 		}
 	}
 	n.items[index] = item
-	if !n.leaf {
+	if !n.leaf() {
 		n.children[index+1] = nd
 	}
 	n.count++
@@ -255,14 +261,14 @@ func (n *node) insertAt(index int, item *entry, nd *node) {
 
 func (n *node) pushBack(item *entry, nd *node) {
 	n.items[n.count] = item
-	if !n.leaf {
+	if !n.leaf() {
 		n.children[n.count+1] = nd
 	}
 	n.count++
 }
 
 func (n *node) pushFront(item *entry, nd *node) {
-	if !n.leaf {
+	if !n.leaf() {
 		copy(n.children[1:n.count+2], n.children[:n.count+1])
 		n.children[0] = nd
 	}
@@ -275,7 +281,7 @@ func (n *node) pushFront(item *entry, nd *node) {
 // back.
 func (n *node) removeAt(index int) (*entry, *node) {
 	var child *node
-	if !n.leaf {
+	if !n.leaf() {
 		child = n.children[index+1]
 		copy(n.children[index+1:n.count], n.children[index+2:n.count+1])
 		n.children[n.count] = nil
@@ -292,7 +298,7 @@ func (n *node) popBack() (*entry, *node) {
 	n.count--
 	out := n.items[n.count]
 	n.items[n.count] = nilT
-	if n.leaf {
+	if n.leaf() {
 		return out, nil
 	}
 	child := n.children[n.count+1]
@@ -304,7 +310,7 @@ func (n *node) popBack() (*entry, *node) {
 func (n *node) popFront() (*entry, *node) {
 	n.count--
 	var child *node
-	if !n.leaf {
+	if !n.leaf() {
 		child = n.children[0]
 		copy(n.children[:n.count+1], n.children[1:n.count+2])
 		n.children[n.count+1] = nil
@@ -361,7 +367,7 @@ func (n *node) find(item *entry) (index int, found bool) {
 func (n *node) split(i int) (*entry, *node) {
 	out := n.items[i]
 	var next *node
-	if n.leaf {
+	if n.leaf() {
 		next = newLeafNode()
 	} else {
 		next = newNode()
@@ -371,7 +377,7 @@ func (n *node) split(i int) (*entry, *node) {
 	for j := int16(i); j < n.count; j++ {
 		n.items[j] = nilT
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		copy(next.children[:], n.children[i+1:n.count+1])
 		for j := int16(i + 1); j <= n.count; j++ {
 			n.children[j] = nil
@@ -401,7 +407,7 @@ func (n *node) insert(item *entry) (replaced, newBound bool) {
 		n.items[i] = item
 		return true, false
 	}
-	if n.leaf {
+	if n.leaf() {
 		n.insertAt(i, item, nil)
 		return false, n.adjustUpperBoundOnInsertion(item, nil)
 	}
@@ -429,7 +435,7 @@ func (n *node) insert(item *entry) (replaced, newBound bool) {
 // removeMax removes and returns the maximum item from the subtree rooted at
 // this node.
 func (n *node) removeMax() *entry {
-	if n.leaf {
+	if n.leaf() {
 		n.count--
 		out := n.items[n.count]
 		n.items[n.count] = nilT
@@ -454,7 +460,7 @@ func (n *node) removeMax() *entry {
 // the node's upper bound changes.
 func (n *node) remove(item *entry) (out *entry, newBound bool) {
 	i, found := n.find(item)
-	if n.leaf {
+	if n.leaf() {
 		if found {
 			out, _ = n.removeAt(i)
 			return out, n.adjustUpperBoundOnRemoval(out, nil)
@@ -595,7 +601,7 @@ func (n *node) rebalanceOrMerge(i int) {
 		mergeLa, mergeChild := n.removeAt(i)
 		child.items[child.count] = mergeLa
 		copy(child.items[child.count+1:], mergeChild.items[:mergeChild.count])
-		if !child.leaf {
+		if !child.leaf() {
 			copy(child.children[child.count+1:], mergeChild.children[:mergeChild.count+1])
 		}
 		child.count += mergeChild.count + 1
@@ -615,7 +621,7 @@ func (n *node) findUpperBound() keyBound {
 			max = up
 		}
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			up := n.children[i].max()
 			if max.compare(up) < 0 {
@@ -723,7 +729,7 @@ func (t *btree) Delete(item *entry) {
 	}
 	if t.root.count == 0 {
 		old := t.root
-		if t.root.leaf {
+		if t.root.leaf() {
 			t.root = nil
 		} else {
 			t.root = t.root.children[0]
@@ -766,7 +772,7 @@ func (t *btree) Height() int {
 	}
 	h := 1
 	n := t.root
-	for !n.leaf {
+	for !n.leaf() {
 		n = n.children[0]
 		h++
 	}
@@ -790,7 +796,7 @@ func (t *btree) String() string {
 }
 
 func (n *node) writeString(b *strings.Builder) {
-	if n.leaf {
+	if n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			if i != 0 {
 				b.WriteString(",")
@@ -907,7 +913,7 @@ func (i *iterator) SeekGE(item *entry) {
 		if found {
 			return
 		}
-		if i.n.leaf {
+		if i.n.leaf() {
 			if i.pos == i.n.count {
 				i.Next()
 			}
@@ -926,7 +932,7 @@ func (i *iterator) SeekLT(item *entry) {
 	for {
 		pos, found := i.n.find(item)
 		i.pos = int16(pos)
-		if found || i.n.leaf {
+		if found || i.n.leaf() {
 			i.Prev()
 			return
 		}
@@ -940,7 +946,7 @@ func (i *iterator) First() {
 	if i.n == nil {
 		return
 	}
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, 0)
 	}
 	i.pos = 0
@@ -952,7 +958,7 @@ func (i *iterator) Last() {
 	if i.n == nil {
 		return
 	}
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, i.n.count)
 	}
 	i.pos = i.n.count - 1
@@ -965,7 +971,7 @@ func (i *iterator) Next() {
 		return
 	}
 
-	if i.n.leaf {
+	if i.n.leaf() {
 		i.pos++
 		if i.pos < i.n.count {
 			return
@@ -977,7 +983,7 @@ func (i *iterator) Next() {
 	}
 
 	i.descend(i.n, i.pos+1)
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, 0)
 	}
 	i.pos = 0
@@ -990,7 +996,7 @@ func (i *iterator) Prev() {
 		return
 	}
 
-	if i.n.leaf {
+	if i.n.leaf() {
 		i.pos--
 		if i.pos >= 0 {
 			return
@@ -1003,7 +1009,7 @@ func (i *iterator) Prev() {
 	}
 
 	i.descend(i.n, i.pos)
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, i.n.count)
 	}
 	i.pos = i.n.count - 1
@@ -1122,7 +1128,7 @@ func (i *iterator) findNextOverlap(item *entry) {
 		if i.pos > i.n.count {
 			// Iterate up tree.
 			i.ascend()
-		} else if !i.n.leaf {
+		} else if !i.n.leaf() {
 			// Iterate down tree.
 			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
 				par := i.n

--- a/pkg/spanconfig/spanconfigstore/entry_interval_btree.go
+++ b/pkg/spanconfig/spanconfigstore/entry_interval_btree.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"unsafe"
 )
 
 // nilT is a nil instance of the Template type.
@@ -99,42 +98,37 @@ func upperBound(c *entry) keyBound {
 	return keyBound{key: c.Key(), inc: true}
 }
 
-type leafNode struct {
-	ref   int32
-	count int16
-	leaf  bool
-	max   keyBound
-	items [maxItems]*entry
-}
-
 type node struct {
-	leafNode
-	children [maxItems + 1]*node
+	ref      int32
+	count    int16
+	leaf     bool
+	max      keyBound
+	items    [maxItems]*entry
+	children *childrenArray
 }
 
-//go:nocheckptr casts a ptr to a smaller struct to a ptr to a larger struct.
-func leafToNode(ln *leafNode) *node {
-	return (*node)(unsafe.Pointer(ln))
-}
-
-func nodeToLeaf(n *node) *leafNode {
-	return (*leafNode)(unsafe.Pointer(n))
-}
+type childrenArray = [maxItems + 1]*node
 
 var leafPool = sync.Pool{
-	New: func() interface{} {
-		return new(leafNode)
-	},
-}
-
-var nodePool = sync.Pool{
 	New: func() interface{} {
 		return new(node)
 	},
 }
 
+var nodePool = sync.Pool{
+	New: func() interface{} {
+		type interiorNode struct {
+			node
+			children childrenArray
+		}
+		n := new(interiorNode)
+		n.node.children = &n.children
+		return &n.node
+	},
+}
+
 func newLeafNode() *node {
-	n := leafToNode(leafPool.Get().(*leafNode))
+	n := leafPool.Get().(*node)
 	n.leaf = true
 	n.ref = 1
 	return n
@@ -186,9 +180,8 @@ func (n *node) decRef(recursive bool) {
 	}
 	// Clear and release node into memory pool.
 	if n.leaf {
-		ln := nodeToLeaf(n)
-		*ln = leafNode{}
-		leafPool.Put(ln)
+		*n = node{}
+		leafPool.Put(n)
 	} else {
 		// Release child references first, if requested.
 		if recursive {
@@ -196,7 +189,8 @@ func (n *node) decRef(recursive bool) {
 				n.children[i].decRef(true /* recursive */)
 			}
 		}
-		*n = node{}
+		*n = node{children: n.children}
+		*n.children = childrenArray{}
 		nodePool.Put(n)
 	}
 }
@@ -216,7 +210,7 @@ func (n *node) clone() *node {
 	c.items = n.items
 	if !c.leaf {
 		// Copy children and increase each refcount.
-		c.children = n.children
+		*c.children = *n.children
 		for i := int16(0); i <= c.count; i++ {
 			c.children[i].incRef()
 		}

--- a/pkg/spanconfig/spanconfigstore/entry_interval_btree_test.go
+++ b/pkg/spanconfig/spanconfigstore/entry_interval_btree_test.go
@@ -124,14 +124,14 @@ func (t *btree) isUpperBoundCorrect(tt *testing.T) {
 }
 
 func (n *node) isUpperBoundCorrect(t *testing.T) {
-	require.Equal(t, 0, n.findUpperBound().compare(n.max))
+	require.Equal(t, 0, n.findUpperBound().compare(n.max()))
 	for i := int16(1); i < n.count; i++ {
-		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max), 0)
+		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max()), 0)
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
 			child := n.children[i]
-			require.LessOrEqual(t, child.max.compare(n.max), 0)
+			require.LessOrEqual(t, child.max().compare(n.max()), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {

--- a/pkg/spanconfig/spanconfigstore/entry_interval_btree_test.go
+++ b/pkg/spanconfig/spanconfigstore/entry_interval_btree_test.go
@@ -59,7 +59,7 @@ func (t *btree) verifyLeafSameDepth(tt *testing.T) {
 }
 
 func (n *node) verifyDepthEqualToHeight(t *testing.T, depth, height int) {
-	if n.leaf {
+	if n.leaf() {
 		require.Equal(t, height, depth, "all leaves should have the same depth as the tree height")
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -83,7 +83,7 @@ func (n *node) verifyCountAllowed(t *testing.T, root bool) {
 			require.Nil(t, item, "latch above count")
 		}
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i, child := range n.children {
 			if i <= int(n.count) {
 				require.NotNil(t, child, "node below count")
@@ -105,7 +105,7 @@ func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
 		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
@@ -128,7 +128,7 @@ func (n *node) isUpperBoundCorrect(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
 		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max()), 0)
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			child := n.children[i]
 			require.LessOrEqual(t, child.max().compare(n.max()), 0)
@@ -140,7 +140,7 @@ func (n *node) isUpperBoundCorrect(t *testing.T) {
 }
 
 func (n *node) recurse(f func(child *node, pos int16)) {
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			f(n.children[i], i)
 		}

--- a/pkg/util/interval/generic/example_interval_btree.go
+++ b/pkg/util/interval/generic/example_interval_btree.go
@@ -101,7 +101,6 @@ func upperBound(c *example) keyBound {
 type node struct {
 	ref   int32
 	count int16
-	leaf  bool
 
 	// These fields form a keyBound, but by inlining them into node we can avoid
 	// the extra word that would be needed to pad out maxInc if it were part of
@@ -109,7 +108,10 @@ type node struct {
 	maxInc bool
 	maxKey []byte
 
-	items    [maxItems]*example
+	items [maxItems]*example
+
+	// The children array pointer is only populated for interior nodes; it is nil
+	// for leaf nodes.
 	children *childrenArray
 }
 
@@ -135,7 +137,6 @@ var nodePool = sync.Pool{
 
 func newLeafNode() *node {
 	n := leafPool.Get().(*node)
-	n.leaf = true
 	n.ref = 1
 	return n
 }
@@ -172,6 +173,11 @@ func mut(n **node) *node {
 	return *n
 }
 
+// leaf returns true if this is a leaf node.
+func (n *node) leaf() bool {
+	return n.children == nil
+}
+
 // max returns the maximum keyBound in the subtree rooted at this node.
 func (n *node) max() keyBound {
 	return keyBound{
@@ -199,7 +205,7 @@ func (n *node) decRef(recursive bool) {
 		return
 	}
 	// Clear and release node into memory pool.
-	if n.leaf {
+	if n.leaf() {
 		*n = node{}
 		leafPool.Put(n)
 	} else {
@@ -218,7 +224,7 @@ func (n *node) decRef(recursive bool) {
 // clone creates a clone of the receiver with a single reference count.
 func (n *node) clone() *node {
 	var c *node
-	if n.leaf {
+	if n.leaf() {
 		c = newLeafNode()
 	} else {
 		c = newNode()
@@ -229,7 +235,7 @@ func (n *node) clone() *node {
 	c.maxKey = n.maxKey
 	c.maxInc = n.maxInc
 	c.items = n.items
-	if !c.leaf {
+	if !c.leaf() {
 		// Copy children and increase each refcount.
 		*c.children = *n.children
 		for i := int16(0); i <= c.count; i++ {
@@ -242,12 +248,12 @@ func (n *node) clone() *node {
 func (n *node) insertAt(index int, item *example, nd *node) {
 	if index < int(n.count) {
 		copy(n.items[index+1:n.count+1], n.items[index:n.count])
-		if !n.leaf {
+		if !n.leaf() {
 			copy(n.children[index+2:n.count+2], n.children[index+1:n.count+1])
 		}
 	}
 	n.items[index] = item
-	if !n.leaf {
+	if !n.leaf() {
 		n.children[index+1] = nd
 	}
 	n.count++
@@ -255,14 +261,14 @@ func (n *node) insertAt(index int, item *example, nd *node) {
 
 func (n *node) pushBack(item *example, nd *node) {
 	n.items[n.count] = item
-	if !n.leaf {
+	if !n.leaf() {
 		n.children[n.count+1] = nd
 	}
 	n.count++
 }
 
 func (n *node) pushFront(item *example, nd *node) {
-	if !n.leaf {
+	if !n.leaf() {
 		copy(n.children[1:n.count+2], n.children[:n.count+1])
 		n.children[0] = nd
 	}
@@ -275,7 +281,7 @@ func (n *node) pushFront(item *example, nd *node) {
 // back.
 func (n *node) removeAt(index int) (*example, *node) {
 	var child *node
-	if !n.leaf {
+	if !n.leaf() {
 		child = n.children[index+1]
 		copy(n.children[index+1:n.count], n.children[index+2:n.count+1])
 		n.children[n.count] = nil
@@ -292,7 +298,7 @@ func (n *node) popBack() (*example, *node) {
 	n.count--
 	out := n.items[n.count]
 	n.items[n.count] = nilT
-	if n.leaf {
+	if n.leaf() {
 		return out, nil
 	}
 	child := n.children[n.count+1]
@@ -304,7 +310,7 @@ func (n *node) popBack() (*example, *node) {
 func (n *node) popFront() (*example, *node) {
 	n.count--
 	var child *node
-	if !n.leaf {
+	if !n.leaf() {
 		child = n.children[0]
 		copy(n.children[:n.count+1], n.children[1:n.count+2])
 		n.children[n.count+1] = nil
@@ -361,7 +367,7 @@ func (n *node) find(item *example) (index int, found bool) {
 func (n *node) split(i int) (*example, *node) {
 	out := n.items[i]
 	var next *node
-	if n.leaf {
+	if n.leaf() {
 		next = newLeafNode()
 	} else {
 		next = newNode()
@@ -371,7 +377,7 @@ func (n *node) split(i int) (*example, *node) {
 	for j := int16(i); j < n.count; j++ {
 		n.items[j] = nilT
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		copy(next.children[:], n.children[i+1:n.count+1])
 		for j := int16(i + 1); j <= n.count; j++ {
 			n.children[j] = nil
@@ -401,7 +407,7 @@ func (n *node) insert(item *example) (replaced, newBound bool) {
 		n.items[i] = item
 		return true, false
 	}
-	if n.leaf {
+	if n.leaf() {
 		n.insertAt(i, item, nil)
 		return false, n.adjustUpperBoundOnInsertion(item, nil)
 	}
@@ -429,7 +435,7 @@ func (n *node) insert(item *example) (replaced, newBound bool) {
 // removeMax removes and returns the maximum item from the subtree rooted at
 // this node.
 func (n *node) removeMax() *example {
-	if n.leaf {
+	if n.leaf() {
 		n.count--
 		out := n.items[n.count]
 		n.items[n.count] = nilT
@@ -454,7 +460,7 @@ func (n *node) removeMax() *example {
 // the node's upper bound changes.
 func (n *node) remove(item *example) (out *example, newBound bool) {
 	i, found := n.find(item)
-	if n.leaf {
+	if n.leaf() {
 		if found {
 			out, _ = n.removeAt(i)
 			return out, n.adjustUpperBoundOnRemoval(out, nil)
@@ -595,7 +601,7 @@ func (n *node) rebalanceOrMerge(i int) {
 		mergeLa, mergeChild := n.removeAt(i)
 		child.items[child.count] = mergeLa
 		copy(child.items[child.count+1:], mergeChild.items[:mergeChild.count])
-		if !child.leaf {
+		if !child.leaf() {
 			copy(child.children[child.count+1:], mergeChild.children[:mergeChild.count+1])
 		}
 		child.count += mergeChild.count + 1
@@ -615,7 +621,7 @@ func (n *node) findUpperBound() keyBound {
 			max = up
 		}
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			up := n.children[i].max()
 			if max.compare(up) < 0 {
@@ -723,7 +729,7 @@ func (t *btree) Delete(item *example) {
 	}
 	if t.root.count == 0 {
 		old := t.root
-		if t.root.leaf {
+		if t.root.leaf() {
 			t.root = nil
 		} else {
 			t.root = t.root.children[0]
@@ -766,7 +772,7 @@ func (t *btree) Height() int {
 	}
 	h := 1
 	n := t.root
-	for !n.leaf {
+	for !n.leaf() {
 		n = n.children[0]
 		h++
 	}
@@ -790,7 +796,7 @@ func (t *btree) String() string {
 }
 
 func (n *node) writeString(b *strings.Builder) {
-	if n.leaf {
+	if n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			if i != 0 {
 				b.WriteString(",")
@@ -907,7 +913,7 @@ func (i *iterator) SeekGE(item *example) {
 		if found {
 			return
 		}
-		if i.n.leaf {
+		if i.n.leaf() {
 			if i.pos == i.n.count {
 				i.Next()
 			}
@@ -926,7 +932,7 @@ func (i *iterator) SeekLT(item *example) {
 	for {
 		pos, found := i.n.find(item)
 		i.pos = int16(pos)
-		if found || i.n.leaf {
+		if found || i.n.leaf() {
 			i.Prev()
 			return
 		}
@@ -940,7 +946,7 @@ func (i *iterator) First() {
 	if i.n == nil {
 		return
 	}
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, 0)
 	}
 	i.pos = 0
@@ -952,7 +958,7 @@ func (i *iterator) Last() {
 	if i.n == nil {
 		return
 	}
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, i.n.count)
 	}
 	i.pos = i.n.count - 1
@@ -965,7 +971,7 @@ func (i *iterator) Next() {
 		return
 	}
 
-	if i.n.leaf {
+	if i.n.leaf() {
 		i.pos++
 		if i.pos < i.n.count {
 			return
@@ -977,7 +983,7 @@ func (i *iterator) Next() {
 	}
 
 	i.descend(i.n, i.pos+1)
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, 0)
 	}
 	i.pos = 0
@@ -990,7 +996,7 @@ func (i *iterator) Prev() {
 		return
 	}
 
-	if i.n.leaf {
+	if i.n.leaf() {
 		i.pos--
 		if i.pos >= 0 {
 			return
@@ -1003,7 +1009,7 @@ func (i *iterator) Prev() {
 	}
 
 	i.descend(i.n, i.pos)
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, i.n.count)
 	}
 	i.pos = i.n.count - 1
@@ -1122,7 +1128,7 @@ func (i *iterator) findNextOverlap(item *example) {
 		if i.pos > i.n.count {
 			// Iterate up tree.
 			i.ascend()
-		} else if !i.n.leaf {
+		} else if !i.n.leaf() {
 			// Iterate down tree.
 			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
 				par := i.n

--- a/pkg/util/interval/generic/example_interval_btree.go
+++ b/pkg/util/interval/generic/example_interval_btree.go
@@ -99,10 +99,16 @@ func upperBound(c *example) keyBound {
 }
 
 type node struct {
-	ref      int32
-	count    int16
-	leaf     bool
-	max      keyBound
+	ref   int32
+	count int16
+	leaf  bool
+
+	// These fields form a keyBound, but by inlining them into node we can avoid
+	// the extra word that would be needed to pad out maxInc if it were part of
+	// its own struct.
+	maxInc bool
+	maxKey []byte
+
 	items    [maxItems]*example
 	children *childrenArray
 }
@@ -166,6 +172,20 @@ func mut(n **node) *node {
 	return *n
 }
 
+// max returns the maximum keyBound in the subtree rooted at this node.
+func (n *node) max() keyBound {
+	return keyBound{
+		key: n.maxKey,
+		inc: n.maxInc,
+	}
+}
+
+// setMax sets the maximum keyBound for the subtree rooted at this node.
+func (n *node) setMax(k keyBound) {
+	n.maxKey = k.key
+	n.maxInc = k.inc
+}
+
 // incRef acquires a reference to the node.
 func (n *node) incRef() {
 	atomic.AddInt32(&n.ref, 1)
@@ -206,7 +226,8 @@ func (n *node) clone() *node {
 	// NB: copy field-by-field without touching n.ref to avoid
 	// triggering the race detector and looking like a data race.
 	c.count = n.count
-	c.max = n.max
+	c.maxKey = n.maxKey
+	c.maxInc = n.maxInc
 	c.items = n.items
 	if !c.leaf {
 		// Copy children and increase each refcount.
@@ -358,12 +379,14 @@ func (n *node) split(i int) (*example, *node) {
 	}
 	n.count = int16(i)
 
-	next.max = next.findUpperBound()
-	if n.max.compare(next.max) != 0 && n.max.compare(upperBound(out)) != 0 {
+	nextMax := next.findUpperBound()
+	next.setMax(nextMax)
+	nMax := n.max()
+	if nMax.compare(nextMax) != 0 && nMax.compare(upperBound(out)) != 0 {
 		// If upper bound wasn't from new node or item
 		// at index i, it must still be from old node.
 	} else {
-		n.max = n.findUpperBound()
+		n.setMax(n.findUpperBound())
 	}
 	return out, next
 }
@@ -594,7 +617,7 @@ func (n *node) findUpperBound() keyBound {
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
-			up := n.children[i].max
+			up := n.children[i].max()
 			if max.compare(up) < 0 {
 				max = up
 			}
@@ -609,12 +632,12 @@ func (n *node) findUpperBound() keyBound {
 func (n *node) adjustUpperBoundOnInsertion(item *example, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
-		if up.compare(child.max) < 0 {
-			up = child.max
+		if childMax := child.max(); up.compare(childMax) < 0 {
+			up = childMax
 		}
 	}
-	if n.max.compare(up) < 0 {
-		n.max = up
+	if n.max().compare(up) < 0 {
+		n.setMax(up)
 		return true
 	}
 	return false
@@ -626,14 +649,15 @@ func (n *node) adjustUpperBoundOnInsertion(item *example, child *node) bool {
 func (n *node) adjustUpperBoundOnRemoval(item *example, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
-		if up.compare(child.max) < 0 {
-			up = child.max
+		if childMax := child.max(); up.compare(childMax) < 0 {
+			up = childMax
 		}
 	}
-	if n.max.compare(up) == 0 {
+	if n.max().compare(up) == 0 {
 		// up was previous upper bound of n.
-		n.max = n.findUpperBound()
-		return n.max.compare(up) != 0
+		max := n.findUpperBound()
+		n.setMax(max)
+		return max.compare(up) != 0
 	}
 	return false
 }
@@ -720,7 +744,7 @@ func (t *btree) Set(item *example) {
 		newRoot.items[0] = splitLa
 		newRoot.children[0] = t.root
 		newRoot.children[1] = splitNode
-		newRoot.max = newRoot.findUpperBound()
+		newRoot.setMax(newRoot.findUpperBound())
 		t.root = newRoot
 	}
 	if replaced, _ := mut(&t.root).insert(item); !replaced {
@@ -1100,7 +1124,7 @@ func (i *iterator) findNextOverlap(item *example) {
 			i.ascend()
 		} else if !i.n.leaf {
 			// Iterate down tree.
-			if i.o.constrMinReached || i.n.children[i.pos].max.contains(item) {
+			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
 				par := i.n
 				pos := i.pos
 				i.descend(par, pos)

--- a/pkg/util/interval/generic/example_interval_btree_test.go
+++ b/pkg/util/interval/generic/example_interval_btree_test.go
@@ -124,14 +124,14 @@ func (t *btree) isUpperBoundCorrect(tt *testing.T) {
 }
 
 func (n *node) isUpperBoundCorrect(t *testing.T) {
-	require.Equal(t, 0, n.findUpperBound().compare(n.max))
+	require.Equal(t, 0, n.findUpperBound().compare(n.max()))
 	for i := int16(1); i < n.count; i++ {
-		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max), 0)
+		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max()), 0)
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
 			child := n.children[i]
-			require.LessOrEqual(t, child.max.compare(n.max), 0)
+			require.LessOrEqual(t, child.max().compare(n.max()), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {

--- a/pkg/util/interval/generic/example_interval_btree_test.go
+++ b/pkg/util/interval/generic/example_interval_btree_test.go
@@ -59,7 +59,7 @@ func (t *btree) verifyLeafSameDepth(tt *testing.T) {
 }
 
 func (n *node) verifyDepthEqualToHeight(t *testing.T, depth, height int) {
-	if n.leaf {
+	if n.leaf() {
 		require.Equal(t, height, depth, "all leaves should have the same depth as the tree height")
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -83,7 +83,7 @@ func (n *node) verifyCountAllowed(t *testing.T, root bool) {
 			require.Nil(t, item, "latch above count")
 		}
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i, child := range n.children {
 			if i <= int(n.count) {
 				require.NotNil(t, child, "node below count")
@@ -105,7 +105,7 @@ func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
 		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
@@ -128,7 +128,7 @@ func (n *node) isUpperBoundCorrect(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
 		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max()), 0)
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			child := n.children[i]
 			require.LessOrEqual(t, child.max().compare(n.max()), 0)
@@ -140,7 +140,7 @@ func (n *node) isUpperBoundCorrect(t *testing.T) {
 }
 
 func (n *node) recurse(f func(child *node, pos int16)) {
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			f(n.children[i], i)
 		}

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl.go
@@ -100,10 +100,16 @@ func upperBound(c T) keyBound {
 }
 
 type node struct {
-	ref      int32
-	count    int16
-	leaf     bool
-	max      keyBound
+	ref   int32
+	count int16
+	leaf  bool
+
+	// These fields form a keyBound, but by inlining them into node we can avoid
+	// the extra word that would be needed to pad out maxInc if it were part of
+	// its own struct.
+	maxInc bool
+	maxKey []byte
+
 	items    [maxItems]T
 	children *childrenArray
 }
@@ -167,6 +173,20 @@ func mut(n **node) *node {
 	return *n
 }
 
+// max returns the maximum keyBound in the subtree rooted at this node.
+func (n *node) max() keyBound {
+	return keyBound{
+		key: n.maxKey,
+		inc: n.maxInc,
+	}
+}
+
+// setMax sets the maximum keyBound for the subtree rooted at this node.
+func (n *node) setMax(k keyBound) {
+	n.maxKey = k.key
+	n.maxInc = k.inc
+}
+
 // incRef acquires a reference to the node.
 func (n *node) incRef() {
 	atomic.AddInt32(&n.ref, 1)
@@ -207,7 +227,8 @@ func (n *node) clone() *node {
 	// NB: copy field-by-field without touching n.ref to avoid
 	// triggering the race detector and looking like a data race.
 	c.count = n.count
-	c.max = n.max
+	c.maxKey = n.maxKey
+	c.maxInc = n.maxInc
 	c.items = n.items
 	if !c.leaf {
 		// Copy children and increase each refcount.
@@ -359,12 +380,14 @@ func (n *node) split(i int) (T, *node) {
 	}
 	n.count = int16(i)
 
-	next.max = next.findUpperBound()
-	if n.max.compare(next.max) != 0 && n.max.compare(upperBound(out)) != 0 {
+	nextMax := next.findUpperBound()
+	next.setMax(nextMax)
+	nMax := n.max()
+	if nMax.compare(nextMax) != 0 && nMax.compare(upperBound(out)) != 0 {
 		// If upper bound wasn't from new node or item
 		// at index i, it must still be from old node.
 	} else {
-		n.max = n.findUpperBound()
+		n.setMax(n.findUpperBound())
 	}
 	return out, next
 }
@@ -595,7 +618,7 @@ func (n *node) findUpperBound() keyBound {
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
-			up := n.children[i].max
+			up := n.children[i].max()
 			if max.compare(up) < 0 {
 				max = up
 			}
@@ -610,12 +633,12 @@ func (n *node) findUpperBound() keyBound {
 func (n *node) adjustUpperBoundOnInsertion(item T, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
-		if up.compare(child.max) < 0 {
-			up = child.max
+		if childMax := child.max(); up.compare(childMax) < 0 {
+			up = childMax
 		}
 	}
-	if n.max.compare(up) < 0 {
-		n.max = up
+	if n.max().compare(up) < 0 {
+		n.setMax(up)
 		return true
 	}
 	return false
@@ -627,14 +650,15 @@ func (n *node) adjustUpperBoundOnInsertion(item T, child *node) bool {
 func (n *node) adjustUpperBoundOnRemoval(item T, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
-		if up.compare(child.max) < 0 {
-			up = child.max
+		if childMax := child.max(); up.compare(childMax) < 0 {
+			up = childMax
 		}
 	}
-	if n.max.compare(up) == 0 {
+	if n.max().compare(up) == 0 {
 		// up was previous upper bound of n.
-		n.max = n.findUpperBound()
-		return n.max.compare(up) != 0
+		max := n.findUpperBound()
+		n.setMax(max)
+		return max.compare(up) != 0
 	}
 	return false
 }
@@ -721,7 +745,7 @@ func (t *btree) Set(item T) {
 		newRoot.items[0] = splitLa
 		newRoot.children[0] = t.root
 		newRoot.children[1] = splitNode
-		newRoot.max = newRoot.findUpperBound()
+		newRoot.setMax(newRoot.findUpperBound())
 		t.root = newRoot
 	}
 	if replaced, _ := mut(&t.root).insert(item); !replaced {
@@ -1101,7 +1125,7 @@ func (i *iterator) findNextOverlap(item T) {
 			i.ascend()
 		} else if !i.n.leaf {
 			// Iterate down tree.
-			if i.o.constrMinReached || i.n.children[i.pos].max.contains(item) {
+			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
 				par := i.n
 				pos := i.pos
 				i.descend(par, pos)

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl.go
@@ -102,7 +102,6 @@ func upperBound(c T) keyBound {
 type node struct {
 	ref   int32
 	count int16
-	leaf  bool
 
 	// These fields form a keyBound, but by inlining them into node we can avoid
 	// the extra word that would be needed to pad out maxInc if it were part of
@@ -110,7 +109,10 @@ type node struct {
 	maxInc bool
 	maxKey []byte
 
-	items    [maxItems]T
+	items [maxItems]T
+
+	// The children array pointer is only populated for interior nodes; it is nil
+	// for leaf nodes.
 	children *childrenArray
 }
 
@@ -136,7 +138,6 @@ var nodePool = sync.Pool{
 
 func newLeafNode() *node {
 	n := leafPool.Get().(*node)
-	n.leaf = true
 	n.ref = 1
 	return n
 }
@@ -173,6 +174,11 @@ func mut(n **node) *node {
 	return *n
 }
 
+// leaf returns true if this is a leaf node.
+func (n *node) leaf() bool {
+	return n.children == nil
+}
+
 // max returns the maximum keyBound in the subtree rooted at this node.
 func (n *node) max() keyBound {
 	return keyBound{
@@ -200,7 +206,7 @@ func (n *node) decRef(recursive bool) {
 		return
 	}
 	// Clear and release node into memory pool.
-	if n.leaf {
+	if n.leaf() {
 		*n = node{}
 		leafPool.Put(n)
 	} else {
@@ -219,7 +225,7 @@ func (n *node) decRef(recursive bool) {
 // clone creates a clone of the receiver with a single reference count.
 func (n *node) clone() *node {
 	var c *node
-	if n.leaf {
+	if n.leaf() {
 		c = newLeafNode()
 	} else {
 		c = newNode()
@@ -230,7 +236,7 @@ func (n *node) clone() *node {
 	c.maxKey = n.maxKey
 	c.maxInc = n.maxInc
 	c.items = n.items
-	if !c.leaf {
+	if !c.leaf() {
 		// Copy children and increase each refcount.
 		*c.children = *n.children
 		for i := int16(0); i <= c.count; i++ {
@@ -243,12 +249,12 @@ func (n *node) clone() *node {
 func (n *node) insertAt(index int, item T, nd *node) {
 	if index < int(n.count) {
 		copy(n.items[index+1:n.count+1], n.items[index:n.count])
-		if !n.leaf {
+		if !n.leaf() {
 			copy(n.children[index+2:n.count+2], n.children[index+1:n.count+1])
 		}
 	}
 	n.items[index] = item
-	if !n.leaf {
+	if !n.leaf() {
 		n.children[index+1] = nd
 	}
 	n.count++
@@ -256,14 +262,14 @@ func (n *node) insertAt(index int, item T, nd *node) {
 
 func (n *node) pushBack(item T, nd *node) {
 	n.items[n.count] = item
-	if !n.leaf {
+	if !n.leaf() {
 		n.children[n.count+1] = nd
 	}
 	n.count++
 }
 
 func (n *node) pushFront(item T, nd *node) {
-	if !n.leaf {
+	if !n.leaf() {
 		copy(n.children[1:n.count+2], n.children[:n.count+1])
 		n.children[0] = nd
 	}
@@ -276,7 +282,7 @@ func (n *node) pushFront(item T, nd *node) {
 // back.
 func (n *node) removeAt(index int) (T, *node) {
 	var child *node
-	if !n.leaf {
+	if !n.leaf() {
 		child = n.children[index+1]
 		copy(n.children[index+1:n.count], n.children[index+2:n.count+1])
 		n.children[n.count] = nil
@@ -293,7 +299,7 @@ func (n *node) popBack() (T, *node) {
 	n.count--
 	out := n.items[n.count]
 	n.items[n.count] = nilT
-	if n.leaf {
+	if n.leaf() {
 		return out, nil
 	}
 	child := n.children[n.count+1]
@@ -305,7 +311,7 @@ func (n *node) popBack() (T, *node) {
 func (n *node) popFront() (T, *node) {
 	n.count--
 	var child *node
-	if !n.leaf {
+	if !n.leaf() {
 		child = n.children[0]
 		copy(n.children[:n.count+1], n.children[1:n.count+2])
 		n.children[n.count+1] = nil
@@ -362,7 +368,7 @@ func (n *node) find(item T) (index int, found bool) {
 func (n *node) split(i int) (T, *node) {
 	out := n.items[i]
 	var next *node
-	if n.leaf {
+	if n.leaf() {
 		next = newLeafNode()
 	} else {
 		next = newNode()
@@ -372,7 +378,7 @@ func (n *node) split(i int) (T, *node) {
 	for j := int16(i); j < n.count; j++ {
 		n.items[j] = nilT
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		copy(next.children[:], n.children[i+1:n.count+1])
 		for j := int16(i + 1); j <= n.count; j++ {
 			n.children[j] = nil
@@ -402,7 +408,7 @@ func (n *node) insert(item T) (replaced, newBound bool) {
 		n.items[i] = item
 		return true, false
 	}
-	if n.leaf {
+	if n.leaf() {
 		n.insertAt(i, item, nil)
 		return false, n.adjustUpperBoundOnInsertion(item, nil)
 	}
@@ -430,7 +436,7 @@ func (n *node) insert(item T) (replaced, newBound bool) {
 // removeMax removes and returns the maximum item from the subtree rooted at
 // this node.
 func (n *node) removeMax() T {
-	if n.leaf {
+	if n.leaf() {
 		n.count--
 		out := n.items[n.count]
 		n.items[n.count] = nilT
@@ -455,7 +461,7 @@ func (n *node) removeMax() T {
 // the node's upper bound changes.
 func (n *node) remove(item T) (out T, newBound bool) {
 	i, found := n.find(item)
-	if n.leaf {
+	if n.leaf() {
 		if found {
 			out, _ = n.removeAt(i)
 			return out, n.adjustUpperBoundOnRemoval(out, nil)
@@ -596,7 +602,7 @@ func (n *node) rebalanceOrMerge(i int) {
 		mergeLa, mergeChild := n.removeAt(i)
 		child.items[child.count] = mergeLa
 		copy(child.items[child.count+1:], mergeChild.items[:mergeChild.count])
-		if !child.leaf {
+		if !child.leaf() {
 			copy(child.children[child.count+1:], mergeChild.children[:mergeChild.count+1])
 		}
 		child.count += mergeChild.count + 1
@@ -616,7 +622,7 @@ func (n *node) findUpperBound() keyBound {
 			max = up
 		}
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			up := n.children[i].max()
 			if max.compare(up) < 0 {
@@ -724,7 +730,7 @@ func (t *btree) Delete(item T) {
 	}
 	if t.root.count == 0 {
 		old := t.root
-		if t.root.leaf {
+		if t.root.leaf() {
 			t.root = nil
 		} else {
 			t.root = t.root.children[0]
@@ -767,7 +773,7 @@ func (t *btree) Height() int {
 	}
 	h := 1
 	n := t.root
-	for !n.leaf {
+	for !n.leaf() {
 		n = n.children[0]
 		h++
 	}
@@ -791,7 +797,7 @@ func (t *btree) String() string {
 }
 
 func (n *node) writeString(b *strings.Builder) {
-	if n.leaf {
+	if n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			if i != 0 {
 				b.WriteString(",")
@@ -908,7 +914,7 @@ func (i *iterator) SeekGE(item T) {
 		if found {
 			return
 		}
-		if i.n.leaf {
+		if i.n.leaf() {
 			if i.pos == i.n.count {
 				i.Next()
 			}
@@ -927,7 +933,7 @@ func (i *iterator) SeekLT(item T) {
 	for {
 		pos, found := i.n.find(item)
 		i.pos = int16(pos)
-		if found || i.n.leaf {
+		if found || i.n.leaf() {
 			i.Prev()
 			return
 		}
@@ -941,7 +947,7 @@ func (i *iterator) First() {
 	if i.n == nil {
 		return
 	}
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, 0)
 	}
 	i.pos = 0
@@ -953,7 +959,7 @@ func (i *iterator) Last() {
 	if i.n == nil {
 		return
 	}
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, i.n.count)
 	}
 	i.pos = i.n.count - 1
@@ -966,7 +972,7 @@ func (i *iterator) Next() {
 		return
 	}
 
-	if i.n.leaf {
+	if i.n.leaf() {
 		i.pos++
 		if i.pos < i.n.count {
 			return
@@ -978,7 +984,7 @@ func (i *iterator) Next() {
 	}
 
 	i.descend(i.n, i.pos+1)
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, 0)
 	}
 	i.pos = 0
@@ -991,7 +997,7 @@ func (i *iterator) Prev() {
 		return
 	}
 
-	if i.n.leaf {
+	if i.n.leaf() {
 		i.pos--
 		if i.pos >= 0 {
 			return
@@ -1004,7 +1010,7 @@ func (i *iterator) Prev() {
 	}
 
 	i.descend(i.n, i.pos)
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, i.n.count)
 	}
 	i.pos = i.n.count - 1
@@ -1123,7 +1129,7 @@ func (i *iterator) findNextOverlap(item T) {
 		if i.pos > i.n.count {
 			// Iterate up tree.
 			i.ascend()
-		} else if !i.n.leaf {
+		} else if !i.n.leaf() {
 			// Iterate down tree.
 			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
 				par := i.n

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
@@ -125,14 +125,14 @@ func (t *btree) isUpperBoundCorrect(tt *testing.T) {
 }
 
 func (n *node) isUpperBoundCorrect(t *testing.T) {
-	require.Equal(t, 0, n.findUpperBound().compare(n.max))
+	require.Equal(t, 0, n.findUpperBound().compare(n.max()))
 	for i := int16(1); i < n.count; i++ {
-		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max), 0)
+		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max()), 0)
 	}
 	if !n.leaf {
 		for i := int16(0); i <= n.count; i++ {
 			child := n.children[i]
-			require.LessOrEqual(t, child.max.compare(n.max), 0)
+			require.LessOrEqual(t, child.max().compare(n.max()), 0)
 		}
 	}
 	n.recurse(func(child *node, _ int16) {

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
@@ -60,7 +60,7 @@ func (t *btree) verifyLeafSameDepth(tt *testing.T) {
 }
 
 func (n *node) verifyDepthEqualToHeight(t *testing.T, depth, height int) {
-	if n.leaf {
+	if n.leaf() {
 		require.Equal(t, height, depth, "all leaves should have the same depth as the tree height")
 	}
 	n.recurse(func(child *node, _ int16) {
@@ -84,7 +84,7 @@ func (n *node) verifyCountAllowed(t *testing.T, root bool) {
 			require.Nil(t, item, "latch above count")
 		}
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i, child := range n.children {
 			if i <= int(n.count) {
 				require.NotNil(t, child, "node below count")
@@ -106,7 +106,7 @@ func (n *node) isSorted(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
 		require.LessOrEqual(t, cmp(n.items[i-1], n.items[i]), 0)
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			prev := n.children[i]
 			next := n.children[i+1]
@@ -129,7 +129,7 @@ func (n *node) isUpperBoundCorrect(t *testing.T) {
 	for i := int16(1); i < n.count; i++ {
 		require.LessOrEqual(t, upperBound(n.items[i]).compare(n.max()), 0)
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			child := n.children[i]
 			require.LessOrEqual(t, child.max().compare(n.max()), 0)
@@ -141,7 +141,7 @@ func (n *node) isUpperBoundCorrect(t *testing.T) {
 }
 
 func (n *node) recurse(f func(child *node, pos int16)) {
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
 			f(n.children[i], i)
 		}


### PR DESCRIPTION
See individual commits. The basic problem this PR solves is that in the previous formulation, we used unsafe code to cast pointers to `node`s to point beyond their allocation. It's not clear that this is sound with regards to GC, and it's certain that this break tools like viewcore. The argument for this hack was performance. This change removes unsafe code and achieves effectively the same performance.

```
name                                                       old time/op    new time/op    delta                                                                                                                                                                                   
BTreeInsert/count=128-32                                     47.9ns ± 1%    46.5ns ± 6%  -2.80%  (p=0.000 n=8+20)                                                                                                                                                                
BTreeInsert/count=1024-32                                    61.5ns ± 2%    60.3ns ± 3%  -2.10%  (p=0.000 n=10+20)                      
BTreeInsert/count=8192-32                                     128ns ± 1%     129ns ± 2%    ~     (p=0.107 n=9+20)                       
BTreeInsert/count=65536-32                                    196ns ± 1%     199ns ± 3%  +1.87%  (p=0.000 n=10+20)                      
BTreeDelete/count=128-32                                     52.1ns ± 8%    54.6ns ±13%  +4.96%  (p=0.022 n=10+20)                      
BTreeDelete/count=1024-32                                    92.1ns ± 9%    91.4ns ±11%    ~     (p=0.657 n=10+20)                      
BTreeDelete/count=8192-32                                     168ns ± 3%     166ns ± 4%    ~     (p=0.211 n=9+20)                       
BTreeDelete/count=65536-32                                    255ns ± 2%     258ns ± 3%    ~     (p=0.080 n=10+20)                      
BTreeDeleteInsert/count=128-32                               87.2ns ± 3%    86.5ns ± 3%    ~     (p=0.286 n=10+19)                      
BTreeDeleteInsert/count=1024-32                               205ns ± 3%     204ns ± 5%    ~     (p=0.823 n=8+20)                       
BTreeDeleteInsert/count=8192-32                               245ns ± 3%     247ns ± 4%    ~     (p=0.379 n=10+20)                      
BTreeDeleteInsert/count=65536-32                              416ns ±29%     411ns ±22%    ~     (p=0.729 n=9+20)                       
BTreeDeleteInsertCloneOnce/count=128-32                      88.5ns ± 5%    87.2ns ± 4%    ~     (p=0.091 n=10+20)                      
BTreeDeleteInsertCloneOnce/count=1024-32                      212ns ± 2%     207ns ± 5%  -2.31%  (p=0.007 n=8+17)                       
BTreeDeleteInsertCloneOnce/count=8192-32                      247ns ± 1%     250ns ± 4%    ~     (p=0.120 n=8+20)                       
BTreeDeleteInsertCloneOnce/count=65536-32                     432ns ±19%     415ns ±30%    ~     (p=0.373 n=10+20)                      
BTreeDeleteInsertCloneEachTime/count=128/reset=false-32       527ns ± 5%     531ns ± 6%    ~     (p=0.443 n=10+20)                      
BTreeDeleteInsertCloneEachTime/count=128/reset=true-32        141ns ± 7%     147ns ± 5%  +4.36%  (p=0.001 n=10+20)                      
BTreeDeleteInsertCloneEachTime/count=1024/reset=false-32      951ns ± 3%     965ns ± 3%    ~     (p=0.051 n=9+20)                       
BTreeDeleteInsertCloneEachTime/count=1024/reset=true-32       360ns ± 2%     370ns ± 6%  +2.89%  (p=0.011 n=9+20)                       
BTreeDeleteInsertCloneEachTime/count=8192/reset=false-32     1.04µs ± 1%    1.06µs ± 2%  +1.48%  (p=0.000 n=10+19)                      
BTreeDeleteInsertCloneEachTime/count=8192/reset=true-32       441ns ± 2%     463ns ± 3%  +5.00%  (p=0.000 n=10+20)                      
BTreeDeleteInsertCloneEachTime/count=65536/reset=false-32    1.59µs ±15%    1.52µs ±24%    ~     (p=0.220 n=9+20)                       
BTreeDeleteInsertCloneEachTime/count=65536/reset=true-32      725ns ±15%     789ns ±37%    ~     (p=0.214 n=10+20)                      
BTreeIterSeekGE/count=128-32                                 58.7ns ± 3%    59.5ns ± 5%    ~     (p=0.165 n=10+20)                      
BTreeIterSeekGE/count=1024-32                                89.5ns ± 3%    90.1ns ± 2%    ~     (p=0.373 n=10+20)                      
BTreeIterSeekGE/count=8192-32                                 128ns ± 3%     128ns ± 2%    ~     (p=0.878 n=10+18)                      
BTreeIterSeekGE/count=65536-32                                213ns ± 4%     216ns ± 4%    ~     (p=0.133 n=10+20)                      
BTreeIterSeekLT/count=128-32                                 59.5ns ± 2%    60.9ns ± 3%  +2.22%  (p=0.008 n=10+20)                      
BTreeIterSeekLT/count=1024-32                                92.0ns ± 1%    93.5ns ± 4%  +1.71%  (p=0.006 n=10+20)                      
BTreeIterSeekLT/count=8192-32                                 133ns ± 3%     134ns ± 3%    ~     (p=0.117 n=10+20)                      
BTreeIterSeekLT/count=65536-32                                220ns ± 4%     218ns ± 7%    ~     (p=0.378 n=10+20)                      
BTreeIterFirstOverlap/count=128-32                            170ns ± 3%     170ns ± 3%    ~     (p=0.441 n=10+20)                      
BTreeIterFirstOverlap/count=1024-32                           298ns ± 2%     300ns ± 4%    ~     (p=0.244 n=10+20)                      
BTreeIterFirstOverlap/count=8192-32                           449ns ± 3%     453ns ± 4%    ~     (p=0.403 n=10+20)                      
BTreeIterFirstOverlap/count=65536-32                          590ns ± 4%     584ns ± 3%    ~     (p=0.350 n=10+20)                      
BTreeInsert/count=16-32                                      29.4ns ± 3%    29.1ns ± 3%    ~     (p=0.179 n=10+20)                      
BTreeDelete/count=16-32                                      31.7ns ±16%    32.2ns ±15%    ~     (p=0.447 n=9+10)                       
BTreeDeleteInsert/count=16-32                                52.5ns ± 2%    52.4ns ± 4%    ~     (p=0.796 n=10+10)                      
BTreeDeleteInsertCloneOnce/count=16-32                       52.4ns ± 2%    52.2ns ± 3%    ~     (p=0.436 n=10+10)                      
BTreeDeleteInsertCloneEachTime/count=16/reset=false-32        200ns ± 3%     199ns ± 2%    ~     (p=0.497 n=10+9)                       
BTreeDeleteInsertCloneEachTime/count=16/reset=true-32        68.1ns ± 4%    68.0ns ± 1%    ~     (p=0.965 n=10+8)                       
BTreeIterSeekGE/count=16-32                                  37.9ns ± 4%    38.2ns ± 3%    ~     (p=0.700 n=10+10)                      
BTreeIterSeekLT/count=16-32                                  39.3ns ± 2%    39.6ns ± 3%    ~     (p=0.592 n=10+10)                      
BTreeIterFirstOverlap/count=16-32                             100ns ± 2%     101ns ± 4%    ~     (p=0.271 n=10+10)   
```
```
name                                           old time/op    new time/op    delta
LockTable/groups=1,outstanding=1,read=0/-32      7.10µs ± 2%    7.08µs ± 2%    ~     (p=0.631 n=10+10)
LockTable/groups=1,outstanding=1,read=1/-32      5.99µs ± 2%    6.09µs ± 2%  +1.56%  (p=0.029 n=10+10)
LockTable/groups=1,outstanding=1,read=2/-32      4.92µs ± 2%    4.94µs ± 2%    ~     (p=0.393 n=10+10)
LockTable/groups=1,outstanding=1,read=3/-32      3.48µs ± 1%    3.54µs ± 2%  +1.79%  (p=0.003 n=10+10)
LockTable/groups=1,outstanding=1,read=4/-32      1.54µs ± 1%    1.56µs ± 1%  +1.07%  (p=0.000 n=10+10)
LockTable/groups=1,outstanding=1,read=5/-32      1.54µs ± 1%    1.56µs ± 1%  +1.15%  (p=0.000 n=10+10)
LockTable/groups=1,outstanding=2,read=0/-32      9.07µs ± 3%    9.15µs ± 1%    ~     (p=0.123 n=10+10)
LockTable/groups=1,outstanding=2,read=1/-32      8.06µs ± 1%    8.09µs ± 2%    ~     (p=0.190 n=10+10)
LockTable/groups=1,outstanding=2,read=2/-32      7.00µs ± 2%    7.09µs ± 1%  +1.24%  (p=0.002 n=10+8)
LockTable/groups=1,outstanding=2,read=3/-32      5.72µs ± 1%    5.77µs ± 4%    ~     (p=0.096 n=8+10)
LockTable/groups=1,outstanding=2,read=4/-32      1.27µs ± 2%    1.29µs ± 2%  +2.09%  (p=0.002 n=10+9)
LockTable/groups=1,outstanding=2,read=5/-32      1.28µs ± 2%    1.29µs ± 2%  +1.21%  (p=0.018 n=9+10)
LockTable/groups=1,outstanding=4,read=0/-32      10.3µs ± 1%    10.3µs ± 1%    ~     (p=1.000 n=10+9)
LockTable/groups=1,outstanding=4,read=1/-32      9.05µs ± 1%    9.11µs ± 2%    ~     (p=0.108 n=10+9)
LockTable/groups=1,outstanding=4,read=2/-32      7.88µs ± 2%    7.96µs ± 1%  +0.98%  (p=0.021 n=10+8)
LockTable/groups=1,outstanding=4,read=3/-32      6.29µs ± 2%    6.39µs ± 1%  +1.66%  (p=0.000 n=9+9)
LockTable/groups=1,outstanding=4,read=4/-32      1.23µs ± 1%    1.24µs ± 2%  +1.06%  (p=0.012 n=10+10)
LockTable/groups=1,outstanding=4,read=5/-32      1.23µs ± 1%    1.25µs ± 1%  +2.22%  (p=0.000 n=10+9)
LockTable/groups=1,outstanding=8,read=0/-32      11.3µs ± 1%    11.4µs ± 4%    ~     (p=0.122 n=8+10)
LockTable/groups=1,outstanding=8,read=1/-32      10.2µs ± 3%    10.2µs ± 1%    ~     (p=0.631 n=10+10)
LockTable/groups=1,outstanding=8,read=2/-32      9.01µs ± 2%    9.17µs ± 1%  +1.81%  (p=0.002 n=10+8)
LockTable/groups=1,outstanding=8,read=3/-32      7.30µs ± 2%    7.39µs ± 2%  +1.21%  (p=0.035 n=10+9)
LockTable/groups=1,outstanding=8,read=4/-32      1.11µs ± 1%    1.12µs ± 1%  +0.90%  (p=0.004 n=10+10)
LockTable/groups=1,outstanding=8,read=5/-32      1.11µs ± 2%    1.13µs ± 3%  +1.86%  (p=0.011 n=10+10)
LockTable/groups=1,outstanding=16,read=0/-32     13.6µs ± 2%    13.5µs ± 3%    ~     (p=0.400 n=9+10)
LockTable/groups=1,outstanding=16,read=1/-32     12.2µs ± 5%    12.1µs ± 5%    ~     (p=0.853 n=10+10)
LockTable/groups=1,outstanding=16,read=2/-32     11.2µs ± 1%    11.0µs ± 6%    ~     (p=0.481 n=10+10)
LockTable/groups=1,outstanding=16,read=3/-32     9.44µs ± 2%    9.50µs ± 2%    ~     (p=0.252 n=10+9)
LockTable/groups=1,outstanding=16,read=4/-32     1.09µs ± 1%    1.10µs ± 1%  +0.89%  (p=0.022 n=10+10)
LockTable/groups=1,outstanding=16,read=5/-32     1.09µs ± 1%    1.10µs ± 1%  +0.83%  (p=0.001 n=10+10)
LockTable/groups=32,outstanding=1,read=0/-32     12.8µs ± 3%    13.0µs ± 0%  +1.26%  (p=0.002 n=9+9)
LockTable/groups=32,outstanding=1,read=1/-32     10.9µs ± 1%    10.8µs ± 3%    ~     (p=0.424 n=10+10)
LockTable/groups=32,outstanding=1,read=2/-32     8.81µs ± 1%    8.93µs ± 1%  +1.32%  (p=0.001 n=10+8)
LockTable/groups=32,outstanding=1,read=3/-32     6.48µs ± 3%    6.52µs ± 1%    ~     (p=0.231 n=9+9)
LockTable/groups=32,outstanding=1,read=4/-32     1.07µs ± 1%    1.07µs ± 0%    ~     (p=0.362 n=10+9)
LockTable/groups=32,outstanding=1,read=5/-32     1.07µs ± 1%    1.08µs ± 1%    ~     (p=0.617 n=10+10)
LockTable/groups=32,outstanding=2,read=0/-32     20.8µs ± 2%    20.8µs ± 3%    ~     (p=0.739 n=10+10)
LockTable/groups=32,outstanding=2,read=1/-32     18.3µs ± 2%    18.3µs ± 2%    ~     (p=0.838 n=10+10)
LockTable/groups=32,outstanding=2,read=2/-32     15.4µs ± 2%    15.7µs ± 2%    ~     (p=0.060 n=10+10)
LockTable/groups=32,outstanding=2,read=3/-32     9.00µs ± 4%    9.11µs ± 2%    ~     (p=0.113 n=10+9)
LockTable/groups=32,outstanding=2,read=4/-32     1.09µs ± 1%    1.09µs ± 1%    ~     (p=0.288 n=10+10)
LockTable/groups=32,outstanding=2,read=5/-32     1.09µs ± 1%    1.09µs ± 1%    ~     (p=0.137 n=10+10)
LockTable/groups=32,outstanding=4,read=0/-32     22.1µs ± 4%    21.7µs ± 2%    ~     (p=0.353 n=10+10)
LockTable/groups=32,outstanding=4,read=1/-32     19.4µs ± 1%    19.4µs ± 3%    ~     (p=0.796 n=10+10)
LockTable/groups=32,outstanding=4,read=2/-32     16.8µs ± 2%    17.0µs ± 3%  +1.05%  (p=0.024 n=9+9)
LockTable/groups=32,outstanding=4,read=3/-32     11.0µs ± 2%    11.1µs ± 1%  +1.01%  (p=0.008 n=9+8)
LockTable/groups=32,outstanding=4,read=4/-32     1.05µs ± 1%    1.04µs ± 1%    ~     (p=0.422 n=10+10)
LockTable/groups=32,outstanding=4,read=5/-32     1.05µs ± 1%    1.05µs ± 1%    ~     (p=0.078 n=10+10)
LockTable/groups=32,outstanding=8,read=0/-32     23.5µs ± 5%    23.4µs ± 4%    ~     (p=0.739 n=10+10)
LockTable/groups=32,outstanding=8,read=1/-32     21.4µs ± 2%    21.6µs ± 3%    ~     (p=0.211 n=9+10)
LockTable/groups=32,outstanding=8,read=2/-32     18.8µs ± 5%    19.3µs ± 1%    ~     (p=0.083 n=10+8)
LockTable/groups=32,outstanding=8,read=3/-32     12.8µs ± 4%    12.9µs ± 1%    ~     (p=0.912 n=10+10)
LockTable/groups=32,outstanding=8,read=4/-32     1.05µs ± 1%    1.05µs ± 1%    ~     (p=0.380 n=10+10)
LockTable/groups=32,outstanding=8,read=5/-32     1.04µs ± 2%    1.04µs ± 1%    ~     (p=0.894 n=10+10)
LockTable/groups=32,outstanding=16,read=0/-32    28.0µs ± 1%    27.8µs ± 2%    ~     (p=0.278 n=9+10)
LockTable/groups=32,outstanding=16,read=1/-32    25.2µs ± 3%    25.2µs ± 5%    ~     (p=0.912 n=10+10)
LockTable/groups=32,outstanding=16,read=2/-32    21.5µs ± 3%    21.8µs ± 2%    ~     (p=0.052 n=10+10)
LockTable/groups=32,outstanding=16,read=3/-32    16.2µs ± 2%    15.9µs ± 5%  -1.83%  (p=0.043 n=10+10)
LockTable/groups=32,outstanding=16,read=4/-32    1.05µs ± 1%    1.04µs ± 1%    ~     (p=0.283 n=10+9)
LockTable/groups=32,outstanding=16,read=5/-32    1.05µs ± 0%    1.05µs ± 2%    ~     (p=0.323 n=9+10)
LockTableMetrics/locks=0-32                      63.1ns ± 2%    63.2ns ± 3%    ~     (p=0.869 n=10+10)
LockTableMetrics/locks=1-32                      89.4ns ± 3%    88.8ns ± 3%    ~     (p=0.251 n=9+10)
LockTableMetrics/locks=16-32                      595ns ± 2%     572ns ± 3%  -3.81%  (p=0.000 n=10+10)
LockTableMetrics/locks=256-32                    9.14µs ± 3%    8.97µs ± 3%  -1.82%  (p=0.019 n=10+10)
LockTableMetrics/locks=4096-32                    153µs ± 1%     151µs ± 3%    ~     (p=0.146 n=8+10)
TxnCache-32                                      15.0ns ± 3%    15.2ns ± 1%    ~     (p=0.704 n=10+9)
```