### PR TITLE
obsservice: add TTL of 7 days to insights

### DIFF
--- a/pkg/obsservice/obslib/migrations/sqlmigrations/0002_stmt_insights.sql
+++ b/pkg/obsservice/obslib/migrations/sqlmigrations/0002_stmt_insights.sql
@@ -68,7 +68,7 @@ CREATE TABLE statement_execution_insights (
      contention_time,
      details
      )
-);
+) WITH (ttl_expiration_expression = 'timestamp + INTERVAL ''7 days''');
 
 -- +goose Down
 DROP TABLE statement_execution_insights;


### PR DESCRIPTION
On the schema table for Insights on Observability Service, add TTL of 7 days on the insight creation.

Fixes CC-26224

Release note: None