### PR TITLE
streamingccl: deflake TestStreamingReplanOnLag

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -517,17 +517,21 @@ func CreateScatteredTable(t *testing.T, c *TenantStreamingClusters, numNodes int
 	c.SrcTenantSQL.Exec(t, "ALTER TABLE d.scattered SPLIT AT (SELECT * FROM generate_series($1::INT, $2::INT, $3::INT))",
 		rowsPerRange, (numRanges-1)*rowsPerRange, rowsPerRange)
 	c.SrcTenantSQL.Exec(t, "ALTER TABLE d.scattered SCATTER")
-	testutils.SucceedsSoon(t, func() error {
+	timeout := 45 * time.Second
+	if skip.Duress() {
+		timeout *= 5
+	}
+	testutils.SucceedsWithin(t, func() error {
 		var leaseHolderCount int
 		c.SrcTenantSQL.QueryRow(t,
 			`SELECT count(DISTINCT lease_holder) FROM [SHOW RANGES FROM DATABASE d WITH DETAILS]`).
 			Scan(&leaseHolderCount)
 		require.Greater(t, leaseHolderCount, 0)
-		if leaseHolderCount == 1 {
+		if leaseHolderCount < numNodes {
 			return errors.New("leaseholders not scattered yet")
 		}
 		return nil
-	})
+	}, timeout)
 }
 
 var defaultSrcClusterSetting = map[string]string{

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -727,7 +727,8 @@ func TestStreamingAutoReplan(t *testing.T) {
 	c.SrcCluster.AddAndStartServer(c.T, replicationtestutils.CreateServerArgs(c.Args))
 	require.NoError(t, c.SrcCluster.WaitForFullReplication())
 
-	replicationtestutils.CreateScatteredTable(t, c, 3)
+	// Only need at least two nodes as leaseholders for test.
+	replicationtestutils.CreateScatteredTable(t, c, 2)
 
 	// Configure the ingestion job to replan eagerly.
 	serverutils.SetClusterSetting(t, c.DestCluster, "stream_replication.replan_flow_threshold", 0.1)


### PR DESCRIPTION
The test would timeout under stress as it relies on node 1 falling behind, but occasonially, partitionSpans would not include node 1 in the c2c distSQL plan. This patch prevents this by modifying the CreateScatteredTable to wait until the desired number of nodes have leases.

Epic: none

Release note: none