### PR TITLE
release-23.1: sql,opt: don't validate AOST during session migration

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -331,7 +331,7 @@ func (ex *connExecutor) populatePrepared(
 	// However, we must be able to handle every type of statement below because
 	// the Postgres extended protocol requires running statements via the prepare
 	// and execute paths.
-	flags, err := p.prepareUsingOptimizer(ctx)
+	flags, err := p.prepareUsingOptimizer(ctx, origin)
 	if err != nil {
 		log.VEventf(ctx, 1, "optimizer prepare failed: %v", err)
 		return 0, err

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -71,6 +71,11 @@ type Builder struct {
 	// This is used when re-preparing invalidated queries.
 	KeepPlaceholders bool
 
+	// SkipAOST is a control knob: if set, optbuilder will not attempt to
+	// validate AS OF SYSTEM TIME clauses. This is used when re-preparing
+	// a statement during session migration.
+	SkipAOST bool
+
 	// -- Results --
 	//
 	// These fields are set during the building process and can be used after

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1370,6 +1370,9 @@ func (b *Builder) buildFromWithLateral(
 // validateAsOf ensures that any AS OF SYSTEM TIME timestamp is consistent with
 // that of the root statement.
 func (b *Builder) validateAsOf(asOfClause tree.AsOfClause) {
+	if b.SkipAOST {
+		return
+	}
 	asOf, err := asof.Eval(
 		b.ctx,
 		asOfClause,

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -624,6 +624,10 @@ const (
 	// planFlagContainsNonDefaultLocking is set if the plan has a node with
 	// non-default key locking strength.
 	planFlagContainsNonDefaultLocking
+
+	// planFlagSessionMigration is set if the plan is being created during
+	// a session migration.
+	planFlagSessionMigration
 )
 
 func (pf planFlags) IsSet(flag planFlags) bool {

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -55,11 +55,16 @@ var queryCacheEnabled = settings.RegisterBoolSetting(
 //   - Types
 //   - AnonymizedStr
 //   - Memo (for reuse during exec, if appropriate).
-func (p *planner) prepareUsingOptimizer(ctx context.Context) (planFlags, error) {
+func (p *planner) prepareUsingOptimizer(
+	ctx context.Context, origin PreparedStatementOrigin,
+) (planFlags, error) {
 	stmt := &p.stmt
 
 	opc := &p.optPlanningCtx
 	opc.reset(ctx)
+	if origin == PreparedStatementOriginSessionMigration {
+		opc.flags.Set(planFlagSessionMigration)
+	}
 
 	switch t := stmt.AST.(type) {
 	case *tree.AlterIndex, *tree.AlterIndexVisible, *tree.AlterTable, *tree.AlterSequence,
@@ -430,6 +435,9 @@ func (opc *optPlanningCtx) buildReusableMemo(ctx context.Context) (_ *memo.Memo,
 	f := opc.optimizer.Factory()
 	bld := optbuilder.New(ctx, &p.semaCtx, p.EvalContext(), opc.catalog, f, opc.p.stmt.AST)
 	bld.KeepPlaceholders = true
+	if opc.flags.IsSet(planFlagSessionMigration) {
+		bld.SkipAOST = true
+	}
 	if err := bld.Build(); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/testdata/session_migration/prepared_statements
+++ b/pkg/sql/testdata/session_migration/prepared_statements
@@ -38,6 +38,11 @@ wire_prepare s5
 SELECT a, b FROM t2 AS OF SYSTEM TIME '-2us'
 ----
 
+# Regression test for transferring statements with AOST and placeholders.
+wire_prepare s6
+SELECT a, b FROM t2 AS OF SYSTEM TIME '-2us' WHERE b > $1
+----
+
 wire_prepare s_empty
 ;
 ----
@@ -113,6 +118,10 @@ SELECT pg_sleep(0.1)
 true
 
 wire_query s5
+----
+1 cat
+
+wire_query s6 0
 ----
 1 cat
 


### PR DESCRIPTION
Backport 1/1 commits from #116549.

/cc @cockroachdb/release

Release justification: low risk bug fix

---

When re-preparing a statement for a session migration, we want to skip evaluating and validating the AS OF SYSTEM TIME clause. During session migrations, we know that the statement will just be prepared, and not executed, and each statement could have different AOST timestamps. Therefore it is incorrect to evaluate the AOST clause and fix the transaction timestamp.

No release note since this fixes a bug that only affects Serverless. See [here](https://cockroachlabsgcp.splunkcloud.com/en-US/app/search/search?earliest=1702141875&latest=1702401075&q=search%20index%3Dcc-app-crdb*%20%20%22could%20not%20prepare%20statement%20during%20session%20migration%22%20host_ip%3D%2210.4.0.19%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&display.general.type=events&display.page.search.tab=events&workload_pool=standard_perf&sid=1702579453.274591) for an example of the error.

Epic: None
Release note: None
