### PR TITLE
release-23.2: catalog: skip TestRangefeedUpdatesHandledProperlyInTheFaceOfRaces under duress

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -2345,6 +2345,7 @@ func TestRangefeedUpdatesHandledProperlyInTheFaceOfRaces(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	defer ensureTestTakesLessThan(t, 30*time.Second)()
+	skip.UnderDuress(t, "test must take less than 30 seconds, so avoid slow configs")
 
 	ctx := context.Background()
 	var interestingTable atomic.Value


### PR DESCRIPTION
Backport 1/1 commits from #116588.

/cc @cockroachdb/release

Release justification: test only change

---


fixes https://github.com/cockroachdb/cockroach/issues/116564
Release note: None
