### PR TITLE
kv: implement BatchRequest methods on pointer receivers

### DIFF
--- a/pkg/kv/kvclient/kvcoord/batch_test.go
+++ b/pkg/kv/kvclient/kvcoord/batch_test.go
@@ -376,7 +376,7 @@ func TestTruncate(t *testing.T) {
 				}
 
 				for i, test := range testCases {
-					goldenOriginal := kvpb.BatchRequest{}
+					goldenOriginal := &kvpb.BatchRequest{}
 					for _, ks := range test.keys {
 						if len(ks[1]) > 0 {
 							goldenOriginal.Add(&kvpb.ResolveIntentRangeRequest{
@@ -392,7 +392,7 @@ func TestTruncate(t *testing.T) {
 						}
 					}
 
-					original := kvpb.BatchRequest{Requests: make([]kvpb.RequestUnion, len(goldenOriginal.Requests))}
+					original := &kvpb.BatchRequest{Requests: make([]kvpb.RequestUnion, len(goldenOriginal.Requests))}
 					for i, request := range goldenOriginal.Requests {
 						original.Requests[i].MustSetInner(request.GetInner().ShallowCopy())
 					}

--- a/pkg/kv/kvserver/apply/asserter.go
+++ b/pkg/kv/kvserver/apply/asserter.go
@@ -150,7 +150,7 @@ func (a *Asserter) Propose(
 	replicaID roachpb.ReplicaID,
 	cmdID, seedID kvserverbase.CmdIDKey,
 	cmd *kvserverpb.RaftCommand,
-	req kvpb.BatchRequest,
+	req *kvpb.BatchRequest,
 ) {
 	a.forRange(rangeID).propose(replicaID, cmdID, seedID, cmd, req)
 }
@@ -159,7 +159,7 @@ func (r *rangeAsserter) propose(
 	replicaID roachpb.ReplicaID,
 	cmdID, seedID kvserverbase.CmdIDKey,
 	cmd *kvserverpb.RaftCommand,
-	req kvpb.BatchRequest,
+	req *kvpb.BatchRequest,
 ) {
 	fail := func(msg string, args ...interface{}) {
 		panic(fmt.Sprintf("r%d/%d cmd %s: %s (%s)",

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -148,7 +148,7 @@ type ProposalFilterArgs struct {
 	QuotaAlloc *quotapool.IntAlloc
 	CmdID      CmdIDKey
 	SeedID     CmdIDKey
-	Req        kvpb.BatchRequest
+	Req        *kvpb.BatchRequest
 }
 
 // ApplyFilterArgs groups the arguments to a ReplicaApplyFilter.

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -148,7 +148,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 				QuotaAlloc: p.quotaAlloc,
 				CmdID:      p.idKey,
 				SeedID:     seedID,
-				Req:        *p.Request,
+				Req:        p.Request,
 			})
 		}
 	}

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -296,7 +296,7 @@ func (r *Replica) evalAndPropose(
 			Cmd:        proposal.command,
 			QuotaAlloc: proposal.quotaAlloc,
 			CmdID:      idKey,
-			Req:        *ba,
+			Req:        ba,
 			// SeedID not set, since this is not a reproposal.
 		}
 		if pErr = filter(filterArgs); pErr != nil {


### PR DESCRIPTION
The commit changes the receiver type of the BatchRequest methods to pointer receivers. This allows *BatchRequest to implement the redact.SafeFormatter interface, which is helpful now that (as of e8226497) BatchRequest is always passed around by pointer.

Informs #114601.
Release note: None