### PR TITLE
roachprod: log unexpected output when trying to parse JSON

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -1290,7 +1290,7 @@ func (c *SyncedCluster) upsertVirtualClusterMetadata(
 
 		var tenants []tenantRow
 		if err := json.Unmarshal([]byte(existsOut), &tenants); err != nil {
-			return -1, fmt.Errorf("failed to unmarshal system.tenants output: %w", err)
+			return -1, fmt.Errorf("failed to unmarshal system.tenants output: %w\n%s", err, existsOut)
 		}
 
 		if len(tenants) == 0 {


### PR DESCRIPTION
Part of creating tenants involves learning about existing tenants in the system. Roachprod uses a query and invokes `cockroach sql --format json` to achieve that. However, we have seen this fail in the past because the output was not valid JSON. In this commit, we log the unexpected output in this case so that we can better understand what happened.

Informs: #116681

Release note: None