### PR TITLE
sql: add `pg_catalog.pg_isolation_test_session_is_blocked` builtin

### DIFF
--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2015,7 +2015,7 @@ var builtinOidsArray = []string{
 	2042: `to_char(interval: interval, format: string) -> string`,
 	2043: `crdb_internal.create_tenant(name: string) -> int`,
 	2044: `crdb_internal.start_replication_stream(tenant_name: string) -> bytes`,
-	2045: `pg_blocking_pids() -> int[]`,
+	2045: `pg_blocking_pids(blocked_pid: int4) -> int[]`,
 	2046: `crdb_internal.fingerprint(span: bytes[], start_time: timestamptz, all_revisions: bool) -> int`,
 	2047: `tsquerysend(tsquery: tsquery) -> bytes`,
 	2048: `tsvectorsend(tsvector: tsvector) -> bytes`,
@@ -2538,6 +2538,7 @@ var builtinOidsArray = []string{
 	2570: `array_position(array: refcursor[], elem: refcursor, start: int) -> int`,
 	2571: `bit_count(val: bytes) -> int`,
 	2572: `bit_count(val: varbit) -> int`,
+	2573: `pg_isolation_test_session_is_blocked(blocked_pid: int4, interesting_pids: int[]) -> bool`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
Informs #95771.

This commit adds the `pg_catalog.pg_isolation_test_session_is_blocked` builtin, which supports Postgres' isolationtester.

The function checks if the specified PID is blocked by any of the PIDs listed in the second argument. Currently, this only looks for blocking caused by waiting for locks.

This is an undocumented function intended for use by the isolation tester. It is not intended for use by end users.

While here, fix the signature of `pg_catalog.pg_blocking_pids` and leave a TODO to implement the builtin using `crdb_internal.cluster_locks`.

Release note: None