### PR TITLE
ui: add lease preference metrics to replication dashboard

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -107,6 +107,28 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Lease Preferences"
+      sources={storeSources}
+      tenantSource={tenantSource}
+      tooltip={`Details about the conformance of range lease preferences. In 
+                the node view, shows details about ranges the node is 
+                responsible for. In the cluster view, shows details about
+                ranges all across the cluster.`}
+      showMetricsInTooltip={true}
+    >
+      <Axis label="ranges">
+        <Metric
+          name="cr.store.leases.preferences.violating"
+          title="Lease Preferences Violating"
+        />
+        <Metric
+          name="cr.store.leases.preferences.less-preferred"
+          title="Lease Preferences Less Preferred"
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Average Replica Queries per Node"
       tenantSource={tenantSource}
       tooltip={`Moving average of the number of KV batch requests processed by


### PR DESCRIPTION
Lease preference metrics were added in https://github.com/cockroachdb/cockroach/pull/107505, however were only
visible in DB Console via custom metrics. This commit adds the
`leases.preferences.violating` and `leases.preferences.less-preferred`
metrics to the replication dashboard under a new lease preferences
graph.

Resolves: https://github.com/cockroachdb/cockroach/issues/116678

Release note (ui change): Introduce a new lease preferences graph on the
replication dashboard. The lease preferences graph will display when the
current leaseholder is not the first lease preference and where the
current leaseholder satisfies no applied lease preference.