### PR TITLE
release-23.2: sql: add disable_changefeed_replication session variable

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/changefeed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/changefeed
@@ -65,3 +65,38 @@ query TT
 SELECT user_name, description FROM [SHOW CHANGEFEED JOBS]
 ----
 testuser  CREATE CHANGEFEED FOR TABLE t INTO 'null://sink' WITH OPTIONS (initial_scan = 'only')
+
+subtest disable_changefeed_replication
+
+user root
+
+statement ok
+GRANT CHANGEFEED ON t TO testuser
+
+user testuser
+
+query T
+SHOW disable_changefeed_replication
+----
+off
+
+statement ok
+CREATE CHANGEFEED FOR t INTO 'null://sink' with initial_scan='only'
+
+statement ok
+SET disable_changefeed_replication TO true
+
+query T
+SHOW disable_changefeed_replication
+----
+on
+
+statement ok
+CREATE CHANGEFEED FOR t INTO 'null://sink' with initial_scan='only'
+
+user root
+
+statement ok
+REVOKE CHANGEFEED ON t FROM testuser
+
+subtest end

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3704,6 +3704,10 @@ func (m *sessionDataMutator) SetOptimizerUseProvidedOrderingFix(val bool) {
 	m.data.OptimizerUseProvidedOrderingFix = val
 }
 
+func (m *sessionDataMutator) SetDisableChangefeedReplication(val bool) {
+	m.data.DisableChangefeedReplication = val
+}
+
 func (m *sessionDataMutator) SetDistSQLPlanGatewayBias(val int64) {
 	m.data.DistsqlPlanGatewayBias = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5501,6 +5501,7 @@ default_transaction_read_only                              off
 default_transaction_use_follower_reads                     off
 default_with_oids                                          off
 descriptor_validation                                      on
+disable_changefeed_replication                             off
 disable_hoist_projection_in_join_limitation                off
 disable_partially_distributed_plans                        off
 disable_plan_gists                                         off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2818,6 +2818,7 @@ default_transaction_read_only                              off                 N
 default_transaction_use_follower_reads                     off                 NULL      NULL        NULL        string
 default_with_oids                                          off                 NULL      NULL        NULL        string
 descriptor_validation                                      on                  NULL      NULL        NULL        string
+disable_changefeed_replication                             off                 NULL      NULL        NULL        string
 disable_hoist_projection_in_join_limitation                off                 NULL      NULL        NULL        string
 disable_partially_distributed_plans                        off                 NULL      NULL        NULL        string
 disable_plan_gists                                         off                 NULL      NULL        NULL        string
@@ -2989,6 +2990,7 @@ default_transaction_read_only                              off                 N
 default_transaction_use_follower_reads                     off                 NULL  user     NULL      off                 off
 default_with_oids                                          off                 NULL  user     NULL      off                 off
 descriptor_validation                                      on                  NULL  user     NULL      on                  on
+disable_changefeed_replication                             off                 NULL  user     NULL      off                 off
 disable_hoist_projection_in_join_limitation                off                 NULL  user     NULL      off                 off
 disable_partially_distributed_plans                        off                 NULL  user     NULL      off                 off
 disable_plan_gists                                         off                 NULL  user     NULL      off                 off
@@ -3156,6 +3158,7 @@ default_transaction_use_follower_reads                     NULL    NULL     NULL
 default_with_oids                                          NULL    NULL     NULL     NULL        NULL
 descriptor_validation                                      NULL    NULL     NULL     NULL        NULL
 direct_columnar_scans_enabled                              NULL    NULL     NULL     NULL        NULL
+disable_changefeed_replication                             NULL    NULL     NULL     NULL        NULL
 disable_hoist_projection_in_join_limitation                NULL    NULL     NULL     NULL        NULL
 disable_partially_distributed_plans                        NULL    NULL     NULL     NULL        NULL
 disable_plan_gists                                         NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -56,6 +56,7 @@ default_transaction_read_only                              off
 default_transaction_use_follower_reads                     off
 default_with_oids                                          off
 descriptor_validation                                      on
+disable_changefeed_replication                             off
 disable_hoist_projection_in_join_limitation                off
 disable_partially_distributed_plans                        off
 disable_plan_gists                                         off

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -463,6 +463,10 @@ message LocalOnlySessionData {
   // internal errors due to incomplete functional dependencies, and also
   // fixes a bug that incorrectly truncated the provided ordering (see #113072).
   bool optimizer_use_provided_ordering_fix = 115;
+  // DisableChangefeedReplication, when true, disables changefeed events from
+  // being emitted for changes to data made in a session.
+  // TODO(yang): Plumb this session variable down to KV.
+  bool disable_changefeed_replication = 116;
   // CopyTxnQualityOfService indicates the default QoSLevel/WorkPriority of the
   // transactions used to evaluate COPY commands.
   int32 copy_txn_quality_of_service = 117 [(gogoproto.casttype)="QoSLevel"];

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3114,6 +3114,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`disable_changefeed_replication`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`disable_changefeed_replication`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar(`disable_changefeed_replication`, s)
+			if err != nil {
+				return err
+			}
+			m.SetDisableChangefeedReplication(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().DisableChangefeedReplication), nil
+		},
+		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
 	`distsql_plan_gateway_bias`: {
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return strconv.FormatInt(evalCtx.SessionData().DistsqlPlanGatewayBias, 10), nil


### PR DESCRIPTION
Backport 1/1 commits from #113992.

/cc @cockroachdb/release

---

This patch adds a `disable_changefeed_replication` session variable
that can be used to disable changefeed replication for changes that
occur within a session. Right now, the session variable has no effect
but in later commits, it will be plumbed to the KV layer.

Fixes #114071

Release note: None

---

Release justification: low-risk, high benefit change