### PR TITLE
liveness: use a manual clock

### DIFF
--- a/pkg/kv/kvserver/liveness/livenesspb/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/livenesspb/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/roachpb",
         "//pkg/util/hlc",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@org_golang_google_grpc//codes",

--- a/pkg/kv/kvserver/liveness/livenesspb/liveness_test_helper.go
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness_test_helper.go
@@ -16,49 +16,57 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-// TestNodeVitalityEntry is here to minimize the impact on tests of changing to
+// testNodeVitalityEntry is here to minimize the impact on tests of changing to
 // the new interface for tests that previously used IsLiveMap. It doesn't
 // directly look at timestamps, so the status must be manually updated.
-type TestNodeVitalityEntry struct {
+type testNodeVitalityEntry struct {
 	Liveness Liveness
 	Alive    bool
+	clock    *hlc.Clock
 }
 
 // TestNodeVitality is a test class for simulating and modifying NodeLiveness
 // directly. The map is intended to be manually created and modified prior to
 // running a test.
-type TestNodeVitality map[roachpb.NodeID]TestNodeVitalityEntry
+type TestNodeVitality struct {
+	Entry map[roachpb.NodeID]testNodeVitalityEntry
+	Clock *hlc.Clock
+}
 
 // TestCreateNodeVitality creates a test instance of node vitality which is easy
 // to simulate different health conditions without requiring the need to take
 // nodes down or publish anything through gossip.  This method takes an optional
 // list of ides which are all marked as healthy when created.
 func TestCreateNodeVitality(ids ...roachpb.NodeID) TestNodeVitality {
-	m := TestNodeVitality{}
+	clock := hlc.NewClock(timeutil.NewManualTime(timeutil.Unix(0, 0)), time.Millisecond, time.Millisecond)
+	m := TestNodeVitality{
+		Clock: clock,
+		Entry: make(map[roachpb.NodeID]testNodeVitalityEntry),
+	}
 	for _, id := range ids {
 		m.AddNode(id)
 	}
 	return m
 }
 
-func (e TestNodeVitalityEntry) Convert() NodeVitality {
-	clock := hlc.NewClockForTesting(hlc.NewHybridManualClock())
-	now := clock.Now()
+func (e testNodeVitalityEntry) convert() NodeVitality {
+	now := e.clock.Now()
 	if e.Alive {
 		return e.Liveness.CreateNodeVitality(now, now, hlc.Timestamp{}, true, time.Second, time.Second)
 	} else {
-		return e.Liveness.CreateNodeVitality(now, now.AddDuration(-time.Hour), hlc.Timestamp{}, true, time.Second, time.Second)
+		return e.Liveness.CreateNodeVitality(now, now.AddDuration(-time.Hour), hlc.Timestamp{}, false, time.Second, time.Second)
 	}
 }
 
 func (tnv TestNodeVitality) GetNodeVitalityFromCache(id roachpb.NodeID) NodeVitality {
-	val, found := tnv[id]
+	val, found := tnv.Entry[id]
 	if !found {
 		return NodeVitality{}
 	}
-	return val.Convert()
+	return val.convert()
 }
 
 // ScanNodeVitalityFromKV is only for testing so doesn't actually scan KV,
@@ -68,16 +76,16 @@ func (tnv TestNodeVitality) ScanNodeVitalityFromKV(_ context.Context) (NodeVital
 }
 
 func (tnv TestNodeVitality) ScanNodeVitalityFromCache() NodeVitalityMap {
-	nvm := make(NodeVitalityMap, len(tnv))
-	for key, entry := range tnv {
-		nvm[key] = entry.Convert()
+	nvm := make(NodeVitalityMap, len(tnv.Entry))
+	for key, entry := range tnv.Entry {
+		nvm[key] = entry.convert()
 	}
 	return nvm
 }
 
 func (tnv TestNodeVitality) AddNextNode() {
 	maxNodeID := roachpb.NodeID(0)
-	for id := range tnv {
+	for id := range tnv.Entry {
 		if id > maxNodeID {
 			maxNodeID = id
 		}
@@ -86,8 +94,9 @@ func (tnv TestNodeVitality) AddNextNode() {
 }
 
 func (tnv TestNodeVitality) AddNode(id roachpb.NodeID) {
-	now := hlc.NewClockForTesting(hlc.NewHybridManualClock()).Now()
-	tnv[id] = TestNodeVitalityEntry{
+	now := tnv.Clock.Now()
+	tnv.Entry[id] = testNodeVitalityEntry{
+		clock: tnv.Clock,
 		Liveness: Liveness{
 			NodeID:     id,
 			Epoch:      1,
@@ -99,47 +108,57 @@ func (tnv TestNodeVitality) AddNode(id roachpb.NodeID) {
 	}
 }
 
+func (tnv TestNodeVitality) AddDead(id roachpb.NodeID) {
+	tnv.Entry[id] = testNodeVitalityEntry{
+		clock: tnv.Clock,
+		Alive: false,
+	}
+}
+
 // Draining marks a given node as draining.
 func (tnv TestNodeVitality) Draining(id roachpb.NodeID, drain bool) {
-	entry := tnv[id]
+	entry := tnv.Entry[id]
 	entry.Liveness.Draining = drain
-	tnv[id] = entry
+	tnv.Entry[id] = entry
 }
 
 // Decommissioning marks a given node as decommissioning.
 func (tnv TestNodeVitality) Decommissioning(id roachpb.NodeID, alive bool) {
-	entry := tnv[id]
+	entry := tnv.Entry[id]
 	entry.Liveness.Membership = MembershipStatus_DECOMMISSIONING
 	entry.Alive = alive
-	tnv[id] = entry
+	tnv.Entry[id] = entry
 }
 
 // Decommissioned marks a given node as decommissioned.
 func (tnv TestNodeVitality) Decommissioned(id roachpb.NodeID, alive bool) {
-	now := hlc.NewClockForTesting(hlc.NewHybridManualClock()).Now()
-	entry := tnv[id]
+	entry := tnv.Entry[id]
 	entry.Liveness.Membership = MembershipStatus_DECOMMISSIONED
 	// Mark the liveness as expired if not alive.
 	if !alive {
-		entry.Liveness.Expiration = now.AddDuration(-1).ToLegacyTimestamp()
+		entry.Liveness.Expiration = entry.clock.Now().AddDuration(-1).ToLegacyTimestamp()
 	}
 	entry.Alive = alive
-	tnv[id] = entry
+	tnv.Entry[id] = entry
+}
+
+func (tnv TestNodeVitality) DeleteNode(id roachpb.NodeID) {
+	delete(tnv.Entry, id)
 }
 
 // DownNode marks a node as expired.
 func (tnv TestNodeVitality) DownNode(id roachpb.NodeID) {
-	entry := tnv[id]
+	entry := tnv.Entry[id]
 	entry.Alive = false
-	tnv[id] = entry
+	tnv.Entry[id] = entry
 }
 
 // RestartNode marks a node as alive by setting the expiration in the future.
 func (tnv TestNodeVitality) RestartNode(id roachpb.NodeID) {
-	entry := tnv[id]
+	entry := tnv.Entry[id]
 	entry.Alive = true
 	entry.Liveness.Epoch++
-	tnv[id] = entry
+	tnv.Entry[id] = entry
 }
 
 // FakeNodeVitality creates a node vitality record that is either dead or alive

--- a/pkg/spanconfig/spanconfigreporter/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigreporter/datadriven_test.go
@@ -231,7 +231,7 @@ func newMockCluster(
 		t:        t,
 		nodes:    make(map[roachpb.NodeID]roachpb.NodeDescriptor),
 		ranges:   make(map[roachpb.RangeID]roachpb.RangeDescriptor),
-		liveness: livenesspb.TestNodeVitality{},
+		liveness: livenesspb.TestCreateNodeVitality(),
 		store: spanconfigstore.New(
 			roachpb.TestingDefaultSpanConfig(),
 			st,


### PR DESCRIPTION
To remove any test raciness, using a manual clock is preferable to using a clock based on time.Now(). This will reduce some test flakiness related to clocks and liveness.

Epic: none

Release note: None