### PR TITLE
logictest: fix rare flake

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -188,21 +188,22 @@ statement ok
 SELECT crdb_internal.create_tenant(5)
 
 # Use retry because source data is eventually consistent.
-query ITT colnames,retry
-SELECT * FROM crdb_internal.node_tenant_capabilities_cache WHERE capability_name = 'can_admin_split'
+query ITT colnames,retry,rowsort
+SELECT * FROM crdb_internal.node_tenant_capabilities_cache WHERE capability_name = 'can_view_node_info'
 ----
-tenant_id  capability_name    capability_value
-1          can_admin_split  true
+tenant_id  capability_name     capability_value
+1          can_view_node_info  true
+5          can_view_node_info  false
 
 statement ok
-ALTER TENANT [5] GRANT CAPABILITY can_admin_split
+ALTER TENANT [5] GRANT CAPABILITY can_view_node_info
 
 # Use retry because source data is eventually consistent.
 query ITT colnames,retry,rowsort
-SELECT * FROM crdb_internal.node_tenant_capabilities_cache WHERE capability_name = 'can_admin_split'
+SELECT * FROM crdb_internal.node_tenant_capabilities_cache WHERE capability_name = 'can_view_node_info'
 ----
 tenant_id  capability_name  capability_value
-1          can_admin_split  true
-5          can_admin_split  true
+1          can_view_node_info  true
+5          can_view_node_info  true
 
 subtest end


### PR DESCRIPTION
This commit fixes a rare flake in `TestCCLLogic_crdb_internal` where the test ensures that a newly-created secondary tenant doesn't have a tenant capability by default, then grants that capability, and the in-memory cache is updated accordingly. The problem was that this test uses "can_admin_split" capability for the check, and the test was added before 879bd1c9efb9c4e8f11910dac5db7c01ebf84c79 merged. That patch made it so that "can_admin_split" capability is granted by default, so it made the existing test racy - namely, the race is between the tenant capabilities watcher propagating the grant and the logic test framework querying the in-memory cache. The fix is simple - use a capability that is not granted by default ("can_view_node_info").

Fixes: #115028.

Release note: None