### PR TITLE
release-23.1: status: add network packet dropped and error metrics

### DIFF
--- a/pkg/server/status/runtime_test.go
+++ b/pkg/server/status/runtime_test.go
@@ -58,24 +58,42 @@ func TestSumNetCounters(t *testing.T) {
 
 	counters := []net.IOCountersStat{
 		{
-			PacketsSent: 1,
+			BytesRecv:   1,
 			PacketsRecv: 1,
 			BytesSent:   1,
-			BytesRecv:   1,
+			PacketsSent: 1,
 		},
 		{
-			PacketsSent: 1,
-			PacketsRecv: 1,
-			BytesSent:   1,
 			BytesRecv:   1,
+			PacketsRecv: 1,
+			Errin:       1,
+			Dropin:      1,
+			BytesSent:   1,
+			PacketsSent: 1,
+			Errout:      1,
+			Dropout:     1,
+		},
+		{
+			BytesRecv:   3,
+			PacketsRecv: 3,
+			Errin:       1,
+			Dropin:      1,
+			BytesSent:   3,
+			PacketsSent: 3,
+			Errout:      1,
+			Dropout:     1,
 		},
 	}
 	summed := sumNetworkCounters(counters)
 	expected := net.IOCountersStat{
-		PacketsSent: 2,
-		PacketsRecv: 2,
-		BytesSent:   2,
-		BytesRecv:   2,
+		BytesRecv:   5,
+		PacketsRecv: 5,
+		Errin:       2,
+		Dropin:      2,
+		BytesSent:   5,
+		PacketsSent: 5,
+		Errout:      2,
+		Dropout:     2,
 	}
 	if !reflect.DeepEqual(summed, expected) {
 		t.Fatalf("expected %+v; got %+v", expected, summed)
@@ -117,22 +135,34 @@ func TestSubtractNetCounters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	from := net.IOCountersStat{
-		PacketsSent: 3,
 		PacketsRecv: 3,
-		BytesSent:   3,
 		BytesRecv:   3,
+		Errin:       2,
+		Dropin:      2,
+		BytesSent:   3,
+		PacketsSent: 3,
+		Errout:      2,
+		Dropout:     2,
 	}
 	sub := net.IOCountersStat{
-		PacketsSent: 1,
 		PacketsRecv: 1,
-		BytesSent:   1,
 		BytesRecv:   1,
+		Errin:       1,
+		Dropin:      1,
+		BytesSent:   1,
+		PacketsSent: 1,
+		Errout:      1,
+		Dropout:     1,
 	}
 	expected := net.IOCountersStat{
-		PacketsSent: 2,
-		PacketsRecv: 2,
-		BytesSent:   2,
 		BytesRecv:   2,
+		PacketsRecv: 2,
+		Dropin:      1,
+		Errin:       1,
+		BytesSent:   2,
+		PacketsSent: 2,
+		Errout:      1,
+		Dropout:     1,
 	}
 	subtractNetworkCounters(&from, sub)
 	if !reflect.DeepEqual(from, expected) {

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -155,6 +155,20 @@ var charts = []sectionDescription{
 					"sys.host.net.send.bytes",
 				},
 			},
+			{
+				Title: "Error",
+				Metrics: []string{
+					"sys.host.net.recv.err",
+					"sys.host.net.send.err",
+				},
+			},
+			{
+				Title: "Drop",
+				Metrics: []string{
+					"sys.host.net.recv.drop",
+					"sys.host.net.send.drop",
+				},
+			},
 		},
 	},
 	{

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -175,6 +175,45 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
+    <LineGraph title="Network Packets Received" sources={nodeSources}>
+      <Axis units={AxisUnits.Count} label="packets">
+        {nodeIDs.map(nid => (
+          <Metric
+            name="cr.node.sys.host.net.recv.packets"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph title="Network Packet Errors on Receive" sources={nodeSources}>
+      <Axis units={AxisUnits.Count} label="packets">
+        {nodeIDs.map(nid => (
+          <Metric
+            name="cr.node.sys.host.net.recv.err"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph title="Network Packet Drops on Receive" sources={nodeSources}>
+      <Axis units={AxisUnits.Count} label="packets">
+        {nodeIDs.map(nid => (
+          <Metric
+            name="cr.node.sys.host.net.recv.drop"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
     <LineGraph title="Network Bytes Sent" sources={nodeSources}>
       <Axis units={AxisUnits.Bytes} label="bytes">
         {nodeIDs.map(nid => (
@@ -182,6 +221,45 @@ export default function (props: GraphDashboardProps) {
             name="cr.node.sys.host.net.send.bytes"
             title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph title="Network Packets Sent" sources={nodeSources}>
+      <Axis units={AxisUnits.Count} label="packets">
+        {nodeIDs.map(nid => (
+          <Metric
+            name="cr.node.sys.host.net.send.packets"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph title="Network Packet Errors on Send" sources={nodeSources}>
+      <Axis units={AxisUnits.Count} label="packets">
+        {nodeIDs.map(nid => (
+          <Metric
+            name="cr.node.sys.host.net.send.err"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph title="Network Packet Drops on Send" sources={nodeSources}>
+      <Axis units={AxisUnits.Count} label="packets">
+        {nodeIDs.map(nid => (
+          <Metric
+            name="cr.node.sys.host.net.send.drop"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             nonNegativeRate
           />
         ))}


### PR DESCRIPTION
Backport 1/2 commits from #116005.

/cc @cockroachdb/release

Release justification: improves observability of networking instability. Assists L2 escalations.

---

This commit adds packet drop/error counter on network's sending and receiving end. These metrics are derived from the os and aims for better observability on tail latencies.

The second added chart looks like below for number of packets, packets error, and packets dropped on sending and receiving end.

<img width="1055" alt="Screenshot 2023-12-13 at 4 49 11 PM" src="https://github.com/cockroachdb/cockroach/assets/20375035/20cfc33c-9db6-4492-a9d6-9194454ef360">





Fixes: #115458

Release note(ui change): the DB Console metrics dashboard's Networking tab is
enhanced with charts that visualize number of packets received, number of
receiving packets with error, number of receiving packets got dropped, number
of packets sent, number of sending packets with error, and number of sending
packets got dropped.
