### PR TITLE
release-23.2: backupccl: remove unused PhysicalPlanChangeChecker

### DIFF
--- a/pkg/ccl/backupccl/bench_covering_test.go
+++ b/pkg/ccl/backupccl/bench_covering_test.go
@@ -91,11 +91,9 @@ func BenchmarkRestoreEntryCover(b *testing.B) {
 
 											spanCh := make(chan execinfrapb.RestoreSpanEntry, 1000)
 
-											checkpointFrontier, err := loadCheckpointFrontier(backups[numBackups-1].Spans, []jobspb.RestoreProgress_FrontierEntry{})
-											require.NoError(b, err)
-
 											filter, err := makeSpanCoveringFilter(
-												checkpointFrontier,
+												backups[numBackups-1].Spans,
+												[]jobspb.RestoreProgress_FrontierEntry{},
 												nil,
 												introducedSpanFrontier,
 												0,

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
@@ -462,12 +462,10 @@ func runGenerativeSplitAndScatter(
 		if err != nil {
 			return errors.Wrap(err, "making backup locality map")
 		}
-		checkpointFrontier, err := loadCheckpointFrontier(spec.Spans, spec.CheckpointedSpans)
-		if err != nil {
-			return errors.Wrap(err, "loading checkpoint frontier")
-		}
+
 		filter, err := makeSpanCoveringFilter(
-			checkpointFrontier,
+			spec.Spans,
+			spec.CheckpointedSpans,
 			spec.HighWater,
 			introducedSpanFrontier,
 			spec.TargetSize,

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"math"
 	"sort"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
@@ -33,21 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
-)
-
-var replanRestoreThreshold = settings.RegisterFloatSetting(
-	settings.ApplicationLevel,
-	"bulkio.restore.replan_flow_threshold",
-	"fraction of initial flow instances that would be added or updated above which a RESTORE execution plan is restarted from the last checkpoint (0=disabled)",
-	0.0,
-)
-
-var replanRestoreFrequency = settings.RegisterDurationSetting(
-	settings.ApplicationLevel,
-	"bulkio.restore.replan_flow_frequency",
-	"frequency at which RESTORE checks to see if restarting would change its updates its physical execution plan",
-	time.Minute*2,
-	settings.PositiveDuration,
 )
 
 var memoryMonitorSSTs = settings.RegisterBoolSetting(

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -283,13 +283,9 @@ func makeImportSpans(
 		return nil
 	})
 
-	checkpointFrontier, err := loadCheckpointFrontier(spans, completedSpans)
-	if err != nil {
-		return nil, err
-	}
-
 	filter, err := makeSpanCoveringFilter(
-		checkpointFrontier,
+		spans,
+		completedSpans,
 		highWaterMark,
 		introducedSpanFrontier,
 		targetSize,
@@ -674,15 +670,15 @@ func TestCheckpointFilter(t *testing.T) {
 			expectedToDoSpans: roachpb.Spans{c.sp("c", "d")},
 		},
 	} {
-		frontier, err := spanUtils.MakeFrontier(requiredSpan)
-		require.NoError(t, err)
+		var checkpointedSpans []jobspb.RestoreProgress_FrontierEntry
 		for i := range tc.completedSpans {
-			_, err := frontier.Forward(tc.completedSpans[i], completedSpanTime)
-			require.NoError(t, err)
+			checkpointedSpans = append(checkpointedSpans,
+				jobspb.RestoreProgress_FrontierEntry{Span: tc.completedSpans[i], Timestamp: completedSpanTime})
 		}
 
 		f, err := makeSpanCoveringFilter(
-			frontier,
+			[]roachpb.Span{requiredSpan},
+			checkpointedSpans,
 			nil,
 			nil,
 			0,


### PR DESCRIPTION
Backport 2/2 commits from #115891.

/cc @cockroachdb/release

---

Please see individual commits.

Fixes: #115844

Release justification: low risk bug fix that prevents misuse of frontier during iteration
