### PR TITLE
release-23.2: kv: disable use of {shared,replicated} locks in conjunction with skip locked

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/kv/kvnemesis/kvnemesisutil",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/batcheval",
         "//pkg/kv/kvserver/concurrency",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -117,6 +118,10 @@ func exceptSharedLockPromotionError(err error) bool { // true if lock promotion 
 
 func exceptSkipLockedReplayError(err error) bool { // true if skip locked replay error
 	return errors.Is(err, &concurrency.SkipLockedReplayError{})
+}
+
+func exceptSkipLockedUnsupportedError(err error) bool { // true if unsupported use of skip locked error
+	return errors.Is(err, &batcheval.SkipLockedUnsupportedError{})
 }
 
 func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {

--- a/pkg/kv/kvnemesis/testdata/TestApplier/get-for-share-skip-locked
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/get-for-share-skip-locked
@@ -1,3 +1,3 @@
 echo
 ----
-db0.GetForShareSkipLocked(ctx, tk(1)) // @<ts> (v1, <nil>)
+db0.GetForShareSkipLocked(ctx, tk(1)) // usage of shared locks in conjunction with skip locked wait policy is currently unsupported

--- a/pkg/kv/kvnemesis/testdata/TestApplier/get-for-share-skip-locked-guaranteed-durability
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/get-for-share-skip-locked-guaranteed-durability
@@ -1,3 +1,3 @@
 echo
 ----
-db0.GetForShareSkipLockedGuaranteedDurability(ctx, tk(1)) // @<ts> (v1, <nil>)
+db0.GetForShareSkipLockedGuaranteedDurability(ctx, tk(1)) // usage of shared locks in conjunction with skip locked wait policy is currently unsupported

--- a/pkg/kv/kvnemesis/testdata/TestApplier/rscan-for-share-skip-locked
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/rscan-for-share-skip-locked
@@ -1,3 +1,3 @@
 echo
 ----
-db0.ReverseScanForShareSkipLocked(ctx, tk(1), tk(2), 0) // @<ts> (/Table/100/"0000000000000001":v21, <nil>)
+db0.ReverseScanForShareSkipLocked(ctx, tk(1), tk(2), 0) // usage of shared locks in conjunction with skip locked wait policy is currently unsupported

--- a/pkg/kv/kvnemesis/testdata/TestApplier/rscan-for-share-skip-locked-guaranteed-durability
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/rscan-for-share-skip-locked-guaranteed-durability
@@ -1,3 +1,3 @@
 echo
 ----
-db0.ReverseScanForShareSkipLockedGuaranteedDurability(ctx, tk(1), tk(2), 0) // @<ts> (/Table/100/"0000000000000001":v21, <nil>)
+db0.ReverseScanForShareSkipLockedGuaranteedDurability(ctx, tk(1), tk(2), 0) // usage of shared locks in conjunction with skip locked wait policy is currently unsupported

--- a/pkg/kv/kvnemesis/testdata/TestApplier/scan-for-share-skip-locked
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/scan-for-share-skip-locked
@@ -1,3 +1,3 @@
 echo
 ----
-db0.ScanForShareSkipLocked(ctx, tk(1), tk(3), 0) // @<ts> (/Table/100/"0000000000000001":v1, <nil>)
+db0.ScanForShareSkipLocked(ctx, tk(1), tk(3), 0) // usage of shared locks in conjunction with skip locked wait policy is currently unsupported

--- a/pkg/kv/kvnemesis/testdata/TestApplier/scan-for-share-skip-locked-guaranteed-durability
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/scan-for-share-skip-locked-guaranteed-durability
@@ -1,3 +1,3 @@
 echo
 ----
-db0.ScanForShareSkipLockedGuaranteedDurability(ctx, tk(1), tk(3), 0) // @<ts> (/Table/100/"0000000000000001":v1, <nil>)
+db0.ScanForShareSkipLockedGuaranteedDurability(ctx, tk(1), tk(3), 0) // usage of shared locks in conjunction with skip locked wait policy is currently unsupported

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -770,6 +770,7 @@ func (v *validator) processOp(op Operation) {
 		v.failIfError(
 			op, t.Result,
 			exceptRollback, exceptAmbiguous, exceptSharedLockPromotionError, exceptSkipLockedReplayError,
+			exceptSkipLockedUnsupportedError,
 		)
 
 		ops := t.Ops
@@ -1273,6 +1274,7 @@ func (v *validator) checkError(
 		exceptDelRangeUsingTombstoneStraddlesRangeBoundary,
 		exceptSharedLockPromotionError,
 		exceptSkipLockedReplayError,
+		exceptSkipLockedUnsupportedError,
 	}
 	sl = append(sl, extraExceptions...)
 	return v.failIfError(op, r, sl...)

--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -91,7 +91,7 @@ func Get(
 		acq, err := acquireLockOnKey(ctx, readWriter, h.Txn, args.KeyLockingStrength,
 			args.KeyLockingDurability, args.Key, cArgs.Stats, cArgs.EvalCtx.ClusterSettings())
 		if err != nil {
-			return result.Result{}, err
+			return result.Result{}, maybeInterceptDisallowedSkipLockedUsage(h, err)
 		}
 		res.Local.AcquiredLocks = []roachpb.LockAcquisition{acq}
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -33,6 +33,10 @@ func Get(
 	h := cArgs.Header
 	reply := resp.(*kvpb.GetResponse)
 
+	if err := maybeDisallowSkipLockedRequest(h, args.KeyLockingStrength); err != nil {
+		return result.Result{}, err
+	}
+
 	getRes, err := storage.MVCCGet(ctx, readWriter, args.Key, h.Timestamp, storage.MVCCGetOptions{
 		Inconsistent:          h.ReadConsistency != kvpb.CONSISTENT,
 		SkipLocked:            h.WaitPolicy == lock.WaitPolicy_SkipLocked,

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -35,6 +35,10 @@ func ReverseScan(
 	h := cArgs.Header
 	reply := resp.(*kvpb.ReverseScanResponse)
 
+	if err := maybeDisallowSkipLockedRequest(h, args.KeyLockingStrength); err != nil {
+		return result.Result{}, err
+	}
+
 	var res result.Result
 	var scanRes storage.MVCCScanResult
 	var err error

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -118,7 +118,7 @@ func ReverseScan(
 			ctx, readWriter, h.Txn, args.KeyLockingStrength, args.KeyLockingDurability,
 			args.ScanFormat, &scanRes, cArgs.Stats, cArgs.EvalCtx.ClusterSettings())
 		if err != nil {
-			return result.Result{}, err
+			return result.Result{}, maybeInterceptDisallowedSkipLockedUsage(h, err)
 		}
 		res.Local.AcquiredLocks = acquiredLocks
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -14,10 +14,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/errors"
 )
 
 func init() {
@@ -34,6 +36,10 @@ func Scan(
 	args := cArgs.Args.(*kvpb.ScanRequest)
 	h := cArgs.Header
 	reply := resp.(*kvpb.ScanResponse)
+
+	if err := maybeDisallowSkipLockedRequest(h, args.KeyLockingStrength); err != nil {
+		return result.Result{}, err
+	}
 
 	var res result.Result
 	var scanRes storage.MVCCScanResult
@@ -121,4 +127,37 @@ func Scan(
 
 	res.Local.EncounteredIntents = scanRes.Intents
 	return res, nil
+}
+
+// maybeDisallowSkipLockedRequest returns an error if the skip locked wait
+// policy is used in conjunction with shared locks.
+//
+// TODO(arul): this won't be needed once
+// https://github.com/cockroachdb/cockroach/issues/110743 is addressed. Until
+// then, we return unimplemented errors.
+func maybeDisallowSkipLockedRequest(h kvpb.Header, str lock.Strength) error {
+	if h.WaitPolicy == lock.WaitPolicy_SkipLocked && str == lock.Shared {
+		return MarkSkipLockedUnsupportedError(errors.UnimplementedError(
+			errors.IssueLink{IssueURL: build.MakeIssueURL(110743)},
+			"usage of shared locks in conjunction with skip locked wait policy is currently unsupported",
+		))
+	}
+	return nil
+}
+
+// SkipLockedUnsupportedError is used to mark errors resulting from unsupported
+// (currently unimplemented) uses of the skip locked wait policy.
+type SkipLockedUnsupportedError struct{}
+
+func (e *SkipLockedUnsupportedError) Error() string {
+	return "unsupported skip locked use error"
+}
+
+// MarkSkipLockedUnsupportedError wraps the given error, if not nil, as a skip
+// locked unsupported error.
+func MarkSkipLockedUnsupportedError(cause error) error {
+	if cause == nil {
+		return nil
+	}
+	return errors.Mark(cause, &SkipLockedUnsupportedError{})
 }

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -120,13 +120,30 @@ func Scan(
 			ctx, readWriter, h.Txn, args.KeyLockingStrength, args.KeyLockingDurability,
 			args.ScanFormat, &scanRes, cArgs.Stats, cArgs.EvalCtx.ClusterSettings())
 		if err != nil {
-			return result.Result{}, err
+			return result.Result{}, maybeInterceptDisallowedSkipLockedUsage(h, err)
 		}
 		res.Local.AcquiredLocks = acquiredLocks
 	}
 
 	res.Local.EncounteredIntents = scanRes.Intents
 	return res, nil
+}
+
+// maybeInterceptDisallowedSkipLockedUsage checks if read evaluation for a skip
+// locked request encountered a replicated lock by checking the supplier error
+// type. It transforms the error into an unimplemented error if that's the case;
+// otherwise, the error is passed through.
+//
+// TODO(arul): this won't be needed once
+// https://github.com/cockroachdb/cockroach/issues/115057 is addressed.
+func maybeInterceptDisallowedSkipLockedUsage(h kvpb.Header, err error) error {
+	if h.WaitPolicy == lock.WaitPolicy_SkipLocked && errors.HasType(err, (*kvpb.LockConflictError)(nil)) {
+		return MarkSkipLockedUnsupportedError(errors.UnimplementedError(
+			errors.IssueLink{IssueURL: build.MakeIssueURL(115057)},
+			"usage of replicated locks in conjunction with skip locked wait policy is currently unsupported",
+		))
+	}
+	return err
 }
 
 // maybeDisallowSkipLockedRequest returns an error if the skip locked wait

--- a/pkg/sql/logictest/testdata/logic_test/select_for_share
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_share
@@ -110,6 +110,12 @@ user testuser
 statement ok
 COMMIT
 
+statement ok
+SET enable_shared_locking_for_serializable = true
+
+statement error usage of shared locks in conjunction with skip locked wait policy is currently unsupported
+SELECT * FROM t FOR SHARE SKIP LOCKED
+
 # TODO(arul): Add a test to show that the session setting doesn't apply to read
 # committed transactions. We currently can't issue SELECT FOR SHARE statements
 # in read committed transactions because durable locking hasn't been fully

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -628,3 +628,51 @@ SELECT * FROM t94290 WHERE b = 2 FOR UPDATE;
 
 statement ok
 RESET statement_timeout;
+
+# Ensure when SKIP LOCKED is used in conjunction with replicated locks we return
+# appropriate errors.
+
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t(a INT PRIMARY KEY);
+INSERT INTO t VALUES(1);
+GRANT ALL ON t TO testuser;
+GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser;
+
+user testuser
+
+statement ok
+SET enable_durable_locking_for_serializable = true;
+
+statement ok
+BEGIN
+
+query I
+SELECT * FROM t WHERE a = 1 FOR UPDATE;
+----
+1
+
+user root
+
+skipif config local-mixed-23.1
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+----
+database_name  schema_name  table_name  lock_key_pretty  lock_strength  durability  isolation_level  granted  contended
+
+skipif config local-mixed-23.1
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+
+# Ensure the replicated lock isn't pulled into the in-memory lock table, even
+# after the skip locked statement has run.
+skipif config local-mixed-23.1
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+----
+database_name  schema_name  table_name  lock_key_pretty   lock_strength  durability    isolation_level  granted  contended
+
+user testuser
+
+statement ok
+COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
@@ -66,19 +66,19 @@ COMMIT;
 
 # SKIP LOCKED reads do not block.
 
-query III rowsort
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM abc FOR UPDATE SKIP LOCKED;
-COMMIT;
-----
-3  30  300
 
-query III rowsort
+statement ok
+ROLLBACK;
+
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM bcd FOR UPDATE SKIP LOCKED;
-COMMIT;
-----
-20  200  2000
+
+statement ok
+ROLLBACK
 
 # Shared reads block on exclusive locks but not on shared locks.
 
@@ -238,19 +238,19 @@ SELECT * FROM bcd WHERE b = 7 FOR UPDATE
 
 user root
 
-query III rowsort
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM abc WHERE a > 4 FOR UPDATE SKIP LOCKED;
-COMMIT;
-----
-6  1  7
 
-query III rowsort
+statement ok
+ROLLBACK
+
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM bcd WHERE b < 8 FOR UPDATE SKIP LOCKED;
-COMMIT;
-----
-6  1  5
+
+statement ok
+ROLLBACK
 
 query III async,rowsort q10
 BEGIN ISOLATION LEVEL READ COMMITTED;
@@ -327,19 +327,19 @@ SELECT * FROM bcd WHERE b = 7 FOR UPDATE
 
 user root
 
-query III rowsort
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM abc WHERE a > 4 FOR UPDATE SKIP LOCKED;
-COMMIT;
-----
-6  1  7
 
-query III rowsort
+statement ok
+ROLLBACK
+
+statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM bcd WHERE b < 8 FOR UPDATE SKIP LOCKED;
-COMMIT;
-----
-6  1  5
+
+statement ok
+ROLLBACK;
 
 query III async,rowsort q12
 BEGIN ISOLATION LEVEL READ COMMITTED;


### PR DESCRIPTION
Backport PRs: #116446 #116461

Release justification: throws error on unsupported behavior to avoid confusion.