### PR TITLE
roachtest : classify vm preemption failure as infraFlake

### DIFF
--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -473,13 +473,10 @@ func (t *testImpl) failedRLocked() bool {
 	return t.mu.numFailures > 0
 }
 
-func (t *testImpl) firstFailure() failure {
+func (t *testImpl) failures() []failure {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	if len(t.mu.failures) == 0 {
-		return failure{}
-	}
-	return t.mu.failures[0]
+	return t.mu.failures
 }
 
 func (t *testImpl) failureMsg() string {
@@ -499,6 +496,16 @@ func failureContainsError(f failure, refError error) bool {
 		}
 	}
 	return errors.Is(f.squashedErr, refError)
+}
+
+// failuresContainsError returns true if any of the failures contains the reference error
+func failuresContainsError(failures []failure, refError error) bool {
+	for _, f := range failures {
+		if failureContainsError(f, refError) {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *testImpl) ArtifactsDir() string {

--- a/pkg/cmd/roachtest/test_impl_test.go
+++ b/pkg/cmd/roachtest/test_impl_test.go
@@ -13,6 +13,8 @@ package main
 import (
 	"testing"
 
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,4 +41,126 @@ func TestTeamCityEscape(t *testing.T) {
 	require.Equal(t, "|0x00bf", TeamCityEscape("\u00bf"))
 	require.Equal(t, "|0x00bfaaa", TeamCityEscape("\u00bfaaa"))
 	require.Equal(t, "bb|0x00bfaaa", TeamCityEscape("bb\u00bfaaa"))
+}
+
+func Test_failuresContainsError(t *testing.T) {
+	createFailure := func(ref error, squashedErr error) failure {
+		return failure{errors: []error{ref}, squashedErr: squashedErr}
+	}
+	type args struct {
+		failures []failure
+		refError error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "empty failures",
+			args: args{
+				failures: []failure{},
+				refError: errors.New("testerror"),
+			},
+			want: false,
+		},
+		{
+			name: "failures contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(errors.New("testerror"), nil),
+				},
+				refError: errors.New("testerror"),
+			},
+			want: true,
+		},
+		{
+			name: "non first failures contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(errors.New("unexpected-error"), nil),
+					createFailure(errors.New("expected-error"), nil),
+				},
+				refError: errors.New("expected-error"),
+			},
+			want: true,
+		},
+		{
+			name: "first failures contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(errors.New("expected-error"), nil),
+					createFailure(errors.New("unexpected-error"), nil),
+				},
+				refError: errors.New("expected-error"),
+			},
+			want: true,
+		},
+		{
+			name: "first failures squashedErr contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(nil, errors.New("expected-error")),
+					createFailure(errors.New("unexpected-error"), nil),
+				},
+				refError: errors.New("expected-error"),
+			},
+			want: true,
+		},
+		{
+			name: "non first failures squashedErr contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(errors.New("unexpected-error"), errors.New("unexpected-squashed-error")),
+					createFailure(nil, errors.New("expected-error")),
+				},
+				refError: errors.New("expected-error"),
+			},
+			want: true,
+		},
+		{
+			name: "both errors and squashedErr contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(errors.New("expected-error"), errors.New("expected-error")),
+				},
+				refError: errors.New("expected-error"),
+			},
+			want: true,
+		},
+		{
+			name: "single failure - none of errors or squashedErr contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(errors.New("unexpected-error"), errors.New("unexpected-error1")),
+				},
+				refError: errors.New("expected-error"),
+			},
+			want: false,
+		},
+		{
+			name: "multiple failures - none of errors or squashedErr contains expected error",
+			args: args{
+				failures: []failure{
+					createFailure(errors.New("unexpected-error"), errors.New("unexpected-error1")),
+					createFailure(errors.New("unexpected-error2"), errors.New("unexpected-error3")),
+				},
+				refError: errors.New("expected-error"),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, failuresContainsError(tt.args.failures, tt.args.refError), "failuresContainsError(%v, %v)", tt.args.failures, tt.args.refError)
+		})
+	}
+}
+
+func Test_failureContainsErrorAndAddFailureCombination(t *testing.T) {
+	ti := testImpl{
+		l: nilLogger(),
+	}
+	ti.addFailure(0, "", errVMPreemption)
+	assert.True(t, failuresContainsError(ti.failures(), errVMPreemption))
 }

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_10.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_10.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_11.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_11.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_12.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_12.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----


### PR DESCRIPTION
roachtest : classify vm preemption failure as infraFlake and route to testeng.

Epic: none

Release note: None