### PR TITLE
kvserver: log 5 hottest ranges when unable to shed load

### DIFF
--- a/pkg/kv/kvserver/allocator/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/BUILD.bazel
@@ -13,6 +13,8 @@ go_library(
         "//pkg/kv/kvserver/constraint",
         "//pkg/roachpb",
         "//pkg/settings",
+        "//pkg/util/humanizeutil",
+        "@com_github_cockroachdb_redact//:redact",
         "@io_etcd_go_raft_v3//:raft",
     ],
 )

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/redact"
 	"go.etcd.io/raft/v3"
 )
 
@@ -125,6 +126,9 @@ const (
 	// replica (lease included) must contribute, in order to consider it
 	// worthwhile rebalancing when overfull.
 	minReplicaLoadFraction = 0.02
+	// maxHotRangesToLog is the maximum number of hot ranges which will be logged
+	// after failing to rebalance below the desired load threshold.
+	maxHotRangesToLog = 5
 )
 
 // StoreRebalancer is responsible for examining how the associated store's load
@@ -230,6 +234,7 @@ type RebalanceContext struct {
 	mode                               LBRebalancingMode
 	allStoresList                      storepool.StoreList
 	hottestRanges, rebalanceCandidates []CandidateReplica
+	leftoverCandidates                 []CandidateReplica
 }
 
 // RebalanceMode returns the mode of the store rebalancer. See
@@ -247,6 +252,35 @@ func (sr *StoreRebalancer) RebalanceObjective() LBRebalancingObjective {
 // threshold w.r.t the balanced load dimension, false otherwise.
 func (r *RebalanceContext) LessThanMaxThresholds() bool {
 	return !load.Greater(r.LocalDesc.Capacity.Load(), r.maxThresholds, r.loadDimension)
+}
+
+// formatHotRanges returns a redactable string containing a new line separated
+// list of ranges given. Each range's descriptor is included alongside range
+// usage information. Note the print order is identical to ranges slice.
+func formatHotRanges(ranges []CandidateReplica) redact.RedactableString {
+	var buf redact.StringBuilder
+	for idx, r := range ranges {
+		if idx > 0 {
+			buf.SafeRune('\n')
+		}
+		desc := r.Desc()
+		buf.Printf("\t%d: r%d:%v replicas=[%v] load=%v",
+			idx+1, desc.RangeID, desc.KeySpan(), desc.Replicas(), r.RangeUsageInfo())
+	}
+	return buf.RedactableString()
+}
+
+// logRemainingHotRanges logs the hottest candidate ranges which have had no
+// rebalance actions taken.
+func (r *RebalanceContext) logRemainingHotRanges(ctx context.Context) {
+	if n := len(r.leftoverCandidates); n > 0 {
+		candidatesToLog := maxHotRangesToLog
+		if candidatesToLog > n {
+			candidatesToLog = n
+		}
+		log.KvDistribution.Infof(ctx,
+			"%v", formatHotRanges(r.leftoverCandidates[:candidatesToLog]))
+	}
 }
 
 // Start runs an infinite loop in a goroutine which regularly checks whether
@@ -589,6 +623,8 @@ func (sr *StoreRebalancer) TransferToRebalanceRanges(
 			"ran out of leases worth transferring and load %s is still above desired threshold %s",
 			rctx.LocalDesc.Capacity.Load(), rctx.maxThresholds)
 		sr.metrics.ImbalancedStateOverfullOptionsExhausted.Inc(1)
+		rctx.leftoverCandidates = append(rctx.leftoverCandidates, rctx.rebalanceCandidates...)
+		rctx.logRemainingHotRanges(ctx)
 		return false
 	}
 
@@ -611,6 +647,7 @@ func (sr *StoreRebalancer) LogRangeRebalanceOutcome(ctx context.Context, rctx *R
 			"ran out of replicas worth transferring and load %s is still above desired threshold %s; will check again soon",
 			rctx.LocalDesc.Capacity.Load(), rctx.maxThresholds)
 		sr.metrics.ImbalancedStateOverfullOptionsExhausted.Inc(1)
+		rctx.logRemainingHotRanges(ctx)
 		return
 	}
 
@@ -864,6 +901,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 				rctx.LocalDesc.StoreID,
 				rctx.LocalDesc.Capacity.Load(),
 			)
+			rctx.leftoverCandidates = append(rctx.leftoverCandidates, candidateReplica)
 			continue
 		}
 
@@ -880,6 +918,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 				expected,
 				actual,
 			)
+			rctx.leftoverCandidates = append(rctx.leftoverCandidates, candidateReplica)
 			continue
 		}
 		if expected, actual := numDesiredNonVoters, len(rangeDesc.Replicas().NonVoterDescriptors()); expected != actual {
@@ -891,6 +930,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 				expected,
 				actual,
 			)
+			rctx.leftoverCandidates = append(rctx.leftoverCandidates, candidateReplica)
 			continue
 		}
 		rebalanceCtx := rangeRebalanceContext{
@@ -942,6 +982,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 			// If the range needs a lease transfer to enable better load distribution,
 			// it will be handled by the logic in `chooseLeaseToTransfer()`.
 			log.KvDistribution.VEventf(ctx, 3, "could not find rebalance opportunities for r%d", candidateReplica.GetRangeID())
+			rctx.leftoverCandidates = append(rctx.leftoverCandidates, candidateReplica)
 			continue
 		}
 
@@ -981,6 +1022,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 				"could not find rebalance opportunities for r%d, no replica found to hold lease",
 				candidateReplica.GetRangeID(),
 			)
+			rctx.leftoverCandidates = append(rctx.leftoverCandidates, candidateReplica)
 			continue
 		}
 


### PR DESCRIPTION
Previously, when a store's store rebalancer was unable to shed load below the overfull threshold, it wouldn't log the remaining hot ranges which constituted its load.

This commit introduces logging of the top 5 hottest remaining ranges post store rebalancer loop e.g.

```
ran out of replicas worth transferring and load ‹(queries-per-second=1457.8 cpu-per-second=475ms)› is still above desired threshold ‹(queries-per-second=1660.3 cpu-per-second=466ms)›; will check again soon
       1: r243:‹/Table/106/1/{5-237}› replicas=[(n1,s1):1,(n2,s2):2,(n3,s3):3] load=[batches/s=275.1 request_cpu/s=37ms raft_cpu/s=15ms write(keys)/s=135.3 write(bytes)/s=276 KiB read(keys)/s=134.7 read(bytes)/s=270 KiB]
       2: r241:‹/Table/106/1/{237-137250}› replicas=[(n1,s1):1,(n2,s2):2,(n3,s3):3] load=[batches/s=290.5 request_cpu/s=37ms raft_cpu/s=15ms write(keys)/s=143.3 write(bytes)/s=292 KiB read(keys)/s=142.2 read(bytes)/s=286 KiB]
       3: r114:‹/Table/106/1/-{2015703822623891408-1893539954586079808}› replicas=[(n3,s3):4,(n4,s4):2,(n1,s1):5] load=[batches/s=48.9 request_cpu/s=6ms raft_cpu/s=4ms write(keys)/s=24.1 write(bytes)/s=49 KiB read(keys)/s=48.1 read(bytes)/s=97 KiB]
       4: r230:‹/Table/106/1/6{047111467871674192-169275335909485792}› replicas=[(n3,s3):5,(n5,s5):4,(n1,s1):6] load=[batches/s=48.0 request_cpu/s=6ms raft_cpu/s=4ms write(keys)/s=23.9 write(bytes)/s=49 KiB read(keys)/s=23.3 read(bytes)/s=47 KiB]
       5: r153:‹/Table/106/1/5{191964391606992992-314128259644804592}› replicas=[(n1,s1):1,(n2,s2):4,(n5,s5):3] load=[batches/s=48.4 request_cpu/s=6ms raft_cpu/s=4ms write(keys)/s=23.7 write(bytes)/s=48 KiB read(keys)/s=23.9 read(bytes)/s=48 KiB]
```

Resolves: #98108
Release note: None