### PR TITLE
kvserver: stop using the cached span config

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -187,7 +187,6 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
-        "//pkg/spanconfig/spanconfigstore",
         "//pkg/storage",
         "//pkg/storage/disk",
         "//pkg/storage/enginepb",

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
@@ -4325,6 +4326,59 @@ func verifyUnmergedSoon(
 	})
 }
 
+// Utility to allow manually setting a span config that is used for all ranges.
+type spanConfigInterceptor struct {
+	syncutil.Mutex
+	spanConfig roachpb.SpanConfig
+	clock      *hlc.Clock
+}
+
+func (s *spanConfigInterceptor) NeedsSplit(
+	ctx context.Context, start, end roachpb.RKey,
+) (bool, error) {
+	// Never require a span config based split. Splits and merges can still
+	// happen for size based reasons.
+	return false, nil
+}
+
+func (s *spanConfigInterceptor) ComputeSplitKey(
+	ctx context.Context, start, end roachpb.RKey,
+) (roachpb.RKey, error) {
+	panic("test should not be computing a split key")
+}
+
+func (s *spanConfigInterceptor) GetSpanConfigForKey(
+	ctx context.Context, key roachpb.RKey,
+) (roachpb.SpanConfig, roachpb.Span, error) {
+	s.Lock()
+	defer s.Unlock()
+	return s.spanConfig, roachpb.Span{}, nil
+}
+
+func (s *spanConfigInterceptor) GetProtectionTimestamps(
+	ctx context.Context, sp roachpb.Span,
+) (protectionTimestamps []hlc.Timestamp, asOf hlc.Timestamp, _ error) {
+	return []hlc.Timestamp{}, s.clock.Now(), nil
+}
+
+func (s *spanConfigInterceptor) LastUpdated() hlc.Timestamp {
+	// Return a non-zero timestamp. This is typically used in the context of "has at least one update".
+	return hlc.Timestamp{
+		WallTime: 1,
+		Logical:  1,
+	}
+}
+
+func (s *spanConfigInterceptor) Subscribe(f func(ctx context.Context, updated roachpb.Span)) {
+	// ignore
+}
+
+func (s *spanConfigInterceptor) set(config roachpb.SpanConfig) {
+	s.Lock()
+	defer s.Unlock()
+	s.spanConfig = config
+}
+
 func TestMergeQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -4336,6 +4390,9 @@ func TestMergeQueue(t *testing.T) {
 
 	zoneConfig := zonepb.DefaultZoneConfig()
 	zoneConfig.RangeMinBytes = proto.Int64(1 << 10) // 1KB
+	conf := zoneConfig.AsSpanConfig()
+	interceptor := spanConfigInterceptor{spanConfig: conf, clock: hlc.NewClockForTesting(manualClock)}
+
 	tc := testcluster.StartTestCluster(t, 2,
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,
@@ -4343,24 +4400,24 @@ func TestMergeQueue(t *testing.T) {
 				Settings: settings,
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
-						WallClock:                 manualClock,
-						DefaultZoneConfigOverride: &zoneConfig,
+						WallClock: manualClock,
 					},
-					Store: &kvserver.StoreTestingKnobs{
-						DisableScanner: true,
+					SpanConfig: &spanconfig.TestingKnobs{
+						StoreKVSubscriberOverride: func(original spanconfig.KVSubscriber) spanconfig.KVSubscriber {
+							return &interceptor
+						},
 					},
 				},
+				DisableSQLServer: true,
 			},
 		})
 	defer tc.Stopper().Stop(ctx)
 
-	conf := zoneConfig.AsSpanConfig()
+	// The cluster is started with manual replication which disables all the
+	// queues. Enable the merge queue only.
 	store := tc.GetFirstStoreFromServer(t, 0)
-	// The cluster with manual replication disables the merge queue,
-	// so we need to re-enable.
-	_, err := tc.ServerConn(0).Exec(`SET CLUSTER SETTING kv.range_merge.queue.enabled = true`)
-	require.NoError(t, err)
 	store.SetMergeQueueActive(true)
+	kvserverbase.MergeQueueEnabled.Override(ctx, &settings.SV, true)
 
 	split := func(t *testing.T, key roachpb.Key, expirationTime hlc.Timestamp) {
 		t.Helper()
@@ -4372,11 +4429,9 @@ func TestMergeQueue(t *testing.T) {
 	}
 
 	clearRange := func(t *testing.T, start, end roachpb.RKey) {
-		if _, pErr := kv.SendWrapped(ctx, store.DB().NonTransactionalSender(), &kvpb.ClearRangeRequest{
-			RequestHeader: kvpb.RequestHeader{Key: start.AsRawKey(), EndKey: end.AsRawKey()},
-		}); pErr != nil {
-			t.Fatal(pErr)
-		}
+		_, pErr := kv.SendWrapped(ctx, store.DB().NonTransactionalSender(), &kvpb.ClearRangeRequest{
+			RequestHeader: kvpb.RequestHeader{Key: start.AsRawKey(), EndKey: end.AsRawKey()}})
+		require.Nil(t, pErr)
 	}
 	rng, _ := randutil.NewTestRand()
 	randBytes := randutil.RandBytes(rng, int(conf.RangeMinBytes))
@@ -4384,14 +4439,6 @@ func TestMergeQueue(t *testing.T) {
 	lhsStartKey := roachpb.RKey(tc.ScratchRange(t))
 	rhsStartKey := lhsStartKey.Next().Next()
 	rhsEndKey := rhsStartKey.Next().Next()
-	lhsSp := roachpb.Span{
-		Key:    lhsStartKey.AsRawKey(),
-		EndKey: rhsStartKey.AsRawKey(),
-	}
-	rhsSp := roachpb.Span{
-		Key:    rhsStartKey.AsRawKey(),
-		EndKey: rhsEndKey.AsRawKey(),
-	}
 
 	for _, k := range []roachpb.RKey{lhsStartKey, rhsStartKey, rhsEndKey} {
 		split(t, k.AsRawKey(), hlc.Timestamp{} /* expirationTime */)
@@ -4399,31 +4446,13 @@ func TestMergeQueue(t *testing.T) {
 	lhs := func() *kvserver.Replica { return store.LookupReplica(lhsStartKey) }
 	rhs := func() *kvserver.Replica { return store.LookupReplica(rhsStartKey) }
 
-	// setThresholds simulates a zone config update that updates the ranges'
-	// minimum and maximum sizes.
-	setSpanConfigs := func(t *testing.T, conf roachpb.SpanConfig) {
-		t.Helper()
-		if l := lhs(); l == nil {
-			t.Fatal("left-hand side range not found")
-		} else {
-			l.SetSpanConfig(conf, lhsSp)
-		}
-		if r := rhs(); r == nil {
-			t.Fatal("right-hand side range not found")
-		} else {
-			r.SetSpanConfig(conf, rhsSp)
-		}
-	}
-
 	reset := func(t *testing.T) {
 		t.Helper()
 		clearRange(t, lhsStartKey, rhsEndKey)
 		for _, k := range []roachpb.RKey{lhsStartKey, rhsStartKey} {
-			if err := store.DB().Put(ctx, k, randBytes); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, store.DB().Put(ctx, k, randBytes))
 		}
-		setSpanConfigs(t, conf)
+		interceptor.set(conf)
 		for _, s := range tc.Servers {
 			// Disable load-based splitting, so that the absence of sufficient QPS
 			// measurements do not prevent ranges from merging. Certain subtests
@@ -4451,9 +4480,9 @@ func TestMergeQueue(t *testing.T) {
 
 	t.Run("lhs-undersize", func(t *testing.T) {
 		reset(t)
-		conf := conf
-		conf.RangeMinBytes *= 2
-		lhs().SetSpanConfig(conf, lhsSp)
+		testConf := conf
+		testConf.RangeMinBytes *= 2
+		interceptor.set(testConf)
 		verifyMergedSoon(t, store, lhsStartKey, rhsStartKey)
 	})
 
@@ -4462,15 +4491,15 @@ func TestMergeQueue(t *testing.T) {
 
 		// The ranges are individually beneath the minimum size threshold, but
 		// together they'll exceed the maximum size threshold.
-		conf := conf
-		conf.RangeMinBytes = rhs().GetMVCCStats().Total() + 1
-		conf.RangeMaxBytes = lhs().GetMVCCStats().Total() + rhs().GetMVCCStats().Total() - 1
-		setSpanConfigs(t, conf)
+		testConf := conf
+		testConf.RangeMinBytes = rhs().GetMVCCStats().Total() + 1
+		testConf.RangeMaxBytes = lhs().GetMVCCStats().Total() + rhs().GetMVCCStats().Total() - 1
+		interceptor.set(testConf)
 		verifyUnmergedSoon(t, store, lhsStartKey, rhsStartKey)
 
 		// Once the maximum size threshold is increased, the merge can occur.
-		conf.RangeMaxBytes += 1
-		setSpanConfigs(t, conf)
+		testConf.RangeMaxBytes += 1
+		interceptor.set(testConf)
 		verifyMergedSoon(t, store, lhsStartKey, rhsStartKey)
 	})
 

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -96,60 +96,6 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 	})
 }
 
-// TestFallbackSpanConfigOverride ensures that
-// spanconfig.store.fallback_config_override works as expected.
-func TestFallbackSpanConfigOverride(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	st := cluster.MakeTestingClusterSettings()
-	spanConfigStore := spanconfigstore.New(
-		roachpb.TestingDefaultSpanConfig(),
-		st,
-		spanconfigstore.NewEmptyBoundsReader(),
-		nil,
-	)
-	var t0 = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
-	mockSubscriber := newMockSpanConfigSubscriber(t0, spanConfigStore)
-
-	ctx := context.Background()
-	args := base.TestServerArgs{
-		Knobs: base.TestingKnobs{
-			Store: &kvserver.StoreTestingKnobs{
-				DisableMergeQueue: true,
-				DisableSplitQueue: true,
-				DisableGCQueue:    true,
-			},
-			SpanConfig: &spanconfig.TestingKnobs{
-				StoreKVSubscriberOverride: func(spanconfig.KVSubscriber) spanconfig.KVSubscriber { return mockSubscriber },
-			},
-		},
-	}
-	s := serverutils.StartServerOnly(t, args)
-	defer s.Stopper().Stop(context.Background())
-
-	key, err := s.ScratchRange()
-	require.NoError(t, err)
-	store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
-	require.NoError(t, err)
-	repl := store.LookupReplica(keys.MustAddr(key))
-	span := repl.Desc().RSpan().AsRawSpanWithNoLocals()
-
-	conf := roachpb.SpanConfig{NumReplicas: 5, NumVoters: 3}
-	spanconfigstore.FallbackConfigOverride.Override(ctx, &st.SV, &conf)
-
-	require.NotNil(t, mockSubscriber.callback)
-	mockSubscriber.callback(ctx, span) // invoke the callback
-	testutils.SucceedsSoon(t, func() error {
-		repl := store.LookupReplica(keys.MustAddr(key))
-		gotConfig, err := repl.LoadSpanConfig(ctx)
-		require.NoError(t, err)
-		if !gotConfig.Equal(conf) {
-			return errors.Newf("expected config=%s, got config=%s", conf.String(), gotConfig.String())
-		}
-		return nil
-	})
-}
-
 type mockSpanConfigSubscriber struct {
 	callback    func(ctx context.Context, config roachpb.Span)
 	lastUpdated time.Time

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -58,6 +58,7 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 				StoreKVSubscriberOverride: func(spanconfig.KVSubscriber) spanconfig.KVSubscriber { return mockSubscriber },
 			},
 		},
+		DisableSQLServer: true,
 	}
 	s := serverutils.StartServerOnly(t, args)
 	defer s.Stopper().Stop(context.Background())

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1545,7 +1545,8 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 		rngDesc := repl.Desc()
 		rngStart, rngEnd := rngDesc.StartKey, rngDesc.EndKey
 		if rngStart.Equal(tableBoundary) || !rngEnd.Equal(roachpb.RKeyMax) {
-			return errors.Errorf("range %s has not yet split", repl)
+			_, _, _ = store.Enqueue(ctx, "split", repl, false, false)
+			return errors.Errorf("range %s has not yet split expected %s-Max", repl, tableBoundary)
 		}
 		return nil
 	})

--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -121,7 +120,7 @@ func newConsistencyQueue(store *Store) *consistencyQueue {
 }
 
 func (q *consistencyQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ *roachpb.SpanConfig,
 ) (bool, float64) {
 	return consistencyQueueShouldQueueImpl(ctx, now,
 		consistencyShouldQueueData{
@@ -171,7 +170,7 @@ func consistencyQueueShouldQueueImpl(
 
 // process() is called on every range for which this node is a lease holder.
 func (q *consistencyQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, _ *roachpb.SpanConfig,
 ) (bool, error) {
 	if q.interval() <= 0 {
 		return false, nil
@@ -219,7 +218,7 @@ func (q *consistencyQueue) process(
 }
 
 func (*consistencyQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, _ *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -17,7 +17,6 @@ package kvserver
 
 import (
 	"context"
-	"fmt"
 	"maps"
 	"testing"
 	"time"
@@ -199,12 +198,12 @@ func (s *Store) EnqueueRaftUpdateCheck(rangeID roachpb.RangeID) {
 }
 
 func manualQueue(s *Store, q queueImpl, repl *Replica) error {
-	cfg := s.cfg.SystemConfigProvider.GetSystemConfig()
-	if cfg == nil {
-		return fmt.Errorf("%s: system config not yet available", s)
-	}
 	ctx := repl.AnnotateCtx(context.Background())
-	_, err := q.process(ctx, repl, cfg)
+	conf, err := repl.LoadSpanConfig(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = q.process(ctx, repl, conf)
 	return err
 }
 
@@ -436,7 +435,7 @@ func (r *Replica) GetTSCacheHighWater() hlc.Timestamp {
 
 // ShouldBackpressureWrites returns whether writes to the range should be
 // subject to backpressure.
-func (r *Replica) ShouldBackpressureWrites(_ context.Context) bool {
+func (r *Replica) ShouldBackpressureWrites(ctx context.Context) bool {
 	return r.shouldBackpressureWrites()
 }
 

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/split"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -142,12 +141,17 @@ func newMergeQueue(store *Store, db *kv.DB) *mergeQueue {
 }
 
 func (mq *mergeQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, conf *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
 	desc := repl.Desc()
 
 	if desc.EndKey.Equal(roachpb.RKeyMax) {
 		// The last range has no right-hand neighbor to merge with.
+		return false, 0
+	}
+	confReader, err := repl.store.GetConfReader(ctx)
+	if err != nil {
+		log.Infof(ctx, "unable to load the span config (err=%v) for range %d", err, desc.RangeID)
 		return false, 0
 	}
 
@@ -168,7 +172,7 @@ func (mq *mergeQueue) shouldQueue(
 		return false, 0
 	}
 
-	sizeRatio := float64(repl.GetMVCCStats().Total()) / float64(repl.GetMinBytes(ctx))
+	sizeRatio := float64(repl.GetMVCCStats().Total()) / float64(conf.RangeMinBytes)
 	if math.IsNaN(sizeRatio) || sizeRatio >= 1 {
 		// This range is above the minimum size threshold. It does not need to be
 		// merged.
@@ -245,12 +249,17 @@ func (mq *mergeQueue) requestRangeStats(
 }
 
 func (mq *mergeQueue) process(
-	ctx context.Context, lhsRepl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, lhsRepl *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
+
+	confReader, err := lhsRepl.store.GetConfReader(ctx)
+	if err != nil {
+		return false, errors.Wrapf(err, "unable to load conf reader")
+	}
 
 	lhsDesc := lhsRepl.Desc()
 	lhsStats := lhsRepl.GetMVCCStats()
-	minBytes := lhsRepl.GetMinBytes(ctx)
+	minBytes := conf.RangeMinBytes
 	if lhsStats.Total() >= minBytes {
 		log.VEventf(ctx, 2, "skipping merge: LHS meets minimum size threshold %d with %d bytes",
 			minBytes, lhsStats.Total())
@@ -297,7 +306,7 @@ func (mq *mergeQueue) process(
 	}
 
 	shouldSplit, _ := shouldSplitRange(ctx, mergedDesc, mergedStats,
-		lhsRepl.GetMaxBytes(ctx), lhsRepl.shouldBackpressureWrites(), confReader)
+		conf.RangeMaxBytes, lhsRepl.shouldBackpressureWrites(), confReader)
 	if shouldSplit {
 		log.VEventf(ctx, 2,
 			"skipping merge to avoid thrashing: merged range %s may split "+
@@ -426,7 +435,7 @@ func (mq *mergeQueue) process(
 		return false, rangeMergePurgatoryError{err}
 	}
 	if testingAggressiveConsistencyChecks {
-		if _, err := mq.store.consistencyQueue.process(ctx, lhsRepl, confReader); err != nil {
+		if _, err := mq.store.consistencyQueue.process(ctx, lhsRepl, conf); err != nil {
 			log.Warningf(ctx, "%v", err)
 		}
 	}
@@ -441,7 +450,7 @@ func (mq *mergeQueue) process(
 }
 
 func (*mergeQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, conf *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/merge_queue_test.go
+++ b/pkg/kv/kvserver/merge_queue_test.go
@@ -156,8 +156,8 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 			repl.mu.state.Stats = &enginepb.MVCCStats{KeyBytes: tc.bytes}
 			zoneConfig := zonepb.DefaultZoneConfigRef()
 			zoneConfig.RangeMinBytes = proto.Int64(tc.minBytes)
-			repl.SetSpanConfig(zoneConfig.AsSpanConfig(), roachpb.Span{Key: tc.startKey, EndKey: tc.endKey})
-			shouldQ, priority := mq.shouldQueue(ctx, hlc.ClockTimestamp{}, repl, config.NewSystemConfig(zoneConfig))
+			conf := zoneConfig.AsSpanConfig()
+			shouldQ, priority := mq.shouldQueue(ctx, hlc.ClockTimestamp{}, repl, &conf)
 			if tc.expShouldQ != shouldQ {
 				t.Errorf("incorrect shouldQ: expected %v but got %v", tc.expShouldQ, shouldQ)
 			}

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -259,15 +258,10 @@ func (r mvccGCQueueScore) String() string {
 // in the event that the cumulative ages of GC'able bytes or extant
 // intents exceed thresholds.
 func (mgcq *mvccGCQueue) shouldQueue(
-	ctx context.Context, _ hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, _ hlc.ClockTimestamp, repl *Replica, conf *roachpb.SpanConfig,
 ) (bool, float64) {
 	// Consult the protected timestamp state to determine whether we can GC and
 	// the timestamp which can be used to calculate the score.
-	conf, err := repl.LoadSpanConfig(ctx)
-	if err != nil {
-		log.VErrEventf(ctx, 2, "failed to load span config: %v", err)
-		return false, 0
-	}
 	canGC, _, gcTimestamp, oldThreshold, newThreshold, err := repl.checkProtectedTimestampsForGC(ctx, conf.TTL())
 	if err != nil {
 		log.VErrEventf(ctx, 2, "failed to check protected timestamp for gc: %v", err)
@@ -681,14 +675,14 @@ func (r *replicaGCer) GC(
 //  7. push these transactions (again, recreating txn entries).
 //  8. send a GCRequest.
 func (mgcq *mvccGCQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	// Record the CPU time processing the request for this replica. This is
 	// recorded regardless of errors that are encountered.
 	defer repl.MeasureReqCPUNanos(grunning.Time())
 
 	// Lookup the descriptor and GC policy for the zone containing this key range.
-	desc, conf := repl.DescAndSpanConfig()
+	desc := repl.Desc()
 
 	// Consult the protected timestamp state to determine whether we can GC and
 	// the timestamp which can be used to calculate the score and updated GC
@@ -856,7 +850,7 @@ func updateStoreMetricsWithGCInfo(metrics *StoreMetrics, info gc.Info) {
 }
 
 func (mgcq *mvccGCQueue) postProcessScheduled(
-	ctx context.Context, processedReplica replicaInQueue, priority float64,
+	ctx context.Context, processedReplica replicaInQueue, conf *roachpb.SpanConfig, priority float64,
 ) {
 	if priority < deleteRangePriority {
 		mgcq.lastRangeWasHighPriority = false
@@ -867,7 +861,7 @@ func (mgcq *mvccGCQueue) postProcessScheduled(
 		// We are most likely processing first range that has a GC hint notifying
 		// that multiple range deletions happen.
 		if err := timeutil.RunWithTimeout(ctx, "gc-check-hinted-hi-pri-replicas", gcHintScannerTimeout, func(ctx context.Context) error {
-			mgcq.scanReplicasForHiPriGCHints(ctx, processedReplica.GetRangeID())
+			mgcq.scanReplicasForHiPriGCHints(ctx, processedReplica.GetRangeID(), conf)
 			return ctx.Err()
 		}); err != nil {
 			log.Infof(ctx, "failed to start mvcc gc scan for range delete hints, error: %s", err)
@@ -882,7 +876,7 @@ func (mgcq *mvccGCQueue) postProcessScheduled(
 // single bad replica that could cause scan to time out be less disruptive
 // in case we need to retry.
 func (mgcq *mvccGCQueue) scanReplicasForHiPriGCHints(
-	ctx context.Context, triggerRange roachpb.RangeID,
+	ctx context.Context, triggerRange roachpb.RangeID, conf *roachpb.SpanConfig,
 ) {
 	var foundReplicas int
 	clockNow := mgcq.store.Clock().NowAsClockTimestamp()
@@ -897,8 +891,8 @@ func (mgcq *mvccGCQueue) scanReplicasForHiPriGCHints(
 		}
 		gCHint := replica.GetGCHint()
 		if !gCHint.LatestRangeDeleteTimestamp.IsEmpty() {
-			desc, spanConfig := replica.DescAndSpanConfig()
-			gcThreshold := now.Add(-int64(spanConfig.GCPolicy.TTLSeconds)*1e9,
+			desc := replica.Desc()
+			gcThreshold := now.Add(-int64(conf.GCPolicy.TTLSeconds)*1e9,
 				0)
 			if gCHint.LatestRangeDeleteTimestamp.Less(gcThreshold) {
 				// If replica has a hint we also need to check if this replica is a

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -833,9 +833,7 @@ func testMVCCGCQueueProcessImpl(t *testing.T, useEfos bool) {
 	}
 
 	cfg, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// TODO: following computations should take care of new local timestamp
 	// for tombstones as they can be non-zero in size.
@@ -874,9 +872,7 @@ func testMVCCGCQueueProcessImpl(t *testing.T, useEfos bool) {
 		defer snap.Close()
 
 		conf, _, err := cfg.GetSpanConfigForKey(ctx, desc.StartKey)
-		if err != nil {
-			t.Fatalf("could not find zone config for range %s: %+v", tc.repl, err)
-		}
+		require.NoError(t, err)
 
 		now := tc.Clock().Now()
 		newThreshold := gc.CalculateThreshold(now, conf.TTL())
@@ -892,9 +888,7 @@ func testMVCCGCQueueProcessImpl(t *testing.T, useEfos bool) {
 				return nil
 			})
 	}()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if gcInfo.AffectedVersionsKeyBytes != expectedVersionsKeyBytes {
 		t.Errorf("expected total keys size: %d bytes; got %d bytes", expectedVersionsKeyBytes,
 			gcInfo.AffectedVersionsKeyBytes)
@@ -917,10 +911,10 @@ func testMVCCGCQueueProcessImpl(t *testing.T, useEfos bool) {
 
 	// Process through a scan queue.
 	mgcq := newMVCCGCQueue(tc.store)
-	processed, err := mgcq.process(ctx, tc.repl, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	conf, err := tc.repl.LoadSpanConfig(ctx)
+	require.NoError(t, err)
+	processed, err := mgcq.process(ctx, tc.repl, conf)
+	require.NoError(t, err)
 	assert.True(t, processed, "queue not processed")
 
 	expKVs := []struct {
@@ -1163,15 +1157,9 @@ func TestMVCCGCQueueTransactionTable(t *testing.T) {
 
 	// Run GC.
 	mgcq := newMVCCGCQueue(tc.store)
-	cfg, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	processed, err := mgcq.process(ctx, tc.repl, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	conf := &roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}}
+	processed, err := mgcq.process(ctx, tc.repl, conf)
+	require.NoError(t, err)
 	assert.True(t, processed, "queue not processed")
 
 	testutils.SucceedsSoon(t, func() error {
@@ -1297,15 +1285,10 @@ func TestMVCCGCQueueIntentResolution(t *testing.T) {
 	}
 
 	// Process through GC queue.
-	confReader, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
 	mgcq := newMVCCGCQueue(tc.store)
-	processed, err := mgcq.process(ctx, tc.repl, confReader)
-	if err != nil {
-		t.Fatal(err)
-	}
+	conf := &roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}}
+	processed, err := mgcq.process(ctx, tc.repl, conf)
+	require.NoError(t, err)
 	assert.True(t, processed, "queue not processed")
 
 	// MVCCIterate through all values to ensure intents have been fully resolved.
@@ -1360,17 +1343,11 @@ func TestMVCCGCQueueLastProcessedTimestamps(t *testing.T) {
 		}
 	}
 
-	confReader, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Process through a scan queue.
 	mgcq := newMVCCGCQueue(tc.store)
-	processed, err := mgcq.process(ctx, tc.repl, confReader)
-	if err != nil {
-		t.Fatal(err)
-	}
+	conf := &roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}}
+	processed, err := mgcq.process(ctx, tc.repl, conf)
+	require.NoError(t, err)
 	assert.True(t, processed, "queue not processed")
 
 	// Verify GC.
@@ -1465,20 +1442,12 @@ func TestMVCCGCQueueChunkRequests(t *testing.T) {
 	}
 
 	// Forward the clock past the default GC time.
-	confReader, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	conf, _, err := confReader.GetSpanConfigForKey(ctx, roachpb.RKey("key"))
-	if err != nil {
-		t.Fatalf("could not find span config for range %s", err)
-	}
+	conf, _, err := tc.store.GetSpanConfigForKey(ctx, roachpb.RKey("key"))
+	require.NoError(t, err)
 	tc.manualClock.Advance(conf.TTL() + 1)
 	mgcq := newMVCCGCQueue(tc.store)
-	processed, err := mgcq.process(ctx, tc.repl, confReader)
-	if err != nil {
-		t.Fatal(err)
-	}
+	processed, err := mgcq.process(ctx, tc.repl, conf)
+	require.NoError(t, err)
 	assert.True(t, processed, "queue not processed")
 	// We wrote two batches worth of keys spread out, and two keys that
 	// each have enough old versions to fill a whole batch each in the
@@ -1523,46 +1492,42 @@ func TestMVCCGCQueueGroupsRangeDeletions(t *testing.T) {
 	require.NoError(t, store.AddReplica(r2))
 	r2.RaftStatus()
 	r2.handleGCHintResult(ctx, &roachpb.GCHint{LatestRangeDeleteTimestamp: hlc.Timestamp{WallTime: 1}})
-	r2.SetSpanConfig(roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}},
-		roachpb.Span{
-			Key:    key("b").AsRawKey(),
-			EndKey: key("c").AsRawKey(),
-		})
+	conf := &roachpb.SpanConfig{GCPolicy: roachpb.GCPolicy{TTLSeconds: 100}}
 
 	gcQueue := newMVCCGCQueue(store)
 
 	// Check that low priority replicas doesn't cause hint scan.
-	gcQueue.postProcessScheduled(ctx, r1, 1)
+	gcQueue.postProcessScheduled(ctx, r1, conf, 1)
 	qr, _ := gcQueue.pop()
 	require.Nil(t, qr, "unexpected enqueued replica")
 
 	// Check that high priority replica is not added if GC hint time didn't exceed
 	// ttl.
-	gcQueue.postProcessScheduled(ctx, r1, deleteRangePriority)
+	gcQueue.postProcessScheduled(ctx, r1, conf, deleteRangePriority)
 	qr, _ = gcQueue.pop()
 	require.Nil(t, qr, "unexpected enqueued replica")
 
 	// Check that replica is not queued if sequence of hi-pri replicas are being
 	// processed.
 	clock.Advance(200 * time.Second)
-	gcQueue.postProcessScheduled(ctx, r1, deleteRangePriority)
+	gcQueue.postProcessScheduled(ctx, r1, conf, deleteRangePriority)
 	qr, _ = gcQueue.pop()
 	require.Nil(t, qr, "unexpected enqueued replica")
 
 	// Reset sequence by running a lo pri replica.
-	gcQueue.postProcessScheduled(ctx, r1, 1)
+	gcQueue.postProcessScheduled(ctx, r1, conf, 1)
 	qr, _ = gcQueue.pop()
 	require.Nil(t, qr, "unexpected enqueued replica")
 
 	// Check that replica is processed when hint criteria is met.
-	gcQueue.postProcessScheduled(ctx, r1, deleteRangePriority)
+	gcQueue.postProcessScheduled(ctx, r1, conf, deleteRangePriority)
 	qr, prio := gcQueue.pop()
 	require.NotNil(t, qr, "unexpected nil replica")
 	require.Equal(t, deleteRangePriority, prio, "expected high priority")
 
 	// Check that non leaseholder replicas are ignored.
 	leaseError = false
-	gcQueue.postProcessScheduled(ctx, r1, deleteRangePriority)
+	gcQueue.postProcessScheduled(ctx, r1, conf, deleteRangePriority)
 	qr, _ = gcQueue.pop()
 	require.Nil(t, qr, "unexpected nil replica")
 }

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -260,19 +259,19 @@ type queueImpl interface {
 	// shouldQueue accepts current time, a replica, and the system config
 	// and returns whether it should be queued and if so, at what priority.
 	// The Replica is guaranteed to be initialized.
-	shouldQueue(context.Context, hlc.ClockTimestamp, *Replica, spanconfig.StoreReader) (shouldQueue bool, priority float64)
+	shouldQueue(context.Context, hlc.ClockTimestamp, *Replica, *roachpb.SpanConfig) (shouldQueue bool, priority float64)
 
 	// process accepts a replica, and the system config and executes
 	// queue-specific work on it. The Replica is guaranteed to be initialized.
 	// We return a boolean to indicate if the Replica was processed successfully
 	// (vs. it being a no-op or an error).
-	process(context.Context, *Replica, spanconfig.StoreReader) (processed bool, err error)
+	process(context.Context, *Replica, *roachpb.SpanConfig) (processed bool, err error)
 
 	// processScheduled is called after async task was created to run process.
 	// This function is called by the process loop synchronously. This method is
 	// called regardless of process being called or not since replica validity
 	// checks are done asynchronously.
-	postProcessScheduled(ctx context.Context, replica replicaInQueue, priority float64)
+	postProcessScheduled(ctx context.Context, replica replicaInQueue, span *roachpb.SpanConfig, priority float64)
 
 	// timer returns a duration to wait between processing the next item
 	// from the queue. The duration of the last processing of a replica
@@ -674,7 +673,7 @@ func (bq *baseQueue) maybeAdd(ctx context.Context, repl replicaInQueue, now hlc.
 	}
 
 	// Load the system config if it's needed.
-	confReader, err := bq.replicaCanBeProcessed(ctx, repl, false /* acquireLeaseIfNeeded */)
+	conf, err := bq.replicaCanBeProcessed(ctx, repl, false /* acquireLeaseIfNeeded */)
 	if err != nil {
 		return
 	}
@@ -683,7 +682,7 @@ func (bq *baseQueue) maybeAdd(ctx context.Context, repl replicaInQueue, now hlc.
 	// it may not be and shouldQueue will be passed a nil realRepl. These tests
 	// know what they're getting into so that's fine.
 	realRepl, _ := repl.(*Replica)
-	should, priority := bq.impl.shouldQueue(ctx, now, realRepl, confReader)
+	should, priority := bq.impl.shouldQueue(ctx, now, realRepl, conf)
 	if !should {
 		return
 	}
@@ -878,8 +877,8 @@ func (bq *baseQueue) processLoop(stopper *stop.Stopper) {
 
 					repl, priority := bq.pop()
 					if repl != nil {
-						bq.processOneAsyncAndReleaseSem(ctx, repl, stopper)
-						bq.impl.postProcessScheduled(ctx, repl, priority)
+						cfg := bq.processOneAsyncAndReleaseSem(ctx, repl, stopper)
+						bq.impl.postProcessScheduled(ctx, repl, cfg, priority)
 					} else {
 						// Release semaphore if no replicas were available.
 						<-bq.processSem
@@ -908,23 +907,24 @@ func (bq *baseQueue) processLoop(stopper *stop.Stopper) {
 // processSem when the processing is complete.
 func (bq *baseQueue) processOneAsyncAndReleaseSem(
 	ctx context.Context, repl replicaInQueue, stopper *stop.Stopper,
-) {
+) *roachpb.SpanConfig {
 	ctx = repl.AnnotateCtx(ctx)
 	taskName := bq.processOpName() + " [outer]"
 	// Validate that the replica is still in a state that can be processed. If
 	// it is no longer processable, return immediately.
-	if _, err := bq.replicaCanBeProcessed(ctx, repl, false /*acquireLeaseIfNeeded */); err != nil {
+	conf, err := bq.replicaCanBeProcessed(ctx, repl, false /*acquireLeaseIfNeeded */)
+	if err != nil {
 		bq.finishProcessingReplica(ctx, stopper, repl, err)
 		log.Infof(ctx, "%s: skipping %d since replica can't be processed %v", taskName, repl.ReplicaID(), err)
 		<-bq.processSem
-		return
+		return conf
 	}
 	if err := stopper.RunAsyncTaskEx(ctx, stop.TaskOpts{TaskName: taskName},
 		func(ctx context.Context) {
 			// Release semaphore when finished processing.
 			defer func() { <-bq.processSem }()
 			start := timeutil.Now()
-			err := bq.processReplica(ctx, repl)
+			err := bq.processReplica(ctx, repl, conf)
 			bq.recordProcessDuration(ctx, timeutil.Since(start))
 			bq.finishProcessingReplica(ctx, stopper, repl, err)
 		}); err != nil {
@@ -935,6 +935,7 @@ func (bq *baseQueue) processOneAsyncAndReleaseSem(
 		log.Warningf(ctx, "%s: task did not start %v", taskName, err)
 		<-bq.processSem
 	}
+	return conf
 }
 
 // lastProcessDuration returns the duration of the last processing attempt.
@@ -957,7 +958,9 @@ func (bq *baseQueue) recordProcessDuration(ctx context.Context, dur time.Duratio
 //
 // ctx should already be annotated by both bq.AnnotateCtx() and
 // repl.AnnotateCtx().
-func (bq *baseQueue) processReplica(ctx context.Context, repl replicaInQueue) error {
+func (bq *baseQueue) processReplica(
+	ctx context.Context, repl replicaInQueue, conf *roachpb.SpanConfig,
+) error {
 
 	ctx, span := tracing.EnsureChildSpan(ctx, bq.Tracer, bq.processOpName())
 	defer span.Finish()
@@ -1006,7 +1009,7 @@ var errMarkNotAcquirableLease = errors.New("lease can't be acquired")
 // only return a nil SpanConfig if the queue does not require span configs.
 func (bq *baseQueue) replicaCanBeProcessed(
 	ctx context.Context, repl replicaInQueue, acquireLeaseIfNeeded bool,
-) (spanconfig.StoreReader, error) {
+) (*roachpb.SpanConfig, error) {
 	if !repl.IsInitialized() {
 		// We checked this when adding the replica, but we need to check it again
 		// in case this is a different replica with the same range ID (see #14193).
@@ -1027,14 +1030,19 @@ func (bq *baseQueue) replicaCanBeProcessed(
 
 	// The conf is only populated if the queue requires a span config. Otherwise
 	// nil is always returned.
-	var confReader spanconfig.StoreReader
+	var conf *roachpb.SpanConfig
 	if bq.needsSpanConfigs {
 		var err error
-		confReader, err = bq.store.GetConfReader(ctx)
+		confReader, err := bq.store.GetConfReader(ctx)
 		if err != nil {
 			if log.V(1) || !errors.Is(err, errSpanConfigsUnavailable) {
 				log.Warningf(ctx, "unable to retrieve conf reader, skipping: %v", err)
 			}
+			return nil, err
+		}
+		conf, _, err = bq.store.GetSpanConfigForKey(ctx, repl.Desc().GetStartKey())
+		if err != nil {
+			log.Infof(ctx, "unable to retrieve conf reader, skipping: %v", err)
 			return nil, err
 		}
 
@@ -1084,7 +1092,7 @@ func (bq *baseQueue) replicaCanBeProcessed(
 			}
 		}
 	}
-	return confReader, nil
+	return conf, nil
 }
 
 // IsPurgatoryError returns true iff the given error is a purgatory error.
@@ -1322,10 +1330,10 @@ func (bq *baseQueue) processReplicasInPurgatory(
 			annotatedCtx := repl.AnnotateCtx(ctx)
 			if stopper.RunTask(
 				annotatedCtx, bq.processOpName(), func(ctx context.Context) {
-					if _, err := bq.replicaCanBeProcessed(ctx, repl, false); err != nil {
+					if conf, err := bq.replicaCanBeProcessed(ctx, repl, false); err != nil {
 						bq.finishProcessingReplica(ctx, stopper, repl, err)
 					} else {
-						err = bq.processReplica(ctx, repl)
+						err = bq.processReplica(ctx, repl, conf)
 						bq.finishProcessingReplica(ctx, stopper, repl, err)
 					}
 				},
@@ -1449,10 +1457,10 @@ func (bq *baseQueue) DrainQueue(ctx context.Context, stopper *stop.Stopper) {
 	ctx = bq.AnnotateCtx(ctx)
 	for repl, _ := bq.pop(); repl != nil; repl, _ = bq.pop() {
 		annotatedCtx := repl.AnnotateCtx(ctx)
-		if _, err := bq.replicaCanBeProcessed(annotatedCtx, repl, false); err != nil {
+		if conf, err := bq.replicaCanBeProcessed(annotatedCtx, repl, false); err != nil {
 			bq.finishProcessingReplica(annotatedCtx, stopper, repl, err)
 		} else {
-			err = bq.processReplica(annotatedCtx, repl)
+			err = bq.processReplica(annotatedCtx, repl, conf)
 			bq.finishProcessingReplica(annotatedCtx, stopper, repl, err)
 		}
 	}

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -84,7 +83,7 @@ func TestBaseQueueConcurrent(t *testing.T) {
 
 	// Set up a queue impl that will return random results from processing.
 	impl := fakeQueueImpl{
-		pr: func(context.Context, *Replica, spanconfig.StoreReader) (bool, error) {
+		pr: func(context.Context, *Replica) (bool, error) {
 			n := rand.Intn(4)
 			if n == 0 {
 				return true, nil
@@ -134,25 +133,25 @@ func TestBaseQueueConcurrent(t *testing.T) {
 }
 
 type fakeQueueImpl struct {
-	pr func(context.Context, *Replica, spanconfig.StoreReader) (processed bool, err error)
+	pr func(context.Context, *Replica) (processed bool, err error)
 }
 
 var _ queueImpl = &fakeQueueImpl{}
 
 func (fakeQueueImpl) shouldQueue(
-	context.Context, hlc.ClockTimestamp, *Replica, spanconfig.StoreReader,
+	context.Context, hlc.ClockTimestamp, *Replica, *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
 	return rand.Intn(5) != 0, 1.0
 }
 
 func (fq fakeQueueImpl) process(
-	ctx context.Context, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, config *roachpb.SpanConfig,
 ) (bool, error) {
-	return fq.pr(ctx, repl, confReader)
+	return fq.pr(ctx, repl)
 }
 
 func (fakeQueueImpl) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, config *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -176,7 +175,7 @@ func newRaftLogQueue(store *Store, db *kv.DB) *raftLogQueue {
 			maxSize:              defaultQueueMaxSize,
 			maxConcurrency:       raftLogQueueConcurrency,
 			needsLease:           false,
-			needsSpanConfigs:     false,
+			needsSpanConfigs:     true,
 			acceptsUnsplitRanges: true,
 			successes:            store.metrics.RaftLogQueueSuccesses,
 			failures:             store.metrics.RaftLogQueueFailures,
@@ -244,7 +243,9 @@ func newRaftLogQueue(store *Store, db *kv.DB) *raftLogQueue {
 // nodes with sufficient disk space. Also, IMPORT/RESTORE's split/scatter
 // phase interacts poorly with overly aggressive truncations and can DDOS the
 // Raft snapshot queue.
-func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, error) {
+func newTruncateDecision(
+	ctx context.Context, r *Replica, conf *roachpb.SpanConfig,
+) (truncateDecision, error) {
 	rangeID := r.RangeID
 	now := timeutil.Now()
 
@@ -263,8 +264,8 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	// efficient to catch up via a snapshot than via applying a long tail of log
 	// entries.
 	targetSize := r.store.cfg.RaftLogTruncationThreshold
-	if targetSize > r.mu.conf.RangeMaxBytes {
-		targetSize = r.mu.conf.RangeMaxBytes
+	if targetSize > conf.RangeMaxBytes {
+		targetSize = conf.RangeMaxBytes
 	}
 	raftStatus := r.raftStatusRLocked()
 
@@ -635,15 +636,15 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 // is true only if the replica is the raft leader and if the total number of
 // the range's raft log's stale entries exceeds RaftLogQueueStaleThreshold.
 func (rlq *raftLogQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, r *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, r *Replica, conf *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
-	decision, err := newTruncateDecision(ctx, r)
+	decision, err := newTruncateDecision(ctx, r, conf)
 	if err != nil {
 		log.Warningf(ctx, "%v", err)
 		return false, 0
 	}
 
-	shouldQ, _, prio := rlq.shouldQueueImpl(ctx, decision)
+	shouldQ, _, prio := rlq.shouldQueueImpl(ctx, decision, conf)
 	return shouldQ, prio
 }
 
@@ -652,7 +653,7 @@ func (rlq *raftLogQueue) shouldQueue(
 // we want to recompute the log size (in which case `recomputeRaftLogSize` and
 // `shouldQ` are both true and a reasonable priority is returned).
 func (rlq *raftLogQueue) shouldQueueImpl(
-	ctx context.Context, decision truncateDecision,
+	ctx context.Context, decision truncateDecision, conf *roachpb.SpanConfig,
 ) (shouldQ bool, recomputeRaftLogSize bool, priority float64) {
 	if decision.ShouldTruncate() {
 		return true, !decision.Input.LogSizeTrusted, float64(decision.Input.LogSize)
@@ -678,14 +679,14 @@ func (rlq *raftLogQueue) shouldQueueImpl(
 // leader and if the total number of the range's raft log's stale entries
 // exceeds RaftLogQueueStaleThreshold.
 func (rlq *raftLogQueue) process(
-	ctx context.Context, r *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, r *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
-	decision, err := newTruncateDecision(ctx, r)
+	decision, err := newTruncateDecision(ctx, r, conf)
 	if err != nil {
 		return false, err
 	}
 
-	if _, recompute, _ := rlq.shouldQueueImpl(ctx, decision); recompute {
+	if _, recompute, _ := rlq.shouldQueueImpl(ctx, decision, conf); recompute {
 		log.VEventf(ctx, 2, "recomputing raft log based on decision %+v", decision)
 
 		// We need to hold raftMu both to access the sideloaded storage and to
@@ -709,7 +710,7 @@ func (rlq *raftLogQueue) process(
 		log.VEventf(ctx, 2, "recomputed raft log size to %s", humanizeutil.IBytes(n))
 
 		// Override the decision, now that an accurate log size is available.
-		decision, err = newTruncateDecision(ctx, r)
+		decision, err = newTruncateDecision(ctx, r, conf)
 		if err != nil {
 			return false, err
 		}
@@ -742,7 +743,7 @@ func (rlq *raftLogQueue) process(
 }
 
 func (*raftLogQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, conf *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -205,7 +205,7 @@ func TestComputeTruncateDecision(t *testing.T) {
 			// we'll just see the decision play out as before.
 			// The real tests for this are in TestRaftLogQueueShouldQueue, but this is
 			// some nice extra coverage.
-			should, recompute, prio := (*raftLogQueue)(nil).shouldQueueImpl(ctx, decision)
+			should, recompute, prio := (*raftLogQueue)(nil).shouldQueueImpl(ctx, decision, nil)
 			assert.Equal(t, decision.ShouldTruncate(), should)
 			assert.False(t, recompute)
 			assert.Equal(t, decision.ShouldTruncate(), prio != 0)
@@ -215,7 +215,7 @@ func TestComputeTruncateDecision(t *testing.T) {
 				input.LastIndex = input.FirstIndex + 1
 			}
 			decision = computeTruncateDecision(input)
-			should, recompute, prio = (*raftLogQueue)(nil).shouldQueueImpl(ctx, decision)
+			should, recompute, prio = (*raftLogQueue)(nil).shouldQueueImpl(ctx, decision, nil)
 			assert.True(t, should)
 			assert.True(t, prio > 0)
 			assert.True(t, recompute)
@@ -434,7 +434,7 @@ func TestNewTruncateDecisionMaxSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	td, err := newTruncateDecision(ctx, repl)
+	td, err := newTruncateDecision(ctx, repl, &cfg.DefaultSpanConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -470,7 +470,7 @@ func TestNewTruncateDecision(t *testing.T) {
 	}
 
 	getIndexes := func() (kvpb.RaftIndex, int, kvpb.RaftIndex, error) {
-		d, err := newTruncateDecision(ctx, r)
+		d, err := newTruncateDecision(ctx, r, &cfg.DefaultSpanConfig)
 		if err != nil {
 			return 0, 0, 0, err
 		}
@@ -821,7 +821,7 @@ func TestRaftLogQueueShouldQueueRecompute(t *testing.T) {
 
 	verify := func(shouldQ bool, recompute bool, prio float64) {
 		t.Helper()
-		isQ, isR, isP := rlq.shouldQueueImpl(ctx, decision)
+		isQ, isR, isP := rlq.shouldQueueImpl(ctx, decision, nil)
 		assert.Equal(t, shouldQ, isQ)
 		assert.Equal(t, recompute, isR)
 		assert.Equal(t, prio, isP)
@@ -884,7 +884,7 @@ func TestTruncateLogRecompute(t *testing.T) {
 
 	put()
 
-	decision, err := newTruncateDecision(ctx, repl)
+	decision, err := newTruncateDecision(ctx, repl, &cfg.DefaultSpanConfig)
 	assert.NoError(t, err)
 	assert.True(t, decision.ShouldTruncate())
 	// Should never trust initially, until recomputed at least once.

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -66,7 +65,7 @@ func newRaftSnapshotQueue(store *Store) *raftSnapshotQueue {
 }
 
 func (rq *raftSnapshotQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
 	// If a follower needs a snapshot, enqueue at the highest priority.
 	if status := repl.RaftStatus(); status != nil {
@@ -84,7 +83,7 @@ func (rq *raftSnapshotQueue) shouldQueue(
 }
 
 func (rq *raftSnapshotQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, _ *roachpb.SpanConfig,
 ) (anyProcessed bool, _ error) {
 	// If a follower requires a Raft snapshot, perform it.
 	if status := repl.RaftStatus(); status != nil {
@@ -157,7 +156,7 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 }
 
 func (*raftSnapshotQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, _ *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3755,15 +3755,11 @@ func (roo *replicaRelocateOneOptions) StorePool() storepool.AllocatorStorePool {
 func (roo *replicaRelocateOneOptions) LoadSpanConfig(
 	ctx context.Context, startKey roachpb.RKey,
 ) (*roachpb.SpanConfig, error) {
-	confReader, err := roo.store.GetConfReader(ctx)
+	conf, _, err := roo.store.GetSpanConfigForKey(ctx, startKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't relocate range")
 	}
-	conf, _, err := confReader.GetSpanConfigForKey(ctx, startKey)
-	if err != nil {
-		return nil, err
-	}
-	return &conf, nil
+	return conf, nil
 }
 
 // Leaseholder returns the descriptor of the replica which holds the lease on

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -110,17 +110,19 @@ const manualAdminReason = "manual"
 // AdminSplit divides the range into two ranges using args.SplitKey.
 func (r *Replica) AdminSplit(
 	ctx context.Context, args kvpb.AdminSplitRequest, reason redact.RedactableString,
-) (reply kvpb.AdminSplitResponse, _ *kvpb.Error) {
+) (reply kvpb.AdminSplitResponse, kvErr *kvpb.Error) {
 	if len(args.SplitKey) == 0 {
 		return kvpb.AdminSplitResponse{}, kvpb.NewErrorf("cannot split range with no key provided")
 	}
-
-	err := r.executeAdminCommandWithDescriptor(ctx, func(desc *roachpb.RangeDescriptor) error {
-		var err error
-		reply, err = r.adminSplitWithDescriptor(ctx, args, desc, true /* delayable */, reason, false /* findFirstSafeKey */)
+	kvErr = r.executeAdminCommandWithDescriptor(ctx, func(desc *roachpb.RangeDescriptor) error {
+		conf, err := r.LoadSpanConfig(ctx)
+		if err != nil {
+			return err
+		}
+		reply, err = r.adminSplitWithDescriptor(ctx, args, desc, conf, true /* delayable */, reason, false /* findFirstSafeKey */)
 		return err
 	})
-	return reply, err
+	return reply, kvErr
 }
 
 func maybeDescriptorChangedError(
@@ -345,6 +347,7 @@ func (r *Replica) adminSplitWithDescriptor(
 	ctx context.Context,
 	args kvpb.AdminSplitRequest,
 	desc *roachpb.RangeDescriptor,
+	conf *roachpb.SpanConfig,
 	delayable bool,
 	reason redact.RedactableString,
 	findFirstSafeKey bool,
@@ -370,7 +373,7 @@ func (r *Replica) adminSplitWithDescriptor(
 		if len(args.SplitKey) == 0 {
 			// Find a key to split by size.
 			var err error
-			targetSize := r.GetMaxBytes(ctx) / 2
+			targetSize := conf.RangeMaxBytes / 2
 			foundSplitKey, err = storage.MVCCFindSplitKey(
 				ctx, r.store.TODOEngine(), desc.StartKey, desc.EndKey, targetSize)
 			if err != nil {
@@ -4160,12 +4163,21 @@ func (r *Replica) adminScatter(
 	}
 
 	// Loop until we hit an error or until we hit `maxAttempts` for the range.
+	// conf gets set within the loop. We want the same conf that processOneChange
+	// used in this loop.
+	var conf *roachpb.SpanConfig
 	for re := retry.StartWithCtx(ctx, retryOpts); re.Next(); {
 		if currentAttempt == maxAttempts {
 			break
 		}
-		desc, conf := r.DescAndSpanConfig()
-		_, err := rq.replicaCanBeProcessed(ctx, r, false /* acquireLeaseIfNeeded */)
+		desc := r.Desc()
+		var err error
+		conf, err = r.LoadSpanConfig(ctx)
+		if err != nil {
+			// The conf can not be loaded, skip this replica.
+			break
+		}
+		_, err = rq.replicaCanBeProcessed(ctx, r, false /* acquireLeaseIfNeeded */)
 		if err != nil {
 			// The replica can not be processed, so skip it.
 			break
@@ -4192,8 +4204,8 @@ func (r *Replica) adminScatter(
 	// queue would do on its own (#17341), do so after the replicate queue is
 	// done by transferring the lease to any of the given N replicas with
 	// probability 1/N of choosing each.
-	if args.RandomizeLeases && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
-		desc, conf := r.DescAndSpanConfig()
+	if args.RandomizeLeases && conf != nil && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
+		desc := r.Desc()
 		potentialLeaseTargets := r.store.allocator.ValidLeaseTargets(
 			ctx, r.store.cfg.StorePool, desc, conf, desc.Replicas().VoterDescriptors(), r, allocator.TransferLeaseOptions{})
 		if len(potentialLeaseTargets) > 0 {

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -4172,12 +4172,7 @@ func (r *Replica) adminScatter(
 		}
 		desc := r.Desc()
 		var err error
-		conf, err = r.LoadSpanConfig(ctx)
-		if err != nil {
-			// The conf can not be loaded, skip this replica.
-			break
-		}
-		_, err = rq.replicaCanBeProcessed(ctx, r, false /* acquireLeaseIfNeeded */)
+		conf, err = rq.replicaCanBeProcessed(ctx, r, false /* acquireLeaseIfNeeded */)
 		if err != nil {
 			// The replica can not be processed, so skip it.
 			break

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
@@ -121,7 +120,7 @@ func newReplicaGCQueue(store *Store, db *kv.DB) *replicaGCQueue {
 // check must have occurred more than ReplicaGCQueueInactivityThreshold
 // in the past.
 func (rgcq *replicaGCQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ *roachpb.SpanConfig,
 ) (shouldQueue bool, priority float64) {
 	if _, currentMember := repl.Desc().GetReplicaDescriptor(repl.store.StoreID()); !currentMember {
 		return true, replicaGCPriorityRemoved
@@ -221,7 +220,7 @@ func replicaGCShouldQueueImpl(now, lastCheck hlc.Timestamp, isSuspect bool) (boo
 // process performs a consistent lookup on the range descriptor to see if we are
 // still a member of the range.
 func (rgcq *replicaGCQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, _ *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	// Note that the Replicas field of desc is probably out of date, so
 	// we should only use `desc` for its static fields like RangeID and
@@ -375,7 +374,7 @@ func (rgcq *replicaGCQueue) process(
 }
 
 func (*replicaGCQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, _ *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -461,8 +461,8 @@ func (r *Replica) updateRangeInfo(ctx context.Context, desc *roachpb.RangeDescri
 	// 2. After a new range is created by a split, only copying maxBytes from
 	// the original range wont work as the original and new ranges might belong
 	// to different zones.
-	// Load the system config.
-	confReader, err := r.store.GetConfReader(ctx)
+	// Find span config for this range.
+	conf, sp, err := r.store.GetSpanConfigForKey(ctx, desc.StartKey)
 	if errors.Is(err, errSpanConfigsUnavailable) {
 		// This could be before the span config subscription was ever
 		// established.
@@ -473,13 +473,7 @@ func (r *Replica) updateRangeInfo(ctx context.Context, desc *roachpb.RangeDescri
 		return err
 	}
 
-	// Find span config for this range.
-	conf, sp, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
-	if err != nil {
-		return errors.Wrapf(err, "%s: failed to lookup span config", r)
-	}
-
-	changed := r.SetSpanConfig(conf, sp)
+	changed := r.SetSpanConfig(*conf, sp)
 	if changed {
 		r.MaybeQueue(ctx, r.store.cfg.Clock.NowAsClockTimestamp())
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10352,13 +10352,11 @@ func TestConsistenctQueueErrorFromCheckConsistency(t *testing.T) {
 	tc := testContext{}
 	tc.StartWithStoreConfig(ctx, t, stopper, cfg)
 
-	confReader, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	conf, err := tc.repl.LoadSpanConfig(ctx)
+	require.NoError(t, err)
 	for i := 0; i < 2; i++ {
 		// Do this twice because it used to deadlock. See #25456.
-		processed, err := tc.store.consistencyQueue.process(ctx, tc.repl, confReader)
+		processed, err := tc.store.consistencyQueue.process(ctx, tc.repl, conf)
 		if !testutils.IsError(err, "boom") {
 			t.Fatal(err)
 		}

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -788,7 +788,10 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, conf := repl.DescAndSpanConfig()
+			conf, err := repl.LoadSpanConfig(ctx)
+			if err != nil {
+				return false
+			}
 			return conf.GetNumNonVoters() == 0
 		}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond)
 
@@ -1215,7 +1218,10 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, conf := repl.DescAndSpanConfig()
+			conf, err := repl.LoadSpanConfig(ctx)
+			if err != nil {
+				return false
+			}
 			return conf.GetNumNonVoters() == 0
 		}, testutils.DefaultSucceedsSoonDuration, 100*time.Millisecond)
 
@@ -2043,23 +2049,26 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 		time.Sleep(13 * time.Millisecond)
 	}
 
-	// Set the zone preference for the replica to show that it has to be moved
-	// to the remote node.
-	desc, conf := leaseHolderRepl.DescAndSpanConfig()
-	newConf := conf
-	newConf.LeasePreferences = []roachpb.LeasePreference{
-		{
-			Constraints: []roachpb.Constraint{
-				{
-					Type:  roachpb.Constraint_REQUIRED,
-					Value: fmt.Sprintf("n%d", remoteNodeID),
-				},
-			},
-		},
-	}
-
 	// By now the lease holder may have changed.
 	testutils.SucceedsSoon(t, func() error {
+		conf, err := leaseHolderRepl.LoadSpanConfig(ctx)
+		if err != nil {
+			return err
+		}
+		newConf := conf
+
+		// Set the zone preference for the replica to show that it has to be moved
+		// to the remote node.
+		newConf.LeasePreferences = []roachpb.LeasePreference{
+			{
+				Constraints: []roachpb.Constraint{
+					{
+						Type:  roachpb.Constraint_REQUIRED,
+						Value: fmt.Sprintf("n%d", remoteNodeID),
+					},
+				},
+			},
+		}
 		leaseBefore, _ := leaseHolderRepl.GetLease()
 		log.Infof(ctx, "Lease before transfer %+v\n", leaseBefore)
 
@@ -2081,7 +2090,7 @@ func TestTransferLeaseToLaggingNode(t *testing.T) {
 			return err
 		}
 		transferred, err := leaseStore.FindTargetAndTransferLease(
-			ctx, leaseRepl, desc, newConf)
+			ctx, leaseRepl, leaseHolderRepl.Desc(), newConf)
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -283,6 +283,10 @@ func (sq *splitQueue) processAttempt(
 	ctx context.Context, r *Replica, confReader spanconfig.StoreReader,
 ) (processed bool, err error) {
 	desc := r.Desc()
+	conf, err := r.LoadSpanConfig(ctx)
+	if err != nil {
+		return false, errors.Wrapf(err, "unable to load span config")
+	}
 	// First handle the case of splitting due to span config maps.
 	splitKey, err := confReader.ComputeSplitKey(ctx, desc.StartKey, desc.EndKey)
 	if err != nil {
@@ -299,6 +303,7 @@ func (sq *splitQueue) processAttempt(
 				ExpirationTime: hlc.Timestamp{},
 			},
 			desc,
+			conf,
 			false, /* delayable */
 			"span config",
 			false, /* findFirstSafeSplitKey */
@@ -324,6 +329,7 @@ func (sq *splitQueue) processAttempt(
 			ctx,
 			kvpb.AdminSplitRequest{},
 			desc,
+			conf,
 			false, /* delayable */
 			reason,
 			false, /* findFirstSafeSplitKey */
@@ -376,6 +382,7 @@ func (sq *splitQueue) processAttempt(
 				ExpirationTime: expTime,
 			},
 			desc,
+			conf,
 			false, /* delayable */
 			reason,
 			true, /* findFirstSafeSplitKey */

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -199,10 +199,19 @@ func shouldSplitRange(
 // prefix or if the range's size in bytes exceeds the limit for the zone,
 // or if the range has too much load on it.
 func (sq *splitQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, conf *roachpb.SpanConfig,
 ) (shouldQ bool, priority float64) {
+	// TODO(baptist): This is a little ugly to read the conf reader here. The
+	// better interface is to have the StoreReader only have one method -
+	// GetSpanConfigForRange and all the other logic would be here. Consider
+	// refactoring in the future. Short term we reload the confReader for this
+	// range.
+	confReader, err := repl.store.GetConfReader(ctx)
+	if err != nil {
+		return false, 0
+	}
 	shouldQ, priority = shouldSplitRange(ctx, repl.Desc(), repl.GetMVCCStats(),
-		repl.GetMaxBytes(ctx), repl.shouldBackpressureWrites(), confReader)
+		conf.RangeMaxBytes, repl.shouldBackpressureWrites(), confReader)
 
 	if !shouldQ && repl.SplitByLoadEnabled() {
 		if splitKey := repl.loadSplitKey(ctx, repl.Clock().PhysicalTime()); splitKey != nil {
@@ -224,9 +233,9 @@ var _ PurgatoryError = unsplittableRangeError{}
 
 // process synchronously invokes admin split for each proposed split key.
 func (sq *splitQueue) process(
-	ctx context.Context, r *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, r *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
-	processed, err = sq.processAttemptWithTracing(ctx, r, confReader)
+	processed, err = sq.processAttemptWithTracing(ctx, r, conf)
 	if errors.HasType(err, (*kvpb.ConditionFailedError)(nil)) {
 		// ConditionFailedErrors are an expected outcome for range split
 		// attempts because splits can race with other descriptor modifications.
@@ -244,14 +253,14 @@ func (sq *splitQueue) process(
 // logging the resulting traces in the case of errors or when the configured log
 // traces threshold is exceeded.
 func (sq *splitQueue) processAttemptWithTracing(
-	ctx context.Context, r *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, r *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, _ error) {
 	processStart := r.Clock().PhysicalTime()
 	ctx, sp := tracing.EnsureChildSpan(ctx, sq.Tracer, "split",
 		tracing.WithRecording(tracingpb.RecordingVerbose))
 	defer sp.Finish()
 
-	processed, err := sq.processAttempt(ctx, r, confReader)
+	processed, err := sq.processAttempt(ctx, r, conf)
 
 	// Utilize a new background context (properly annotated) to avoid writing
 	// traces from a child context into its parent.
@@ -280,12 +289,12 @@ func (sq *splitQueue) processAttemptWithTracing(
 }
 
 func (sq *splitQueue) processAttempt(
-	ctx context.Context, r *Replica, confReader spanconfig.StoreReader,
+	ctx context.Context, r *Replica, conf *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	desc := r.Desc()
-	conf, err := r.LoadSpanConfig(ctx)
+	confReader, err := r.store.GetConfReader(ctx)
 	if err != nil {
-		return false, errors.Wrapf(err, "unable to load span config")
+		return false, errors.Wrapf(err, "unable to load conf reader")
 	}
 	// First handle the case of splitting due to span config maps.
 	splitKey, err := confReader.ComputeSplitKey(ctx, desc.StartKey, desc.EndKey)
@@ -318,7 +327,7 @@ func (sq *splitQueue) processAttempt(
 	// size-based splitting if maxBytes is 0 (happens in certain test
 	// situations).
 	size := r.GetMVCCStats().Total()
-	maxBytes := r.GetMaxBytes(ctx)
+	maxBytes := conf.RangeMaxBytes
 	if maxBytes > 0 && size > maxBytes {
 		reason := redact.Sprintf(
 			"%s above threshold size %s",
@@ -402,7 +411,7 @@ func (sq *splitQueue) processAttempt(
 }
 
 func (*splitQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, config *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/kv/kvserver/split_queue_test.go
+++ b/pkg/kv/kvserver/split_queue_test.go
@@ -75,11 +75,6 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		{roachpb.RKey(keys.SystemSQLCodec.TablePrefix(2001)), roachpb.RKeyMax, 32<<20 + 1, 64 << 20, true, 1},
 	}
 
-	cfg, err := tc.store.GetConfReader(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	{
 		// This test plays fast and loose and if there are raft commands ongoing then
 		// we'll hit internal assertions in the tests below. Sending a write through
@@ -105,22 +100,19 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		conf := zonepb.DefaultZoneConfigRef()
+		conf.RangeMaxBytes = proto.Int64(test.maxBytes)
+		repl.store.cfg.DefaultSpanConfig.RangeMaxBytes = test.maxBytes
+
 		repl.mu.Lock()
 		repl.mu.state.Stats = &enginepb.MVCCStats{KeyBytes: test.bytes}
 		repl.mu.Unlock()
-		conf := roachpb.TestingDefaultSpanConfig()
-		conf.RangeMaxBytes = test.maxBytes
-		sp := roachpb.Span{
-			Key:    cpy.StartKey.AsRawKey().Clone(),
-			EndKey: cpy.EndKey.AsRawKey().Clone(),
-		}
-		repl.SetSpanConfig(conf, sp)
 
 		// Testing using shouldSplitRange instead of shouldQueue to avoid using the splitFinder
 		// This tests the merge queue behavior too as a result. For splitFinder tests,
 		// see split/split_test.go.
 		shouldQ, priority := shouldSplitRange(ctx, repl.Desc(), repl.GetMVCCStats(),
-			repl.GetMaxBytes(ctx), repl.ShouldBackpressureWrites(ctx), cfg)
+			*conf.RangeMaxBytes, repl.ShouldBackpressureWrites(ctx), config.NewSystemConfig(conf))
 		if shouldQ != test.shouldQ {
 			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)
 		}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3816,7 +3816,16 @@ func (s *Store) Enqueue(
 		return nil, nil, errors.Errorf("unknown queue type %q", queueName)
 	}
 
-	confReader, err := s.GetConfReader(ctx)
+	// TODO(baptist): Remove this check. We read the conf reader just to see if
+	// we can without error. Once we load the SpanConfig from the Reader instead
+	// of the cached version, these two checks are the same.
+	_, err := s.GetConfReader(ctx)
+	if err != nil {
+		return nil, nil, errors.Wrap(err,
+			"unable to retrieve conf reader, cannot run queue; make sure "+
+				"the cluster has been initialized and all nodes connected to it")
+	}
+	conf, err := repl.LoadSpanConfig(ctx)
 	if err != nil {
 		return nil, nil, errors.Wrap(err,
 			"unable to retrieve conf reader, cannot run queue; make sure "+
@@ -3855,7 +3864,7 @@ func (s *Store) Enqueue(
 
 	if !skipShouldQueue {
 		log.Eventf(ctx, "running %s.shouldQueue", queueName)
-		shouldQueue, priority := qImpl.shouldQueue(ctx, s.cfg.Clock.NowAsClockTimestamp(), repl, confReader)
+		shouldQueue, priority := qImpl.shouldQueue(ctx, s.cfg.Clock.NowAsClockTimestamp(), repl, conf)
 		log.Eventf(ctx, "shouldQueue=%v, priority=%f", shouldQueue, priority)
 		if !shouldQueue {
 			return collectAndFinish(), nil, nil
@@ -3863,7 +3872,7 @@ func (s *Store) Enqueue(
 	}
 
 	log.Eventf(ctx, "running %s.process", queueName)
-	processed, processErr := qImpl.process(ctx, repl, confReader)
+	processed, processErr := qImpl.process(ctx, repl, conf)
 	log.Eventf(ctx, "processed: %t (err: %v)", processed, processErr)
 	return collectAndFinish(), processErr, nil
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2546,6 +2546,32 @@ func (s *Store) removeReplicaWithRangefeed(rangeID roachpb.RangeID) {
 	s.rangefeedReplicas.Unlock()
 }
 
+// GetSpanConfigForKey loads the span config starting at the given key. This
+// allows inserting test configurations through knobs.
+func (s *Store) GetSpanConfigForKey(
+	ctx context.Context, key roachpb.RKey,
+) (*roachpb.SpanConfig, roachpb.Span, error) {
+	if s.cfg.TestingKnobs.MakeSystemConfigSpanUnavailableToQueues {
+		return nil, roachpb.Span{}, errSpanConfigsUnavailable
+	}
+
+	// TODO(baptist): Tests should correctly set the span configs.
+	if s.cfg.SpanConfigsDisabled {
+		return &s.cfg.DefaultSpanConfig, roachpb.Span{}, nil
+	}
+	confReader, err := s.GetConfReader(ctx)
+	if err != nil {
+		return nil, roachpb.Span{}, err
+	}
+	if s.cfg.TestingKnobs.ConfReaderInterceptor != nil {
+		if reader := s.cfg.TestingKnobs.ConfReaderInterceptor(); reader != nil {
+			confReader = reader
+		}
+	}
+	conf, span, err := confReader.GetSpanConfigForKey(ctx, key)
+	return &conf, span, err
+}
+
 // onSpanConfigUpdate is the callback invoked whenever this store learns of a
 // span config update.
 func (s *Store) onSpanConfigUpdate(ctx context.Context, updated roachpb.Span) {
@@ -2585,12 +2611,12 @@ func (s *Store) onSpanConfigUpdate(ctx context.Context, updated roachpb.Span) {
 				// adjacent table. This results in a single update, corresponding to the
 				// new table's span, which forms the right-hand side post split.
 
-				conf, sp, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, startKey)
+				conf, sp, err := s.GetSpanConfigForKey(replCtx, startKey)
 				if err != nil {
 					log.Errorf(replCtx, "skipped applying update, unexpected error reading from subscriber: %v", err)
 					return err
 				}
-				changed = repl.SetSpanConfig(conf, sp)
+				changed = repl.SetSpanConfig(*conf, sp)
 			}
 			if changed {
 				repl.MaybeQueue(ctx, now)
@@ -2610,13 +2636,13 @@ func (s *Store) applyAllFromSpanConfigStore(ctx context.Context) {
 	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
 		replCtx := repl.AnnotateCtx(ctx)
 		key := repl.Desc().StartKey
-		conf, confSpan, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, key)
+		conf, confSpan, err := s.GetSpanConfigForKey(replCtx, key)
 		if err != nil {
 			log.Errorf(ctx, "skipped applying config update, unexpected error reading from subscriber: %v", err)
 			return true // more
 		}
 
-		changed := repl.SetSpanConfig(conf, confSpan)
+		changed := repl.SetSpanConfig(*conf, confSpan)
 		if changed {
 			repl.MaybeQueue(replCtx, now)
 		}
@@ -3724,13 +3750,7 @@ func (s *Store) AllocatorCheckRange(
 	}
 	ctx, sp := tracing.EnsureChildSpan(ctx, s.cfg.AmbientCtx.Tracer, "allocator check range", spanOptions...)
 
-	confReader, err := s.GetConfReader(ctx)
-	if err != nil {
-		log.Eventf(ctx, "span configs unavailable: %s", err)
-		return allocatorimpl.AllocatorNoop, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err
-	}
-
-	conf, _, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
+	conf, _, err := s.GetSpanConfigForKey(ctx, desc.StartKey)
 	if err != nil {
 		log.Eventf(ctx, "error retrieving span config for range %s: %s", desc, err)
 		return allocatorimpl.AllocatorNoop, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err
@@ -3745,7 +3765,7 @@ func (s *Store) AllocatorCheckRange(
 		storePool = s.cfg.StorePool
 	}
 
-	action, _ := s.allocator.ComputeAction(ctx, storePool, &conf, desc)
+	action, _ := s.allocator.ComputeAction(ctx, storePool, conf, desc)
 
 	// In the case that the action does not require a target, return immediately.
 	if !(action.Add() || action.Replace()) {
@@ -3759,7 +3779,7 @@ func (s *Store) AllocatorCheckRange(
 		return action, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err
 	}
 
-	target, _, err := s.allocator.AllocateTarget(ctx, storePool, &conf,
+	target, _, err := s.allocator.AllocateTarget(ctx, storePool, conf,
 		filteredVoters, filteredNonVoters, replacing, action.ReplicaStatus(), action.TargetReplicaType(),
 	)
 	if err == nil {
@@ -3770,7 +3790,7 @@ func (s *Store) AllocatorCheckRange(
 		fragileQuorumErr := s.allocator.CheckAvoidsFragileQuorum(
 			ctx,
 			storePool,
-			&conf,
+			conf,
 			desc.Replicas().VoterDescriptors(),
 			filteredVoters,
 			action.ReplicaStatus(),

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -502,7 +502,6 @@ func loadRanges(rr *ReplicaRankings, s *Store, ranges []testRange) {
 		rangeID := roachpb.RangeID(i + 1)
 		repl := &Replica{store: s, RangeID: rangeID}
 		repl.mu.state.Desc = &roachpb.RangeDescriptor{RangeID: rangeID}
-		repl.mu.conf = s.cfg.DefaultSpanConfig
 		for _, storeID := range r.voters {
 			repl.mu.state.Desc.InternalReplicas = append(repl.mu.state.Desc.InternalReplicas, roachpb.ReplicaDescriptor{
 				NodeID:    roachpb.NodeID(storeID),
@@ -1272,6 +1271,12 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			)
 
 			hottestRanges := sr.replicaRankings.TopLoad(lbRebalanceDimension)
+			// TODO(baptist): Remove this once the cached span conf is removed
+			// from the replica. The DefaultSpanConfig can be removed also once
+			// this change is made.
+			for _, replica := range hottestRanges {
+				replica.Repl().SetSpanConfig(s.cfg.DefaultSpanConfig, replica.Desc().KeySpan().AsRawSpanWithNoLocals())
+			}
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, LBRebalancingLeasesAndReplicas)
 			rctx.options.IOOverloadOptions = allocatorimpl.IOOverloadOptions{
@@ -1529,6 +1534,12 @@ func TestChooseRangeToRebalanceOffHotNodes(t *testing.T) {
 			)
 
 			hottestRanges := sr.replicaRankings.TopLoad(lbRebalanceDimension)
+			// TODO(baptist): Remove this once the cached span conf is removed
+			// from the replica. The DefaultSpanConfig can be removed also once
+			// this change is made.
+			for _, replica := range hottestRanges {
+				replica.Repl().SetSpanConfig(s.cfg.DefaultSpanConfig, replica.Desc().KeySpan().AsRawSpanWithNoLocals())
+			}
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, sr.RebalanceMode())
 			rctx.options.IOOverloadOptions = allocatorimpl.IOOverloadOptions{
@@ -1796,6 +1807,12 @@ func TestStoreRebalancerIOOverloadCheck(t *testing.T) {
 			loadRanges(rr, s, []testRange{{voters: []roachpb.StoreID{1, 3, 5}, qps: 100, reqCPU: 100 * float64(time.Millisecond)}})
 
 			hottestRanges := sr.replicaRankings.TopLoad(lbRebalanceDimension)
+			// TODO(baptist): Remove this once the cached span conf is removed
+			// from the replica. The DefaultSpanConfig can be removed also once
+			// this change is made.
+			for _, replica := range hottestRanges {
+				replica.Repl().SetSpanConfig(s.cfg.DefaultSpanConfig, replica.Desc().KeySpan().AsRawSpanWithNoLocals())
+			}
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, sr.RebalanceMode())
 			require.Greater(t, len(rctx.hottestRanges), 0)

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -3507,39 +3506,6 @@ func TestSnapshotRateLimit(t *testing.T) {
 	require.Equal(t, int64(32<<20), limit)
 }
 
-type entry struct {
-	conf   roachpb.SpanConfig
-	bounds roachpb.Span
-}
-
-type mockSpanConfigReader struct {
-	real      spanconfig.StoreReader
-	overrides map[string]entry
-}
-
-func (m *mockSpanConfigReader) NeedsSplit(
-	ctx context.Context, start, end roachpb.RKey,
-) (bool, error) {
-	panic("unimplemented")
-}
-
-func (m *mockSpanConfigReader) ComputeSplitKey(
-	ctx context.Context, start, end roachpb.RKey,
-) (roachpb.RKey, error) {
-	panic("unimplemented")
-}
-
-func (m *mockSpanConfigReader) GetSpanConfigForKey(
-	ctx context.Context, key roachpb.RKey,
-) (roachpb.SpanConfig, roachpb.Span, error) {
-	if e, ok := m.overrides[string(key)]; ok {
-		return e.conf, roachpb.Span{}, nil
-	}
-	return m.GetSpanConfigForKey(ctx, key)
-}
-
-var _ spanconfig.StoreReader = &mockSpanConfigReader{}
-
 // TestAllocatorCheckRangeUnconfigured tests evaluating the allocation decisions
 // for a range with a single replica using the default system configuration and
 // no other available allocation targets.
@@ -3691,7 +3657,6 @@ func TestAllocatorCheckRange(t *testing.T) {
 				{NodeID: 4, StoreID: 4, ReplicaID: 4},
 				{NodeID: 5, StoreID: 5, ReplicaID: 5},
 			},
-			spanConfig: &defaultSystemSpanConfig,
 			livenessOverrides: map[roachpb.NodeID]livenesspb.NodeLivenessStatus{
 				3: livenesspb.NodeLivenessStatus_DECOMMISSIONING,
 			},
@@ -3709,7 +3674,6 @@ func TestAllocatorCheckRange(t *testing.T) {
 				{NodeID: 4, StoreID: 4, ReplicaID: 4},
 				{NodeID: 5, StoreID: 5, ReplicaID: 5},
 			},
-			spanConfig: &defaultSystemSpanConfig,
 			livenessOverrides: map[roachpb.NodeID]livenesspb.NodeLivenessStatus{
 				3: livenesspb.NodeLivenessStatus_DECOMMISSIONING,
 				4: livenesspb.NodeLivenessStatus_DECOMMISSIONING,
@@ -3733,7 +3697,6 @@ func TestAllocatorCheckRange(t *testing.T) {
 				// Region "c"
 				{NodeID: 7, StoreID: 7, ReplicaID: 5},
 			},
-			spanConfig: &defaultSystemSpanConfig,
 			livenessOverrides: map[roachpb.NodeID]livenesspb.NodeLivenessStatus{
 				// Downsize to one node per region: 3,6,9.
 				1: livenesspb.NodeLivenessStatus_DECOMMISSIONING,
@@ -3984,22 +3947,8 @@ func TestAllocatorCheckRange(t *testing.T) {
 			cfg.Gossip = g
 			cfg.StorePool = sp
 			if tc.spanConfig != nil {
-				mockSr := &mockSpanConfigReader{
-					real: cfg.SystemConfigProvider.GetSystemConfig(),
-					overrides: map[string]entry{
-						"a": {
-							conf: *tc.spanConfig,
-							bounds: roachpb.Span{
-								Key:    []byte("a"),
-								EndKey: []byte("b"),
-							},
-						},
-					},
-				}
-
-				cfg.TestingKnobs.ConfReaderInterceptor = func() spanconfig.StoreReader {
-					return mockSr
-				}
+				cfg.SpanConfigsDisabled = true
+				cfg.DefaultSpanConfig = *tc.spanConfig
 			}
 
 			s := createTestStoreWithoutStart(ctx, t, stopper, testStoreOpts{createSystemRanges: true}, &cfg)

--- a/pkg/kv/kvserver/ts_maintenance_queue.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -121,7 +120,7 @@ func newTimeSeriesMaintenanceQueue(
 }
 
 func (q *timeSeriesMaintenanceQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ *roachpb.SpanConfig,
 ) (shouldQ bool, priority float64) {
 	if !repl.store.cfg.TestingKnobs.DisableLastProcessedCheck {
 		lpTS, err := repl.getQueueLastProcessed(ctx, q.name)
@@ -141,7 +140,7 @@ func (q *timeSeriesMaintenanceQueue) shouldQueue(
 }
 
 func (q *timeSeriesMaintenanceQueue) process(
-	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, repl *Replica, _ *roachpb.SpanConfig,
 ) (processed bool, err error) {
 	desc := repl.Desc()
 	eng := repl.store.StateEngine()
@@ -159,7 +158,7 @@ func (q *timeSeriesMaintenanceQueue) process(
 }
 
 func (*timeSeriesMaintenanceQueue) postProcessScheduled(
-	ctx context.Context, replica replicaInQueue, priority float64,
+	ctx context.Context, replica replicaInQueue, _ *roachpb.SpanConfig, priority float64,
 ) {
 }
 

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -25,14 +25,12 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// FallbackConfigOverride is a hidden cluster setting to override the fallback
-// config used for ranges with no explicit span configs set.
-var FallbackConfigOverride = settings.RegisterProtobufSetting(
-	settings.SystemOnly,
-	"spanconfig.store.fallback_config_override",
-	"override the fallback used for ranges with no explicit span configs set",
-	&roachpb.SpanConfig{},
-)
+func (s *Store) getFallbackConfig() roachpb.SpanConfig {
+	if s.knobs != nil && s.knobs.OverrideFallbackConf != nil {
+		return s.knobs.OverrideFallbackConf(s.fallback)
+	}
+	return s.fallback
+}
 
 // BoundsEnabled is a hidden cluster setting which controls whether
 // SpanConfigBounds should be consulted (to perform clamping of secondary tenant
@@ -169,16 +167,6 @@ func (s *Store) getSpanConfigForKeyRLocked(
 		log.VInfof(ctx, 3, "span config for tenant clamped to %v", conf)
 	}
 	return conf, confSpan, nil
-}
-
-func (s *Store) getFallbackConfig() roachpb.SpanConfig {
-	if conf := FallbackConfigOverride.Get(&s.settings.SV).(*roachpb.SpanConfig); !conf.IsEmpty() {
-		return *conf
-	}
-	if s.knobs != nil && s.knobs.OverrideFallbackConf != nil {
-		return s.knobs.OverrideFallbackConf(s.fallback)
-	}
-	return s.fallback
 }
 
 // Apply is part of the spanconfig.StoreWriter interface.

--- a/pkg/spanconfig/testing_knobs.go
+++ b/pkg/spanconfig/testing_knobs.go
@@ -132,6 +132,7 @@ type TestingKnobs struct {
 	// applying mutations in dry run mode.
 	StoreInternConfigsInDryRuns bool
 
+	// TODO(baptist): Remove this by injecting the fallback config directly.
 	// OverrideFallbackConf, if set, allows tests to override fields in the
 	// fallback config that will be applied to the span.
 	OverrideFallbackConf func(roachpb.SpanConfig) roachpb.SpanConfig


### PR DESCRIPTION
This change removes almost all uses of the cached span config from the replica. The cached span config is removed in a future commit.

Epic: none

Release note: None