### PR TITLE
multiregionccl: deflake TestMrSystemDatabase

### DIFF
--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -46,8 +46,7 @@ import (
 func TestColdStartLatency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderRace(t, "too slow")
-	skip.UnderStress(t, "too slow")
+	skip.UnderDuress(t, "too slow")
 
 	// We'll need to make some per-node args to assign the different
 	// KV nodes to different regions and AZs. We'll want to do it to


### PR DESCRIPTION
This test depends on stats being generated for a system table, but was flaky since it didn't check that the stats actually got created.

fixes https://github.com/cockroachdb/cockroach/issues/112781
fixes https://github.com/cockroachdb/cockroach/issues/112782
Release note: None