### PR TITLE
sql: prevent a race in indexSplitAndScatter

### DIFF
--- a/pkg/sql/index_split_scatter.go
+++ b/pkg/sql/index_split_scatter.go
@@ -127,7 +127,10 @@ func (is *indexSplitAndScatter) MaybeSplitIndexSpansForPartitioning(
 		// If there are partitioning prefixes, pre-split each of them.
 		for _, partPrefix := range partitionKeyPrefixes {
 			for _, shard := range splitAtShards {
-				splitKey := encoding.EncodeVarintAscending(partPrefix, shard)
+				// Ensure that we don't reuse memory that came from the
+				// descriptor.
+				keyPrefix := partPrefix[:len(partPrefix):len(partPrefix)]
+				splitKey := encoding.EncodeVarintAscending(keyPrefix, shard)
 				if err := splitAndScatter(ctx, is.db, splitKey, expirationTime); err != nil {
 					return err
 				}


### PR DESCRIPTION
This commit fixes a race that was just exposed by the nightly test. In particular, previously it was possible for us to reuse `[]byte` that came from the partitioning descriptor to append the shard suffix. Modification of the protos isn't allowed, so we now set the cap on the slice to force a fresh allocation when encoding the shard suffix.

Fixes: #116754.

Release note: None