### PR TITLE
release-23.2: pkg/util/metric: reduce allocations used when recording histogram metrics

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1088,8 +1088,7 @@ func (j *jobState) checkpointCompleted(ctx context.Context, checkpointDuration t
 
 	j.metrics.CheckpointHistNanos.RecordValue(checkpointDuration.Nanoseconds())
 	j.lastProgressUpdate = j.ts.Now()
-	j.checkpointDuration = time.Duration(j.metrics.CheckpointHistNanos.Mean(
-		j.metrics.CheckpointHistNanos.ToPrometheusMetric()))
+	j.checkpointDuration = time.Duration(j.metrics.CheckpointHistNanos.CumulativeSnapshot().Mean())
 	j.progressUpdatesSkipped = false
 }
 

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1088,7 +1088,8 @@ func (j *jobState) checkpointCompleted(ctx context.Context, checkpointDuration t
 
 	j.metrics.CheckpointHistNanos.RecordValue(checkpointDuration.Nanoseconds())
 	j.lastProgressUpdate = j.ts.Now()
-	j.checkpointDuration = time.Duration(j.metrics.CheckpointHistNanos.Mean())
+	j.checkpointDuration = time.Duration(j.metrics.CheckpointHistNanos.Mean(
+		j.metrics.CheckpointHistNanos.ToPrometheusMetric()))
 	j.progressUpdatesSkipped = false
 }
 

--- a/pkg/ccl/sqlproxyccl/connector_test.go
+++ b/pkg/ccl/sqlproxyccl/connector_test.go
@@ -432,7 +432,7 @@ func TestConnector_dialTenantCluster(t *testing.T) {
 		// Assert existing calls.
 		require.Equal(t, 1, dialSQLServerCount)
 		require.Equal(t, 1, reportFailureFnCount)
-		count, _ := c.DialTenantLatency.Total()
+		count, _ := c.DialTenantLatency.CumulativeSnapshot().Total()
 		require.Equal(t, count, int64(1))
 		require.Equal(t, c.DialTenantRetries.Count(), int64(0))
 
@@ -454,7 +454,7 @@ func TestConnector_dialTenantCluster(t *testing.T) {
 		// Assert existing calls.
 		require.Equal(t, 2, dialSQLServerCount)
 		require.Equal(t, 2, reportFailureFnCount)
-		count, _ = c.DialTenantLatency.Total()
+		count, _ = c.DialTenantLatency.CumulativeSnapshot().Total()
 		require.Equal(t, count, int64(2))
 		require.Equal(t, c.DialTenantRetries.Count(), int64(0))
 	})
@@ -480,7 +480,7 @@ func TestConnector_dialTenantCluster(t *testing.T) {
 		conn, err := c.dialTenantCluster(ctx, nil /* requester */)
 		require.EqualError(t, err, "baz")
 		require.Nil(t, conn)
-		count, _ := c.DialTenantLatency.Total()
+		count, _ := c.DialTenantLatency.CumulativeSnapshot().Total()
 		require.Equal(t, count, int64(1))
 		require.Equal(t, c.DialTenantRetries.Count(), int64(0))
 	})
@@ -553,7 +553,7 @@ func TestConnector_dialTenantCluster(t *testing.T) {
 		require.Equal(t, 3, addrLookupFnCount)
 		require.Equal(t, 2, dialSQLServerCount)
 		require.Equal(t, 1, reportFailureFnCount)
-		count, _ := c.DialTenantLatency.Total()
+		count, _ := c.DialTenantLatency.CumulativeSnapshot().Total()
 		require.Equal(t, count, int64(1))
 		require.Equal(t, c.DialTenantRetries.Count(), int64(2))
 	})

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -783,7 +783,7 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 		})
 	}
 	require.Equal(t, int64(4), s.metrics.SuccessfulConnCount.Count())
-	count, _ := s.metrics.ConnectionLatency.Total()
+	count, _ := s.metrics.ConnectionLatency.CumulativeSnapshot().Total()
 	require.Equal(t, int64(4), count)
 	require.Equal(t, int64(2), s.metrics.AuthFailedCount.Count())
 	require.Equal(t, int64(1), s.metrics.RoutingErrCount.Count())
@@ -921,7 +921,7 @@ func TestProxyTLSClose(t *testing.T) {
 	_ = conn.Close(ctx)
 
 	require.Equal(t, int64(1), s.metrics.SuccessfulConnCount.Count())
-	count, _ := s.metrics.ConnectionLatency.Total()
+	count, _ := s.metrics.ConnectionLatency.CumulativeSnapshot().Total()
 	require.Equal(t, int64(1), count)
 	require.Equal(t, int64(0), s.metrics.AuthFailedCount.Count())
 }
@@ -1028,7 +1028,7 @@ func TestInsecureProxy(t *testing.T) {
 		}
 		return nil
 	})
-	count, _ := s.metrics.ConnectionLatency.Total()
+	count, _ := s.metrics.ConnectionLatency.CumulativeSnapshot().Total()
 	require.Equal(t, int64(1), count)
 }
 
@@ -1138,7 +1138,7 @@ func TestProxyRefuseConn(t *testing.T) {
 	_ = te.TestConnectErr(ctx, t, url, codeProxyRefusedConnection, "too many attempts")
 	require.Equal(t, int64(1), s.metrics.RefusedConnCount.Count())
 	require.Equal(t, int64(0), s.metrics.SuccessfulConnCount.Count())
-	count, _ := s.metrics.ConnectionLatency.Total()
+	count, _ := s.metrics.ConnectionLatency.CumulativeSnapshot().Total()
 	require.Equal(t, int64(0), count)
 	require.Equal(t, int64(0), s.metrics.AuthFailedCount.Count())
 }
@@ -1920,9 +1920,9 @@ func TestConnectionMigration(t *testing.T) {
 			proxy.metrics.ConnMigrationErrorRecoverableCount.Count() +
 			proxy.metrics.ConnMigrationErrorFatalCount.Count()
 		require.Equal(t, totalAttempts, proxy.metrics.ConnMigrationAttemptedCount.Count())
-		count, _ := proxy.metrics.ConnMigrationAttemptedLatency.Total()
+		count, _ := proxy.metrics.ConnMigrationAttemptedLatency.CumulativeSnapshot().Total()
 		require.Equal(t, totalAttempts, count)
-		count, _ = proxy.metrics.ConnMigrationTransferResponseMessageSize.Total()
+		count, _ = proxy.metrics.ConnMigrationTransferResponseMessageSize.CumulativeSnapshot().Total()
 		require.Equal(t, totalAttempts, count)
 	}
 
@@ -2246,11 +2246,11 @@ func TestConnectionMigration(t *testing.T) {
 			f.metrics.ConnMigrationErrorRecoverableCount.Count() +
 			f.metrics.ConnMigrationErrorFatalCount.Count()
 		require.Equal(t, totalAttempts, f.metrics.ConnMigrationAttemptedCount.Count())
-		count, _ := f.metrics.ConnMigrationAttemptedLatency.Total()
+		count, _ := f.metrics.ConnMigrationAttemptedLatency.CumulativeSnapshot().Total()
 		require.Equal(t, totalAttempts, count)
 		// Here, we get a transfer timeout in response, so the message size
 		// should not be recorded.
-		count, _ = f.metrics.ConnMigrationTransferResponseMessageSize.Total()
+		count, _ = f.metrics.ConnMigrationTransferResponseMessageSize.CumulativeSnapshot().Total()
 		require.Equal(t, totalAttempts-1, count)
 	})
 

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4245,7 +4245,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 		require.Equal(t, exp.expClientRefreshFailure, metrics.ClientRefreshFail.Count() != 0, "TxnMetrics.ClientRefreshFail")
 		require.Equal(t, exp.expClientAutoRetryAfterRefresh, metrics.ClientRefreshAutoRetries.Count() != 0, "TxnMetrics.ClientRefreshAutoRetries")
 		require.Equal(t, exp.expServerRefresh, metrics.ServerRefreshSuccess.Count() != 0, "TxnMetrics.ServerRefreshSuccess")
-		_, restartsSum := metrics.Restarts.Total()
+		_, restartsSum := metrics.Restarts.CumulativeSnapshot().Total()
 		require.Equal(t, exp.expClientRestart, restartsSum != 0, "TxnMetrics.Restarts")
 		require.Equal(t, exp.expOnePhaseCommit, metrics.Commits1PC.Count() != 0, "TxnMetrics.Commits1PC")
 		require.Equal(t, exp.expParallelCommitAutoRetry, metrics.ParallelCommitAutoRetries.Count() != 0, "TxnMetrics.ParallelCommitAutoRetries")

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -1199,8 +1199,8 @@ func checkTxnMetrics(
 func checkTxnMetricsOnce(
 	metrics kvcoord.TxnMetrics, name string, commits, commits1PC, aborts, restarts int64,
 ) error {
-	durationCounts, _ := metrics.Durations.Total()
-	restartsCounts, _ := metrics.Restarts.Total()
+	durationCounts, _ := metrics.Durations.CumulativeSnapshot().Total()
+	restartsCounts, _ := metrics.Restarts.CumulativeSnapshot().Total()
 	testcases := []struct {
 		name string
 		a, e int64
@@ -1426,7 +1426,7 @@ func TestTxnDurations(t *testing.T) {
 	// introducing spurious errors or being overly lax.
 	//
 	// TODO(cdo): look into cause of variance.
-	count, _ := hist.Total()
+	count, _ := hist.CumulativeSnapshot().Total()
 	if a, e := count, int64(puts); a != e {
 		t.Fatalf("durations %d != expected %d", a, e)
 	}

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -243,7 +243,7 @@ func TestSchedulerLoop(t *testing.T) {
 		return nil
 	})
 
-	count, _ := m.RaftSchedulerLatency.Total()
+	count, _ := m.RaftSchedulerLatency.CumulativeSnapshot().Total()
 	require.Equal(t, int64(3), count)
 }
 

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -695,7 +695,7 @@ func extractValue(name string, mtr interface{}, fn func(string, float64)) error 
 		fn(name+"-sum", sum)
 		// Use windowed stats for avg and quantiles
 		histWindow := mtr.ToPrometheusMetricWindowed()
-		avg := mtr.MeanWindowed()
+		avg := mtr.Mean(histWindow)
 		if math.IsNaN(avg) || math.IsInf(avg, +1) || math.IsInf(avg, -1) {
 			avg = 0
 		}

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -686,13 +686,14 @@ func extractValue(name string, mtr interface{}, fn func(string, float64)) error 
 		fn(name+"-count", float64(count))
 		fn(name+"-sum", sum)
 		// Use windowed stats for avg and quantiles
+		histWindow := mtr.ToPrometheusMetricWindowed()
 		avg := mtr.MeanWindowed()
 		if math.IsNaN(avg) || math.IsInf(avg, +1) || math.IsInf(avg, -1) {
 			avg = 0
 		}
 		fn(name+"-avg", avg)
 		for _, pt := range metric.RecordHistogramQuantiles {
-			fn(name+pt.Suffix, mtr.ValueAtQuantileWindowed(pt.Quantile))
+			fn(name+pt.Suffix, mtr.ValueAtQuantileWindowed(pt.Quantile, histWindow))
 		}
 	case metric.PrometheusExportable:
 		// NB: this branch is intentionally at the bottom since all metrics implement it.

--- a/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
@@ -77,7 +77,7 @@ func BenchmarkConcurrentSelect1(b *testing.B) {
 					totalLat += <-latencyChan
 				}
 				histogram := sqlServer.ServerMetrics.StatsMetrics.SQLTxnStatsCollectionOverhead
-				b.ReportMetric(histogram.Mean(histogram.ToPrometheusMetric()), "overhead(ns/op)")
+				b.ReportMetric(histogram.CumulativeSnapshot().Mean(), "overhead(ns/op)")
 			})
 	}
 }

--- a/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
@@ -76,12 +76,8 @@ func BenchmarkConcurrentSelect1(b *testing.B) {
 				for i := 0; i < numOfConcurrentConn; i++ {
 					totalLat += <-latencyChan
 				}
-				b.ReportMetric(
-					sqlServer.ServerMetrics.
-						StatsMetrics.
-						SQLTxnStatsCollectionOverhead.
-						Mean(),
-					"overhead(ns/op)")
+				histogram := sqlServer.ServerMetrics.StatsMetrics.SQLTxnStatsCollectionOverhead
+				b.ReportMetric(histogram.Mean(histogram.ToPrometheusMetric()), "overhead(ns/op)")
 			})
 	}
 }

--- a/pkg/util/asciitsdb/BUILD.bazel
+++ b/pkg/util/asciitsdb/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/syncutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_guptarohit_asciigraph//:asciigraph",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/util/asciitsdb/asciitsdb.go
+++ b/pkg/util/asciitsdb/asciitsdb.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 	"github.com/guptarohit/asciigraph"
 	"github.com/stretchr/testify/require"
 )
@@ -106,9 +107,17 @@ func (t *TSDB) Scrape(ctx context.Context) {
 			if _, ok := t.mu.points[name]; !ok {
 				return
 			}
-			histWindow := mtr.ToPrometheusMetricWindowed()
-			count, _ := mtr.Total()
+			// Use cumulative stats here. Count must be calculated against the cumulative histogram.
+			promExportable, ok := mtr.(metric.PrometheusExportable)
+			if !ok {
+				panic(errors.AssertionFailedf(`extractValue called on histogram metric %q that does not implement the
+				PrometheusExportable interface. All histogram metrics are expected to implement this interface`, name))
+			}
+			histCumulative := promExportable.ToPrometheusMetric()
+			count, _ := mtr.Total(histCumulative)
 			t.mu.points[name+"-count"] = append(t.mu.points[name+"-count"], float64(count))
+			// Use windowed stats for avg and quantiles
+			histWindow := mtr.ToPrometheusMetricWindowed()
 			avg := mtr.MeanWindowed()
 			if math.IsNaN(avg) || math.IsInf(avg, +1) || math.IsInf(avg, -1) {
 				avg = 0

--- a/pkg/util/asciitsdb/asciitsdb.go
+++ b/pkg/util/asciitsdb/asciitsdb.go
@@ -106,6 +106,7 @@ func (t *TSDB) Scrape(ctx context.Context) {
 			if _, ok := t.mu.points[name]; !ok {
 				return
 			}
+			histWindow := mtr.ToPrometheusMetricWindowed()
 			count, _ := mtr.Total()
 			t.mu.points[name+"-count"] = append(t.mu.points[name+"-count"], float64(count))
 			avg := mtr.MeanWindowed()
@@ -120,7 +121,7 @@ func (t *TSDB) Scrape(ctx context.Context) {
 				{"-p75", 75},
 				{"-p50", 50},
 			} {
-				t.mu.points[name+pt.suffix] = append(t.mu.points[name+pt.suffix], mtr.ValueAtQuantileWindowed(pt.quantile))
+				t.mu.points[name+pt.suffix] = append(t.mu.points[name+pt.suffix], mtr.ValueAtQuantileWindowed(pt.quantile, histWindow))
 			}
 		case metric.PrometheusExportable:
 			// NB: this branch is intentionally at the bottom since all metrics

--- a/pkg/util/asciitsdb/asciitsdb.go
+++ b/pkg/util/asciitsdb/asciitsdb.go
@@ -118,7 +118,7 @@ func (t *TSDB) Scrape(ctx context.Context) {
 			t.mu.points[name+"-count"] = append(t.mu.points[name+"-count"], float64(count))
 			// Use windowed stats for avg and quantiles
 			histWindow := mtr.ToPrometheusMetricWindowed()
-			avg := mtr.MeanWindowed()
+			avg := mtr.Mean(histWindow)
 			if math.IsNaN(avg) || math.IsInf(avg, +1) || math.IsInf(avg, -1) {
 				avg = 0
 			}

--- a/pkg/util/metric/BUILD.bazel
+++ b/pkg/util/metric/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "graphite_exporter.go",
         "hdrhistogram.go",
         "histogram_buckets.go",
+        "histogram_snapshot.go",
         "metric.go",
         "prometheus_exporter.go",
         "prometheus_rule_exporter.go",

--- a/pkg/util/metric/aggmetric/agg_metric_test.go
+++ b/pkg/util/metric/aggmetric/agg_metric_test.go
@@ -222,9 +222,9 @@ func TestAggHistogramRotate(t *testing.T) {
 		// Windowed histogram is initially empty.
 		h.Inspect(func(interface{}) {}) // triggers ticking
 		// Verify new histogram windows have a 0 sum.
-		_, parentSum := h.TotalWindowed()
-		_, child1Sum := child1.h.TotalWindowed()
-		_, child2Sum := child2.h.TotalWindowed()
+		_, parentSum := h.Total(h.ToPrometheusMetricWindowed())
+		_, child1Sum := child1.h.Total(child1.h.ToPrometheusMetricWindowed())
+		_, child2Sum := child2.h.Total(child2.h.ToPrometheusMetricWindowed())
 		require.Zero(t, parentSum)
 		require.Zero(t, child1Sum)
 		require.Zero(t, child2Sum)
@@ -246,9 +246,9 @@ func TestAggHistogramRotate(t *testing.T) {
 			child2SumExp := float64(child2RecVal) + child2Sum
 			// The children should aggregate to the parent.
 			parentSumExp := float64(child1RecVal) + float64(child2RecVal) + parentSum
-			_, parentWindowSum := h.TotalWindowed()
-			_, child1WindowSum := child1.h.TotalWindowed()
-			_, child2WindowSum := child2.h.TotalWindowed()
+			_, parentWindowSum := h.Total(h.ToPrometheusMetricWindowed())
+			_, child1WindowSum := child1.h.Total(child1.h.ToPrometheusMetricWindowed())
+			_, child2WindowSum := child2.h.Total(child2.h.ToPrometheusMetricWindowed())
 			require.Equal(t, parentSumExp, parentWindowSum)
 			require.Equal(t, child1SumExp, child1WindowSum)
 			require.Equal(t, child2SumExp, child2WindowSum)

--- a/pkg/util/metric/aggmetric/agg_metric_test.go
+++ b/pkg/util/metric/aggmetric/agg_metric_test.go
@@ -229,9 +229,9 @@ func TestAggHistogramRotate(t *testing.T) {
 		require.Zero(t, child1Sum)
 		require.Zero(t, child2Sum)
 		// But cumulative histogram has history (if i > 0).
-		parentCount, _ := h.Total()
-		child1Count, _ := child1.h.Total()
-		child2Count, _ := child2.h.Total()
+		parentCount, _ := h.Total(h.ToPrometheusMetric())
+		child1Count, _ := child1.h.Total(child1.h.ToPrometheusMetric())
+		child2Count, _ := child2.h.Total(child2.h.ToPrometheusMetric())
 		require.EqualValues(t, i, child1Count)
 		require.EqualValues(t, i, child2Count)
 		// The children aggregate into the parent.

--- a/pkg/util/metric/aggmetric/agg_metric_test.go
+++ b/pkg/util/metric/aggmetric/agg_metric_test.go
@@ -222,16 +222,16 @@ func TestAggHistogramRotate(t *testing.T) {
 		// Windowed histogram is initially empty.
 		h.Inspect(func(interface{}) {}) // triggers ticking
 		// Verify new histogram windows have a 0 sum.
-		_, parentSum := h.Total(h.ToPrometheusMetricWindowed())
-		_, child1Sum := child1.h.Total(child1.h.ToPrometheusMetricWindowed())
-		_, child2Sum := child2.h.Total(child2.h.ToPrometheusMetricWindowed())
+		_, parentSum := h.WindowedSnapshot().Total()
+		_, child1Sum := child1.h.WindowedSnapshot().Total()
+		_, child2Sum := child2.h.WindowedSnapshot().Total()
 		require.Zero(t, parentSum)
 		require.Zero(t, child1Sum)
 		require.Zero(t, child2Sum)
 		// But cumulative histogram has history (if i > 0).
-		parentCount, _ := h.Total(h.ToPrometheusMetric())
-		child1Count, _ := child1.h.Total(child1.h.ToPrometheusMetric())
-		child2Count, _ := child2.h.Total(child2.h.ToPrometheusMetric())
+		parentCount, _ := h.CumulativeSnapshot().Total()
+		child1Count, _ := child1.h.CumulativeSnapshot().Total()
+		child2Count, _ := child2.h.CumulativeSnapshot().Total()
 		require.EqualValues(t, i, child1Count)
 		require.EqualValues(t, i, child2Count)
 		// The children aggregate into the parent.
@@ -246,9 +246,9 @@ func TestAggHistogramRotate(t *testing.T) {
 			child2SumExp := float64(child2RecVal) + child2Sum
 			// The children should aggregate to the parent.
 			parentSumExp := float64(child1RecVal) + float64(child2RecVal) + parentSum
-			_, parentWindowSum := h.Total(h.ToPrometheusMetricWindowed())
-			_, child1WindowSum := child1.h.Total(child1.h.ToPrometheusMetricWindowed())
-			_, child2WindowSum := child2.h.Total(child2.h.ToPrometheusMetricWindowed())
+			_, parentWindowSum := h.WindowedSnapshot().Total()
+			_, child1WindowSum := child1.h.WindowedSnapshot().Total()
+			_, child2WindowSum := child2.h.WindowedSnapshot().Total()
 			require.Equal(t, parentSumExp, parentWindowSum)
 			require.Equal(t, child1SumExp, child1WindowSum)
 			require.Equal(t, child2SumExp, child2WindowSum)

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -121,11 +121,6 @@ func (a *AggHistogram) Inspect(f func(interface{})) {
 	f(a)
 }
 
-// TotalWindowed is part of the metric.WindowedHistogram interface
-func (a *AggHistogram) TotalWindowed() (int64, float64) {
-	return a.h.TotalWindowed()
-}
-
 // Total is part of the metric.WindowedHistogram interface
 func (a *AggHistogram) Total(hist *prometheusgo.Metric) (int64, float64) {
 	return a.h.Total(hist)

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -131,14 +131,9 @@ func (a *AggHistogram) Total(hist *prometheusgo.Metric) (int64, float64) {
 	return a.h.Total(hist)
 }
 
-// MeanWindowed is part of the metric.WindowedHistogram interface
-func (a *AggHistogram) MeanWindowed() float64 {
-	return a.h.MeanWindowed()
-}
-
 // Mean is part of the metric.WindowedHistogram interface
-func (a *AggHistogram) Mean() float64 {
-	return a.h.Mean()
+func (a *AggHistogram) Mean(hist *prometheusgo.Metric) float64 {
+	return a.h.Mean(hist)
 }
 
 // ToPrometheusMetricWindowed returns a filled-in prometheus metric of the

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -65,6 +65,7 @@ var _ metric.Iterable = (*AggHistogram)(nil)
 var _ metric.PrometheusIterable = (*AggHistogram)(nil)
 var _ metric.PrometheusExportable = (*AggHistogram)(nil)
 var _ metric.WindowedHistogram = (*AggHistogram)(nil)
+var _ metric.CumulativeHistogram = (*AggHistogram)(nil)
 
 // NewHistogram constructs a new AggHistogram.
 func NewHistogram(opts metric.HistogramOptions, childLabels ...string) *AggHistogram {
@@ -121,25 +122,14 @@ func (a *AggHistogram) Inspect(f func(interface{})) {
 	f(a)
 }
 
-// Total is part of the metric.WindowedHistogram interface
-func (a *AggHistogram) Total(hist *prometheusgo.Metric) (int64, float64) {
-	return a.h.Total(hist)
+// CumulativeSnapshot is part of the metric.CumulativeHistogram interface.
+func (a *AggHistogram) CumulativeSnapshot() metric.HistogramSnapshot {
+	return a.h.CumulativeSnapshot()
 }
 
-// Mean is part of the metric.WindowedHistogram interface
-func (a *AggHistogram) Mean(hist *prometheusgo.Metric) float64 {
-	return a.h.Mean(hist)
-}
-
-// ToPrometheusMetricWindowed returns a filled-in prometheus metric of the
-// right type for the current histogram window.
-func (a *AggHistogram) ToPrometheusMetricWindowed() *prometheusgo.Metric {
-	return a.h.ToPrometheusMetricWindowed()
-}
-
-// ValueAtQuantileWindowed is part of the metric.WindowedHistogram interface
-func (a *AggHistogram) ValueAtQuantileWindowed(q float64, window *prometheusgo.Metric) float64 {
-	return a.h.ValueAtQuantileWindowed(q, window)
+// WindowedSnapshot is part of the metric.WindowedHistogram interface.
+func (a *AggHistogram) WindowedSnapshot() metric.HistogramSnapshot {
+	return a.h.WindowedSnapshot()
 }
 
 // GetType is part of the metric.PrometheusExportable interface.

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/google/btree"
-	io_prometheus_client "github.com/prometheus/client_model/go"
+	prometheusgo "github.com/prometheus/client_model/go"
 )
 
 var now = timeutil.Now
@@ -141,23 +141,29 @@ func (a *AggHistogram) Mean() float64 {
 	return a.h.Mean()
 }
 
+// ToPrometheusMetricWindowed returns a filled-in prometheus metric of the
+// right type for the current histogram window.
+func (a *AggHistogram) ToPrometheusMetricWindowed() *prometheusgo.Metric {
+	return a.h.ToPrometheusMetricWindowed()
+}
+
 // ValueAtQuantileWindowed is part of the metric.WindowedHistogram interface
-func (a *AggHistogram) ValueAtQuantileWindowed(q float64) float64 {
-	return a.h.ValueAtQuantileWindowed(q)
+func (a *AggHistogram) ValueAtQuantileWindowed(q float64, window *prometheusgo.Metric) float64 {
+	return a.h.ValueAtQuantileWindowed(q, window)
 }
 
 // GetType is part of the metric.PrometheusExportable interface.
-func (a *AggHistogram) GetType() *io_prometheus_client.MetricType {
+func (a *AggHistogram) GetType() *prometheusgo.MetricType {
 	return a.h.GetType()
 }
 
 // GetLabels is part of the metric.PrometheusExportable interface.
-func (a *AggHistogram) GetLabels() []*io_prometheus_client.LabelPair {
+func (a *AggHistogram) GetLabels() []*prometheusgo.LabelPair {
 	return a.h.GetLabels()
 }
 
 // ToPrometheusMetric is part of the metric.PrometheusExportable interface.
-func (a *AggHistogram) ToPrometheusMetric() *io_prometheus_client.Metric {
+func (a *AggHistogram) ToPrometheusMetric() *prometheusgo.Metric {
 	return a.h.ToPrometheusMetric()
 }
 
@@ -184,7 +190,7 @@ type Histogram struct {
 }
 
 // ToPrometheusMetric constructs a prometheus metric for this Histogram.
-func (g *Histogram) ToPrometheusMetric() *io_prometheus_client.Metric {
+func (g *Histogram) ToPrometheusMetric() *prometheusgo.Metric {
 	return g.h.ToPrometheusMetric()
 }
 

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -127,8 +127,8 @@ func (a *AggHistogram) TotalWindowed() (int64, float64) {
 }
 
 // Total is part of the metric.WindowedHistogram interface
-func (a *AggHistogram) Total() (int64, float64) {
-	return a.h.Total()
+func (a *AggHistogram) Total(hist *prometheusgo.Metric) (int64, float64) {
+	return a.h.Total(hist)
 }
 
 // MeanWindowed is part of the metric.WindowedHistogram interface

--- a/pkg/util/metric/hdrhistogram.go
+++ b/pkg/util/metric/hdrhistogram.go
@@ -251,15 +251,6 @@ func (h *HdrHistogram) ValueAtQuantileWindowed(q float64, window *prometheusgo.M
 	return ValueAtQuantileWindowed(window.Histogram, q)
 }
 
-func (h *HdrHistogram) Mean() float64 {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	return h.mu.cumulative.Mean()
-}
-
-func (h *HdrHistogram) MeanWindowed() float64 {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	hist := h.mu.sliding.Merge()
-	return hist.Mean()
+func (h *HdrHistogram) Mean(hist *prometheusgo.Metric) float64 {
+	return hist.Histogram.GetSampleSum() / float64(hist.Histogram.GetSampleCount())
 }

--- a/pkg/util/metric/hdrhistogram.go
+++ b/pkg/util/metric/hdrhistogram.go
@@ -100,11 +100,6 @@ func (h *HdrHistogram) RecordValue(v int64) {
 	}
 }
 
-// Total returns the (cumulative) number of samples and sum of samples.
-func (h *HdrHistogram) Total(hist *prometheusgo.Metric) (int64, float64) {
-	return int64(hist.Histogram.GetSampleCount()), hist.Histogram.GetSampleSum()
-}
-
 // Min returns the minimum.
 func (h *HdrHistogram) Min() int64 {
 	h.mu.Lock()
@@ -186,7 +181,13 @@ func (h *HdrHistogram) ToPrometheusMetric() *prometheusgo.Metric {
 	}
 }
 
-func (h *HdrHistogram) toPrometheusMetricWindowedLocked() *prometheusgo.Metric {
+func (h *HdrHistogram) CumulativeSnapshot() HistogramSnapshot {
+	return MakeHistogramSnapshot(h.ToPrometheusMetric().Histogram)
+}
+
+func (h *HdrHistogram) WindowedSnapshot() HistogramSnapshot {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	hist := &prometheusgo.Histogram{}
 
 	tick.MaybeTick(h.mu.Ticker)
@@ -214,17 +215,7 @@ func (h *HdrHistogram) toPrometheusMetricWindowedLocked() *prometheusgo.Metric {
 	}
 	hist.SampleCount = &cumCount
 	hist.SampleSum = &sum // can do better here; we approximate in the loop
-	return &prometheusgo.Metric{
-		Histogram: hist,
-	}
-}
-
-// ToPrometheusMetricWindowed returns a filled-in prometheus metric of the
-// right type for the current histogram window.
-func (h *HdrHistogram) ToPrometheusMetricWindowed() *prometheusgo.Metric {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	return h.toPrometheusMetricWindowedLocked()
+	return MakeHistogramSnapshot(hist)
 }
 
 // GetMetadata returns the metric's metadata including the Prometheus
@@ -233,12 +224,4 @@ func (h *HdrHistogram) GetMetadata() Metadata {
 	baseMetadata := h.Metadata
 	baseMetadata.MetricType = prometheusgo.MetricType_HISTOGRAM
 	return baseMetadata
-}
-
-func (h *HdrHistogram) ValueAtQuantileWindowed(q float64, window *prometheusgo.Metric) float64 {
-	return ValueAtQuantileWindowed(window.Histogram, q)
-}
-
-func (h *HdrHistogram) Mean(hist *prometheusgo.Metric) float64 {
-	return hist.Histogram.GetSampleSum() / float64(hist.Histogram.GetSampleCount())
 }

--- a/pkg/util/metric/hdrhistogram.go
+++ b/pkg/util/metric/hdrhistogram.go
@@ -101,7 +101,7 @@ func (h *HdrHistogram) RecordValue(v int64) {
 }
 
 // Total returns the (cumulative) number of samples and sum of samples.
-func (h *HdrHistogram) Total() (int64, float64) {
+func (h *HdrHistogram) Total(_ *prometheusgo.Metric) (int64, float64) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	totalSum := float64(h.mu.cumulative.TotalCount()) * h.mu.cumulative.Mean()

--- a/pkg/util/metric/hdrhistogram.go
+++ b/pkg/util/metric/hdrhistogram.go
@@ -231,7 +231,8 @@ func (h *HdrHistogram) toPrometheusMetricWindowedLocked() *prometheusgo.Metric {
 	}
 }
 
-// ToPrometheusMetricWindowed returns a filled-in prometheus metric of the right type.
+// ToPrometheusMetricWindowed returns a filled-in prometheus metric of the
+// right type for the current histogram window.
 func (h *HdrHistogram) ToPrometheusMetricWindowed() *prometheusgo.Metric {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -246,11 +247,8 @@ func (h *HdrHistogram) GetMetadata() Metadata {
 	return baseMetadata
 }
 
-func (h *HdrHistogram) ValueAtQuantileWindowed(q float64) float64 {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	return ValueAtQuantileWindowed(h.toPrometheusMetricWindowedLocked().Histogram, q)
+func (h *HdrHistogram) ValueAtQuantileWindowed(q float64, window *prometheusgo.Metric) float64 {
+	return ValueAtQuantileWindowed(window.Histogram, q)
 }
 
 func (h *HdrHistogram) Mean() float64 {

--- a/pkg/util/metric/hdrhistogram.go
+++ b/pkg/util/metric/hdrhistogram.go
@@ -101,11 +101,8 @@ func (h *HdrHistogram) RecordValue(v int64) {
 }
 
 // Total returns the (cumulative) number of samples and sum of samples.
-func (h *HdrHistogram) Total(_ *prometheusgo.Metric) (int64, float64) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	totalSum := float64(h.mu.cumulative.TotalCount()) * h.mu.cumulative.Mean()
-	return h.mu.cumulative.TotalCount(), totalSum
+func (h *HdrHistogram) Total(hist *prometheusgo.Metric) (int64, float64) {
+	return int64(hist.Histogram.GetSampleCount()), hist.Histogram.GetSampleSum()
 }
 
 // Min returns the minimum.
@@ -187,15 +184,6 @@ func (h *HdrHistogram) ToPrometheusMetric() *prometheusgo.Metric {
 	return &prometheusgo.Metric{
 		Histogram: hist,
 	}
-}
-
-// TotalWindowed implements the WindowedHistogram interface.
-func (h *HdrHistogram) TotalWindowed() (int64, float64) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	hist := h.mu.sliding.Merge()
-	totalSum := float64(hist.TotalCount()) * hist.Mean()
-	return hist.TotalCount(), totalSum
 }
 
 func (h *HdrHistogram) toPrometheusMetricWindowedLocked() *prometheusgo.Metric {

--- a/pkg/util/metric/histogram_snapshot.go
+++ b/pkg/util/metric/histogram_snapshot.go
@@ -1,0 +1,106 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package metric
+
+import (
+	"math"
+	"sort"
+
+	prometheusgo "github.com/prometheus/client_model/go"
+)
+
+// HistogramSnapshot represents a point-in-time snapshot of a Histogram metric, against
+// which calculations like Mean, Total, and Quantiles can be calculated.
+//
+// This allows a consistent dataset to be used across calculations to avoid inaccuracies
+// from one calculation to another, and isolates the supported operations to a single
+// implementation.
+type HistogramSnapshot struct {
+	h *prometheusgo.Histogram
+}
+
+// MakeHistogramSnapshot returns a new HistogramSnapshot instance, backed by the provided
+// Histogram.
+func MakeHistogramSnapshot(h *prometheusgo.Histogram) HistogramSnapshot {
+	return HistogramSnapshot{
+		h: h,
+	}
+}
+
+// ValueAtQuantile takes a quantile value [0,100] and returns the interpolated value
+// at that quantile for this HistogramSnapshot.
+func (hs HistogramSnapshot) ValueAtQuantile(q float64) float64 {
+	histogram := hs.h
+	buckets := histogram.Bucket
+	n := float64(histogram.GetSampleCount())
+	if n == 0 {
+		return 0
+	}
+
+	// NB: The 0.5 is added for rounding purposes; it helps in cases where
+	// SampleCount is small.
+	rank := uint64(((q / 100) * n) + 0.5)
+
+	// Since we are missing the +Inf bucket, CumulativeCounts may never exceed
+	// rank. By omitting the highest bucket we have from the search, the failed
+	// search will land on that last bucket and we don't have to do any special
+	// checks regarding landing on a non-existent bucket.
+	b := sort.Search(len(buckets)-1, func(i int) bool { return *buckets[i].CumulativeCount >= rank })
+
+	var (
+		bucketStart float64 // defaults to 0, which we assume is the lower bound of the smallest bucket
+		bucketEnd   = *buckets[b].UpperBound
+		count       = *buckets[b].CumulativeCount
+	)
+
+	// Calculate the linearly interpolated value within the bucket.
+	if b > 0 {
+		bucketStart = *buckets[b-1].UpperBound
+		count -= *buckets[b-1].CumulativeCount
+		rank -= *buckets[b-1].CumulativeCount
+	}
+	val := bucketStart + (bucketEnd-bucketStart)*(float64(rank)/float64(count))
+	if math.IsNaN(val) || math.IsInf(val, -1) {
+		return 0
+	}
+
+	// Should not extrapolate past the upper bound of the largest bucket.
+	//
+	// NB: SampleCount includes the implicit +Inf bucket but the
+	// buckets[len(buckets)-1].UpperBound refers to the largest bucket defined
+	// by us -- the client library doesn't give us access to the +Inf bucket
+	// which Prometheus uses under the hood. With a high enough quantile, the
+	// val computed further below surpasses the upper bound of the largest
+	// bucket. Using that interpolated value feels wrong since we'd be
+	// extrapolating. Also, for specific metrics if we see our q99 values to be
+	// hitting the top-most bucket boundary, that's an indication for us to
+	// choose better buckets for more accuracy. It's also worth noting that the
+	// prometheus client library does the same thing when the resulting value is
+	// in the +Inf bucket, whereby they return the upper bound of the second
+	// last bucket -- see [1].
+	//
+	// [1]: https://github.com/prometheus/prometheus/blob/d9162189/promql/quantile.go#L103.
+	if val > *buckets[len(buckets)-1].UpperBound {
+		return *buckets[len(buckets)-1].UpperBound
+	}
+
+	return val
+}
+
+// Mean returns the average for this HistogramSnapshot.
+func (hs HistogramSnapshot) Mean() float64 {
+	return hs.h.GetSampleSum() / float64(hs.h.GetSampleCount())
+}
+
+// Total returns the sample count and sample sum for this HistogramSnapshot.
+func (hs HistogramSnapshot) Total() (int64, float64) {
+	return int64(hs.h.GetSampleCount()), hs.h.GetSampleSum()
+}

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -96,10 +96,6 @@ type PrometheusIterable interface {
 // and values at specific quantiles from "windowed" histograms and record that
 // data directly. These windows could be arbitrary and overlapping.
 type WindowedHistogram interface {
-	// TotalWindowed returns the number of samples and their sum (respectively)
-	// in the current window.
-	// TODO(abarganier): Take in histogram window as a parameter.
-	TotalWindowed() (int64, float64)
 	// Total returns the number of samples and their sum (respectively). Generally,
 	// this should be done against a cumulative histogram.
 	Total(hist *prometheusgo.Metric) (int64, float64)
@@ -473,12 +469,6 @@ func (h *Histogram) Total(hist *prometheusgo.Metric) (int64, float64) {
 	return int64(pHist.GetSampleCount()), pHist.GetSampleSum()
 }
 
-// TotalWindowed implements the WindowedHistogram interface.
-func (h *Histogram) TotalWindowed() (int64, float64) {
-	pHist := h.ToPrometheusMetricWindowed().Histogram
-	return int64(pHist.GetSampleCount()), pHist.GetSampleSum()
-}
-
 // Mean returns the (cumulative) mean of samples.
 func (h *Histogram) Mean(hist *prometheusgo.Metric) float64 {
 	return hist.Histogram.GetSampleSum() / float64(hist.Histogram.GetSampleCount())
@@ -679,14 +669,6 @@ func (mwh *ManualWindowHistogram) ToPrometheusMetricWindowedLocked() *prometheus
 		MergeWindowedHistogram(cur.Histogram, mwh.mu.prev)
 	}
 	return cur
-}
-
-// TotalWindowed implements the WindowedHistogram interface.
-func (mwh *ManualWindowHistogram) TotalWindowed() (int64, float64) {
-	mwh.mu.RLock()
-	defer mwh.mu.RUnlock()
-	pHist := mwh.ToPrometheusMetricWindowedLocked().Histogram
-	return int64(pHist.GetSampleCount()), pHist.GetSampleSum()
 }
 
 // Total implements the WindowedHistogram interface.

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -13,7 +13,6 @@ package metric
 import (
 	"encoding/json"
 	"math"
-	"sort"
 	"sync/atomic"
 	"time"
 
@@ -95,23 +94,34 @@ type PrometheusIterable interface {
 // histograms. What it does instead is scrape off sample count, sum of values,
 // and values at specific quantiles from "windowed" histograms and record that
 // data directly. These windows could be arbitrary and overlapping.
+//
+// WindowedHistogram are generally only useful when recording histograms to TSDB,
+// where they are used to calculate quantiles and the mean. The exception is that
+// count and sum are calculated against the CumulativeHistogram instead when
+// recording to TSDB, as these values should always be monotonically increasing.
 type WindowedHistogram interface {
-	// Total returns the number of samples and their sum (respectively). Generally,
-	// this should be done against a cumulative histogram.
-	Total(hist *prometheusgo.Metric) (int64, float64)
-	// Mean returns the average of the sample in the provided histogram.
-	// A cumulative histogram or a histogram window can both be provided,
-	// depending on the use case. (Generally, we want to calculate the mean
-	// against the current window when using a WindowedHistogram).
-	Mean(hist *prometheusgo.Metric) float64
-	// ValueAtQuantileWindowed takes a quantile value [0,100] and returns the
-	// interpolated value at that quantile for the windowed histogram.
-	// Methods implementing this interface should the merge buckets, sums,
-	// and counts of previous and current windows.
-	ValueAtQuantileWindowed(q float64, window *prometheusgo.Metric) float64
-	// ToPrometheusMetricWindowed returns a filled-in prometheus metric of the
-	// right type for the current histogram window.
-	ToPrometheusMetricWindowed() *prometheusgo.Metric
+	// WindowedSnapshot returns a filled-in snapshot of the metric containing the current
+	// histogram window. Things like Mean, Quantiles, etc. can be calculated
+	// against the returned HistogramSnapshot.
+	//
+	// Methods implementing this interface should the merge buckets, sums, and counts
+	// of previous and current windows.
+	WindowedSnapshot() HistogramSnapshot
+}
+
+// CumulativeHistogram represents a histogram with data over the cumulative lifespan
+// of the histogram metric.
+//
+// CumulativeHistograms are considered the familiar standard when using histograms,
+// and are used except when recording to an internal TSDB. The exception is that
+// count and sum are calculated against the CumulativeHistogram when recording to TSDB,
+// instead of the WindowedHistogram, as these values should always be monotonically
+// increasing.
+type CumulativeHistogram interface {
+	// CumulativeSnapshot returns a filled-in snapshot of the metric's cumulative histogram.
+	// Things like Mean, Quantiles, etc. can be calculated against the returned
+	// HistogramSnapshot.
+	CumulativeSnapshot() HistogramSnapshot
 }
 
 // GetName returns the metric's name.
@@ -327,6 +337,8 @@ func newHistogram(
 
 var _ PrometheusExportable = (*Histogram)(nil)
 var _ WindowedHistogram = (*Histogram)(nil)
+var _ CumulativeHistogram = (*Histogram)(nil)
+var _ IHistogram = (*Histogram)(nil)
 
 // Histogram is a prometheus-backed histogram. It collects observed values by
 // keeping bucketed counts. For convenience, internally two sets of buckets are
@@ -359,6 +371,7 @@ type IHistogram interface {
 	Iterable
 	PrometheusExportable
 	WindowedHistogram
+	CumulativeHistogram
 	// Periodic exposes tick-related functions as part of the public API.
 	// TODO(obs-infra): This shouldn't be necessary, but we need to expose tick functions
 	// to metric.AggHistogram so that it has the ability to rotate the underlying histogram
@@ -370,11 +383,7 @@ type IHistogram interface {
 	tick.Periodic
 
 	RecordValue(n int64)
-	Total(hist *prometheusgo.Metric) (int64, float64)
-	Mean(hist *prometheusgo.Metric) float64
 }
-
-var _ IHistogram = &Histogram{}
 
 // NextTick returns the next tick timestamp of the underlying tick.Ticker
 // used by this Histogram.  Generally not useful - this is part of a band-aid
@@ -428,9 +437,11 @@ func (h *Histogram) ToPrometheusMetric() *prometheusgo.Metric {
 	return m
 }
 
-// ToPrometheusMetricWindowed returns a filled-in prometheus metric of the
-// right type for the current histogram window.
-func (h *Histogram) ToPrometheusMetricWindowed() *prometheusgo.Metric {
+func (h *Histogram) CumulativeSnapshot() HistogramSnapshot {
+	return MakeHistogramSnapshot(h.ToPrometheusMetric().Histogram)
+}
+
+func (h *Histogram) WindowedSnapshot() HistogramSnapshot {
 	h.windowed.Lock()
 	defer h.windowed.Unlock()
 	cur := &prometheusgo.Metric{}
@@ -444,7 +455,7 @@ func (h *Histogram) ToPrometheusMetricWindowed() *prometheusgo.Metric {
 		}
 		MergeWindowedHistogram(cur.Histogram, prev.Histogram)
 	}
-	return cur
+	return MakeHistogramSnapshot(cur.Histogram)
 }
 
 // GetMetadata returns the metric's metadata including the Prometheus
@@ -463,34 +474,10 @@ func (h *Histogram) Inspect(f func(interface{})) {
 	f(h)
 }
 
-// Total returns the (cumulative) number of samples and the sum of all samples.
-func (h *Histogram) Total(hist *prometheusgo.Metric) (int64, float64) {
-	pHist := hist.Histogram
-	return int64(pHist.GetSampleCount()), pHist.GetSampleSum()
-}
-
-// Mean returns the (cumulative) mean of samples.
-func (h *Histogram) Mean(hist *prometheusgo.Metric) float64 {
-	return hist.Histogram.GetSampleSum() / float64(hist.Histogram.GetSampleCount())
-}
-
-// ValueAtQuantileWindowed implements the WindowedHistogram interface.
-//
-// https://github.com/prometheus/prometheus/blob/d9162189/promql/quantile.go#L75
-// This function is mostly taken from a prometheus internal function that
-// does the same thing. There are a few differences for our use case:
-//  1. As a user of the prometheus go client library, we don't have access
-//     to the implicit +Inf bucket, so we don't need special cases to deal
-//     with the quantiles that include the +Inf bucket.
-//  2. Since the prometheus client library ensures buckets are in a strictly
-//     increasing order at creation, we do not sort them.
-func (h *Histogram) ValueAtQuantileWindowed(q float64, window *prometheusgo.Metric) float64 {
-	return ValueAtQuantileWindowed(window.Histogram, q)
-}
-
 var _ PrometheusExportable = (*ManualWindowHistogram)(nil)
 var _ Iterable = (*ManualWindowHistogram)(nil)
 var _ WindowedHistogram = (*ManualWindowHistogram)(nil)
+var _ CumulativeHistogram = (*ManualWindowHistogram)(nil)
 
 // NewManualWindowHistogram is a prometheus-backed histogram. Depending on the
 // value of the buckets parameter, this is suitable for recording any kind of
@@ -650,17 +637,13 @@ func (mwh *ManualWindowHistogram) ToPrometheusMetric() *prometheusgo.Metric {
 	return m
 }
 
-// ToPrometheusMetricWindowed returns a filled-in prometheus metric of the
-// right type for the current histogram window.
-func (mwh *ManualWindowHistogram) ToPrometheusMetricWindowed() *prometheusgo.Metric {
-	mwh.mu.RLock()
-	defer mwh.mu.RUnlock()
-	return mwh.ToPrometheusMetricWindowedLocked()
+func (mwh *ManualWindowHistogram) CumulativeSnapshot() HistogramSnapshot {
+	return MakeHistogramSnapshot(mwh.ToPrometheusMetric().Histogram)
 }
 
-// ToPrometheusMetricWindowedLocked returns a filled-in prometheus metric of the
-// right type.
-func (mwh *ManualWindowHistogram) ToPrometheusMetricWindowedLocked() *prometheusgo.Metric {
+func (mwh *ManualWindowHistogram) WindowedSnapshot() HistogramSnapshot {
+	mwh.mu.RLock()
+	defer mwh.mu.RUnlock()
 	cur := &prometheusgo.Metric{}
 	if err := mwh.mu.cum.Write(cur); err != nil {
 		panic(err)
@@ -668,27 +651,7 @@ func (mwh *ManualWindowHistogram) ToPrometheusMetricWindowedLocked() *prometheus
 	if mwh.mu.prev != nil {
 		MergeWindowedHistogram(cur.Histogram, mwh.mu.prev)
 	}
-	return cur
-}
-
-// Total implements the WindowedHistogram interface.
-func (mwh *ManualWindowHistogram) Total(hist *prometheusgo.Metric) (int64, float64) {
-	h := hist.Histogram
-	return int64(h.GetSampleCount()), h.GetSampleSum()
-}
-
-func (mwh *ManualWindowHistogram) Mean(hist *prometheusgo.Metric) float64 {
-	return hist.Histogram.GetSampleSum() / float64(hist.Histogram.GetSampleCount())
-}
-
-// ValueAtQuantileWindowed implements the WindowedHistogram interface.
-//
-// This function is very similar to Histogram.ValueAtQuantileWindowed. Thus see
-// Histogram.ValueAtQuantileWindowed for a more in-depth description.
-func (mwh *ManualWindowHistogram) ValueAtQuantileWindowed(
-	q float64, window *prometheusgo.Metric,
-) float64 {
-	return ValueAtQuantileWindowed(window.Histogram, q)
+	return MakeHistogramSnapshot(cur.Histogram)
 }
 
 // A Counter holds a single mutable atomic value.
@@ -956,65 +919,6 @@ func MergeWindowedHistogram(cur *prometheusgo.Histogram, prev *prometheusgo.Hist
 	*cur.SampleCount = sampleCount
 	sampleSum := *cur.SampleSum + *prev.SampleSum
 	*cur.SampleSum = sampleSum
-}
-
-// ValueAtQuantileWindowed takes a quantile value [0,100] and returns the
-// interpolated value at that quantile for the given histogram.
-func ValueAtQuantileWindowed(histogram *prometheusgo.Histogram, q float64) float64 {
-	buckets := histogram.Bucket
-	n := float64(*histogram.SampleCount)
-	if n == 0 {
-		return 0
-	}
-
-	// NB: The 0.5 is added for rounding purposes; it helps in cases where
-	// SampleCount is small.
-	rank := uint64(((q / 100) * n) + 0.5)
-
-	// Since we are missing the +Inf bucket, CumulativeCounts may never exceed
-	// rank. By omitting the highest bucket we have from the search, the failed
-	// search will land on that last bucket and we don't have to do any special
-	// checks regarding landing on a non-existent bucket.
-	b := sort.Search(len(buckets)-1, func(i int) bool { return *buckets[i].CumulativeCount >= rank })
-
-	var (
-		bucketStart float64 // defaults to 0, which we assume is the lower bound of the smallest bucket
-		bucketEnd   = *buckets[b].UpperBound
-		count       = *buckets[b].CumulativeCount
-	)
-
-	// Calculate the linearly interpolated value within the bucket.
-	if b > 0 {
-		bucketStart = *buckets[b-1].UpperBound
-		count -= *buckets[b-1].CumulativeCount
-		rank -= *buckets[b-1].CumulativeCount
-	}
-	val := bucketStart + (bucketEnd-bucketStart)*(float64(rank)/float64(count))
-	if math.IsNaN(val) || math.IsInf(val, -1) {
-		return 0
-	}
-
-	// Should not extrapolate past the upper bound of the largest bucket.
-	//
-	// NB: SampleCount includes the implicit +Inf bucket but the
-	// buckets[len(buckets)-1].UpperBound refers to the largest bucket defined
-	// by us -- the client library doesn't give us access to the +Inf bucket
-	// which Prometheus uses under the hood. With a high enough quantile, the
-	// val computed further below surpasses the upper bound of the largest
-	// bucket. Using that interpolated value feels wrong since we'd be
-	// extrapolating. Also, for specific metrics if we see our q99 values to be
-	// hitting the top-most bucket boundary, that's an indication for us to
-	// choose better buckets for more accuracy. It's also worth noting that the
-	// prometheus client library does the same thing when the resulting value is
-	// in the +Inf bucket, whereby they return the upper bound of the second
-	// last bucket -- see [1].
-	//
-	// [1]: https://github.com/prometheus/prometheus/blob/d9162189/promql/quantile.go#L103.
-	if val > *buckets[len(buckets)-1].UpperBound {
-		return *buckets[len(buckets)-1].UpperBound
-	}
-
-	return val
 }
 
 // Quantile is a quantile along with a string suffix to be attached to the metric

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -97,13 +97,16 @@ type PrometheusIterable interface {
 type WindowedHistogram interface {
 	// TotalWindowed returns the number of samples and their sum (respectively)
 	// in the current window.
+	// TODO(abarganier): Take in histogram window as a parameter.
 	TotalWindowed() (int64, float64)
-	// Total returns the number of samples and their sum (respectively) in the
-	// cumulative histogram.
-	Total() (int64, float64)
+	// Total returns the number of samples and their sum (respectively). Generally,
+	// this should be done against a cumulative histogram.
+	Total(hist *prometheusgo.Metric) (int64, float64)
 	// MeanWindowed returns the average of the samples in the current window.
+	// TODO(abarganier): Take in histogram window as a parameter.
 	MeanWindowed() float64
 	// Mean returns the average of the sample in the cumulative histogram.
+	// TODO(abarganier): Take in cumulative histogram as a parameter.
 	Mean() float64
 	// ValueAtQuantileWindowed takes a quantile value [0,100] and returns the
 	// interpolated value at that quantile for the windowed histogram.
@@ -371,7 +374,7 @@ type IHistogram interface {
 	tick.Periodic
 
 	RecordValue(n int64)
-	Total() (int64, float64)
+	Total(hist *prometheusgo.Metric) (int64, float64)
 	Mean() float64
 }
 
@@ -465,8 +468,8 @@ func (h *Histogram) Inspect(f func(interface{})) {
 }
 
 // Total returns the (cumulative) number of samples and the sum of all samples.
-func (h *Histogram) Total() (int64, float64) {
-	pHist := h.ToPrometheusMetric().Histogram
+func (h *Histogram) Total(hist *prometheusgo.Metric) (int64, float64) {
+	pHist := hist.Histogram
 	return int64(pHist.GetSampleCount()), pHist.GetSampleSum()
 }
 
@@ -694,8 +697,8 @@ func (mwh *ManualWindowHistogram) TotalWindowed() (int64, float64) {
 }
 
 // Total implements the WindowedHistogram interface.
-func (mwh *ManualWindowHistogram) Total() (int64, float64) {
-	h := mwh.ToPrometheusMetric().Histogram
+func (mwh *ManualWindowHistogram) Total(hist *prometheusgo.Metric) (int64, float64) {
+	h := hist.Histogram
 	return int64(h.GetSampleCount()), h.GetSampleSum()
 }
 

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -109,7 +109,10 @@ type WindowedHistogram interface {
 	// interpolated value at that quantile for the windowed histogram.
 	// Methods implementing this interface should the merge buckets, sums,
 	// and counts of previous and current windows.
-	ValueAtQuantileWindowed(q float64) float64
+	ValueAtQuantileWindowed(q float64, window *prometheusgo.Metric) float64
+	// ToPrometheusMetricWindowed returns a filled-in prometheus metric of the
+	// right type for the current histogram window.
+	ToPrometheusMetricWindowed() *prometheusgo.Metric
 }
 
 // GetName returns the metric's name.
@@ -427,7 +430,7 @@ func (h *Histogram) ToPrometheusMetric() *prometheusgo.Metric {
 }
 
 // ToPrometheusMetricWindowed returns a filled-in prometheus metric of the
-// right type.
+// right type for the current histogram window.
 func (h *Histogram) ToPrometheusMetricWindowed() *prometheusgo.Metric {
 	h.windowed.Lock()
 	defer h.windowed.Unlock()
@@ -495,9 +498,8 @@ func (h *Histogram) MeanWindowed() float64 {
 //     with the quantiles that include the +Inf bucket.
 //  2. Since the prometheus client library ensures buckets are in a strictly
 //     increasing order at creation, we do not sort them.
-func (h *Histogram) ValueAtQuantileWindowed(q float64) float64 {
-	return ValueAtQuantileWindowed(h.ToPrometheusMetricWindowed().Histogram,
-		q)
+func (h *Histogram) ValueAtQuantileWindowed(q float64, window *prometheusgo.Metric) float64 {
+	return ValueAtQuantileWindowed(window.Histogram, q)
 }
 
 var _ PrometheusExportable = (*ManualWindowHistogram)(nil)
@@ -662,6 +664,14 @@ func (mwh *ManualWindowHistogram) ToPrometheusMetric() *prometheusgo.Metric {
 	return m
 }
 
+// ToPrometheusMetricWindowed returns a filled-in prometheus metric of the
+// right type for the current histogram window.
+func (mwh *ManualWindowHistogram) ToPrometheusMetricWindowed() *prometheusgo.Metric {
+	mwh.mu.RLock()
+	defer mwh.mu.RUnlock()
+	return mwh.ToPrometheusMetricWindowedLocked()
+}
+
 // ToPrometheusMetricWindowedLocked returns a filled-in prometheus metric of the
 // right type.
 func (mwh *ManualWindowHistogram) ToPrometheusMetricWindowedLocked() *prometheusgo.Metric {
@@ -705,13 +715,10 @@ func (mwh *ManualWindowHistogram) Mean() float64 {
 //
 // This function is very similar to Histogram.ValueAtQuantileWindowed. Thus see
 // Histogram.ValueAtQuantileWindowed for a more in-depth description.
-func (mwh *ManualWindowHistogram) ValueAtQuantileWindowed(q float64) float64 {
-	mwh.mu.RLock()
-	defer mwh.mu.RUnlock()
-	if mwh.mu.cur == nil {
-		return 0
-	}
-	return ValueAtQuantileWindowed(mwh.ToPrometheusMetricWindowedLocked().Histogram, q)
+func (mwh *ManualWindowHistogram) ValueAtQuantileWindowed(
+	q float64, window *prometheusgo.Metric,
+) float64 {
+	return ValueAtQuantileWindowed(window.Histogram, q)
 }
 
 // A Counter holds a single mutable atomic value.

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -303,7 +303,8 @@ func TestNewHistogramRotate(t *testing.T) {
 		_, sum := h.TotalWindowed()
 		require.Zero(t, sum)
 		// But cumulative histogram has history (if i > 0).
-		count, _ := h.Total()
+		cumulative := h.ToPrometheusMetric()
+		count, _ := h.Total(cumulative)
 		require.EqualValues(t, i, count)
 		// Add a measurement and verify it's there.
 		{

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -300,7 +300,7 @@ func TestNewHistogramRotate(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		// Windowed histogram is initially empty.
 		h.Inspect(func(interface{}) {}) // triggers ticking
-		_, sum := h.TotalWindowed()
+		_, sum := h.Total(h.ToPrometheusMetricWindowed())
 		require.Zero(t, sum)
 		// But cumulative histogram has history (if i > 0).
 		cumulative := h.ToPrometheusMetric()
@@ -310,7 +310,7 @@ func TestNewHistogramRotate(t *testing.T) {
 		{
 			h.RecordValue(12345)
 			f := float64(12345) + sum
-			_, wSum := h.TotalWindowed()
+			_, wSum := h.Total(h.ToPrometheusMetricWindowed())
 			require.Equal(t, wSum, f)
 		}
 		// Tick. This rotates the histogram.

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -370,8 +370,9 @@ func TestHistogramWindowed(t *testing.T) {
 		if i == 0 {
 			// If there is no previous window, we should be unable to calculate mean
 			// or quantile without any observations.
-			require.Equal(t, 0.0, h.ValueAtQuantileWindowed(99.99, h.ToPrometheusMetricWindowed()))
-			if !math.IsNaN(h.MeanWindowed()) {
+			histWindow := h.ToPrometheusMetricWindowed()
+			require.Equal(t, 0.0, h.ValueAtQuantileWindowed(99.99, histWindow))
+			if !math.IsNaN(h.Mean(histWindow)) {
 				t.Fatalf("mean should be undefined with no observations")
 			}
 			// Record all measurements on first iteration.
@@ -383,7 +384,7 @@ func TestHistogramWindowed(t *testing.T) {
 			// Because we have 10 observations, we expect quantiles to correspond
 			// to observation indices (e.g., the 8th expected quantile value is equal
 			// to the value interpolated at the 80th percentile).
-			histWindow := h.ToPrometheusMetricWindowed()
+			histWindow = h.ToPrometheusMetricWindowed()
 			require.Equal(t, 0.0, h.ValueAtQuantileWindowed(0, histWindow))
 			require.Equal(t, expQuantileValues[0], h.ValueAtQuantileWindowed(10, histWindow))
 			require.Equal(t, expQuantileValues[4], h.ValueAtQuantileWindowed(50, histWindow))
@@ -411,7 +412,7 @@ func TestHistogramWindowed(t *testing.T) {
 		}
 
 		// In all cases, the windowed mean should be equal to the expected sum/count
-		require.Equal(t, expSum/float64(expCount), h.MeanWindowed())
+		require.Equal(t, expSum/float64(expCount), h.Mean(h.ToPrometheusMetricWindowed()))
 
 		expHist = append(expHist, prometheusgo.Histogram{
 			SampleCount: &expCount,

--- a/pkg/util/schedulerlatency/histogram.go
+++ b/pkg/util/schedulerlatency/histogram.go
@@ -152,12 +152,13 @@ func (h *runtimeHistogram) Inspect(f func(interface{})) { f(h) }
 
 // TotalWindowed implements the WindowedHistogram interface.
 func (h *runtimeHistogram) TotalWindowed() (int64, float64) {
-	return h.Total()
+	// TODO(abarganier): take in windowed histogram as a parameter.
+	return int64(h.ToPrometheusMetricWindowed().Histogram.GetSampleCount()), h.ToPrometheusMetricWindowed().Histogram.GetSampleSum()
 }
 
 // Total implements the WindowedHistogram interface.
-func (h *runtimeHistogram) Total() (int64, float64) {
-	pHist := h.ToPrometheusMetric().Histogram
+func (h *runtimeHistogram) Total(hist *prometheusgo.Metric) (int64, float64) {
+	pHist := hist.Histogram
 	return int64(pHist.GetSampleCount()), pHist.GetSampleSum()
 }
 

--- a/pkg/util/schedulerlatency/histogram.go
+++ b/pkg/util/schedulerlatency/histogram.go
@@ -136,6 +136,12 @@ func (h *runtimeHistogram) ToPrometheusMetric() *prometheusgo.Metric {
 	return m
 }
 
+// ToPrometheusMetricWindowed returns a filled-in prometheus metric of the
+// right type for the current histogram window.
+func (h *runtimeHistogram) ToPrometheusMetricWindowed() *prometheusgo.Metric {
+	return h.ToPrometheusMetric()
+}
+
 // GetMetadata is part of the PrometheusExportable interface.
 func (h *runtimeHistogram) GetMetadata() metric.Metadata {
 	return h.Metadata
@@ -156,8 +162,8 @@ func (h *runtimeHistogram) Total() (int64, float64) {
 }
 
 // ValueAtQuantileWindowed implements the WindowedHistogram interface.
-func (h *runtimeHistogram) ValueAtQuantileWindowed(q float64) float64 {
-	return metric.ValueAtQuantileWindowed(h.ToPrometheusMetric().Histogram, q)
+func (h *runtimeHistogram) ValueAtQuantileWindowed(q float64, window *prometheusgo.Metric) float64 {
+	return metric.ValueAtQuantileWindowed(window.Histogram, q)
 }
 
 // MeanWindowed implements the WindowedHistogram interface.

--- a/pkg/util/schedulerlatency/histogram.go
+++ b/pkg/util/schedulerlatency/histogram.go
@@ -167,14 +167,9 @@ func (h *runtimeHistogram) ValueAtQuantileWindowed(q float64, window *prometheus
 	return metric.ValueAtQuantileWindowed(window.Histogram, q)
 }
 
-// MeanWindowed implements the WindowedHistogram interface.
-func (h *runtimeHistogram) MeanWindowed() float64 {
-	return h.Mean()
-}
-
 // Mean implements the WindowedHistogram interface.
-func (h *runtimeHistogram) Mean() float64 {
-	pHist := h.ToPrometheusMetric().Histogram
+func (h *runtimeHistogram) Mean(hist *prometheusgo.Metric) float64 {
+	pHist := hist.Histogram
 	return pHist.GetSampleSum() / float64(pHist.GetSampleCount())
 }
 

--- a/pkg/util/schedulerlatency/histogram.go
+++ b/pkg/util/schedulerlatency/histogram.go
@@ -150,12 +150,6 @@ func (h *runtimeHistogram) GetMetadata() metric.Metadata {
 // Inspect is part of the Iterable interface.
 func (h *runtimeHistogram) Inspect(f func(interface{})) { f(h) }
 
-// TotalWindowed implements the WindowedHistogram interface.
-func (h *runtimeHistogram) TotalWindowed() (int64, float64) {
-	// TODO(abarganier): take in windowed histogram as a parameter.
-	return int64(h.ToPrometheusMetricWindowed().Histogram.GetSampleCount()), h.ToPrometheusMetricWindowed().Histogram.GetSampleSum()
-}
-
 // Total implements the WindowedHistogram interface.
 func (h *runtimeHistogram) Total(hist *prometheusgo.Metric) (int64, float64) {
 	pHist := hist.Histogram

--- a/pkg/util/schedulerlatency/histogram_test.go
+++ b/pkg/util/schedulerlatency/histogram_test.go
@@ -97,8 +97,7 @@ func TestRuntimeHistogram(t *testing.T) {
 
 			case "print":
 				var buf strings.Builder
-				cumulative := rh.ToPrometheusMetric()
-				count, sum := rh.Total(cumulative)
+				count, sum := rh.CumulativeSnapshot().Total()
 				buf.WriteString(fmt.Sprintf("count=%d sum=%0.2f\n", count, sum))
 				hist := rh.ToPrometheusMetric().GetHistogram()
 				require.NotNil(t, hist)

--- a/pkg/util/schedulerlatency/histogram_test.go
+++ b/pkg/util/schedulerlatency/histogram_test.go
@@ -97,7 +97,8 @@ func TestRuntimeHistogram(t *testing.T) {
 
 			case "print":
 				var buf strings.Builder
-				count, sum := rh.Total()
+				cumulative := rh.ToPrometheusMetric()
+				count, sum := rh.Total(cumulative)
 				buf.WriteString(fmt.Sprintf("count=%d sum=%0.2f\n", count, sum))
 				hist := rh.ToPrometheusMetric().GetHistogram()
 				require.NotNil(t, hist)

--- a/pkg/util/schedulerlatency/scheduler_latency_test.go
+++ b/pkg/util/schedulerlatency/scheduler_latency_test.go
@@ -78,12 +78,13 @@ func TestSchedulerLatencySampler(t *testing.T) {
 		var err error
 		reg.Each(func(name string, mtr interface{}) {
 			wh := mtr.(metric.WindowedHistogram)
-			avg := wh.MeanWindowed()
+			windowSnapshot := wh.WindowedSnapshot()
+			avg := windowSnapshot.Mean()
 			if math.IsNaN(avg) || math.IsInf(avg, +1) || math.IsInf(avg, -1) {
 				avg = 0
 			}
 
-			if wh.ValueAtQuantileWindowed(99, wh.ToPrometheusMetricWindowed()) == 0 || avg == 0 {
+			if windowSnapshot.ValueAtQuantile(99) == 0 || avg == 0 {
 				err = fmt.Errorf("expected non-zero p99 scheduling latency metrics")
 			}
 		})
@@ -194,13 +195,13 @@ func TestComputeSchedulerPercentileAgainstPrometheus(t *testing.T) {
 			}
 		}
 
-		histWindow := promhist.ToPrometheusMetricWindowed()
-		require.InDelta(t, promhist.ValueAtQuantileWindowed(100, histWindow), percentile(&hist, 1.00), 1) // pmax
-		require.InDelta(t, promhist.ValueAtQuantileWindowed(0, histWindow), percentile(&hist, 0.00), 1)   // pmin
-		require.InDelta(t, promhist.ValueAtQuantileWindowed(50, histWindow), percentile(&hist, 0.50), 1)  // p50
-		require.InDelta(t, promhist.ValueAtQuantileWindowed(75, histWindow), percentile(&hist, 0.75), 1)  // p75
-		require.InDelta(t, promhist.ValueAtQuantileWindowed(90, histWindow), percentile(&hist, 0.90), 1)  // p90
-		require.InDelta(t, promhist.ValueAtQuantileWindowed(99, histWindow), percentile(&hist, 0.99), 1)  // p99
+		histWindow := promhist.WindowedSnapshot()
+		require.InDelta(t, histWindow.ValueAtQuantile(100), percentile(&hist, 1.00), 1) // pmax
+		require.InDelta(t, histWindow.ValueAtQuantile(0), percentile(&hist, 0.00), 1)   // pmin
+		require.InDelta(t, histWindow.ValueAtQuantile(50), percentile(&hist, 0.50), 1)  // p50
+		require.InDelta(t, histWindow.ValueAtQuantile(75), percentile(&hist, 0.75), 1)  // p75
+		require.InDelta(t, histWindow.ValueAtQuantile(90), percentile(&hist, 0.90), 1)  // p90
+		require.InDelta(t, histWindow.ValueAtQuantile(99), percentile(&hist, 0.99), 1)  // p99
 	}
 }
 

--- a/pkg/util/schedulerlatency/scheduler_latency_test.go
+++ b/pkg/util/schedulerlatency/scheduler_latency_test.go
@@ -83,7 +83,7 @@ func TestSchedulerLatencySampler(t *testing.T) {
 				avg = 0
 			}
 
-			if wh.ValueAtQuantileWindowed(99) == 0 || avg == 0 {
+			if wh.ValueAtQuantileWindowed(99, wh.ToPrometheusMetricWindowed()) == 0 || avg == 0 {
 				err = fmt.Errorf("expected non-zero p99 scheduling latency metrics")
 			}
 		})
@@ -194,12 +194,13 @@ func TestComputeSchedulerPercentileAgainstPrometheus(t *testing.T) {
 			}
 		}
 
-		require.InDelta(t, promhist.ValueAtQuantileWindowed(100), percentile(&hist, 1.00), 1) // pmax
-		require.InDelta(t, promhist.ValueAtQuantileWindowed(0), percentile(&hist, 0.00), 1)   // pmin
-		require.InDelta(t, promhist.ValueAtQuantileWindowed(50), percentile(&hist, 0.50), 1)  // p50
-		require.InDelta(t, promhist.ValueAtQuantileWindowed(75), percentile(&hist, 0.75), 1)  // p75
-		require.InDelta(t, promhist.ValueAtQuantileWindowed(90), percentile(&hist, 0.90), 1)  // p90
-		require.InDelta(t, promhist.ValueAtQuantileWindowed(99), percentile(&hist, 0.99), 1)  // p99
+		histWindow := promhist.ToPrometheusMetricWindowed()
+		require.InDelta(t, promhist.ValueAtQuantileWindowed(100, histWindow), percentile(&hist, 1.00), 1) // pmax
+		require.InDelta(t, promhist.ValueAtQuantileWindowed(0, histWindow), percentile(&hist, 0.00), 1)   // pmin
+		require.InDelta(t, promhist.ValueAtQuantileWindowed(50, histWindow), percentile(&hist, 0.50), 1)  // p50
+		require.InDelta(t, promhist.ValueAtQuantileWindowed(75, histWindow), percentile(&hist, 0.75), 1)  // p75
+		require.InDelta(t, promhist.ValueAtQuantileWindowed(90, histWindow), percentile(&hist, 0.90), 1)  // p90
+		require.InDelta(t, promhist.ValueAtQuantileWindowed(99, histWindow), percentile(&hist, 0.99), 1)  // p99
 	}
 }
 


### PR DESCRIPTION
Backport 6/6 commits from #116581.

/cc @cockroachdb/release

---

Fixes: https://github.com/cockroachdb/cockroach/issues/116325

### Summary

When TSDB scrapes metrics registries, it doesn't store histograms in their entirety. Instead, we calculate a [predefined set of quantiles](https://github.com/cockroachdb/cockroach/blob/50a47aa0b457821da7ec3831f32eee8d397fe4d0/pkg/util/metric/metric.go#L1052-L1061) against the latest histogram window, and store the quantiles instead.

Previously, when calculating quantiles and averages, the metrics recorder and histogram library would allocate a new prometheus histogram for each calculation. This led to a massive spike in allocations caused by the metrics library twice every 10 seconds - once to record metrics into TSDB, and once to generate the node status. These allocations were frequently showing up in heap profiles, sometimes accounting for up to 30% of total objects allocation when the profile was timed properly. 

In addition to wasting memory, this also cause inconsistencies in our quantile, average, and sum/count calculations, since each was calculated against a potentially different view of the current histogram window. 

This PR optimizes the code that records histogram metrics to reduce allocations. It alters the interfaces used to always take in a histogram to calculate against as a parameter. This makes it obvious to the caller when they are allocation a prometheus histogram, and allows us to share a singly allocated histogram to be reused across calculations for consistency.

The PR also does some cleanup of the histogram interfaces, where certain functions have been made redundant now that we provide histograms as an argument to Mean/Total/Quantile calculations.

### Benchmark Results

Via benchmarking, it's revealed that these changes reduce the # of allocations for the metrics recorder's `extractValue()` function by **~84%**. 
```
// Master branch (without changes)
BenchmarkExtractValueAllocs
BenchmarkExtractValueAllocs-10         20692       56826 ns/op    107912 B/op     3526 allocs/op

// PR's branch (with changes)
BenchmarkExtractValueAllocs
BenchmarkExtractValueAllocs-10         87542       12169 ns/op     17288 B/op      566 allocs/op
```

This indicates that these changes accomplish their intended purpose, and that allocations caused by recording histogram metrics should be reduced significantly. 

### Follow Ups:

I've filed https://github.com/cockroachdb/cockroach/issues/116584 to address the quality of histograms within CRDB at a broader level. 

#### Note: please review this PR commit-wise for easier reading.

Release justification: correctness fix & important memory optimization related to observability.  