### PR TITLE
logictestccl: skip 3node-tenant under race

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -81,9 +81,7 @@ func TestMain(m *testing.M) {
 }
 
 func runLogicTest(t *testing.T, file string) {
-	if file == "fk" || file == "alter_primary_key" {
-		skip.UnderRace(t, "times out and/or OOM's")
-	}
+	skip.UnderRace(t, "large engflow executor is overloaded by 3node-tenant config")
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -51,9 +51,7 @@ const templateText = `
 {{- define "runLogicTest" }}
 {{- if .LogicTest -}}
 func runLogicTest(t *testing.T, file string) {
-	{{ if .Is3NodeTenant }}if file == "fk" || file == "alter_primary_key" {
-		skip.UnderRace(t, "times out and/or OOM's")
-	}
+	{{ if .Is3NodeTenant }}skip.UnderRace(t, "large engflow executor is overloaded by 3node-tenant config")
 	{{ end }}skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }


### PR DESCRIPTION
3node-tenant config is quite CPU intensive, and we have seen a handful of failures under race on different files where the only symptom appears to be the environment overload. For context, we now run race tests via the engflow large pool where we get 2 CPU machine which appears to be insufficient for 3node-tenant, so this commit skips this config under race unconditionally (previously, we skipped only a couple of most expensive files).

Fixes: #116760.
Fixes: #116761.
Fixes: #116763.
Fixes: #116764.

Note that these issues are a bit different than others, but I think it has the same underlying cause - the overload.

Fixes: #115976.
Fixes: #116755.

Release note: None