### PR TITLE
kv: rename SpanConfig to LoadSpanConfig

### DIFF
--- a/pkg/kv/kvserver/asim/op/relocate_range.go
+++ b/pkg/kv/kvserver/asim/op/relocate_range.go
@@ -69,8 +69,8 @@ func (s *SimRelocateOneOptions) StorePool() storepool.AllocatorStorePool {
 	return s.storePool
 }
 
-// SpanConfig returns the span configuration for the range with start key.
-func (s *SimRelocateOneOptions) SpanConfig(
+// LoadSpanConfig loads the span configuration for the range with start key.
+func (s *SimRelocateOneOptions) LoadSpanConfig(
 	ctx context.Context, startKey roachpb.RKey,
 ) (*roachpb.SpanConfig, error) {
 	return s.state.RangeFor(state.ToKey(startKey.AsRawKey())).SpanConfig(), nil

--- a/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
+++ b/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
@@ -77,10 +77,10 @@ func (sr *simulatorReplica) GetFirstIndex() kvpb.RaftIndex {
 	return 2
 }
 
-// DescAndSpanConfig returns the authoritative range descriptor as well
+// LoadSpanConfig returns the authoritative range descriptor as well
 // as the span config for the replica.
-func (sr *simulatorReplica) DescAndSpanConfig() (*roachpb.RangeDescriptor, *roachpb.SpanConfig) {
-	return sr.rng.Descriptor(), sr.rng.SpanConfig()
+func (sr *simulatorReplica) LoadSpanConfig(ctx context.Context) (*roachpb.SpanConfig, error) {
+	return sr.rng.SpanConfig(), nil
 }
 
 // Desc returns the authoritative range descriptor, acquiring a replica lock in

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3562,9 +3562,9 @@ type RelocateOneOptions interface {
 	Allocator() allocatorimpl.Allocator
 	// StorePool returns the store's configured store pool.
 	StorePool() storepool.AllocatorStorePool
-	// SpanConfig returns the span configuration for the range with start key.
-	SpanConfig(ctx context.Context, startKey roachpb.RKey) (*roachpb.SpanConfig, error)
-	// LeaseHolder returns the descriptor of the replica which holds the lease
+	// LoadSpanConfig loads the span configuration for the range with start key.
+	LoadSpanConfig(ctx context.Context, startKey roachpb.RKey) (*roachpb.SpanConfig, error)
+	// Leaseholder returns the descriptor of the replica which holds the lease
 	// on the range with start key.
 	Leaseholder(ctx context.Context, startKey roachpb.RKey) (roachpb.ReplicaDescriptor, error)
 }
@@ -3583,8 +3583,8 @@ func (roo *replicaRelocateOneOptions) StorePool() storepool.AllocatorStorePool {
 	return roo.store.cfg.StorePool
 }
 
-// SpanConfig returns the span configuration for the range with start key.
-func (roo *replicaRelocateOneOptions) SpanConfig(
+// LoadSpanConfig loads the span configuration for the range with start key.
+func (roo *replicaRelocateOneOptions) LoadSpanConfig(
 	ctx context.Context, startKey roachpb.RKey,
 ) (*roachpb.SpanConfig, error) {
 	confReader, err := roo.store.GetConfReader(ctx)
@@ -3635,7 +3635,7 @@ func RelocateOne(
 	allocator := options.Allocator()
 	storePool := options.StorePool()
 
-	conf, err := options.SpanConfig(ctx, desc.StartKey)
+	conf, err := options.LoadSpanConfig(ctx, desc.StartKey)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/kv/kvserver/replica_rankings.go
+++ b/pkg/kv/kvserver/replica_rankings.go
@@ -45,9 +45,9 @@ type CandidateReplica interface {
 	// GetFirstIndex returns the index of the first entry in the replica's Raft
 	// log.
 	GetFirstIndex() kvpb.RaftIndex
-	// DescAndSpanConfig returns the authoritative range descriptor as well
-	// as the span config for the replica.
-	DescAndSpanConfig() (*roachpb.RangeDescriptor, *roachpb.SpanConfig)
+	// LoadSpanConfig returns the span config for the replica or an error if it can't
+	// be determined.
+	LoadSpanConfig(context.Context) (*roachpb.SpanConfig, error)
 	// Desc returns the authoritative range descriptor.
 	Desc() *roachpb.RangeDescriptor
 	// RangeUsageInfo returns usage information (sizes and traffic) needed by
@@ -77,7 +77,7 @@ func (cr candidateReplica) RangeUsageInfo() allocator.RangeUsageInfo {
 	return cr.usage
 }
 
-// Replica returns the underlying replica for this CandidateReplica. It is
+// Repl returns the underlying replica for this CandidateReplica. It is
 // only used for determining timeouts in production code and not the
 // simulator.
 func (cr candidateReplica) Repl() *Replica {

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -654,7 +654,7 @@ func (sr *StoreRebalancer) applyRangeRebalance(
 	candidateReplica CandidateReplica,
 	voterTargets, nonVoterTargets []roachpb.ReplicationTarget,
 ) bool {
-	descBeforeRebalance, _ := candidateReplica.DescAndSpanConfig()
+	descBeforeRebalance := candidateReplica.Desc()
 	log.KvDistribution.Infof(
 		ctx,
 		"rebalancing r%d (%s load) to better balance load: voters from %v to %v; non-voters from %v to %v",
@@ -740,7 +740,12 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			continue
 		}
 
-		desc, conf := candidateReplica.DescAndSpanConfig()
+		desc := candidateReplica.Desc()
+		conf, err := candidateReplica.LoadSpanConfig(ctx)
+		if err != nil {
+			log.KvDistribution.VEventf(ctx, 2, "unable to load span config: %v", err)
+			continue
+		}
 		log.KvDistribution.VEventf(ctx, 3, "considering lease transfer for r%d with %s load",
 			desc.RangeID, candidateReplica.RangeUsageInfo().TransferImpact())
 
@@ -867,7 +872,12 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 			continue
 		}
 
-		rangeDesc, conf := candidateReplica.DescAndSpanConfig()
+		rangeDesc := candidateReplica.Desc()
+		conf, err := candidateReplica.LoadSpanConfig(ctx)
+		if err != nil {
+			log.KvDistribution.VEventf(ctx, 2, "unable to load span config: %v", err)
+			continue
+		}
 		clusterNodes := sr.storePool.ClusterNodeCount()
 		numDesiredVoters := allocatorimpl.GetNeededVoters(conf.GetNumVoters(), clusterNodes)
 		numDesiredNonVoters := allocatorimpl.GetNeededNonVoters(numDesiredVoters, int(conf.GetNumNonVoters()), clusterNodes)


### PR DESCRIPTION
Clean up the method name to make it clear that this method is loading the span config not using the cached span config.

Epic: none

Release note: None