### PR TITLE
ccl/multiregionccl: TestRegionLivenessProber fix flake

### DIFF
--- a/pkg/sql/catalog/lease/count.go
+++ b/pkg/sql/catalog/lease/count.go
@@ -127,7 +127,7 @@ func countLeasesByRegion(
 			return err
 		}
 		var err error
-		if hasTimeout, timeout := prober.GetTableTimeout(); hasTimeout {
+		if hasTimeout, timeout := prober.GetProbeTimeout(); hasTimeout {
 			err = timeutil.RunWithTimeout(ctx, "count-leases-region", timeout, queryRegionRows)
 		} else {
 			err = queryRegionRows(ctx)


### PR DESCRIPTION
This patch does the following to improve test reliability:

1. Moves the regionliveness table timeout interval into a clustersetting, so it can be adjusted after the setup phase. This is a generally useful change, since it allows this timeout to be fully tuneable.
2. Updates TestRegionLivenessProber to adopt this new cluster setting after the setup phase is complete. Reducing the surface area that the shorter timeout used by the test applies. Additionally, the timeout is increased to reduce the odds of it triggering as well.

Fixes: #116629