### PR TITLE
kvclient: remove unused field from DistSender

### DIFF
--- a/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
+++ b/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
@@ -92,7 +92,6 @@ func NewDistSenderForLocalTestCluster(
 		NodeDescs:          g,
 		RPCContext:         rpcContext,
 		RPCRetryOptions:    &retryOpts,
-		nodeDescriptor:     nodeDesc,
 		NodeDialer:         nodedialer.New(rpcContext, gossip.AddressResolver(g)),
 		FirstRangeProvider: g,
 		TestingKnobs: ClientTestingKnobs{


### PR DESCRIPTION
Remove the unused NodeDescriptor field from DistSender.

Epic: none

Release note: None