### PR TITLE
sql: improve check on idx rec cache

### DIFF
--- a/pkg/sql/idxrecommendations/idx_recommendations_cache.go
+++ b/pkg/sql/idxrecommendations/idx_recommendations_cache.go
@@ -11,7 +11,6 @@
 package idxrecommendations
 
 import (
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -52,13 +51,10 @@ type IndexRecCache struct {
 		// lastCleanupTs has the last time we cleaned up the cache.
 		lastCleanupTs time.Time
 	}
-
-	atomic struct {
-		// uniqueIndexRecInfo is the number of unique index recommendations info
-		// we are storing in memory.
-		uniqueIndexRecInfo int64
-	}
 }
+
+const timeBetweenCleanups = 5 * time.Minute
+const timeThresholdForDeletion = 24 * time.Hour
 
 // NewIndexRecommendationsCache creates a new map to be used as a cache for index recommendations.
 func NewIndexRecommendationsCache(setting *cluster.Settings) *IndexRecCache {
@@ -158,17 +154,17 @@ func (idxRec *IndexRecCache) statementCanHaveRecommendation(
 	return true
 }
 
-func (idxRec *IndexRecCache) getIndexRecommendation(key indexRecKey) (indexRecInfo, bool) {
+func (idxRec *IndexRecCache) getIndexRecommendationAndInfo(
+	key indexRecKey,
+) (indexRecInfo, bool, int, time.Time) {
 	idxRec.mu.RLock()
 	defer idxRec.mu.RUnlock()
-
 	recInfo, found := idxRec.mu.idxRecommendations[key]
-
-	return recInfo, found
+	return recInfo, found, len(idxRec.mu.idxRecommendations), idxRec.mu.lastCleanupTs
 }
 
 func (idxRec *IndexRecCache) getOrCreateIndexRecommendation(key indexRecKey) (indexRecInfo, bool) {
-	recInfo, found := idxRec.getIndexRecommendation(key)
+	recInfo, found, cacheSize, lastCleanupTs := idxRec.getIndexRecommendationAndInfo(key)
 	if found {
 		return recInfo, true
 	}
@@ -176,24 +172,10 @@ func (idxRec *IndexRecCache) getOrCreateIndexRecommendation(key indexRecKey) (in
 	// Get the cluster setting value of the limit on number of unique index
 	// recommendations info we can store in memory.
 	limit := sqlstats.MaxMemReportedSampleIndexRecommendations.Get(&idxRec.st.SV)
-	incrementedCount :=
-		atomic.AddInt64(&idxRec.atomic.uniqueIndexRecInfo, int64(1))
 
-	// If it was not found, check if a new entry can be created, without
-	// passing the limit of unique index recommendations from the cache.
-	if incrementedCount > limit {
-		atomic.AddInt64(&idxRec.atomic.uniqueIndexRecInfo, -int64(1))
-		// If we have exceeded the limit of unique index recommendations try to delete older data.
-		idxRec.clearOldIdxRecommendations()
-
-		// Confirm if after the cleanup we can add new entries.
-		incrementedCount =
-			atomic.AddInt64(&idxRec.atomic.uniqueIndexRecInfo, int64(1))
-		// Abort if no entries were deleted.
-		if incrementedCount > limit {
-			atomic.AddInt64(&idxRec.atomic.uniqueIndexRecInfo, -int64(1))
-			return indexRecInfo{}, false
-		}
+	// Check if the limit was reached and if we can do cleanup (in case it was reached).
+	if int64(cacheSize) >= limit && timeutil.Since(lastCleanupTs) < timeBetweenCleanups {
+		return indexRecInfo{}, false
 	}
 
 	idxRec.mu.Lock()
@@ -203,6 +185,30 @@ func (idxRec *IndexRecCache) getOrCreateIndexRecommendation(key indexRecKey) (in
 	recInfo, found = idxRec.mu.idxRecommendations[key]
 	if found {
 		return recInfo, true
+	}
+
+	// If it was not found, check if a new entry can be created, without
+	// passing the limit of unique index recommendations from the cache.
+	// Calculate the size again, because it could have been updated by another thread.
+	if int64(len(idxRec.mu.idxRecommendations)) >= limit {
+		timeNow := timeutil.Now()
+		// Check if has been at least 5min since last cleanup, to avoid
+		// lock contention when we reached the limit.
+		if timeNow.Sub(idxRec.mu.lastCleanupTs) < timeBetweenCleanups {
+			return indexRecInfo{}, false
+		}
+
+		// Clear entries that were last updated more than a day ago.
+		for idxKey, value := range idxRec.mu.idxRecommendations {
+			if timeNow.Sub(value.lastGeneratedTs) >= timeThresholdForDeletion {
+				delete(idxRec.mu.idxRecommendations, idxKey)
+			}
+		}
+		idxRec.mu.lastCleanupTs = timeNow
+
+		if int64(len(idxRec.mu.idxRecommendations)) >= limit {
+			return indexRecInfo{}, false
+		}
 	}
 
 	// For a new entry, we want the lastGeneratedTs to be in the past, in case we reach
@@ -232,33 +238,4 @@ func (idxRec *IndexRecCache) setIndexRecommendations(
 			executionCount:  execCount,
 		}
 	}
-}
-
-// clearOldIdxRecommendations clear entries that was last updated
-// more than a day ago. Returns the total deleted entries.
-func (idxRec *IndexRecCache) clearOldIdxRecommendations() {
-	timeSinceLastCleanup := timeutil.Since(idxRec.getLastCleanupTs())
-	// Check if has been at least 5min since last cleanup, to avoid
-	// lock contention when we reached the limit.
-	if timeSinceLastCleanup.Minutes() >= 5 {
-		idxRec.mu.Lock()
-		defer idxRec.mu.Unlock()
-
-		deleted := 0
-		for key, value := range idxRec.mu.idxRecommendations {
-			if timeutil.Since(value.lastGeneratedTs).Hours() >= 24 {
-				delete(idxRec.mu.idxRecommendations, key)
-				deleted++
-			}
-		}
-		atomic.AddInt64(&idxRec.atomic.uniqueIndexRecInfo, int64(-deleted))
-		idxRec.mu.lastCleanupTs = timeutil.Now()
-	}
-}
-
-func (idxRec *IndexRecCache) getLastCleanupTs() time.Time {
-	idxRec.mu.RLock()
-	defer idxRec.mu.RUnlock()
-
-	return idxRec.mu.lastCleanupTs
 }


### PR DESCRIPTION
Previously, there was a possibility that the atomic value `uniqueIndexRecInfo` could not reflect the value from `len(mu.idxRecommendations)` on cases where another thread could have updated the size.

For example, if the index rec was found [here](https://github.com/cockroachdb/cockroach/blob/69db94aa0037679b6cf17c4e2dfd2b52c3cc893e/pkg/sql/idxrecommendations/idx_recommendations_cache.go#L223), but delete by another thread after that and before [here](https://github.com/cockroachdb/cockroach/blob/69db94aa0037679b6cf17c4e2dfd2b52c3cc893e/pkg/sql/idxrecommendations/idx_recommendations_cache.go#L225)

This commit removes the usage of the atomic value, and only calculates the length when required, so it won't increase overhead on fast-path.

Epic: none

Release note: None