### PR TITLE
kv: don't include lease start time or merge freeze time in PriorReadSummary

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_lease_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_test.go
@@ -162,18 +162,14 @@ func TestLeaseTransferForwardsStartTime(t *testing.T) {
 			// The previous lease should have been revoked.
 			require.Equal(t, prevLease.Sequence, evalCtx.RevokedLeaseSeq)
 
-			// The prior read summary should reflect the maximum read times
-			// served under the current leaseholder.
+			// The prior read summary should reflect the maximum read times served
+			// under the current leaseholder, even if this time is below the proposed
+			// lease start time.
 			propReadSum, err := readsummary.Load(ctx, batch, desc.RangeID)
 			require.NoError(t, err)
 			require.NotNil(t, propReadSum, "should write prior read summary")
-			if servedFutureReads {
-				require.Equal(t, maxPriorReadTS, propReadSum.Local.LowWater)
-				require.Equal(t, maxPriorReadTS, propReadSum.Global.LowWater)
-			} else {
-				require.Equal(t, propLease.Start.ToTimestamp(), propReadSum.Local.LowWater)
-				require.Equal(t, propLease.Start.ToTimestamp(), propReadSum.Global.LowWater)
-			}
+			require.Equal(t, maxPriorReadTS, propReadSum.Local.LowWater)
+			require.Equal(t, maxPriorReadTS, propReadSum.Global.LowWater)
 		})
 	})
 }

--- a/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/lockspanset"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -121,17 +120,6 @@ func TransferLease(
 	// to update its timestamp cache to ensure that no future writes are allowed
 	// to invalidate prior reads.
 	priorReadSum := cArgs.EvalCtx.GetCurrentReadSummary(ctx)
-	// For now, forward this summary to the proposed lease's start time. This
-	// may appear to undermine the benefit of the read summary, but it doesn't
-	// entirely. Until we ship higher-resolution read summaries, the read
-	// summary doesn't provide much value in avoiding transaction retries, but
-	// it is necessary for correctness if the outgoing leaseholder has served
-	// reads at future times above the proposed lease start time.
-	//
-	// We can remove this in the future when we increase the resolution of read
-	// summaries and have a per-range closed timestamp system that is easier to
-	// think about.
-	priorReadSum.Merge(rspb.FromTimestamp(newLease.Start.ToTimestamp()))
 
 	log.VEventf(ctx, 2, "lease transfer: prev lease: %+v, new lease: %+v", prevLease, newLease)
 	return evalNewLease(ctx, cArgs.EvalCtx, readWriter, cArgs.Stats,

--- a/pkg/kv/kvserver/batcheval/cmd_subsume.go
+++ b/pkg/kv/kvserver/batcheval/cmd_subsume.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/lockspanset"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -158,17 +157,6 @@ func Subsume(
 	// timestamp cache to ensure that no future writes are allowed to invalidate
 	// prior reads performed to this point on the RHS range.
 	priorReadSum := cArgs.EvalCtx.GetCurrentReadSummary(ctx)
-	// For now, forward this summary to the freeze time. This may appear to
-	// undermine the benefit of the read summary, but it doesn't entirely. Until
-	// we ship higher-resolution read summaries, the read summary doesn't
-	// provide much value in avoiding transaction retries, but it is necessary
-	// for correctness if the RHS has served reads at future times above the
-	// freeze time.
-	//
-	// We can remove this in the future when we increase the resolution of read
-	// summaries and have a per-range closed timestamp system that is easier to
-	// think about.
-	priorReadSum.Merge(rspb.FromTimestamp(reply.FreezeStart.ToTimestamp()))
 	reply.ReadSummary = &priorReadSum
 	reply.ClosedTimestamp = cArgs.EvalCtx.GetCurrentClosedTimestamp(ctx)
 


### PR DESCRIPTION
Informs #61986.

Now that the use of ReadSummaries has been fully phased in, we don't need this logic.

However, ReadSummaries are still low resolution. This means that we'll still bump the incoming leaseholder's timestamp cache to the maximum timestamp in the outgoing leaseholder's timestamp cache. It also means that we'll still bump the merged range's timestamp cache to the maximum timestamp in the right-hand side's timestamp cache.

Release note: None