### PR TITLE
kvclient: simplify the creation of the TransportFactory

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcostmodel"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
-	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -530,10 +529,8 @@ type DistSender struct {
 	// This is not required if a RangeDescriptorDB is supplied.
 	firstRangeProvider FirstRangeProvider
 	transportFactory   TransportFactory
-	// nodeDialer allows RPC calls from the SQL layer to the KV layer.
-	nodeDialer      *nodedialer.Dialer
-	rpcRetryOptions retry.Options
-	asyncSenderSem  *quotapool.IntPool
+	rpcRetryOptions    retry.Options
+	asyncSenderSem     *quotapool.IntPool
 
 	// batchInterceptor is set for tenants; when set, information about all
 	// BatchRequests and BatchResponses are passed through this interceptor, which
@@ -590,10 +587,9 @@ type DistSenderConfig struct {
 	// NodeIDGetter, if set, provides non-gossip based implementation for
 	// obtaining the local KV node ID. The DistSender uses the node ID to
 	// preferentially route requests to a local replica (if one exists).
-	NodeIDGetter    func() roachpb.NodeID
-	RPCRetryOptions *retry.Options
-	// NodeDialer is the dialer from the SQL layer to the KV layer.
-	NodeDialer *nodedialer.Dialer
+	NodeIDGetter     func() roachpb.NodeID
+	RPCRetryOptions  *retry.Options
+	TransportFactory TransportFactory
 
 	// One of the following two must be provided, but not both.
 	//
@@ -680,10 +676,12 @@ func NewDistSender(cfg DistSenderConfig) *DistSender {
 		return rangeDescriptorCacheSize.Get(&ds.st.SV)
 	}
 	ds.rangeCache = rangecache.NewRangeCache(ds.st, rdb, getRangeDescCacheSize, cfg.Stopper)
+	if cfg.TransportFactory == nil {
+		panic("no TransportFactory set")
+	}
+	ds.transportFactory = cfg.TransportFactory
 	if tf := cfg.TestingKnobs.TransportFactory; tf != nil {
-		ds.transportFactory = tf
-	} else {
-		ds.transportFactory = GRPCTransportFactory
+		ds.transportFactory = tf(ds.transportFactory)
 	}
 	ds.dontReorderReplicas = cfg.TestingKnobs.DontReorderReplicas
 	ds.dontConsiderConnHealth = cfg.TestingKnobs.DontConsiderConnHealth
@@ -693,7 +691,6 @@ func NewDistSender(cfg DistSenderConfig) *DistSender {
 	if cfg.RPCRetryOptions != nil {
 		ds.rpcRetryOptions = *cfg.RPCRetryOptions
 	}
-	ds.nodeDialer = cfg.NodeDialer
 	if ds.rpcRetryOptions.Closer == nil {
 		ds.rpcRetryOptions.Closer = cfg.Stopper.ShouldQuiesce()
 	}
@@ -2295,7 +2292,7 @@ func (ds *DistSender) sendToReplicas(
 		metrics:                &ds.metrics,
 		dontConsiderConnHealth: ds.dontConsiderConnHealth,
 	}
-	transport, err := ds.transportFactory(opts, ds.nodeDialer, replicas)
+	transport, err := ds.transportFactory(opts, replicas)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -762,7 +762,7 @@ func newTransportForRange(
 	}
 	replicas.OptimizeReplicaOrder(ds.st, ds.nodeIDGetter(), ds.healthFunc, ds.latencyFunc, ds.locality)
 	opts := SendOptions{class: connectionClass(&ds.st.SV)}
-	return ds.transportFactory(opts, ds.nodeDialer, replicas)
+	return ds.transportFactory(opts, replicas)
 }
 
 // makeRangeFeedRequest constructs kvpb.RangeFeedRequest for specified span and

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_mock_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb/kvpbmock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
-	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -156,13 +155,10 @@ func TestDistSenderRangeFeedRetryOnTransportErrors(t *testing.T) {
 						NodeDescs:       g,
 						RPCRetryOptions: &retry.Options{MaxRetries: 10},
 						Stopper:         stopper,
-						TestingKnobs: ClientTestingKnobs{
-							TransportFactory: func(SendOptions, *nodedialer.Dialer, ReplicaSlice) (Transport, error) {
-								return transport, nil
-							},
+						TransportFactory: func(options SendOptions, slice ReplicaSlice) (Transport, error) {
+							return transport, nil
 						},
 						RangeDescriptorDB: rangeDB,
-						NodeDialer:        nodedialer.New(rpcContext, gossip.AddressResolver(g)),
 						Settings:          cluster.MakeTestingClusterSettings(),
 					})
 					ds.rangeCache.Insert(ctx, roachpb.RangeInfo{

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -93,7 +93,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 		Clock:              s.Clock(),
 		NodeDescs:          gs,
 		Stopper:            s.Stopper(),
-		NodeDialer:         nodedialer.New(s.RPCContext(), gossip.AddressResolver(gs)),
+		TransportFactory:   kvcoord.GRPCTransportFactory(nodedialer.New(s.RPCContext(), gossip.AddressResolver(gs))),
 		FirstRangeProvider: gs,
 	})
 	tsf := kvcoord.NewTxnCoordSenderFactory(
@@ -1129,7 +1129,7 @@ func TestMultiRangeScanReverseScanInconsistent(t *testing.T) {
 						Clock:              clock,
 						NodeDescs:          gs,
 						Stopper:            s.Stopper(),
-						NodeDialer:         nodedialer.New(s.RPCContext(), gossip.AddressResolver(gs)),
+						TransportFactory:   kvcoord.GRPCTransportFactory(nodedialer.New(s.RPCContext(), gossip.AddressResolver(gs))),
 						FirstRangeProvider: gs,
 					})
 
@@ -1657,7 +1657,7 @@ func TestBatchPutWithConcurrentSplit(t *testing.T) {
 		Clock:              s.Clock(),
 		NodeDescs:          gs,
 		Stopper:            s.Stopper(),
-		NodeDialer:         nodedialer.New(s.RPCContext(), gossip.AddressResolver(gs)),
+		TransportFactory:   kvcoord.GRPCTransportFactory(nodedialer.New(s.RPCContext(), gossip.AddressResolver(gs))),
 		Settings:           cluster.MakeTestingClusterSettings(),
 		FirstRangeProvider: gs,
 	})

--- a/pkg/kv/kvclient/kvcoord/range_iter_test.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter_test.go
@@ -26,6 +26,7 @@ import (
 
 var alphaRangeDescriptors []roachpb.RangeDescriptor
 var alphaRangeDescriptorDB MockRangeDescriptorDB
+var tf TransportFactory
 
 func init() {
 	lastKey := testMetaEndKey
@@ -47,6 +48,9 @@ func init() {
 	alphaRangeDescriptorDB = mockRangeDescriptorDBForDescs(
 		append(alphaRangeDescriptors, TestMetaRangeDescriptor)...,
 	)
+	tf = func(options SendOptions, slice ReplicaSlice) (Transport, error) {
+		panic("transport not set up for use")
+	}
 }
 
 func TestRangeIterForward(t *testing.T) {
@@ -66,6 +70,7 @@ func TestRangeIterForward(t *testing.T) {
 		Stopper:           stopper,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
+		TransportFactory:  tf,
 	})
 
 	ri := MakeRangeIterator(ds)
@@ -102,6 +107,7 @@ func TestRangeIterSeekForward(t *testing.T) {
 		Stopper:           stopper,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
+		TransportFactory:  tf,
 	})
 
 	ri := MakeRangeIterator(ds)
@@ -141,6 +147,7 @@ func TestRangeIterReverse(t *testing.T) {
 		Stopper:           stopper,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
+		TransportFactory:  tf,
 	})
 
 	ri := MakeRangeIterator(ds)
@@ -177,6 +184,7 @@ func TestRangeIterSeekReverse(t *testing.T) {
 		Stopper:           stopper,
 		RangeDescriptorDB: alphaRangeDescriptorDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
+		TransportFactory:  tf,
 	})
 
 	ri := MakeRangeIterator(ds)

--- a/pkg/kv/kvclient/kvcoord/testing_knobs.go
+++ b/pkg/kv/kvclient/kvcoord/testing_knobs.go
@@ -19,9 +19,9 @@ import (
 // ClientTestingKnobs contains testing options that dictate the behavior
 // of the key-value client.
 type ClientTestingKnobs struct {
-	// The RPC dispatcher. Defaults to grpc but can be changed here for
-	// testing purposes.
-	TransportFactory TransportFactory
+	// This is used to wrap the existing factory rather than to inject a brand
+	// new one. Otherwise, set DistSenderConfig.TransportFactory directly.
+	TransportFactory func(TransportFactory) TransportFactory
 
 	// DontConsiderConnHealth, if set, makes the GRPCTransport not take into
 	// consideration the connection health when deciding the ordering for

--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -49,9 +49,7 @@ type SendOptions struct {
 //
 // The caller is responsible for ordering the replicas in the slice according to
 // the order in which the should be tried.
-type TransportFactory func(
-	SendOptions, *nodedialer.Dialer, ReplicaSlice,
-) (Transport, error)
+type TransportFactory func(SendOptions, ReplicaSlice) (Transport, error)
 
 // Transport objects can send RPCs to one or more replicas of a range.
 // All calls to Transport methods are made from a single thread, so
@@ -319,9 +317,7 @@ func (h *byHealth) Less(i, j int) bool {
 // Transport. This is useful for tests that want to use DistSender
 // without a full RPC stack.
 func SenderTransportFactory(tracer *tracing.Tracer, sender kv.Sender) TransportFactory {
-	return func(
-		_ SendOptions, _ *nodedialer.Dialer, replicas ReplicaSlice,
-	) (Transport, error) {
+	return func(_ SendOptions, replicas ReplicaSlice) (Transport, error) {
 		// Always send to the first replica.
 		replica := replicas[0].ReplicaDescriptor
 		return &senderTransport{tracer, sender, replica, false}, nil

--- a/pkg/kv/kvclient/kvcoord/transport_race.go
+++ b/pkg/kv/kvclient/kvcoord/transport_race.go
@@ -91,66 +91,66 @@ func (tr raceTransport) SendNext(
 // Instead of this transport, we should find other mechanisms ensuring that:
 // a) the server doesn't hold on to any memory, and
 // b) the server doesn't mutate the request
-func GRPCTransportFactory(
-	opts SendOptions, nodeDialer *nodedialer.Dialer, replicas ReplicaSlice,
-) (Transport, error) {
-	if atomic.AddInt32(&running, 1) <= 1 {
-		if err := nodeDialer.Stopper().RunAsyncTask(
-			context.TODO(), "transport racer", func(ctx context.Context) {
-				var iters int
-				var curIdx int
-				defer func() {
-					atomic.StoreInt32(&running, 0)
-					log.Infof(
-						ctx,
-						"transport race promotion: ran %d iterations on up to %d requests",
-						iters, curIdx+1,
-					)
-				}()
-				// Make a fixed-size slice of *BatchRequest. When full, entries
-				// are evicted in FIFO order.
-				const size = 1000
-				bas := make([]*kvpb.BatchRequest, size)
-				encoder := json.NewEncoder(io.Discard)
-				for {
-					iters++
-					start := timeutil.Now()
-					for _, ba := range bas {
-						if ba != nil {
-							if err := encoder.Encode(ba); err != nil {
-								panic(err)
+func GRPCTransportFactory(nodeDialer *nodedialer.Dialer) TransportFactory {
+	return func(opts SendOptions, replicas ReplicaSlice) (Transport, error) {
+		if atomic.AddInt32(&running, 1) <= 1 {
+			if err := nodeDialer.Stopper().RunAsyncTask(
+				context.TODO(), "transport racer", func(ctx context.Context) {
+					var iters int
+					var curIdx int
+					defer func() {
+						atomic.StoreInt32(&running, 0)
+						log.Infof(
+							ctx,
+							"transport race promotion: ran %d iterations on up to %d requests",
+							iters, curIdx+1,
+						)
+					}()
+					// Make a fixed-size slice of *BatchRequest. When full, entries
+					// are evicted in FIFO order.
+					const size = 1000
+					bas := make([]*kvpb.BatchRequest, size)
+					encoder := json.NewEncoder(io.Discard)
+					for {
+						iters++
+						start := timeutil.Now()
+						for _, ba := range bas {
+							if ba != nil {
+								if err := encoder.Encode(ba); err != nil {
+									panic(err)
+								}
 							}
 						}
-					}
-					// Prevent the goroutine from spinning too hot as this lets CI
-					// times skyrocket. Sleep on average for as long as we worked
-					// on the last iteration so we spend no more than half our CPU
-					// time on this task.
-					jittered := time.After(jitter(timeutil.Since(start)))
-					// Collect incoming requests until the jittered timer fires,
-					// then access everything we have.
-					for {
-						select {
-						case <-nodeDialer.Stopper().ShouldQuiesce():
-							return
-						case ba := <-incoming:
-							bas[curIdx%size] = ba
-							curIdx++
-							continue
-						case <-jittered:
+						// Prevent the goroutine from spinning too hot as this lets CI
+						// times skyrocket. Sleep on average for as long as we worked
+						// on the last iteration so we spend no more than half our CPU
+						// time on this task.
+						jittered := time.After(jitter(timeutil.Since(start)))
+						// Collect incoming requests until the jittered timer fires,
+						// then access everything we have.
+						for {
+							select {
+							case <-nodeDialer.Stopper().ShouldQuiesce():
+								return
+							case ba := <-incoming:
+								bas[curIdx%size] = ba
+								curIdx++
+								continue
+							case <-jittered:
+							}
+							break
 						}
-						break
 					}
-				}
-			}); err != nil {
-			// Failed to start async task, reset our state.
-			atomic.StoreInt32(&running, 0)
+				}); err != nil {
+				// Failed to start async task, reset our state.
+				atomic.StoreInt32(&running, 0)
+			}
 		}
-	}
 
-	t, err := grpcTransportFactoryImpl(opts, nodeDialer, replicas)
-	if err != nil {
-		return nil, err
+		t, err := grpcTransportFactoryImpl(opts, nodeDialer, replicas)
+		if err != nil {
+			return nil, err
+		}
+		return &raceTransport{Transport: t}, nil
 	}
-	return &raceTransport{Transport: t}, nil
 }

--- a/pkg/kv/kvclient/kvcoord/transport_regular.go
+++ b/pkg/kv/kvclient/kvcoord/transport_regular.go
@@ -16,8 +16,8 @@ package kvcoord
 import "github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 
 // GRPCTransportFactory is the default TransportFactory, using GRPC.
-func GRPCTransportFactory(
-	opts SendOptions, nodeDialer *nodedialer.Dialer, replicas ReplicaSlice,
-) (Transport, error) {
-	return grpcTransportFactoryImpl(opts, nodeDialer, replicas)
+func GRPCTransportFactory(nodeDialer *nodedialer.Dialer) TransportFactory {
+	return func(options SendOptions, slice ReplicaSlice) (Transport, error) {
+		return grpcTransportFactoryImpl(options, nodeDialer, slice)
+	}
 }

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_client_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_client_test.go
@@ -106,13 +106,11 @@ func TestTxnPipelinerCondenseLockSpans(t *testing.T) {
 	}
 	ambient := log.MakeTestingAmbientCtxWithNewTracer()
 	ds := kvcoord.NewDistSender(kvcoord.DistSenderConfig{
-		AmbientCtx: ambient,
-		Clock:      s.Clock,
-		NodeDescs:  s.Gossip,
-		Stopper:    s.Stopper(),
-		TestingKnobs: kvcoord.ClientTestingKnobs{
-			TransportFactory: kvcoord.TestingAdaptSimpleTransport(sendFn),
-		},
+		AmbientCtx:        ambient,
+		Clock:             s.Clock,
+		NodeDescs:         s.Gossip,
+		Stopper:           s.Stopper(),
+		TransportFactory:  kvcoord.TestingAdaptSimpleTransport(sendFn),
 		RangeDescriptorDB: descDB,
 		Settings:          cluster.MakeTestingClusterSettings(),
 	})

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -258,11 +258,8 @@ func createTestStoreWithoutStart(
 		NodeDescs:          mockNodeStore{desc: nodeDesc},
 		Stopper:            stopper,
 		RPCRetryOptions:    &retry.Options{},
-		NodeDialer:         cfg.NodeDialer,
+		TransportFactory:   kvcoord.SenderTransportFactory(cfg.AmbientCtx.Tracer, &storeSender),
 		FirstRangeProvider: rangeProv,
-		TestingKnobs: kvcoord.ClientTestingKnobs{
-			TransportFactory: kvcoord.SenderTransportFactory(cfg.AmbientCtx.Tracer, &storeSender),
-		},
 	})
 
 	txnCoordSenderFactory := kvcoord.NewTxnCoordSenderFactory(kvcoord.TxnCoordSenderFactoryConfig{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -455,7 +455,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		Stopper:            stopper,
 		LatencyFunc:        rpcContext.RemoteClocks.Latency,
 		RPCRetryOptions:    &retryOpts,
-		NodeDialer:         kvNodeDialer,
+		TransportFactory:   kvcoord.GRPCTransportFactory(kvNodeDialer),
 		FirstRangeProvider: g,
 		Locality:           cfg.Locality,
 		TestingKnobs:       clientTestingKnobs,

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1193,7 +1193,7 @@ func makeTenantSQLServerArgs(
 		RPCRetryOptions:   &rpcRetryOptions,
 		Stopper:           stopper,
 		LatencyFunc:       rpcContext.RemoteClocks.Latency,
-		NodeDialer:        kvNodeDialer,
+		TransportFactory:  kvcoord.GRPCTransportFactory(kvNodeDialer),
 		RangeDescriptorDB: tenantConnect,
 		Locality:          baseCfg.Locality,
 		KVInterceptor:     costController,

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -783,7 +783,6 @@ go_test(
         "//pkg/obs",
         "//pkg/roachpb",
         "//pkg/rpc",
-        "//pkg/rpc/nodedialer",
         "//pkg/scheduledjobs",
         "//pkg/security",
         "//pkg/security/securityassets",


### PR DESCRIPTION
Previously the TransportFactory was automatically created as a GRPCTransportFactory inside DistSender. This made it hard to test. This change simplifies the construction of DistSender by taking a TransportFactory. Additionally the TransportFactory is divorced from the notion of a Dialer and instead only works on BatchRequest and BatchResponses directly.

Epic: none

Release note: None