### PR TITLE
roachtest/cdc: disable distribution strategy in old versions 

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -386,6 +386,14 @@ func (cmvt *cdcMixedVersionTester) createChangeFeed(
 		ff.RangeFeedScheduler.v = &featureUnset
 	}
 
+	distributionStrategySupported, err := cmvt.distributionStrategySupported(r, h)
+	if err != nil {
+		return err
+	}
+	if !distributionStrategySupported {
+		ff.DistributionStrategy.v = &featureUnset
+	}
+
 	jobID, err := newChangefeedCreator(db, l, r, fmt.Sprintf("%s.%s", targetDB, targetTable),
 		cmvt.kafka.manager.sinkURL(ctx), ff).
 		With(options).
@@ -432,6 +440,12 @@ func (cmvt *cdcMixedVersionTester) muxRangeFeedSupported(
 const v232CV = "23.2"
 
 func (cmvt *cdcMixedVersionTester) rangefeedSchedulerSupported(
+	r *rand.Rand, h *mixedversion.Helper,
+) (bool, error) {
+	return h.ClusterVersionAtLeast(r, v232CV)
+}
+
+func (cmvt *cdcMixedVersionTester) distributionStrategySupported(
 	r *rand.Rand, h *mixedversion.Helper,
 ) (bool, error) {
 	return h.ClusterVersionAtLeast(r, v232CV)


### PR DESCRIPTION
oachtest/cdc: disable distribution strategy in old versions
The `DistributionStrategy` feature flag was added to randomly set the
`changefeed.default_range_distribution_strategy` cluster setting. Since this setting
was added in 23.2, this feature flag should be disabled when testing versions < 23.2.

This change updates the feature flag to not be set in versions < 23.2. It also
refactors how enum feature flags work: they should use the `featureUnset`, `featureDisabled`,
and `featureEnabled` states. For enum feature flags, unset and disabled can be considered
equivalent (ie. for a cluster setting which is an enum, don't set a value). In the future,
this can be changed to add a specific case for disabled. For now, this suffices.

Closes: https://github.com/cockroachdb/cockroach/issues/116865
Release note: None
Epic: None