### PR TITLE
storage: increase testing shard count

### DIFF
--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -142,7 +142,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":storage"],
     exec_properties = {"Pool": "large"},
-    shard_count = 2,
+    shard_count = 4,
     deps = [
         "//pkg/base",
         "//pkg/clusterversion",


### PR DESCRIPTION
We're starting to sporadically see failures when the test shard for pkg/storage times out as a whole. This change doubles the shard count to give each test more headroom before it times out.

Fixes #116692.

Epic: none

Release note: None