### PR TITLE
metric: fix windowing for manual histograms

### DIFF
--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -492,17 +492,26 @@ var _ CumulativeHistogram = (*ManualWindowHistogram)(nil)
 // ManualWindowHistogram.RecordValue and ManualWindowHistogram.Rotate. If
 // NewManualWindowHistogram is called withRotate as true, only the RecordValue
 // and Rotate method may be used; withRotate as false, only Update may be used.
+//
 // TODO(kvoli,aadityasondhi): The two ways to use this histogram is a hack and
 // "temporary", rationalize the interface. Tracked in #98622.
+// TODO(aaditya): A tracking issue to overhaul the histogram interfaces into a
+// more coherent one: #116584.
 func NewManualWindowHistogram(
-	meta Metadata, buckets []float64, withRotate bool,
+	meta Metadata, buckets []float64, manualRotate bool,
 ) *ManualWindowHistogram {
 	opts := prometheus.HistogramOpts{
 		Buckets: buckets,
 	}
 	cum := prometheus.NewHistogram(opts)
+	// We initialize the histogram with the same bucket bounds as the cumulative
+	// histogram.
 	prev := &prometheusgo.Metric{}
 	if err := cum.Write(prev); err != nil {
+		panic(err.Error())
+	}
+	cur := &prometheusgo.Metric{}
+	if err := cum.Write(cur); err != nil {
 		panic(err.Error())
 	}
 
@@ -510,10 +519,30 @@ func NewManualWindowHistogram(
 	h := &ManualWindowHistogram{
 		Metadata: meta,
 	}
-	h.mu.rotating = withRotate
+	h.mu.disableTick = manualRotate
 	h.mu.cum = cum
+	h.mu.cur = cur.GetHistogram()
 	h.mu.prev = prev.GetHistogram()
-
+	// If the caller specifies that it will not manually control rotating the
+	// histogram, it will use the ticker in the same way as metric.Histogram does.
+	if !manualRotate {
+		h.mu.Ticker = tick.NewTicker(
+			now(),
+			// We want to divide the total window duration by the number of windows
+			// because we need to rotate the windows at uniformly distributed
+			// intervals within a histogram's total duration.
+			60*time.Second/WindowedHistogramWrapNum,
+			func() {
+				// This is called while holding a mutex prior to calling Tick().
+				newH := &prometheusgo.Metric{}
+				h.mu.prev = h.mu.cur
+				// Initialize the histogram with the same bucket bounds as original.
+				if err := prometheus.NewHistogram(opts).Write(newH); err != nil {
+					panic(err.Error())
+				}
+				h.mu.cur = newH.GetHistogram()
+			})
+	}
 	return h
 }
 
@@ -532,23 +561,26 @@ type ManualWindowHistogram struct {
 		// RecordValue. When calling Update or Rotate, we require a WLock since we
 		// swap out fields.
 		syncutil.RWMutex
-		rotating  bool
-		cum       prometheus.Histogram
-		prev, cur *prometheusgo.Histogram
+		*tick.Ticker
+		disableTick bool
+		cum         prometheus.Histogram
+		prev, cur   *prometheusgo.Histogram
 	}
 }
 
-// Update replaces the cumulative and current windowed histograms.
+// Update replaces the cumulative histogram and adds the new current values to
+// the previous ones.
 func (mwh *ManualWindowHistogram) Update(cum prometheus.Histogram, cur *prometheusgo.Histogram) {
 	mwh.mu.Lock()
 	defer mwh.mu.Unlock()
 
-	if mwh.mu.rotating {
-		panic("Unexpected call to Update with rotate enabled")
+	if mwh.mu.disableTick {
+		panic("Unexpected call to Update with manual rotate enabled")
 	}
 
 	mwh.mu.cum = cum
-	mwh.mu.cur = cur
+	// Add the new values to the current histogram.
+	MergeWindowedHistogram(mwh.mu.cur, cur)
 }
 
 // RecordValue records a value to the cumulative histogram. The value is only
@@ -557,8 +589,8 @@ func (mwh *ManualWindowHistogram) RecordValue(val float64) {
 	mwh.mu.RLock()
 	defer mwh.mu.RUnlock()
 
-	if !mwh.mu.rotating {
-		panic("Unexpected call to RecordValue with rotate disabled")
+	if !mwh.mu.disableTick {
+		panic("Unexpected call to RecordValue with manual rotate disabled")
 	}
 	mwh.mu.cum.Observe(val)
 }
@@ -588,8 +620,8 @@ func (mwh *ManualWindowHistogram) Rotate() error {
 	mwh.mu.Lock()
 	defer mwh.mu.Unlock()
 
-	if !mwh.mu.rotating {
-		panic("Unexpected call to Rotate with rotate disabled")
+	if !mwh.mu.disableTick {
+		panic("Unexpected call to Rotate with manual rotate disabled")
 	}
 
 	cur := &prometheusgo.Metric{}
@@ -617,6 +649,13 @@ func (mwh *ManualWindowHistogram) GetMetadata() Metadata {
 
 // Inspect calls the closure.
 func (mwh *ManualWindowHistogram) Inspect(f func(interface{})) {
+	if !mwh.mu.disableTick {
+		func() {
+			mwh.mu.Lock()
+			defer mwh.mu.Unlock()
+			tick.MaybeTick(&mwh.mu)
+		}()
+	}
 	f(mwh)
 }
 
@@ -644,14 +683,37 @@ func (mwh *ManualWindowHistogram) CumulativeSnapshot() HistogramSnapshot {
 func (mwh *ManualWindowHistogram) WindowedSnapshot() HistogramSnapshot {
 	mwh.mu.RLock()
 	defer mwh.mu.RUnlock()
-	cur := &prometheusgo.Metric{}
-	if err := mwh.mu.cum.Write(cur); err != nil {
-		panic(err)
-	}
+	// Take a copy of the mwh.mu.cur.
+	cur := deepCopy(*mwh.mu.cur)
 	if mwh.mu.prev != nil {
-		MergeWindowedHistogram(cur.Histogram, mwh.mu.prev)
+		MergeWindowedHistogram(cur, mwh.mu.prev)
 	}
-	return MakeHistogramSnapshot(cur.Histogram)
+	return MakeHistogramSnapshot(cur)
+}
+
+// deepCopy performs a deep copy of the source histogram and returns the newly
+// allocated copy.
+//
+// NB: It only copies sample count, sample sum, and buckets (cumulative count,
+// upper bounds) since those are the only things we care about in this package.
+func deepCopy(source prometheusgo.Histogram) *prometheusgo.Histogram {
+	count := source.GetSampleCount()
+	sum := source.GetSampleSum()
+	bucket := make([]*prometheusgo.Bucket, len(source.Bucket))
+
+	for i := range bucket {
+		cumCount := source.Bucket[i].GetCumulativeCount()
+		upperBound := source.Bucket[i].GetUpperBound()
+		bucket[i] = &prometheusgo.Bucket{
+			CumulativeCount: &cumCount,
+			UpperBound:      &upperBound,
+		}
+	}
+	return &prometheusgo.Histogram{
+		SampleCount: &count,
+		SampleSum:   &sum,
+		Bucket:      bucket,
+	}
 }
 
 // A Counter holds a single mutable atomic value.

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -284,6 +284,102 @@ func TestManualWindowHistogram(t *testing.T) {
 	require.Equal(t, 17.5, histWindow.ValueAtQuantile(50))
 	require.Equal(t, 75.0, histWindow.ValueAtQuantile(80))
 	require.Equal(t, 100.0, histWindow.ValueAtQuantile(99.99))
+
+	// This section will test that updating the histogram with new values results
+	// in a correctly merged view when quantiles are calculated.
+	prev := pMetric
+	new := &prometheusgo.Metric{}
+	measurements2 := []float64{3, 20, 50}
+	for _, m := range measurements2 {
+		histogram.Observe(m)
+		expSum += m
+	}
+	require.NoError(t, histogram.Write(new))
+	SubtractPrometheusHistograms(new.GetHistogram(), prev.GetHistogram())
+	h.Update(histogram, new.GetHistogram())
+
+	// Adding extra values to cumulative histogram to make sure it is not used in
+	// the expected outcome.
+	histogram.Observe(5)
+	histogram.Observe(5)
+
+	act = *h.WindowedSnapshot().h
+	exp = prometheusgo.Histogram{
+		SampleCount: u(len(measurements) + len(measurements2)),
+		SampleSum:   &expSum,
+		Bucket: []*prometheusgo.Bucket{
+			{CumulativeCount: u(1), UpperBound: f(1)},
+			{CumulativeCount: u(4), UpperBound: f(5)},
+			{CumulativeCount: u(5), UpperBound: f(10)},
+			{CumulativeCount: u(8), UpperBound: f(25)},
+			{CumulativeCount: u(12), UpperBound: f(100)},
+		},
+	}
+
+	if !reflect.DeepEqual(act, exp) {
+		t.Fatalf("expected differs from actual: %s", pretty.Diff(exp, act))
+	}
+}
+
+func TestManualWindowHistogramTicker(t *testing.T) {
+	now := time.UnixMicro(1699565116)
+	defer TestingSetNow(func() time.Time {
+		return now
+	})()
+
+	buckets := []float64{
+		0.25,
+		0.5,
+		1.0,
+		2.0,
+	}
+
+	h := NewManualWindowHistogram(
+		Metadata{},
+		buckets,
+		false, /* withRotate */
+	)
+
+	phistogram := prometheus.NewHistogram(prometheus.HistogramOpts{Buckets: buckets})
+	pMetric := &prometheusgo.Metric{}
+
+	recordValue := func() {
+		phistogram.Observe(1)
+		wHistogram := prometheus.NewHistogram(prometheus.HistogramOpts{Buckets: buckets})
+		wHistogram.Observe(1)
+		require.NoError(t, wHistogram.Write(pMetric))
+		h.Update(phistogram, pMetric.Histogram)
+	}
+
+	// Test 0 case, sum and count should be 0.
+	h.Inspect(func(interface{}) {})
+	wCount, wSum := h.WindowedSnapshot().Total()
+	require.Equal(t, float64(0), wSum)
+	require.Equal(t, int64(0), wCount)
+
+	// Record a value.
+	h.Inspect(func(interface{}) {})
+	recordValue()
+	wCount, wSum = h.WindowedSnapshot().Total()
+	require.Equal(t, float64(1), wSum)
+	require.Equal(t, int64(1), wCount)
+
+	// Add 30 seconds, the previous value will rotate but the merged window should
+	// still have the previous value.
+	now = now.Add(30 * time.Second)
+	h.Inspect(func(interface{}) {})
+	recordValue()
+	wCount, wSum = h.WindowedSnapshot().Total()
+	require.Equal(t, float64(2), wSum)
+	require.Equal(t, int64(2), wCount)
+
+	// Add another 30 seconds, the prev window should have reset, and the new
+	// value is now in the prev window, expect 1.
+	now = now.Add(30 * time.Second)
+	h.Inspect(func(interface{}) {})
+	wCount, wSum = h.WindowedSnapshot().Total()
+	require.Equal(t, float64(1), wSum)
+	require.Equal(t, int64(1), wCount)
 }
 
 func TestNewHistogramRotate(t *testing.T) {


### PR DESCRIPTION
These histograms were missing the windowing logic we use in histograms to store them in our internal time series DB. The logic we follow there is that we keep 3 histograms. The first one is a cumulative one that we export to prometheus through the `status/vars` page. The second and third are `prev` and `cur` that together cover the entire duration of the histogram, default being 60s. When the ticker rotates these, we swap out the prev with the current, and start a brand new current histogram. When calculating derivative statistics, we use the combined view of the windows which is used to display these metrics in DB console. This is similar to the way Grafana handles these using its rate interval.

Fixes #115825.

Release note: None