### PR TITLE
roachtest: disable AC in OR tests

### DIFF
--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -96,6 +96,16 @@ func registerOnlineRestore(r registry.Registry) {
 								return err
 							}
 							defer db.Close()
+
+							// TODO(dt): what's the right value for this? How do we tune this
+							// on the fly automatically during the restore instead of by-hand?
+							// Context: We expect many operations to take longer than usual
+							// when some or all of the data they touch is remote. For now this
+							// is being blanket set to 1h manually, and a user's run-book
+							// would need to do this by hand before an online restore and
+							// reset it manually after, but ideally the queues would be aware
+							// of remote-ness when they pick their own timeouts and pick
+							// accordingly.
 							if _, err := db.Exec("SET CLUSTER SETTING kv.queue.process.guaranteed_time_budget='1h'"); err != nil {
 								return err
 							}

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -105,6 +105,18 @@ func registerOnlineRestore(r registry.Registry) {
 							if _, err := db.Exec("SET CLUSTER SETTING sql.stats.automatic_collection.enabled=false"); err != nil {
 								return err
 							}
+							// TODO(dt): AC appears periodically reduce the workload to 0 QPS
+							// during the download phase (sudden jumps from 0 to 2k qps to 0).
+							// Disable for now until we figure out how to smooth this out.
+							if _, err := db.Exec("SET CLUSTER SETTING admission.disk_bandwidth_tokens.elastic.enabled=false"); err != nil {
+								return err
+							}
+							if _, err := db.Exec("SET CLUSTER SETTING admission.kv.enabled=false"); err != nil {
+								return err
+							}
+							if _, err := db.Exec("SET CLUSTER SETTING admission.sql_kv_response.enabled=false"); err != nil {
+								return err
+							}
 							opts := ""
 							if runOnline {
 								opts = "WITH EXPERIMENTAL DEFERRED COPY"


### PR DESCRIPTION
Release note: none.
Epic: none.