### PR TITLE
release-23.1: backupccl: replace UDT IDs within routine bodies and views

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
@@ -11,6 +11,7 @@ CREATE TYPE sc1.enum1 AS ENUM('Good');
 CREATE SEQUENCE sc1.sq1;
 CREATE FUNCTION sc1.f1(a sc1.enum1) RETURNS INT LANGUAGE SQL AS $$
   SELECT a FROM sc1.tbl1;
+  SELECT 'Good'::sc1.enum1;
   SELECT nextval('sc1.sq1');
 $$;
 CREATE SCHEMA sc2;
@@ -60,6 +61,7 @@ CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	LANGUAGE SQL
 	AS $$
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 $$
 
@@ -95,6 +97,7 @@ CREATE FUNCTION sc1.f1(IN a db1_new.sc1.enum1)
 	LANGUAGE SQL
 	AS $$
 	SELECT a FROM db1_new.sc1.tbl1;
+	SELECT 'Good':::db1_new.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 $$
 
@@ -155,6 +158,7 @@ CREATE TYPE sc1.enum1 AS ENUM('Good');
 CREATE SEQUENCE sc1.sq1;
 CREATE FUNCTION sc1.f1(a sc1.enum1) RETURNS INT LANGUAGE SQL AS $$
   SELECT a FROM sc1.tbl1;
+  SELECT 'Good'::sc1.enum1;
   SELECT nextval('sc1.sq1');
 $$;
 CREATE SCHEMA sc2;
@@ -209,6 +213,7 @@ CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	LANGUAGE SQL
 	AS $$
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 $$
 
@@ -245,6 +250,7 @@ CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	LANGUAGE SQL
 	AS $$
 	SELECT a FROM db1.sc1.tbl1;
+	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
 $$
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/views
+++ b/pkg/ccl/backupccl/testdata/backup-restore/views
@@ -6,8 +6,9 @@ exec-sql
 CREATE DATABASE db1;
 USE db1;
 CREATE SCHEMA sc1;
+CREATE TYPE sc1.enum1 AS ENUM('Good');
 CREATE TABLE sc1.tbl1(a INT PRIMARY KEY);
-CREATE VIEW sc1.v1 AS SELECT a FROM sc1.tbl1;
+CREATE VIEW sc1.v1 AS SELECT a, 'Good'::sc1.enum1 FROM sc1.tbl1;
 ----
 
 exec-sql
@@ -17,26 +18,36 @@ INSERT INTO sc1.tbl1 VALUES (123);
 query-sql
 SELECT * FROM sc1.v1;
 ----
-123
+123 Good
 
 query-sql
 SHOW CREATE VIEW sc1.v1;
 ----
 sc1.v1 CREATE VIEW sc1.v1 (
-	a
-) AS SELECT a FROM db1.sc1.tbl1
+	a,
+	enum1
+) AS SELECT a, 'Good':::db1.sc1.enum1 FROM db1.sc1.tbl1
 
 exec-sql
 BACKUP DATABASE db1 INTO 'nodelocal://1/test/'
 ----
 
 exec-sql
+DROP DATABASE db1
+----
+
+exec-sql
 RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://1/test/' WITH new_db_name = db1_new
+----
+
+exec-sql
+USE db1_new
 ----
 
 query-sql
 SHOW CREATE VIEW db1_new.sc1.v1;
 ----
 db1_new.sc1.v1 CREATE VIEW sc1.v1 (
-	a
-) AS SELECT a FROM db1_new.sc1.tbl1
+	a,
+	enum1
+) AS SELECT a, 'Good':::db1_new.sc1.enum1 FROM db1_new.sc1.tbl1


### PR DESCRIPTION
Backport 1/1 commits from #116656.

/cc @cockroachdb/release

---

  During a database RESTORE, it is necessary to replace descriptor IDs
  from the old database with those from the new. Previously, we forgot
  to do this rewrite for UDT IDs in routine bodies and views. This would
  prevent using a database RESTORE with a user-defined function, stored
  procedure, or view, that referenced a user-defined type. This patch
  adds the needed rewrite logic and expands existing tests.

  Fixes #116653

  Release note (bug fix): Fixed a bug that prevented database RESTORE when
  the database contained a view or routine that referenced a user-defined
  type in the body string. For views, this bug was introduced in v20.2, when
  UDTs were introduced. For routines, this bug was introduced in v22.2, when
  UDFs were introduced.

Release justification: bug fix for broken functions after restore