### PR TITLE
cmd/roachtest: pick port for test UI dynamically

### DIFF
--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -248,7 +248,7 @@ var (
 		Usage: `The number of cloud CPUs roachtest is allowed to use at any one time.`,
 	})
 
-	HTTPPort int = 8080
+	HTTPPort int = 0
 	_            = registerRunFlag(&HTTPPort, FlagInfo{
 		Name:  "port",
 		Usage: `The port on which to serve the HTTP interface`,

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -58,16 +58,16 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 	parallelism := roachtestflags.Parallelism
 	if roachtestflags.Cloud == spec.Local {
 		clusterType = localCluster
-
-		// This will suppress the annoying "Allow incoming network connections" popup from
-		// OSX when running a roachtest
-		bindTo = "localhost"
-
-		fmt.Printf("--local specified. Binding http listener to localhost only")
 		if parallelism != 1 {
 			fmt.Printf("--local specified. Overriding --parallelism to 1.\n")
 			parallelism = 1
 		}
+	}
+
+	if runtime.GOOS == "darwin" {
+		// This will suppress the annoying "Allow incoming network connections" popup from
+		// OSX when running a roachtest
+		bindTo = "localhost"
 	}
 
 	opt := clustersOpt{

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1492,7 +1492,7 @@ func (r *testRunner) runHTTPServer(httpPort int, stdout io.Writer, bindTo string
 	if bindTo != "" {
 		bindToDesc = bindTo
 	}
-	fmt.Fprintf(stdout, "HTTP server listening on %s, port %d.\n", bindToDesc, httpPort)
+	fmt.Fprintf(stdout, "HTTP server listening on port %d on %s: http://%s:%d/\n", httpPort, bindToDesc, bindTo, httpPort)
 	return nil
 }
 


### PR DESCRIPTION
 Having to manually allocate ports for concurrent runs was annoying.

While I'm here: 1) print a clickable URI to the local UI, and 2) bind to localhost on Darwin, even when starting remote cloud clusters, since the localness of the UI being on Darwin, not the remote vs local execution nodes, determines the annoying popup.

Release note: none.
Epic: none.
