### PR TITLE
testserver: disable tenant randomization under race in multi-node clusters

### DIFF
--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -271,8 +271,6 @@ func TestImportFixtureNodeCount(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderRaceWithIssue(t, 115977, "probable OOM")
-
 	ctx := context.Background()
 
 	const (

--- a/pkg/sql/pgwire/pgwirecancel/cancel_test.go
+++ b/pkg/sql/pgwire/pgwirecancel/cancel_test.go
@@ -76,8 +76,6 @@ func TestCancelQueryOtherNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderRaceWithIssue(t, 116031, "likely OOM")
-
 	ctx, cancel := context.WithCancel(context.Background())
 	args := base.TestServerArgs{
 		Knobs: base.TestingKnobs{

--- a/pkg/sql/physicalplan/BUILD.bazel
+++ b/pkg/sql/physicalplan/BUILD.bazel
@@ -78,7 +78,6 @@ go_test(
         "//pkg/testutils/distsqlutils",
         "//pkg/testutils/physicalplanutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/sql/physicalplan/fake_span_resolver_test.go
+++ b/pkg/sql/physicalplan/fake_span_resolver_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/physicalplanutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -33,8 +32,6 @@ import (
 func TestFakeSpanResolver(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	skip.UnderRaceWithIssue(t, 115619, "probable OOM")
 
 	ctx := context.Background()
 	tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{})

--- a/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
@@ -35,7 +35,7 @@ func TestPersistedSQLStatsReset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderRaceWithIssue(t, 116037, "probable OOM")
+	skip.UnderStress(t, "the test is too slow to run under stress")
 
 	ctx := context.Background()
 	cluster := serverutils.StartCluster(t, 3 /* numNodes */, base.TestClusterArgs{})

--- a/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
@@ -37,8 +37,8 @@ import (
 func TestPersistedSQLStatsReadMemory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
 	skip.UnderStress(t, "the test is too slow to run under stress")
-	skip.UnderRaceWithIssue(t, 116036, "likely OOM")
 
 	testCluster, ctx := createCluster(t)
 	defer testCluster.Stopper().Stop(ctx)
@@ -51,8 +51,8 @@ func TestPersistedSQLStatsReadMemory(t *testing.T) {
 func TestPersistedSQLStatsReadDisk(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
 	skip.UnderStress(t, "the test is too slow to run under stress")
-	skip.UnderRaceWithIssue(t, 116035, "likely OOM")
 
 	testCluster, ctx := createCluster(t)
 	defer testCluster.Stopper().Stop(ctx)
@@ -66,8 +66,8 @@ func TestPersistedSQLStatsReadDisk(t *testing.T) {
 func TestPersistedSQLStatsReadHybrid(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
 	skip.UnderStress(t, "the test is too slow to run under stress")
-	skip.UnderRaceWithIssue(t, 116033, "likely OOM")
 
 	testCluster, ctx := createCluster(t)
 	defer testCluster.Stopper().Stop(ctx)

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -85,7 +85,7 @@ var PreventStartTenantError = errors.New("attempting to manually start a virtual
 // directly so that it only gets linked into test code (and to avoid a linter
 // error that 'skip' must only be used in test code).
 func ShouldStartDefaultTestTenant(
-	t TestLogger, baseArg base.DefaultTestTenantOptions,
+	t TestLogger, baseArg base.DefaultTestTenantOptions, multiNodeCluster bool,
 ) (retval base.DefaultTestTenantOptions) {
 	// Explicit case for disabling the default test tenant.
 	if baseArg.TestTenantAlwaysDisabled() {
@@ -147,6 +147,17 @@ func ShouldStartDefaultTestTenant(
 			t.Log(defaultTestTenantMessage(shared) + "\n(override via TestingSetDefaultTenantSelectionOverride)")
 		}
 		return override
+	}
+
+	if multiNodeCluster && util.RaceEnabled {
+		// Race builds now run in the EngFlow environment which seems to be
+		// often overloaded if we have multi-node clusters and start a default
+		// test tenant, so we disable the tenant randomization in such a
+		// scenario.
+		if t != nil {
+			t.Log("cluster virtualization disabled under race")
+		}
+		return base.InternalNonDefaultDecision(baseArg, false /* enable */, false /* shared */)
 	}
 
 	// Note: we ask the metamorphic framework for a "disable" value, instead
@@ -258,7 +269,9 @@ func StartServerOnlyE(t TestLogger, params base.TestServerArgs) (TestServerInter
 	allowAdditionalTenants := params.DefaultTestTenant.AllowAdditionalTenants()
 	// Update the flags with the actual decision as to whether we should
 	// start the service for a default test tenant.
-	params.DefaultTestTenant = ShouldStartDefaultTestTenant(t, params.DefaultTestTenant)
+	params.DefaultTestTenant = ShouldStartDefaultTestTenant(
+		t, params.DefaultTestTenant, false, /* multiNodeCluster */
+	)
 
 	s, err := NewServer(params)
 	if err != nil {

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -294,7 +294,9 @@ func NewTestCluster(
 				args.DefaultTestTenant, defaultTestTenantOptions)
 		}
 	}
-	tc.defaultTestTenantOptions = serverutils.ShouldStartDefaultTestTenant(t, defaultTestTenantOptions)
+	tc.defaultTestTenantOptions = serverutils.ShouldStartDefaultTestTenant(
+		t, defaultTestTenantOptions, nodes > 1, /* multiNodeCluster */
+	)
 
 	var firstListener net.Listener
 	for i := 0; i < nodes; i++ {


### PR DESCRIPTION
We now run `race` builds in the EngFlow environment which has either 1 CPU or 2 CPU executors. If we have a multi-node cluster and then start a default test tenant, then it's very likely for that environment to be overloaded and lead to unactionable test failures. This commit prevents this from happening by disabling the tenant randomization under race in multi-node clusters. As a result, it optimistically unskips a few tests that we skipped due to those unactionable failures.

Fixes: #115619.

Release note: None