### PR TITLE
kvserver: remove FallbackSpanConfig

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -180,7 +180,6 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
-        "//pkg/spanconfig/spanconfigstore",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -96,60 +96,6 @@ func TestSpanConfigUpdateAppliedToReplica(t *testing.T) {
 	})
 }
 
-// TestFallbackSpanConfigOverride ensures that
-// spanconfig.store.fallback_config_override works as expected.
-func TestFallbackSpanConfigOverride(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	st := cluster.MakeTestingClusterSettings()
-	spanConfigStore := spanconfigstore.New(
-		roachpb.TestingDefaultSpanConfig(),
-		st,
-		spanconfigstore.NewEmptyBoundsReader(),
-		nil,
-	)
-	var t0 = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
-	mockSubscriber := newMockSpanConfigSubscriber(t0, spanConfigStore)
-
-	ctx := context.Background()
-	args := base.TestServerArgs{
-		Knobs: base.TestingKnobs{
-			Store: &kvserver.StoreTestingKnobs{
-				DisableMergeQueue: true,
-				DisableSplitQueue: true,
-				DisableGCQueue:    true,
-			},
-			SpanConfig: &spanconfig.TestingKnobs{
-				StoreKVSubscriberOverride: mockSubscriber,
-			},
-		},
-	}
-	s := serverutils.StartServerOnly(t, args)
-	defer s.Stopper().Stop(context.Background())
-
-	key, err := s.ScratchRange()
-	require.NoError(t, err)
-	store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
-	require.NoError(t, err)
-	repl := store.LookupReplica(keys.MustAddr(key))
-	span := repl.Desc().RSpan().AsRawSpanWithNoLocals()
-
-	conf := roachpb.SpanConfig{NumReplicas: 5, NumVoters: 3}
-	spanconfigstore.FallbackConfigOverride.Override(ctx, &st.SV, &conf)
-
-	require.NotNil(t, mockSubscriber.callback)
-	mockSubscriber.callback(ctx, span) // invoke the callback
-	testutils.SucceedsSoon(t, func() error {
-		repl := store.LookupReplica(keys.MustAddr(key))
-		gotConfig, err := repl.LoadSpanConfig(ctx)
-		require.NoError(t, err)
-		if !gotConfig.Equal(conf) {
-			return errors.Newf("expected config=%s, got config=%s", conf.String(), gotConfig.String())
-		}
-		return nil
-	})
-}
-
 type mockSpanConfigSubscriber struct {
 	callback    func(ctx context.Context, config roachpb.Span)
 	lastUpdated time.Time

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -66,7 +66,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
-	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigstore"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
@@ -2233,11 +2232,6 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		s.cfg.SpanConfigSubscriber.Subscribe(func(ctx context.Context, update roachpb.Span) {
 			s.onSpanConfigUpdate(ctx, update)
 		})
-
-		// We also want to do it when the fallback config setting is changed.
-		spanconfigstore.FallbackConfigOverride.SetOnChange(&s.ClusterSettings().SV, func(ctx context.Context) {
-			s.applyAllFromSpanConfigStore(ctx)
-		})
 	}
 
 	// Start Raft processing goroutines.
@@ -2534,27 +2528,6 @@ func (s *Store) onSpanConfigUpdate(ctx context.Context, updated roachpb.Span) {
 		// Errors here should not be possible, but if there is one, log loudly.
 		log.Errorf(ctx, "unexpected error visiting replicas: %v", err)
 	}
-}
-
-// applyAllFromSpanConfigStore applies, on each replica, span configs from the
-// embedded span config store.
-func (s *Store) applyAllFromSpanConfigStore(ctx context.Context) {
-	now := s.cfg.Clock.NowAsClockTimestamp()
-	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
-		replCtx := repl.AnnotateCtx(ctx)
-		key := repl.Desc().StartKey
-		conf, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, key)
-		if err != nil {
-			log.Errorf(ctx, "skipped applying config update, unexpected error reading from subscriber: %v", err)
-			return true // more
-		}
-
-		changed := repl.SetSpanConfig(conf)
-		if changed {
-			repl.MaybeQueue(replCtx, now)
-		}
-		return true // more
-	})
 }
 
 // GossipStore broadcasts the store on the gossip network.

--- a/pkg/spanconfig/testing_knobs.go
+++ b/pkg/spanconfig/testing_knobs.go
@@ -132,6 +132,7 @@ type TestingKnobs struct {
 	// applying mutations in dry run mode.
 	StoreInternConfigsInDryRuns bool
 
+	// TODO(baptist): Remove this by injecting the fallback config directly.
 	// OverrideFallbackConf, if set, allows tests to override fields in the
 	// fallback config that will be applied to the span.
 	OverrideFallbackConf func(roachpb.SpanConfig) roachpb.SpanConfig


### PR DESCRIPTION
The FallbackSpanConfig no longer makes sense now that we have the SpanConfig architecture creating a span for every possible key. This path would only happen on errors and we should never set the FallbackSpanConfig in practice.

Epic: none

Release note: None