### PR TITLE
pass SpanConfig to more methods

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3742,15 +3742,11 @@ func (roo *replicaRelocateOneOptions) StorePool() storepool.AllocatorStorePool {
 func (roo *replicaRelocateOneOptions) LoadSpanConfig(
 	ctx context.Context, startKey roachpb.RKey,
 ) (*roachpb.SpanConfig, error) {
-	confReader, err := roo.store.GetConfReader(ctx)
+	conf, _, err := roo.store.GetSpanConfigForKey(ctx, startKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't relocate range")
 	}
-	conf, _, err := confReader.GetSpanConfigForKey(ctx, startKey)
-	if err != nil {
-		return nil, err
-	}
-	return &conf, nil
+	return conf, nil
 }
 
 // Leaseholder returns the descriptor of the replica which holds the lease on

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -105,17 +105,19 @@ const manualAdminReason = "manual"
 // AdminSplit divides the range into two ranges using args.SplitKey.
 func (r *Replica) AdminSplit(
 	ctx context.Context, args kvpb.AdminSplitRequest, reason redact.RedactableString,
-) (reply kvpb.AdminSplitResponse, _ *kvpb.Error) {
+) (reply kvpb.AdminSplitResponse, kvErr *kvpb.Error) {
 	if len(args.SplitKey) == 0 {
 		return kvpb.AdminSplitResponse{}, kvpb.NewErrorf("cannot split range with no key provided")
 	}
-
-	err := r.executeAdminCommandWithDescriptor(ctx, func(desc *roachpb.RangeDescriptor) error {
-		var err error
-		reply, err = r.adminSplitWithDescriptor(ctx, args, desc, true /* delayable */, reason, false /* findFirstSafeKey */)
+	kvErr = r.executeAdminCommandWithDescriptor(ctx, func(desc *roachpb.RangeDescriptor) error {
+		conf, err := r.LoadSpanConfig(ctx)
+		if err != nil {
+			return err
+		}
+		reply, err = r.adminSplitWithDescriptor(ctx, args, desc, conf, true /* delayable */, reason, false /* findFirstSafeKey */)
 		return err
 	})
-	return reply, err
+	return reply, kvErr
 }
 
 func maybeDescriptorChangedError(
@@ -340,6 +342,7 @@ func (r *Replica) adminSplitWithDescriptor(
 	ctx context.Context,
 	args kvpb.AdminSplitRequest,
 	desc *roachpb.RangeDescriptor,
+	conf *roachpb.SpanConfig,
 	delayable bool,
 	reason redact.RedactableString,
 	findFirstSafeKey bool,
@@ -365,7 +368,7 @@ func (r *Replica) adminSplitWithDescriptor(
 		if len(args.SplitKey) == 0 {
 			// Find a key to split by size.
 			var err error
-			targetSize := r.GetMaxBytes(ctx) / 2
+			targetSize := conf.RangeMaxBytes / 2
 			foundSplitKey, err = storage.MVCCFindSplitKey(
 				ctx, r.store.TODOEngine(), desc.StartKey, desc.EndKey, targetSize)
 			if err != nil {
@@ -4146,13 +4149,22 @@ func (r *Replica) adminScatter(
 		preScatterReplicaIDs[rd.ReplicaID] = struct{}{}
 	}
 
+	// conf is loaded prior to looping and we use the same span config for all
+	// replicas.
+	conf, err := r.LoadSpanConfig(ctx)
+	if err != nil {
+		// This is expected to be extremely rare. Every range should always have a
+		// span config for it or it falls back to the default span config.
+		return kvpb.AdminScatterResponse{}, err
+	}
 	// Loop until we hit an error or until we hit `maxAttempts` for the range.
 	for re := retry.StartWithCtx(ctx, retryOpts); re.Next(); {
 		if currentAttempt == maxAttempts {
 			break
 		}
-		desc, conf := r.DescAndSpanConfig()
-		_, err := rq.replicaCanBeProcessed(ctx, r, false /* acquireLeaseIfNeeded */)
+		desc := r.Desc()
+		var err error
+		_, err = rq.replicaCanBeProcessed(ctx, r, false /* acquireLeaseIfNeeded */)
 		if err != nil {
 			// The replica can not be processed, so skip it.
 			break
@@ -4179,8 +4191,8 @@ func (r *Replica) adminScatter(
 	// queue would do on its own (#17341), do so after the replicate queue is
 	// done by transferring the lease to any of the given N replicas with
 	// probability 1/N of choosing each.
-	if args.RandomizeLeases && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
-		desc, conf := r.DescAndSpanConfig()
+	if args.RandomizeLeases && conf != nil && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
+		desc := r.Desc()
 		potentialLeaseTargets := r.store.allocator.ValidLeaseTargets(
 			ctx, r.store.cfg.StorePool, desc, conf, desc.Replicas().VoterDescriptors(), r, allocator.TransferLeaseOptions{})
 		if len(potentialLeaseTargets) > 0 {

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -373,8 +373,8 @@ func (r *Replica) updateRangeInfo(ctx context.Context, desc *roachpb.RangeDescri
 	// 2. After a new range is created by a split, only copying maxBytes from
 	// the original range wont work as the original and new ranges might belong
 	// to different zones.
-	// Load the system config.
-	confReader, err := r.store.GetConfReader(ctx)
+	// Find span config for this range.
+	conf, sp, err := r.store.GetSpanConfigForKey(ctx, desc.StartKey)
 	if errors.Is(err, errSpanConfigsUnavailable) {
 		// This could be before the span config subscription was ever
 		// established.
@@ -385,13 +385,7 @@ func (r *Replica) updateRangeInfo(ctx context.Context, desc *roachpb.RangeDescri
 		return err
 	}
 
-	// Find span config for this range.
-	conf, sp, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
-	if err != nil {
-		return errors.Wrapf(err, "%s: failed to lookup span config", r)
-	}
-
-	changed := r.SetSpanConfig(conf, sp)
+	changed := r.SetSpanConfig(*conf, sp)
 	if changed {
 		r.MaybeQueue(ctx, r.store.cfg.Clock.NowAsClockTimestamp())
 	}

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -280,6 +280,10 @@ func (sq *splitQueue) processAttempt(
 	ctx context.Context, r *Replica, confReader spanconfig.StoreReader,
 ) (processed bool, err error) {
 	desc := r.Desc()
+	conf, err := r.LoadSpanConfig(ctx)
+	if err != nil {
+		return false, errors.Wrapf(err, "unable to load span config")
+	}
 	// First handle the case of splitting due to span config maps.
 	splitKey, err := confReader.ComputeSplitKey(ctx, desc.StartKey, desc.EndKey)
 	if err != nil {
@@ -296,6 +300,7 @@ func (sq *splitQueue) processAttempt(
 				ExpirationTime: hlc.Timestamp{},
 			},
 			desc,
+			conf,
 			false, /* delayable */
 			"span config",
 			false, /* findFirstSafeSplitKey */
@@ -321,6 +326,7 @@ func (sq *splitQueue) processAttempt(
 			ctx,
 			kvpb.AdminSplitRequest{},
 			desc,
+			conf,
 			false, /* delayable */
 			reason,
 			false, /* findFirstSafeSplitKey */
@@ -373,6 +379,7 @@ func (sq *splitQueue) processAttempt(
 				ExpirationTime: expTime,
 			},
 			desc,
+			conf,
 			false, /* delayable */
 			reason,
 			true, /* findFirstSafeSplitKey */

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2642,6 +2642,27 @@ func (s *Store) removeReplicaWithRangefeed(rangeID roachpb.RangeID) {
 	s.rangefeedReplicas.Unlock()
 }
 
+// GetSpanConfigForKey loads the span config starting at the given key. This
+// allows inserting test configurations through knobs.
+func (s *Store) GetSpanConfigForKey(
+	ctx context.Context, key roachpb.RKey,
+) (*roachpb.SpanConfig, roachpb.Span, error) {
+	if s.cfg.TestingKnobs.MakeSystemConfigSpanUnavailableToQueues {
+		return nil, roachpb.Span{}, errSpanConfigsUnavailable
+	}
+
+	// TODO(baptist): Tests should correctly set the span configs.
+	if s.cfg.SpanConfigsDisabled {
+		return &s.cfg.DefaultSpanConfig, roachpb.Span{}, nil
+	}
+	confReader, err := s.GetConfReader(ctx)
+	if err != nil {
+		return nil, roachpb.Span{}, err
+	}
+	conf, span, err := confReader.GetSpanConfigForKey(ctx, key)
+	return &conf, span, err
+}
+
 // onSpanConfigUpdate is the callback invoked whenever this store learns of a
 // span config update.
 func (s *Store) onSpanConfigUpdate(ctx context.Context, updated roachpb.Span) {
@@ -2681,12 +2702,12 @@ func (s *Store) onSpanConfigUpdate(ctx context.Context, updated roachpb.Span) {
 				// adjacent table. This results in a single update, corresponding to the
 				// new table's span, which forms the right-hand side post split.
 
-				conf, sp, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, startKey)
+				conf, sp, err := s.GetSpanConfigForKey(replCtx, startKey)
 				if err != nil {
 					log.Errorf(replCtx, "skipped applying update, unexpected error reading from subscriber: %v", err)
 					return err
 				}
-				changed = repl.SetSpanConfig(conf, sp)
+				changed = repl.SetSpanConfig(*conf, sp)
 			}
 			if changed {
 				repl.MaybeQueue(ctx, now)
@@ -2706,13 +2727,13 @@ func (s *Store) applyAllFromSpanConfigStore(ctx context.Context) {
 	newStoreReplicaVisitor(s).Visit(func(repl *Replica) bool {
 		replCtx := repl.AnnotateCtx(ctx)
 		key := repl.Desc().StartKey
-		conf, confSpan, err := s.cfg.SpanConfigSubscriber.GetSpanConfigForKey(replCtx, key)
+		conf, confSpan, err := s.GetSpanConfigForKey(replCtx, key)
 		if err != nil {
 			log.Errorf(ctx, "skipped applying config update, unexpected error reading from subscriber: %v", err)
 			return true // more
 		}
 
-		changed := repl.SetSpanConfig(conf, confSpan)
+		changed := repl.SetSpanConfig(*conf, confSpan)
 		if changed {
 			repl.MaybeQueue(replCtx, now)
 		}
@@ -3852,13 +3873,7 @@ func (s *Store) AllocatorCheckRange(
 	}
 	ctx, sp := tracing.EnsureChildSpan(ctx, s.cfg.AmbientCtx.Tracer, "allocator check range", spanOptions...)
 
-	confReader, err := s.GetConfReader(ctx)
-	if err != nil {
-		log.Eventf(ctx, "span configs unavailable: %s", err)
-		return allocatorimpl.AllocatorNoop, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err
-	}
-
-	conf, _, err := confReader.GetSpanConfigForKey(ctx, desc.StartKey)
+	conf, _, err := s.GetSpanConfigForKey(ctx, desc.StartKey)
 	if err != nil {
 		log.Eventf(ctx, "error retrieving span config for range %s: %s", desc, err)
 		return allocatorimpl.AllocatorNoop, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err
@@ -3873,7 +3888,7 @@ func (s *Store) AllocatorCheckRange(
 		storePool = s.cfg.StorePool
 	}
 
-	action, _ := s.allocator.ComputeAction(ctx, storePool, &conf, desc)
+	action, _ := s.allocator.ComputeAction(ctx, storePool, conf, desc)
 
 	// In the case that the action does not require a target, return immediately.
 	if !(action.Add() || action.Replace()) {
@@ -3887,7 +3902,7 @@ func (s *Store) AllocatorCheckRange(
 		return action, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err
 	}
 
-	target, _, err := s.allocator.AllocateTarget(ctx, storePool, &conf,
+	target, _, err := s.allocator.AllocateTarget(ctx, storePool, conf,
 		filteredVoters, filteredNonVoters, replacing, action.ReplicaStatus(), action.TargetReplicaType(),
 	)
 	if err == nil {
@@ -3898,7 +3913,7 @@ func (s *Store) AllocatorCheckRange(
 		fragileQuorumErr := s.allocator.CheckAvoidsFragileQuorum(
 			ctx,
 			storePool,
-			&conf,
+			conf,
 			desc.Replicas().VoterDescriptors(),
 			filteredVoters,
 			action.ReplicaStatus(),


### PR DESCRIPTION
A few cleanup commits that make the use of SpanConfigs more explicit and consistent.