### PR TITLE
sql: skip Test{Experimental}RelocateVoters under duress

### DIFF
--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -683,6 +683,8 @@ func TestRelocateVoters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderDuress(t, "test flakes in slow builds; see #108081")
+
 	testCases := []testCase{
 		{
 			desc:  "ALTER RANGE x RELOCATE VOTERS",
@@ -773,6 +775,8 @@ func TestRelocateVoters(t *testing.T) {
 func TestExperimentalRelocateVoters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderDuress(t, "test flakes in slow builds; see #108081")
 
 	testCases := []testCase{
 		{


### PR DESCRIPTION
There is little value in running these tests in complex configs.

Fixes: #116939.

Release note: None