### PR TITLE
backupccl: wrap restore processor errors as retryable after progress is made

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1414,7 +1414,7 @@ func TestRestoreCheckpointing(t *testing.T) {
 	knobs := base.TestingKnobs{
 		DistSQL: &execinfra.TestingKnobs{
 			BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
-				RunAfterProcessingRestoreSpanEntry: func(_ context.Context, _ *execinfrapb.RestoreSpanEntry) {
+				RunAfterProcessingRestoreSpanEntry: func(_ context.Context, _ *execinfrapb.RestoreSpanEntry) error {
 					//  Because the restore processor has several workers that
 					//  concurrently send addsstable requests and because all workers will
 					//  wait on the lock below, when one flush gets blocked on the
@@ -1436,6 +1436,7 @@ func TestRestoreCheckpointing(t *testing.T) {
 					if wasPausedBeforeWaiting {
 						postResumeCount++
 					}
+					return nil
 				},
 			},
 		},
@@ -1564,6 +1565,75 @@ func TestRestoreJobRetryReset(t *testing.T) {
 	jobutils.WaitForJobToPause(t, sqlDB, restoreJobId)
 
 	require.Greater(t, mu.retryCount, maxRetries+2)
+}
+
+// TestRestoreRetryProcErr tests that the restore data processor will mark
+// errors as retryable if and only if it has made progress.
+func TestRestoreRetryProcErr(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testutils.RunTrueAndFalse(t, "restore processor progress", func(t *testing.T, makeProgress bool) {
+		mu := struct {
+			syncutil.Mutex
+			flowCount int
+			spanCount int
+		}{}
+		params := base.TestClusterArgs{}
+		knobs := base.TestingKnobs{
+			DistSQL: &execinfra.TestingKnobs{
+				BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
+					RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, _ *execinfrapb.RestoreSpanEntry) error {
+						mu.Lock()
+						defer mu.Unlock()
+						if makeProgress && mu.spanCount == 0 {
+							// Allow a span entry to progress to test that the restore processor
+							// sends a retryable error after progress was sent.
+							mu.spanCount++
+							return nil
+						}
+						// This error will only get retried if a span entry has already been processed.
+						return errors.New("gross external storage error")
+					}}},
+			BackupRestore: &sql.BackupRestoreTestingKnobs{
+				RestoreDistSQLRetryPolicy: &retry.Options{
+					InitialBackoff: time.Microsecond,
+					Multiplier:     2,
+					MaxBackoff:     2 * time.Microsecond,
+					MaxRetries:     4,
+				},
+				RunBeforeRestoreFlow: func() error {
+					mu.Lock()
+					defer mu.Unlock()
+					mu.flowCount++
+					return nil
+				},
+			},
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		}
+		params.ServerArgs = base.TestServerArgs{Knobs: knobs}
+
+		_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, 10, InitManualReplication, params)
+		defer cleanupFn()
+
+		sqlDB.Exec(t, `CREATE DATABASE d`)
+		for i := 1; i <= 4; i++ {
+			tableName := fmt.Sprintf("d.t%d", i)
+			sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE %s (id INT PRIMARY KEY, s STRING)`, tableName))
+			sqlDB.Exec(t, fmt.Sprintf(`INSERT INTO %s VALUES (1, 'x'),(2,'y')`, tableName))
+		}
+
+		sqlDB.Exec(t, `BACKUP DATABASE d INTO $1`, localFoo)
+		var restoreJobId jobspb.JobID
+		sqlDB.QueryRow(t, `RESTORE DATABASE d FROM LATEST IN $1 with new_db_name=d2, detached`, localFoo).Scan(&restoreJobId)
+		jobutils.WaitForJobToPause(t, sqlDB, restoreJobId)
+
+		expectedFlowCount := 1
+		if makeProgress {
+			expectedFlowCount = 2
+		}
+		require.Equal(t, mu.flowCount, expectedFlowCount)
+	})
 }
 
 func createAndWaitForJob(
@@ -7497,8 +7567,9 @@ func TestClientDisconnect(t *testing.T) {
 
 			args := base.TestClusterArgs{}
 			knobs := base.TestingKnobs{
-				DistSQL: &execinfra.TestingKnobs{BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, _ *execinfrapb.RestoreSpanEntry) {
+				DistSQL: &execinfra.TestingKnobs{BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, _ *execinfrapb.RestoreSpanEntry) error {
 					blockBackupOrRestore(ctx)
+					return nil
 				}}},
 				Store: &kvserver.StoreTestingKnobs{
 					TestingResponseFilter: func(ctx context.Context, ba *kvpb.BatchRequest, br *kvpb.BatchResponse) *kvpb.Error {
@@ -11355,8 +11426,9 @@ func TestRestoreMemoryMonitoringWithShadowing(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			DistSQL: &execinfra.TestingKnobs{
 				BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
-					RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, entry *execinfrapb.RestoreSpanEntry) {
+					RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, entry *execinfrapb.RestoreSpanEntry) error {
 						restoreProcessorKnobCount.Add(1)
+						return nil
 					},
 				},
 			},

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -193,11 +193,11 @@ func restoreWithRetry(
 			break
 		}
 
-		if errors.HasType(err, &kvpb.InsufficientSpaceError{}) {
+		if errors.HasType(err, &kvpb.InsufficientSpaceError{}) || errors.Is(err, restoreProcError) {
 			return roachpb.RowCount{}, jobs.MarkPauseRequestError(errors.UnwrapAll(err))
 		}
 
-		if joberror.IsPermanentBulkJobError(err) {
+		if joberror.IsPermanentBulkJobError(err) && !errors.Is(err, retryableRestoreProcError) {
 			return roachpb.RowCount{}, err
 		}
 

--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -584,11 +584,12 @@ func runTestRestoreMemoryMonitoring(t *testing.T, numSplits, numInc, restoreProc
 		Knobs: base.TestingKnobs{
 			DistSQL: &execinfra.TestingKnobs{
 				BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
-					RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, entry *execinfrapb.RestoreSpanEntry) {
+					RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, entry *execinfrapb.RestoreSpanEntry) error {
 						// The total size of the backup files should be less than the target
 						// SST size, thus should all fit in one import span.
 						require.Equal(t, actualNumFiles, len(entry.Files))
 						restoreProcessorKnobCount.Add(1)
+						return nil
 					},
 				},
 			},

--- a/pkg/jobs/joberror/errors.go
+++ b/pkg/jobs/joberror/errors.go
@@ -38,5 +38,4 @@ func IsPermanentBulkJobError(err error) bool {
 		!sysutil.IsErrConnectionReset(err) &&
 		!sysutil.IsErrConnectionRefused(err) &&
 		!errors.Is(err, sqlinstance.NonExistentInstanceError)
-
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1756,7 +1756,7 @@ type BackupRestoreTestingKnobs struct {
 
 	// RunAfterProcessingRestoreSpanEntry allows blocking the RESTORE job after a
 	// single RestoreSpanEntry has been processed and added to the SSTBatcher.
-	RunAfterProcessingRestoreSpanEntry func(ctx context.Context, entry *execinfrapb.RestoreSpanEntry)
+	RunAfterProcessingRestoreSpanEntry func(ctx context.Context, entry *execinfrapb.RestoreSpanEntry) error
 
 	// RunAfterExportingSpanEntry allows blocking the BACKUP job after a single
 	// span has been exported.


### PR DESCRIPTION
Previously, if a restore processor returned an error that the restore coordinator didn't whitelist as retryable, the restore job would fail. This was problematic because the processor could return a retryable error that may not have been on the whitelist (e.g. an external storage unavailability error).

Instead of attempting to maintain a whitelist, this pr marks all restore data processor errors as retryable, if the processor has made forward progress. If the processor returns an error without making forward progress, the restore now pauses instead of failing.  This strategy avoids looping over truly unretryable erors (like an external storage permission issue) because if the error is persistent, the processor will hit the error again on the next attempt without having made forward progress.

Informs #116486

Release note: none