### PR TITLE
opt: optimize stats and FD computation

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -1445,6 +1445,121 @@ var slowQueries = [...]benchQuery{
 			"'EJ'", "'LQIZHIJX'", "'NNSMWHCO'", "'UDJG'", "'82894'", "'AAYUMINX'", "'JGJYKJZR'", 0,
 		},
 	},
+	{
+		name: "slow-query-7",
+		query: `
+			WITH t1 AS MATERIALIZED (
+				SELECT tmp1.*, tmp2.*
+				FROM sq6a AS tmp1
+				JOIN sq6a AS tmp2 ON tmp1.c1 = tmp2.c1 AND tmp1.c2 = tmp2.c2
+			)
+			SELECT t1.*, t2.*, t4.*, t17.*, t8.*, t9.*, t3.*, t11.*
+			FROM t1
+			JOIN sq6b AS t2 ON
+				t2.c1 = t1.c1
+				AND t2.c2 = t1.c2
+				AND t2.c3 = t1.c3
+				AND t2.c4 = t1.c4
+				AND t2.c44 = t1.c100
+			JOIN sq6c AS t3 ON
+				t3.c1 = t2.c1
+				AND t3.c2 = t2.c6
+				AND t3.c34 = t2.c44
+			JOIN sq6d AS t4 ON
+				t4.c1 = t2.c1
+				AND t4.c2 = t2.c41
+				AND t4.c3 = $1
+				AND t4.c28 = t2.c44
+			JOIN sq6e AS t5 ON
+				t5.c1 = t1.c81
+				AND t5.c23 = t1.c100
+			JOIN sq6f AS t6 ON
+				t6.c12 = t1.c100
+				AND t6.c1 = t1.c1
+				AND t6.c4 = t1.c2
+				AND t6.c5 = t1.c3
+				AND t6.c6 = t1.c4
+				AND t6.c2 IN ($1, $2)
+			JOIN sq6g AS t7 ON
+				t7.c24 = t6.c12
+				AND t7.c1 = t6.c1
+				AND t7.c3 = t6.c3
+				AND t7.c2 = t6.c2
+			LEFT JOIN sq6h AS t8 ON
+				t8.c2 = t2.c37
+				AND t8.c1 = t2.c1
+				AND t8.c3 = $3
+				AND t8.c13 = t2.c44
+			LEFT JOIN sq6h AS t9 ON
+				t9.c2 = t2.c37
+				AND t9.c1 = t2.c1
+				AND t9.c3 = $4
+				AND t9.c13 = t2.c44
+			LEFT JOIN sq6i AS t10 ON
+				t10.c1 = t1.c1
+				AND t10.c2 = t1.c2
+				AND t10.c3 = t1.c3
+				AND t10.c4 = t1.c4
+				AND t10.c6 = 1
+				AND t10.c7 = t1.c100
+			LEFT JOIN sq6j AS t11 ON
+				t11.c1 = t1.c1
+				AND t11.c2 = t1.c2
+				AND t11.c3 = t1.c3
+				AND t11.c4 = t1.c4
+				AND t11.c36 = t1.c100
+			LEFT JOIN sq6k AS t12 ON
+				t12.c1 = t1.c1
+				AND t12.c2 = t1.c2
+				AND t12.c3 = t1.c3
+				AND t12.c4 = t1.c4
+				AND t12.c6 = $5
+				AND t12.c5 = t1.c100
+			LEFT JOIN sq6k AS t13 ON
+				t13.c1 = t1.c1
+				AND t13.c2 = t1.c2
+				AND t13.c3 = t1.c3
+				AND t13.c4 = t1.c4
+				AND t13.c6 = $6
+				AND t13.c5 = t1.c100
+			LEFT JOIN sq6k AS t15 ON
+				t15.c1 = t1.c1
+				AND t15.c2 = t1.c2
+				AND t15.c3 = t1.c3
+				AND t15.c4 = t1.c4
+				AND t15.c6 = $7
+				AND t15.c5 = t1.c100
+			LEFT JOIN sq6k AS t16 ON
+				t16.c1 = t1.c1
+				AND t16.c2 = t1.c2
+				AND t16.c3 = t1.c3
+				AND t16.c4 = t1.c4
+				AND t16.c6 = $8
+				AND t16.c5 = t1.c100
+			LEFT JOIN sq6l AS t17 ON
+				t17.c1 = t1.c1
+				AND t17.c2 = t1.c2
+				AND t17.c3 = t1.c3
+				AND t17.c4 = t1.c4
+				AND t17.c5 = $9
+				AND t17.c28 = t1.c100
+			LEFT JOIN sq6m AS t18 ON
+				t18.c4 = t1.c2
+				AND t18.c1 = t1.c3
+				AND t18.c2 = t1.c4
+				AND t18.c36 = t1.c100
+			WHERE
+				t1.c1 IN ($10, $11, $12)
+				AND t1.c2 = $13
+				AND t1.c3 = $14
+				AND t1.c4 = $15
+				AND t1.c100 = $16
+    `,
+		args: []interface{}{
+			"'WX'", "'ZG'", "'TTT'", "'FFF'", "'JQYJSUWE'", "'RDDQXFRN'", "'HCLDUJOA'", "'GESIUACE'",
+			"'EJ'", "'LQIZHIJX'", "'NNSMWHCO'", "'UDJG'", "'82894'", "'AAYUMINX'", "'JGJYKJZR'", 0,
+		},
+	},
 }
 
 func BenchmarkSlowQueries(b *testing.B) {

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -968,11 +968,7 @@ func (b *logicalPropsBuilder) buildWithScanProps(withScan *WithScanExpr, rel *pr
 	// -----------------------
 	// Inherit dependencies from the referenced expression (remapping the
 	// columns).
-	rel.FuncDeps.CopyFrom(&bindingProps.FuncDeps)
-	for i := range withScan.InCols {
-		rel.FuncDeps.AddEquivalency(withScan.InCols[i], withScan.OutCols[i])
-	}
-	rel.FuncDeps.ProjectCols(withScan.OutCols.ToSet())
+	rel.FuncDeps.RemapFrom(&bindingProps.FuncDeps, withScan.InCols, withScan.OutCols)
 
 	// Cardinality
 	// -----------

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -2878,7 +2878,7 @@ func (sb *statisticsBuilder) finalizeFromRowCountAndDistinctCounts(
 		product := 1.0
 		maxDistinct := 0.0
 		colStat.Cols.ForEach(func(col opt.ColumnID) {
-			if singleColStat, ok := s.ColStats.Lookup(opt.MakeColSet(col)); ok {
+			if singleColStat, ok := s.ColStats.LookupSingleton(col); ok {
 				if singleColStat.DistinctCount > 1 {
 					product *= singleColStat.DistinctCount
 				}
@@ -3761,10 +3761,10 @@ func (sb *statisticsBuilder) updateDistinctNullCountsFromEquivalency(
 	// group.
 	minDistinctCount := s.RowCount
 	minNullCount := s.RowCount
-	equivGroup.ForEach(func(i opt.ColumnID) {
-		colSet := opt.MakeColSet(i)
-		colStat, ok := s.ColStats.Lookup(colSet)
+	equivGroup.ForEach(func(col opt.ColumnID) {
+		colStat, ok := s.ColStats.LookupSingleton(col)
 		if !ok {
+			colSet := opt.MakeColSet(col)
 			colStat, _ = sb.colStatFromInput(colSet, e)
 			colStat = sb.copyColStat(colSet, s, colStat)
 			if colStat.NullCount > 0 && colSet.Intersects(notNullCols) {
@@ -3782,8 +3782,8 @@ func (sb *statisticsBuilder) updateDistinctNullCountsFromEquivalency(
 
 	// Set the distinct and null counts to the minimum for all columns in this
 	// equivalency group.
-	equivGroup.ForEach(func(i opt.ColumnID) {
-		colStat, _ := s.ColStats.Lookup(opt.MakeColSet(i))
+	equivGroup.ForEach(func(col opt.ColumnID) {
+		colStat, _ := s.ColStats.LookupSingleton(col)
 		colStat.DistinctCount = minDistinctCount
 		colStat.NullCount = minNullCount
 	})
@@ -3898,7 +3898,7 @@ func (sb *statisticsBuilder) selectivityFromMultiColDistinctCounts(
 	multiColNullCount := -1.0
 	minLocalSel := props.OneSelectivity
 	for col, ok := cols.Next(0); ok; col, ok = cols.Next(col + 1) {
-		colStat, ok := s.ColStats.Lookup(opt.MakeColSet(col))
+		colStat, ok := s.ColStats.LookupSingleton(col)
 		if !ok {
 			multiColSet.Remove(col)
 			continue
@@ -3982,7 +3982,7 @@ func (sb *statisticsBuilder) selectivityFromMultiColDistinctCounts(
 		var lowDistinctCountCols opt.ColSet
 		multiColSet.ForEach(func(col opt.ColumnID) {
 			// We already know the column stat exists if it's in multiColSet.
-			colStat, _ := s.ColStats.Lookup(opt.MakeColSet(col))
+			colStat, _ := s.ColStats.LookupSingleton(col)
 			if colStat.DistinctCount <= 1 {
 				lowDistinctCountCols.Add(col)
 			}
@@ -4117,7 +4117,7 @@ func (sb *statisticsBuilder) selectivityFromSingleColDistinctCounts(
 	selectivity = props.OneSelectivity
 	selectivityUpperBound = props.OneSelectivity
 	for col, ok := cols.Next(0); ok; col, ok = cols.Next(col + 1) {
-		colStat, ok := s.ColStats.Lookup(opt.MakeColSet(col))
+		colStat, ok := s.ColStats.LookupSingleton(col)
 		if !ok {
 			continue
 		}
@@ -4179,7 +4179,7 @@ func (sb *statisticsBuilder) selectivityFromHistograms(
 	selectivity = props.OneSelectivity
 	selectivityUpperBound = props.OneSelectivity
 	for col, ok := cols.Next(0); ok; col, ok = cols.Next(col + 1) {
-		colStat, ok := s.ColStats.Lookup(opt.MakeColSet(col))
+		colStat, ok := s.ColStats.LookupSingleton(col)
 		if !ok {
 			continue
 		}
@@ -4469,18 +4469,17 @@ func (sb *statisticsBuilder) selectivityFromEquivalency(
 	// Find the maximum input distinct count for all columns in this equivalency
 	// group.
 	maxDistinctCount := float64(0)
-	equivGroup.ForEach(func(i opt.ColumnID) {
-		if derivedEquivCols.Contains(i) {
+	equivGroup.ForEach(func(col opt.ColumnID) {
+		if derivedEquivCols.Contains(col) {
 			// Don't apply selectivity from derived equivalencies internally
 			// manufactured by lookup join solely to facilitate index lookups.
 			return
 		}
 		// If any of the distinct counts were updated by the filter, we want to use
 		// the updated value.
-		colSet := opt.MakeColSet(i)
-		colStat, ok := s.ColStats.Lookup(colSet)
+		colStat, ok := s.ColStats.LookupSingleton(col)
 		if !ok {
-			colStat, _ = sb.colStatFromInput(colSet, e)
+			colStat, _ = sb.colStatFromInput(opt.MakeColSet(col), e)
 		}
 		if maxDistinctCount < colStat.DistinctCount {
 			maxDistinctCount = colStat.DistinctCount
@@ -4521,19 +4520,18 @@ func (sb *statisticsBuilder) selectivityFromEquivalencySemiJoin(
 	// equivalency group from the right (left).
 	minDistinctCountRight := math.MaxFloat64
 	maxDistinctCountLeft := float64(0)
-	equivGroup.ForEach(func(i opt.ColumnID) {
+	equivGroup.ForEach(func(col opt.ColumnID) {
 		// If any of the distinct counts were updated by the filter, we want to use
 		// the updated value.
-		colSet := opt.MakeColSet(i)
-		colStat, ok := s.ColStats.Lookup(colSet)
+		colStat, ok := s.ColStats.LookupSingleton(col)
 		if !ok {
-			colStat, _ = sb.colStatFromInput(colSet, e)
+			colStat, _ = sb.colStatFromInput(opt.MakeColSet(col), e)
 		}
-		if leftOutputCols.Contains(i) {
+		if leftOutputCols.Contains(col) {
 			if maxDistinctCountLeft < colStat.DistinctCount {
 				maxDistinctCountLeft = colStat.DistinctCount
 			}
-		} else if rightOutputCols.Contains(i) {
+		} else if rightOutputCols.Contains(col) {
 			if minDistinctCountRight > colStat.DistinctCount {
 				minDistinctCountRight = colStat.DistinctCount
 			}
@@ -4586,7 +4584,7 @@ func (sb *statisticsBuilder) tryReduceCols(
 	}
 
 	for i, ok := reducedCols.Next(0); ok; i, ok = reducedCols.Next(i + 1) {
-		colStat, ok := s.ColStats.Lookup(opt.MakeColSet(i))
+		colStat, ok := s.ColStats.LookupSingleton(i)
 		if !ok || colStat.DistinctCount != 1 {
 			// The reduced columns are not all constant, so return the original
 			// column set.

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -1347,7 +1347,14 @@ func (sb *statisticsBuilder) buildJoin(
 	// Ignore columns that are already null in the input when calculating
 	// selectivity from null-removing filters - the selectivity would always be
 	// 1.
-	ignoreCols := constrainedCols
+	//
+	// NOTE: Aliasing constrainedCols without copying it is safe here because
+	// constrainedCols is not used after this point of the function. We set
+	// constrainedCols to the empty set to prevent future changes to this
+	// function from unknowingly breaking this invariant.
+	var ignoreCols opt.ColSet
+	ignoreCols, constrainedCols = constrainedCols, opt.ColSet{}
+	_ = constrainedCols
 	if relProps.NotNullCols.Intersects(h.leftProps.NotNullCols) ||
 		relProps.NotNullCols.Intersects(h.rightProps.NotNullCols) {
 		ignoreCols = ignoreCols.Union(h.leftProps.NotNullCols)

--- a/pkg/sql/opt/props/col_stats_map.go
+++ b/pkg/sql/opt/props/col_stats_map.go
@@ -173,6 +173,11 @@ func (m *ColStatsMap) LookupSingleton(col opt.ColumnID) (colStat *ColumnStatisti
 	// Fetch index entry for next prefix+col combo.
 	key := colStatKey{prefix: 0, id: col}
 	if val, ok := m.index[key]; ok {
+		if val.pos == -1 {
+			// No stat exists for this column set.
+			return nil, false
+		}
+
 		// A stat exists, so return it.
 		return m.Get(int(val.pos)), true
 	}


### PR DESCRIPTION
#### opt: make ColSet alias safer

This commit makes a minor change to the aliasing of an `opt.ColSet` that
makes it resilient to future misuse. A comment has been added for
additional clarity.

Release note: None

#### opt: fix bug in ColStatsMap.LookupSingleton

This commit fixes a bug in `(*ColStatsMap).LookupSingleton` that caused
"index out-of-bounds" errors when looking up a column that is not in the
map, but is a prefix of a column set in the map. For example, if the map
`m` contained the column set `(2,3)`, `m.LookupSingleton(2)` would err.

There is no release note because the bug is not present in any releases.

Release note: None

#### opt: add slow-query-7 benchmark

This commit add a `slow-query-7` benchmark which is based on
`slow-query-6` and contains a CTE.

Release note: None

#### opt: use ColStatsMap.LookupSingleton in more places

This commit replaces uses of `(*ColStatsMap).Lookup` with
`(*ColStatsMap).LookupSingleton` in a handful of places. This avoids
allocations for single-column sets of column IDs that exceed 128 (the
maximum column ID that fits in the stack-allocated part of an
`opt.ColSet`).

Release note: None

#### opt: optimize building WithScan functional dependencies

A WithScan expression's functional dependencies are inherited from the
underlying With expression, with the columns remapped. Prior to this
commit, the remapping was performed by first copying the With
expression's FDs, adding equivalencies between each corresponding column
in with With and WithScan, and finally projecting away the With's
columns. The latter two steps can be particularly expensive when FDs
contain column IDs greater than 128. Now, the more efficient
`(*FuncDeps).RemapFrom` method is used.

Epic: None

Release note: None
