### PR TITLE
sql: fix possible race in runPlanInsidePlan

### DIFF
--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -556,22 +556,6 @@ func internalExtendedEvalCtx(
 	return ret
 }
 
-// ExtendedEvalContextCopyAndReset returns a function that produces
-// extendedEvalContexts for parallel subquery, cascade, and check execution.
-func (p *planner) ExtendedEvalContextCopyAndReset() *extendedEvalContext {
-	evalCtx := p.ExtendedEvalContextCopy()
-	p.ExtendedEvalContextReset(evalCtx)
-	return evalCtx
-}
-
-// ExtendedEvalContextReset resets context fields so that the context may be
-// reused across subquery, cascade, and check execution.
-func (p *planner) ExtendedEvalContextReset(evalCtx *extendedEvalContext) {
-	evalCtx.Placeholders = &p.semaCtx.Placeholders
-	evalCtx.Annotations = &p.semaCtx.Annotations
-	evalCtx.SessionID = p.ExtendedEvalContext().SessionID
-}
-
 // SemaCtx provides access to the planner's SemaCtx.
 func (p *planner) SemaCtx() *tree.SemaContext {
 	return &p.semaCtx


### PR DESCRIPTION
This commit fixes a data race that was introduced in 187eabd0692fbfc9fe76affb5adf95a9eb49cf08. In particular, in that commit we made it so that `evalCtxFactory` method, in addition to creating a fresh copy of the eval context, also modifies the planner to point to the updated eval context. I believe this was needed so that `deferredRoutineSender` could be visible from the planner. However, `evalCtxFactory` method can be called concurrently (in the parallel checks code path), yet we'd be modifying the same `plannerCopy` object. This race is now eliminated by setting the deferred routine sender once on the eval context of the planner copy, meaning that the deferred routine sender will be visible from all code paths inside of `runPlanInsidePlan`.

The second commit in this PR is the reduced version of the commit that is reverted in the first commit.

Fixes: #116748.

Release note: None