### PR TITLE
cloud/amazon: disable network access for unit test

### DIFF
--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -51,9 +51,6 @@ go_test(
         "s3_storage_test.go",
     ],
     embed = [":amazon"],
-    exec_properties = {
-        "dockerNetwork": "standard",
-    },
     deps = [
         "//pkg/base",
         "//pkg/blobs",


### PR DESCRIPTION
No longer necessary since #116251

Epic: CRDB-8308
Release note: None