### PR TITLE
backuppcl: disable automatic stats collection during download job

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -2214,6 +2214,14 @@ func (r *restoreResumer) publishDescriptors(
 	// accessed.
 	for i := range details.TableDescs {
 		mutTable := all.LookupDescriptor(details.TableDescs[i].GetID()).(*tabledesc.Mutable)
+
+		if details.ExperimentalOnline {
+			// We disable automatic stats refresh on all restored tables until the
+			// download job finishes.
+			boolean := false
+			mutTable.AutoStatsSettings = &catpb.AutoStatsSettings{Enabled: &boolean}
+		}
+
 		// Note that we don't need to worry about the re-validated indexes for descriptors
 		// with a declarative schema change job.
 		if mutTable.GetDeclarativeSchemaChangerState() != nil {


### PR DESCRIPTION
Previously, the automatic stats job could refresh sql stats on a downloading table which would use precious IO resources during the download job. This patch disables automatic stats collection on restored tables during the download job.

Epic: none

Release note: none