### PR TITLE
roachtest: improve unoptimized-query-oracle a bit

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -488,16 +488,21 @@ func (h *queryComparisonHelper) runQuery(stmt string) ([][]string, error) {
 	// Only save the stmt on success - this makes it easier to reproduce the
 	// log. The caller still can include it into the statements later if
 	// necessary.
+	h.addStmtForLogging(stmt, rows)
+	return rows, nil
+}
+
+// addStmtForLogging includes the provided stmt (as well as optional output
+// rows) to be included into logging later.
+func (h *queryComparisonHelper) addStmtForLogging(stmt string, rows [][]string) {
 	h.statements = append(h.statements, stmt)
 	h.statementsAndExplains = append(h.statementsAndExplains, sqlAndOutput{sql: stmt, output: rows})
-	return rows, nil
 }
 
 // execStmt executes the given statement. As a side effect, it also saves the
 // statement so it can be logged in case of failure.
 func (h *queryComparisonHelper) execStmt(stmt string) error {
-	h.statements = append(h.statements, stmt)
-	h.statementsAndExplains = append(h.statementsAndExplains, sqlAndOutput{sql: stmt})
+	h.addStmtForLogging(stmt, nil /* rows */)
 	_, err := h.conn.Exec(stmt)
 	return err
 }

--- a/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
+++ b/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
@@ -133,6 +133,9 @@ func runUnoptimizedQueryOracleImpl(
 		// internal error).
 		if es := err.Error(); strings.Contains(es, "internal error") {
 			verboseLogging = true
+			// The stmt wasn't already included since it resulted in an error,
+			// but to make the reproduction easier, we do want to include it.
+			h.addStmtForLogging(stmt, nil /* rows */)
 			return h.makeError(err, "internal error while running unoptimized statement")
 		}
 		//nolint:returnerrcheck
@@ -181,6 +184,9 @@ func runUnoptimizedQueryOracleImpl(
 		es := err.Error()
 		if strings.Contains(es, "internal error") {
 			verboseLogging = true
+			// The stmt wasn't already included since it resulted in an error,
+			// but to make the reproduction easier, we do want to include it.
+			h.addStmtForLogging(stmt, nil /* rows */)
 			return h.makeError(err, "internal error while running optimized statement")
 		}
 		// Otherwise, skip optimized statements that fail with a non-internal


### PR DESCRIPTION
This commit makes it so that whenever the unoptimized query oracle encounters an internal error, the stmt that caused it is included into the logs. Previously, because the stmt resulted in an error, it wouldn't be included in the helper and would require an extra step when reproducing the problem.

Informs: #116943

Epic: None

Release note: None