### PR TITLE
stats: skip TestStatsAreDeletedForDroppedTables under deadlock

### DIFF
--- a/pkg/server/application_api/schema_inspection_test.go
+++ b/pkg/server/application_api/schema_inspection_test.go
@@ -482,8 +482,7 @@ func TestAdminAPITableStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderDeadlockWithIssue(t, 115914, "likely to time out")
-
+	skip.UnderDeadlock(t, "low ScanMaxIdleTime and deadlock overloads the EngFlow executor")
 	skip.UnderStress(t, "flaky under stress #107156")
 	skip.UnderRace(t, "flaky under race #107156")
 

--- a/pkg/sql/stats/delete_stats_test.go
+++ b/pkg/sql/stats/delete_stats_test.go
@@ -673,6 +673,7 @@ func TestStatsAreDeletedForDroppedTables(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t) // slow test
+	skip.UnderDeadlock(t, "low ScanMaxIdleTime and deadlock overloads the EngFlow executor")
 
 	var params base.TestServerArgs
 	params.ScanMaxIdleTime = time.Millisecond // speed up MVCC GC queue scans


### PR DESCRIPTION
This test sets low `MaxScanIdleTime` testing knob which appears to overload the EngFlow executor under deadlock, so we skip a test in such config.

I also looked at other places where we set this knob and found that only one of those failed so far, so I only adjusted the skip reason there.

Fixes: #116856.

Release note: None