### PR TITLE
opt: move the common field of Relation/Scaler into Shared

### DIFF
--- a/pkg/sql/opt/memo/multiplicity_builder.go
+++ b/pkg/sql/opt/memo/multiplicity_builder.go
@@ -81,7 +81,7 @@ func deriveUnfilteredCols(in RelExpr) opt.ColSet {
 	if relational.IsAvailable(props.UnfilteredCols) {
 		return relational.Rule.UnfilteredCols
 	}
-	relational.Rule.Available |= props.UnfilteredCols
+	relational.SetAvailable(props.UnfilteredCols)
 	unfilteredCols := opt.ColSet{}
 
 	// Derive UnfilteredCols now.


### PR DESCRIPTION
Both `Relational` and `Scaler` have the field `Rule.Available` and this PR move the field into those base struct `Shared` and refactor relevant methods.