### PR TITLE
kv/tscache: remove propagation of synthetic timestamp bit

### DIFF
--- a/pkg/kv/kvserver/tscache/cache.go
+++ b/pkg/kv/kvserver/tscache/cache.go
@@ -123,16 +123,13 @@ func ratchetValue(old, new cacheValue) (res cacheValue, updated bool) {
 	}
 
 	// Equal times.
-	if new.ts.Synthetic != old.ts.Synthetic {
-		// old.ts == new.ts but the values have different synthetic flags.
-		// Remove the synthetic flag from the resulting value.
-		new.ts.Synthetic = false
-	}
 	if new.txnID != old.txnID {
 		// old.ts == new.ts but the values have different txnIDs. Remove the
 		// transaction ID from the resulting value so that it is no longer owned
 		// by any transaction.
 		new.txnID = noTxnID
+		return new, old.txnID != noTxnID
 	}
-	return new, new != old
+	// old == new.
+	return old, false
 }

--- a/pkg/kv/kvserver/tscache/cache_test.go
+++ b/pkg/kv/kvserver/tscache/cache_test.go
@@ -546,7 +546,7 @@ func TestTimestampCacheImplsIdentical(t *testing.T) {
 						to = nil
 					}
 
-					ts := start.Add(int64(j), 100).WithSynthetic(false)
+					ts := start.Add(int64(j), 100)
 					if useClock {
 						ts = clock.Now()
 					}

--- a/pkg/kv/kvserver/tscache/interval_skl.go
+++ b/pkg/kv/kvserver/tscache/interval_skl.go
@@ -198,7 +198,7 @@ func newIntervalSkl(clock *hlc.Clock, minRet time.Duration, metrics sklMetrics) 
 		minPages: defaultMinSklPages,
 		metrics:  metrics,
 	}
-	s.pushNewPage(0 /* maxTime */, nil /* arena */)
+	s.pushNewPage(0 /* maxWallTime */, nil /* arena */)
 	s.metrics.Pages.Update(1)
 	return &s
 }
@@ -301,10 +301,9 @@ func (s *intervalSkl) addRange(
 	s.rotMutex.TracedRLock(ctx)
 	defer s.rotMutex.RUnlock()
 
-	// If floor ts is greater than the requested timestamp, then no need to
-	// perform a search or add any records. We don't return early when the
-	// timestamps are equal, because their flags may differ.
-	if val.ts.Less(s.floorTS) {
+	// If floor ts is >= requested timestamp, then no need to perform a search or
+	// add any records.
+	if val.ts.LessEq(s.floorTS) {
 		return nil
 	}
 
@@ -386,7 +385,7 @@ func (s *intervalSkl) frontPage() *sklPage {
 
 // pushNewPage prepends a new empty page to the front of the pages list. It
 // accepts an optional arena argument to facilitate re-use.
-func (s *intervalSkl) pushNewPage(maxTime ratchetingTime, arena *arenaskl.Arena) {
+func (s *intervalSkl) pushNewPage(maxWallTime int64, arena *arenaskl.Arena) {
 	size := s.nextPageSize()
 	if arena != nil && arena.Cap() == size {
 		// Re-use the provided arena, if possible.
@@ -396,7 +395,7 @@ func (s *intervalSkl) pushNewPage(maxTime ratchetingTime, arena *arenaskl.Arena)
 		arena = arenaskl.NewArena(size)
 	}
 	p := newSklPage(arena)
-	p.maxTime = maxTime
+	p.maxWallTime = maxWallTime
 	s.pages.PushFront(p)
 }
 
@@ -473,13 +472,13 @@ func (s *intervalSkl) rotatePages(ctx context.Context, filledPage *sklPage) {
 		s.pages.Remove(evict)
 	}
 
-	// Push a new empty page on the front of the pages list. We give this page
-	// the maxTime of the old front page. This assures that the maxTime for a
+	// Push a new empty page on the front of the pages list. We give this page the
+	// maxWallTime of the old front page. This assures that the maxWallTime for a
 	// page is always equal to or greater than that for all earlier pages. In
-	// other words, it assures that the maxTime for a page is not only the
+	// other words, it assures that the maxWallTime for a page is not only the
 	// maximum timestamp for all values it contains, but also for all values any
 	// earlier pages contain.
-	s.pushNewPage(fp.maxTime, oldArena)
+	s.pushNewPage(fp.maxWallTime, oldArena)
 
 	// Update metrics.
 	s.metrics.Pages.Update(int64(s.pages.Len()))
@@ -557,9 +556,9 @@ func (s *intervalSkl) FloorTS() hlc.Timestamp {
 // filled up, it returns arenaskl.ErrArenaFull. At that point, a new fixed page
 // must be allocated and used instead.
 type sklPage struct {
-	list    *arenaskl.Skiplist
-	maxTime ratchetingTime // accessed atomically
-	isFull  int32          // accessed atomically
+	list        *arenaskl.Skiplist
+	maxWallTime int64 // accessed atomically
+	isFull      int32 // accessed atomically
 }
 
 func newSklPage(arena *arenaskl.Arena) *sklPage {
@@ -805,55 +804,6 @@ func (p *sklPage) ensureFloorValue(it *arenaskl.Iterator, to []byte, val cacheVa
 }
 
 func (p *sklPage) ratchetMaxTimestamp(ts hlc.Timestamp) {
-	new := makeRatchetingTime(ts)
-	for {
-		old := ratchetingTime(atomic.LoadInt64((*int64)(&p.maxTime)))
-		if new <= old {
-			break
-		}
-
-		if atomic.CompareAndSwapInt64((*int64)(&p.maxTime), int64(old), int64(new)) {
-			break
-		}
-	}
-}
-
-func (p *sklPage) getMaxTimestamp() hlc.Timestamp {
-	return ratchetingTime(atomic.LoadInt64((*int64)(&p.maxTime))).get()
-}
-
-// ratchetingTime is a compressed representation of an hlc.Timestamp, reduced
-// down to 64 bits to support atomic access.
-//
-// ratchetingTime implements compression such that any loss of information when
-// passing through the type results in the resulting Timestamp being ratcheted
-// to a larger value. This provides the guarantee that the following relation
-// holds, regardless of the value of x:
-//
-//	x.LessEq(makeRatchetingTime(x).get())
-//
-// It also provides the guarantee that if the synthetic flag is set on the
-// initial timestamp, then this flag is set on the resulting Timestamp. So the
-// following relation is guaranteed to hold, regardless of the value of x:
-//
-//	x.IsFlagSet(SYNTHETIC) == makeRatchetingTime(x).get().IsFlagSet(SYNTHETIC)
-//
-// Compressed ratchetingTime values compare such that taking the maximum of any
-// two ratchetingTime values and converting that back to a Timestamp is always
-// equal to or larger than the equivalent call through the Timestamp.Forward
-// method. So the following relation is guaranteed to hold, regardless of the
-// value of x or y:
-//
-//	z := max(makeRatchetingTime(x), makeRatchetingTime(y)).get()
-//	x.Forward(y).LessEq(z)
-//
-// Bit layout (LSB to MSB):
-//
-//	bits 0:      inverted synthetic flag
-//	bits 1 - 63: upper 63 bits of wall time
-type ratchetingTime int64
-
-func makeRatchetingTime(ts hlc.Timestamp) ratchetingTime {
 	// Cheat and just use the max wall time portion of the timestamp, since it's
 	// fine for the max timestamp to be a bit too large. This is the case
 	// because it's always safe to increase the timestamp in a range. It's also
@@ -867,38 +817,25 @@ func makeRatchetingTime(ts hlc.Timestamp) ratchetingTime {
 	// We could use an atomic.Value to store a "MaxValue" cacheValue for a given
 	// page, but this would be more expensive and it's not clear that it would
 	// be worth it.
-	rt := ratchetingTime(ts.WallTime)
+	new := ts.WallTime
 	if ts.Logical > 0 {
-		rt++
+		new++
 	}
 
-	// Similarly, cheat and use the last bit in the wall time to indicate
-	// whether the timestamp is synthetic or not. Do so by first rounding up the
-	// last bit of the wall time so that it is empty. This is safe for the same
-	// reason that rounding up the logical portion of the timestamp in the wall
-	// time is safe (see above).
-	//
-	// We use the last bit to indicate that the flag is NOT set. This ensures
-	// that if two timestamps have the same ordering but different values for
-	// the synthetic flag, the timestamp without the synthetic flag has a larger
-	// ratchetingTime value. This follows how Timestamp.Forward treats the flag.
-	if rt&1 == 1 {
-		rt++
-	}
-	if !ts.Synthetic {
-		rt |= 1
-	}
+	for {
+		old := atomic.LoadInt64(&p.maxWallTime)
+		if new <= old {
+			break
+		}
 
-	return rt
+		if atomic.CompareAndSwapInt64(&p.maxWallTime, old, new) {
+			break
+		}
+	}
 }
 
-func (rt ratchetingTime) get() hlc.Timestamp {
-	var ts hlc.Timestamp
-	ts.WallTime = int64(rt &^ 1)
-	if rt&1 == 0 {
-		ts.Synthetic = true
-	}
-	return ts
+func (p *sklPage) getMaxTimestamp() hlc.Timestamp {
+	return hlc.Timestamp{WallTime: atomic.LoadInt64(&p.maxWallTime)}
 }
 
 // ratchetPolicy defines the behavior a ratcheting attempt should take when

--- a/pkg/kv/kvserver/tscache/interval_skl_test.go
+++ b/pkg/kv/kvserver/tscache/interval_skl_test.go
@@ -90,13 +90,13 @@ func TestIntervalSklAdd(t *testing.T) {
 	s := newIntervalSkl(nil /* clock */, 0 /* minRet */, makeSklMetrics())
 
 	s.Add(ctx, []byte("apricot"), val1)
-	require.Equal(t, ts1.WallTime, s.frontPage().maxWallTime)
+	require.Equal(t, ts1.WallTime, s.frontPage().maxWallTime.Load())
 	require.Equal(t, emptyVal, s.LookupTimestamp(ctx, []byte("apple")))
 	require.Equal(t, val1, s.LookupTimestamp(ctx, []byte("apricot")))
 	require.Equal(t, emptyVal, s.LookupTimestamp(ctx, []byte("banana")))
 
 	s.Add(ctx, []byte("banana"), val2)
-	require.Equal(t, ts2Ceil.WallTime, s.frontPage().maxWallTime)
+	require.Equal(t, ts2Ceil.WallTime, s.frontPage().maxWallTime.Load())
 	require.Equal(t, emptyVal, s.LookupTimestamp(ctx, []byte("apple")))
 	require.Equal(t, val1, s.LookupTimestamp(ctx, []byte("apricot")))
 	require.Equal(t, val2, s.LookupTimestamp(ctx, []byte("banana")))
@@ -450,7 +450,7 @@ func TestIntervalSklSingleKeyRanges(t *testing.T) {
 
 	// Don't allow inverted ranges.
 	require.Panics(t, func() { s.AddRange(ctx, []byte("kiwi"), []byte("apple"), 0, val1) })
-	require.Equal(t, int64(0), s.frontPage().maxWallTime)
+	require.Equal(t, int64(0), s.frontPage().maxWallTime.Load())
 	require.Equal(t, emptyVal, s.LookupTimestamp(ctx, []byte("apple")))
 	require.Equal(t, emptyVal, s.LookupTimestamp(ctx, []byte("banana")))
 	require.Equal(t, emptyVal, s.LookupTimestamp(ctx, []byte("kiwi")))
@@ -762,7 +762,7 @@ func TestIntervalSklLookupEqualsEarlierMaxWallTime(t *testing.T) {
 		if logical {
 			expMaxTS = ts2Ceil
 		}
-		require.Equal(t, expMaxTS.WallTime, s.frontPage().maxWallTime)
+		require.Equal(t, expMaxTS.WallTime, s.frontPage().maxWallTime.Load())
 
 		// Rotate the page so that new writes will go to a different page.
 		s.rotatePages(ctx, s.frontPage())


### PR DESCRIPTION
Informs #101938.

This commit is essentially a revert of cc61e09f. It removes the propagation of the synthetic flag through the timestamp cache.

This flag has been deprecated since v22.2 and is no longer consulted in uncertainty interval checks or by transaction commit-wait. It does not need to be propagated from readers to writers during read-write txn conflicts.

Release note: None