### PR TITLE
kv/closedts: remove use and propagation of synthetic timestamp bit 

### DIFF
--- a/pkg/kv/kvserver/closedts/policy.go
+++ b/pkg/kv/kvserver/closedts/policy.go
@@ -121,8 +121,7 @@ func TargetForPolicy(
 			leadTimeAtSender = leadTargetOverride
 		}
 
-		// Mark as synthetic, because this time is in the future.
-		res = now.ToTimestamp().Add(leadTimeAtSender.Nanoseconds(), 0).WithSynthetic(true)
+		res = now.ToTimestamp().Add(leadTimeAtSender.Nanoseconds(), 0)
 	default:
 		panic("unexpected RangeClosedTimestampPolicy")
 	}

--- a/pkg/kv/kvserver/closedts/policy_test.go
+++ b/pkg/kv/kvserver/closedts/policy_test.go
@@ -55,8 +55,7 @@ func TestTargetForPolicy(t *testing.T) {
 			expClosedTSTarget: now.
 				Add((maxClockOffset +
 					millis(275) /* sideTransportPropTime */ +
-					millis(25) /* bufferTime */).Nanoseconds(), 0).
-				WithSynthetic(true),
+					millis(25) /* bufferTime */).Nanoseconds(), 0),
 		},
 		{
 			sideTransportCloseInterval: millis(50),
@@ -64,14 +63,13 @@ func TestTargetForPolicy(t *testing.T) {
 			expClosedTSTarget: now.
 				Add((maxClockOffset +
 					millis(245) /* raftTransportPropTime */ +
-					millis(25) /* bufferTime */).Nanoseconds(), 0).
-				WithSynthetic(true),
+					millis(25) /* bufferTime */).Nanoseconds(), 0),
 		},
 		{
 			leadTargetOverride:         millis(1234),
 			sideTransportCloseInterval: millis(200),
 			rangePolicy:                roachpb.LEAD_FOR_GLOBAL_READS,
-			expClosedTSTarget:          now.Add(millis(1234).Nanoseconds(), 0).WithSynthetic(true),
+			expClosedTSTarget:          now.Add(millis(1234).Nanoseconds(), 0),
 		},
 	} {
 		t.Run("", func(t *testing.T) {

--- a/pkg/kv/kvserver/closedts/sidetransport/receiver_test.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/receiver_test.go
@@ -62,9 +62,9 @@ func (m *mockStores) getAndClearRecording() []rangeUpdate {
 var ts10 = hlc.Timestamp{WallTime: 10}
 var ts11 = hlc.Timestamp{WallTime: 11}
 var ts12 = hlc.Timestamp{WallTime: 12}
-var ts20 = hlc.Timestamp{WallTime: 20, Synthetic: true}
-var ts21 = hlc.Timestamp{WallTime: 21, Synthetic: true}
-var ts22 = hlc.Timestamp{WallTime: 22, Synthetic: true}
+var ts20 = hlc.Timestamp{WallTime: 20}
+var ts21 = hlc.Timestamp{WallTime: 21}
+var ts22 = hlc.Timestamp{WallTime: 22}
 var laiZero = kvpb.LeaseAppliedIndex(0)
 
 const lai100 = kvpb.LeaseAppliedIndex(100)

--- a/pkg/kv/kvserver/closedts/tracker/tracker.go
+++ b/pkg/kv/kvserver/closedts/tracker/tracker.go
@@ -81,11 +81,6 @@ type Tracker interface {
 	// The returned timestamp might be smaller than the lowest timestamp ever
 	// inserted into the set. Implementations are allowed to round timestamps
 	// down.
-	//
-	// Synthetic timestamps: The Tracker doesn't necessarily track synthetic /
-	// physical timestamps precisely; the only guarantee implementations need to
-	// make is that, if no synthethic timestamp is inserted into the tracked set
-	// for a while, eventually the LowerBound value will not be synthetic.
 	LowerBound(context.Context) hlc.Timestamp
 
 	// Count returns the current size of the tracked set.

--- a/pkg/kv/kvserver/closedts/tracker/tracker_test.go
+++ b/pkg/kv/kvserver/closedts/tracker/tracker_test.go
@@ -79,19 +79,6 @@ func testTracker(ctx context.Context, t *testing.T, tr Tracker) {
 	}
 	tr.Untrack(ctx, tok30)
 	require.True(t, tr.LowerBound(ctx).IsEmpty())
-
-	// Check that synthetic timestamps are tracked as such.
-	synthTS := hlc.Timestamp{
-		WallTime:  10,
-		Synthetic: true,
-	}
-	tok := tr.Track(ctx, synthTS)
-	require.Equal(t, synthTS, tr.LowerBound(ctx))
-	// Check that after the Tracker is emptied, lowerbounds are not synthetic any
-	// more.
-	tr.Untrack(ctx, tok)
-	tr.Track(ctx, ts(10))
-	require.Equal(t, ts(10), tr.LowerBound(ctx))
 }
 
 // Test the tracker by throwing random requests at it. We verify that, at all

--- a/pkg/kv/kvserver/kvserverpb/lease_status.go
+++ b/pkg/kv/kvserver/kvserverpb/lease_status.go
@@ -60,10 +60,5 @@ func (st LeaseStatus) Expiration() hlc.Timestamp {
 // Until a new lease is acquired, all writes will be pushed into this last
 // nanosecond of the lease.
 func (st LeaseStatus) ClosedTimestampUpperBound() hlc.Timestamp {
-	// HACK(andrei): We declare the lease expiration to be synthetic by fiat,
-	// because it frequently is synthetic even though currently it's not marked
-	// as such. See the TODO in Timestamp.Add() about the work remaining to
-	// properly mark these timestamps as synthetic. We need to make sure it's
-	// synthetic here so that the results of Backwards() can be synthetic.
-	return st.Expiration().WithSynthetic(true).WallPrev()
+	return st.Expiration().WallPrev()
 }

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -924,8 +924,7 @@ func TestProposalBufferClosedTimestamp(t *testing.T) {
 	nowMinusTwiceClosedLag := nowTS.Add(-2*closedts.TargetDuration.Get(&st.SV).Nanoseconds(), 0)
 	nowPlusGlobalReadLead := nowTS.Add((maxOffset +
 		275*time.Millisecond /* sideTransportPropTime */ +
-		25*time.Millisecond /* bufferTime */).Nanoseconds(), 0).
-		WithSynthetic(true)
+		25*time.Millisecond /* bufferTime */).Nanoseconds(), 0)
 	expiredLeaseTimestamp := nowTS.Add(-1000, 0)
 	someClosedTS := nowTS.Add(-2000, 0)
 


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/101938.

This PR removes the handling of synthetic timestamps from the closed timestamp tracker data structure.

It then stops setting the synthetic timestamp bit on the closed timestamps selected for ranges with a `LEAD_FOR_GLOBAL_READS` closed timestamp policy.

This flag has been deprecated since v22.2 and is no longer consulted in uncertainty interval checks or by transaction commit-wait. It does not need to be propagated from evaluating requests to the closed timestamp.

Release note: None