### PR TITLE
sql: disallow functions returning unknown data type

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -2829,3 +2829,6 @@ SELECT f114678();
 CALL p114678();
 
 subtest end
+
+statement error pgcode 42P13 PL/pgSQL functions cannot return type unknown
+CREATE FUNCTION f() RETURNS UNKNOWN LANGUAGE PLpgSQL AS $$ BEGIN RETURN NULL; END $$;

--- a/pkg/sql/opt/optbuilder/testdata/create_function
+++ b/pkg/sql/opt/optbuilder/testdata/create_function
@@ -133,3 +133,8 @@ build
 CREATE FUNCTION f() RETURNS INT LANGUAGE SQL BEGIN ATOMIC SELECT 1; END;
 ----
 error (0A000): unimplemented: CREATE FUNCTION...sql_body unimplemented
+
+build
+CREATE FUNCTION f() RETURNS UNKNOWN LANGUAGE SQL AS $$ SELECT NULL; $$;
+----
+error (42P13): SQL functions cannot return type unknown


### PR DESCRIPTION
Disallow creating functions that return UNKNOWN, for consistency with postgres.
I couldn't add a PL/pgSQL test because I don't have a license for it, but I tested it manually through the cockroach demo.

Fixes: #112573

Release note: None