### PR TITLE
sql: allow schema changes under READ COMMITTED

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -224,10 +224,6 @@ func (ex *connExecutor) prepare(
 			ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime())
 		}
 
-		if err := ex.maybeUpgradeToSerializable(ctx, stmt); err != nil {
-			return err
-		}
-
 		if placeholderHints == nil {
 			placeholderHints = make(tree.PlaceholderTypes, stmt.NumPlaceholders)
 		} else if rawTypeHints != nil {


### PR DESCRIPTION
This restriction was added out of an abundance of caution for the initial read committed release. Back when CRDB supported SNAPSHOT isolation, this restriction existed. (See
https://github.com/cockroachdb/cockroach/blob/fa80a5a70ddf120df13e8b040515398c8266208f/pkg/sql/lease.go#L294-L299 for that version of the restriction.)

However, the reasons we had to disallow it no longer apply. Specifically, we disallowed schema changes before so that the descriptor modification time would always match the commit timestamp. Now, the descriptor modification time is populated directly from the MVCC timestamp whenever a descriptor is read, so there's no need to disallow other isolation levels for descriptor modifications.

fixes https://github.com/cockroachdb/cockroach/issues/114778
Release note (sql change): Schema changes are now allowed under when using the READ COMMITTED transaction isolation level.