### PR TITLE
tracing: simplify meta injection in RPC ctx

### DIFF
--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -1659,19 +1659,6 @@ func (w MetadataCarrier) ForEach(fn func(key, val string) error) error {
 	return nil
 }
 
-// SpanInclusionFuncForClient is used as a SpanInclusionFunc for the client-side
-// of RPCs, deciding for which operations the gRPC tracing interceptor should
-// create a span.
-//
-// We use this to circumvent the interceptor's work when tracing is
-// disabled. Otherwise, the interceptor causes an increase in the
-// number of packets (even with an Empty context!).
-//
-// See #17177.
-func SpanInclusionFuncForClient(parent *Span) bool {
-	return parent != nil && !parent.IsNoop()
-}
-
 // SpanInclusionFuncForServer is used as a SpanInclusionFunc for the server-side
 // of RPCs, deciding for which operations the gRPC tracing interceptor should
 // create a span.

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -339,21 +339,18 @@ func TestTracerInjectExtract(t *testing.T) {
 }
 
 func TestTracer_PropagateNonRecordingRealSpanAcrossRPCBoundaries(t *testing.T) {
-	// Verify that when a span is put on the wire on one end, and is checked
-	// against the span inclusion functions both on the client and server, a real
-	// span results in a real span.
+	// Verify that when a span is put on the wire on one end a real span results
+	// in a real span.
 	tr1 := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
 	sp1 := tr1.StartSpan("tr1.root")
 	defer sp1.Finish()
 	carrier := MetadataCarrier{MD: metadata.MD{}}
-	require.True(t, SpanInclusionFuncForClient(sp1))
 	tr1.InjectMetaInto(sp1.Meta(), carrier)
 	require.Equal(t, 3, carrier.Len(), "%+v", carrier) // trace id, span id, recording mode
 
 	tr2 := NewTracer()
 	meta, err := tr2.ExtractMetaFrom(carrier)
 	require.NoError(t, err)
-	require.True(t, SpanInclusionFuncForServer(tr2, meta))
 	sp2 := tr2.StartSpan("tr2.child", WithRemoteParentFromSpanMeta(meta))
 	defer sp2.Finish()
 	require.NotZero(t, sp2.i.crdb.spanID)


### PR DESCRIPTION
This is a minor cleanup. The gRPC tracing interceptor has logic for avoiding populating the grpc metadata for no-op client spans. This patch pushes this logic down a level, where it belongs.

Epic: None

Release note: None