### PR TITLE
sqlproxyccl: delete destroy tenant portion of refresh throttling test

### DIFF
--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
@@ -586,22 +586,6 @@ func TestRefreshThrottling(t *testing.T) {
 		Addr:     addr,
 		State:    tenant.RUNNING,
 	}}, pods)
-
-	// Now destroy the tenant and call ReportFailure again. This should be a
-	// no-op due to refresh throttling.
-	require.NoError(t, destroyTenant(tc, tenantID))
-	require.NoError(t, dir.ReportFailure(ctx, tenantID, addr))
-	pods, err = dir.TryLookupTenantPods(ctx, tenantID)
-	require.NoError(t, err)
-	require.NotEmpty(t, pods)
-
-	// Reset StateTimestamp for deterministic comparison.
-	pods[0].StateTimestamp = time.Time{}
-	require.Equal(t, []*tenant.Pod{{
-		TenantID: tenantID.ToUint64(),
-		Addr:     addr,
-		State:    tenant.RUNNING,
-	}}, pods)
 }
 
 func createTenant(tc serverutils.TestClusterInterface, id roachpb.TenantID) error {


### PR DESCRIPTION
TestRefreshThrottling is flakey because the test tenant directory server detects the shut down of the tenant sql server and pushes an event to the cache via the watch api. If the DELETE event is delivered to the cache before the pods are queried, the test flakes.

Fixes: #115139