### PR TITLE
span: Add strict mode

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -81,6 +81,9 @@ var envVars = []string{
 	// NB: This is crucial for chaos tests as we expect changefeeds to see
 	// many retries.
 	"COCKROACH_CHANGEFEED_TESTING_FAST_RETRY=true",
+
+	// Enable "strict mode" for span frontier.
+	"COCKROACH_SPAN_FRONTIER_STRICT_MODE_ENABLED=true",
 }
 
 type cdcTester struct {


### PR DESCRIPTION
Two commits to help debug #116661 

1.
Log "slow span" messages both from the coordinator and from the aggregators.

2.
span: Add strict mode

Add strict mode for span frontier implementations that
requires the forwarded span to be a sub-span of the spans
tracked by the frontier.

The functionality is opt-in, and is enabled via
`COCKROACH_SPAN_FRONTIER_STRICT_MODE_ENABLED` env var.

Enroll cdc roachtests to use strict mode.

Informs #116661

Release Note: None