### PR TITLE
jobs: make gc test only look for gc-able jobs

### DIFF
--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -315,7 +315,7 @@ func TestRegistryGCPagination(t *testing.T) {
 	ts := timeutil.Now()
 	require.NoError(t, s.JobRegistry().(*Registry).cleanupOldJobs(ctx, ts.Add(-10*time.Minute)))
 	var count int
-	db.QueryRow(t, `SELECT count(1) FROM system.jobs`).Scan(&count)
+	db.QueryRow(t, `SELECT count(1) FROM system.jobs WHERE status = $1`, StatusCanceled).Scan(&count)
 	require.Zero(t, count)
 }
 


### PR DESCRIPTION
Assuming there are zero other jobs in the jobs system is prone to failure. Instead, just assume that any gc-eligible jobs were GC'ed.

Closes #116766.

Release note: none.
Epic: none.