### PR TITLE
sql/rowcontainer: remove propagation of synthetic timestamp bit

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
@@ -173,9 +173,8 @@ func makeResultWithGetResp(rng *rand.Rand, empty bool) Result {
 		r.GetResp.Value = &roachpb.Value{
 			RawBytes: rawBytes,
 			Timestamp: hlc.Timestamp{
-				WallTime:  rng.Int63(),
-				Logical:   rng.Int31(),
-				Synthetic: rng.Float64() < 0.5,
+				WallTime: rng.Int63(),
+				Logical:  rng.Int31(),
 			},
 		}
 	}

--- a/pkg/sql/catalog/lease/lease_internal_test.go
+++ b/pkg/sql/catalog/lease/lease_internal_test.go
@@ -288,7 +288,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "t", "test")
-	futureTime := s.Clock().Now().Add(500*time.Millisecond.Nanoseconds(), 0).WithSynthetic(true)
+	futureTime := s.Clock().Now().Add(500*time.Millisecond.Nanoseconds(), 0)
 
 	getLatestDesc := func() catalog.TableDescriptor {
 		if err := leaseManager.AcquireFreshestFromStore(ctx, tableDesc.GetID()); err != nil {

--- a/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
+++ b/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
@@ -158,8 +158,7 @@ var inOrderResultsBufferSpillTypeSchema = []*types.T{
 	//	Timestamp hlc.Timestamp
 	//	  WallTime int64
 	//	  Logical int32
-	//	  Synthetic bool
-	types.Bytes, types.Int, types.Int, types.Bool,
+	types.Bytes, types.Int, types.Int,
 	// ScanResp:
 	//  BatchResponses [][]byte
 	types.BytesArray,
@@ -172,7 +171,6 @@ const (
 	getRawBytesIdx
 	getTSWallTimeIdx
 	getTSLogicalIdx
-	getTSSyntheticIdx
 	scanBatchResponsesIdx
 )
 
@@ -186,13 +184,11 @@ func serialize(r *kvstreamer.Result, row rowenc.EncDatumRow, alloc *tree.DatumAl
 		row[getRawBytesIdx] = rowenc.EncDatum{Datum: alloc.NewDBytes(tree.DBytes(v.RawBytes))}
 		row[getTSWallTimeIdx] = rowenc.EncDatum{Datum: alloc.NewDInt(tree.DInt(v.Timestamp.WallTime))}
 		row[getTSLogicalIdx] = rowenc.EncDatum{Datum: alloc.NewDInt(tree.DInt(v.Timestamp.Logical))}
-		row[getTSSyntheticIdx] = rowenc.EncDatum{Datum: tree.MakeDBool(tree.DBool(v.Timestamp.Synthetic))}
 		row[scanBatchResponsesIdx] = rowenc.EncDatum{Datum: tree.DNull}
 	} else {
 		row[getRawBytesIdx] = rowenc.EncDatum{Datum: tree.DNull}
 		row[getTSWallTimeIdx] = rowenc.EncDatum{Datum: tree.DNull}
 		row[getTSLogicalIdx] = rowenc.EncDatum{Datum: tree.DNull}
-		row[getTSSyntheticIdx] = rowenc.EncDatum{Datum: tree.DNull}
 		if r.GetResp != nil {
 			// We have an empty Get response.
 			row[scanBatchResponsesIdx] = rowenc.EncDatum{Datum: tree.DNull}
@@ -229,9 +225,8 @@ func deserialize(r *kvstreamer.Result, row rowenc.EncDatumRow, alloc *tree.Datum
 			r.GetResp.Value = &roachpb.Value{
 				RawBytes: []byte(tree.MustBeDBytes(row[getRawBytesIdx].Datum)),
 				Timestamp: hlc.Timestamp{
-					WallTime:  int64(tree.MustBeDInt(row[getTSWallTimeIdx].Datum)),
-					Logical:   int32(tree.MustBeDInt(row[getTSLogicalIdx].Datum)),
-					Synthetic: bool(tree.MustBeDBool(row[getTSSyntheticIdx].Datum)),
+					WallTime: int64(tree.MustBeDInt(row[getTSWallTimeIdx].Datum)),
+					Logical:  int32(tree.MustBeDInt(row[getTSLogicalIdx].Datum)),
 				},
 			}
 		}

--- a/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer_test.go
+++ b/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer_test.go
@@ -70,9 +70,8 @@ func makeResultWithGetResp(rng *rand.Rand, empty bool) kvstreamer.Result {
 		r.GetResp.Value = &roachpb.Value{
 			RawBytes: rawBytes,
 			Timestamp: hlc.Timestamp{
-				WallTime:  rng.Int63(),
-				Logical:   rng.Int31(),
-				Synthetic: rng.Float64() < 0.5,
+				WallTime: rng.Int63(),
+				Logical:  rng.Int31(),
 			},
 		}
 	}


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/101938.

This PR removes the propagation of the synthetic flag through `kvStreamerResultDiskBuffer`. It then cleans up the use of synthetic timestamps in a few SQL tests.

This flag has been deprecated since v22.2 and is no longer consulted in uncertainty interval checks or by transaction commit-wait. It does not need to be propagated.

Release note: None