### PR TITLE
kv: remove unnecessary use of Timestamp.WithSynthetic in tests

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -733,8 +733,8 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 func testTxnCoordSenderTxnUpdatedOnError(t *testing.T, isoLevel isolation.Level) {
 	ctx := context.Background()
 	origTS := makeTS(123, 0)
-	plus10 := origTS.Add(10, 10).WithSynthetic(false)
-	plus20 := origTS.Add(20, 0).WithSynthetic(false)
+	plus10 := origTS.Add(10, 10)
+	plus20 := origTS.Add(20, 0)
 	testCases := []struct {
 		// The test's name.
 		name                  string
@@ -1526,9 +1526,7 @@ func TestTxnCommitWait(t *testing.T) {
 				// transaction is read-write, it will need to bump its write
 				// timestamp above the other value.
 				if futureTime {
-					ts := txn.TestingCloneTxn().WriteTimestamp.
-						Add(futureOffset.Nanoseconds(), 0).
-						WithSynthetic(true)
+					ts := txn.TestingCloneTxn().WriteTimestamp.Add(futureOffset.Nanoseconds(), 0)
 					h := kvpb.Header{Timestamp: ts}
 					put := kvpb.NewPut(key, roachpb.Value{})
 					if _, pErr := kv.SendWrappedWith(ctx, s.DB.NonTransactionalSender(), h, put); pErr != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -1301,13 +1301,8 @@ func TestCommitWaitBeforeIntentResolutionIfCommitTrigger(t *testing.T) {
 				expError: false,
 			},
 			{
-				name:     "past-syn",
-				commitTS: func(now hlc.Timestamp) hlc.Timestamp { return now.WithSynthetic(true) },
-				expError: false,
-			},
-			{
-				name:     "future-syn",
-				commitTS: func(now hlc.Timestamp) hlc.Timestamp { return now.Add(100, 0).WithSynthetic(true) },
+				name:     "future",
+				commitTS: func(now hlc.Timestamp) hlc.Timestamp { return now.Add(100, 0) },
 				// If the EndTxn carried a commit trigger and its transaction will need
 				// to commit-wait because the transaction has a future-time commit
 				// timestamp, evaluating the request should return an error.

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -621,7 +621,7 @@ func TestStoreLeaseTransferTimestampCacheRead(t *testing.T) {
 		// Determine when to read.
 		readTS := tc.Servers[0].Clock().Now()
 		if futureRead {
-			readTS = readTS.Add(500*time.Millisecond.Nanoseconds(), 0).WithSynthetic(true)
+			readTS = readTS.Add(500*time.Millisecond.Nanoseconds(), 0)
 		}
 
 		// Read the key at readTS.
@@ -651,7 +651,6 @@ func TestStoreLeaseTransferTimestampCacheRead(t *testing.T) {
 		require.Nil(t, pErr)
 		require.NotEqual(t, readTS, br.Timestamp)
 		require.True(t, readTS.Less(br.Timestamp))
-		require.Equal(t, readTS.Synthetic, br.Timestamp.Synthetic)
 	})
 }
 

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -416,7 +416,7 @@ func mergeWithData(t *testing.T, retries int64) {
 //
 //   - futureRead: configures whether or not the reads performed on the RHS range
 //     before the merge is initiated are performed in the future of present
-//     time using synthetic timestamps.
+//     time.
 func TestStoreRangeMergeTimestampCache(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -565,7 +565,7 @@ func mergeCheckingTimestampCaches(
 
 	readTS := tc.Servers[0].Clock().Now()
 	if futureRead {
-		readTS = readTS.Add(500*time.Millisecond.Nanoseconds(), 0).WithSynthetic(true)
+		readTS = readTS.Add(500*time.Millisecond.Nanoseconds(), 0)
 	}
 
 	// Simulate a read on the RHS from a node with a newer clock.
@@ -1178,14 +1178,8 @@ func TestStoreRangeMergeTxnRefresh(t *testing.T) {
 			// Detect the range merge's deletion of the local range descriptor
 			// and use it as an opportunity to bump the merge transaction's
 			// write timestamp. This will necessitate a refresh.
-			//
-			// Also mark as synthetic, while we're here, to simulate the
-			// behavior of a range merge across two ranges with the
-			// LEAD_FOR_GLOBAL_READS closed timestamp policy.
 			if !v.Value.IsPresent() && bytes.HasSuffix(v.Key, keys.LocalRangeDescriptorSuffix) {
-				br.Txn.WriteTimestamp = br.Txn.WriteTimestamp.
-					Add(100*time.Millisecond.Nanoseconds(), 0).
-					WithSynthetic(true)
+				br.Txn.WriteTimestamp = br.Txn.WriteTimestamp.Add(100*time.Millisecond.Nanoseconds(), 0)
 			}
 		case *kvpb.RefreshRequest:
 			if bytes.HasSuffix(v.Key, keys.LocalRangeDescriptorSuffix) {

--- a/pkg/kv/kvserver/txn_recovery_integration_test.go
+++ b/pkg/kv/kvserver/txn_recovery_integration_test.go
@@ -47,8 +47,7 @@ func TestTxnRecoveryFromStaging(t *testing.T) {
 		// implicit-commit condition.
 		implicitCommit bool
 		// futureWrites dictates whether the transaction has been writing at the
-		// present time or whether it has been writing into the future with a
-		// synthetic timestamp.
+		// present time or whether it has been writing into the future.
 		futureWrites bool
 	}{
 		{
@@ -85,7 +84,7 @@ func TestTxnRecoveryFromStaging(t *testing.T) {
 			// where it has refreshed up to its write timestamp in preparation
 			// to commit.
 			if tc.futureWrites {
-				txn.WriteTimestamp = txn.ReadTimestamp.Add(50, 0).WithSynthetic(true)
+				txn.WriteTimestamp = txn.ReadTimestamp.Add(50, 0)
 				txn.ReadTimestamp = txn.WriteTimestamp // simulate refresh
 			}
 


### PR DESCRIPTION
Informs #101938.

These tests were using the Timestamp.WithSynthetic method even when doing so was not necessary.

Release note: None