### PR TITLE
backup: disbale value blocks

### DIFF
--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -171,7 +171,7 @@ func (s *fileSSTSink) open(ctx context.Context) error {
 		s.out = e
 	}
 	// TODO(dt): make ExternalStorage.Writer return objstorage.Writable.
-	s.sst = storage.MakeIngestionSSTWriter(ctx, s.dest.Settings(), storage.NoopFinishAbortWritable(s.out))
+	s.sst = storage.MakeIngestibleBackupSSTWriter(ctx, s.dest.Settings(), storage.NoopFinishAbortWritable(s.out))
 
 	return nil
 }


### PR DESCRIPTION
Release note: none.
Epic: none.