### PR TITLE
sqlccl: increase statement timeout in TestShowCreateRedactableValues

### DIFF
--- a/pkg/ccl/testccl/sqlccl/show_create_test.go
+++ b/pkg/ccl/testccl/sqlccl/show_create_test.go
@@ -76,7 +76,7 @@ func TestShowCreateRedactableValues(t *testing.T) {
 
 	// Perform a few random initial CREATE TABLEs and check for PII leaks.
 	setup := sqlsmith.RandTablesPrefixStringConsts(rng, pii)
-	setup = append(setup, "SET statement_timeout = '5s';")
+	setup = append(setup, "SET statement_timeout = '30s';")
 	for _, stmt := range setup {
 		t.Log(stmt)
 		if _, err := sqlDB.ExecContext(ctx, stmt); err != nil {


### PR DESCRIPTION
When running TestShowCreateRedactableValues under race, DDLs take longer to finish. Let's try increasing the statement timeout from 5s to 30s.

Fixes: #116853

Epic: None

Release note: None