### PR TITLE
backupinfo: sort stats before comparing

### DIFF
--- a/pkg/ccl/backupccl/backupinfo/backup_metadata_test.go
+++ b/pkg/ccl/backupccl/backupinfo/backup_metadata_test.go
@@ -285,6 +285,11 @@ func checkStats(
 		expectedStats = nil
 	}
 
+	sort.Slice(expectedStats, func(i, j int) bool {
+		return expectedStats[i].TableID < expectedStats[j].TableID ||
+			(expectedStats[i].TableID == expectedStats[j].TableID && expectedStats[i].StatisticID < expectedStats[j].StatisticID)
+	})
+
 	it := bm.NewStatsIter(ctx)
 	defer it.Close()
 	metaStats, err := bulk.CollectToSlice(it)


### PR DESCRIPTION
The SST version always sorts the stats it stores but this may alter the order compared to the proto version.

Release note: none.
Epic: none.
Fixes: #117053.