### PR TITLE
ttljob: fix statistics err handler logging

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -134,10 +134,13 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 			group.GoCtx(func(ctx context.Context) error {
 
 				handleError := func(err error) error {
+					if err == nil {
+						return nil
+					}
 					if knobs.ReturnStatsError {
 						return err
 					}
-					log.Warningf(ctx, "failed to get statistics for table id %d: %s", details.TableID, err)
+					log.Warningf(ctx, "failed to get statistics for table id %d: %v", details.TableID, err)
 					return nil
 				}
 


### PR DESCRIPTION
Currently any call to `fetchStatistics` in the ttl job will log a warning:
```
failed to get statistics for table id 116: %!s(<nil>)
```

Fixes: https://github.com/cockroachdb/cockroach/issues/117128

Return early in the error handler if there is no error to handle.