### PR TITLE
cli: remove `t` field from `TestCLI` usage

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -434,15 +434,12 @@ func TestUnavailableZip(t *testing.T) {
 
 	t.Run("server 1", func(t *testing.T) {
 		c := TestCLI{
-			t:        t,
 			Server:   tc.Server(0),
 			Insecure: true,
 		}
 
 		out, err := c.RunWithCapture(debugZipCommand)
-		if err != nil {
-			c.fail(err)
-		}
+		require.NoError(t, err)
 
 		// Assert debug zip output for cluster, node 1, node 2, node 3.
 		assert.NotEmpty(t, out)
@@ -470,15 +467,12 @@ func TestUnavailableZip(t *testing.T) {
 	t.Run("server 2", func(t *testing.T) {
 		// Run debug zip against node 2.
 		c := TestCLI{
-			t:        t,
 			Server:   tc.Server(1),
 			Insecure: true,
 		}
 
 		out, err := c.RunWithCapture(debugZipCommand)
-		if err != nil {
-			c.fail(err)
-		}
+		require.NoError(t, err)
 
 		// Assert debug zip output for cluster, node 2.
 		assert.NotEmpty(t, out)


### PR DESCRIPTION
Currently, these tests fail in CI with a nil pointer at runtime when we call `c.t.Fail` when an error is produced.

This change removes the sharing of the `t` variable with `TestCLI` since it seems to result in a conflict between the outer test code and what runs inside `RunWithCapture`.

I was unable to reproduce the error locally and do not have further clues. My hope is that, the simplified error handling will surface the actual error in CI instead of the continued nil pointer exception.

Resolves: #116228
Epic: None
Release note: None