### PR TITLE
sctest: remove t.Parallel calls and cleanup

### DIFF
--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -114,7 +114,6 @@ func maybeRandomlySkip(t *testing.T) {
 
 func backupSuccess(t *testing.T, factory TestServerFactory, cs CumulativeTestCaseSpec) {
 	maybeRandomlySkip(t)
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
 	ctx := context.Background()
 	url := fmt.Sprintf("userfile://backups.public.userfiles_$user/data_%s_%d",
 		cs.Phase, cs.StageOrdinal)
@@ -224,7 +223,6 @@ func backupRollbacks(t *testing.T, factory TestServerFactory, cs CumulativeTestC
 		return
 	}
 	maybeRandomlySkip(t)
-	t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
 	ctx := context.Background()
 	var urls atomic.Value
 	var dbForBackup atomic.Pointer[gosql.DB]

--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -648,89 +648,85 @@ func (cs CumulativeTestCaseSpec) run(t *testing.T, fn func(t *testing.T)) bool {
 }
 
 // cumulativeTestForEachPostCommitStage invokes `tf` once for each stage in the
-// PostCommitPhase. These invocation are run in parallel.
+// PostCommitPhase.
 func cumulativeTestForEachPostCommitStage(
 	t *testing.T,
 	relTestCaseDir string,
 	factory TestServerFactory,
 	tf func(t *testing.T, spec CumulativeTestCaseSpec),
 ) {
-	// Grouping the parallel subtests into a non-parallel subtest allows any defer
-	// calls to work as expected.
-	t.Run("group", func(t *testing.T) {
-		testFunc := func(t *testing.T, spec CumulativeTestSpec) {
-			// Skip this test if any of the stmts is not fully supported.
-			if err := areStmtsFullySupportedAtClusterVersion(t, spec, factory); err != nil {
-				skip.IgnoreLint(t, "test is skipped because", err.Error())
-			}
-			var postCommitCount, postCommitNonRevertibleCount int
-			var after [][]string
-			var dbName string
-			prepfn := func(db *gosql.DB, p scplan.Plan) {
-				for _, s := range p.Stages {
-					switch s.Phase {
-					case scop.PostCommitPhase:
-						postCommitCount++
-					case scop.PostCommitNonRevertiblePhase:
-						postCommitNonRevertibleCount++
-					}
+	testFunc := func(t *testing.T, spec CumulativeTestSpec) {
+		// Skip this test if any of the stmts is not fully supported.
+		if err := areStmtsFullySupportedAtClusterVersion(t, spec, factory); err != nil {
+			skip.IgnoreLint(t, "test is skipped because", err.Error())
+		}
+		var postCommitCount, postCommitNonRevertibleCount int
+		var after [][]string
+		var dbName string
+		prepfn := func(db *gosql.DB, p scplan.Plan) {
+			for _, s := range p.Stages {
+				switch s.Phase {
+				case scop.PostCommitPhase:
+					postCommitCount++
+				case scop.PostCommitNonRevertiblePhase:
+					postCommitNonRevertibleCount++
 				}
-				tdb := sqlutils.MakeSQLRunner(db)
-				var ok bool
-				dbName, ok = maybeGetDatabaseForIDs(t, tdb, screl.AllTargetStateDescIDs(p.TargetState))
-				if ok {
-					tdb.Exec(t, fmt.Sprintf("USE %q", dbName))
+			}
+			tdb := sqlutils.MakeSQLRunner(db)
+			var ok bool
+			dbName, ok = maybeGetDatabaseForIDs(t, tdb, screl.AllTargetStateDescIDs(p.TargetState))
+			if ok {
+				tdb.Exec(t, fmt.Sprintf("USE %q", dbName))
+			}
+			after = tdb.QueryStr(t, fetchDescriptorStateQuery)
+		}
+		withPostCommitPlanAfterSchemaChange(t, spec, factory, prepfn)
+		if postCommitCount+postCommitNonRevertibleCount == 0 {
+			skip.IgnoreLint(t, "test case has no post-commit stages")
+			return
+		}
+		if dbName == "" {
+			skip.IgnoreLint(t, "test case has no usable database")
+			return
+		}
+		var testCases []CumulativeTestCaseSpec
+		for stageOrdinal := 1; stageOrdinal <= postCommitCount; stageOrdinal++ {
+			testCases = append(testCases, CumulativeTestCaseSpec{
+				CumulativeTestSpec: spec,
+				Phase:              scop.PostCommitPhase,
+				StageOrdinal:       stageOrdinal,
+				StagesCount:        postCommitCount,
+				After:              after,
+				DatabaseName:       dbName,
+			})
+		}
+		for stageOrdinal := 1; stageOrdinal <= postCommitNonRevertibleCount; stageOrdinal++ {
+			testCases = append(testCases, CumulativeTestCaseSpec{
+				CumulativeTestSpec: spec,
+				Phase:              scop.PostCommitNonRevertiblePhase,
+				StageOrdinal:       stageOrdinal,
+				StagesCount:        postCommitNonRevertibleCount,
+				After:              after,
+				DatabaseName:       dbName,
+			})
+		}
+		var hasFailed bool
+		for _, tc := range testCases {
+			tc := tc // capture loop variable
+			fn := func(t *testing.T) {
+				tf(t, tc)
+			}
+			if hasFailed {
+				fn = func(t *testing.T) {
+					skip.IgnoreLint(t, "skipping test cases subsequent to earlier failure")
 				}
-				after = tdb.QueryStr(t, fetchDescriptorStateQuery)
 			}
-			withPostCommitPlanAfterSchemaChange(t, spec, factory, prepfn)
-			if postCommitCount+postCommitNonRevertibleCount == 0 {
-				skip.IgnoreLint(t, "test case has no post-commit stages")
-				return
-			}
-			if dbName == "" {
-				skip.IgnoreLint(t, "test case has no usable database")
-				return
-			}
-			var testCases []CumulativeTestCaseSpec
-			for stageOrdinal := 1; stageOrdinal <= postCommitCount; stageOrdinal++ {
-				testCases = append(testCases, CumulativeTestCaseSpec{
-					CumulativeTestSpec: spec,
-					Phase:              scop.PostCommitPhase,
-					StageOrdinal:       stageOrdinal,
-					StagesCount:        postCommitCount,
-					After:              after,
-					DatabaseName:       dbName,
-				})
-			}
-			for stageOrdinal := 1; stageOrdinal <= postCommitNonRevertibleCount; stageOrdinal++ {
-				testCases = append(testCases, CumulativeTestCaseSpec{
-					CumulativeTestSpec: spec,
-					Phase:              scop.PostCommitNonRevertiblePhase,
-					StageOrdinal:       stageOrdinal,
-					StagesCount:        postCommitNonRevertibleCount,
-					After:              after,
-					DatabaseName:       dbName,
-				})
-			}
-			var hasFailed bool
-			for _, tc := range testCases {
-				tc := tc // capture loop variable
-				fn := func(t *testing.T) {
-					tf(t, tc)
-				}
-				if hasFailed {
-					fn = func(t *testing.T) {
-						skip.IgnoreLint(t, "skipping test cases subsequent to earlier failure")
-					}
-				}
-				if !tc.run(t, fn) {
-					hasFailed = true
-				}
+			if !tc.run(t, fn) {
+				hasFailed = true
 			}
 		}
-		cumulativeTest(t, relTestCaseDir, testFunc)
-	})
+	}
+	cumulativeTest(t, relTestCaseDir, testFunc)
 }
 
 // fetchDescriptorStateQuery returns the CREATE statements for all descriptors


### PR DESCRIPTION
In 943a7fdf5cf18b06eacf75e190384d098f0be9f2 and f397c130b22872a2a8def4aa026ece936269b9ac these tests were made parallel. This makes debugging harder, and now that the tests run in a remote execution environment, the speed benefits seem dubious. Let's make it non-parallel to see if the tests become more stable.

informs https://github.com/cockroachdb/cockroach/issues/116740
informs https://github.com/cockroachdb/cockroach/issues/117103
Release note: None