### PR TITLE
roachprod: revert AdminUIPort back to DefaultAdminUIPort

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -568,6 +568,8 @@ environment variables to the cockroach process.
 			install.EnvOption(nodeEnv),
 			install.NumRacksOption(numRacks),
 		}
+		// TODO(DarrylWong): remove once #117125 is addressed.
+		startOpts.AdminUIPort = 0
 
 		startOpts.Target = install.StartSharedProcessForVirtualCluster
 		if externalProcessNodes != "" {

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -344,13 +344,17 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 	if startOpts.Target == StartRoutingProxy {
 		return fmt.Errorf("start SQL proxy not implemented")
 	}
+
 	// Local clusters do not support specifying ports. An error is returned if we
 	// detect that they were set.
-	if c.IsLocal() && (startOpts.SQLPort != 0 || startOpts.AdminUIPort != 0) {
+	if c.IsLocal() {
 		// We don't need to return an error if the ports are the default values
 		// specified in DefaultStartOps, as these have not been specified explicitly
 		// by the user.
-		if startOpts.SQLPort != config.DefaultSQLPort || startOpts.AdminUIPort != config.DefaultAdminUIPort {
+		if startOpts.SQLPort != 0 && startOpts.SQLPort != config.DefaultSQLPort {
+			return fmt.Errorf("local clusters do not support specifying ports")
+		}
+		if startOpts.AdminUIPort != 0 && startOpts.AdminUIPort != config.DefaultAdminUIPort {
 			return fmt.Errorf("local clusters do not support specifying ports")
 		}
 		startOpts.SQLPort = 0

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -683,7 +683,8 @@ func DefaultStartOpts() install.StartOpts {
 		ScheduleBackupArgs: "",
 		InitTarget:         1,
 		SQLPort:            0,
-		AdminUIPort:        0,
+		// TODO(DarrylWong): revert back to 0 once #117125 is addressed.
+		AdminUIPort: config.DefaultAdminUIPort,
 	}
 }
 


### PR DESCRIPTION
The change #114097 removed default port assumptions for SQLPort and AdminUIPort, and instead finds open ports to assign. However, Prometheus scraping relies on this hardcoded AdminUIPort as it can't discover the port itself.

This change temporarily reverts AdminUIPort back to the hardcoded port.

Release note: none
Epic: none
Informs: #117125