### PR TITLE
multiregionccl: deflake TestMultiRegionDataDriven

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "//pkg/kv/kvbase",
         "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/allocator/allocatorimpl",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/security/securityassets",


### PR DESCRIPTION
The test is checking that leaseholders correctly reflect multiregion configuration. This change makes flakes less likely by reducing the chance that leases get rebalanced during the test.

fixes https://github.com/cockroachdb/cockroach/issues/115898
Release note: None