### PR TITLE
memo: fix cardinality for anti- and semi-joins with empty right side

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -2621,10 +2621,16 @@ func (h *joinPropsHelper) cardinality() props.Cardinality {
 
 	switch h.joinType {
 	case opt.AntiJoinOp, opt.AntiJoinApplyOp:
+		if right.IsZero() {
+			return left
+		}
 		// Anti join cardinality never exceeds left input cardinality, and
 		// allows zero rows.
 		return left.AsLowAs(0)
 	case opt.SemiJoinOp, opt.SemiJoinApplyOp:
+		if right.IsZero() {
+			return props.ZeroCardinality
+		}
 		// Semi join cardinality never exceeds left input cardinality, and
 		// allows zero rows.
 		semiJoinCard := left.AsLowAs(0)

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -915,7 +915,7 @@ expr
 ----
 semi-join-apply
  ├── columns: a:1(int)
- ├── cardinality: [0 - 10]
+ ├── cardinality: [0 - 0]
  ├── fake-rel
  │    ├── columns: a:1(int)
  │    └── cardinality: [0 - 10]
@@ -3052,3 +3052,120 @@ inner-join (hash)
       └── eq [type=bool, outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
            ├── variable: xyz.x:1 [type=int]
            └── variable: foo.x:6 [type=int]
+
+# Regression tests for #116943.
+
+# Semi-joins with right side cardinality of 0 have cardinality of 0.
+norm disable=(EliminateExistsZeroRows,SimplifyZeroCardinalitySemiJoin)
+SELECT * FROM mn WHERE m = 5 AND n::FLOAT IN (SELECT x::FLOAT FROM xysd WHERE false)
+----
+project
+ ├── columns: m:1(int!null) n:2(int)
+ ├── cardinality: [0 - 0]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── prune: (1,2)
+ └── semi-join (hash)
+      ├── columns: m:1(int!null) n:2(int) column12:12(float)
+      ├── cardinality: [0 - 0]
+      ├── immutable
+      ├── key: ()
+      ├── fd: ()-->(1,2,12)
+      ├── prune: (1,2)
+      ├── project
+      │    ├── columns: column12:12(float) m:1(int!null) n:2(int)
+      │    ├── cardinality: [0 - 1]
+      │    ├── immutable
+      │    ├── key: ()
+      │    ├── fd: ()-->(1,2,12)
+      │    ├── prune: (1,2,12)
+      │    ├── select
+      │    │    ├── columns: m:1(int!null) n:2(int)
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1,2)
+      │    │    ├── prune: (2)
+      │    │    ├── scan mn
+      │    │    │    ├── columns: m:1(int!null) n:2(int)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2), (2)~~>(1)
+      │    │    │    ├── prune: (1,2)
+      │    │    │    └── interesting orderings: (+1) (+2,+1)
+      │    │    └── filters
+      │    │         └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+      │    │              ├── variable: m:1 [type=int]
+      │    │              └── const: 5 [type=int]
+      │    └── projections
+      │         └── cast: FLOAT8 [as=column12:12, type=float, outer=(2), immutable]
+      │              └── variable: n:2 [type=int]
+      ├── project
+      │    ├── columns: x:11(float!null)
+      │    ├── cardinality: [0 - 0]
+      │    ├── immutable
+      │    ├── key: ()
+      │    ├── fd: ()-->(11)
+      │    ├── prune: (11)
+      │    ├── values
+      │    │    ├── columns: xysd.x:5(int!null)
+      │    │    ├── cardinality: [0 - 0]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(5)
+      │    │    └── prune: (5)
+      │    └── projections
+      │         └── cast: FLOAT8 [as=x:11, type=float, outer=(5), immutable]
+      │              └── variable: xysd.x:5 [type=int]
+      └── filters
+           └── eq [type=bool, outer=(11,12), constraints=(/11: (/NULL - ]; /12: (/NULL - ]), fd=(11)==(12), (12)==(11)]
+                ├── variable: column12:12 [type=float]
+                └── variable: x:11 [type=float]
+
+# Anti-joins with right side cardinality of 0 have cardinality equal to left side cardinality.
+norm disable=(EliminateExistsZeroRows,EliminateAntiJoin)
+SELECT * FROM mn WHERE m = 5 AND n::FLOAT NOT IN (SELECT x::FLOAT FROM xysd WHERE false)
+----
+anti-join (cross)
+ ├── columns: m:1(int!null) n:2(int)
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── select
+ │    ├── columns: m:1(int!null) n:2(int)
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2)
+ │    ├── prune: (2)
+ │    ├── scan mn
+ │    │    ├── columns: m:1(int!null) n:2(int)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2), (2)~~>(1)
+ │    │    ├── prune: (1,2)
+ │    │    └── interesting orderings: (+1) (+2,+1)
+ │    └── filters
+ │         └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight), fd=()-->(1)]
+ │              ├── variable: m:1 [type=int]
+ │              └── const: 5 [type=int]
+ ├── project
+ │    ├── columns: x:11(float!null)
+ │    ├── cardinality: [0 - 0]
+ │    ├── immutable
+ │    ├── key: ()
+ │    ├── fd: ()-->(11)
+ │    ├── prune: (11)
+ │    ├── values
+ │    │    ├── columns: xysd.x:5(int!null)
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(5)
+ │    │    └── prune: (5)
+ │    └── projections
+ │         └── cast: FLOAT8 [as=x:11, type=float, outer=(5), immutable]
+ │              └── variable: xysd.x:5 [type=int]
+ └── filters
+      └── is-not [type=bool, outer=(2,11), immutable]
+           ├── eq [type=bool]
+           │    ├── variable: x:11 [type=float]
+           │    └── cast: FLOAT8 [type=float]
+           │         └── variable: n:2 [type=int]
+           └── false [type=bool]

--- a/pkg/sql/opt/props/selectivity.go
+++ b/pkg/sql/opt/props/selectivity.go
@@ -17,19 +17,25 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// epsilon is the minimum value Selectivity can hold, since it cannot be 0.
+// epsilon is the minimum selectivity for normal conditions (that is, conditions
+// that are not contradictions).
 const epsilon = 1e-10
 
-// Selectivity is a value is within the range of [epsilon, 1.0] representing
-// the estimated fraction of rows that pass a given condition.
+// Selectivity is a value is within the range of [epsilon, 1.0] representing the
+// estimated fraction of rows that pass a given condition. (Selectivity can be
+// 0.0 for conditions that are always false, i.e. contradictions.)
 type Selectivity struct {
 	selectivity float64
 }
 
-// ZeroSelectivity is used in cases where selectivity is known to be zero.
+// ZeroSelectivity is used in cases where selectivity is known to be zero, i.e.
+// contradictions or other expressions with cardinality zero. Note that zero
+// selectivity will not be propagated through any of the operations below, and
+// must be detected and set as a special case.
 var ZeroSelectivity = Selectivity{0}
 
-// OneSelectivity is used in cases where selectivity is known to be one.
+// OneSelectivity is used in cases where selectivity is known to be one,
+// i.e. tautologies or other expressions that always preserve cardinality.
 var OneSelectivity = Selectivity{1.0}
 
 // MakeSelectivity initializes and validates a float64 to ensure it is in a
@@ -119,5 +125,5 @@ func selectivityInRange(sel float64) float64 {
 }
 
 func (s Selectivity) String() string {
-	return fmt.Sprintf("%f", s.selectivity)
+	return fmt.Sprintf("%v", s.selectivity)
 }

--- a/pkg/sql/opt/props/statistics.go
+++ b/pkg/sql/opt/props/statistics.go
@@ -54,6 +54,9 @@ type Statistics struct {
 	// the row counts can be unpredictable; thus, a row count of 0.001 should be
 	// considered 1000 times better than a row count of 1, even though if this was
 	// a true row count they would be pretty much the same thing.
+	//
+	// For expressions with Cardinality.Max = 0, RowCount will be 0. For
+	// expressions with Cardinality.Max > 0, RowCount will be >= epsilon.
 	RowCount float64
 
 	// ColStats is a collection of statistics that pertain to columns in an
@@ -61,9 +64,18 @@ type Statistics struct {
 	// the statistic is defined.
 	ColStats ColStatsMap
 
-	// Selectivity is a value between 0 and 1 representing the estimated
-	// reduction in number of rows for the top-level operator in this
-	// expression.
+	// Selectivity is a value between 0 and 1 representing the estimated reduction
+	// in number of rows for the top-level operator in this expression, relative
+	// to some input. The input depends on the expression, e.g. for semi joins the
+	// input is the left child, for inner joins the input is the left child times
+	// the right child, for constrained scans the input is a full table scan, etc.
+	//
+	// Selectivity is used to calculate column statistics after the corresponding
+	// expression statistics have been derived.
+	//
+	// For expressions with Cardinality.Max = 0, selectivity will be 0. For
+	// expressions with Cardinality.Max > 0, selectivity will be in the range
+	// [epsilon, 1.0].
 	Selectivity Selectivity
 
 	// AvgColSizes contains the estimated average size of columns that


### PR DESCRIPTION
**memo: fix cardinality for anti- and semi-joins with empty right side**

When the right side of anti- and semi-joins has zero cardinality, we know the cardinality of the join will be exactly the cardinality of the left side, or zero, respectively.

Fixes: #116943

Epic: None

Release note: None

---

**props: change Selectivity.String() and clarify comments**

Change Selectivity.String() to use %v instead of %f to make it easier to distinguish between zero and epsilon. Also add some clarification about zero and epsilon to comments.

Epic: None

Release note: None

---

**props: propagate zero selectivity in ApplySelectivity and UnionWith**

I don't have any evidence that this is currently causing a problem, but neither `props.(*Statistics).ApplySelectivity` nor `props.(*Statistics).UnionWith` were handling zero selectivity correctly. Instead, they were setting Selectivity to epsilon while setting RowCount to zero. This makes me suspicious because both `props.(*ColumnStatistic).ApplySelectivity` and
`props.(*Histogram).ApplySelectivity` specifically handle zero selectivity.

This commit adds cases to both for zero selectivity.

Epic: None

Release note: None