### PR TITLE
concurrency: filter locks with no active waiters when includeContented flag is on

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -1879,16 +1879,10 @@ func (kl *keyLocks) collectLockStateInfo(
 		return nil
 	}
 
-	// Filter out locks without waiting readers/locking requests unless explicitly
+	// Filter out locks without waiting readers/active locking requests unless explicitly
 	// requested.
-	//
-	// TODO(arul): This should consider the active/inactive status of all queued
-	// locking requests. If all waiting requests are inactive (and there are no
-	// waiting readers either), we should consider the lock to be uncontended.
-	// See https://github.com/cockroachdb/cockroach/issues/103894.
 	if !includeUncontended && kl.waitingReaders.Len() == 0 &&
-		(kl.queuedLockingRequests.Len() == 0 ||
-			(kl.queuedLockingRequests.Len() == 1 && !kl.queuedLockingRequests.Front().Value.active)) {
+		!kl.hasActivelyWaitingLockingRequest() {
 		return nil
 	}
 
@@ -4061,6 +4055,15 @@ func (kl *keyLocks) verify(st *cluster.Settings) error {
 	}
 
 	return nil
+}
+
+func (kl *keyLocks) hasActivelyWaitingLockingRequest() bool {
+	for e := kl.lockWaitQueue.queuedLockingRequests.Front(); e != nil; e = e.Next() {
+		if e.Value.active {
+			return true
+		}
+	}
+	return false
 }
 
 // Delete removes the specified lock from the tree.

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -471,7 +471,7 @@ func TestLockTableBasic(t *testing.T) {
 					d.Fatalf(t, "unknown txn %s", txnName)
 				}
 				foundLock := roachpb.MakeLock(txnMeta, roachpb.Key(key), lock.Intent)
-				seq := int(1)
+				seq := 1
 				if d.HasArg("lease-seq") {
 					d.ScanArgs(t, "lease-seq", &seq)
 				}

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
@@ -73,6 +73,16 @@ num=1
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 3
 
+# When uncontented=false one or more active waiters marks the lock as contented.
+query span=a,c
+----
+num locks: 1, bytes returned: 85, resume reason: RESUME_UNKNOWN, resume span: <nil>
+ locks:
+  range_id=3 key="a" holder=<nil> durability=Unreplicated duration=0s
+   waiters:
+    waiting_txn:00000000-0000-0000-0000-000000000002 active_waiter:false strength:Exclusive wait_duration:0s
+    waiting_txn:00000000-0000-0000-0000-000000000003 active_waiter:true strength:Exclusive wait_duration:0s
+
 guard-state r=req2
 ----
 new: state=doneWaiting
@@ -120,6 +130,11 @@ num=1
  lock: "a"
    queued locking requests:
     active: false req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
+
+# When uncontented=false no reader and no active waiter marks the lock as uncontented.
+query span=a,c
+----
+num locks: 0, bytes returned: 0, resume reason: RESUME_UNKNOWN, resume span: <nil>
 
 guard-state r=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
@@ -229,6 +229,14 @@ num=3
     active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
    distinguished req: 5
 
+query span=a,d
+----
+num locks: 1, bytes returned: 77, resume reason: RESUME_UNKNOWN, resume span: <nil>
+ locks:
+  range_id=3 key="c" holder=00000000-0000-0000-0000-000000000001 durability=Unreplicated duration=0s
+   waiters:
+    waiting_txn:00000000-0000-0000-0000-000000000003 active_waiter:true strength:Exclusive wait_duration:0s
+
 # req5 encounters the reservation by req4 at "b" when looking at it for its read access, but ignores
 # it.
 release txn=txn1 span=c


### PR DESCRIPTION
This commit updated the condition on lock table query fitlers uncontented locks by identify uncontented locks as a lock does not have waiting readers nor active waiting request.

Fixes: #108798

Release note: None