### PR TITLE
restore: don't check desc IDs

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1229,7 +1229,6 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 	backupTableID := sqlutils.QueryTableID(t, conn, "data", "public", "bank")
 
 	sqlDB.Exec(t, `CREATE DATABASE restoredb`)
-	restoreDatabaseID := sqlutils.QueryDatabaseID(t, conn, "restoredb")
 
 	// We create a full backup so that, below, we can test that incremental
 	// backups sanitize credentials in "INCREMENTAL FROM" URLs.
@@ -1265,10 +1264,6 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 			`RESTORE TABLE bank FROM '%s', '%s' WITH OPTIONS (into_db = 'restoredb')`,
 			sanitizedFullDir+"redacted", sanitizedIncDir+"redacted",
 		),
-		DescriptorIDs: descpb.IDs{
-			descpb.ID(restoreDatabaseID + 1),
-			descpb.ID(restoreDatabaseID + 2),
-		},
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -159,11 +159,13 @@ func verifySystemJob(
 		runningStatusString = runningStatus.String
 	}
 
-	for _, id := range rawDescriptorIDs {
-		actual.DescriptorIDs = append(actual.DescriptorIDs, descpb.ID(id))
+	if len(expected.DescriptorIDs) > 0 {
+		for _, id := range rawDescriptorIDs {
+			actual.DescriptorIDs = append(actual.DescriptorIDs, descpb.ID(id))
+		}
+		sort.Sort(actual.DescriptorIDs)
+		sort.Sort(expected.DescriptorIDs)
 	}
-	sort.Sort(actual.DescriptorIDs)
-	sort.Sort(expected.DescriptorIDs)
 	expected.Details = nil
 	if e, a := expected, actual; !assert.Equal(logT{t}, e, a) {
 		return errors.Errorf("job %d did not match:\n%s",


### PR DESCRIPTION
If some other upgrade or somehting allocates an ID these are wrong but we don't really care about them so we can just not test them.

Release note: none.
Epic: none.