### PR TITLE
restore: tolerate extra stats in restore tests

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -5860,7 +5860,7 @@ func TestBatchedInsertStats(t *testing.T) {
 			}
 			var count int
 			sqlDB.QueryRow(t, `SELECT	count(*) FROM system.table_statistics`).Scan(&count)
-			require.Equal(t, test.numTableStats, count)
+			require.GreaterOrEqual(t, count, test.numTableStats)
 
 			// Reset the job state, for the next iteration of the test.
 			details := job.Details().(jobspb.RestoreDetails)


### PR DESCRIPTION
When the test is slow enough, sometimes more stats show up via other mechanisms and cause it to flake.

Release note: none.
Epic: none.