### PR TITLE
changefeedccl: skip TestChangefeedDistributionStrategy under deadlock

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist_test.go
@@ -223,6 +223,7 @@ func (rdt *rangeDistributionTester) getPartitions() (partitions []sql.SpanPartit
 			return errors.New("no partitions found")
 		}
 	})
+	rdt.t.Logf("found partitions: %v", partitions)
 	return
 }
 
@@ -330,8 +331,8 @@ func (rdt *rangeDistributionTester) countRangesPerNode(partitions []sql.SpanPart
 				}
 			}
 		}
-
 	}
+	rdt.t.Logf("range counts: %v", counts)
 	return counts
 }
 
@@ -345,10 +346,9 @@ func TestChangefeedDistributionStrategy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// The test is slow.
+	// The test is slow and will time out under deadlock/race/stress.
 	skip.UnderShort(t)
-	skip.UnderStress(t)
-	skip.UnderRace(t)
+	skip.UnderDuress(t)
 
 	noLocality := func(i int) []roachpb.Tier {
 		return make([]roachpb.Tier, 0)


### PR DESCRIPTION
Previously, the test `TestChangefeedDistributionStrategy` would time out or OOM when
run under deadlock. Since this test is large (it creates an 8 node cluster and takes
up to 90s to run in normal conditions), deadlock detection causes the test to take
very long (over 1h) and timeout. This slow down can cause OOMs as well. The test
relies on disabling replication queues to prevent range merging/splitting. This
also disables MVCC gc. If 8 nodes are running in one process for >1h without gc,
OOMing is likely.

For the above reasons, this change disables deadlock. This change also adds some logging
to make debugging failures easier.

Closes: https://github.com/cockroachdb/cockroach/issues/116847
Release note: None
Epic: None