### PR TITLE
sqlproxyccl: add proxy protocol listener

### DIFF
--- a/pkg/ccl/cliccl/flags.go
+++ b/pkg/ccl/cliccl/flags.go
@@ -69,6 +69,7 @@ func init() {
 		cliflagcfg.StringFlag(f, &proxyContext.Denylist, cliflags.DenyList)
 		cliflagcfg.StringFlag(f, &proxyContext.Allowlist, cliflags.AllowList)
 		cliflagcfg.StringFlag(f, &proxyContext.ListenAddr, cliflags.ProxyListenAddr)
+		cliflagcfg.StringFlag(f, &proxyContext.ProxyProtocolListenAddr, cliflags.ProxyProtocolListenAddr)
 		cliflagcfg.StringFlag(f, &proxyContext.ListenCert, cliflags.ListenCert)
 		cliflagcfg.StringFlag(f, &proxyContext.ListenKey, cliflags.ListenKey)
 		cliflagcfg.StringFlag(f, &proxyContext.MetricsAddress, cliflags.ListenMetrics)

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -73,6 +73,10 @@ type ProxyOptions struct {
 	Denylist string
 	// ListenAddr is the listen address for incoming connections.
 	ListenAddr string
+	// ProxyProtocolListenAddr is the optional listen address for incoming
+	// connections for which it will be enforced that the connections have proxy
+	// headers set.
+	ProxyProtocolListenAddr string
 	// ListenCert is the file containing PEM-encoded x509 certificate for listen
 	// address. Set to "*" to auto-generate self-signed cert.
 	ListenCert string
@@ -113,8 +117,10 @@ type ProxyOptions struct {
 	DisableConnectionRebalancing bool
 	// RequireProxyProtocol changes the server's behavior to support the PROXY
 	// protocol (SQL=required, HTTP=best-effort). With this set to true, the
-	// PROXY info from upstream will be trusted on both HTTP and SQL, if the
-	// headers are allowed.
+	// PROXY info from upstream will be trusted on both HTTP and SQL (on the
+	// ListenAddr port), if the headers are allowed. The ProxyProtocolListenAddr
+	// port, if specified, will require the proxy protocol regardless of
+	// RequireProxyProtocol.
 	RequireProxyProtocol bool
 
 	// testingKnobs are knobs used for testing.

--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -47,6 +47,11 @@ wait for the tenant id to be fully written to the file (with a newline character
 		Description: "Listen address for incoming connections.",
 	}
 
+	ProxyProtocolListenAddr = FlagInfo{
+		Name:        "proxy-protocol-listen-addr",
+		Description: "Listen address for incoming connections which require proxy protocol headers.",
+	}
+
 	ThrottleBaseDelay = FlagInfo{
 		Name:        "throttle-base-delay",
 		Description: "Initial value for the exponential backoff used to throttle connection attempts.",
@@ -94,6 +99,9 @@ wait for the tenant id to be fully written to the file (with a newline character
 		Description: "If true, proxy will not attempt to rebalance connections.",
 	}
 
+	// TODO(joel): Remove this flag, and use --listen-addr for a non-proxy
+	// protocol listener, and use --proxy-protocol-listen-addr for a proxy
+	// protocol listener.
 	RequireProxyProtocol = FlagInfo{
 		Name: "require-proxy-protocol",
 		Description: `Requires PROXY protocol on the SQL listener. The HTTP


### PR DESCRIPTION
To support GCP Private Service Connect, we need to have a listener in
SQLProxy which expects packets to contain proxy protocol headers. This
listener will be used for all traffic inbound from PSC. At the same
time, SQLProxy must continue to accept connections through the public
Internet which will not contain proxy protocol headers, and for which
any proxy protocol headers we receive cannot be trusted.

This commit introduces an optional second listener in SQLProxy,
controlled by `--proxy-protocol-listen-addr`, which requires
proxy protocol even as the primary listener doesn't. Private Service
Connect will direct traffic to this second listener.

Resolves #117240

Release note: None