### PR TITLE
opt: update join comments

### DIFF
--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -459,14 +459,12 @@ type JoinFlags uint16
 
 // Each flag indicates if a certain type of join is disallowed.
 const (
-	// DisallowHashJoinStoreLeft corresponds to a hash join where the left side is
-	// stored into the hashtable. Note that execution can override the stored side
-	// if it finds that the other side is smaller (up to a certain size).
+	// DisallowHashJoinStoreLeft corresponds to a hash join where the left side
+	// is stored into the hashtable.
 	DisallowHashJoinStoreLeft JoinFlags = 1 << iota
 
-	// DisallowHashJoinStoreRight corresponds to a hash join where the right side
-	// is stored into the hashtable. Note that execution can override the stored
-	// side if it finds that the other side is smaller (up to a certain size).
+	// DisallowHashJoinStoreRight corresponds to a hash join where the right
+	// side is stored into the hashtable.
 	DisallowHashJoinStoreRight
 
 	// DisallowMergeJoin corresponds to a merge join.


### PR DESCRIPTION
This commit updates some outdated comments in the optimizer regarding
joins. Since 01dc11f68c16db0f40f0e4a29052a6c0e848a821, the execution
engine always builds the hash table from the right side of a hash join.
Comments for some `JoinFlags` have been updated to reflect this. Also,
some TODOs for deciding the right side of a semi and anti hash join have
been removed because they are not necessary.

Epic: None

Release note: None
