### PR TITLE
changefeedccl: reduce job record polling frequency in tests

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -300,6 +300,7 @@ go_test(
         "//pkg/util/protoutil",
         "//pkg/util/randident",
         "//pkg/util/randutil",
+        "//pkg/util/retry",
         "//pkg/util/span",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",


### PR DESCRIPTION
Previously, `TestAlterChangefeedAddTargetsDuringSchemaChangeError` and `TestAlterChangefeedAddTargetsDuringBackfill` would flake due to polling the changefeed job record too often. Polling too often may abort the transactions which are attempting to update the changefeed progress. This can cause the progress to never update, causing the tests to fail. This phenomenon can be seen in https://github.com/cockroachdb/cockroach/issues/115969#issuecomment-1874365250, where the progress is not updated during the test, but is updated immediately after polling stops. This theory also aligns with the transaction retry and job updating semantics: https://github.com/cockroachdb/cockroach/issues/115969#issuecomment-1874429644

This change updates polling to happen no faster than 1 time every 3 seconds.

Closes: https://github.com/cockroachdb/cockroach/issues/115969
Closes: https://github.com/cockroachdb/cockroach/issues/116524
Release note: None
Epic: None