### PR TITLE
pkg/util/log: include buffered httpSinks in iterHTTPSinks

### DIFF
--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -155,6 +155,7 @@ go_test(
         "log_decoder_test.go",
         "main_test.go",
         "redact_test.go",
+        "registry_test.go",
         "secondary_log_test.go",
         "test_log_scope_test.go",
         "trace_client_test.go",

--- a/pkg/util/log/log_flush.go
+++ b/pkg/util/log/log_flush.go
@@ -162,7 +162,7 @@ func StartAlwaysFlush() {
 // RefreshHttpSinkHeaders will iterate over all http sinks and replace the sink's
 // dynamicHeaders with newly generated dynamicHeaders.
 func RefreshHttpSinkHeaders() error {
-	return logging.allSinkInfos.iterHttpSinks(func(hs *httpSink) error {
+	return logging.allSinkInfos.iterHTTPSinks(func(hs *httpSink) error {
 		return hs.RefreshDynamicHeaders()
 	})
 }

--- a/pkg/util/log/registry.go
+++ b/pkg/util/log/registry.go
@@ -104,11 +104,15 @@ func (r *sinkInfoRegistry) iterBufferedSinks(fn func(bs *bufferedSink) error) er
 
 // iterHttpSink iterates over all the http sinks and stops at the first error
 // encountered.
-func (r *sinkInfoRegistry) iterHttpSinks(fn func(hs *httpSink) error) error {
+func (r *sinkInfoRegistry) iterHTTPSinks(fn func(hs *httpSink) error) error {
 	return r.iter(func(si *sinkInfo) error {
 		if hs, ok := si.sink.(*httpSink); ok {
-			if err := fn(hs); err != nil {
-				return err
+			return fn(hs)
+		}
+		// Many times we buffer HTTP sinks, so be sure to check that case as well.
+		if bs, isBuffered := si.sink.(*bufferedSink); isBuffered {
+			if ch, ok := bs.child.(*httpSink); ok {
+				return fn(ch)
 			}
 		}
 		return nil

--- a/pkg/util/log/registry_test.go
+++ b/pkg/util/log/registry_test.go
@@ -1,0 +1,97 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package log
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log/channel"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIterHTTPSinks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	sc := ScopeWithoutShowLogs(t)
+	defer sc.Close(t)
+
+	oneMicro := 1 * time.Microsecond
+	oneByte := logconfig.ByteSize(1)
+	oneThousandBytes := logconfig.ByteSize(1000)
+	bufferedAddr := "buffered.sink.com"
+	unbufferedAddr := "unbuffered.sink.com"
+
+	// Set up a log config containing both buffered and unbuffered HTTP sinks.
+	cfg := logconfig.DefaultConfig()
+	cfg.Sinks.HTTPServers = map[string]*logconfig.HTTPSinkConfig{
+		"unbuffered": {
+			Channels: logconfig.SelectChannels(channel.OPS),
+			HTTPDefaults: logconfig.HTTPDefaults{
+				Address: &unbufferedAddr,
+			},
+		},
+		"buffered": {
+			Channels: logconfig.SelectChannels(channel.OPS),
+			HTTPDefaults: logconfig.HTTPDefaults{
+				Address: &bufferedAddr,
+				CommonSinkConfig: logconfig.CommonSinkConfig{
+					Buffering: logconfig.CommonBufferSinkConfigWrapper{
+						CommonBufferSinkConfig: logconfig.CommonBufferSinkConfig{
+							MaxStaleness:     &oneMicro,
+							MaxBufferSize:    &oneThousandBytes,
+							FlushTriggerSize: &oneByte,
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg.Sinks.FluentServers = map[string]*logconfig.FluentSinkConfig{
+		"excluded": {
+			Channels: logconfig.SelectChannels(channel.OPS),
+			Address:  "some-addr.com",
+		},
+	}
+	require.NoError(t, cfg.Validate(&sc.logDir))
+
+	// Apply the configuration
+	TestingResetActive()
+	cleanup, err := ApplyConfig(cfg)
+	require.NoError(t, err)
+	defer cleanup()
+
+	// Verify both sinks are selected when iterating. Also, make sure that
+	// we don't have any extra calls for non-http sinks (e.g. the fluent
+	// server we added earlier).
+	callCount := 0
+	expCallCount := 2
+	calls := map[string]bool{
+		bufferedAddr:   false,
+		unbufferedAddr: false,
+	}
+	fn := func(hs *httpSink) error {
+		callCount++
+		if called, ok := calls[*hs.config.Address]; ok {
+			if called {
+				t.Errorf("httpSink %q unexpectedly called twice", *hs.config.Address)
+			}
+			calls[*hs.config.Address] = true
+		}
+		return nil
+	}
+	require.NoError(t, logging.allSinkInfos.iterHTTPSinks(fn))
+	for k, v := range calls {
+		require.Truef(t, v, "httpSink %q was never called during iteration", k)
+	}
+	require.Equal(t, expCallCount, callCount)
+}


### PR DESCRIPTION
Previously, `iterHTTPSinks` did not include buffered httpSinks in its iteration. This meant that functionality related to reloading request header values from files (added in
https://github.com/cockroachdb/cockroach/pull/111235#issue-1912269909), was not triggered properly for any httpSink that used buffering.

Buffering should be the **default** behavior for httpSinks, and therefore we should be sure to account for buffered httpSinks when looking for them in the sink registry.

This patch updates the iteration code accordingly, and adds a test to verify that both are included.

Release note: none

Epic: CRDB-25399