### PR TITLE
release-23.1: multiregionccl: deflake TestMultiRegionDataDriven

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "//pkg/kv/kvbase",
         "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/allocator/allocatorimpl",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/security/securityassets",

--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -22,7 +22,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocatorimpl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -161,6 +163,12 @@ func TestMultiRegionDataDriven(t *testing.T) {
 							{Key: "zone", Value: localityName + "a"},
 						},
 					}
+					st := cluster.MakeClusterSettings()
+					// Prevent rebalancing from happening automatically (i.e., make it
+					// exceedingly unlikely).
+					// TODO(rafi): use more explicit cluster setting once it's available;
+					// see https://github.com/cockroachdb/cockroach/issues/110740.
+					allocatorimpl.LeaseRebalanceThreshold.Override(ctx, &st.SV, 10.0)
 					serverArgs[i] = base.TestServerArgs{
 						Locality: localityCfg,
 						// We need to disable the default test tenant here
@@ -169,6 +177,7 @@ func TestMultiRegionDataDriven(t *testing.T) {
 						// when called from the system tenant. More
 						// investigation is required (tracked with #76378).
 						DisableDefaultTestTenant: true,
+						Settings:                 st,
 						Knobs: base.TestingKnobs{
 							SQLExecutor: &sql.ExecutorTestingKnobs{
 								WithStatementTrace: func(trace tracingpb.Recording, stmt string) {


### PR DESCRIPTION
Backport 1/1 commits from #117145.

/cc @cockroachdb/release

Release justification: test only change

---

The test is checking that leaseholders correctly reflect multiregion configuration. This change makes flakes less likely by reducing the chance that leases get rebalanced during the test.

fixes https://github.com/cockroachdb/cockroach/issues/115898
Release note: None
