### PR TITLE
test: fix index usage TenantAPI tests

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -45,6 +45,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// This value is arbitrary and needs to be enough in case of slow tests.
+const LastReadThresholdSeconds = 30
+
 func TestTenantStatusAPI(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := log.ScopeWithoutShowLogs(t)
@@ -713,17 +716,29 @@ SELECT
   table_id,
   index_id,
   total_reads,
-  extract_duration('second', now() - last_read) < 5
+  extract_duration('second', now() - last_read)
 FROM
   crdb_internal.index_usage_statistics
 WHERE
   table_id = ` + testTableIDStr
 				// Assert index usage data was inserted.
-				expected := [][]string{
-					{testTableIDStr, "1", "2", "true"}, // Primary index
-					{testTableIDStr, "2", "1", "true"},
+				expected := []struct {
+					tableID    string
+					indexID    string
+					totalReads string
+				}{
+					{tableID: testTableIDStr, indexID: "1", totalReads: "2"},
+					{tableID: testTableIDStr, indexID: "2", totalReads: "1"},
 				}
-				cluster.TenantConn(serverccl.RandomServer).CheckQueryResults(t, query, expected)
+				rows := cluster.TenantConn(serverccl.RandomServer).QueryStr(t, query)
+				for idx, e := range expected {
+					require.Equal(t, e.tableID, rows[idx][0])
+					require.Equal(t, e.indexID, rows[idx][1])
+					require.Equal(t, e.totalReads, rows[idx][2])
+					lastReadDurationSec, err := strconv.Atoi(rows[idx][3])
+					require.NoError(t, err)
+					require.LessOrEqualf(t, lastReadDurationSec, LastReadThresholdSeconds, "Last Read was %ss ago, expected less than 30s", lastReadDurationSec)
+				}
 			}
 
 			// Reset index usage stats.
@@ -1047,25 +1062,33 @@ SELECT
   table_id,
   index_id,
   total_reads,
-  extract_duration('second', now() - last_read) < 5
+  extract_duration('second', now() - last_read)
 FROM
   crdb_internal.index_usage_statistics
 WHERE
   table_id = $1
 `
-	actual := testingCluster.TenantConn(2).QueryStr(t, query, testTableID)
-	expected := [][]string{
-		{testTableIDStr, "1", "2", "true"},
-		{testTableIDStr, "2", "1", "true"},
+	expected := []struct {
+		tableID    string
+		indexID    string
+		totalReads string
+	}{
+		{tableID: testTableIDStr, indexID: "1", totalReads: "2"},
+		{tableID: testTableIDStr, indexID: "2", totalReads: "1"},
+	}
+	rows := testingCluster.TenantConn(2).QueryStr(t, query, testTableID)
+	for idx, e := range expected {
+		require.Equal(t, e.tableID, rows[idx][0])
+		require.Equal(t, e.indexID, rows[idx][1])
+		require.Equal(t, e.totalReads, rows[idx][2])
+		lastReadDurationSec, err := strconv.Atoi(rows[idx][3])
+		require.NoError(t, err)
+		require.LessOrEqualf(t, lastReadDurationSec, LastReadThresholdSeconds, "Last Read was %ss ago, expected less than 30s", lastReadDurationSec)
 	}
 
-	require.Equal(t, expected, actual)
-
 	// Ensure tenant data isolation.
-	actual = controlledCluster.TenantConn(0).QueryStr(t, query, testTableID)
-	expected = [][]string{}
-
-	require.Equal(t, expected, actual)
+	actual := controlledCluster.TenantConn(0).QueryStr(t, query, testTableID)
+	require.Equal(t, [][]string{}, actual)
 }
 
 func selectClusterSessionIDs(t *testing.T, conn *sqlutils.SQLRunner) []string {


### PR DESCRIPTION
Previously, the test was using 5 seconds to check the last time an index was read. But sometimes it could cause for this value to be larger than that.
This commit updates to 30s and also adds some changes on the test so if happens to fail again, we know what value is (instead of return just true/false like it was prior to this commit).

Fixes #117111

Release note: None