### PR TITLE
release-23.1: tenantcostclient: add client consumption metrics

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/metrics.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/metrics.go
@@ -8,7 +8,10 @@
 
 package tenantcostclient
 
-import "github.com/cockroachdb/cockroach/pkg/util/metric"
+import (
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+)
 
 var (
 	metaCurrentBlocked = metric.Metadata{
@@ -17,14 +20,143 @@ var (
 		Measurement: "Requests",
 		Unit:        metric.Unit_COUNT,
 	}
+
+	// SQL usage related metrics.
+	metaTotalRU = metric.Metadata{
+		Name:        "tenant.sql_usage.request_units",
+		Help:        "RU consumption",
+		Measurement: "Request Units",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalKVRU = metric.Metadata{
+		Name:        "tenant.sql_usage.kv_request_units",
+		Help:        "RU consumption attributable to KV",
+		Measurement: "Request Units",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalReadBatches = metric.Metadata{
+		Name:        "tenant.sql_usage.read_batches",
+		Help:        "Total number of KV read batches",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalReadRequests = metric.Metadata{
+		Name:        "tenant.sql_usage.read_requests",
+		Help:        "Total number of KV read requests",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalReadBytes = metric.Metadata{
+		Name:        "tenant.sql_usage.read_bytes",
+		Help:        "Total number of bytes read from KV",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalWriteBatches = metric.Metadata{
+		Name:        "tenant.sql_usage.write_batches",
+		Help:        "Total number of KV write batches",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalWriteRequests = metric.Metadata{
+		Name:        "tenant.sql_usage.write_requests",
+		Help:        "Total number of KV write requests",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalWriteBytes = metric.Metadata{
+		Name:        "tenant.sql_usage.write_bytes",
+		Help:        "Total number of bytes written to KV",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalSQLPodsCPUSeconds = metric.Metadata{
+		Name:        "tenant.sql_usage.sql_pods_cpu_seconds",
+		Help:        "Total amount of CPU used by SQL pods",
+		Measurement: "CPU Seconds",
+		Unit:        metric.Unit_SECONDS,
+	}
+	metaTotalPGWireEgressBytes = metric.Metadata{
+		Name:        "tenant.sql_usage.pgwire_egress_bytes",
+		Help:        "Total number of bytes transferred from a SQL pod to the client",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalExternalIOIngressBytes = metric.Metadata{
+		Name:        "tenant.sql_usage.external_io_ingress_bytes",
+		Help:        "Total number of bytes read from external services such as cloud storage providers",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalExternalIOEgressBytes = metric.Metadata{
+		Name:        "tenant.sql_usage.external_io_egress_bytes",
+		Help:        "Total number of bytes written to external services such as cloud storage providers",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaTotalCrossRegionNetworkRU = metric.Metadata{
+		Name:        "tenant.sql_usage.cross_region_network_ru",
+		Help:        "Total number of RUs charged for cross-region network traffic",
+		Measurement: "Request Units",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 // metrics manage the metrics used by the tenant cost client.
 type metrics struct {
-	CurrentBlocked *metric.Gauge
+	CurrentBlocked              *metric.Gauge
+	TotalRU                     *metric.CounterFloat64
+	TotalKVRU                   *metric.CounterFloat64
+	TotalReadBatches            *metric.Counter
+	TotalReadRequests           *metric.Counter
+	TotalReadBytes              *metric.Counter
+	TotalWriteBatches           *metric.Counter
+	TotalWriteRequests          *metric.Counter
+	TotalWriteBytes             *metric.Counter
+	TotalSQLPodsCPUSeconds      *metric.CounterFloat64
+	TotalPGWireEgressBytes      *metric.Counter
+	TotalExternalIOEgressBytes  *metric.Counter
+	TotalExternalIOIngressBytes *metric.Counter
+	TotalCrossRegionNetworkRU   *metric.CounterFloat64
 }
+
+var _ metric.Struct = (*metrics)(nil)
+
+// MetricStruct indicates that Metrics is a metric.Struct.
+func (m *metrics) MetricStruct() {}
 
 // Init initializes the tenant cost client metrics.
 func (m *metrics) Init() {
 	m.CurrentBlocked = metric.NewGauge(metaCurrentBlocked)
+	m.TotalRU = metric.NewCounterFloat64(metaTotalRU)
+	m.TotalKVRU = metric.NewCounterFloat64(metaTotalKVRU)
+	m.TotalReadBatches = metric.NewCounter(metaTotalReadBatches)
+	m.TotalReadRequests = metric.NewCounter(metaTotalReadRequests)
+	m.TotalReadBytes = metric.NewCounter(metaTotalReadBytes)
+	m.TotalWriteBatches = metric.NewCounter(metaTotalWriteBatches)
+	m.TotalWriteRequests = metric.NewCounter(metaTotalWriteRequests)
+	m.TotalWriteBytes = metric.NewCounter(metaTotalWriteBytes)
+	m.TotalSQLPodsCPUSeconds = metric.NewCounterFloat64(metaTotalSQLPodsCPUSeconds)
+	m.TotalPGWireEgressBytes = metric.NewCounter(metaTotalPGWireEgressBytes)
+	m.TotalExternalIOEgressBytes = metric.NewCounter(metaTotalExternalIOEgressBytes)
+	m.TotalExternalIOIngressBytes = metric.NewCounter(metaTotalExternalIOIngressBytes)
+	m.TotalCrossRegionNetworkRU = metric.NewCounterFloat64(metaTotalCrossRegionNetworkRU)
+}
+
+// incrementConsumption updates consumption-related metrics with the delta
+// consumption.
+func (m *metrics) incrementConsumption(delta kvpb.TenantConsumption) {
+	m.TotalRU.Inc(delta.RU)
+	m.TotalKVRU.Inc(delta.KVRU)
+	m.TotalReadBatches.Inc(int64(delta.ReadBatches))
+	m.TotalReadRequests.Inc(int64(delta.ReadRequests))
+	m.TotalReadBytes.Inc(int64(delta.ReadBytes))
+	m.TotalWriteBatches.Inc(int64(delta.WriteBatches))
+	m.TotalWriteRequests.Inc(int64(delta.WriteRequests))
+	m.TotalWriteBytes.Inc(int64(delta.WriteBytes))
+	m.TotalSQLPodsCPUSeconds.Inc(delta.SQLPodsCPUSeconds)
+	m.TotalPGWireEgressBytes.Inc(int64(delta.PGWireEgressBytes))
+	m.TotalExternalIOEgressBytes.Inc(int64(delta.ExternalIOEgressBytes))
+	m.TotalExternalIOIngressBytes.Inc(int64(delta.ExternalIOIngressBytes))
+	m.TotalCrossRegionNetworkRU.Inc(delta.CrossRegionNetworkRU)
 }

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -342,6 +343,9 @@ type tenantSideCostController struct {
 		// lastReportedConsumption is the set of tenant resource consumption
 		// metrics last sent to the token bucket server.
 		lastReportedConsumption kvpb.TenantConsumption
+		// lastExportedConsumption is the set of tenant resource consumption
+		// metrics last sent to the metrics registry.
+		lastExportedConsumption kvpb.TenantConsumption
 		// lastRate is the token bucket fill rate that was last configured.
 		lastRate float64
 
@@ -486,6 +490,13 @@ func (c *tenantSideCostController) onTick(ctx context.Context, newTime time.Time
 		})
 		c.run.fallbackRateStart = time.Time{}
 	}
+
+	// Report consumption metrics. Update local data first before sending a
+	// token bucket request to the KV servers.
+	deltaConsumption := c.run.consumption
+	deltaConsumption.Sub(&c.run.lastExportedConsumption)
+	c.run.lastExportedConsumption = c.run.consumption
+	c.metrics.incrementConsumption(deltaConsumption)
 
 	// Should a token bucket request be sent? It might be for a retry or for
 	// periodic consumption reporting.
@@ -908,4 +919,9 @@ func (c *tenantSideCostController) GetCPUMovingAvg() float64 {
 // GetCostConfig is part of the multitenant.TenantSideCostController interface.
 func (c *tenantSideCostController) GetCostConfig() *tenantcostmodel.Config {
 	return c.costCfg.Load()
+}
+
+// Metrics returns a metric.Struct which holds metrics for the controller.
+func (c *tenantSideCostController) Metrics() metric.Struct {
+	return &c.metrics
 }

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -56,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -274,6 +276,7 @@ var testStateCommands = map[string]func(
 	"enable-external-ru-accounting":  (*testState).enableRUAccounting,
 	"disable-external-ru-accounting": (*testState).disableRUAccounting,
 	"usage":                          (*testState).usage,
+	"metrics":                        (*testState).metrics,
 	"configure":                      (*testState).configure,
 	"token-bucket":                   (*testState).tokenBucket,
 	"unblock-request":                (*testState).unblockRequest,
@@ -581,6 +584,51 @@ func (ts *testState) usage(*testing.T, *datadriven.TestData, cmdArgs) string {
 		c.ExternalIOEgressBytes,
 		c.ExternalIOIngressBytes,
 	)
+}
+
+// metrics prints out cost client related consumption metrics. Callers are
+// responsible for waiting on tick events since that is when metrics will be
+// updated.
+func (ts *testState) metrics(*testing.T, *datadriven.TestData, cmdArgs) string {
+	metricNames := []string{
+		"tenant.sql_usage.request_units",
+		"tenant.sql_usage.kv_request_units",
+		"tenant.sql_usage.read_batches",
+		"tenant.sql_usage.read_requests",
+		"tenant.sql_usage.read_bytes",
+		"tenant.sql_usage.write_batches",
+		"tenant.sql_usage.write_requests",
+		"tenant.sql_usage.write_bytes",
+		"tenant.sql_usage.sql_pods_cpu_seconds",
+		"tenant.sql_usage.pgwire_egress_bytes",
+		"tenant.sql_usage.external_io_ingress_bytes",
+		"tenant.sql_usage.external_io_egress_bytes",
+		"tenant.sql_usage.cross_region_network_ru",
+	}
+	state := make(map[string]interface{})
+	v := reflect.ValueOf(ts.controller.Metrics()).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		switch typ := v.Field(i).Interface().(type) {
+		case metric.Iterable:
+			typ.Inspect(func(v interface{}) {
+				switch it := v.(type) {
+				case *metric.Counter:
+					state[typ.GetName()] = it.Count()
+				case *metric.CounterFloat64:
+					state[typ.GetName()] = fmt.Sprintf("%.2f", it.Count())
+				}
+			})
+		}
+	}
+	var output string
+	for _, name := range metricNames {
+		v, ok := state[name]
+		if !ok {
+			panic(fmt.Sprintf("missing data for metric %q", name))
+		}
+		output += fmt.Sprintf("%s: %v\n", name, v)
+	}
+	return output
 }
 
 type event struct {

--- a/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
+++ b/pkg/ccl/multitenantccl/tenantcostclient/testdata/consumption
@@ -1,8 +1,36 @@
 # Test that the controller reports consumption as expected.
 
-# With no usage, consumption gets reported only every 40s.
+# With no usage, consumption metrics should still get reported. Tick occurs
+# once every 10s.
 advance
-40s
+10s
+----
+00:00:10.000
+
+wait-for-event
+tick
+----
+
+metrics
+----
+tenant.sql_usage.request_units: 0.00
+tenant.sql_usage.kv_request_units: 0.00
+tenant.sql_usage.read_batches: 0
+tenant.sql_usage.read_requests: 0
+tenant.sql_usage.read_bytes: 0
+tenant.sql_usage.write_batches: 0
+tenant.sql_usage.write_requests: 0
+tenant.sql_usage.write_bytes: 0
+tenant.sql_usage.sql_pods_cpu_seconds: 0.00
+tenant.sql_usage.pgwire_egress_bytes: 0
+tenant.sql_usage.external_io_ingress_bytes: 0
+tenant.sql_usage.external_io_egress_bytes: 0
+tenant.sql_usage.cross_region_network_ru: 0.00
+
+# With no usage, consumption gets reported only every 40s. Advance by 30s here
+# since we're at the 10s mark.
+advance
+30s
 ----
 00:00:40.000
 
@@ -31,6 +59,27 @@ advance
 10s
 ----
 00:00:50.000
+
+# Metrics should already be updated, even if it's a small read.
+wait-for-event
+tick
+----
+
+metrics
+----
+tenant.sql_usage.request_units: 16.62
+tenant.sql_usage.kv_request_units: 16.62
+tenant.sql_usage.read_batches: 1
+tenant.sql_usage.read_requests: 1
+tenant.sql_usage.read_bytes: 1048576
+tenant.sql_usage.write_batches: 0
+tenant.sql_usage.write_requests: 0
+tenant.sql_usage.write_bytes: 0
+tenant.sql_usage.sql_pods_cpu_seconds: 0.00
+tenant.sql_usage.pgwire_egress_bytes: 0
+tenant.sql_usage.external_io_ingress_bytes: 0
+tenant.sql_usage.external_io_egress_bytes: 0
+tenant.sql_usage.cross_region_network_ru: 0.00
 
 usage
 ----
@@ -65,6 +114,23 @@ PGWire egress:  0 bytes
 ExternalIO egress: 0 bytes
 ExternalIO ingress: 0 bytes
 
+# Metrics remain after we report consumption since there's no diff.
+metrics
+----
+tenant.sql_usage.request_units: 16.62
+tenant.sql_usage.kv_request_units: 16.62
+tenant.sql_usage.read_batches: 1
+tenant.sql_usage.read_requests: 1
+tenant.sql_usage.read_bytes: 1048576
+tenant.sql_usage.write_batches: 0
+tenant.sql_usage.write_requests: 0
+tenant.sql_usage.write_bytes: 0
+tenant.sql_usage.sql_pods_cpu_seconds: 0.00
+tenant.sql_usage.pgwire_egress_bytes: 0
+tenant.sql_usage.external_io_ingress_bytes: 0
+tenant.sql_usage.external_io_egress_bytes: 0
+tenant.sql_usage.cross_region_network_ru: 0.00
+
 # Test write operation consumption.
 write bytes=1024
 ----
@@ -89,6 +155,23 @@ SQL Pods CPU seconds:  0.00
 PGWire egress:  0 bytes
 ExternalIO egress: 0 bytes
 ExternalIO ingress: 0 bytes
+
+# Metrics now include write operation consumption.
+metrics
+----
+tenant.sql_usage.request_units: 19.62
+tenant.sql_usage.kv_request_units: 19.62
+tenant.sql_usage.read_batches: 1
+tenant.sql_usage.read_requests: 1
+tenant.sql_usage.read_bytes: 1048576
+tenant.sql_usage.write_batches: 1
+tenant.sql_usage.write_requests: 1
+tenant.sql_usage.write_bytes: 1024
+tenant.sql_usage.sql_pods_cpu_seconds: 0.00
+tenant.sql_usage.pgwire_egress_bytes: 0
+tenant.sql_usage.external_io_ingress_bytes: 0
+tenant.sql_usage.external_io_egress_bytes: 0
+tenant.sql_usage.cross_region_network_ru: 0.00
 
 # Test CPU consumption.
 advance wait=true
@@ -124,6 +207,23 @@ PGWire egress:  0 bytes
 ExternalIO egress: 0 bytes
 ExternalIO ingress: 0 bytes
 
+# Metrics with CPU usage.
+metrics
+----
+tenant.sql_usage.request_units: 319.62
+tenant.sql_usage.kv_request_units: 19.62
+tenant.sql_usage.read_batches: 1
+tenant.sql_usage.read_requests: 1
+tenant.sql_usage.read_bytes: 1048576
+tenant.sql_usage.write_batches: 1
+tenant.sql_usage.write_requests: 1
+tenant.sql_usage.write_bytes: 1024
+tenant.sql_usage.sql_pods_cpu_seconds: 0.90
+tenant.sql_usage.pgwire_egress_bytes: 0
+tenant.sql_usage.external_io_ingress_bytes: 0
+tenant.sql_usage.external_io_egress_bytes: 0
+tenant.sql_usage.cross_region_network_ru: 0.00
+
 # Test multiple operations together.
 write bytes=4096
 ----
@@ -135,7 +235,32 @@ write bytes=4096
 ----
 
 advance
-40s
+10s
+----
+00:02:50.000
+
+wait-for-event
+tick
+----
+
+metrics
+----
+tenant.sql_usage.request_units: 333.25
+tenant.sql_usage.kv_request_units: 33.25
+tenant.sql_usage.read_batches: 2
+tenant.sql_usage.read_requests: 2
+tenant.sql_usage.read_bytes: 1114112
+tenant.sql_usage.write_batches: 3
+tenant.sql_usage.write_requests: 3
+tenant.sql_usage.write_bytes: 9216
+tenant.sql_usage.sql_pods_cpu_seconds: 0.90
+tenant.sql_usage.pgwire_egress_bytes: 0
+tenant.sql_usage.external_io_ingress_bytes: 0
+tenant.sql_usage.external_io_egress_bytes: 0
+tenant.sql_usage.cross_region_network_ru: 0.00
+
+advance
+30s
 ----
 00:03:20.000
 
@@ -154,6 +279,22 @@ SQL Pods CPU seconds:  0.90
 PGWire egress:  0 bytes
 ExternalIO egress: 0 bytes
 ExternalIO ingress: 0 bytes
+
+metrics
+----
+tenant.sql_usage.request_units: 333.25
+tenant.sql_usage.kv_request_units: 33.25
+tenant.sql_usage.read_batches: 2
+tenant.sql_usage.read_requests: 2
+tenant.sql_usage.read_bytes: 1114112
+tenant.sql_usage.write_batches: 3
+tenant.sql_usage.write_requests: 3
+tenant.sql_usage.write_bytes: 9216
+tenant.sql_usage.sql_pods_cpu_seconds: 0.90
+tenant.sql_usage.pgwire_egress_bytes: 0
+tenant.sql_usage.external_io_ingress_bytes: 0
+tenant.sql_usage.external_io_egress_bytes: 0
+tenant.sql_usage.cross_region_network_ru: 0.00
 
 # Test larger amount of CPU usage that exceeds 100 RUs. The consumption report
 # should be sent after only 10s. In addition, the CPU usage should only be
@@ -183,6 +324,22 @@ PGWire egress:  0 bytes
 ExternalIO egress: 0 bytes
 ExternalIO ingress: 0 bytes
 
+metrics
+----
+tenant.sql_usage.request_units: 1299.92
+tenant.sql_usage.kv_request_units: 33.25
+tenant.sql_usage.read_batches: 2
+tenant.sql_usage.read_requests: 2
+tenant.sql_usage.read_bytes: 1114112
+tenant.sql_usage.write_batches: 3
+tenant.sql_usage.write_requests: 3
+tenant.sql_usage.write_bytes: 9216
+tenant.sql_usage.sql_pods_cpu_seconds: 3.80
+tenant.sql_usage.pgwire_egress_bytes: 0
+tenant.sql_usage.external_io_ingress_bytes: 0
+tenant.sql_usage.external_io_egress_bytes: 0
+tenant.sql_usage.cross_region_network_ru: 0.00
+
 # Test egress.
 pgwire-egress
 12345
@@ -208,6 +365,22 @@ SQL Pods CPU seconds:  3.80
 PGWire egress:  12345 bytes
 ExternalIO egress: 0 bytes
 ExternalIO ingress: 0 bytes
+
+metrics
+----
+tenant.sql_usage.request_units: 1311.97
+tenant.sql_usage.kv_request_units: 33.25
+tenant.sql_usage.read_batches: 2
+tenant.sql_usage.read_requests: 2
+tenant.sql_usage.read_bytes: 1114112
+tenant.sql_usage.write_batches: 3
+tenant.sql_usage.write_requests: 3
+tenant.sql_usage.write_bytes: 9216
+tenant.sql_usage.sql_pods_cpu_seconds: 3.80
+tenant.sql_usage.pgwire_egress_bytes: 12345
+tenant.sql_usage.external_io_ingress_bytes: 0
+tenant.sql_usage.external_io_egress_bytes: 0
+tenant.sql_usage.cross_region_network_ru: 0.00
 
 # Test multiple requests in the same batch.
 write count=2 bytes=1024
@@ -236,6 +409,22 @@ SQL Pods CPU seconds:  3.80
 PGWire egress:  12345 bytes
 ExternalIO egress: 0 bytes
 ExternalIO ingress: 0 bytes
+
+metrics
+----
+tenant.sql_usage.request_units: 1317.72
+tenant.sql_usage.kv_request_units: 39.00
+tenant.sql_usage.read_batches: 3
+tenant.sql_usage.read_requests: 4
+tenant.sql_usage.read_bytes: 1179648
+tenant.sql_usage.write_batches: 4
+tenant.sql_usage.write_requests: 5
+tenant.sql_usage.write_bytes: 10240
+tenant.sql_usage.sql_pods_cpu_seconds: 3.80
+tenant.sql_usage.pgwire_egress_bytes: 12345
+tenant.sql_usage.external_io_ingress_bytes: 0
+tenant.sql_usage.external_io_egress_bytes: 0
+tenant.sql_usage.cross_region_network_ru: 0.00
 
 # Test a small amount of CPU usage in a tick that has no read/write operations.
 # Anything under 30ms (3% of one CPU) should be ignored.
@@ -276,6 +465,22 @@ PGWire egress:  12345 bytes
 ExternalIO egress: 0 bytes
 ExternalIO ingress: 0 bytes
 
+metrics
+----
+tenant.sql_usage.request_units: 1317.72
+tenant.sql_usage.kv_request_units: 39.00
+tenant.sql_usage.read_batches: 3
+tenant.sql_usage.read_requests: 4
+tenant.sql_usage.read_bytes: 1179648
+tenant.sql_usage.write_batches: 4
+tenant.sql_usage.write_requests: 5
+tenant.sql_usage.write_bytes: 10240
+tenant.sql_usage.sql_pods_cpu_seconds: 3.80
+tenant.sql_usage.pgwire_egress_bytes: 12345
+tenant.sql_usage.external_io_ingress_bytes: 0
+tenant.sql_usage.external_io_egress_bytes: 0
+tenant.sql_usage.cross_region_network_ru: 0.00
+
 # Now ensure that 30ms meets the threshold and is reported.
 cpu
 30ms
@@ -307,6 +512,22 @@ SQL Pods CPU seconds:  3.82
 PGWire egress:  12345 bytes
 ExternalIO egress: 0 bytes
 ExternalIO ingress: 0 bytes
+
+metrics
+----
+tenant.sql_usage.request_units: 1324.39
+tenant.sql_usage.kv_request_units: 39.00
+tenant.sql_usage.read_batches: 3
+tenant.sql_usage.read_requests: 4
+tenant.sql_usage.read_bytes: 1179648
+tenant.sql_usage.write_batches: 4
+tenant.sql_usage.write_requests: 5
+tenant.sql_usage.write_bytes: 10240
+tenant.sql_usage.sql_pods_cpu_seconds: 3.82
+tenant.sql_usage.pgwire_egress_bytes: 12345
+tenant.sql_usage.external_io_ingress_bytes: 0
+tenant.sql_usage.external_io_egress_bytes: 0
+tenant.sql_usage.cross_region_network_ru: 0.00
 
 # Ensure no RU usage is reported, but ingress/egress bytes are reported.
 disable-external-ru-accounting
@@ -340,6 +561,22 @@ PGWire egress:  12345 bytes
 ExternalIO egress: 2000 bytes
 ExternalIO ingress: 10000 bytes
 
+metrics
+----
+tenant.sql_usage.request_units: 1324.39
+tenant.sql_usage.kv_request_units: 39.00
+tenant.sql_usage.read_batches: 3
+tenant.sql_usage.read_requests: 4
+tenant.sql_usage.read_bytes: 1179648
+tenant.sql_usage.write_batches: 4
+tenant.sql_usage.write_requests: 5
+tenant.sql_usage.write_bytes: 10240
+tenant.sql_usage.sql_pods_cpu_seconds: 3.82
+tenant.sql_usage.pgwire_egress_bytes: 12345
+tenant.sql_usage.external_io_ingress_bytes: 10000
+tenant.sql_usage.external_io_egress_bytes: 2000
+tenant.sql_usage.cross_region_network_ru: 0.00
+
 # Enable accounting and ensure RUs are updated.
 enable-external-ru-accounting
 ----
@@ -372,6 +609,22 @@ PGWire egress:  12345 bytes
 ExternalIO egress: 1026000 bytes
 ExternalIO ingress: 1034000 bytes
 
+metrics
+----
+tenant.sql_usage.request_units: 2324.39
+tenant.sql_usage.kv_request_units: 39.00
+tenant.sql_usage.read_batches: 3
+tenant.sql_usage.read_requests: 4
+tenant.sql_usage.read_bytes: 1179648
+tenant.sql_usage.write_batches: 4
+tenant.sql_usage.write_requests: 5
+tenant.sql_usage.write_bytes: 10240
+tenant.sql_usage.sql_pods_cpu_seconds: 3.82
+tenant.sql_usage.pgwire_egress_bytes: 12345
+tenant.sql_usage.external_io_ingress_bytes: 1034000
+tenant.sql_usage.external_io_egress_bytes: 1026000
+tenant.sql_usage.cross_region_network_ru: 0.00
+
 # Read the same amount of bytes as the first subtest. Should have an increase
 # of ~10.5 RUs compared to the first test.
 read bytes=1048576 networkCost=0.00001
@@ -398,6 +651,22 @@ PGWire egress:  12345 bytes
 ExternalIO egress: 1026000 bytes
 ExternalIO ingress: 1034000 bytes
 
+metrics
+----
+tenant.sql_usage.request_units: 2351.50
+tenant.sql_usage.kv_request_units: 55.62
+tenant.sql_usage.read_batches: 4
+tenant.sql_usage.read_requests: 5
+tenant.sql_usage.read_bytes: 2228224
+tenant.sql_usage.write_batches: 4
+tenant.sql_usage.write_requests: 5
+tenant.sql_usage.write_bytes: 10240
+tenant.sql_usage.sql_pods_cpu_seconds: 3.82
+tenant.sql_usage.pgwire_egress_bytes: 12345
+tenant.sql_usage.external_io_ingress_bytes: 1034000
+tenant.sql_usage.external_io_egress_bytes: 1026000
+tenant.sql_usage.cross_region_network_ru: 10.49
+
 # This write is expected to consume an extra 5.12 RUs from network cost usage.
 write bytes=1024 networkCost=0.005
 ----
@@ -422,6 +691,22 @@ SQL Pods CPU seconds:  3.82
 PGWire egress:  12345 bytes
 ExternalIO egress: 1026000 bytes
 ExternalIO ingress: 1034000 bytes
+
+metrics
+----
+tenant.sql_usage.request_units: 2359.62
+tenant.sql_usage.kv_request_units: 58.62
+tenant.sql_usage.read_batches: 4
+tenant.sql_usage.read_requests: 5
+tenant.sql_usage.read_bytes: 2228224
+tenant.sql_usage.write_batches: 5
+tenant.sql_usage.write_requests: 6
+tenant.sql_usage.write_bytes: 11264
+tenant.sql_usage.sql_pods_cpu_seconds: 3.82
+tenant.sql_usage.pgwire_egress_bytes: 12345
+tenant.sql_usage.external_io_ingress_bytes: 1034000
+tenant.sql_usage.external_io_egress_bytes: 1026000
+tenant.sql_usage.cross_region_network_ru: 15.61
 
 # Test multiple requests in the same batch with RU multiplier of 1.
 write count=2 bytes=1024 networkCost=0
@@ -450,3 +735,19 @@ SQL Pods CPU seconds:  3.82
 PGWire egress:  12345 bytes
 ExternalIO egress: 1026000 bytes
 ExternalIO ingress: 1034000 bytes
+
+metrics
+----
+tenant.sql_usage.request_units: 2365.37
+tenant.sql_usage.kv_request_units: 64.38
+tenant.sql_usage.read_batches: 5
+tenant.sql_usage.read_requests: 7
+tenant.sql_usage.read_bytes: 2293760
+tenant.sql_usage.write_batches: 6
+tenant.sql_usage.write_requests: 8
+tenant.sql_usage.write_bytes: 12288
+tenant.sql_usage.sql_pods_cpu_seconds: 3.82
+tenant.sql_usage.pgwire_egress_bytes: 12345
+tenant.sql_usage.external_io_ingress_bytes: 1034000
+tenant.sql_usage.external_io_egress_bytes: 1026000
+tenant.sql_usage.cross_region_network_ru: 15.61

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -6112,3 +6112,7 @@ func (mockTenantSideCostController) GetCPUMovingAvg() float64 {
 func (m *mockTenantSideCostController) GetCostConfig() *tenantcostmodel.Config {
 	return m.cfg
 }
+
+func (m *mockTenantSideCostController) Metrics() metric.Struct {
+	return nil
+}

--- a/pkg/multitenant/cost_controller.go
+++ b/pkg/multitenant/cost_controller.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcostmodel"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
@@ -40,6 +41,9 @@ type TenantSideCostController interface {
 	// GetCostConfig returns the cost model config this TenantSideCostController
 	// is using.
 	GetCostConfig() *tenantcostmodel.Config
+
+	// Metrics returns a metric.Struct which holds metrics for the controller.
+	Metrics() metric.Struct
 
 	TenantSideKVInterceptor
 

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1067,6 +1067,7 @@ func makeTenantSQLServerArgs(
 	if err != nil {
 		return sqlServerArgs{}, err
 	}
+	registry.AddMetricStruct(costController.Metrics())
 
 	dsCfg := kvcoord.DistSenderConfig{
 		AmbientCtx:        baseCfg.AmbientCtx,
@@ -1357,4 +1358,8 @@ func (noopTenantSideCostController) GetCPUMovingAvg() float64 {
 
 func (noopTenantSideCostController) GetCostConfig() *tenantcostmodel.Config {
 	return nil
+}
+
+func (noopTenantSideCostController) Metrics() metric.Struct {
+	return emptyMetricStruct{}
 }

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -157,15 +157,18 @@ func (m *Metadata) AddLabel(name, value string) {
 var _ Iterable = &Gauge{}
 var _ Iterable = &GaugeFloat64{}
 var _ Iterable = &Counter{}
+var _ Iterable = &CounterFloat64{}
 
 var _ json.Marshaler = &Gauge{}
 var _ json.Marshaler = &GaugeFloat64{}
 var _ json.Marshaler = &Counter{}
+var _ json.Marshaler = &CounterFloat64{}
 var _ json.Marshaler = &Registry{}
 
 var _ PrometheusExportable = &Gauge{}
 var _ PrometheusExportable = &GaugeFloat64{}
 var _ PrometheusExportable = &Counter{}
+var _ PrometheusExportable = &CounterFloat64{}
 
 var now = timeutil.Now
 
@@ -764,6 +767,9 @@ func (c *CounterFloat64) Snapshot() *CounterFloat64 {
 func (c *CounterFloat64) GetType() *prometheusgo.MetricType {
 	return prometheusgo.MetricType_COUNTER.Enum()
 }
+
+// Inspect calls the given closure with the empty string and itself.
+func (c *CounterFloat64) Inspect(f func(interface{})) { f(c) }
 
 // ToPrometheusMetric returns a filled-in prometheus metric of the right type.
 func (c *CounterFloat64) ToPrometheusMetric() *prometheusgo.Metric {

--- a/pkg/util/metric/registry_test.go
+++ b/pkg/util/metric/registry_test.go
@@ -76,6 +76,8 @@ func TestRegistry(t *testing.T) {
 	topCounter := NewCounter(Metadata{Name: "top.counter"})
 	r.AddMetric(topCounter)
 
+	r.AddMetric(NewCounterFloat64(Metadata{Name: "top.floatcounter"}))
+
 	r.AddMetric(NewHistogram(HistogramOptions{
 		Mode:     HistogramModePrometheus,
 		Metadata: Metadata{Name: "top.histogram"},
@@ -88,6 +90,7 @@ func TestRegistry(t *testing.T) {
 		StructGauge         *Gauge
 		StructGauge64       *GaugeFloat64
 		StructCounter       *Counter
+		StructCounter64     *CounterFloat64
 		StructHistogram     IHistogram
 		NestedStructGauge   NestedStruct
 		ArrayStructCounters [4]*Counter
@@ -105,9 +108,10 @@ func TestRegistry(t *testing.T) {
 		ReallyNotAMetric              *Registry
 		DefinitelyNotAnArrayOfMetrics [2]int
 	}{
-		StructGauge:   NewGauge(Metadata{Name: "struct.gauge"}),
-		StructGauge64: NewGaugeFloat64(Metadata{Name: "struct.gauge64"}),
-		StructCounter: NewCounter(Metadata{Name: "struct.counter"}),
+		StructGauge:     NewGauge(Metadata{Name: "struct.gauge"}),
+		StructGauge64:   NewGaugeFloat64(Metadata{Name: "struct.gauge64"}),
+		StructCounter:   NewCounter(Metadata{Name: "struct.counter"}),
+		StructCounter64: NewCounterFloat64(Metadata{Name: "struct.counter64"}),
 		StructHistogram: NewHistogram(HistogramOptions{
 			Mode:     HistogramModePrometheus,
 			Metadata: Metadata{Name: "struct.histogram"},
@@ -157,10 +161,12 @@ func TestRegistry(t *testing.T) {
 		"top.gauge":                   {},
 		"top.floatgauge":              {},
 		"top.counter":                 {},
+		"top.floatcounter":            {},
 		"bottom.gauge":                {},
 		"struct.gauge":                {},
 		"struct.gauge64":              {},
 		"struct.counter":              {},
+		"struct.counter64":            {},
 		"struct.histogram":            {},
 		"nested.struct.gauge":         {},
 		"array.struct.counter.0":      {},


### PR DESCRIPTION
Backport 1/1 commits from #116987.

/cc @cockroachdb/release

---

Previously, consumption metrics were only available in KV servers. These
metrics are updated whenever SQL servers send a TokenBucketRequest with the
consumption since the last request to KV servers. However, those metrics were
insufficient for CockroachDB Cloud's use case. Specifically, for metrics
export to work, we need to fetch these data separately from the KV servers,
which introduces its own issues.

To address that, this commit introduces consumption metrics within the SQL
servers. This change allows us to rely solely on metrics exported by the SQL
servers, eliminating the need to build something externally to fetch data from
the KV servers. It is worth nothing that the aggregated values for these
metrics will always be greater than or equal to the values in the KV servers
since metrics are updated locally before requests to KV servers.

Additionally, this commit also fixes a bug where the existing tenantcostclient
metrics, introduced in https://github.com/cockroachdb/cockroach/pull/113512, were not added to the main registry. As a
result, they were unavailable via the status server.

Epic: [CC-26682](https://cockroachlabs.atlassian.net/browse/CC-26682)

Release note: None

Release justification: Changes in this PR will only affect Serverless clusters.
These are required for Serverless metrics export in CockroachDB Cloud.
