### PR TITLE
sql: use high priority for populating RoleMemberCache

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -585,6 +586,15 @@ func MemberOfWithAdminOption(
 		return userMapping, nil
 	}
 
+	// If `txn` is high priority and in a retry, do not launch the singleflight to
+	// populate the cache because it can potentially cause a deadlock (see
+	// TestConcurrentGrants/concurrent-GRANTs-high-priority for a repro) and
+	// instead just issue a read using `txn` to `system.role_members` table and
+	// return the result.
+	if txn.KV().UserPriority() == roachpb.MaxUserPriority && txn.KV().Epoch() > 0 {
+		return resolveMemberOfWithAdminOption(ctx, member, txn, useSingleQueryForRoleMembershipCache.Get(execCfg.SV()))
+	}
+
 	// Lookup memberships outside the lock. There will be at most one request
 	// in-flight for each user. The role_memberships table version is also part
 	// of the request key so that we don't read data from an old version of the
@@ -605,6 +615,15 @@ func MemberOfWithAdminOption(
 		func(ctx context.Context) (interface{}, error) {
 			var m map[username.SQLUsername]bool
 			err = execCfg.InternalDB.Txn(ctx, func(ctx context.Context, newTxn isql.Txn) error {
+				// Run the membership read as high-priority, thereby pushing any intents
+				// out of its way. This prevents deadlocks in cases where a GRANT/REVOKE
+				// txn, which has already laid a write intent on the
+				// `system.role_members` table, waits for `newTxn` and `newTxn`, which
+				// attempts to read the same system table, is blocked by the
+				// GRANT/REVOKE txn.
+				if err := newTxn.KV().SetUserPriority(roachpb.MaxUserPriority); err != nil {
+					return err
+				}
 				err := newTxn.KV().SetFixedTimestamp(ctx, newTxnTimestamp)
 				if err != nil {
 					return err

--- a/pkg/sql/authorization_test.go
+++ b/pkg/sql/authorization_test.go
@@ -12,12 +12,18 @@ package sql_test
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -83,4 +89,75 @@ func TestCheckAnyPrivilegeForNodeUser(t *testing.T) {
 		t.Fatal(err)
 	}
 
+}
+
+// TestConcurrentGrant tests that populating MembershipCache with a high
+// priority can avoid deadlock from concurrent GRANTs, an issue detailed in
+// #117144.
+func TestConcurrentGrants(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t, "this test needs to sleep half a second")
+
+	runConcurrentGrantsWithPriority := func(t *testing.T, priority string) {
+		ctx := context.Background()
+		s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+		defer s.Stopper().Stop(ctx)
+		tdb := sqlutils.MakeSQLRunner(db)
+
+		// Shortening this cluster setting is essential for this test. A small value
+		// will force `txn1` to bump up its write timestamp by the time it gets to
+		// commit. This is needed to force `txn2` to encounter a WriteTooOldError
+		// after being unblocked, and hence enter a retry, as retry in `txn2` is
+		// prerequisite for the potential deadlock described in #117144.
+		tdb.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1ms'")
+
+		tdb.Exec(t, "CREATE ROLE developer;")
+		tdb.Exec(t, "CREATE USER user1")
+		tdb.Exec(t, "CREATE USER user2")
+
+		// 1. Start a txn1, GRANT something
+		// 2. Start another txn2 that issues a concurrent GRANT (it will block)
+		// 3. Wait a short while
+		// 4. Commit txn1 and that will unblock txn2
+		cg := ctxgroup.WithContext(ctx)
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+
+		cg.Go(func() error {
+			wg.Wait()
+			// txn2
+			_, err := db.Exec(fmt.Sprintf("BEGIN PRIORITY %s; GRANT developer TO user2; COMMIT", priority))
+			return err
+		})
+
+		txn1, err := db.Begin()
+		require.NoError(t, err)
+		_, err = txn1.Exec(fmt.Sprintf("SET TRANSACTION PRIORITY %s", priority))
+		require.NoError(t, err)
+		_, err = txn1.Exec("GRANT developer TO user1")
+		require.NoError(t, err)
+		wg.Done()
+
+		// Wait for a few seconds. It allows:
+		// 1. txn2 to start running and blocking
+		// 2. (more importantly) `txn1` to bump up its write timestamp upon commit,
+		//    so, it will cause txn2 to encounter a WriteTooOld error after
+		//    unblocking and retry.
+		time.Sleep(500 * time.Millisecond)
+		err = txn1.Commit()
+		require.NoError(t, err)
+
+		// Wait to ensure `grant developer to user2` also completed successfully.
+		err = cg.Wait()
+		require.NoError(t, err)
+	}
+
+	for _, priority := range []string{"NORMAL", "HIGH"} {
+		t.Run(fmt.Sprintf("priority=%s", priority), func(
+			t *testing.T,
+		) {
+			runConcurrentGrantsWithPriority(t, priority)
+		})
+	}
 }


### PR DESCRIPTION
Previously, when the RoleMemberCache is invalid, it launches a new txn in a singleflight to read from `system.role_members` table to populate the cache. If, however, the original txn has previously laid a write intent on the same system table, then we end up having a deadlock: original txn waits for this new txn; this new txn waits for original txn. 

Fixes #117144
Release note (bug fix): Fixed a bug where concurrent GRANTs can cause deadlocks.