### PR TITLE
kvcoord: fix bug in distsender.AllRangeSpans

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -21,6 +22,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -442,4 +445,73 @@ func TestChangefeedDistributionStrategy(t *testing.T) {
 		}
 		require.Equal(t, totalRanges, 64)
 	})
+}
+
+// TestDistSenderAllRangeSpans tests (*distserver).AllRangeSpans.
+func TestDistSenderAllRangeSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const nodes = 1
+	args := base.TestClusterArgs{
+		ServerArgsPerNode: map[int]base.TestServerArgs{},
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TestTenantProbabilisticOnly,
+		},
+	}
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, nodes, args)
+	defer tc.Stopper().Stop(ctx)
+
+	node := tc.Server(0).ApplicationLayer()
+	systemLayer := tc.Server(0).SystemLayer()
+	sqlDB := sqlutils.MakeSQLRunner(node.SQLConn(t))
+	distSender := node.DistSenderI().(*kvcoord.DistSender)
+
+	tenantPrefix := ""
+	if tc.StartedDefaultTestTenant() {
+		tenantPrefix = "/Tenant/10"
+	}
+
+	// Use manual merging/splitting only.
+	tc.ToggleReplicateQueues(false)
+
+	mergeRange := func(key interface{}) {
+		err := systemLayer.DB().AdminMerge(ctx, key)
+		if err != nil {
+			if !strings.Contains(err.Error(), "cannot merge final range") {
+				t.Fatal(err)
+			}
+		}
+	}
+	getTableSpan := func(tableName string) roachpb.Span {
+		desc := desctestutils.TestingGetPublicTableDescriptor(
+			node.DB(), node.Codec(), "defaultdb", "a")
+		return desc.PrimaryIndexSpan(node.Codec())
+	}
+	getTableDesc := func(tableName string) catalog.TableDescriptor {
+		return desctestutils.TestingGetPublicTableDescriptor(
+			node.DB(), node.Codec(), "defaultdb", "a")
+	}
+
+	// Regression test for the issue in #117286.
+	t.Run("returned range does not exceed input span boundaries", func(t *testing.T) {
+		// Merge 3 tables into one range.
+		sqlDB.Exec(t, "create table a (i int primary key)")
+		sqlDB.Exec(t, "create table b (j int primary key)")
+		sqlDB.Exec(t, "create table c (k int primary key)")
+		mergeRange(getTableSpan("a").Key)
+		mergeRange(getTableSpan("b").Key)
+
+		bTableID := getTableDesc("b").GetID()
+		rangeSpans, _, err := distSender.AllRangeSpans(ctx, []roachpb.Span{getTableSpan("b")})
+		require.NoError(t, err)
+
+		// Assert that the returned range is trimmed, so it only contains spans from "b" and not the entire
+		// range containing "a" and "c".
+		require.Equal(t, 1, len(rangeSpans), fmt.Sprintf("%v", rangeSpans))
+		require.Equal(t, fmt.Sprintf("%s/Table/%d/{1-2}", tenantPrefix, bTableID), rangeSpans[0].String())
+	})
+
 }


### PR DESCRIPTION
Previously, the method `distsender.AllRangeSpans` would sometimes return a list of spans containing keys outside of the input list of spans. This is seen in #117270, where the input span `/Table/104/1{-/2}` gets expanded to `/Table/{65-104/1/1}, /Table/104/1/{1-2}`. The reason this occurs is because the start key of table 104 is in the middle of a range. `distsender.AllRangeSpans` would use the start key of the range in the output span.

This change modifies the above behavior by making sure the output list of spans is trimmed such that it contains no keys outside of the input list of spans.

Release note: None
Fixes: #117270
Epic: None