### PR TITLE
storage: bump FormatMajorVersion for shared storage

### DIFF
--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -171,6 +171,9 @@ func BallastSize(size int64) ConfigOption {
 func SharedStorage(sharedStorage cloud.ExternalStorage) ConfigOption {
 	return func(cfg *engineConfig) error {
 		cfg.SharedStorage = sharedStorage
+		if cfg.SharedStorage != nil && cfg.Opts.FormatMajorVersion < pebble.FormatMinForSharedObjects {
+			cfg.Opts.FormatMajorVersion = pebble.FormatMinForSharedObjects
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
Previously, we'd leave the FormatMajorVersion at a lower value for stores created with shared storage, than what is necessary for shared storage. This change fixes that to bump the FMV up if shared storage is being configured.

Fixes #117043
Epic: none

Release note: None