### PR TITLE
release-23.1: logstore: sync sideloaded storage directories

### DIFF
--- a/pkg/kv/kvserver/logstore/BUILD.bazel
+++ b/pkg/kv/kvserver/logstore/BUILD.bazel
@@ -68,6 +68,7 @@ go_test(
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//require",
         "@io_etcd_go_raft_v3//raftpb",
         "@org_golang_x_time//rate",

--- a/pkg/kv/kvserver/logstore/BUILD.bazel
+++ b/pkg/kv/kvserver/logstore/BUILD.bazel
@@ -69,6 +69,7 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_pebble//vfs",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_etcd_go_raft_v3//raftpb",
         "@org_golang_x_time//rate",

--- a/pkg/kv/kvserver/logstore/sideload_disk.go
+++ b/pkg/kv/kvserver/logstore/sideload_disk.go
@@ -177,6 +177,7 @@ func (ss *DiskSideloadStorage) possiblyTruncateTo(
 			return nil
 		}
 		if index < from {
+			// TODO(pavelkalinnikov): these files may never be removed. Clean them up.
 			return nil
 		}
 		// index is in [from, to)
@@ -201,6 +202,8 @@ func (ss *DiskSideloadStorage) possiblyTruncateTo(
 		// Not worth trying to figure out which one, just try to delete.
 		err := ss.eng.Remove(ss.dir)
 		if err != nil && !oserror.IsNotExist(err) {
+			// TODO(pavelkalinnikov): this is possible because deletedAll can be left
+			// true despite existence of files with index < from which are skipped.
 			log.Infof(ctx, "unable to remove sideloaded dir %s: %v", ss.dir, err)
 			err = nil // handled
 		}

--- a/pkg/kv/kvserver/logstore/sideload_disk.go
+++ b/pkg/kv/kvserver/logstore/sideload_disk.go
@@ -47,7 +47,7 @@ func sideloadedPath(baseDir string, rangeID roachpb.RangeID) string {
 	// per directory, respectively. Newer FS typically have no such limitation,
 	// but still.
 	//
-	// For example, r1828 will end up in baseDir/r1XXX/r1828.
+	// For example, r1828 will end up in baseDir/sideloading/r1XXX/r1828.
 	return filepath.Join(
 		baseDir,
 		"sideloading",
@@ -93,7 +93,7 @@ func (ss *DiskSideloadStorage) Put(ctx context.Context, index, term uint64, cont
 		}
 		// Ensure that ss.dir exists. The filename() is placed directly in ss.dir,
 		// so the next loop iteration should succeed.
-		if err := ss.eng.MkdirAll(ss.dir); err != nil {
+		if err := mkdirAllAndSyncParents(ss.eng, ss.dir); err != nil {
 			return err
 		}
 		continue
@@ -266,4 +266,56 @@ func (ss *DiskSideloadStorage) String() string {
 	}
 	fmt.Fprintf(&buf, "(%d files)\n", count)
 	return buf.String()
+}
+
+// mkdirAllAndSyncParents creates the given directory and all its missing
+// parents if any. For every newly created directory, it syncs the corresponding
+// parent directory.
+//
+// For example, if path is "/x/y/z", and "/x" previously existed, then this func
+// creates "/x/y" and "/x/y/z", and syncs directories "/x" and "/x/y".
+//
+// TODO(pavelkalinnikov): this does not work well with paths containing . and ..
+// elements inside the data-dir directory. We don't construct the path this way
+// though, right now any non-canonical part of the path would be only in the
+// <data-dir> path.
+//
+// TODO(pavelkalinnikov): have a type-safe canonical path type which can be
+// iterated without thinking about . and .. placeholders.
+func mkdirAllAndSyncParents(fs fs.FS, path string) error {
+	// Find the lowest existing directory in the hierarchy.
+	var exists string
+	for dir, parent := path, ""; ; dir = parent {
+		if _, err := fs.Stat(dir); err == nil {
+			exists = dir
+			break
+		} else if !oserror.IsNotExist(err) {
+			return errors.Wrapf(err, "could not get dir info: %s", dir)
+		}
+		parent = filepath.Dir(dir)
+		// NB: not checking against the separator, to be platform-agnostic.
+		if dir == "." || parent == dir { // reached the topmost dir or the root
+			return errors.Newf("topmost dir does not exist: %s", dir)
+		}
+	}
+
+	// Create the destination directory and any of its missing parents.
+	if err := fs.MkdirAll(path); err != nil {
+		return errors.Wrapf(err, "could not create all directories: %s", path)
+	}
+
+	// Sync parent directories up to the lowest existing ancestor, included.
+	for dir, parent := path, ""; dir != exists; dir = parent {
+		parent = filepath.Dir(dir)
+		if handle, err := fs.OpenDir(parent); err != nil {
+			return errors.Wrapf(err, "could not open parent dir: %s", parent)
+		} else if err := handle.Sync(); err != nil {
+			_ = handle.Close()
+			return errors.Wrapf(err, "could not sync parent dir: %s", parent)
+		} else if err := handle.Close(); err != nil {
+			return errors.Wrapf(err, "could not close parent dir: %s", parent)
+		}
+	}
+
+	return nil
 }

--- a/pkg/kv/kvserver/logstore/sideload_disk.go
+++ b/pkg/kv/kvserver/logstore/sideload_disk.go
@@ -35,11 +35,10 @@ var _ SideloadStorage = &DiskSideloadStorage{}
 //
 // TODO(pavelkalinnikov): remove the interface, this type is the only impl.
 type DiskSideloadStorage struct {
-	st         *cluster.Settings
-	limiter    *rate.Limiter
-	dir        string
-	dirCreated bool
-	eng        storage.Engine
+	st      *cluster.Settings
+	limiter *rate.Limiter
+	dir     string
+	eng     storage.Engine
 }
 
 func sideloadedPath(baseDir string, rangeID roachpb.RangeID) string {
@@ -75,9 +74,7 @@ func NewDiskSideloadStorage(
 }
 
 func (ss *DiskSideloadStorage) createDir() error {
-	err := ss.eng.MkdirAll(ss.dir)
-	ss.dirCreated = ss.dirCreated || err == nil
-	return err
+	return ss.eng.MkdirAll(ss.dir)
 }
 
 // Dir implements SideloadStorage.
@@ -158,9 +155,7 @@ func (ss *DiskSideloadStorage) purgeFile(ctx context.Context, filename string) (
 
 // Clear implements SideloadStorage.
 func (ss *DiskSideloadStorage) Clear(_ context.Context) error {
-	err := ss.eng.RemoveAll(ss.dir)
-	ss.dirCreated = ss.dirCreated && err != nil
-	return err
+	return ss.eng.RemoveAll(ss.dir)
 }
 
 // TruncateTo implements SideloadStorage.

--- a/pkg/kv/kvserver/logstore/sideload_disk.go
+++ b/pkg/kv/kvserver/logstore/sideload_disk.go
@@ -73,10 +73,6 @@ func NewDiskSideloadStorage(
 	}
 }
 
-func (ss *DiskSideloadStorage) createDir() error {
-	return ss.eng.MkdirAll(ss.dir)
-}
-
 // Dir implements SideloadStorage.
 func (ss *DiskSideloadStorage) Dir() string {
 	return ss.dir
@@ -95,9 +91,9 @@ func (ss *DiskSideloadStorage) Put(ctx context.Context, index, term uint64, cont
 		} else if !oserror.IsNotExist(err) {
 			return err
 		}
-		// createDir() ensures ss.dir exists but will not create any subdirectories
-		// within ss.dir because filename() does not make subdirectories in ss.dir.
-		if err := ss.createDir(); err != nil {
+		// Ensure that ss.dir exists. The filename() is placed directly in ss.dir,
+		// so the next loop iteration should succeed.
+		if err := ss.eng.MkdirAll(ss.dir); err != nil {
 			return err
 		}
 		continue

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/raft/v3/raftpb"
 	"golang.org/x/time/rate"
@@ -604,17 +605,176 @@ func TestSideloadStorageSync(t *testing.T) {
 	defer eng.Close()
 	ss = newTestingSideloadStorage(eng)
 
-	// The sideloaded got lost because all its parents were not synced.
-	// TODO(pavelkalinnikov): make sure the directory structure is persisted.
+	// The sideloaded directory must exist because all its parents are synced.
 	_, err := eng.Stat(ss.Dir())
-	require.True(t, oserror.IsNotExist(err), err)
+	require.NoError(t, err)
 
-	// The stored entry is lost too because the sideloaded storage did not sync
-	// the directory structure.
+	// However, the stored entry is lost because the sideloaded storage did not
+	// sync ss.Dir().
 	// TODO(pavelkalinnikov): make the entries durable.
 	_, err = ss.Get(ctx, 100 /* index */, 6 /* term */)
 	require.ErrorIs(t, err, errSideloadedFileNotFound)
 	// A "control" check that missing entries are unconditionally missing.
 	_, err = ss.Get(ctx, 200 /* index */, 7 /* term */)
 	require.ErrorIs(t, err, errSideloadedFileNotFound)
+}
+
+func TestMkdirAllAndSyncParents(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, tc := range []struct {
+		path   string   // a directory that exists
+		sync   []string // prefix directories of `path` that were synced
+		create string   // the directory to be created
+
+		wantExist []string // directories we want to exist after a crash
+		wantGone  []string // un-synced directories we expect removed after a crash
+	}{{
+		path:      "/",
+		create:    "/a/b",
+		wantExist: []string{"/", "/a", "/a/b"},
+	}, {
+		path:      "/a",
+		sync:      []string{"/"},
+		create:    "/a", // edge case, just makes sure the base dir exists
+		wantExist: []string{"/", "/a"},
+	}, {
+		path:      "/a",
+		create:    "/a", // same edge case, but we test that there is no sync
+		wantExist: []string{"/"},
+		wantGone:  []string{"/a"}, // "a" was created, but the root was not synced
+	}, {
+		path:      "/a/b",
+		sync:      []string{"/"}, // "a" is not synced, so mkdir won't persist
+		create:    "/a/b/c/d/",
+		wantExist: []string{"/", "/a"},
+		wantGone:  []string{"/a/b", "/a/b/c", "/a/b/c/d"},
+	}, {
+		path:      "/a/b",
+		sync:      []string{"/", "/a"}, // "a" is synced, so mkdir will persist
+		create:    "/a/b/c",
+		wantExist: []string{"/", "/a", "/a/b", "/a/b/c"},
+	}, {
+		path:      "/a/b",
+		sync:      []string{"/", "/a"}, // "a" is synced, so mkdir will persist
+		create:    "/a/b/c/d",
+		wantExist: []string{"/", "/a", "/a/b", "/a/b/c", "/a/b/c/d"},
+	}, {
+		path:      "/a/b/c",
+		sync:      []string{"/", "/a"}, // "b" is not synced, and won't be because "c" exists
+		create:    "/a/b/c/d",
+		wantExist: []string{"/", "/a", "/a/b"},
+		wantGone:  []string{"/a/b/c", "/a/b/c/d"},
+	}, {
+		path:      "/a/b/c",
+		sync:      []string{"/", "/a"}, // "b" is not synced, and won't be because "c" exists
+		create:    "/a/b/c/d",
+		wantExist: []string{"/", "/a", "/a/b"},
+		wantGone:  []string{"/a/b/c", "/a/b/c/d"},
+	}, {
+		path:      "/a/b/c",
+		sync:      []string{"/", "/a"}, // "b" is not synced, and won't be because "c" exists
+		create:    "/a/b/c/d",
+		wantExist: []string{"/", "/a", "/a/b"},
+		wantGone:  []string{"/a/b/c", "/a/b/c/d"},
+	}, {
+		path:      "a/b", // test relative paths too
+		sync:      []string{"", "a"},
+		create:    "a/b/c",
+		wantExist: []string{"a", "a/b", "a/b/c"},
+	}, {
+		path:      "a/b",
+		sync:      []string{""},
+		create:    "a/b/c",
+		wantExist: []string{"a"},
+		wantGone:  []string{"a/b", "a/b/c"},
+	}, {
+		path:      "../a/b",
+		sync:      []string{"", "..", "../a"},
+		create:    "../a/b/c",
+		wantExist: []string{"../a/b/c"},
+	}, {
+		path:      "../a/b",
+		sync:      []string{"", ".."}, // "a" not synced, the dirs will be lost
+		create:    "../a/b/c",
+		wantExist: []string{".."},
+		wantGone:  []string{"../a/b/c"},
+	}} {
+		t.Run("", func(t *testing.T) {
+			fs := vfs.NewStrictMem()
+			// NB: only converting to storage.Engine because vfs.FS is incompatible
+			// with fs.FS. Fixed in later releases.
+			eng := storage.InMemFromFS(context.Background(), fs, "", cluster.MakeTestingClusterSettings())
+			defer eng.Close()
+
+			require.NoError(t, eng.MkdirAll(tc.path))
+			for _, dir := range tc.sync {
+				handle, err := eng.OpenDir(dir)
+				require.NoError(t, err)
+				require.NoError(t, handle.Sync())
+				require.NoError(t, handle.Close())
+			}
+			require.NoError(t, mkdirAllAndSyncParents(eng, tc.create))
+
+			assertExistence := func(t *testing.T, dirs []string, exist bool) {
+				t.Helper()
+				for _, dir := range dirs {
+					handle, err := eng.OpenDir(dir)
+					if exist {
+						require.NoError(t, err, dir)
+						require.NoError(t, handle.Close(), dir)
+					} else {
+						require.True(t, oserror.IsNotExist(err), dir)
+					}
+				}
+			}
+
+			// Before crash, all the relevant directories must exist.
+			assertExistence(t, tc.wantExist, true)
+			assertExistence(t, tc.wantGone, true)
+			// After crash and resetting to the synced state, wantExist directories
+			// must exist, and wantGone are lost.
+			fs.ResetToSyncedState()
+			assertExistence(t, tc.wantExist, true)
+			assertExistence(t, tc.wantGone, false)
+		})
+	}
+}
+
+func TestMkdirAllAndSyncParentsErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Run("empty", func(t *testing.T) {
+		fs := vfs.NewMem()
+		eng := storage.InMemFromFS(context.Background(), fs, "", cluster.MakeTestingClusterSettings())
+		defer eng.Close()
+		for _, path := range []string{".", "./a", ".."} {
+			require.ErrorContains(t, mkdirAllAndSyncParents(eng, path),
+				"topmost dir does not exist", path)
+		}
+		// The root exists in an empty MemFS.
+		require.NoError(t, mkdirAllAndSyncParents(eng, "/"))
+		// TODO(pavelkalinnikov): find a way to remove "/", and exercise the missing
+		// root error for absolute paths.
+		// For now, removing "/" does not succeed in MemFS.
+		assert.ErrorContains(t, fs.Remove("/"), "empty file name")
+	})
+
+	t.Run("not-a-directory", func(t *testing.T) {
+		fs := vfs.NewMem()
+		eng := storage.InMemFromFS(context.Background(), fs, "", cluster.MakeTestingClusterSettings())
+		defer eng.Close()
+		require.NoError(t, mkdirAllAndSyncParents(eng, "/a"))
+
+		// Write a file, and try to trick mkdir into thinking that it's a directory.
+		f, err := fs.Create("/a/file")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		for _, path := range []string{"/a/file", "/a/file/sub"} {
+			require.ErrorContains(t, mkdirAllAndSyncParents(eng, path), "not a directory")
+		}
+	})
 }

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/raft/v3/raftpb"
 	"golang.org/x/time/rate"
@@ -569,4 +570,51 @@ func newOnDiskEngine(ctx context.Context, t *testing.T) (func(), storage.Engine)
 		t.Fatal(err)
 	}
 	return cleanup, eng
+}
+
+// TestSideloadStorageSync tests that the sideloaded storage syncs files and
+// directories properly, to survive crashes.
+func TestSideloadStorageSync(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Create a sideloaded storage with an in-memory FS. Use strict MemFS to be
+	// able to emulate crash restart by rolling it back to last synced state.
+	ctx := context.Background()
+	fs := vfs.NewStrictMem()
+	eng := storage.InMemFromFS(ctx, fs, "",
+		cluster.MakeTestingClusterSettings(), storage.ForTesting)
+	ss := newTestingSideloadStorage(eng)
+
+	// Put an entry which should trigger the lazy creation of the sideloaded
+	// directories structure, and create a file for this entry.
+	const testEntry = "test-entry"
+	require.NoError(t, ss.Put(ctx, 100 /* index */, 6 /* term */, []byte(testEntry)))
+	// Cut off all syncs from this point, to emulate a crash.
+	fs.SetIgnoreSyncs(true)
+	ss = nil
+	eng.Close()
+	// Reset filesystem to the last synced state.
+	fs.ResetToSyncedState()
+	fs.SetIgnoreSyncs(false)
+
+	// Emulate process restart. Load from the last synced state.
+	eng = storage.InMemFromFS(ctx, fs, "",
+		cluster.MakeTestingClusterSettings(), storage.ForTesting)
+	defer eng.Close()
+	ss = newTestingSideloadStorage(eng)
+
+	// The sideloaded got lost because all its parents were not synced.
+	// TODO(pavelkalinnikov): make sure the directory structure is persisted.
+	_, err := eng.Stat(ss.Dir())
+	require.True(t, oserror.IsNotExist(err), err)
+
+	// The stored entry is lost too because the sideloaded storage did not sync
+	// the directory structure.
+	// TODO(pavelkalinnikov): make the entries durable.
+	_, err = ss.Get(ctx, 100 /* index */, 6 /* term */)
+	require.ErrorIs(t, err, errSideloadedFileNotFound)
+	// A "control" check that missing entries are unconditionally missing.
+	_, err = ss.Get(ctx, 200 /* index */, 7 /* term */)
+	require.ErrorIs(t, err, errSideloadedFileNotFound)
 }

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -345,9 +345,10 @@ func (r *Replica) handleTruncatedStateResult(
 	// to and including the most recently truncated index.
 	r.store.raftEntryCache.Clear(r.RangeID, t.Index+1)
 
-	// Truncate the sideloaded storage. Note that this is safe only if the new truncated state
-	// is durably on disk (i.e.) synced. This is true at the time of writing but unfortunately
-	// could rot.
+	// Truncate the sideloaded storage. This is safe only if the new truncated
+	// state is durably stored on disk, i.e. synced.
+	// TODO(#38566, #113135): this is unfortunately not true, need to fix this.
+	//
 	// TODO(sumeer): once we remove the legacy caller of
 	// handleTruncatedStateResult, stop calculating the size of the removed
 	// files and the remaining files.
@@ -358,6 +359,14 @@ func (r *Replica) handleTruncatedStateResult(
 		// loud error, but keep humming along.
 		log.Errorf(ctx, "while removing sideloaded files during log truncation: %+v", err)
 	}
+	// NB: we don't sync the sideloaded entry files removal here for performance
+	// reasons. If a crash occurs, and these files get recovered after a restart,
+	// we should clean them up on the server startup.
+	//
+	// TODO(#113135): this removal survives process crashes though, and system
+	// crashes if the filesystem is quick enough to sync it for us. Add a test
+	// that syncs the files removal here, and "crashes" right after, to help
+	// reproduce and fix #113135.
 	return -size, expectedFirstIndexWasAccurate
 }
 

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -84,6 +84,10 @@ func (r *Replica) postDestroyRaftMuLocked(ctx context.Context, ms enginepb.MVCCS
 	// is set on creation and never changes over the lifetime of a Replica. Also,
 	// the replica is always contained in its descriptor. So this code below should
 	// be removable.
+	//
+	// TODO(pavelkalinnikov): coming back in 2023, the above may still happen if:
+	// (1) state machine syncs, (2) OS crashes before (3) sideloaded was able to
+	// sync the files removal. The files should be cleaned up on restart.
 	if r.raftMu.sideloaded != nil {
 		if err := r.raftMu.sideloaded.Clear(ctx); err != nil {
 			return err


### PR DESCRIPTION
Backport 5/6 commits from #114616.

/cc @cockroachdb/release

---

This PR ensures that the hierarchy of directories/files created by the sideloaded log storage is properly synced.

Previously, only the "leaf" files in this hierarchy were fsync-ed. Even though this guarantees the files content and metadata is synced, this still does not guarantee that the references to these files are durable. For example, Linux man page for `fsync` [^1] says:

```
Calling fsync() does not necessarily ensure that the entry in the
directory containing the file has also reached disk.  For that an
explicit fsync() on a file descriptor for the directory is also
needed.
```

It means that these files can be lost after a system crash of power off. This leads to issues because:

1. Pebble WAL syncs are not atomic with the sideloaded files syncs. It is thus possible that raft log metadata "references" a sideloaded file and gets synced, but the file is not yet. A power off/on at this point leads to an internal inconsistency, and can result in a crash loop when raft will try to load these entries to apply and/or send to other replicas.

2. The durability of entry files is used as a pre-condition to sending raft messages that trigger committing these entries. A coordinated power off/on on a majority of replicas can thus lead to losing committed entries and unrecoverable loss-of-quorum.

This PR fixes the above issues, by syncing parents of all the directories and files that the sideloaded storage creates.

[^1]: https://man7.org/linux/man-pages/man2/fsync.2.html

Part of #114411

Epic: none

Release note (bug fix): this commit fixes a durability bug in raft log storage, caused by incorrect syncing of filesystem metadata. It was possible to lose writes of a particular kind (`AddSSTable`) that is e.g. used by `RESTORE`. This loss was possible only under power-off or OS crash conditions. As a result, CRDB could enter a crash loop on restart. In the worst case of a correlated power-off/crash across multiple nodes this could lead to loss of quorum or data loss.

Release justification: critical bug fix