### PR TITLE
release-23.1: kvserver: sync before removing sideloaded files

### DIFF
--- a/pkg/kv/kvserver/client_raft_log_queue_test.go
+++ b/pkg/kv/kvserver/client_raft_log_queue_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/listenerutil"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -167,6 +168,9 @@ func TestRaftLogQueue(t *testing.T) {
 func TestCrashWhileTruncatingSideloadedEntries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// Skip under stress until we fix the circuit breaker behaviour in #117785.
+	skip.UnderStressWithIssue(t, 117785)
 
 	// Use sticky engine registry to "survive" a node restart. Use the strict
 	// in-memory engine to be able to stop flushes and emulate data loss.

--- a/pkg/kv/kvserver/client_raft_log_queue_test.go
+++ b/pkg/kv/kvserver/client_raft_log_queue_test.go
@@ -13,15 +13,27 @@ package kvserver_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/listenerutil"
+	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -121,4 +133,288 @@ func TestRaftLogQueue(t *testing.T) {
 		t.Fatalf("second truncation destroyed state: afterTruncationIndex:%d after2ndTruncationIndex:%d",
 			afterTruncationIndex, after2ndTruncationIndex)
 	}
+}
+
+// TestCrashWhileTruncatingSideloadedEntries emulates a process crash in the
+// middle of applying a raft log truncation command that removes some entries
+// from the sideloaded storage. The test expects that storage remains in a
+// correct state, and the replica recovers and catches up after restart.
+//
+// This is a regression test for issues #38566 and #113135. Previously such a
+// crash could invalidate storage, and lead to restart crash loops.
+//
+// The scenario is as follows:
+//
+//  1. Commit a few AddSST commands to raft (written to the sideloaded log
+//     storage as individual files).
+//  2. Commit a log truncation command.
+//  3. Wait for the application of this command on a follower (it will remove
+//     some files from the sideloaded storage).
+//  4. Emulate the follower process crash (which discards all the storage engine
+//     state that was not flushed).
+//  5. However, make sure that the files removal is synced (because the
+//     filesystem is still running after the crash).
+//  6. Restart the follower process.
+//  7. The follower recovers and catches up to the leader.
+//
+// Previously, steps 6-7 would crash loop because the application of AddSST and
+// truncation commands to Pebble in (step 3) was not fully flushed/synced before
+// the truncation command would remove files. After a restart, some suffix of
+// AddSST commands would need to be replayed, but the files would be missing.
+//
+// This is now fixed: the application of the truncation command is synced before
+// deleting the sideloaded files.
+func TestCrashWhileTruncatingSideloadedEntries(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Use sticky engine registry to "survive" a node restart. Use the strict
+	// in-memory engine to be able to stop flushes and emulate data loss.
+	vfsReg := server.NewStickyVFSRegistry(server.UseStrictMemFS)
+	// Use the sticky listener registry so that server port assignments survive
+	// node restarts, and don't get erroneously used by other clusters.
+	netReg := listenerutil.NewListenerRegistry()
+	defer netReg.Close()
+	// TODO(pavelkalinnikov): make sticky VFS and listeners the default.
+
+	// Boilerplate to make the hooks dynamically changeable.
+	propFilter := newAtomicFunc(func(kvserverbase.ProposalFilterArgs) *kvpb.Error {
+		return nil
+	})
+	applyThrottle := newAtomicFunc(func(storage.FullReplicaID) {})
+	postSideEffects := newAtomicFunc(func(args kvserverbase.ApplyFilterArgs) (int, *kvpb.Error) {
+		return 0, nil
+	})
+
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ReplicationMode:     base.ReplicationManual,
+		ReusableListenerReg: netReg,
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					DisableRaftLogQueue:     true, // we send a log truncation manually
+					DisableSyncLogWriteToss: true, // always use async log writes
+					TestingAfterRaftLogSync: func(id storage.FullReplicaID) { applyThrottle.get()(id) },
+					TestingProposalFilter: func(args kvserverbase.ProposalFilterArgs) *kvpb.Error {
+						return propFilter.get()(args)
+					},
+					TestingPostApplySideEffectsFilter: func(
+						args kvserverbase.ApplyFilterArgs,
+					) (int, *kvpb.Error) {
+						return postSideEffects.get()(args)
+					},
+				},
+				Server: &server.TestingKnobs{StickyVFSRegistry: vfsReg},
+			},
+			RaftConfig: base.RaftConfig{
+				RangeLeaseDuration:       24 * time.Hour, // disable lease moves
+				RaftElectionTimeoutTicks: 1 << 30,        // disable elections
+				RaftProposalQuota:        1 << 30,        // unlimited proposals
+			},
+		},
+	})
+	ctx := context.Background()
+	defer tc.Stopper().Stop(ctx)
+	store := tc.GetFirstStoreFromServer(t, 0)
+
+	// Write a single value to ensure we have a leader on n1.
+	key := tc.ScratchRange(t)
+	_, pErr := kv.SendWrapped(ctx, store.TestSender(), putArgs(key, []byte("value")))
+	require.NoError(t, pErr.GoError())
+	require.NoError(t, tc.WaitForSplitAndInitialization(key))
+	// We need 3 voters so that stalling one follower does not block committing writes.
+	tc.AddVotersOrFatal(t, key, tc.Targets(1, 2)...)
+	tc.WaitForVotersOrFatal(t, key, tc.Targets(1, 2)...)
+
+	// Get the raft leader (and ensure one exists).
+	leader := tc.GetRaftLeader(t, roachpb.RKey(key))
+	require.NotNil(t, leader)
+	require.Equal(t, store.NodeID(), leader.NodeID())
+	t.Logf("leader replica: %v", leader)
+	// Get the follower on n2.
+	follower, err := tc.GetFirstStoreFromServer(t, 1).GetReplica(leader.RangeID)
+	require.NoError(t, err)
+	require.NotNil(t, follower)
+	t.Logf("follower replica: %v", follower)
+	// Pin the leaseholder to the leader node (most likely it's already there).
+	require.NoError(t, tc.TransferRangeLease(*leader.Desc(), tc.Target(0)))
+
+	info := func(r *kvserver.Replica, name string) (uint64, uint64) {
+		first, last := r.GetFirstIndex(), r.GetLastIndex()
+		t.Logf("%s: log indices: [%d..%d]", name, first, last)
+		t.Logf("%s: applied to: %d", name, r.State(ctx).ReplicaState.RaftAppliedIndex)
+		return first, last
+	}
+	info(leader, "leader")
+	info(follower, "follower")
+
+	// Get the follower's file system.
+	memFS, err := vfsReg.Get(base.StoreSpec{StickyVFSID: "auto-node2-store1"})
+	require.NoError(t, err)
+
+	// Before writing more commands, block the raft commands application flow on
+	// the follower replica.
+	unblockApply := make(chan struct{})
+	applyThrottle.set(func(id storage.FullReplicaID) {
+		if id == follower.ID() {
+			applyThrottle.reset()
+			<-unblockApply
+		}
+	})
+
+	// Write a few AddSST requests to increase the raft log.
+	for i := 0; i < 20; i++ {
+		_, pErr = kv.SendWrapped(ctx, store.TestSender(), makeAddSST(t, store.ClusterSettings(), key, 10))
+		require.NoError(t, pErr.GoError())
+	}
+	t.Log("committed AddSSTs")
+	_, lastIndex := info(leader, "leader")
+	info(follower, "follower")
+
+	// Trigger raft log truncation. When the corresponding command is proposed,
+	// record its ID. Use this ID to watch other events related to this command,
+	// in particular we're interested to catch the moment when the command has
+	// been applied at the follower replica.
+	//
+	// TODO(#115759): group proposal lifecycle callbacks into a convenient
+	// watcher, so that each test doesn't have to write ad-hoc things like this.
+	var cmdID atomicValue[kvserverbase.CmdIDKey]
+	propFilter.set(func(args kvserverbase.ProposalFilterArgs) *kvpb.Error {
+		if _, ok := args.Req.GetArg(kvpb.TruncateLog); !ok {
+			return nil
+		}
+		propFilter.reset()
+		cmdID.set(args.CmdID)
+		return nil
+	})
+	_, pErr = kv.SendWrapped(ctx, store.TestSender(), &kvpb.TruncateLogRequest{
+		RequestHeader:      kvpb.RequestHeader{Key: key},
+		Index:              lastIndex - 1, // truncate all but the last AddSST
+		RangeID:            leader.RangeID,
+		ExpectedFirstIndex: 0,
+	})
+	require.NoError(t, pErr.GoError())
+	require.NotEmpty(t, cmdID.get(), "truncation command ID not captured")
+	t.Logf("committed truncation for indices < %d", lastIndex-1)
+	info(leader, "leader")
+	info(follower, "follower")
+
+	// Catch when the truncation command and its side effects have been applied.
+	truncateApplied := make(chan struct{})
+	postSideEffects.set(func(args kvserverbase.ApplyFilterArgs) (int, *kvpb.Error) {
+		if args.StoreID != follower.StoreID() || args.CmdID != cmdID.get() {
+			return 0, nil
+		}
+		postSideEffects.reset()
+		// Assume that the filesystem will live longer than the process, and will
+		// eventually sync the sideloaded storage.
+		require.NoError(t, follower.SideloadedRaftMuLocked().Sync())
+		close(truncateApplied)
+		return 0, nil
+	})
+	// Unblock the command application flow on the follower replica, and wait
+	// until the truncation command has applied.
+	close(unblockApply)
+	t.Log("unblocked follower application flow")
+	<-truncateApplied
+	t.Log("follower applied the truncation")
+
+	// Emulate process crash at this point.
+	//
+	//	1. First, block the outgoing RPC traffic.
+	//	2. Then capture the storage state and start ignoring all the syncs.
+	//	3. Turn down the follower node.
+	//
+	// Without step 1, a flake is possible and has been observed while writing
+	// this test. Between steps 2 and 3, the follower may persist a log entry and
+	// send an ack to leader thinking that it's durable. The leader now, too,
+	// thinks that it's durable, and may a) commit this entry, and b) send a
+	// commit index advancement to the follower. If (b) happens after the follower
+	// restarted and lost the last entry, it will panic because commit index the
+	// leader sent is now above the last index in the log.
+	for _, peer := range []int{0, 2} { // the leader and the other follower
+		dialer := tc.Servers[1].NodeDialer().(*nodedialer.Dialer)
+		for c := 0; c < rpc.NumConnectionClasses; c++ {
+			brk := dialer.GetCircuitBreaker(tc.Servers[peer].NodeID(), rpc.ConnectionClass(c))
+			brk.Trip()
+		}
+	}
+	memFS.SetIgnoreSyncs(true)
+	info(follower, "follower")
+	t.Log("CRASH!")
+	// TODO(pavelkalinnikov): add "crash" helpers to the TestCluster.
+	tc.StopServer(1)
+
+	t.Log("restarting follower")
+	memFS.ResetToSyncedState()
+	memFS.SetIgnoreSyncs(false)
+	t.Logf("FS after restart:\n%s", memFS.String())
+	require.NoError(t, tc.RestartServer(1))
+
+	// Update the follower variable to point at a newly restarted replica.
+	follower, err = tc.GetFirstStoreFromServer(t, 1).GetReplica(leader.RangeID)
+	require.NoError(t, err)
+	require.NotNil(t, follower)
+	info(follower, "follower")
+
+	// We still should be able to write.
+	_, pErr = kv.SendWrapped(ctx, store.TestSender(), putArgs(key, []byte("another value")))
+	require.NoError(t, pErr.GoError())
+	// The follower replica should catch up to leader.
+	leaderLAI := leader.State(ctx).ReplicaState.LeaseAppliedIndex
+	t.Logf("leader LAI %d", leaderLAI)
+	testutils.SucceedsSoon(t, func() error {
+		if lai := follower.State(ctx).ReplicaState.LeaseAppliedIndex; lai < leaderLAI {
+			return fmt.Errorf("follower still catching up from LAI %d to %d", lai, leaderLAI)
+		}
+		return nil
+	})
+}
+
+func makeAddSST(
+	t *testing.T, st *cluster.Settings, key roachpb.Key, values int,
+) *kvpb.AddSSTableRequest {
+	kvs := make(storageutils.KVs, values)
+	for i := range kvs {
+		k := testutils.MakeKey(key, []byte(fmt.Sprintf("%d", i)))
+		kvs[i] = storageutils.PointKV(string(k), 1, "value")
+	}
+	sst, start, end := storageutils.MakeSST(t, st, kvs)
+	return &kvpb.AddSSTableRequest{
+		RequestHeader: kvpb.RequestHeader{Key: start, EndKey: end},
+		Data:          sst,
+		MVCCStats:     storageutils.SSTStats(t, sst, 0),
+	}
+}
+
+type atomicValue[T any] atomic.Value
+
+func newAtomicValue[T any](v T) atomicValue[T] {
+	var ret atomicValue[T]
+	ret.set(v)
+	return ret
+}
+
+func (a *atomicValue[T]) get() T {
+	return (*atomic.Value)(a).Load().(T)
+}
+
+func (a *atomicValue[T]) set(v T) {
+	(*atomic.Value)(a).Store(v)
+}
+
+type atomicFunc[T any] struct {
+	noop T
+	atomicValue[T]
+}
+
+func newAtomicFunc[T any](fn T) atomicFunc[T] {
+	return atomicFunc[T]{
+		noop:        fn,
+		atomicValue: newAtomicValue(fn),
+	}
+}
+
+func (a *atomicFunc[T]) reset() {
+	a.set(a.noop)
 }

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -111,6 +111,8 @@ type LogStore struct {
 	EntryCache  *raftentry.Cache
 	Settings    *cluster.Settings
 	Metrics     Metrics
+
+	DisableSyncLogWriteToss bool // for testing only
 }
 
 // SyncCallback is a callback that is notified when a raft log write has been
@@ -243,8 +245,9 @@ func (s *LogStore) storeEntriesAndCommitBatch(
 		// optimizing for.
 		!overwriting &&
 		// Also, randomly disable non-blocking sync in test builds to exercise the
-		// interleaved blocking and non-blocking syncs.
-		!(buildutil.CrdbTestBuild && rand.Intn(2) == 0)
+		// interleaved blocking and non-blocking syncs (unless the testing knobs
+		// disable this randomization explicitly).
+		!(buildutil.CrdbTestBuild && !s.DisableSyncLogWriteToss && rand.Intn(2) == 0)
 	if nonBlockingSync {
 		// If non-blocking synchronization is enabled, apply the batched updates to
 		// the engine and initiate a synchronous disk write, but don't wait for the

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -48,6 +48,8 @@ type SideloadStorage interface {
 	Purge(_ context.Context, index, term uint64) (int64, error)
 	// Clear files that may have been written by this SideloadStorage.
 	Clear(context.Context) error
+	// HasAnyEntry returns whether there is any entry in [from, to).
+	HasAnyEntry(_ context.Context, from, to uint64) (bool, error)
 	// TruncateTo removes all files belonging to an index strictly smaller than
 	// the given one. Returns the number of bytes freed, the number of bytes in
 	// files that remain, or an error.

--- a/pkg/kv/kvserver/logstore/sideload_disk.go
+++ b/pkg/kv/kvserver/logstore/sideload_disk.go
@@ -188,19 +188,19 @@ func (ss *DiskSideloadStorage) possiblyTruncateTo(
 	ctx context.Context, from uint64, to uint64, doTruncate bool,
 ) (bytesFreed, bytesRetained int64, _ error) {
 	deletedAll := true
-	if err := ss.forEach(ctx, func(index uint64, filename string) error {
+	if err := ss.forEach(ctx, func(index uint64, filename string) (bool, error) {
 		if index >= to {
 			size, err := ss.fileSize(filename)
 			if err != nil {
-				return err
+				return false, err
 			}
 			bytesRetained += size
 			deletedAll = false
-			return nil
+			return true, nil
 		}
 		if index < from {
 			// TODO(pavelkalinnikov): these files may never be removed. Clean them up.
-			return nil
+			return true, nil
 		}
 		// index is in [from, to)
 		var fileSize int64
@@ -211,10 +211,10 @@ func (ss *DiskSideloadStorage) possiblyTruncateTo(
 			fileSize, err = ss.fileSize(filename)
 		}
 		if err != nil {
-			return err
+			return false, err
 		}
 		bytesFreed += fileSize
-		return nil
+		return true, nil
 	}); err != nil {
 		return 0, 0, err
 	}
@@ -233,6 +233,22 @@ func (ss *DiskSideloadStorage) possiblyTruncateTo(
 	return bytesFreed, bytesRetained, nil
 }
 
+// HasAnyEntry implements SideloadStorage.
+func (ss *DiskSideloadStorage) HasAnyEntry(ctx context.Context, from, to uint64) (bool, error) {
+	// Find any file at index in [from, to).
+	found := false
+	if err := ss.forEach(ctx, func(index uint64, _ string) (bool, error) {
+		if index >= from && index < to {
+			found = true
+			return false, nil // stop the iteration
+		}
+		return true, nil
+	}); err != nil {
+		return false, err
+	}
+	return found, nil
+}
+
 // BytesIfTruncatedFromTo implements SideloadStorage.
 func (ss *DiskSideloadStorage) BytesIfTruncatedFromTo(
 	ctx context.Context, from uint64, to uint64,
@@ -240,15 +256,17 @@ func (ss *DiskSideloadStorage) BytesIfTruncatedFromTo(
 	return ss.possiblyTruncateTo(ctx, from, to, false /* doTruncate */)
 }
 
+// forEach runs the given visit function for each file in the sideloaded storage
+// directory. If visit returns false, forEach terminates early and returns nil.
+// If visit returns an error, forEach terminates early and returns an error.
 func (ss *DiskSideloadStorage) forEach(
-	ctx context.Context, visit func(index uint64, filename string) error,
+	ctx context.Context, visit func(index uint64, filename string) (bool, error),
 ) error {
+	// TODO(pavelkalinnikov): consider making the List method iterative.
 	matches, err := ss.eng.List(ss.dir)
 	if oserror.IsNotExist(err) {
-		// Nothing to do.
-		return nil
-	}
-	if err != nil {
+		return nil // nothing to do
+	} else if err != nil {
 		return err
 	}
 	for _, match := range matches {
@@ -268,8 +286,10 @@ func (ss *DiskSideloadStorage) forEach(
 			log.Infof(ctx, "unexpected file %s in sideloaded directory %s", match, ss.dir)
 			continue
 		}
-		if err := visit(logIdx, match); err != nil {
+		if keepGoing, err := visit(logIdx, match); err != nil {
 			return errors.Wrapf(err, "matching pattern %q on dir %s", match, ss.dir)
+		} else if !keepGoing {
+			return nil
 		}
 	}
 	return nil
@@ -279,10 +299,10 @@ func (ss *DiskSideloadStorage) forEach(
 func (ss *DiskSideloadStorage) String() string {
 	var buf strings.Builder
 	var count int
-	if err := ss.forEach(context.Background(), func(_ uint64, filename string) error {
+	if err := ss.forEach(context.Background(), func(_ uint64, filename string) (bool, error) {
 		count++
 		_, _ = fmt.Fprintln(&buf, filename)
-		return nil
+		return true, nil
 	}); err != nil {
 		return err.Error()
 	}

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -92,6 +92,7 @@ func newTestingSideloadStorage(eng storage.Engine) *DiskSideloadStorage {
 		rate.NewLimiter(rate.Inf, math.MaxInt64), eng)
 }
 
+// TODO(pavelkalinnikov): give these tests a good refactor.
 func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 	ctx := context.Background()
 	ss := newTestingSideloadStorage(eng)
@@ -282,6 +283,10 @@ func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 		// Ensure directory is removed, now that all files should be gone.
 		_, err = eng.Stat(ss.Dir())
 		require.True(t, oserror.IsNotExist(err), "%v", err)
+		// Ensure HasAnyEntry doesn't find anything.
+		found, err := ss.HasAnyEntry(ctx, 0, 10000)
+		require.NoError(t, err)
+		require.False(t, found)
 
 		// Repopulate with some random indexes to test deletion when there are a
 		// non-zero number of filepath.Glob matches.
@@ -291,6 +296,22 @@ func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 			require.NoError(t, ss.Put(ctx, i, highTerm, file(i*highTerm)))
 		}
 		assertExists(true)
+		// Verify the HasAnyEntry semantics.
+		for _, check := range []struct {
+			from, to uint64
+			want     bool
+		}{
+			{from: 0, to: 3, want: false}, // 3 is excluded
+			{from: 0, to: 4, want: true},  // but included if to == 4
+			{from: 3, to: 5, want: true},  // 3 is included
+			{from: 4, to: 5, want: false},
+			{from: 50, to: 60, want: false},
+			{from: 1, to: 10, want: true},
+		} {
+			found, err := ss.HasAnyEntry(ctx, check.from, check.to)
+			require.NoError(t, err)
+			require.Equal(t, check.want, found)
+		}
 		freed, retained, err := ss.BytesIfTruncatedFromTo(ctx, 0, math.MaxUint64)
 		require.NoError(t, err)
 		require.Zero(t, retained)

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -85,8 +85,7 @@ import (
 // kv.raft_log.enable_loosely_coupled_truncation. When not doing loose
 // coupling (legacy), the proposal causes immediate truncation -- this is
 // correct because other externally maintained invariants ensure that the
-// state machine is durable (though we have some concerns in
-// https://github.com/cockroachdb/cockroach/issues/38566).
+// state machine is durable.
 //
 // NB: Loosely coupled truncation loses the pending truncations that were
 // queued in-memory when a node restarts. This is considered ok for now since

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -250,6 +250,19 @@ func (sm *replicaStateMachine) ApplySideEffects(
 		}
 		cmd.proposal.applied = true
 	}
+
+	if f := sm.r.store.TestingKnobs().TestingPostApplySideEffectsFilter; f != nil {
+		// NB: ReplicatedEvalResult is emptied by now, so don't include it.
+		if _, pErr := f(kvserverbase.ApplyFilterArgs{
+			CmdID:       cmd.ID,
+			StoreID:     sm.r.store.StoreID(),
+			RangeID:     sm.r.RangeID,
+			ForcedError: cmd.ForcedError,
+		}); pErr != nil {
+			return nil, pErr.GoError()
+		}
+	}
+
 	return cmd, nil
 }
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1527,6 +1527,10 @@ func (r *replicaSyncCallback) OnLogSync(
 	ctx context.Context, msgs []raftpb.Message, commitStats storage.BatchCommitStats,
 ) {
 	repl := (*Replica)(r)
+	// Block sending the responses back to raft, if a test needs to.
+	if fn := repl.store.TestingKnobs().TestingAfterRaftLogSync; fn != nil {
+		fn(repl.ID())
+	}
 	// Send MsgStorageAppend's responses.
 	repl.sendRaftMessages(ctx, msgs, nil /* blocked */, false /* willDeliverLocal */)
 	if commitStats.TotalDuration > defaultReplicaRaftMuWarnThreshold {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -974,6 +974,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 				Metrics: logstore.Metrics{
 					RaftLogCommitLatency: r.store.metrics.RaftLogCommitLatency,
 				},
+				DisableSyncLogWriteToss: buildutil.CrdbTestBuild &&
+					r.store.TestingKnobs().DisableSyncLogWriteToss,
 			}
 			m := logstore.MakeMsgStorageAppend(msgStorageAppend)
 			cb := (*replicaSyncCallback)(r)

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -312,6 +312,11 @@ type StoreTestingKnobs struct {
 	// EnableUnconditionalRefreshesInRaftReady will always set the refresh reason
 	// in handleRaftReady to refreshReasonNewLeaderOrConfigChange.
 	EnableUnconditionalRefreshesInRaftReady bool
+	// DisableSyncLogWriteToss forces raft log appends to always be asynchronous
+	// when possible, if configured so by the cluster settings. If false, some
+	// asynchronous log writes can be randomly made synchronous in tests. Should
+	// be set to true by tests that require or test asynchronous log writes.
+	DisableSyncLogWriteToss bool
 
 	// SendSnapshot is run after receiving a DelegateRaftSnapshot request but
 	// before any throttling or sending logic.

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -64,6 +64,25 @@ type StoreTestingKnobs struct {
 	// reproposed due to ticks.
 	TestingProposalSubmitFilter func(*ProposalData) (drop bool, err error)
 
+	// TestingAfterRaftLogSync is invoked after completion of a synced write to
+	// Raft log for the given replica, before the corresponding message is sent
+	// back to Raft and these entries can next be applied to the state machine.
+	//
+	// If async log writes are enabled, this callback blocks async log write
+	// responses flow for the entire store, until it returns. This effectively
+	// blocks (most of) the command application flow. Some sync log writes may
+	// fall through because they use a different flow. Note that this callback
+	// does not block the entire raft flow, commands are still being committed.
+	//
+	// If async log writes are disabled, blocks this replica's entire raft
+	// processing while also holding raftMu for the replica. May block raft
+	// processing for other replicas in the same raft scheduler shard, so must be
+	// used with caution.
+	//
+	// TODO(pavelkalinnikov): have a more stable and less nuanced way of blocking
+	// the commands application flow for the entire store.
+	TestingAfterRaftLogSync func(storage.FullReplicaID)
+
 	// TestingApplyCalledTwiceFilter is called before applying the results of a command on
 	// each replica assuming the command was cleared for application (i.e. no
 	// forced error occurred; the supplied AppliedFilterArgs will have a nil
@@ -95,6 +114,13 @@ type StoreTestingKnobs struct {
 	// with a forced error. That is, the "command" will apply as a
 	// no-op write, and the ForcedError field will be set.
 	TestingPostApplyFilter kvserverbase.ReplicaApplyFilter
+
+	// TestingPostApplySideEffectsFilter is called after a command is applied to
+	// state machine, and its side effects are applied to memory. Called on each
+	// replica that applies the command.
+	//
+	// NB: not all fields are passed in to this callback, see the implementation.
+	TestingPostApplySideEffectsFilter kvserverbase.ReplicaApplyFilter
 
 	// TestingResponseErrorEvent is called when an error is returned applying
 	// a command.

--- a/pkg/server/sticky_vfs.go
+++ b/pkg/server/sticky_vfs.go
@@ -69,7 +69,7 @@ type StickyVFSRegistry interface {
 	// engines.
 	Open(ctx context.Context, cfg *Config, spec base.StoreSpec) (storage.Engine, error)
 	// Get returns the named in-memory FS.
-	Get(spec base.StoreSpec) (vfs.FS, error)
+	Get(spec base.StoreSpec) (*vfs.MemFS, error)
 	// CloseAllEngines closes all open sticky in-memory engines that were
 	// created by this registry. Calling this method is required when using the
 	// ReuseEnginesDeprecated option.
@@ -170,7 +170,7 @@ func (registry *stickyVFSRegistryImpl) Open(
 	return engine, nil
 }
 
-func (registry *stickyVFSRegistryImpl) Get(spec base.StoreSpec) (vfs.FS, error) {
+func (registry *stickyVFSRegistryImpl) Get(spec base.StoreSpec) (*vfs.MemFS, error) {
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
 


### PR DESCRIPTION
Backport:
  * 2/2 commits from "server: support strict MemFS in StickyVFSRegistry" (#115595)
  * 6/6 commits from "kvserver: sync before removing sideloaded files" (#114191)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: critical bug fix