### PR TITLE
sql: respect IF NOT EXISTS in CREATE EXTERNAL CONNECTION

### DIFF
--- a/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
@@ -25,6 +25,18 @@ CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo';
 ----
 pq: failed to create external connection: external connection with connection name 'foo' already exists
 
+# Trying to create another External Connection with the same name using
+# IF NOT EXISTS should not fail and should leave the existing
+# connection unmodified.
+exec-sql
+CREATE EXTERNAL CONNECTION IF NOT EXISTS foo AS 'nodelocal://1/nope';
+----
+
+inspect-system-table
+----
+foo STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo/bar"}} root 1
+
+
 # Create another External Connection with a unique name.
 exec-sql
 CREATE EXTERNAL CONNECTION bar123 AS 'nodelocal://1/baz';

--- a/pkg/sql/create_external_connection.go
+++ b/pkg/sql/create_external_connection.go
@@ -144,6 +144,10 @@ func (p *planner) createExternalConnection(
 	// Create the External Connection and persist it in the
 	// `system.external_connections` table.
 	if err := ex.Create(params.ctx, txn); err != nil {
+		ifNotExists := n.ConnectionLabelSpec.IfNotExists
+		if ifNotExists && pgerror.GetPGCode(err) == pgcode.DuplicateObject {
+			return nil
+		}
 		return errors.Wrap(err, "failed to create external connection")
 	}
 


### PR DESCRIPTION
Previously, while the IF NOT EXISTS syntax was allowed nothing checked the boolean on the constructed tree node. Here, we check the boolean and elide DuplicateViolation errors from create.

Fixes #116997

Release note (bug fix): CREATE EXTERNAL CONNECTION IF NOT EXISTS no longer returns an error if the connection already exists.