### PR TITLE
sql: allow empty search path parameters

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -400,6 +400,21 @@ SELECT pg_catalog.set_config('woo', 'woo', false)
 query error configuration setting.*not supported
 SELECT set_config('vacuum_cost_delay', '0', false)
 
+# Regression test for #117316. Setting an empty search_path should succeed.
+query T
+SELECT pg_catalog.set_config('search_path', '', false)
+----
+·
+
+query T
+SHOW search_path
+----
+·
+
+# Reset the search paths for subsequent tests.
+statement ok
+RESET search_path
+
 # pg_my_temp_schema
 #
 # Before a temporary schema is created, it returns 0. Afterwards, it returns the

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -1701,9 +1701,9 @@ func TestParseSearchPathInConnectionString(t *testing.T) {
 			expectedErr: `option "Ghi" is invalid`,
 		},
 		{
-			desc:        "empty search_path is not allowed",
-			query:       `options=-c search_path=`,
-			expectedErr: `invalid value for parameter "search_path": ""`,
+			desc:               "empty search_path is allowed",
+			query:              `options=-c search_path=`,
+			expectedSearchPath: ``,
 		},
 		{
 			desc:        "unbalanced quotes in search_path are not allowed",

--- a/pkg/sql/sessiondata/parse_search_path.go
+++ b/pkg/sql/sessiondata/parse_search_path.go
@@ -143,6 +143,11 @@ func doParseSearchPathFromString(s string) ([]string, bool) {
 		result: make([]string, 0, strings.Count(s, ",")),
 	}
 
+	// Empty strings are valid search paths.
+	if parser.eof() {
+		return parser.result, true
+	}
+
 	parser.eatWhitespace()
 	if parser.eof() {
 		return nil, false

--- a/pkg/sql/sessiondata/search_path_test.go
+++ b/pkg/sql/sessiondata/search_path_test.go
@@ -399,7 +399,7 @@ func TestParseSearchPathEdgeCases(t *testing.T) {
 		expected    []string
 		expectedErr bool
 	}{
-		{input: ``, expectedErr: true},
+		{input: ``, expected: []string{}},
 		{input: `""`, expected: []string{""}},
 		{input: `  `, expectedErr: true},
 		{input: `a, `, expectedErr: true},


### PR DESCRIPTION
Before this change, when parsing search path parameters as part of setting the search path, CRDB would return an error if the parameter was empty. This PR fixes that edge case to succeed, as in postgres. This bug has been present since 23.1

Epic: None
Fixes: #117316

Release note (bug fix): Trying to set an empty search_path no longer results in an error.