### PR TITLE
roachtest: pass RunOptions instead of NodeListOption

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1159,7 +1159,7 @@ func (c *clusterImpl) FetchLogs(ctx context.Context, l *logger.Logger) error {
 			}
 		}
 
-		if err := c.RunE(ctx, c.All(), fmt.Sprintf("mkdir -p logs/redacted && %s debug merge-logs --redact logs/*.log > logs/redacted/combined.log", test.DefaultCockroachPath)); err != nil {
+		if err := c.RunE(ctx, option.WithNodes(c.All()), fmt.Sprintf("mkdir -p logs/redacted && %s debug merge-logs --redact logs/*.log > logs/redacted/combined.log", test.DefaultCockroachPath)); err != nil {
 			l.Printf("failed to redact logs: %v", err)
 			if ctx.Err() != nil {
 				return err
@@ -1182,7 +1182,7 @@ func saveDiskUsageToLogsDir(ctx context.Context, c cluster.Cluster) error {
 
 	// Don't hang forever.
 	return timeutil.RunWithTimeout(ctx, "disk usage", 20*time.Second, func(ctx context.Context) error {
-		return c.RunE(ctx, c.All(),
+		return c.RunE(ctx, option.WithNodes(c.All()),
 			"du -c /mnt/data1 --exclude lost+found >> logs/diskusage.txt")
 	})
 }
@@ -1240,7 +1240,7 @@ func (c *clusterImpl) FetchTimeseriesData(ctx context.Context, l *logger.Logger)
 			sec = fmt.Sprintf("--certs-dir=%s", certs)
 		}
 		if err := c.RunE(
-			ctx, c.Node(node), fmt.Sprintf("%s debug tsdump %s --port={pgport%s} --format=raw > tsdump.gob", test.DefaultCockroachPath, sec, c.Node(node)),
+			ctx, option.WithNodes(c.Node(node)), fmt.Sprintf("%s debug tsdump %s --port={pgport%s} --format=raw > tsdump.gob", test.DefaultCockroachPath, sec, c.Node(node)),
 		); err != nil {
 			return err
 		}
@@ -1335,7 +1335,7 @@ func (c *clusterImpl) FetchDebugZip(
 				MaybeFlag(c.IsSecure(), "certs-dir", "certs").
 				Arg(zipName).
 				String()
-			if err := c.RunE(ctx, c.Node(node), cmd); err != nil {
+			if err := c.RunE(ctx, option.WithNodes(c.Node(node)), cmd); err != nil {
 				l.Printf("%s debug zip failed on node %d: %v", test.DefaultCockroachPath, node, err)
 				continue
 			}
@@ -1825,7 +1825,7 @@ func (c *clusterImpl) PutLibraries(
 	c.status("uploading library files")
 	defer c.status("")
 
-	if err := c.RunE(ctx, c.All(), "mkdir", "-p", libraryDir); err != nil {
+	if err := c.RunE(ctx, option.WithNodes(c.All()), "mkdir", "-p", libraryDir); err != nil {
 		return err
 	}
 
@@ -1925,7 +1925,7 @@ func (c *clusterImpl) GitClone(
   		fi
   		'`, dest, branch, src),
 	}
-	return errors.Wrap(c.RunE(ctx, nodes, cmd...), "cluster.GitClone")
+	return errors.Wrap(c.RunE(ctx, option.WithNodes(nodes), cmd...), "cluster.GitClone")
 }
 
 func (c *clusterImpl) setStatusForClusterOpt(
@@ -2266,8 +2266,8 @@ func (c *clusterImpl) Wipe(ctx context.Context, preserveCerts bool, nodes ...opt
 }
 
 // Run a command on the specified nodes and call test.Fatal if there is an error.
-func (c *clusterImpl) Run(ctx context.Context, nodes option.NodeListOption, args ...string) {
-	err := c.RunE(ctx, nodes, args...)
+func (c *clusterImpl) Run(ctx context.Context, options install.RunOptions, args ...string) {
+	err := c.RunE(ctx, options, args...)
 	if err != nil {
 		c.t.Fatal(err)
 	}
@@ -2277,9 +2277,13 @@ func (c *clusterImpl) Run(ctx context.Context, nodes option.NodeListOption, args
 // will be redirected to a file which is logged via the cluster-wide logger in
 // case of an error. Logs will sort chronologically. Failing invocations will
 // have an additional marker file with a `.failed` extension instead of `.log`.
-func (c *clusterImpl) RunE(ctx context.Context, nodes option.NodeListOption, args ...string) error {
+func (c *clusterImpl) RunE(ctx context.Context, options install.RunOptions, args ...string) error {
 	if len(args) == 0 {
 		return errors.New("No command passed")
+	}
+	nodes := option.NodeListOption{}
+	for _, n := range options.Nodes {
+		nodes = append(nodes, int(n))
 	}
 
 	l, logFile, err := c.loggerForCmd(nodes, args...)
@@ -2293,7 +2297,7 @@ func (c *clusterImpl) RunE(ctx context.Context, nodes option.NodeListOption, arg
 	l.Printf("> %s", cmd)
 	if err := roachprod.Run(
 		ctx, l, c.MakeNodes(nodes), "", "", c.IsSecure(),
-		l.Stdout, l.Stderr, args, install.OnNodes(nodes.InstallNodes()),
+		l.Stdout, l.Stderr, args, options,
 	); err != nil {
 		if err := ctx.Err(); err != nil {
 			l.Printf("(note: incoming context was canceled: %s)", err)
@@ -2352,7 +2356,7 @@ func (c *clusterImpl) RunWithDetails(
 	l.Printf("> %s", cmd)
 	results, err := roachprod.RunWithDetails(
 		ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "", /* processTag */
-		c.IsSecure(), args, install.OnNodes(nodes.InstallNodes()),
+		c.IsSecure(), args, install.WithNodes(nodes.InstallNodes()),
 	)
 
 	var logFileFull string
@@ -2783,7 +2787,7 @@ func (c *clusterImpl) WipeForReuse(
 	// reusing files from previous tests, i.e. cockroach binaries, perf artifacts.
 	// N.B. we don't remove the entire home directory to safeguard against this ever
 	// running locally and deleting someone's local directory.
-	if err := c.RunE(ctx, c.All(), fmt.Sprintf("rm -rf /home/%s/*", config.SharedUser)); err != nil {
+	if err := c.RunE(ctx, option.WithNodes(c.All()), fmt.Sprintf("rm -rf /home/%s/*", config.SharedUser)); err != nil {
 		return errors.Wrapf(err, "failed to remove home directory")
 	}
 	if c.localCertsDir != "" {

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -100,13 +100,20 @@ type Cluster interface {
 	// Use it when you need output details such as stdout or stderr, or remote exit status.
 	RunWithDetails(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string) ([]install.RunResultDetails, error)
 
-	// Run is fatal on errors.
+	// Run is just like RunE, except it is fatal on errors.
 	// Use it when an error means the test should fail.
-	Run(ctx context.Context, node option.NodeListOption, args ...string)
+	// See RunE for more details on the options and specifying nodes to run on.
+	Run(ctx context.Context, options install.RunOptions, args ...string)
 
-	// RunE runs a command on the specified nodes and returns an error.
-	// Use it when you need to run a command and only care if it ran successfully or not.
-	RunE(ctx context.Context, node option.NodeListOption, args ...string) error
+	// RunE runs a command on the given nodes, specified via `RunOptions.Nodes`,
+	// and returns an error. Use it when you need to run a command and only care
+	// if it ran successfully or not. With default options, it will run the
+	// command on all nodes.
+	//
+	// If a subset of nodes is desired, use the `option.WithNodes` function to
+	// specify the nodes. See `install.RunOptions` for more details on the
+	// options.
+	RunE(ctx context.Context, options install.RunOptions, args ...string) error
 
 	// RunWithDetailsSingleNode is just like RunWithDetails but used when 1) operating
 	// on a single node AND 2) an error from roachprod itself would be treated the same way

--- a/pkg/cmd/roachtest/clusterstats/BUILD.bazel
+++ b/pkg/cmd/roachtest/clusterstats/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cmd/roachtest/cluster",
+        "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/test",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/prometheus",

--- a/pkg/cmd/roachtest/clusterstats/exporter.go
+++ b/pkg/cmd/roachtest/clusterstats/exporter.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/errors"
@@ -167,7 +168,7 @@ func writeOutRoachPerf(
 ) error {
 	l := t.L()
 	dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
-	if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
+	if err := c.RunE(ctx, option.WithNodes(c.Node(1)), "mkdir -p "+filepath.Dir(dest)); err != nil {
 		l.ErrorfCtx(ctx, "failed to create perf dir: %+v", err)
 		return err
 	}

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -91,3 +91,8 @@ type StopOpts struct {
 func DefaultStopOpts() StopOpts {
 	return StopOpts{RoachprodOpts: roachprod.DefaultStopOpts()}
 }
+
+// WithNodes returns a RunOptions that will run on the given nodes.
+func WithNodes(nodes NodeListOption) install.RunOptions {
+	return install.WithNodes(nodes.InstallNodes())
+}

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -215,12 +215,12 @@ func uploadBinaryVersion(
 	} else {
 		dir := filepath.Dir(dstBinary)
 		// Avoid staging the binary if it already exists.
-		if err := c.RunE(ctx, nodes, "test -e", dstBinary); err == nil {
+		if err := c.RunE(ctx, option.WithNodes(nodes), "test -e", dstBinary); err == nil {
 			return dstBinary, nil
 		}
 
 		// Ensure binary directory exists.
-		if err := c.RunE(ctx, nodes, "mkdir -p", dir); err != nil {
+		if err := c.RunE(ctx, option.WithNodes(nodes), "mkdir -p", dir); err != nil {
 			return "", err
 		}
 
@@ -253,7 +253,7 @@ func uploadBinaryVersion(
 func InstallFixtures(
 	ctx context.Context, l *logger.Logger, c cluster.Cluster, nodes option.NodeListOption, v *Version,
 ) error {
-	if err := c.RunE(ctx, nodes, "mkdir -p {store-dir}"); err != nil {
+	if err := c.RunE(ctx, option.WithNodes(nodes), "mkdir -p {store-dir}"); err != nil {
 		return fmt.Errorf("creating store-dir: %w", err)
 	}
 
@@ -271,7 +271,7 @@ func InstallFixtures(
 		}
 	}
 	// Extract fixture. Fail if there's already an LSM in the store dir.
-	if err := c.RunE(ctx, nodes, "ls {store-dir}/marker.* 1> /dev/null 2>&1 && exit 1 || (cd {store-dir} && tar -xf fixture.tgz)"); err != nil {
+	if err := c.RunE(ctx, option.WithNodes(nodes), "ls {store-dir}/marker.* 1> /dev/null 2>&1 && exit 1 || (cd {store-dir} && tar -xf fixture.tgz)"); err != nil {
 		return fmt.Errorf("extracting fixtures: %w", err)
 	}
 

--- a/pkg/cmd/roachtest/roachtestutil/jaeger.go
+++ b/pkg/cmd/roachtest/roachtestutil/jaeger.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 )
 
@@ -46,13 +47,13 @@ func InstallLaunchAndConfigureJaegerAllInOne(
 	}
 	// Don't install under `m.Go`, we want this method to return only when the collector is
 	// almost (and ideally fully, but that's harder) ready.
-	if err := c.RunE(ctx, c.Node(1), `[ -f jaeger-all-in-one ] ||
+	if err := c.RunE(ctx, option.WithNodes(c.Node(1)), `[ -f jaeger-all-in-one ] ||
 curl -sSL https://github.com/jaegertracing/jaeger/releases/download/v1.22.0/jaeger-1.22.0-linux-amd64.tar.gz |
 tar --strip-components=1 -xvzf -`); err != nil {
 		return err
 	}
 	m.Go(func(ctx context.Context) error {
-		err := c.RunE(ctx, c.Node(1), `SPAN_STORAGE_TYPE=badger BADGER_EPHEMERAL=false \
+		err := c.RunE(ctx, option.WithNodes(c.Node(1)), `SPAN_STORAGE_TYPE=badger BADGER_EPHEMERAL=false \
 BADGER_DIRECTORY_VALUE=/mnt/data1/jaeger.badger/data BADGER_DIRECTORY_KEY=/mnt/data1/jaeger.badger/key \
 ./jaeger-all-in-one --collector.zipkin.host-port=:9411`)
 		if ctx.Err() != nil {
@@ -72,7 +73,7 @@ BADGER_DIRECTORY_VALUE=/mnt/data1/jaeger.badger/data BADGER_DIRECTORY_KEY=/mnt/d
 	if err != nil {
 		return err
 	}
-	c.Run(ctx, c.Node(1), "ln -s /mnt/data1/jaeger.badger logs/jaeger.badger")
+	c.Run(ctx, option.WithNodes(c.Node(1)), "ln -s /mnt/data1/jaeger.badger logs/jaeger.badger")
 	l.Printf("jaeger UI should now be running at http://%s:16686", hps[0])
 	return nil
 }

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
@@ -125,7 +125,7 @@ func (h *Helper) BackgroundCommand(cmd string, nodes option.NodeListOption) cont
 	desc := fmt.Sprintf("run command: %q", cmd)
 	return h.Background(desc, func(ctx context.Context, l *logger.Logger) error {
 		l.Printf("running command `%s` on nodes %v in the background", cmd, nodes)
-		return h.runner.cluster.RunE(ctx, nodes, cmd)
+		return h.runner.cluster.RunE(ctx, option.WithNodes(nodes), cmd)
 	})
 }
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -578,7 +578,7 @@ func (t *Test) clusterArch() vm.CPUArch {
 func (t *Test) runCommandFunc(nodes option.NodeListOption, cmd string) userFunc {
 	return func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *Helper) error {
 		l.Printf("running command `%s` on nodes %v", cmd, nodes)
-		return t.cluster.RunE(ctx, nodes, cmd)
+		return t.cluster.RunE(ctx, option.WithNodes(nodes), cmd)
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -81,7 +81,7 @@ func registerDatabaseDrop(r registry.Registry) {
 				//
 				// TODO(irfansharif): Make this versioning business a bit more
 				// explicit throughout. It works, but too tacitly.
-				c.Run(ctx, c.All(), fmt.Sprintf("cp %s ./cockroach", path))
+				c.Run(ctx, option.WithNodes(c.All()), fmt.Sprintf("cp %s ./cockroach", path))
 
 				// Set up TPC-E with 100k customers.
 				//

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
@@ -86,7 +86,7 @@ func registerElasticIO(r registry.Registry) {
 				cmd := "./workload run kv --init --histograms=perf/stats.json --concurrency=512 " +
 					"--splits=1000 --read-percent=0 --min-block-bytes=65536 --max-block-bytes=65536 " +
 					"--txn-qos=background --tolerate-errors" + dur + url
-				c.Run(ctx, c.Node(workAndPromNode), cmd)
+				c.Run(ctx, option.WithNodes(c.Node(workAndPromNode)), cmd)
 				return nil
 			})
 			m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/admission_control_follower_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_follower_overload.go
@@ -113,8 +113,8 @@ func runAdmissionControlFollowerOverload(
 
 	resetSystemdUnits := func() {
 		for _, cmd := range []string{"stop", "reset-failed"} {
-			_ = c.RunE(ctx, c.Node(4), "sudo", "systemctl", cmd, "kv-n12")
-			_ = c.RunE(ctx, c.Node(4), "sudo", "systemctl", cmd, "kv-n3")
+			_ = c.RunE(ctx, option.WithNodes(c.Node(4)), "sudo", "systemctl", cmd, "kv-n12")
+			_ = c.RunE(ctx, option.WithNodes(c.Node(4)), "sudo", "systemctl", cmd, "kv-n3")
 		}
 	}
 
@@ -158,11 +158,11 @@ func runAdmissionControlFollowerOverload(
 	if cfg.kv0N12 {
 		args := strings.Fields("./cockroach workload init kv {pgurl:1}")
 		args = append(args, strings.Fields(cfg.kvN12ExtraArgs)...)
-		c.Run(ctx, c.Node(1), args...)
+		c.Run(ctx, option.WithNodes(c.Node(1)), args...)
 	}
 	if cfg.kv50N3 {
 		args := strings.Fields("./cockroach workload init kv --db kvn3 {pgurl:1}")
-		c.Run(ctx, c.Node(1), args...)
+		c.Run(ctx, option.WithNodes(c.Node(1)), args...)
 	}
 
 	// Node 3 should not have any leases (excepting kvn3, if present).
@@ -233,7 +233,7 @@ sudo systemd-run --property=Type=exec \
 --property=StandardError=file:/home/ubuntu/logs/kv-n12.stderr.log \
 --remain-after-exit --unit kv-n12 -- ./cockroach workload run kv --read-percent 0 \
 --max-rate 400 --concurrency 400 --min-block-bytes 5000 --max-block-bytes 5000 --tolerate-errors {pgurl:1-2}`
-		c.Run(ctx, c.Node(4), deployWorkload)
+		c.Run(ctx, option.WithNodes(c.Node(4)), deployWorkload)
 	}
 	if cfg.kv50N3 {
 		// On n3, we run a "trickle" workload that does not add much work to the
@@ -247,7 +247,7 @@ sudo systemd-run --property=Type=exec \
 --remain-after-exit --unit kv-n3 -- ./cockroach workload run kv --db kvn3 \
 --read-percent 50 --max-rate 100 --concurrency 1000 --min-block-bytes 100 --max-block-bytes 100 \
 --prometheus-port 2113 --tolerate-errors {pgurl:3}`
-		c.Run(ctx, c.Node(4), deployWorkload)
+		c.Run(ctx, option.WithNodes(c.Node(4)), deployWorkload)
 	}
 	t.L().Printf("deployed workload")
 
@@ -266,7 +266,7 @@ sudo systemd-run --property=Type=exec \
 		//   └─md0         9:0    0 872.3G  0 raid0 /mnt/data1
 		//
 		// and so the actual write throttle is about 2x what was set.
-		c.Run(ctx, c.Node(3), "sudo", "systemctl", "set-property", "cockroach", "'IOWriteBandwidthMax={store-dir} 20971520'")
+		c.Run(ctx, option.WithNodes(c.Node(3)), "sudo", "systemctl", "set-property", "cockroach", "'IOWriteBandwidthMax={store-dir} 20971520'")
 		t.L().Printf("installed write throughput limit on n3")
 	}
 

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -92,7 +92,7 @@ func registerIndexBackfill(r registry.Registry) {
 						// path. The reason it can't just poke at the running
 						// CRDB process is because when grabbing snapshots, CRDB
 						// is not running.
-						c.Run(ctx, c.All(), fmt.Sprintf("cp %s ./cockroach", path))
+						c.Run(ctx, option.WithNodes(c.All()), fmt.Sprintf("cp %s ./cockroach", path))
 						settings := install.MakeClusterSettings(install.NumRacksOption(crdbNodes))
 						startOpts := option.DefaultStartOptsNoBackups()
 						roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)

--- a/pkg/cmd/roachtest/tests/admission_control_index_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_overload.go
@@ -73,12 +73,12 @@ func registerIndexOverload(r registry.Registry) {
 			if !t.SkipInit() {
 				t.Status("initializing kv dataset ", time.Minute)
 				splits := ifLocal(c, " --splits=3", " --splits=100")
-				c.Run(ctx, c.Node(workloadNode), "./cockroach workload init kv "+splits+" {pgurl:1}")
+				c.Run(ctx, option.WithNodes(c.Node(workloadNode)), "./cockroach workload init kv "+splits+" {pgurl:1}")
 
 				// We need a big enough size so index creation will take enough time.
 				t.Status("initializing tpcc dataset ", duration)
 				warehouses := ifLocal(c, " --warehouses=1", " --warehouses=2000")
-				c.Run(ctx, c.Node(workloadNode), "./cockroach workload fixtures import tpcc --checks=false"+warehouses+" {pgurl:1}")
+				c.Run(ctx, option.WithNodes(c.Node(workloadNode)), "./cockroach workload fixtures import tpcc --checks=false"+warehouses+" {pgurl:1}")
 
 				// Setting this low allows us to hit overload. In a larger cluster with
 				// more nodes and larger tables, it will hit the unmodified 1000 limit.
@@ -96,7 +96,7 @@ func registerIndexOverload(r registry.Registry) {
 			m.Go(func(ctx context.Context) error {
 				testDurationStr := " --duration=" + testDuration.String()
 				concurrency := ifLocal(c, "  --concurrency=8", " --concurrency=2048")
-				c.Run(ctx, c.Node(crdbNodes+1),
+				c.Run(ctx, option.WithNodes(c.Node(crdbNodes+1)),
 					"./cockroach workload run kv --read-percent=50 --max-rate=1000 --max-block-bytes=4096"+
 						testDurationStr+concurrency+fmt.Sprintf(" {pgurl:1-%d}", crdbNodes),
 				)

--- a/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
@@ -69,7 +69,7 @@ func registerMultiStoreOverload(r registry.Registry) {
 			cmdRegular := fmt.Sprintf("./workload run kv --init"+
 				dbRegular+histograms+concurrencyRegular+duration+readPercentRegular+
 				" {pgurl:1-%d}", nodes)
-			c.Run(ctx, c.Node(nodes+1), cmdRegular)
+			c.Run(ctx, option.WithNodes(c.Node(nodes+1)), cmdRegular)
 			return nil
 		})
 		m2 := c.NewMonitor(ctx, c.Range(1, nodes))
@@ -83,7 +83,7 @@ func registerMultiStoreOverload(r registry.Registry) {
 			cmdOverload := fmt.Sprintf("./workload run kv --init"+
 				dbOverload+histograms+concurrencyOverload+duration+readPercentOverload+blockSizeOverload+
 				" {pgurl:1-%d}", nodes)
-			c.Run(ctx, c.Node(nodes+1), cmdOverload)
+			c.Run(ctx, option.WithNodes(c.Node(nodes+1)), cmdOverload)
 			return nil
 		})
 		m1.Wait()

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
@@ -110,7 +110,7 @@ func registerSnapshotOverload(r registry.Registry) {
 			t.Status(fmt.Sprintf("initializing kv dataset (<%s)", time.Minute))
 			if !t.SkipInit() {
 				splits := ifLocal(c, " --splits=10", " --splits=100")
-				c.Run(ctx, c.Node(workloadNode), "./cockroach workload init kv "+splits+" {pgurl:1}")
+				c.Run(ctx, option.WithNodes(c.Node(workloadNode)), "./cockroach workload init kv "+splits+" {pgurl:1}")
 
 				if _, err := db.ExecContext(ctx, fmt.Sprintf(
 					"ALTER DATABASE kv CONFIGURE ZONE USING num_replicas = %d, constraints = '{%s}', lease_preferences = '[[+n1]]'",
@@ -123,7 +123,7 @@ func registerSnapshotOverload(r registry.Registry) {
 			t.Status(fmt.Sprintf("initializing tpcc dataset (<%s)", 20*time.Minute))
 			if !t.SkipInit() {
 				warehouses := ifLocal(c, " --warehouses=10", " --warehouses=2000")
-				c.Run(ctx, c.Node(workloadNode), "./cockroach workload fixtures import tpcc --checks=false"+warehouses+" {pgurl:1}")
+				c.Run(ctx, option.WithNodes(c.Node(workloadNode)), "./cockroach workload fixtures import tpcc --checks=false"+warehouses+" {pgurl:1}")
 			}
 
 			const iters = 4
@@ -152,7 +152,7 @@ func registerSnapshotOverload(r registry.Registry) {
 				concurrency := ifLocal(c, "  --concurrency=8", " --concurrency=256")
 				maxRate := ifLocal(c, "  --max-rate=100", " --max-rate=12000")
 				splits := ifLocal(c, "  --splits=10", " --splits=100")
-				c.Run(ctx, c.Node(crdbNodes+1),
+				c.Run(ctx, option.WithNodes(c.Node(crdbNodes+1)),
 					"./cockroach workload run kv --max-block-bytes=1 --read-percent=95 "+
 						histograms+duration+concurrency+maxRate+splits+fmt.Sprintf(" {pgurl:1-%d}", crdbNodes),
 				)

--- a/pkg/cmd/roachtest/tests/allocation_bench.go
+++ b/pkg/cmd/roachtest/tests/allocation_bench.go
@@ -146,7 +146,7 @@ func (r kvAllocBenchEventRunner) run(ctx context.Context, c cluster.Cluster, t t
 		}
 	}
 	setupCmd += " {pgurl:1}"
-	err := c.RunE(ctx, c.Node(workloadNode), setupCmd)
+	err := c.RunE(ctx, option.WithNodes(c.Node(workloadNode)), setupCmd)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (r kvAllocBenchEventRunner) run(ctx context.Context, c cluster.Cluster, t t
 		runCmd, defaultAllocBenchConcurrency, defaultAllocBenchDuration.String(), workloadNode-1)
 
 	t.Status("running kv workload", runCmd)
-	return c.RunE(ctx, c.Node(workloadNode), runCmd)
+	return c.RunE(ctx, option.WithNodes(c.Node(workloadNode)), runCmd)
 }
 func registerAllocationBench(r registry.Registry) {
 	for _, spec := range []allocationBenchSpec{

--- a/pkg/cmd/roachtest/tests/allocator.go
+++ b/pkg/cmd/roachtest/tests/allocator.go
@@ -57,7 +57,7 @@ func registerAllocator(r registry.Registry) {
 		m.Go(func(ctx context.Context) error {
 			t.Status("loading fixture")
 			if err := c.RunE(
-				ctx, c.Node(1),
+				ctx, option.WithNodes(c.Node(1)),
 				"./cockroach", "workload", "fixtures", "import", "tpch", "--scale-factor", "10", pgurl,
 			); err != nil {
 				t.Fatal(err)
@@ -91,7 +91,7 @@ func registerAllocator(r registry.Registry) {
 
 		// Start the remaining nodes to kick off upreplication/rebalancing.
 		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Range(start+1, nodes))
-		c.Run(ctx, c.Node(1), fmt.Sprintf("./cockroach workload init kv --drop '%s'", pgurl))
+		c.Run(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf("./cockroach workload init kv --drop '%s'", pgurl))
 		for node := 1; node <= nodes; node++ {
 			node := node
 			// TODO(dan): Ideally, the test would fail if this queryload failed,
@@ -103,7 +103,7 @@ func registerAllocator(r registry.Registry) {
 					t.Fatal(err)
 				}
 				defer l.Close()
-				_ = c.RunE(ctx, c.Node(node), cmd)
+				_ = c.RunE(ctx, option.WithNodes(c.Node(node)), cmd)
 			}()
 		}
 
@@ -462,7 +462,7 @@ FROM crdb_internal.kv_store_status
 		t.Fatal(err)
 	}
 	decom := func(id int) {
-		c.Run(ctx, c.Node(1),
+		c.Run(ctx, option.WithNodes(c.Node(1)),
 			fmt.Sprintf("./cockroach node decommission --insecure --url=%s --wait=none %d", pgurl, id))
 	}
 

--- a/pkg/cmd/roachtest/tests/alterpk.go
+++ b/pkg/cmd/roachtest/tests/alterpk.go
@@ -54,19 +54,19 @@ func registerAlterPK(r registry.Registry) {
 
 			// Init the workload.
 			cmd := fmt.Sprintf("./workload init bank --drop --rows %d {pgurl%s}", numRows, roachNodes)
-			if err := c.RunE(ctx, loadNode, cmd); err != nil {
+			if err := c.RunE(ctx, option.WithNodes(loadNode), cmd); err != nil {
 				t.Fatal(err)
 			}
 			initDone <- struct{}{}
 
 			// Run the workload while the primary key change is happening.
 			cmd = fmt.Sprintf("./workload run bank --duration=%s {pgurl%s}", duration, roachNodes)
-			c.Run(ctx, loadNode, cmd)
+			c.Run(ctx, option.WithNodes(loadNode), cmd)
 			// Wait for the primary key change to finish.
 			<-pkChangeDone
 			t.Status("starting second run of the workload after primary key change")
 			// Run the workload after the primary key change occurs.
-			c.Run(ctx, loadNode, cmd)
+			c.Run(ctx, option.WithNodes(loadNode), cmd)
 			return nil
 		})
 		m.Go(func(ctx context.Context) error {
@@ -114,7 +114,7 @@ func registerAlterPK(r registry.Registry) {
 			warehouses,
 			pgurl,
 		)
-		if err := c.RunE(ctx, c.Node(roachNodes[0]), cmd); err != nil {
+		if err := c.RunE(ctx, option.WithNodes(c.Node(roachNodes[0])), cmd); err != nil {
 			t.Fatal(err)
 		}
 
@@ -128,7 +128,7 @@ func registerAlterPK(r registry.Registry) {
 				roachNodes,
 			)
 			t.Status("beginning workload")
-			c.Run(ctx, loadNode, runCmd)
+			c.Run(ctx, option.WithNodes(loadNode), runCmd)
 			t.Status("finished running workload")
 			return nil
 		})
@@ -178,7 +178,7 @@ func registerAlterPK(r registry.Registry) {
 			c.Node(roachNodes[0]),
 		)
 		t.Status("beginning database verification")
-		c.Run(ctx, loadNode, checkCmd)
+		c.Run(ctx, option.WithNodes(loadNode), checkCmd)
 		t.Status("finished database verification")
 	}
 	r.Add(registry.TestSpec{

--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -140,7 +140,7 @@ func registerAsyncpg(r registry.Registry) {
 		t.L().Printf("Test results for asyncpg: %s", result.Stdout+result.Stderr)
 		t.L().Printf("Test stdout for asyncpg")
 		if err := c.RunE(
-			ctx, node, "cd /mnt/data1/asyncpg && cat asyncpg.stdout",
+			ctx, option.WithNodes(node), "cd /mnt/data1/asyncpg && cat asyncpg.stdout",
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/autoupgrade.go
+++ b/pkg/cmd/roachtest/tests/autoupgrade.go
@@ -78,7 +78,7 @@ func registerAutoUpgrade(r registry.Registry) {
 			if err != nil {
 				return err
 			}
-			if err := c.RunE(ctx, c.Node(node),
+			if err := c.RunE(ctx, option.WithNodes(c.Node(node)),
 				fmt.Sprintf("./cockroach node decommission %d --insecure --url=%s", node, pgurl)); err != nil {
 				return err
 			}

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -184,12 +184,12 @@ func waitForPort(
 func runImportBankDataSplit(ctx context.Context, rows, ranges int, t test.Test, c cluster.Cluster) {
 	csvPort := 8081
 	csvCmd := importBankCSVServerCommand("./cockroach", csvPort)
-	c.Run(ctx, c.All(), csvCmd+` &> logs/workload-csv-server.log < /dev/null &`)
+	c.Run(ctx, option.WithNodes(c.All()), csvCmd+` &> logs/workload-csv-server.log < /dev/null &`)
 	if err := waitForPort(ctx, t.L(), c.All(), csvPort, c); err != nil {
 		t.Fatal(err)
 	}
 	importNode := 1
-	c.Run(ctx, c.Node(importNode), importBankCommand("./cockroach", rows, ranges, csvPort, importNode))
+	c.Run(ctx, option.WithNodes(c.Node(importNode)), importBankCommand("./cockroach", rows, ranges, csvPort, importNode))
 }
 
 func importBankData(ctx context.Context, rows int, t test.Test, c cluster.Cluster) string {
@@ -343,14 +343,14 @@ func registerBackup(r registry.Registry) {
 				// total elapsed time. This is used by roachperf to compute and display
 				// the average MB/sec per node.
 				tick()
-				c.Run(ctx, c.Node(1), `./cockroach sql --insecure --url=`+pgurl+` -e "
+				c.Run(ctx, option.WithNodes(c.Node(1)), `./cockroach sql --insecure --url=`+pgurl+` -e "
 				BACKUP bank.bank TO 'gs://`+backupTestingBucket+`/`+dest+`?AUTH=implicit'"`)
 				tick()
 
 				// Upload the perf artifacts to any one of the nodes so that the test
 				// runner copies it into an appropriate directory path.
 				dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
-				if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
+				if err := c.RunE(ctx, option.WithNodes(c.Node(1)), "mkdir -p "+filepath.Dir(dest)); err != nil {
 					log.Errorf(ctx, "failed to create perf dir: %+v", err)
 				}
 				if err := c.PutString(ctx, perfBuf.String(), dest, 0755, c.Node(1)); err != nil {
@@ -634,7 +634,7 @@ func runBackupMVCCRangeTombstones(
 		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings())
 	}
 	t.Status("starting csv servers")
-	c.Run(ctx, c.All(), `./cockroach workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
+	c.Run(ctx, option.WithNodes(c.All()), `./cockroach workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 
 	conn := c.Conn(ctx, t.L(), 1, option.TenantName(config.tenantName))
 

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -229,16 +229,16 @@ func startBackgroundWorkloads(
 		return nil, err
 	}
 
-	err := c.RunE(ctx, workloadNode, bankInit.String())
+	err := c.RunE(ctx, option.WithNodes(workloadNode), bankInit.String())
 	if err != nil {
 		return nil, err
 	}
 
-	err = c.RunE(ctx, workloadNode, tpccInit.String())
+	err = c.RunE(ctx, option.WithNodes(workloadNode), tpccInit.String())
 	if err != nil {
 		return nil, err
 	}
-	err = c.RunE(ctx, workloadNode, scInit.String())
+	err = c.RunE(ctx, option.WithNodes(workloadNode), scInit.String())
 	if err != nil {
 		return nil, err
 	}
@@ -250,14 +250,14 @@ func startBackgroundWorkloads(
 		}
 
 		stopBank := workloadWithCancel(m, func(ctx context.Context) error {
-			return c.RunE(ctx, workloadNode, bankRun.String())
+			return c.RunE(ctx, option.WithNodes(workloadNode), bankRun.String())
 		})
 
 		stopTPCC := workloadWithCancel(m, func(ctx context.Context) error {
-			return c.RunE(ctx, workloadNode, tpccRun.String())
+			return c.RunE(ctx, option.WithNodes(workloadNode), tpccRun.String())
 		})
 		stopSC := workloadWithCancel(m, func(ctx context.Context) error {
-			return c.RunE(ctx, workloadNode, scRun.String())
+			return c.RunE(ctx, option.WithNodes(workloadNode), scRun.String())
 		})
 
 		stopSystemWriter := workloadWithCancel(m, func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/build_info.go
+++ b/pkg/cmd/roachtest/tests/build_info.go
@@ -83,8 +83,8 @@ func RunBuildAnalyze(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// we can use, choose `scanelf` for being the simplest to use (empty
 	// output indicates everything's fine, non-empty means something
 	// bad).
-	c.Run(ctx, c.Node(1), "sudo apt-get update")
-	c.Run(ctx, c.Node(1), "sudo apt-get -qqy install pax-utils")
+	c.Run(ctx, option.WithNodes(c.Node(1)), "sudo apt-get update")
+	c.Run(ctx, option.WithNodes(c.Node(1)), "sudo apt-get -qqy install pax-utils")
 
 	result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(1), "scanelf -qe cockroach")
 	if err != nil {

--- a/pkg/cmd/roachtest/tests/canary.go
+++ b/pkg/cmd/roachtest/tests/canary.go
@@ -112,7 +112,7 @@ func repeatRunE(
 		}
 		attempt++
 		t.L().Printf("attempt %d - %s", attempt, operation)
-		lastError = c.RunE(ctx, node, args...)
+		lastError = c.RunE(ctx, option.WithNodes(node), args...)
 		if lastError != nil {
 			t.L().Printf("error - retrying: %s", lastError)
 			continue
@@ -301,5 +301,5 @@ func gitCloneWithRecurseSubmodules(
 		fi
 	'`, dest, branch, src),
 	}
-	return errors.Wrap(c.RunE(ctx, node, cmd...), "gitCloneWithRecurseSubmodules")
+	return errors.Wrap(c.RunE(ctx, option.WithNodes(node), cmd...), "gitCloneWithRecurseSubmodules")
 }

--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -257,7 +257,7 @@ func runCDCBenchScan(
 	// NB: don't scatter -- the ranges end up fairly well-distributed anyway, and
 	// the scatter can often fail with 100k ranges.
 	t.L().Printf("creating table with %s ranges", humanize.Comma(numRanges))
-	c.Run(ctx, nCoord, fmt.Sprintf(
+	c.Run(ctx, option.WithNodes(nCoord), fmt.Sprintf(
 		`./cockroach workload init kv --splits %d {pgurl:%d}`, numRanges, nData[0]))
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
 
@@ -270,7 +270,7 @@ func runCDCBenchScan(
 		loader = "insert"
 	}
 	t.L().Printf("ingesting %s rows using %s", humanize.Comma(numRows), loader)
-	c.Run(ctx, nCoord, fmt.Sprintf(
+	c.Run(ctx, option.WithNodes(nCoord), fmt.Sprintf(
 		`./cockroach workload init kv --insert-count %d --data-loader %s {pgurl:%d}`,
 		numRows, loader, nData[0]))
 
@@ -398,7 +398,7 @@ func runCDCBenchWorkload(
 	// NB: don't scatter -- the ranges end up fairly well-distributed anyway, and
 	// the scatter can often fail with 100k ranges.
 	t.L().Printf("creating table with %s ranges", humanize.Comma(numRanges))
-	c.Run(ctx, nWorkload, fmt.Sprintf(
+	c.Run(ctx, option.WithNodes(nWorkload), fmt.Sprintf(
 		`./cockroach workload init kv --splits %d {pgurl:%d}`, numRanges, nData[0]))
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
 
@@ -410,7 +410,7 @@ func runCDCBenchWorkload(
 		const batchSize = 1000
 		batches := (insertCount-1)/batchSize + 1 // ceiling division
 		t.L().Printf("ingesting %s rows", humanize.Comma(insertCount))
-		c.Run(ctx, nWorkload, fmt.Sprintf(
+		c.Run(ctx, option.WithNodes(nWorkload), fmt.Sprintf(
 			`./cockroach workload run kv --seed %d --read-percent 0 --batch %d --max-ops %d {pgurl:%d}`,
 			workloadSeed, batchSize, batches, nData[0]))
 	}
@@ -498,7 +498,7 @@ func runCDCBenchWorkload(
 			extra += ` --tolerate-errors`
 		}
 		t.L().Printf("running workload")
-		err := c.RunE(ctx, nWorkload, fmt.Sprintf(
+		err := c.RunE(ctx, option.WithNodes(nWorkload), fmt.Sprintf(
 			`./cockroach workload run kv --seed %d --histograms=%s/stats.json `+
 				`--concurrency %d --duration %s --write-seq R%d --read-percent %d %s {pgurl:%d-%d}`,
 			workloadSeed, t.PerfArtifactsDir(), concurrency, duration, insertCount, readPercent, extra,
@@ -606,7 +606,7 @@ func writeCDCBenchStats(
 
 	// Upload the perf artifacts to the given node.
 	path := filepath.Join(t.PerfArtifactsDir(), "stats.json")
-	if err := c.RunE(ctx, node, "mkdir -p "+filepath.Dir(path)); err != nil {
+	if err := c.RunE(ctx, option.WithNodes(node), "mkdir -p "+filepath.Dir(path)); err != nil {
 		return err
 	}
 	if err := c.PutString(ctx, bytesBuf.String(), path, 0755, node); err != nil {

--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -74,7 +74,7 @@ func runClearRange(ctx context.Context, t test.Test, c cluster.Cluster, aggressi
 	m.Go(func(ctx context.Context) error {
 		// NB: on a 10 node cluster, this should take well below 3h.
 		tBegin := timeutil.Now()
-		c.Run(ctx, c.Node(1), "./cockroach", "workload", "fixtures", "import", "bank",
+		c.Run(ctx, option.WithNodes(c.Node(1)), "./cockroach", "workload", "fixtures", "import", "bank",
 			"--payload-bytes=10240", "--ranges=10", "--rows=65104166", "--seed=4", "--db=bigbank", pgurl)
 		t.L().Printf("import took %.2fs", timeutil.Since(tBegin).Seconds())
 		return nil
@@ -104,9 +104,9 @@ func runClearRange(ctx context.Context, t test.Test, c cluster.Cluster, aggressi
 	// Use a 120s connect timeout to work around the fact that the server will
 	// declare itself ready before it's actually 100% ready. See:
 	// https://github.com/cockroachdb/cockroach/issues/34897#issuecomment-465089057
-	c.Run(ctx, c.Node(1), fmt.Sprintf(
+	c.Run(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf(
 		`COCKROACH_CONNECT_TIMEOUT=120 ./cockroach sql --url=%s --insecure -e "DROP DATABASE IF EXISTS tinybank"`, pgurl))
-	c.Run(ctx, c.Node(1), "./cockroach", "workload", "fixtures", "import", "bank", "--db=tinybank",
+	c.Run(ctx, option.WithNodes(c.Node(1)), "./cockroach", "workload", "fixtures", "import", "bank", "--db=tinybank",
 		"--payload-bytes=100", "--ranges=10", "--rows=800", "--seed=1", pgurl)
 
 	t.Status()
@@ -139,8 +139,8 @@ ORDER BY raw_start_key ASC LIMIT 1`,
 	}()
 
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, c.Node(1), `./cockroach workload init kv`, pgurl)
-		c.Run(ctx, c.All(), fmt.Sprintf(`./cockroach workload run kv --concurrency=32 --duration=1h --tolerate-errors {pgurl%s}`, c.All()))
+		c.Run(ctx, option.WithNodes(c.Node(1)), `./cockroach workload init kv`, pgurl)
+		c.Run(ctx, option.WithNodes(c.All()), fmt.Sprintf(`./cockroach workload run kv --concurrency=32 --duration=1h --tolerate-errors {pgurl%s}`, c.All()))
 		return nil
 	})
 	m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/cluster_init.go
+++ b/pkg/cmd/roachtest/tests/cluster_init.go
@@ -150,7 +150,7 @@ func runClusterInit(ctx context.Context, t test.Test, c cluster.Cluster) {
 		}
 
 		t.L().Printf("sending init command to node %d", initNode)
-		c.Run(ctx, c.Node(initNode),
+		c.Run(ctx, option.WithNodes(c.Node(initNode)),
 			fmt.Sprintf(`./cockroach init --insecure --port={pgport:%d}`, initNode))
 
 		// This will only succeed if 3 nodes joined the cluster.

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -211,7 +211,7 @@ type streamingWorkload interface {
 func defaultWorkloadDriver(
 	workloadCtx context.Context, setup *c2cSetup, c cluster.Cluster, workload streamingWorkload,
 ) error {
-	return c.RunE(workloadCtx, setup.workloadNode, workload.sourceRunCmd(setup.src.name, setup.src.gatewayNodes))
+	return c.RunE(workloadCtx, option.WithNodes(setup.workloadNode), workload.sourceRunCmd(setup.src.name, setup.src.gatewayNodes))
 }
 
 type replicateTPCC struct {
@@ -656,7 +656,7 @@ func (rd *replicationDriver) preStreamingWorkload(ctx context.Context) {
 	if initCmd := rd.rs.workload.sourceInitCmd(rd.setup.src.name, rd.setup.src.nodes); initCmd != "" {
 		rd.t.Status("populating source cluster before replication")
 		initStart := timeutil.Now()
-		rd.c.Run(ctx, rd.setup.workloadNode, initCmd)
+		rd.c.Run(ctx, option.WithNodes(rd.setup.workloadNode), initCmd)
 		rd.t.L().Printf("src cluster workload initialization took %s",
 			timeutil.Since(initStart))
 	}

--- a/pkg/cmd/roachtest/tests/connection_latency.go
+++ b/pkg/cmd/roachtest/tests/connection_latency.go
@@ -54,17 +54,17 @@ func runConnectionLatencyTest(
 	// Only create the user once.
 	t.L().Printf("creating testuser")
 	if password {
-		err = c.RunE(ctx, c.Node(1), `./cockroach sql --certs-dir certs --port={pgport:1} -e "CREATE USER testuser WITH PASSWORD '123' CREATEDB"`)
+		err = c.RunE(ctx, option.WithNodes(c.Node(1)), `./cockroach sql --certs-dir certs --port={pgport:1} -e "CREATE USER testuser WITH PASSWORD '123' CREATEDB"`)
 		require.NoError(t, err)
-		err = c.RunE(ctx, c.Node(1), fmt.Sprintf("./workload init connectionlatency --user testuser --password '123' --secure '%s'", urlTemplate("localhost")))
+		err = c.RunE(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf("./workload init connectionlatency --user testuser --password '123' --secure '%s'", urlTemplate("localhost")))
 		require.NoError(t, err)
 		passwordFlag = "--password 123 "
 	} else {
 		// NB: certs for `testuser` are created by `roachprod start --secure`.
-		err = c.RunE(ctx, c.Node(1), `./cockroach sql --certs-dir certs --port={pgport:1} -e "CREATE USER testuser CREATEDB"`)
+		err = c.RunE(ctx, option.WithNodes(c.Node(1)), `./cockroach sql --certs-dir certs --port={pgport:1} -e "CREATE USER testuser CREATEDB"`)
 		require.NoError(t, err)
 		require.NoError(t, err)
-		err = c.RunE(ctx, c.Node(1), fmt.Sprintf("./workload init connectionlatency --user testuser --secure '%s'", urlTemplate("localhost")))
+		err = c.RunE(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf("./workload init connectionlatency --user testuser --secure '%s'", urlTemplate("localhost")))
 		require.NoError(t, err)
 	}
 
@@ -89,7 +89,7 @@ func runConnectionLatencyTest(
 			t.PerfArtifactsDir(),
 			locality,
 		)
-		err = c.RunE(ctx, loadNode, workloadCmd)
+		err = c.RunE(ctx, option.WithNodes(loadNode), workloadCmd)
 		require.NoError(t, err)
 	}
 

--- a/pkg/cmd/roachtest/tests/copy.go
+++ b/pkg/cmd/roachtest/tests/copy.go
@@ -76,7 +76,7 @@ func registerCopy(r registry.Registry) {
 			}
 
 			t.Status("importing Bank fixture")
-			c.Run(ctx, c.Node(1), fmt.Sprintf(
+			c.Run(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf(
 				"./workload fixtures load bank --rows=%d --payload-bytes=%d --seed %d {pgurl:1}",
 				rows, payload, fixturesRandomSeed))
 			if _, err := db.Exec("ALTER TABLE bank.bank RENAME TO bank.bank_orig"); err != nil {
@@ -84,7 +84,7 @@ func registerCopy(r registry.Registry) {
 			}
 
 			t.Status("create copy of Bank schema")
-			c.Run(ctx, c.Node(1), "./workload init bank --rows=0 --ranges=0 {pgurl:1}")
+			c.Run(ctx, option.WithNodes(c.Node(1)), "./workload init bank --rows=0 --ranges=0 {pgurl:1}")
 
 			rangeCount := func() int {
 				var count int

--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -73,8 +73,8 @@ func initTest(ctx context.Context, t test.Test, c cluster.Cluster, sf int) {
 		t.L().Printf("when running locally, ensure that psql is installed")
 	}
 	csv := fmt.Sprintf(tpchLineitemFmt, sf)
-	c.Run(ctx, c.Node(1), "rm -f /tmp/lineitem-table.csv")
-	c.Run(ctx, c.Node(1), fmt.Sprintf("curl '%s' -o /tmp/lineitem-table.csv", csv))
+	c.Run(ctx, option.WithNodes(c.Node(1)), "rm -f /tmp/lineitem-table.csv")
+	c.Run(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf("curl '%s' -o /tmp/lineitem-table.csv", csv))
 }
 
 func runTest(ctx context.Context, t test.Test, c cluster.Cluster, pg string) {
@@ -120,18 +120,18 @@ func runTest(ctx context.Context, t test.Test, c cluster.Cluster, pg string) {
 	dataRate := bytes / 1024 / 1024 / dur.Seconds()
 	t.L().Printf("results: %d rows/s, %f mb/s", rate, dataRate)
 	// Write the copy rate into the stats.json file to be used by roachperf.
-	c.Run(ctx, c.Node(1), "mkdir", t.PerfArtifactsDir())
+	c.Run(ctx, option.WithNodes(c.Node(1)), "mkdir", t.PerfArtifactsDir())
 	cmd := fmt.Sprintf(
 		`echo '{ "copy_row_rate": %d, "copy_data_rate": %f}' > %s/stats.json`,
 		rate, dataRate, t.PerfArtifactsDir(),
 	)
-	c.Run(ctx, c.Node(1), cmd)
+	c.Run(ctx, option.WithNodes(c.Node(1)), cmd)
 }
 
 func runCopyFromPG(ctx context.Context, t test.Test, c cluster.Cluster, sf int) {
 	initTest(ctx, t, c, sf)
-	c.Run(ctx, c.Node(1), "sudo -i -u postgres psql -c 'DROP TABLE IF EXISTS lineitem'")
-	c.Run(ctx, c.Node(1), fmt.Sprintf("sudo -i -u postgres psql -c '%s'", lineitemSchema))
+	c.Run(ctx, option.WithNodes(c.Node(1)), "sudo -i -u postgres psql -c 'DROP TABLE IF EXISTS lineitem'")
+	c.Run(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf("sudo -i -u postgres psql -c '%s'", lineitemSchema))
 	runTest(ctx, t, c, "sudo -i -u postgres psql")
 }
 
@@ -164,8 +164,8 @@ func runCopyFromCRDB(ctx context.Context, t test.Test, c cluster.Cluster, sf int
 		require.NoError(t, err)
 		u.User = url.User("importer")
 		urlstr = u.String()
-		c.Run(ctx, c.Node(1), fmt.Sprintf("psql %s -c 'SELECT 1'", urlstr))
-		c.Run(ctx, c.Node(1), fmt.Sprintf("psql %s -c '%s'", urlstr, lineitemSchema))
+		c.Run(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf("psql %s -c 'SELECT 1'", urlstr))
+		c.Run(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf("psql %s -c '%s'", urlstr, lineitemSchema))
 		runTest(ctx, t, c, fmt.Sprintf("psql '%s'", urlstr))
 		return nil
 	})

--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -52,7 +52,7 @@ func registerDisaggRebalance(r registry.Registry) {
 			)
 			m := c.NewMonitor(ctx, c.Range(1, 3))
 			m.Go(func(ctx context.Context) error {
-				return c.RunE(ctx, c.Node(1), cmd)
+				return c.RunE(ctx, option.WithNodes(c.Node(1)), cmd)
 			})
 			m.Wait()
 
@@ -66,7 +66,7 @@ func registerDisaggRebalance(r registry.Registry) {
 					warehouses,
 				)
 
-				return c.RunE(ctx, c.Node(1), cmd)
+				return c.RunE(ctx, option.WithNodes(c.Node(1)), cmd)
 			})
 
 			select {

--- a/pkg/cmd/roachtest/tests/disk_full.go
+++ b/pkg/cmd/roachtest/tests/disk_full.go
@@ -60,13 +60,13 @@ func registerDiskFull(r registry.Registry) {
 					"./cockroach workload run kv --tolerate-errors --init --read-percent=0"+
 						" --concurrency=10 --duration=4m {pgurl:2-%d}",
 					nodes)
-				c.Run(ctx, c.Node(nodes+1), cmd)
+				c.Run(ctx, option.WithNodes(c.Node(nodes+1)), cmd)
 				return nil
 			})
 
 			// Each node should have an automatically created
 			// EMERGENCY_BALLAST file in the auxiliary directory.
-			c.Run(ctx, c.Range(1, nodes), "stat {store-dir}/auxiliary/EMERGENCY_BALLAST")
+			c.Run(ctx, option.WithNodes(c.Range(1, nodes)), "stat {store-dir}/auxiliary/EMERGENCY_BALLAST")
 
 			m.Go(func(ctx context.Context) error {
 				const n = 1
@@ -76,7 +76,7 @@ func registerDiskFull(r registry.Registry) {
 				// (size=100%). The "|| true" is used to ignore the
 				// error returned by `debug ballast`.
 				m.ExpectDeath()
-				c.Run(ctx, c.Node(n), "./cockroach debug ballast {store-dir}/largefile --size=100% || true")
+				c.Run(ctx, option.WithNodes(c.Node(n)), "./cockroach debug ballast {store-dir}/largefile --size=100% || true")
 
 				// Node 1 should forcibly exit due to a full disk.
 				for isLive := true; isLive; {
@@ -138,7 +138,7 @@ func registerDiskFull(r registry.Registry) {
 				// file removed and has been successfully restarted.
 				t.L().Printf("removing the emergency ballast on n%d\n", n)
 				m.ExpectDeath()
-				c.Run(ctx, c.Node(n), "rm -f {store-dir}/auxiliary/EMERGENCY_BALLAST")
+				c.Run(ctx, option.WithNodes(c.Node(n)), "rm -f {store-dir}/auxiliary/EMERGENCY_BALLAST")
 				if err := c.StartE(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(n)); err != nil {
 					t.Fatal(err)
 				}
@@ -148,14 +148,14 @@ func registerDiskFull(r registry.Registry) {
 				// added to induce the out-of-disk condition.
 				time.Sleep(30 * time.Second)
 				t.L().Printf("removing n%d's large file to free up available disk space.\n", n)
-				c.Run(ctx, c.Node(n), "rm -f {store-dir}/largefile")
+				c.Run(ctx, option.WithNodes(c.Node(n)), "rm -f {store-dir}/largefile")
 
 				// When CockroachDB detects that it has sufficient
 				// capacity available, it should recreate the emergency
 				// ballast file automatically.
 				t.L().Printf("waiting for node n%d's emergency ballast to be restored.\n", n)
 				for {
-					err := c.RunE(ctx, c.Node(1), "stat {store-dir}/auxiliary/EMERGENCY_BALLAST")
+					err := c.RunE(ctx, option.WithNodes(c.Node(1)), "stat {store-dir}/auxiliary/EMERGENCY_BALLAST")
 					if err == nil {
 						return nil
 					}

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -120,7 +120,7 @@ func runDiskStalledDetection(
 	// Wait for upreplication.
 	require.NoError(t, WaitFor3XReplication(ctx, t, n2conn))
 
-	c.Run(ctx, c.Node(4), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
+	c.Run(ctx, option.WithNodes(c.Node(4)), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
 
 	_, err = n2conn.ExecContext(ctx, `USE kv;`)
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func runDiskStalledDetection(
 		// NB: Since we stall node 1, we run the workload only on nodes 2-3 so
 		// the post-stall QPS isn't affected by the fact that 1/3rd of workload
 		// workers just can't connect to a working node.
-		c.Run(ctx, c.Node(4), `./cockroach workload run kv --read-percent 50 `+
+		c.Run(ctx, option.WithNodes(c.Node(4)), `./cockroach workload run kv --read-percent 50 `+
 			`--duration 10m --concurrency 256 --max-rate 2048 --tolerate-errors `+
 			` --min-block-bytes=512 --max-block-bytes=512 `+
 			`{pgurl:2-3}`)
@@ -301,35 +301,35 @@ func (s *dmsetupDiskStaller) Setup(ctx context.Context) {
 	// snapd will run "snapd auto-import /dev/dm-0" via udev triggers when
 	// /dev/dm-0 is created. This possibly interferes with the dmsetup create
 	// reload, so uninstall snapd.
-	s.c.Run(ctx, s.c.All(), `sudo apt-get purge -y snapd`)
-	s.c.Run(ctx, s.c.All(), `sudo umount -f /mnt/data1 || true`)
-	s.c.Run(ctx, s.c.All(), `sudo dmsetup remove_all`)
-	err := s.c.RunE(ctx, s.c.All(), `echo "0 $(sudo blockdev --getsz `+dev+`) linear `+dev+` 0" | `+
+	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo apt-get purge -y snapd`)
+	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo umount -f /mnt/data1 || true`)
+	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo dmsetup remove_all`)
+	err := s.c.RunE(ctx, option.WithNodes(s.c.All()), `echo "0 $(sudo blockdev --getsz `+dev+`) linear `+dev+` 0" | `+
 		`sudo dmsetup create data1`)
 	if err != nil {
 		// This has occasionally been seen to fail with "Device or resource busy",
 		// with no clear explanation. Try to find out who it is.
-		s.c.Run(ctx, s.c.All(), "sudo bash -c 'ps aux; dmsetup status; mount; lsof'")
+		s.c.Run(ctx, option.WithNodes(s.c.All()), "sudo bash -c 'ps aux; dmsetup status; mount; lsof'")
 		s.t.Fatal(err)
 	}
-	s.c.Run(ctx, s.c.All(), `sudo mount /dev/mapper/data1 /mnt/data1`)
+	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo mount /dev/mapper/data1 /mnt/data1`)
 }
 
 func (s *dmsetupDiskStaller) Cleanup(ctx context.Context) {
-	s.c.Run(ctx, s.c.All(), `sudo dmsetup resume data1`)
-	s.c.Run(ctx, s.c.All(), `sudo umount /mnt/data1`)
-	s.c.Run(ctx, s.c.All(), `sudo dmsetup remove_all`)
-	s.c.Run(ctx, s.c.All(), `sudo mount /mnt/data1`)
+	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo dmsetup resume data1`)
+	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo umount /mnt/data1`)
+	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo dmsetup remove_all`)
+	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo mount /mnt/data1`)
 	// Reinstall snapd in case subsequent tests need it.
-	s.c.Run(ctx, s.c.All(), `sudo apt-get install -y snapd`)
+	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo apt-get install -y snapd`)
 }
 
 func (s *dmsetupDiskStaller) Stall(ctx context.Context, nodes option.NodeListOption) {
-	s.c.Run(ctx, nodes, `sudo dmsetup suspend --noflush --nolockfs data1`)
+	s.c.Run(ctx, option.WithNodes(nodes), `sudo dmsetup suspend --noflush --nolockfs data1`)
 }
 
 func (s *dmsetupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOption) {
-	s.c.Run(ctx, nodes, `sudo dmsetup resume data1`)
+	s.c.Run(ctx, option.WithNodes(nodes), `sudo dmsetup resume data1`)
 }
 
 func (s *dmsetupDiskStaller) DataDir() string { return "{store-dir}" }
@@ -350,8 +350,8 @@ func (s *cgroupDiskStaller) LogDir() string {
 }
 func (s *cgroupDiskStaller) Setup(ctx context.Context) {
 	if s.logsToo {
-		s.c.Run(ctx, s.c.All(), "mkdir -p {store-dir}/logs")
-		s.c.Run(ctx, s.c.All(), "rm -f logs && ln -s {store-dir}/logs logs || true")
+		s.c.Run(ctx, option.WithNodes(s.c.All()), "mkdir -p {store-dir}/logs")
+		s.c.Run(ctx, option.WithNodes(s.c.All()), "rm -f logs && ln -s {store-dir}/logs logs || true")
 	}
 }
 func (s *cgroupDiskStaller) Cleanup(ctx context.Context) {}
@@ -429,7 +429,7 @@ func (s *cgroupDiskStaller) setThroughput(
 	if bw.limited {
 		bytesPerSecondStr = fmt.Sprintf("%d", bw.bytesPerSecond)
 	}
-	return s.c.RunE(ctx, nodes, "sudo", "/bin/bash", "-c", fmt.Sprintf(
+	return s.c.RunE(ctx, option.WithNodes(nodes), "sudo", "/bin/bash", "-c", fmt.Sprintf(
 		`'echo %d:%d %s=%s > %s'`,
 		maj,
 		min,

--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -200,7 +200,7 @@ func registerDjango(r registry.Registry) {
 			t.L().Printf("Test results for app %s: %s", testName, rawResults)
 			t.L().Printf("Test stdout for app %s:", testName)
 			if err := c.RunE(
-				ctx, node, fmt.Sprintf("cd /mnt/data1/django/tests && cat %s.stdout", testName),
+				ctx, option.WithNodes(node), fmt.Sprintf("cd /mnt/data1/django/tests && cat %s.stdout", testName),
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/roachtest/tests/drain.go
+++ b/pkg/cmd/roachtest/tests/drain.go
@@ -265,7 +265,7 @@ func runWarningForConnWait(ctx context.Context, t test.Test, c cluster.Cluster) 
 			t.Fatal(err)
 		}
 		return c.RunE(ctx,
-			c.Node(nodeToDrain),
+			option.WithNodes(c.Node(nodeToDrain)),
 			fmt.Sprintf("./cockroach node drain --self --insecure --drain-wait=600s --url=%s", pgurl),
 		)
 	})
@@ -319,7 +319,7 @@ func runWarningForConnWait(ctx context.Context, t test.Test, c cluster.Cluster) 
 	require.NoError(t, err, "error waiting for the draining to finish")
 
 	logFile := filepath.Join("logs", "*.log")
-	err = c.RunE(ctx, c.Node(nodeToDrain),
+	err = c.RunE(ctx, option.WithNodes(c.Node(nodeToDrain)),
 		"grep", "-q", "'proceeding to drain SQL connections'", logFile)
 	require.NoError(t, err, "warning is not logged in the log file")
 }

--- a/pkg/cmd/roachtest/tests/drop.go
+++ b/pkg/cmd/roachtest/tests/drop.go
@@ -47,7 +47,7 @@ func registerDrop(r registry.Registry) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			c.Run(ctx, c.Node(1), tpccImportCmd(warehouses, pgurl))
+			c.Run(ctx, option.WithNodes(c.Node(1)), tpccImportCmd(warehouses, pgurl))
 
 			// Don't open the DB connection until after the data has been imported.
 			// Otherwise the ALTER TABLE query below might fail to find the

--- a/pkg/cmd/roachtest/tests/encryption.go
+++ b/pkg/cmd/roachtest/tests/encryption.go
@@ -36,7 +36,7 @@ func registerEncryption(r registry.Registry) {
 			t.Fatal(err)
 		}
 		for _, addr := range adminAddrs {
-			if err := c.RunE(ctx, c.Node(nodes), fmt.Sprintf(`curl http://%s/_status/stores/local | (! grep '"encryptionStatus": null')`, addr)); err != nil {
+			if err := c.RunE(ctx, option.WithNodes(c.Node(nodes)), fmt.Sprintf(`curl http://%s/_status/stores/local | (! grep '"encryptionStatus": null')`, addr)); err != nil {
 				t.Fatalf("encryption status from /_status/stores/local endpoint is null")
 			}
 		}
@@ -52,12 +52,12 @@ func registerEncryption(r registry.Registry) {
 
 		testCLIGenKey := func(size int) error {
 			// Generate encryption store key through `./cockroach gen encryption-key -s=size aes-size.key`.
-			if err := c.RunE(ctx, c.Node(nodes), fmt.Sprintf("./cockroach gen encryption-key -s=%[1]d aes-%[1]d.key", size)); err != nil {
+			if err := c.RunE(ctx, option.WithNodes(c.Node(nodes)), fmt.Sprintf("./cockroach gen encryption-key -s=%[1]d aes-%[1]d.key", size)); err != nil {
 				return errors.Wrapf(err, "failed to generate AES key with size %d through CLI", size)
 			}
 
 			// Check the size of generated aes key has expected size.
-			if err := c.RunE(ctx, c.Node(nodes), fmt.Sprintf(`size=$(wc -c <"aes-%d.key"); test $size -eq %d && exit 0 || exit 1`, size, 32+size/8)); err != nil {
+			if err := c.RunE(ctx, option.WithNodes(c.Node(nodes)), fmt.Sprintf(`size=$(wc -c <"aes-%d.key"); test $size -eq %d && exit 0 || exit 1`, size, 32+size/8)); err != nil {
 				return errors.Errorf("expected aes-%d.key has size %d bytes, but got different size", size, 32+size/8)
 			}
 

--- a/pkg/cmd/roachtest/tests/flowable.go
+++ b/pkg/cmd/roachtest/tests/flowable.go
@@ -136,7 +136,7 @@ grep "force-commit" . -lr | xargs sed -i 's/-- force-commit//g'`,
 			t.Fatal(err)
 		}
 
-		if err := c.RunE(ctx, node,
+		if err := c.RunE(ctx, option.WithNodes(node),
 			`cd /mnt/data1/flowable-engine/ && \
 ./mvnw clean test -Dtest=Flowable6Test#testLongServiceTaskLoop -Ddatabase=cockroachdb`,
 		); err != nil {

--- a/pkg/cmd/roachtest/tests/gopg.go
+++ b/pkg/cmd/roachtest/tests/gopg.go
@@ -94,7 +94,7 @@ func registerGopg(r registry.Registry) {
 		t.L().Printf("Running cockroach version %s, using blocklist %s, using ignorelist %s",
 			version, "gopgBlockList", "gopgIgnoreList")
 
-		if err := c.RunE(ctx, node, fmt.Sprintf("mkdir -p %s", resultsDirPath)); err != nil {
+		if err := c.RunE(ctx, option.WithNodes(node), fmt.Sprintf("mkdir -p %s", resultsDirPath)); err != nil {
 			t.Fatal(err)
 		}
 		t.Status("running gopg test suite")
@@ -143,7 +143,7 @@ func registerGopg(r registry.Registry) {
 		// It's safer to clean up dependencies this way than it is to give the cluster
 		// wipe root access.
 		defer func() {
-			c.Run(ctx, c.All(), "go clean -modcache")
+			c.Run(ctx, option.WithNodes(c.All()), "go clean -modcache")
 		}()
 
 		// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.

--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -433,7 +433,7 @@ SELECT count(replicas)
 	// Restart node 1, but have it listen on a different port for internal
 	// connections. This will require node 1 to reach out to the other nodes in
 	// the cluster for gossip info.
-	err = c.RunE(ctx, c.Node(1),
+	err = c.RunE(ctx, option.WithNodes(c.Node(1)),
 		` ./cockroach start --insecure --background --store={store-dir} `+
 			`--log-dir={log-dir} --cache=10% --max-sql-memory=10% `+
 			fmt.Sprintf(`--listen-addr=:$[{pgport:1}+1000] --http-port=%d `, adminPorts[0])+

--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -193,7 +193,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 		// Note that this will take upwards of 3 hours.
 		// Also note that this is expected to return an error, since the test suite
 		// will fail. And it is safe to swallow it here.
-		_ = c.RunE(ctx, node, opt.testCmd)
+		_ = c.RunE(ctx, option.WithNodes(node), opt.testCmd)
 
 		t.Status("collecting the test results")
 		// Copy all of the test results to the cockroach logs directory to be

--- a/pkg/cmd/roachtest/tests/hotspotsplits.go
+++ b/pkg/cmd/roachtest/tests/hotspotsplits.go
@@ -37,7 +37,7 @@ func registerHotSpotSplits(r registry.Registry) {
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), roachNodes)
 
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload", appNode)
-		c.Run(ctx, appNode, `./workload init kv --drop {pgurl:1}`)
+		c.Run(ctx, option.WithNodes(appNode), `./workload init kv --drop {pgurl:1}`)
 
 		var m *errgroup.Group // see comment in version.go
 		m, ctx = errgroup.WithContext(ctx)
@@ -46,7 +46,7 @@ func registerHotSpotSplits(r registry.Registry) {
 			t.L().Printf("starting load generator\n")
 
 			const blockSize = 1 << 18 // 256 KB
-			return c.RunE(ctx, appNode, fmt.Sprintf(
+			return c.RunE(ctx, option.WithNodes(appNode), fmt.Sprintf(
 				"./workload run kv --read-percent=0 --tolerate-errors --concurrency=%d "+
 					"--min-block-bytes=%d --max-block-bytes=%d --duration=%s {pgurl:1-3}",
 				concurrency, blockSize, blockSize, duration.String()))

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -131,7 +131,7 @@ func registerImportTPCC(r registry.Registry) {
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload")
 		t.Status("starting csv servers")
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
-		c.Run(ctx, c.All(), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
+		c.Run(ctx, option.WithNodes(c.All()), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 
 		t.Status("running workload")
 		m := c.NewMonitor(ctx)
@@ -154,13 +154,13 @@ func registerImportTPCC(r registry.Registry) {
 			// total elapsed time. This is used by roachperf to compute and display
 			// the average MB/sec per node.
 			tick()
-			c.Run(ctx, c.Node(1), cmd)
+			c.Run(ctx, option.WithNodes(c.Node(1)), cmd)
 			tick()
 
 			// Upload the perf artifacts to any one of the nodes so that the test
 			// runner copies it into an appropriate directory path.
 			dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
-			if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
+			if err := c.RunE(ctx, option.WithNodes(c.Node(1)), "mkdir -p "+filepath.Dir(dest)); err != nil {
 				log.Errorf(ctx, "failed to create perf dir: %+v", err)
 			}
 			if err := c.PutString(ctx, perfBuf.String(), dest, 0755, c.Node(1)); err != nil {
@@ -328,7 +328,7 @@ func registerImportTPCH(r registry.Registry) {
 					// Upload the perf artifacts to any one of the nodes so that the test
 					// runner copies it into an appropriate directory path.
 					dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
-					if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
+					if err := c.RunE(ctx, option.WithNodes(c.Node(1)), "mkdir -p "+filepath.Dir(dest)); err != nil {
 						log.Errorf(ctx, "failed to create perf dir: %+v", err)
 					}
 					if err := c.PutString(ctx, perfBuf.String(), dest, 0755, c.Node(1)); err != nil {
@@ -354,7 +354,7 @@ func registerImportDecommissioned(r registry.Registry) {
 		c.Put(ctx, t.DeprecatedWorkload(), "./workload")
 		t.Status("starting csv servers")
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
-		c.Run(ctx, c.All(), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
+		c.Run(ctx, option.WithNodes(c.All()), `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 
 		// Decommission a node.
 		nodeToDecommission := 2
@@ -363,7 +363,7 @@ func registerImportDecommissioned(r registry.Registry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.Run(ctx, c.Node(nodeToDecommission),
+		c.Run(ctx, option.WithNodes(c.Node(nodeToDecommission)),
 			fmt.Sprintf(`./cockroach node decommission --insecure --self --wait=all --url=%s`, pgurl))
 
 		// Wait for a bit for node liveness leases to expire.
@@ -374,7 +374,7 @@ func registerImportDecommissioned(r registry.Registry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.Run(ctx, c.Node(1), tpccImportCmd(warehouses, pgurl))
+		c.Run(ctx, option.WithNodes(c.Node(1)), tpccImportCmd(warehouses, pgurl))
 	}
 
 	r.Add(registry.TestSpec{

--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
@@ -53,7 +54,7 @@ func runImportCancellation(ctx context.Context, t test.Test, c cluster.Cluster) 
 	startOpts.RoachprodOpts.ScheduleBackups = true
 	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings())
 	t.Status("starting csv servers")
-	c.Run(ctx, c.All(), `./cockroach workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
+	c.Run(ctx, option.WithNodes(c.All()), `./cockroach workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 
 	// Create the tables.
 	conn := c.Conn(ctx, t.L(), 1)
@@ -165,7 +166,7 @@ func runImportCancellation(ctx context.Context, t test.Test, c cluster.Cluster) 
 		cmd := fmt.Sprintf(
 			"./workload run tpch --db=csv --concurrency=1 --queries=%s --max-ops=%d {pgurl%s} "+
 				"--enable-checks=true", queries, maxOps, c.All())
-		if err := c.RunE(ctx, c.Node(1), cmd); err != nil {
+		if err := c.RunE(ctx, option.WithNodes(c.Node(1)), cmd); err != nil {
 			t.Fatal(err)
 		}
 		return nil

--- a/pkg/cmd/roachtest/tests/inconsistency.go
+++ b/pkg/cmd/roachtest/tests/inconsistency.go
@@ -86,7 +86,7 @@ func runInconsistency(ctx context.Context, t test.Test, c cluster.Cluster) {
 	//     t.Error(fmt.Sprintf("hex:%x", data))
 	//   }
 	// }
-	c.Run(ctx, c.Node(1), "./cockroach debug pebble db set {store-dir} "+
+	c.Run(ctx, option.WithNodes(c.Node(1)), "./cockroach debug pebble db set {store-dir} "+
 		"hex:016b1202000174786e2d0000000000000000000000000000000000 "+
 		"hex:120408001000180020002800322a0a10000000000000000000000000000000001a1266616b65207472616e73616374696f6e20302a004a00")
 
@@ -134,21 +134,21 @@ func runInconsistency(ctx context.Context, t test.Test, c cluster.Cluster) {
 	require.Len(t, ids, 1, "expected one dead NodeID")
 
 	const expr = "This.node.is.terminating.because.a.replica.inconsistency.was.detected"
-	c.Run(ctx, c.Node(1), "grep "+expr+" {log-dir}/cockroach.log")
+	c.Run(ctx, option.WithNodes(c.Node(1)), "grep "+expr+" {log-dir}/cockroach.log")
 
 	// Make sure that every node creates a checkpoint.
 	for n := 1; n <= 3; n++ {
 		// Notes it in the log.
 		const expr = "creating.checkpoint.*with.spans"
-		c.Run(ctx, c.Node(n), "grep "+expr+" {log-dir}/cockroach.log")
+		c.Run(ctx, option.WithNodes(c.Node(n)), "grep "+expr+" {log-dir}/cockroach.log")
 		// Creates at least one checkpoint directory (in rare cases it can be
 		// multiple if multiple consistency checks fail in close succession), and
 		// puts spans information into the checkpoint.txt file in it.
-		c.Run(ctx, c.Node(n), "find {store-dir}/auxiliary/checkpoints -name checkpoint.txt")
+		c.Run(ctx, option.WithNodes(c.Node(n)), "find {store-dir}/auxiliary/checkpoints -name checkpoint.txt")
 		// The checkpoint can be inspected by the tooling.
-		c.Run(ctx, c.Node(n), "./cockroach debug range-descriptors "+
+		c.Run(ctx, option.WithNodes(c.Node(n)), "./cockroach debug range-descriptors "+
 			"$(find {store-dir}/auxiliary/checkpoints/* -maxdepth 0 -type d | head -n1)")
-		c.Run(ctx, c.Node(n), "./cockroach debug range-data --limit 10 "+
+		c.Run(ctx, option.WithNodes(c.Node(n)), "./cockroach debug range-data --limit 10 "+
 			"$(find {store-dir}/auxiliary/checkpoints/* -maxdepth 0 -type d | head -n1) 1")
 	}
 

--- a/pkg/cmd/roachtest/tests/indexes.go
+++ b/pkg/cmd/roachtest/tests/indexes.go
@@ -63,7 +63,7 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 			m.Go(func(ctx context.Context) error {
 				secondary := " --secondary-indexes=" + strconv.Itoa(secondaryIndexes)
 				initCmd := "./workload init indexes" + secondary + " {pgurl:1}"
-				c.Run(ctx, loadNode, initCmd)
+				c.Run(ctx, option.WithNodes(loadNode), initCmd)
 
 				// Set lease preferences so that all leases for the table are
 				// located in the availability zone with the load generator.
@@ -136,7 +136,7 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 				duration := " --duration=" + ifLocal(c, "10s", "10m")
 				runCmd := fmt.Sprintf("./workload run indexes --histograms="+t.PerfArtifactsDir()+"/stats.json"+
 					payload+concurrency+duration+" {pgurl%s}", gatewayNodes)
-				c.Run(ctx, loadNode, runCmd)
+				c.Run(ctx, option.WithNodes(loadNode), runCmd)
 				return nil
 			})
 			m.Wait()

--- a/pkg/cmd/roachtest/tests/inverted_index.go
+++ b/pkg/cmd/roachtest/tests/inverted_index.go
@@ -47,7 +47,7 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t test.Test, c cluster.Cl
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), crdbNodes)
 
 	cmdInit := "./workload init json {pgurl:1}"
-	c.Run(ctx, workloadNode, cmdInit)
+	c.Run(ctx, option.WithNodes(workloadNode), cmdInit)
 
 	// On a 4-node GCE cluster with the standard configuration, this generates ~10 million rows
 	initialDataDuration := time.Minute * 20
@@ -66,7 +66,7 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t test.Test, c cluster.Cl
 		initialDataDuration.String(), c.Spec().NodeCount-1,
 	)
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, workloadNode, cmdWrite)
+		c.Run(ctx, option.WithNodes(workloadNode), cmdWrite)
 
 		db := c.Conn(ctx, t.L(), 1)
 		defer db.Close()
@@ -90,7 +90,7 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t test.Test, c cluster.Cl
 		indexDuration.String(), c.Spec().NodeCount-1,
 	)
 	m.Go(func(ctx context.Context) error {
-		c.Run(ctx, workloadNode, cmdWriteAndRead)
+		c.Run(ctx, option.WithNodes(workloadNode), cmdWriteAndRead)
 		return nil
 	})
 

--- a/pkg/cmd/roachtest/tests/jasyncsql.go
+++ b/pkg/cmd/roachtest/tests/jasyncsql.go
@@ -57,7 +57,7 @@ func registerJasyncSQL(r registry.Registry) {
 
 		if err := c.RunE(
 			ctx,
-			node,
+			option.WithNodes(node),
 			"cd /mnt/data1 && git clone https://github.com/jasync-sql/jasync-sql.git",
 		); err != nil {
 			t.Fatal(err)
@@ -65,7 +65,7 @@ func registerJasyncSQL(r registry.Registry) {
 
 		// TODO: Currently we are pointing to a JasyncSQL branch, we will change
 		// this once the official release is available
-		if err := c.RunE(ctx, node, fmt.Sprintf("cd /mnt/data1/jasync-sql && git checkout %s",
+		if err := c.RunE(ctx, option.WithNodes(node), fmt.Sprintf("cd /mnt/data1/jasync-sql && git checkout %s",
 			supportedJasyncCommit)); err != nil {
 			t.Fatal(err)
 		}
@@ -92,15 +92,15 @@ func registerJasyncSQL(r registry.Registry) {
 
 		_ = c.RunE(
 			ctx,
-			node,
+			option.WithNodes(node),
 			`cd /mnt/data1/jasync-sql && PGUSER=root PGHOST=localhost PGPORT={pgport:1} PGDATABASE=defaultdb ./gradlew :postgresql-async:test`,
 		)
 
-		_ = c.RunE(ctx, node, `mkdir -p ~/logs/report/jasyncsql-results`)
+		_ = c.RunE(ctx, option.WithNodes(node), `mkdir -p ~/logs/report/jasyncsql-results`)
 
 		t.Status("making test directory")
 
-		_ = c.RunE(ctx, node,
+		_ = c.RunE(ctx, option.WithNodes(node),
 			`mkdir -p ~/logs/report/jasyncsql-results`,
 		)
 

--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -65,7 +65,7 @@ func registerKnex(r registry.Registry) {
 		// can use npm to reduce the potential of trying to add another nodesource key
 		// (preventing gpg: dearmoring failed: File exists) errors.
 		err = c.RunE(
-			ctx, node, `sudo npm i -g npm`,
+			ctx, option.WithNodes(node), `sudo npm i -g npm`,
 		)
 
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/kvbench.go
+++ b/pkg/cmd/roachtest/tests/kvbench.go
@@ -245,7 +245,7 @@ func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSp
 				initCmd.WriteString(` --secondary-index`)
 			}
 			fmt.Fprintf(&initCmd, ` {pgurl%s}`, roachNodes)
-			if err := c.RunE(ctx, loadNodes, initCmd.String()); err != nil {
+			if err := c.RunE(ctx, option.WithNodes(loadNodes), initCmd.String()); err != nil {
 				return err
 			}
 
@@ -300,7 +300,7 @@ func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSp
 				panic(`unexpected`)
 			}
 
-			err := c.RunE(ctx, loadNodes, workloadCmd.String())
+			err := c.RunE(ctx, option.WithNodes(loadNodes), workloadCmd.String())
 			if err != nil {
 				return errors.Wrapf(err, `error running workload`)
 			}

--- a/pkg/cmd/roachtest/tests/lease_preferences.go
+++ b/pkg/cmd/roachtest/tests/lease_preferences.go
@@ -256,7 +256,7 @@ func runLeasePreferences(
 	// creating the splits and waiting for up-replication on kv will be much
 	// quicker.
 	require.NoError(t, WaitForReplication(ctx, t, conn, spec.replFactor, atLeastReplicationFactor))
-	c.Run(ctx, c.Node(numNodes), fmt.Sprintf(
+	c.Run(ctx, option.WithNodes(c.Node(numNodes)), fmt.Sprintf(
 		`./cockroach workload init kv --scatter --splits %d {pgurl:%d}`,
 		spec.ranges, numNodes))
 	// Wait for under-replicated ranges before checking lease preference

--- a/pkg/cmd/roachtest/tests/ledger.go
+++ b/pkg/cmd/roachtest/tests/ledger.go
@@ -53,7 +53,7 @@ func registerLedger(r registry.Registry) {
 				// See https://github.com/cockroachdb/cockroach/issues/94062 for the --data-loader.
 				cmd := fmt.Sprintf("./workload run ledger --init --data-loader=INSERT --histograms="+t.PerfArtifactsDir()+"/stats.json"+
 					concurrency+duration+" {pgurl%s}", gatewayNodes)
-				c.Run(ctx, loadNode, cmd)
+				c.Run(ctx, option.WithNodes(loadNode), cmd)
 				return nil
 			})
 			m.Wait()

--- a/pkg/cmd/roachtest/tests/libpq.go
+++ b/pkg/cmd/roachtest/tests/libpq.go
@@ -78,7 +78,7 @@ func registerLibPQ(r registry.Registry) {
 		// It's safer to clean up dependencies this way than it is to give the cluster
 		// wipe root access.
 		defer func() {
-			c.Run(ctx, c.All(), "go clean -modcache")
+			c.Run(ctx, option.WithNodes(c.All()), "go clean -modcache")
 		}()
 
 		err = repeatGitCloneE(
@@ -91,7 +91,7 @@ func registerLibPQ(r registry.Registry) {
 			node,
 		)
 		require.NoError(t, err)
-		if err := c.RunE(ctx, node, fmt.Sprintf("mkdir -p %s", resultsDir)); err != nil {
+		if err := c.RunE(ctx, option.WithNodes(node), fmt.Sprintf("mkdir -p %s", resultsDir)); err != nil {
 			t.Fatal(err)
 		}
 
@@ -130,7 +130,7 @@ func registerLibPQ(r registry.Registry) {
 		// Ignore the error as there will be failing tests.
 		_ = c.RunE(
 			ctx,
-			node,
+			option.WithNodes(node),
 			fmt.Sprintf("cd %s && PGPORT={pgport:1} PGUSER=root PGSSLMODE=disable PGDATABASE=postgres go test -run %s -v 2>&1 | %s/bin/go-junit-report > %s",
 				libPQPath, allowedTestsRegExp, goPath, resultsPath),
 		)

--- a/pkg/cmd/roachtest/tests/liquibase.go
+++ b/pkg/cmd/roachtest/tests/liquibase.go
@@ -83,10 +83,10 @@ func registerLiquibase(r registry.Registry) {
 
 		// TODO(richardjcai): When liquibase-test-harness 1.0.3 is released and tagged,
 		//    use the tag version instead of the commit.
-		if err = c.RunE(ctx, node, "cd /mnt/data1/ && git clone https://github.com/liquibase/liquibase-test-harness.git"); err != nil {
+		if err = c.RunE(ctx, option.WithNodes(node), "cd /mnt/data1/ && git clone https://github.com/liquibase/liquibase-test-harness.git"); err != nil {
 			t.Fatal(err)
 		}
-		if err = c.RunE(ctx, node, fmt.Sprintf("cd /mnt/data1/liquibase-test-harness/ && git checkout %s",
+		if err = c.RunE(ctx, option.WithNodes(node), fmt.Sprintf("cd /mnt/data1/liquibase-test-harness/ && git checkout %s",
 			supportedLiquibaseHarnessCommit)); err != nil {
 			t.Fatal(err)
 		}
@@ -95,10 +95,10 @@ func registerLiquibase(r registry.Registry) {
 		// The script executes the cockroach binary from /cockroach/cockroach.sh
 		// so we symlink that here.
 		t.Status("creating database/user used by tests")
-		if err = c.RunE(ctx, node, `sudo mkdir /cockroach && sudo ln -sf /home/ubuntu/cockroach /cockroach/cockroach.sh`); err != nil {
+		if err = c.RunE(ctx, option.WithNodes(node), `sudo mkdir /cockroach && sudo ln -sf /home/ubuntu/cockroach /cockroach/cockroach.sh`); err != nil {
 			t.Fatal(err)
 		}
-		if err = c.RunE(ctx, node, `/mnt/data1/liquibase-test-harness/src/test/resources/docker/setup_db.sh localhost`); err != nil {
+		if err = c.RunE(ctx, option.WithNodes(node), `/mnt/data1/liquibase-test-harness/src/test/resources/docker/setup_db.sh localhost`); err != nil {
 			t.Fatal(err)
 		}
 
@@ -116,7 +116,7 @@ func registerLiquibase(r registry.Registry) {
 			"mvn surefire-report:report-only test -Dtest=LiquibaseHarnessSuiteTest "+
 			"-DdbName=cockroachdb -DdbVersion=20.2 -DoutputDirectory=%s", repoDir)
 
-		err = c.RunE(ctx, node, cmd)
+		err = c.RunE(ctx, option.WithNodes(node), cmd)
 		if err != nil {
 			t.L().Printf("error whilst running tests (may be expected): %#v", err)
 		}

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2015,7 +2015,7 @@ func (u *CommonTestUtils) disableJobAdoption(
 			if err != nil {
 				return err
 			}
-			if err := u.cluster.RunE(ctx, u.cluster.Node(node), "touch", sentinelFilePath); err != nil {
+			if err := u.cluster.RunE(ctx, option.WithNodes(u.cluster.Node(node)), "touch", sentinelFilePath); err != nil {
 				return fmt.Errorf("node %d: failed to touch sentinel file %q: %w", node, sentinelFilePath, err)
 			}
 
@@ -2066,7 +2066,7 @@ func (u *CommonTestUtils) enableJobAdoption(
 				return err
 			}
 
-			if err := u.cluster.RunE(ctx, u.cluster.Node(node), "rm -f", sentinelFilePath); err != nil {
+			if err := u.cluster.RunE(ctx, option.WithNodes(u.cluster.Node(node)), "rm -f", sentinelFilePath); err != nil {
 				return fmt.Errorf("node %d: failed to remove sentinel file %q: %w", node, sentinelFilePath, err)
 			}
 

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -417,7 +417,7 @@ func (cmvt *cdcMixedVersionTester) initWorkload(
 		Flag("seed", r.Int63()).
 		Arg("{pgurl%s}", cmvt.crdbNodes)
 
-	if err := cmvt.c.RunE(ctx, option.NodeListOption{h.RandomNode(r, cmvt.workloadNodes)}, bankInit.String()); err != nil {
+	if err := cmvt.c.RunE(ctx, option.WithNodes(option.NodeListOption{h.RandomNode(r, cmvt.workloadNodes)}), bankInit.String()); err != nil {
 		return err
 	}
 	close(cmvt.workloadInit)

--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
@@ -67,7 +68,7 @@ func fetchCorpusToTmpDir(
 		versionsToCheck = []string{versionNumber, alternateVersion}
 	}
 	for i, version := range versionsToCheck {
-		err = c.RunE(ctx, c.Node(1),
+		err = c.RunE(ctx, option.WithNodes(c.Node(1)),
 			fmt.Sprintf(" gsutil cp gs://cockroach-corpus/corpus-%s/corpus %s",
 				version,
 				corpusFilePath))

--- a/pkg/cmd/roachtest/tests/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decommission.go
@@ -139,7 +139,7 @@ func preloadDataStep(target int) versionStep {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.Run(ctx, c.Node(target),
+		c.Run(ctx, option.WithNodes(c.Node(target)),
 			`./cockroach workload fixtures import tpcc --warehouses=100`, pgurl)
 		db := c.Conn(ctx, t.L(), target)
 		defer db.Close()
@@ -155,7 +155,7 @@ func preloadDataStep(target int) versionStep {
 func partialDecommissionStep(target, from int, binaryVersion *clusterupgrade.Version) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		c := u.c
-		c.Run(ctx, c.Node(from), clusterupgrade.CockroachPathForVersion(t, binaryVersion), "node", "decommission",
+		c.Run(ctx, option.WithNodes(c.Node(from)), clusterupgrade.CockroachPathForVersion(t, binaryVersion), "node", "decommission",
 			"--wait=none", "--insecure", strconv.Itoa(target), "--port", fmt.Sprintf("{pgport:%d}", from))
 	}
 }
@@ -166,7 +166,7 @@ func partialDecommissionStep(target, from int, binaryVersion *clusterupgrade.Ver
 func recommissionAllStep(from int, binaryVersion *clusterupgrade.Version) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		c := u.c
-		c.Run(ctx, c.Node(from), clusterupgrade.CockroachPathForVersion(t, binaryVersion), "node", "recommission",
+		c.Run(ctx, option.WithNodes(c.Node(from)), clusterupgrade.CockroachPathForVersion(t, binaryVersion), "node", "recommission",
 			"--insecure", c.All().NodeIDsString(), "--port", fmt.Sprintf("{pgport:%d}", from))
 	}
 }
@@ -180,7 +180,7 @@ func fullyDecommissionStep(target, from int, binaryVersion *clusterupgrade.Versi
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.Run(ctx, c.Node(from), clusterupgrade.CockroachPathForVersion(t, binaryVersion), "node", "decommission",
+		c.Run(ctx, option.WithNodes(c.Node(from)), clusterupgrade.CockroachPathForVersion(t, binaryVersion), "node", "decommission",
 			"--wait=all", "--insecure", strconv.Itoa(target), fmt.Sprintf("--url=%s", pgurl))
 
 		// If we are decommissioning a target node from the same node, the drain

--- a/pkg/cmd/roachtest/tests/mixed_version_import.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_import.go
@@ -16,6 +16,7 @@ import (
 	"math/rand"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
@@ -50,7 +51,7 @@ func runImportMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster,
 		node := h.RandomNode(r, c.All())
 		cmd := tpccImportCmdWithCockroachBinary(test.DefaultCockroachPath, warehouses) + fmt.Sprintf(" {pgurl%s}", c.Node(node))
 		l.Printf("executing %q on node %d", cmd, node)
-		return c.RunE(ctx, c.Node(node), cmd)
+		return c.RunE(ctx, option.WithNodes(c.Node(node)), cmd)
 	}
 	mvt.InMixedVersion("import", runImport)
 	mvt.AfterUpgradeFinalized("import", runImport)

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -17,6 +17,7 @@ import (
 	"math/rand"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
@@ -68,7 +69,7 @@ func runSchemaChangeMixedVersions(
 			Flag("concurrency", concurrency).
 			Arg("{pgurl%s}", c.All()).
 			String()
-		if err := c.RunE(ctx, workloadNode, runCmd); err != nil {
+		if err := c.RunE(ctx, option.WithNodes(workloadNode), runCmd); err != nil {
 			return err
 		}
 
@@ -78,15 +79,12 @@ func runSchemaChangeMixedVersions(
 		runCmd = roachtestutil.NewCommand("%s debug doctor examine cluster", test.DefaultCockroachPath).
 			Flag("url", doctorURL).
 			String()
-		return c.RunE(ctx,
-			workloadNode,
-			//option.NodeListOption{randomNode},
-			runCmd)
+		return c.RunE(ctx, option.WithNodes(workloadNode), runCmd)
 	}
 
 	// Stage our workload node with the schemachange workload.
 	mvt.OnStartup("set up schemachange workload", func(ctx context.Context, l *logger.Logger, r *rand.Rand, helper *mixedversion.Helper) error {
-		return c.RunE(ctx, workloadNode, fmt.Sprintf("./workload init schemachange {pgurl%s}", workloadNode))
+		return c.RunE(ctx, option.WithNodes(workloadNode), fmt.Sprintf("./workload init schemachange {pgurl%s}", workloadNode))
 	})
 
 	mvt.InMixedVersion("run schemachange workload and validation in mixed version", schemaChangeAndValidationStep)

--- a/pkg/cmd/roachtest/tests/multitenant.go
+++ b/pkg/cmd/roachtest/tests/multitenant.go
@@ -56,15 +56,15 @@ func runAcceptanceMultitenant(ctx context.Context, t test.Test, c cluster.Cluste
 
 	// Check that the server identifiers are present in the tenant log file.
 	logFile := filepath.Join(tenant.logDir(), "*.log")
-	if err := c.RunE(ctx, c.Node(1),
+	if err := c.RunE(ctx, option.WithNodes(c.Node(1)),
 		"grep", "-q", "'start\\.go.*clusterID:'", logFile); err != nil {
 		t.Fatal(errors.Wrap(err, "cluster ID not found in log file"))
 	}
-	if err := c.RunE(ctx, c.Node(1),
+	if err := c.RunE(ctx, option.WithNodes(c.Node(1)),
 		"grep", "-q", "'start\\.go.*tenantID:'", logFile); err != nil {
 		t.Fatal(errors.Wrap(err, "tenant ID not found in log file"))
 	}
-	if err := c.RunE(ctx, c.Node(1),
+	if err := c.RunE(ctx, option.WithNodes(c.Node(1)),
 		"grep", "-q", "'start\\.go.*instanceID:'", logFile); err != nil {
 		t.Fatal(errors.Wrap(err, "SQL instance ID not found in log file"))
 	}

--- a/pkg/cmd/roachtest/tests/multitenant_shared_process.go
+++ b/pkg/cmd/roachtest/tests/multitenant_shared_process.go
@@ -53,12 +53,12 @@ func registerMultiTenantSharedProcess(r registry.Registry) {
 			t.Status(`initialize tpcc workload`)
 			initCmd := fmt.Sprintf(`./workload init tpcc --data-loader import --warehouses %d {pgurl%s:%s}`,
 				tpccWarehouses, crdbNodes, appTenantName)
-			c.Run(ctx, workloadNode, initCmd)
+			c.Run(ctx, option.WithNodes(workloadNode), initCmd)
 
 			t.Status(`run tpcc workload`)
 			runCmd := fmt.Sprintf(`./workload run tpcc --warehouses %d --tolerate-errors --duration 10m {pgurl%s:%s}`,
 				tpccWarehouses, crdbNodes, appTenantName)
-			c.Run(ctx, workloadNode, runCmd)
+			c.Run(ctx, option.WithNodes(workloadNode), runCmd)
 		},
 	})
 }

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -139,7 +139,7 @@ func (tn *tenantNode) createTenantCert(
 	cmd := fmt.Sprintf(
 		"./cockroach cert create-tenant-client --certs-dir=certs --ca-key=certs/ca.key %d %s --overwrite",
 		tn.tenantID, strings.Join(names, " "))
-	c.Run(ctx, c.Node(tn.node), cmd)
+	c.Run(ctx, option.WithNodes(c.Node(tn.node)), cmd)
 }
 
 func (tn *tenantNode) stop(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -148,7 +148,7 @@ func (tn *tenantNode) stop(ctx context.Context, t test.Test, c cluster.Cluster) 
 	}
 	// Must use pkill because the context cancellation doesn't wait for the
 	// process to exit.
-	c.Run(ctx, c.Node(tn.node),
+	c.Run(ctx, option.WithNodes(c.Node(tn.node)),
 		fmt.Sprintf("pkill -o -f '^%s mt start.*tenant-id=%d.*%d'", tn.binary, tn.tenantID, tn.sqlPort))
 	t.L().Printf("mt cluster exited: %v", <-tn.errCh)
 	tn.errCh = nil
@@ -266,7 +266,7 @@ func startTenantServer(
 		// runs that use a build with runtime assertions enabled, and
 		// ignored otherwise.
 		envVars = append(envVars, fmt.Sprintf("COCKROACH_RANDOM_SEED=%d", randomSeed))
-		errCh <- c.RunE(tenantCtx, node,
+		errCh <- c.RunE(tenantCtx, option.WithNodes(node),
 			append(append(append([]string{}, envVars...), binary, "mt", "start-sql"), args...)...,
 		)
 		close(errCh)

--- a/pkg/cmd/roachtest/tests/mvcc_gc.go
+++ b/pkg/cmd/roachtest/tests/mvcc_gc.go
@@ -133,7 +133,7 @@ func runMVCCGC(ctx context.Context, t test.Test, c cluster.Cluster) {
 			Flag("cycle-length", 20000).
 			Arg("%s", pgurl).
 			String()
-		c.Run(ctx, c.Node(1), cmd)
+		c.Run(ctx, option.WithNodes(c.Node(1)), cmd)
 
 		execSQLOrFail("alter database kv configure zone using gc.ttlseconds = $1", 120)
 
@@ -153,7 +153,7 @@ func runMVCCGC(ctx context.Context, t test.Test, c cluster.Cluster) {
 				Flag("max-rate", 1800).
 				Arg("{pgurl%s}", c.Node(1)).
 				String()
-			err := c.RunE(wlCtx, c.Node(1), cmd)
+			err := c.RunE(wlCtx, option.WithNodes(c.Node(1)), cmd)
 			wlFailure <- err
 		}()
 

--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -139,7 +139,7 @@ func runNetworkAuthentication(ctx context.Context, t test.Test, c cluster.Cluste
 					Flag("port", "{pgport:1}").
 					String()
 				t.L().Printf("SQL: %s", dumpRangesCmd)
-				err = c.RunE(ctx, c.Node(1), dumpRangesCmd)
+				err = c.RunE(ctx, option.WithNodes(c.Node(1)), dumpRangesCmd)
 				require.NoError(t, err)
 			}
 
@@ -268,7 +268,7 @@ sudo iptables -A OUTPUT -p tcp --dport 26257 -j DROP;
 sudo iptables-save
 `
 		t.L().Printf("partitioning using iptables; config cmd:\n%s", netConfigCmd)
-		require.NoError(t, c.RunE(ctx, c.Node(expectedLeaseholder), netConfigCmd))
+		require.NoError(t, c.RunE(ctx, option.WithNodes(c.Node(expectedLeaseholder)), netConfigCmd))
 
 		// (attempt to) restore iptables when test end, so that cluster
 		// can be investigated afterwards.
@@ -280,7 +280,7 @@ sudo iptables -D OUTPUT -p tcp --dport 26257 -j DROP;
 sudo iptables-save
 `
 			t.L().Printf("restoring iptables; config cmd:\n%s", restoreNet)
-			require.NoError(t, c.RunE(ctx, c.Node(expectedLeaseholder), restoreNet))
+			require.NoError(t, c.RunE(ctx, option.WithNodes(c.Node(expectedLeaseholder)), restoreNet))
 		}()
 
 		t.L().Printf("waiting while clients attempt to connect...")

--- a/pkg/cmd/roachtest/tests/network_logging.go
+++ b/pkg/cmd/roachtest/tests/network_logging.go
@@ -50,7 +50,7 @@ func registerNetworkLogging(r registry.Registry) {
 
 		t.Status("installing FluentBit containers on CRDB nodes")
 		// Create FluentBit container on the node with a TCP input and dev/null output.
-		err := c.RunE(ctx, crdbNodes, fmt.Sprintf(
+		err := c.RunE(ctx, option.WithNodes(crdbNodes), fmt.Sprintf(
 			"sudo docker run -d -p %d:%d --name=fluentbit fluent/fluent-bit -i tcp -o null",
 			fluentBitTCPPort,
 			fluentBitTCPPort))
@@ -96,14 +96,14 @@ func registerNetworkLogging(r registry.Registry) {
 		// Init & run a workload on the workload node.
 		t.Status("initializing workload")
 		initWorkloadCmd := fmt.Sprintf("./cockroach workload init kv %s ", secureUrls[0])
-		c.Run(ctx, workloadNode, initWorkloadCmd)
+		c.Run(ctx, option.WithNodes(workloadNode), initWorkloadCmd)
 
 		t.Status("running workload")
 		m := c.NewMonitor(ctx, crdbNodes)
 		m.Go(func(ctx context.Context) error {
 			joinedURLs := strings.Join(workloadPGURLs, " ")
 			runWorkloadCmd := fmt.Sprintf("./cockroach workload run kv --concurrency=32 --duration=1h %s", joinedURLs)
-			return c.RunE(ctx, workloadNode, runWorkloadCmd)
+			return c.RunE(ctx, option.WithNodes(workloadNode), runWorkloadCmd)
 		})
 		m.Wait()
 	}

--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -69,7 +69,7 @@ func registerNodeJSPostgres(r registry.Registry) {
 		// can use npm to reduce the potential of trying to add another nodesource key
 		// (preventing gpg: dearmoring failed: File exists) errors.
 		err = c.RunE(
-			ctx, node, `sudo npm i -g npm`,
+			ctx, option.WithNodes(node), `sudo npm i -g npm`,
 		)
 
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/pebble_ycsb.go
+++ b/pkg/cmd/roachtest/tests/pebble_ycsb.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
@@ -163,7 +164,7 @@ func runPebbleYCSB(
 // runPebbleCmd runs the given command on all worker nodes in the test cluster.
 func runPebbleCmd(ctx context.Context, t test.Test, c cluster.Cluster, cmd string) {
 	t.L().PrintfCtx(ctx, "> %s", cmd)
-	err := c.RunE(ctx, c.All(), cmd)
+	err := c.RunE(ctx, option.WithNodes(c.All()), cmd)
 	t.L().Printf("> result: %+v", err)
 	if err := ctx.Err(); err != nil {
 		t.L().Printf("(note: incoming context was canceled: %s", err)

--- a/pkg/cmd/roachtest/tests/pgjdbc.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc.go
@@ -174,11 +174,11 @@ func registerPgjdbc(r registry.Registry) {
 		t.Status("running pgjdbc test suite")
 		// Note that this is expected to return an error, since the test suite
 		// will fail. And it is safe to swallow it here.
-		_ = c.RunE(ctx, node,
+		_ = c.RunE(ctx, option.WithNodes(node),
 			`cd /mnt/data1/pgjdbc/pgjdbc/ && ../gradlew test`,
 		)
 
-		_ = c.RunE(ctx, node,
+		_ = c.RunE(ctx, option.WithNodes(node),
 			`mkdir -p ~/logs/report/pgjdbc-results`,
 		)
 

--- a/pkg/cmd/roachtest/tests/pgx.go
+++ b/pkg/cmd/roachtest/tests/pgx.go
@@ -86,7 +86,7 @@ func registerPgx(r registry.Registry) {
 		// It's safer to clean up dependencies this way than it is to give the cluster
 		// wipe root access.
 		defer func() {
-			c.Run(ctx, c.All(), "go clean -modcache")
+			c.Run(ctx, option.WithNodes(c.All()), "go clean -modcache")
 		}()
 
 		RunningStatus := fmt.Sprintf("Running cockroach version %s, using blocklist %s, using ignorelist %s",

--- a/pkg/cmd/roachtest/tests/pop.go
+++ b/pkg/cmd/roachtest/tests/pop.go
@@ -81,22 +81,22 @@ func registerPop(r registry.Registry) {
 
 		t.Status("building and setting up tests")
 
-		err = c.RunE(ctx, node, fmt.Sprintf(`cd %s && go build -v -tags sqlite -o tsoda ./soda`, popPath))
+		err = c.RunE(ctx, option.WithNodes(node), fmt.Sprintf(`cd %s && go build -v -tags sqlite -o tsoda ./soda`, popPath))
 		require.NoError(t, err)
 
-		err = c.RunE(ctx, node, fmt.Sprintf(`cd %s && ./tsoda drop -e cockroach -c ./database.yml -p ./testdata/migrations`, popPath))
+		err = c.RunE(ctx, option.WithNodes(node), fmt.Sprintf(`cd %s && ./tsoda drop -e cockroach -c ./database.yml -p ./testdata/migrations`, popPath))
 		require.NoError(t, err)
 
-		err = c.RunE(ctx, node, fmt.Sprintf(`cd %s && ./tsoda create -e cockroach -c ./database.yml -p ./testdata/migrations`, popPath))
+		err = c.RunE(ctx, option.WithNodes(node), fmt.Sprintf(`cd %s && ./tsoda create -e cockroach -c ./database.yml -p ./testdata/migrations`, popPath))
 		require.NoError(t, err)
 
-		err = c.RunE(ctx, node, fmt.Sprintf(`cd %s && ./tsoda migrate -e cockroach -c ./database.yml -p ./testdata/migrations`, popPath))
+		err = c.RunE(ctx, option.WithNodes(node), fmt.Sprintf(`cd %s && ./tsoda migrate -e cockroach -c ./database.yml -p ./testdata/migrations`, popPath))
 		require.NoError(t, err)
 
 		t.Status("running pop test suite")
 
 		// No tests are expected to fail.
-		err = c.RunE(ctx, node, fmt.Sprintf(`cd %s && SODA_DIALECT=cockroach go test -race -tags sqlite -v ./... -count=1`, popPath))
+		err = c.RunE(ctx, option.WithNodes(node), fmt.Sprintf(`cd %s && SODA_DIALECT=cockroach go test -race -tags sqlite -v ./... -count=1`, popPath))
 		require.NoError(t, err, "error while running pop tests")
 	}
 

--- a/pkg/cmd/roachtest/tests/process_lock.go
+++ b/pkg/cmd/roachtest/tests/process_lock.go
@@ -57,7 +57,7 @@ func registerProcessLock(r registry.Registry) {
 			require.NoError(t, conn.PingContext(ctx))
 			require.NoError(t, WaitFor3XReplication(ctx, t, conn))
 
-			c.Run(ctx, c.Node(4), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
+			c.Run(ctx, option.WithNodes(c.Node(4)), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
 
 			seed := int64(1666467482296309000)
 			rng := randutil.NewTestRandWithSeed(seed)
@@ -65,7 +65,7 @@ func registerProcessLock(r registry.Registry) {
 			t.Status("starting workload")
 			m := c.NewMonitor(ctx, c.Range(1, 3))
 			m.Go(func(ctx context.Context) error {
-				c.Run(ctx, c.Node(4), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
+				c.Run(ctx, option.WithNodes(c.Node(4)), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
 					`--duration %s --concurrency 512 --max-rate 4096 --tolerate-errors `+
 					` --min-block-bytes=1024 --max-block-bytes=1024 `+
 					`{pgurl:1-3}`, runDuration.String()))
@@ -131,12 +131,12 @@ func registerProcessLock(r registry.Registry) {
 						ops := []func(){
 							func() {
 								// Try to start the node again.
-								err := c.RunE(ctx, c.Node(n), startCommands[n-1])
+								err := c.RunE(ctx, option.WithNodes(c.Node(n)), startCommands[n-1])
 								t.L().PrintfCtx(ctx, "Attempt to start cockroach process on n%d while another cockroach process is still running; error expected: %v", n, err)
 							},
 							func() {
 								// Try to perform a manual compaction.
-								err := c.RunE(ctx, c.Node(n), fmt.Sprintf("./cockroach debug compact /mnt/data1/cockroach %s", enterpriseEncryption[n-1]))
+								err := c.RunE(ctx, option.WithNodes(c.Node(n)), fmt.Sprintf("./cockroach debug compact /mnt/data1/cockroach %s", enterpriseEncryption[n-1]))
 								t.L().PrintfCtx(ctx, "Attempt to manual compact store on n%d while another cockroach process is still running; error expected: %v", n, err)
 							},
 							func() {

--- a/pkg/cmd/roachtest/tests/psycopg.go
+++ b/pkg/cmd/roachtest/tests/psycopg.go
@@ -89,10 +89,10 @@ func registerPsycopg(r registry.Registry) {
 		// ); err != nil {
 		//	t.Fatal(err)
 		// }
-		if err = c.RunE(ctx, node, "git clone https://github.com/psycopg/psycopg2.git /mnt/data1/psycopg"); err != nil {
+		if err = c.RunE(ctx, option.WithNodes(node), "git clone https://github.com/psycopg/psycopg2.git /mnt/data1/psycopg"); err != nil {
 			t.Fatal(err)
 		}
-		if err = c.RunE(ctx, node, fmt.Sprintf("cd /mnt/data1/psycopg/ && git checkout %s", supportedPsycopgTag)); err != nil {
+		if err = c.RunE(ctx, option.WithNodes(node), fmt.Sprintf("cd /mnt/data1/psycopg/ && git checkout %s", supportedPsycopgTag)); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/cmd/roachtest/tests/queue.go
+++ b/pkg/cmd/roachtest/tests/queue.go
@@ -68,7 +68,7 @@ func runQueue(ctx context.Context, t test.Test, c cluster.Cluster) {
 					" {pgurl:1-%d}",
 				dbNodeCount,
 			)
-			c.Run(ctx, c.Node(workloadNode), cmd)
+			c.Run(ctx, option.WithNodes(c.Node(workloadNode)), cmd)
 			return nil
 		})
 		m.Wait()

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -239,7 +239,7 @@ func rebalanceByLoad(
 	// Note that we only assert on the CPU of each store w.r.t the mean, not
 	// the lease count.
 	splits := (numStores * storeToRangeFactor) - 1
-	c.Run(ctx, appNode, fmt.Sprintf("./cockroach workload init kv --drop --splits=%d {pgurl:1}", splits))
+	c.Run(ctx, option.WithNodes(appNode), fmt.Sprintf("./cockroach workload init kv --drop --splits=%d {pgurl:1}", splits))
 
 	db := c.Conn(ctx, t.L(), 1)
 	defer db.Close()
@@ -256,7 +256,7 @@ func rebalanceByLoad(
 
 	m.Go(func() error {
 		t.L().Printf("starting load generator\n")
-		err := c.RunE(ctx, appNode, fmt.Sprintf(
+		err := c.RunE(ctx, option.WithNodes(appNode), fmt.Sprintf(
 			"./cockroach workload run kv --read-percent=95 --tolerate-errors --concurrency=%d "+
 				"--duration=%v {pgurl:1-%d}",
 			concurrency, maxDuration, numNodes))

--- a/pkg/cmd/roachtest/tests/replicagc.go
+++ b/pkg/cmd/roachtest/tests/replicagc.go
@@ -86,7 +86,7 @@ func runReplicaGCChangedPeers(
 	}()
 
 	// Fill in a bunch of data.
-	c.Run(ctx, c.Node(1), "./cockroach workload init kv {pgurl:1} --splits 100")
+	c.Run(ctx, option.WithNodes(c.Node(1)), "./cockroach workload init kv {pgurl:1} --splits 100")
 
 	// Kill the third node so it won't know that all of its replicas are moved
 	// elsewhere (we don't use the first because that's what roachprod will

--- a/pkg/cmd/roachtest/tests/restart.go
+++ b/pkg/cmd/roachtest/tests/restart.go
@@ -41,7 +41,7 @@ func runRestart(ctx context.Context, t test.Test, c cluster.Cluster, downDuratio
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Run(ctx, workloadNode,
+	c.Run(ctx, option.WithNodes(workloadNode),
 		"./cockroach workload fixtures import tpcc --warehouses=100 --fks=false --checks=false",
 		pgurl,
 	)
@@ -68,7 +68,7 @@ func runRestart(ctx context.Context, t test.Test, c cluster.Cluster, downDuratio
 	// traffic to one of the nodes that are not down. This used to cause lots of
 	// raft log truncation, which caused node 3 to need lots of snapshots when it
 	// came back up.
-	c.Run(ctx, workloadNode, "./cockroach workload run tpcc --warehouses=100 "+
+	c.Run(ctx, option.WithNodes(workloadNode), "./cockroach workload run tpcc --warehouses=100 "+
 		fmt.Sprintf("--tolerate-errors --wait=false --duration=%s {pgurl:1-2}", downDuration))
 
 	// Bring it back up and make sure it can serve a query within a reasonable
@@ -94,7 +94,7 @@ func runRestart(ctx context.Context, t test.Test, c cluster.Cluster, downDuratio
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Run(ctx, restartNode, fmt.Sprintf(`./cockroach sql --insecure --url=%s -e "%s"`, pgurl, tracedQ))
+	c.Run(ctx, option.WithNodes(restartNode), fmt.Sprintf(`./cockroach sql --insecure --url=%s -e "%s"`, pgurl, tracedQ))
 	if took := timeutil.Since(start); took > downDuration {
 		t.Fatalf(`expected to recover within %s took %s`, downDuration, took)
 	} else {

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -1019,7 +1019,7 @@ func exportToRoachperf(
 	// Upload the perf artifacts to any one of the nodes so that the test
 	// runner copies it into an appropriate directory path.
 	dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
-	if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
+	if err := c.RunE(ctx, option.WithNodes(c.Node(1)), "mkdir -p "+filepath.Dir(dest)); err != nil {
 		log.Errorf(ctx, "failed to create perf dir: %+v", err)
 	}
 	if err := c.PutString(ctx, bytesBuf.String(), dest, 0755, c.Node(1)); err != nil {

--- a/pkg/cmd/roachtest/tests/roachmart.go
+++ b/pkg/cmd/roachtest/tests/roachmart.go
@@ -46,7 +46,7 @@ func registerRoachmart(r registry.Registry) {
 				"--orders=100",
 				fmt.Sprintf("--partition=%v", partition))
 
-			if err := c.RunE(ctx, c.Node(nodes[i].i), args...); err != nil {
+			if err := c.RunE(ctx, option.WithNodes(c.Node(nodes[i].i)), args...); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -63,7 +63,7 @@ func registerSchemaChangeDuringKV(r registry.Registry) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			c.Run(ctx, c.Node(1), `./workload init kv --drop --db=test`, pgurl)
+			c.Run(ctx, option.WithNodes(c.Node(1)), `./workload init kv --drop --db=test`, pgurl)
 			for node := 1; node <= c.Spec().NodeCount; node++ {
 				node := node
 				// TODO(dan): Ideally, the test would fail if this queryload failed,
@@ -75,7 +75,7 @@ func registerSchemaChangeDuringKV(r registry.Registry) {
 						t.Fatal(err)
 					}
 					defer l.Close()
-					_ = c.RunE(ctx, c.Node(node), fmt.Sprintf(cmd, c.Nodes(node)))
+					_ = c.RunE(ctx, option.WithNodes(c.Node(node)), fmt.Sprintf(cmd, c.Nodes(node)))
 				}()
 			}
 
@@ -389,7 +389,7 @@ func makeSchemaChangeBulkIngestTest(
 				aNum, bNum, cNum, payloadBytes,
 			)
 
-			c.Run(ctx, workloadNode, cmdWrite)
+			c.Run(ctx, option.WithNodes(workloadNode), cmdWrite)
 
 			m := c.NewMonitor(ctx, crdbNodes)
 
@@ -402,7 +402,7 @@ func makeSchemaChangeBulkIngestTest(
 				indexDuration.String(), c.Spec().NodeCount-1, aNum, bNum, cNum, payloadBytes,
 			)
 			m.Go(func(ctx context.Context) error {
-				c.Run(ctx, workloadNode, cmdWriteAndRead)
+				c.Run(ctx, option.WithNodes(workloadNode), cmdWriteAndRead)
 				return nil
 			})
 

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -102,7 +102,7 @@ func runSchemaChangeRandomLoad(
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Run(ctx, loadNode, fmt.Sprintf("./workload init schemachange '%s'", pgurl))
+	c.Run(ctx, option.WithNodes(loadNode), fmt.Sprintf("./workload init schemachange '%s'", pgurl))
 
 	result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(1), "echo", "-n", "{store-dir}")
 	if err != nil {
@@ -121,7 +121,7 @@ func runSchemaChangeRandomLoad(
 		fmt.Sprintf("{pgurl%s}", loadNode),
 	}
 	t.Status("running schemachange workload")
-	err = c.RunE(ctx, loadNode, runCmd...)
+	err = c.RunE(ctx, option.WithNodes(loadNode), runCmd...)
 	if err != nil {
 		saveArtifacts(ctx, t, c, storeDirectory)
 		t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -96,7 +96,7 @@ func registerSequelize(r registry.Registry) {
 		// can use npm to reduce the potential of trying to add another nodesource key
 		// (preventing gpg: dearmoring failed: File exists) errors.
 		if err := c.RunE(
-			ctx, node, `sudo npm i -g npm`,
+			ctx, option.WithNodes(node), `sudo npm i -g npm`,
 		); err != nil {
 			if err := repeatRunE(
 				ctx,

--- a/pkg/cmd/roachtest/tests/slow_drain.go
+++ b/pkg/cmd/roachtest/tests/slow_drain.go
@@ -124,7 +124,7 @@ func runSlowDrain(ctx context.Context, t test.Test, c cluster.Cluster, duration 
 					t.Fatal(err)
 				}
 				return c.RunE(ctx,
-					c.Node(id),
+					option.WithNodes(c.Node(id)),
 					fmt.Sprintf("./cockroach node drain %d --insecure --drain-wait=%s --url=%s", id, duration.String(), pgurl),
 				)
 			}
@@ -141,7 +141,7 @@ func runSlowDrain(ctx context.Context, t test.Test, c cluster.Cluster, duration 
 	t.Status("checking for stalling drain logging...")
 	testutils.SucceedsWithin(t, func() error {
 		for nodeID := 2; nodeID <= numNodes; nodeID++ {
-			if err := c.RunE(ctx, c.Node(nodeID),
+			if err := c.RunE(ctx, option.WithNodes(c.Node(nodeID)),
 				fmt.Sprintf("grep -q '%s' logs/cockroach.log", verboseStoreLogRe),
 			); err == nil {
 				return nil

--- a/pkg/cmd/roachtest/tests/smoketest_secure.go
+++ b/pkg/cmd/roachtest/tests/smoketest_secure.go
@@ -83,7 +83,7 @@ func multitenantSmokeTest(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	// init kv and check new database was done right
 	cmd := fmt.Sprintf("./cockroach workload init kv '%s'", ten.secureURL())
-	err = c.RunE(ctx, c.Node(2), cmd)
+	err = c.RunE(ctx, option.WithNodes(c.Node(2)), cmd)
 	require.NoError(t, err)
 
 	sqlutils.MakeSQLRunner(db).CheckQueryResultsRetry(t, fmt.Sprintf(`

--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -58,7 +58,7 @@ type kvSplitLoad struct {
 
 func (ksl kvSplitLoad) init(ctx context.Context, t test.Test, c cluster.Cluster) error {
 	t.Status("running uniform kv workload")
-	return c.RunE(ctx, c.Node(c.Spec().NodeCount), fmt.Sprintf("./workload init kv {pgurl:1-%d}", c.Spec().NodeCount-1))
+	return c.RunE(ctx, option.WithNodes(c.Node(c.Spec().NodeCount)), fmt.Sprintf("./workload init kv {pgurl:1-%d}", c.Spec().NodeCount-1))
 }
 
 func (ksl kvSplitLoad) rangeCount(db *gosql.DB) (int, error) {
@@ -74,7 +74,7 @@ func (ksl kvSplitLoad) run(ctx context.Context, t test.Test, c cluster.Cluster) 
 		extraFlags += fmt.Sprintf("--min-block-bytes=%d --max-block-bytes=%d ",
 			ksl.blockSize, ksl.blockSize)
 	}
-	return c.RunE(ctx, c.Node(c.Spec().NodeCount), fmt.Sprintf("./workload run kv "+
+	return c.RunE(ctx, option.WithNodes(c.Node(c.Spec().NodeCount)), fmt.Sprintf("./workload run kv "+
 		"--init --concurrency=%d --read-percent=%d --span-percent=%d %s {pgurl:1-%d} --duration='%s'",
 		ksl.concurrency, ksl.readPercent, ksl.spanPercent, extraFlags, c.Spec().NodeCount-1,
 		ksl.waitDuration.String()))
@@ -100,7 +100,7 @@ func (ysl ycsbSplitLoad) init(ctx context.Context, t test.Test, c cluster.Cluste
 		extraArgs += "--insert-hash"
 	}
 
-	return c.RunE(ctx, c.Node(c.Spec().NodeCount), fmt.Sprintf(
+	return c.RunE(ctx, option.WithNodes(c.Node(c.Spec().NodeCount)), fmt.Sprintf(
 		"./workload init ycsb --insert-count=%d --workload=%s %s {pgurl:1-%d}",
 		ysl.insertCount, ysl.workload, extraArgs, c.Spec().NodeCount-1))
 }
@@ -115,7 +115,7 @@ func (ysl ycsbSplitLoad) run(ctx context.Context, t test.Test, c cluster.Cluster
 		extraArgs += "--insert-hash"
 	}
 
-	return c.RunE(ctx, c.Node(c.Spec().NodeCount), fmt.Sprintf(
+	return c.RunE(ctx, option.WithNodes(c.Node(c.Spec().NodeCount)), fmt.Sprintf(
 		"./workload run ycsb --record-count=%d --workload=%s --concurrency=%d "+
 			"--duration='%s' %s {pgurl:1-%d}",
 		ysl.insertCount, ysl.workload, ysl.concurrency,
@@ -639,7 +639,7 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 
 			// NB: would probably be faster to use --data-loader=IMPORT here, but IMPORT
 			// will disregard our preference to keep things in a single range.
-			c.Run(ctx, c.Node(1), fmt.Sprintf("./workload init bank "+
+			c.Run(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf("./workload init bank "+
 				"--rows=%d --payload-bytes=%d --data-loader INSERT --ranges=1 {pgurl:1}", rows, payload))
 
 			if rc, s := rangeCount(t); rc != 1 {

--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -109,8 +109,8 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 	if err = c.Install(ctx, t.L(), loadNode, "haproxy"); err != nil {
 		t.Fatal(err)
 	}
-	c.Run(ctx, loadNode, "./cockroach gen haproxy --insecure --url {pgurl:1}")
-	c.Run(ctx, loadNode, "haproxy -f haproxy.cfg -D")
+	c.Run(ctx, option.WithNodes(loadNode), "./cockroach gen haproxy --insecure --url {pgurl:1}")
+	c.Run(ctx, option.WithNodes(loadNode), "haproxy -f haproxy.cfg -D")
 
 	t.Status("installing sysbench")
 	if err := c.Install(ctx, t.L(), loadNode, "sysbench"); err != nil {
@@ -124,8 +124,8 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.Run(ctx, c.Node(1), fmt.Sprintf(`./cockroach sql --insecure --url=%s -e "CREATE DATABASE sysbench"`, pgurl))
-		c.Run(ctx, loadNode, opts.cmd(false /* haproxy */)+" prepare")
+		c.Run(ctx, option.WithNodes(c.Node(1)), fmt.Sprintf(`./cockroach sql --insecure --url=%s -e "CREATE DATABASE sysbench"`, pgurl))
+		c.Run(ctx, option.WithNodes(loadNode), opts.cmd(false /* haproxy */)+" prepare")
 
 		t.Status("running workload")
 		cmd := opts.cmd(true /* haproxy */) + " run"

--- a/pkg/cmd/roachtest/tests/tombstones.go
+++ b/pkg/cmd/roachtest/tests/tombstones.go
@@ -60,7 +60,7 @@ func registerPointTombstone(r registry.Registry) {
 				}
 			}
 
-			c.Run(ctx, c.Node(4), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
+			c.Run(ctx, option.WithNodes(c.Node(4)), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
 
 			// Set a low 2m GC ttl.
 			execSQLOrFail("alter database kv configure zone using gc.ttlseconds = $1", 120)
@@ -71,7 +71,7 @@ func registerPointTombstone(r registry.Registry) {
 			t.Status("starting 1MB-value workload")
 			m := c.NewMonitor(ctx, c.Range(1, 3))
 			m.Go(func(ctx context.Context) error {
-				c.Run(ctx, c.Node(4), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
+				c.Run(ctx, option.WithNodes(c.Node(4)), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
 					`--concurrency 128 --max-rate 512 --tolerate-errors `+
 					` --min-block-bytes=1048576 --max-block-bytes=1048576 `+
 					` --max-ops %d `+
@@ -87,7 +87,7 @@ func registerPointTombstone(r registry.Registry) {
 			t.Status("starting 4KB-value workload")
 			m = c.NewMonitor(ctx, c.Range(1, 3))
 			m.Go(func(ctx context.Context) error {
-				c.Run(ctx, c.Node(4), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
+				c.Run(ctx, option.WithNodes(c.Node(4)), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
 					`--concurrency 256 --max-rate 1024 --tolerate-errors `+
 					` --min-block-bytes=4096 --max-block-bytes=4096 `+
 					` --max-ops 122880 --write-seq R%d `+

--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -89,7 +89,7 @@ func (ts *tpceSpec) newCmd(o tpceCmdOptions) *roachtestutil.Command {
 // import of the data and schema creation.
 func (ts *tpceSpec) init(ctx context.Context, t test.Test, c cluster.Cluster, o tpceCmdOptions) {
 	cmd := ts.newCmd(o).Option("init")
-	c.Run(ctx, c.Node(ts.loadNode), fmt.Sprintf("%s %s", cmd, ts.roachNodeIPFlags[0]))
+	c.Run(ctx, option.WithNodes(c.Node(ts.loadNode)), fmt.Sprintf("%s %s", cmd, ts.roachNodeIPFlags[0]))
 }
 
 // run runs the tpce workload on cluster that has been initialized with the tpce schema.

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -62,7 +62,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 	checkConcurrency := func(ctx context.Context, t test.Test, c cluster.Cluster, concurrency int) error {
 		// Make sure to kill any workloads running from the previous
 		// iteration.
-		_ = c.RunE(ctx, c.Node(numNodes), "killall workload")
+		_ = c.RunE(ctx, option.WithNodes(c.Node(numNodes)), "killall workload")
 
 		restartCluster(ctx, c, t)
 
@@ -144,7 +144,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 						"--count-errors --queries=%d --concurrency=%d --max-ops=%d",
 					numNodes-1, queryNum, concurrency, maxOps,
 				)
-				if err := c.RunE(ctx, c.Node(numNodes), cmd); err != nil {
+				if err := c.RunE(ctx, option.WithNodes(c.Node(numNodes)), cmd); err != nil {
 					return err
 				}
 			}

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -58,7 +58,7 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 
 	filename := b.benchType
 	t.Status(fmt.Sprintf("downloading %s query file from %s", filename, b.url))
-	if err := c.RunE(ctx, loadNode, fmt.Sprintf("curl %s > %s", b.url, filename)); err != nil {
+	if err := c.RunE(ctx, option.WithNodes(loadNode), fmt.Sprintf("curl %s > %s", b.url, filename)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -99,7 +99,7 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 			roachNodes,
 			b.maxLatency.String(),
 		)
-		if err := c.RunE(ctx, loadNode, cmd); err != nil {
+		if err := c.RunE(ctx, option.WithNodes(loadNode), cmd); err != nil {
 			t.Fatal(err)
 		}
 		return nil

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -360,7 +360,7 @@ func (p *tpchVecPerfTest) postTestRunHook(
 					curlCmd := fmt.Sprintf(
 						"curl %s > logs/bundle_%s_%d.zip", url, runConfig.setupNames[setupIdx], i,
 					)
-					if err = c.RunE(ctx, c.Node(1), curlCmd); err != nil {
+					if err = c.RunE(ctx, option.WithNodes(c.Node(1)), curlCmd); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -572,16 +572,16 @@ func smithcmpTestRun(
 		configURL  = `https://raw.githubusercontent.com/cockroachdb/cockroach/master/pkg/cmd/roachtest/tests/` + configFile
 	)
 	firstNode := c.Node(1)
-	if err := c.RunE(ctx, firstNode, fmt.Sprintf("curl %s > %s", configURL, configFile)); err != nil {
+	if err := c.RunE(ctx, option.WithNodes(firstNode), fmt.Sprintf("curl %s > %s", configURL, configFile)); err != nil {
 		t.Fatal(err)
 	}
 	// smithcmp cannot access the pgport env variable, so we must edit the config file here
 	// to tell it the port to use.
-	if err := c.RunE(ctx, firstNode, fmt.Sprintf(`port=$(echo -n {pgport:1}) && sed -i "s|26257|$port|g" %s`, configFile)); err != nil {
+	if err := c.RunE(ctx, option.WithNodes(firstNode), fmt.Sprintf(`port=$(echo -n {pgport:1}) && sed -i "s|26257|$port|g" %s`, configFile)); err != nil {
 		t.Fatal(err)
 	}
 	cmd := fmt.Sprintf("./%s %s", tpchVecSmithcmp, configFile)
-	if err := c.RunE(ctx, firstNode, cmd); err != nil {
+	if err := c.RunE(ctx, option.WithNodes(firstNode), cmd); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -92,7 +92,7 @@ func registerTypeORM(r registry.Registry) {
 		// can use npm to reduce the potential of trying to add another nodesource key
 		// (preventing gpg: dearmoring failed: File exists) errors.
 		if err := c.RunE(
-			ctx, node, `sudo npm i -g npm`,
+			ctx, option.WithNodes(node), `sudo npm i -g npm`,
 		); err != nil {
 			if err := repeatRunE(
 				ctx,

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -116,7 +116,7 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 			}
 
 			l.Printf("executing workload init on node %d", node)
-			return c.RunE(ctx, c.Node(node), fmt.Sprintf("%s init schemachange {pgurl%s}", workloadPath, c.All()))
+			return c.RunE(ctx, option.WithNodes(c.Node(node)), fmt.Sprintf("%s init schemachange {pgurl%s}", workloadPath, c.All()))
 		})
 	mvt.InMixedVersion(
 		"run backup",
@@ -177,7 +177,7 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 				Arg("{pgurl:1-%d}", len(c.All())).
 				String()
 
-			return c.RunE(ctx, c.Node(randomNode), runCmd)
+			return c.RunE(ctx, option.WithNodes(c.Node(randomNode)), runCmd)
 		},
 	)
 
@@ -391,17 +391,17 @@ func makeVersionFixtureAndFatal(
 			u.c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.All())
 
 			binaryPath := clusterupgrade.CockroachPathForVersion(t, fixtureVersion)
-			c.Run(ctx, c.All(), binaryPath, "debug", "pebble", "db", "checkpoint",
+			c.Run(ctx, option.WithNodes(c.All()), binaryPath, "debug", "pebble", "db", "checkpoint",
 				"{store-dir}", "{store-dir}/"+name)
 			// The `cluster-bootstrapped` marker can already be found within
 			// store-dir, but the rocksdb checkpoint step above does not pick it
 			// up as it isn't recognized by RocksDB. We copy the marker
 			// manually, it's necessary for roachprod created clusters. See
 			// #54761.
-			c.Run(ctx, c.Node(1), "cp", "{store-dir}/cluster-bootstrapped", "{store-dir}/"+name)
+			c.Run(ctx, option.WithNodes(c.Node(1)), "cp", "{store-dir}/cluster-bootstrapped", "{store-dir}/"+name)
 			// Similar to the above - newer versions require the min version file to open a store.
-			c.Run(ctx, c.All(), "cp", fmt.Sprintf("{store-dir}/%s", storage.MinVersionFilename), "{store-dir}/"+name)
-			c.Run(ctx, c.All(), "tar", "-C", "{store-dir}/"+name, "-czf", "{log-dir}/"+name+".tgz", ".")
+			c.Run(ctx, option.WithNodes(c.All()), "cp", fmt.Sprintf("{store-dir}/%s", storage.MinVersionFilename), "{store-dir}/"+name)
+			c.Run(ctx, option.WithNodes(c.All()), "tar", "-C", "{store-dir}/"+name, "-czf", "{log-dir}/"+name+".tgz", ".")
 			t.Fatalf(`successfully created checkpoints; failing test on purpose.
 
 Invoke the following to move the archives to the right place and commit the

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -94,7 +94,7 @@ func registerYCSB(r registry.Registry) {
 					" --splits=%d --histograms="+t.PerfArtifactsDir()+"/stats.json"+args+
 					" {pgurl:1-%d}",
 				wl, conc, nodes, nodes)
-			c.Run(ctx, c.Node(nodes+1), cmd)
+			c.Run(ctx, option.WithNodes(c.Node(nodes+1)), cmd)
 			return nil
 		})
 		m.Wait()

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -272,7 +272,7 @@ func (c *SyncedCluster) servicesWithOpenPortSelection(
 ) (ServiceDescriptors, error) {
 	var mu syncutil.Mutex
 	var servicesToRegister ServiceDescriptors
-	err := c.Parallel(ctx, l, OnNodes(c.Nodes), func(ctx context.Context, node Node) (*RunResultDetails, error) {
+	err := c.Parallel(ctx, l, WithNodes(c.Nodes), func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		services := make(ServiceDescriptors, 0)
 		res := &RunResultDetails{Node: node}
 		if _, ok := serviceMap[node][ServiceTypeSQL]; !ok {
@@ -572,7 +572,7 @@ func (c *SyncedCluster) ExecSQL(
 	args []string,
 ) ([]*RunResultDetails, error) {
 	display := fmt.Sprintf("%s: executing sql", c.Name)
-	results, _, err := c.ParallelE(ctx, l, OnNodes(nodes).WithDisplay(display).WithFailSlow(),
+	results, _, err := c.ParallelE(ctx, l, WithNodes(nodes).WithDisplay(display).WithFailSlow(),
 		func(ctx context.Context, node Node) (*RunResultDetails, error) {
 			desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
 			if err != nil {

--- a/pkg/roachprod/install/download.go
+++ b/pkg/roachprod/install/download.go
@@ -74,7 +74,7 @@ func Download(
 		dest,
 	)
 	if err := c.Run(ctx, l, l.Stdout, l.Stderr,
-		OnNodes(downloadNodes),
+		WithNodes(downloadNodes),
 		fmt.Sprintf("downloading %s", basename),
 		downloadCmd,
 	); err != nil {
@@ -86,7 +86,7 @@ func Download(
 	if c.IsLocal() && !filepath.IsAbs(dest) {
 		src := filepath.Join(c.localVMDir(downloadNodes[0]), dest)
 		cpCmd := fmt.Sprintf(`cp "%s" "%s"`, src, dest)
-		return c.Run(ctx, l, l.Stdout, l.Stderr, OnNodes(c.Nodes[1:]), "copying to remaining nodes", cpCmd)
+		return c.Run(ctx, l, l.Stdout, l.Stderr, WithNodes(c.Nodes[1:]), "copying to remaining nodes", cpCmd)
 	}
 
 	return nil

--- a/pkg/roachprod/install/install.go
+++ b/pkg/roachprod/install/install.go
@@ -185,5 +185,5 @@ func InstallTool(
 	}
 	// Ensure that we early exit if any of the shell statements fail.
 	cmd = "set -exuo pipefail;" + cmd
-	return c.Run(ctx, l, stdout, stderr, OnNodes(nodes), "installing "+softwareName, cmd)
+	return c.Run(ctx, l, stdout, stderr, WithNodes(nodes), "installing "+softwareName, cmd)
 }

--- a/pkg/roachprod/install/run_options.go
+++ b/pkg/roachprod/install/run_options.go
@@ -47,7 +47,7 @@ const (
 	FailSlow
 )
 
-func OnNodes(nodes Nodes) RunOptions {
+func WithNodes(nodes Nodes) RunOptions {
 	return RunOptions{
 		Nodes: nodes,
 	}

--- a/pkg/roachprod/install/staging.go
+++ b/pkg/roachprod/install/staging.go
@@ -303,7 +303,7 @@ func stageRemoteBinary(
 		`curl -sfSL -o "%s" "%s" && chmod 755 %s`, target, binURL, target,
 	)
 	return c.Run(
-		ctx, l, l.Stdout, l.Stderr, OnNodes(c.Nodes), fmt.Sprintf("staging binary (%s)", applicationName), cmdStr,
+		ctx, l, l.Stdout, l.Stderr, WithNodes(c.Nodes), fmt.Sprintf("staging binary (%s)", applicationName), cmdStr,
 	)
 }
 
@@ -333,7 +333,7 @@ curl -sfSL -o "%s" "%s" 2>/dev/null || echo 'optional library %s not found; cont
 		libraryName+ext,
 	)
 	return c.Run(
-		ctx, l, l.Stdout, l.Stderr, OnNodes(c.Nodes), fmt.Sprintf("staging library (%s)", libraryName), cmdStr,
+		ctx, l, l.Stdout, l.Stderr, WithNodes(c.Nodes), fmt.Sprintf("staging library (%s)", libraryName), cmdStr,
 	)
 }
 
@@ -372,6 +372,6 @@ if [ -d ${tmpdir}/lib ]; then mv ${tmpdir}/lib/* ${dir}/lib; fi && \
 chmod 755 ${dir}/cockroach
 `, dir, binURL)
 	return c.Run(
-		ctx, l, l.Stdout, l.Stderr, OnNodes(c.Nodes), "staging cockroach release binary", cmdStr,
+		ctx, l, l.Stdout, l.Stderr, WithNodes(c.Nodes), "staging cockroach release binary", cmdStr,
 	)
 }

--- a/pkg/roachprod/prometheus/prometheus.go
+++ b/pkg/roachprod/prometheus/prometheus.go
@@ -265,7 +265,7 @@ rm -rf node_exporter && mkdir -p node_exporter && curl -fsSL \
 		}
 
 		// Start node_exporter.
-		if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.OnNodes(cfg.NodeExporter), "init node exporter",
+		if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(cfg.NodeExporter), "init node exporter",
 			`cd node_exporter &&
 sudo systemd-run --unit node_exporter --same-dir ./node_exporter`,
 		); err != nil {
@@ -325,7 +325,7 @@ sudo systemd-run --unit node_exporter --same-dir ./node_exporter`,
 		l,
 		l.Stdout,
 		l.Stderr,
-		install.OnNodes(cfg.PrometheusNode),
+		install.WithNodes(cfg.PrometheusNode),
 		"start-prometheus",
 		`cd /tmp/prometheus &&
 sudo systemd-run --unit prometheus --same-dir \
@@ -396,7 +396,7 @@ org_role = Admin
 
 		for idx, u := range cfg.Grafana.DashboardURLs {
 			cmd := fmt.Sprintf("curl -fsSL %s -o /var/lib/grafana/dashboards/%d.json", u, idx)
-			if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.OnNodes(cfg.PrometheusNode), "download dashboard",
+			if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(cfg.PrometheusNode), "download dashboard",
 				cmd); err != nil {
 				l.PrintfCtx(ctx, "failed to download dashboard from %s: %s", u, err)
 			}
@@ -410,7 +410,7 @@ org_role = Admin
 		}
 
 		// Start Grafana. Default port is 3000.
-		if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.OnNodes(cfg.PrometheusNode), "start grafana",
+		if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(cfg.PrometheusNode), "start grafana",
 			`sudo systemctl restart grafana-server`); err != nil {
 			return nil, err
 		}
@@ -434,7 +434,7 @@ func Snapshot(
 		l,
 		l.Stdout,
 		l.Stderr,
-		install.OnNodes(promNode),
+		install.WithNodes(promNode),
 		"prometheus snapshot",
 		`sudo rm -rf /tmp/prometheus/data/snapshots/* && curl -XPOST http://localhost:9090/api/v1/admin/tsdb/snapshot &&
 	cd /tmp/prometheus && tar cvf prometheus-snapshot.tar.gz data/snapshots`,
@@ -504,13 +504,13 @@ func Shutdown(
 			shutdownErr = errors.CombineErrors(shutdownErr, err)
 		}
 	}
-	if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.OnNodes(nodes), "stop node exporter",
+	if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(nodes), "stop node exporter",
 		`sudo systemctl stop node_exporter || echo 'Stopped node exporter'`); err != nil {
 		l.Printf("Failed to stop node exporter: %v", err)
 		shutdownErr = errors.CombineErrors(shutdownErr, err)
 	}
 
-	if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.OnNodes(promNode), "stop grafana",
+	if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(promNode), "stop grafana",
 		`sudo systemctl stop grafana-server || echo 'Stopped grafana'`); err != nil {
 		l.Printf("Failed to stop grafana server: %v", err)
 		shutdownErr = errors.CombineErrors(shutdownErr, err)


### PR DESCRIPTION
This change updates the `Run` and `RunE` cluster interface methods to take `install.RunOptions` as a parameter instead of `option.NodeListOption` to expose the additional available options to `roachtest`.

Epic: None
Release Note: None