### PR TITLE
roachprod: replace prom setup retries with default

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1351,35 +1351,6 @@ func (c *SyncedCluster) RunWithDetails(
 	return results, nil
 }
 
-var roachprodRetryOptions = retry.Options{
-	InitialBackoff: 10 * time.Second,
-	Multiplier:     2,
-	MaxBackoff:     5 * time.Minute,
-	MaxRetries:     10,
-}
-
-// RepeatRun is the same function as c.Run, but with an automatic retry loop.
-func (c *SyncedCluster) RepeatRun(
-	ctx context.Context, l *logger.Logger, stdout, stderr io.Writer, nodes Nodes, title,
-	cmd string,
-) error {
-	var lastError error
-	for attempt, r := 0, retry.StartWithCtx(ctx, roachprodRetryOptions); r.Next(); {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		attempt++
-		l.Printf("attempt %d - %s", attempt, title)
-		lastError = c.Run(ctx, l, stdout, stderr, WithNodes(nodes), title, cmd)
-		if lastError != nil {
-			l.Printf("error - retrying: %s", lastError)
-			continue
-		}
-		return nil
-	}
-	return errors.Wrapf(lastError, "all attempts failed for %s", title)
-}
-
 // Wait TODO(peter): document
 func (c *SyncedCluster) Wait(ctx context.Context, l *logger.Logger) error {
 	display := fmt.Sprintf("%s: waiting for nodes to start", c.Name)

--- a/pkg/roachprod/install/run_options.go
+++ b/pkg/roachprod/install/run_options.go
@@ -47,6 +47,10 @@ const (
 	FailSlow
 )
 
+// AlwaysRetry is a retry function that always returns true to indicate that
+// the operation should be retried.
+var AlwaysRetry = func(res *RunResultDetails) bool { return true }
+
 func WithNodes(nodes Nodes) RunOptions {
 	return RunOptions{
 		Nodes: nodes,

--- a/pkg/roachprod/install/run_options.go
+++ b/pkg/roachprod/install/run_options.go
@@ -47,8 +47,8 @@ const (
 	FailSlow
 )
 
-// AlwaysRetry is a retry function that always returns true to indicate that
-// the operation should be retried.
+// AlwaysRetry is a should retry function that always returns true to indicate that
+// the operation is always retryable no matter what the previous result was.
 var AlwaysRetry = func(res *RunResultDetails) bool { return true }
 
 func WithNodes(nodes Nodes) RunOptions {
@@ -67,7 +67,7 @@ func (r RunOptions) WithRetryDisabled() RunOptions {
 	return r
 }
 
-func (r RunOptions) WithRetryFn(fn func(*RunResultDetails) bool) RunOptions {
+func (r RunOptions) WithShouldRetryFn(fn func(*RunResultDetails) bool) RunOptions {
 	r.ShouldRetryFn = fn
 	return r
 }

--- a/pkg/roachprod/install/run_options.go
+++ b/pkg/roachprod/install/run_options.go
@@ -47,9 +47,10 @@ const (
 	FailSlow
 )
 
-// AlwaysRetry is a should retry function that always returns true to indicate that
-// the operation is always retryable no matter what the previous result was.
-var AlwaysRetry = func(res *RunResultDetails) bool { return true }
+// AlwaysTrue is a should retry predicate function that always returns true to
+// indicate that the operation is always retryable no matter what the previous
+// result was.
+var AlwaysTrue = func(res *RunResultDetails) bool { return true }
 
 func WithNodes(nodes Nodes) RunOptions {
 	return RunOptions{

--- a/pkg/roachprod/prometheus/prometheus.go
+++ b/pkg/roachprod/prometheus/prometheus.go
@@ -253,7 +253,7 @@ func Init(
 		// NB: when upgrading here, make sure to target a version that picks up this PR:
 		// https://github.com/prometheus/node_exporter/pull/2311
 		// At time of writing, there hasn't been a release in over half a year.
-		if err := c.RepeatRun(ctx, l, l.Stdout, l.Stderr, cfg.NodeExporter,
+		if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(cfg.NodeExporter).WithRetryFn(install.AlwaysRetry),
 			"download node exporter",
 			fmt.Sprintf(`
 (sudo systemctl stop node_exporter || true) &&
@@ -274,24 +274,24 @@ sudo systemd-run --unit node_exporter --same-dir ./node_exporter`,
 			return nil, errors.Wrap(err, "grafana-start currently cannot run on darwin")
 		}
 	}
-	if err := c.RepeatRun(
+	if err := c.Run(
 		ctx,
 		l,
 		l.Stdout,
 		l.Stderr,
-		cfg.PrometheusNode,
+		install.WithNodes(cfg.PrometheusNode).WithRetryFn(install.AlwaysRetry),
 		"reset prometheus",
 		"sudo systemctl stop prometheus || echo 'no prometheus is running'",
 	); err != nil {
 		return nil, err
 	}
 
-	if err := c.RepeatRun(
+	if err := c.Run(
 		ctx,
 		l,
 		l.Stdout,
 		l.Stderr,
-		cfg.PrometheusNode,
+		install.WithNodes(cfg.PrometheusNode).WithRetryFn(install.AlwaysRetry),
 		"download prometheus",
 		fmt.Sprintf(`sudo rm -rf /tmp/prometheus && mkdir /tmp/prometheus && cd /tmp/prometheus &&
 			curl -fsSL https://storage.googleapis.com/cockroach-test-artifacts/prometheus/prometheus-2.27.1.linux-%s.tar.gz | tar zxv --strip-components=1`,
@@ -336,9 +336,9 @@ sudo systemd-run --unit prometheus --same-dir \
 
 	if cfg.Grafana.Enabled {
 		// Install Grafana.
-		if err := c.RepeatRun(ctx, l,
+		if err := c.Run(ctx, l,
 			l.Stdout,
-			l.Stderr, cfg.PrometheusNode, "install grafana",
+			l.Stderr, install.WithNodes(cfg.PrometheusNode).WithRetryFn(install.AlwaysRetry), "install grafana",
 			fmt.Sprintf(`
 sudo apt-get install -qqy apt-transport-https &&
 sudo apt-get install -qqy software-properties-common &&
@@ -352,9 +352,9 @@ sudo mkdir -p /var/lib/grafana/dashboards`,
 		}
 
 		// Provision local prometheus instance as data source.
-		if err := c.RepeatRun(ctx, l,
+		if err := c.Run(ctx, l,
 			l.Stdout,
-			l.Stderr, cfg.PrometheusNode, "permissions",
+			l.Stderr, install.WithNodes(cfg.PrometheusNode).WithRetryFn(install.AlwaysRetry), "permissions",
 			`sudo chmod -R 777 /etc/grafana/provisioning/datasources /etc/grafana/provisioning/dashboards /var/lib/grafana/dashboards /etc/grafana/grafana.ini`,
 		); err != nil {
 			return nil, err
@@ -516,12 +516,12 @@ func Shutdown(
 		shutdownErr = errors.CombineErrors(shutdownErr, err)
 	}
 
-	if err := c.RepeatRun(
+	if err := c.Run(
 		ctx,
 		l,
 		l.Stdout,
 		l.Stderr,
-		promNode,
+		install.WithNodes(promNode).WithRetryFn(install.AlwaysRetry),
 		"stop prometheus",
 		"sudo systemctl stop prometheus || echo 'Stopped prometheus'",
 	); err != nil {

--- a/pkg/roachprod/prometheus/prometheus.go
+++ b/pkg/roachprod/prometheus/prometheus.go
@@ -253,7 +253,7 @@ func Init(
 		// NB: when upgrading here, make sure to target a version that picks up this PR:
 		// https://github.com/prometheus/node_exporter/pull/2311
 		// At time of writing, there hasn't been a release in over half a year.
-		if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(cfg.NodeExporter).WithRetryFn(install.AlwaysRetry),
+		if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(cfg.NodeExporter).WithShouldRetryFn(install.AlwaysRetry),
 			"download node exporter",
 			fmt.Sprintf(`
 (sudo systemctl stop node_exporter || true) &&
@@ -279,7 +279,7 @@ sudo systemd-run --unit node_exporter --same-dir ./node_exporter`,
 		l,
 		l.Stdout,
 		l.Stderr,
-		install.WithNodes(cfg.PrometheusNode).WithRetryFn(install.AlwaysRetry),
+		install.WithNodes(cfg.PrometheusNode).WithShouldRetryFn(install.AlwaysRetry),
 		"reset prometheus",
 		"sudo systemctl stop prometheus || echo 'no prometheus is running'",
 	); err != nil {
@@ -291,7 +291,7 @@ sudo systemd-run --unit node_exporter --same-dir ./node_exporter`,
 		l,
 		l.Stdout,
 		l.Stderr,
-		install.WithNodes(cfg.PrometheusNode).WithRetryFn(install.AlwaysRetry),
+		install.WithNodes(cfg.PrometheusNode).WithShouldRetryFn(install.AlwaysRetry),
 		"download prometheus",
 		fmt.Sprintf(`sudo rm -rf /tmp/prometheus && mkdir /tmp/prometheus && cd /tmp/prometheus &&
 			curl -fsSL https://storage.googleapis.com/cockroach-test-artifacts/prometheus/prometheus-2.27.1.linux-%s.tar.gz | tar zxv --strip-components=1`,
@@ -338,7 +338,7 @@ sudo systemd-run --unit prometheus --same-dir \
 		// Install Grafana.
 		if err := c.Run(ctx, l,
 			l.Stdout,
-			l.Stderr, install.WithNodes(cfg.PrometheusNode).WithRetryFn(install.AlwaysRetry), "install grafana",
+			l.Stderr, install.WithNodes(cfg.PrometheusNode).WithShouldRetryFn(install.AlwaysRetry), "install grafana",
 			fmt.Sprintf(`
 sudo apt-get install -qqy apt-transport-https &&
 sudo apt-get install -qqy software-properties-common &&
@@ -354,7 +354,7 @@ sudo mkdir -p /var/lib/grafana/dashboards`,
 		// Provision local prometheus instance as data source.
 		if err := c.Run(ctx, l,
 			l.Stdout,
-			l.Stderr, install.WithNodes(cfg.PrometheusNode).WithRetryFn(install.AlwaysRetry), "permissions",
+			l.Stderr, install.WithNodes(cfg.PrometheusNode).WithShouldRetryFn(install.AlwaysRetry), "permissions",
 			`sudo chmod -R 777 /etc/grafana/provisioning/datasources /etc/grafana/provisioning/dashboards /var/lib/grafana/dashboards /etc/grafana/grafana.ini`,
 		); err != nil {
 			return nil, err
@@ -521,7 +521,7 @@ func Shutdown(
 		l,
 		l.Stdout,
 		l.Stderr,
-		install.WithNodes(promNode).WithRetryFn(install.AlwaysRetry),
+		install.WithNodes(promNode).WithShouldRetryFn(install.AlwaysRetry),
 		"stop prometheus",
 		"sudo systemctl stop prometheus || echo 'Stopped prometheus'",
 	); err != nil {

--- a/pkg/roachprod/prometheus/prometheus.go
+++ b/pkg/roachprod/prometheus/prometheus.go
@@ -253,7 +253,7 @@ func Init(
 		// NB: when upgrading here, make sure to target a version that picks up this PR:
 		// https://github.com/prometheus/node_exporter/pull/2311
 		// At time of writing, there hasn't been a release in over half a year.
-		if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(cfg.NodeExporter).WithShouldRetryFn(install.AlwaysRetry),
+		if err := c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(cfg.NodeExporter).WithShouldRetryFn(install.AlwaysTrue),
 			"download node exporter",
 			fmt.Sprintf(`
 (sudo systemctl stop node_exporter || true) &&
@@ -279,7 +279,7 @@ sudo systemd-run --unit node_exporter --same-dir ./node_exporter`,
 		l,
 		l.Stdout,
 		l.Stderr,
-		install.WithNodes(cfg.PrometheusNode).WithShouldRetryFn(install.AlwaysRetry),
+		install.WithNodes(cfg.PrometheusNode).WithShouldRetryFn(install.AlwaysTrue),
 		"reset prometheus",
 		"sudo systemctl stop prometheus || echo 'no prometheus is running'",
 	); err != nil {
@@ -291,7 +291,7 @@ sudo systemd-run --unit node_exporter --same-dir ./node_exporter`,
 		l,
 		l.Stdout,
 		l.Stderr,
-		install.WithNodes(cfg.PrometheusNode).WithShouldRetryFn(install.AlwaysRetry),
+		install.WithNodes(cfg.PrometheusNode).WithShouldRetryFn(install.AlwaysTrue),
 		"download prometheus",
 		fmt.Sprintf(`sudo rm -rf /tmp/prometheus && mkdir /tmp/prometheus && cd /tmp/prometheus &&
 			curl -fsSL https://storage.googleapis.com/cockroach-test-artifacts/prometheus/prometheus-2.27.1.linux-%s.tar.gz | tar zxv --strip-components=1`,
@@ -338,7 +338,7 @@ sudo systemd-run --unit prometheus --same-dir \
 		// Install Grafana.
 		if err := c.Run(ctx, l,
 			l.Stdout,
-			l.Stderr, install.WithNodes(cfg.PrometheusNode).WithShouldRetryFn(install.AlwaysRetry), "install grafana",
+			l.Stderr, install.WithNodes(cfg.PrometheusNode).WithShouldRetryFn(install.AlwaysTrue), "install grafana",
 			fmt.Sprintf(`
 sudo apt-get install -qqy apt-transport-https &&
 sudo apt-get install -qqy software-properties-common &&
@@ -354,7 +354,7 @@ sudo mkdir -p /var/lib/grafana/dashboards`,
 		// Provision local prometheus instance as data source.
 		if err := c.Run(ctx, l,
 			l.Stdout,
-			l.Stderr, install.WithNodes(cfg.PrometheusNode).WithShouldRetryFn(install.AlwaysRetry), "permissions",
+			l.Stderr, install.WithNodes(cfg.PrometheusNode).WithShouldRetryFn(install.AlwaysTrue), "permissions",
 			`sudo chmod -R 777 /etc/grafana/provisioning/datasources /etc/grafana/provisioning/dashboards /var/lib/grafana/dashboards /etc/grafana/grafana.ini`,
 		); err != nil {
 			return nil, err
@@ -521,7 +521,7 @@ func Shutdown(
 		l,
 		l.Stdout,
 		l.Stderr,
-		install.WithNodes(promNode).WithShouldRetryFn(install.AlwaysRetry),
+		install.WithNodes(promNode).WithShouldRetryFn(install.AlwaysTrue),
 		"stop prometheus",
 		"sudo systemctl stop prometheus || echo 'Stopped prometheus'",
 	); err != nil {


### PR DESCRIPTION
This change removes `c.RepeatRun` in favour of using the existing `c.Run` with the `install.WithRetryFn` option.

Epic: None
Release Note: None