### PR TITLE
release-23.2: Revert "kv: stop encoding or decoding synthetic timestamp bit in/from mvcc keys"

### DIFF
--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -909,6 +909,7 @@ func TestDecodeKey(t *testing.T) {
 		{Key: []byte("foo")},
 		{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1}},
 		{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1, Logical: 1}},
+		{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1, Logical: 1, Synthetic: true}},
 	}
 	for _, test := range tests {
 		t.Run(test.String(), func(t *testing.T) {

--- a/pkg/storage/engine_key.go
+++ b/pkg/storage/engine_key.go
@@ -31,7 +31,7 @@ import (
 // should consider changing all the legacy code).
 //
 // The version can have the following lengths in addition to 0 length.
-// - Timestamp of MVCC keys: 8, 12, or 13 bytes.
+// - Timestamp of MVCC keys: 8 or 12 bytes.
 // - Lock table key: 17 bytes.
 type EngineKey struct {
 	Key     roachpb.Key
@@ -153,11 +153,13 @@ func (k EngineKey) ToMVCCKey() (MVCCKey, error) {
 		// No-op.
 	case engineKeyVersionWallTimeLen:
 		key.Timestamp.WallTime = int64(binary.BigEndian.Uint64(k.Version[0:8]))
-	case engineKeyVersionWallAndLogicalTimeLen, engineKeyVersionWallLogicalAndSyntheticTimeLen:
+	case engineKeyVersionWallAndLogicalTimeLen:
 		key.Timestamp.WallTime = int64(binary.BigEndian.Uint64(k.Version[0:8]))
 		key.Timestamp.Logical = int32(binary.BigEndian.Uint32(k.Version[8:12]))
-		// NOTE: byte 13 used to store the timestamp's synthetic bit, but this is no
-		// longer consulted and can be ignored during decoding.
+	case engineKeyVersionWallLogicalAndSyntheticTimeLen:
+		key.Timestamp.WallTime = int64(binary.BigEndian.Uint64(k.Version[0:8]))
+		key.Timestamp.Logical = int32(binary.BigEndian.Uint32(k.Version[8:12]))
+		key.Timestamp.Synthetic = k.Version[12] != 0
 	default:
 		return MVCCKey{}, errors.Errorf("version is not an encoded timestamp %x", k.Version)
 	}

--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -191,14 +191,12 @@ func TestMVCCAndEngineKeyEncodeDecode(t *testing.T) {
 
 // TestMVCCAndEngineKeyDecodeSyntheticTimestamp tests decoding an MVCC key with
 // a synthetic timestamp. The synthetic timestamp bit is now ignored during key
-// encoding and decoding, but synthetic timestamps may still be present in the
-// wild, so they must not confuse decoding.
+// encoding, but synthetic timestamps may still be present in the wild, so they
+// must be decoded.
 func TestMVCCAndEngineKeyDecodeSyntheticTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	key := MVCCKey{Key: roachpb.Key("bar"), Timestamp: hlc.Timestamp{WallTime: 99, Logical: 45, Synthetic: true}}
-	keyNoSynthetic := key
-	keyNoSynthetic.Timestamp.Synthetic = false
 
 	// encodedStr was computed from key using a previous version of the code that
 	// that included synthetic timestamps in the MVCC key encoding.
@@ -214,7 +212,7 @@ func TestMVCCAndEngineKeyDecodeSyntheticTimestamp(t *testing.T) {
 	require.NoError(t, eKeyDecoded.Validate())
 	keyDecoded, err := eKeyDecoded.ToMVCCKey()
 	require.NoError(t, err)
-	require.Equal(t, keyNoSynthetic, keyDecoded)
+	require.Equal(t, key, keyDecoded)
 }
 
 func TestEngineKeyValidate(t *testing.T) {

--- a/pkg/storage/enginepb/decode.go
+++ b/pkg/storage/enginepb/decode.go
@@ -59,11 +59,13 @@ func DecodeKey(encodedKey []byte) ([]byte, hlc.Timestamp, error) {
 		// No-op.
 	case 8:
 		timestamp.WallTime = int64(binary.BigEndian.Uint64(encodedTS[0:8]))
-	case 12, 13:
+	case 12:
 		timestamp.WallTime = int64(binary.BigEndian.Uint64(encodedTS[0:8]))
 		timestamp.Logical = int32(binary.BigEndian.Uint32(encodedTS[8:12]))
-		// NOTE: byte 13 used to store the timestamp's synthetic bit, but this is no
-		// longer consulted and can be ignored during decoding.
+	case 13:
+		timestamp.WallTime = int64(binary.BigEndian.Uint64(encodedTS[0:8]))
+		timestamp.Logical = int32(binary.BigEndian.Uint32(encodedTS[8:12]))
+		timestamp.Synthetic = encodedTS[12] != 0
 	default:
 		return nil, hlc.Timestamp{}, errors.Errorf(
 			"invalid encoded mvcc key: %x bad timestamp %x", encodedKey, encodedTS)

--- a/pkg/storage/mvcc_key.go
+++ b/pkg/storage/mvcc_key.go
@@ -178,11 +178,6 @@ func (k MVCCKey) Len() int {
 //
 // The sentinel byte can be used to detect a key without a timestamp, since
 // timeLength will never be 0 (it includes itself in the length).
-//
-// The timeSynthetic form is no longer written by the current version of the
-// code, but can be encountered in the wild until we migrate it away. Until
-// then, decoding routines must be prepared to handle it, but can ignore the
-// synthetic bit.
 func EncodeMVCCKey(key MVCCKey) []byte {
 	keyLen := encodedMVCCKeyLength(key)
 	buf := make([]byte, keyLen)
@@ -355,11 +350,14 @@ func decodeMVCCTimestamp(encodedTS []byte) (hlc.Timestamp, error) {
 		// No-op.
 	case 8:
 		ts.WallTime = int64(binary.BigEndian.Uint64(encodedTS[0:8]))
-	case 12, 13:
+	case 12:
 		ts.WallTime = int64(binary.BigEndian.Uint64(encodedTS[0:8]))
 		ts.Logical = int32(binary.BigEndian.Uint32(encodedTS[8:12]))
-		// NOTE: byte 13 used to store the timestamp's synthetic bit, but this is no
-		// longer consulted and can be ignored during decoding.
+	case 13:
+		ts.WallTime = int64(binary.BigEndian.Uint64(encodedTS[0:8]))
+		ts.Logical = int32(binary.BigEndian.Uint32(encodedTS[8:12]))
+		// TODO(nvanbenschoten): stop writing Synthetic timestamps in v23.1.
+		ts.Synthetic = encodedTS[12] != 0
 	default:
 		return hlc.Timestamp{}, errors.Errorf("bad timestamp %x", encodedTS)
 	}

--- a/pkg/storage/mvcc_key_test.go
+++ b/pkg/storage/mvcc_key_test.go
@@ -259,28 +259,23 @@ func TestDecodeUnnormalizedMVCCKey(t *testing.T) {
 			equalToNormal: false,
 		},
 		"synthetic": {
-			encoded: "666f6f00000000000000000000000000010e",
-			// Synthetic bit set to true when decoded by older versions of the code.
-			expected: MVCCKey{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 0, Logical: 0}},
-			// See comment above on "zero walltime and logical".
-			equalToNormal: false,
+			encoded:       "666f6f00000000000000000000000000010e",
+			expected:      MVCCKey{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 0, Logical: 0, Synthetic: true}},
+			equalToNormal: true,
 		},
 		"walltime and synthetic": {
-			encoded: "666f6f0016cf10bc0505574100000000010e",
-			// Synthetic bit set to true when decoded by older versions of the code.
-			expected:      MVCCKey{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1643550788737652545, Logical: 0}},
+			encoded:       "666f6f0016cf10bc0505574100000000010e",
+			expected:      MVCCKey{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1643550788737652545, Logical: 0, Synthetic: true}},
 			equalToNormal: true,
 		},
 		"logical and synthetic": {
-			encoded: "666f6f0000000000000000000000ffff010e",
-			// Synthetic bit set to true when decoded by older versions of the code.
-			expected:      MVCCKey{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 0, Logical: 65535}},
+			encoded:       "666f6f0000000000000000000000ffff010e",
+			expected:      MVCCKey{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 0, Logical: 65535, Synthetic: true}},
 			equalToNormal: true,
 		},
 		"walltime, logical, and synthetic": {
-			encoded: "666f6f0016cf10bc050557410000ffff010e",
-			// Synthetic bit set to true when decoded by older versions of the code.
-			expected:      MVCCKey{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1643550788737652545, Logical: 65535}},
+			encoded:       "666f6f0016cf10bc050557410000ffff010e",
+			expected:      MVCCKey{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1643550788737652545, Logical: 65535, Synthetic: true}},
 			equalToNormal: true,
 		},
 	}
@@ -392,6 +387,7 @@ func BenchmarkDecodeMVCCKey(b *testing.B) {
 		"empty":            {},
 		"walltime":         {WallTime: 1643550788737652545},
 		"walltime+logical": {WallTime: 1643550788737652545, Logical: 4096},
+		"all":              {WallTime: 1643550788737652545, Logical: 4096, Synthetic: true},
 	}
 	if testing.Short() {
 		// Reduce the number of configurations under -short.

--- a/pkg/storage/mvcc_key_test.go
+++ b/pkg/storage/mvcc_key_test.go
@@ -75,6 +75,7 @@ func TestMVCCKeyCompare(t *testing.T) {
 	b0 := MVCCKey{roachpb.Key("b"), hlc.Timestamp{Logical: 0}}
 	b1 := MVCCKey{roachpb.Key("b"), hlc.Timestamp{Logical: 1}}
 	b2 := MVCCKey{roachpb.Key("b"), hlc.Timestamp{Logical: 2}}
+	b2S := MVCCKey{roachpb.Key("b"), hlc.Timestamp{Logical: 2, Synthetic: true}}
 
 	testcases := map[string]struct {
 		a      MVCCKey
@@ -89,6 +90,7 @@ func TestMVCCKeyCompare(t *testing.T) {
 		"empty time lt set":   {b0, b1, -1}, // empty MVCC timestamps sort before non-empty
 		"set time gt empty":   {b1, b0, 1},  // empty MVCC timestamps sort before non-empty
 		"key time precedence": {a1, b2, -1}, // a before b, but 2 before 1; key takes precedence
+		"synthetic equal":     {b2, b2S, 0}, // synthetic bit does not affect ordering
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
@@ -151,6 +153,10 @@ func (k randMVCCKey) Generate(r *rand.Rand, size int) reflect.Value {
 	k.Key = []byte([...]string{"a", "b", "c"}[r.Intn(3)])
 	k.Timestamp.WallTime = r.Int63n(5)
 	k.Timestamp.Logical = r.Int31n(5)
+	if !k.Timestamp.IsEmpty() {
+		// NB: the zero timestamp cannot be synthetic.
+		k.Timestamp.Synthetic = r.Intn(2) != 0
+	}
 	return reflect.ValueOf(k)
 }
 
@@ -162,12 +168,16 @@ func TestEncodeDecodeMVCCKeyAndTimestampWithLength(t *testing.T) {
 		ts      hlc.Timestamp
 		encoded string // hexadecimal
 	}{
-		"empty":                {"", hlc.Timestamp{}, "00"},
-		"only key":             {"foo", hlc.Timestamp{}, "666f6f00"},
-		"no key":               {"", hlc.Timestamp{WallTime: 1643550788737652545}, "0016cf10bc0505574109"},
-		"walltime":             {"foo", hlc.Timestamp{WallTime: 1643550788737652545}, "666f6f0016cf10bc0505574109"},
-		"logical":              {"foo", hlc.Timestamp{Logical: 65535}, "666f6f0000000000000000000000ffff0d"},
-		"walltime and logical": {"foo", hlc.Timestamp{WallTime: 1643550788737652545, Logical: 65535}, "666f6f0016cf10bc050557410000ffff0d"},
+		"empty":                  {"", hlc.Timestamp{}, "00"},
+		"only key":               {"foo", hlc.Timestamp{}, "666f6f00"},
+		"no key":                 {"", hlc.Timestamp{WallTime: 1643550788737652545}, "0016cf10bc0505574109"},
+		"walltime":               {"foo", hlc.Timestamp{WallTime: 1643550788737652545}, "666f6f0016cf10bc0505574109"},
+		"logical":                {"foo", hlc.Timestamp{Logical: 65535}, "666f6f0000000000000000000000ffff0d"},
+		"synthetic":              {"foo", hlc.Timestamp{Synthetic: true}, "666f6f00000000000000000000000000010e"},
+		"walltime and logical":   {"foo", hlc.Timestamp{WallTime: 1643550788737652545, Logical: 65535}, "666f6f0016cf10bc050557410000ffff0d"},
+		"walltime and synthetic": {"foo", hlc.Timestamp{WallTime: 1643550788737652545, Synthetic: true}, "666f6f0016cf10bc0505574100000000010e"},
+		"logical and synthetic":  {"foo", hlc.Timestamp{Logical: 65535, Synthetic: true}, "666f6f0000000000000000000000ffff010e"},
+		"all":                    {"foo", hlc.Timestamp{WallTime: 1643550788737652545, Logical: 65535, Synthetic: true}, "666f6f0016cf10bc050557410000ffff010e"},
 	}
 
 	buf := []byte{}
@@ -258,26 +268,6 @@ func TestDecodeUnnormalizedMVCCKey(t *testing.T) {
 			// keys that only contain (at most) a walltime.
 			equalToNormal: false,
 		},
-		"synthetic": {
-			encoded:       "666f6f00000000000000000000000000010e",
-			expected:      MVCCKey{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 0, Logical: 0, Synthetic: true}},
-			equalToNormal: true,
-		},
-		"walltime and synthetic": {
-			encoded:       "666f6f0016cf10bc0505574100000000010e",
-			expected:      MVCCKey{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1643550788737652545, Logical: 0, Synthetic: true}},
-			equalToNormal: true,
-		},
-		"logical and synthetic": {
-			encoded:       "666f6f0000000000000000000000ffff010e",
-			expected:      MVCCKey{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 0, Logical: 65535, Synthetic: true}},
-			equalToNormal: true,
-		},
-		"walltime, logical, and synthetic": {
-			encoded:       "666f6f0016cf10bc050557410000ffff010e",
-			expected:      MVCCKey{Key: []byte("foo"), Timestamp: hlc.Timestamp{WallTime: 1643550788737652545, Logical: 65535, Synthetic: true}},
-			equalToNormal: true,
-		},
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
@@ -355,6 +345,7 @@ func BenchmarkEncodeMVCCKey(b *testing.B) {
 		"empty":            {},
 		"walltime":         {WallTime: 1643550788737652545},
 		"walltime+logical": {WallTime: 1643550788737652545, Logical: 4096},
+		"all":              {WallTime: 1643550788737652545, Logical: 4096, Synthetic: true},
 	}
 	if testing.Short() {
 		// Reduce the number of configurations under -short.
@@ -604,6 +595,11 @@ func TestMVCCRangeKeyEncodedSize(t *testing.T) {
 		"only end":      {MVCCRangeKey{EndKey: roachpb.Key("foo")}, 5},
 		"only walltime": {MVCCRangeKey{Timestamp: hlc.Timestamp{WallTime: 1}}, 11},
 		"only logical":  {MVCCRangeKey{Timestamp: hlc.Timestamp{Logical: 1}}, 15},
+		"all": {MVCCRangeKey{
+			StartKey:  roachpb.Key("start"),
+			EndKey:    roachpb.Key("end"),
+			Timestamp: hlc.Timestamp{WallTime: 1, Logical: 1, Synthetic: true},
+		}, 24},
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/storage/mvcc_value_test.go
+++ b/pkg/storage/mvcc_value_test.go
@@ -59,16 +59,18 @@ func TestMVCCValueGetLocalTimestamp(t *testing.T) {
 	ts0 := hlc.Timestamp{Logical: 0}
 	ts1 := hlc.Timestamp{Logical: 1}
 	ts2 := hlc.Timestamp{Logical: 2}
+	ts2S := hlc.Timestamp{Logical: 2, Synthetic: true}
 
 	testcases := map[string]struct {
 		localTs   hlc.Timestamp
 		versionTs hlc.Timestamp
 		expect    hlc.Timestamp
 	}{
-		"no local timestamp":      {ts0, ts2, ts2},
-		"smaller local timestamp": {ts1, ts2, ts1},
-		"equal local timestamp":   {ts2, ts2, ts2},
-		"larger local timestamp":  {ts2, ts1, ts2},
+		"no local timestamp":                    {ts0, ts2, ts2},
+		"no local timestamp, version synthetic": {ts0, ts2S, hlc.MinTimestamp},
+		"smaller local timestamp":               {ts1, ts2, ts1},
+		"equal local timestamp":                 {ts2, ts2, ts2},
+		"larger local timestamp":                {ts2, ts1, ts2},
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -458,6 +458,10 @@ func makeRandEncodedKeys() [][]byte {
 			// 20% of keys have a logical component.
 			k.Timestamp.Logical = rng.Int31n(4) + 1
 		}
+		if rng.Int31n(1000) == 0 && !k.Timestamp.IsEmpty() {
+			// 0.1% of keys have a synthetic component.
+			k.Timestamp.Synthetic = true
+		}
 		keys[i] = EncodeMVCCKey(k)
 	}
 	return keys

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit_and_synthetic_timestamps
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit_and_synthetic_timestamps
@@ -1,0 +1,3065 @@
+# Setup:
+#
+# k1: value  @ ts 20
+# k1: value  @ ts 10
+#
+# k2: value  @ ts 20
+# k2: value  @ ts 10?
+#
+# k3: value  @ ts 20?
+# k3: value  @ ts 10
+#
+# k4: value  @ ts 20?
+# k4: value  @ ts 10?
+#
+# k5: intent @ ts 20
+# k5: value  @ ts 10
+#
+# k6: intent @ ts 20
+# k6: value  @ ts 10?
+#
+# k7: intent @ ts 20?
+# k7: value  @ ts 10
+#
+# k8: intent @ ts 20?
+# k8: value  @ ts 10?
+#
+
+run ok
+with k=k1
+  put v=v1 ts=10,0
+  put v=v2 ts=20,0
+----
+>> at end:
+data: "k1"/20.000000000,0 -> /BYTES/v2
+data: "k1"/10.000000000,0 -> /BYTES/v1
+
+run ok
+with k=k2
+  put v=v3 ts=10,0?
+  put v=v4 ts=20,0
+----
+>> at end:
+data: "k1"/20.000000000,0 -> /BYTES/v2
+data: "k1"/10.000000000,0 -> /BYTES/v1
+data: "k2"/20.000000000,0 -> /BYTES/v4
+data: "k2"/10.000000000,0? -> /BYTES/v3
+
+run ok
+with k=k3
+  put v=v5 ts=10,0
+  put v=v6 ts=20,0?
+----
+>> at end:
+data: "k1"/20.000000000,0 -> /BYTES/v2
+data: "k1"/10.000000000,0 -> /BYTES/v1
+data: "k2"/20.000000000,0 -> /BYTES/v4
+data: "k2"/10.000000000,0? -> /BYTES/v3
+data: "k3"/20.000000000,0? -> /BYTES/v6
+data: "k3"/10.000000000,0 -> /BYTES/v5
+
+run ok
+with k=k4
+  put v=v7 ts=10,0?
+  put v=v8 ts=20,0?
+----
+>> at end:
+data: "k1"/20.000000000,0 -> /BYTES/v2
+data: "k1"/10.000000000,0 -> /BYTES/v1
+data: "k2"/20.000000000,0 -> /BYTES/v4
+data: "k2"/10.000000000,0? -> /BYTES/v3
+data: "k3"/20.000000000,0? -> /BYTES/v6
+data: "k3"/10.000000000,0 -> /BYTES/v5
+data: "k4"/20.000000000,0? -> /BYTES/v8
+data: "k4"/10.000000000,0? -> /BYTES/v7
+
+run ok
+with k=k5
+  put v=v9 ts=10,0
+  txn_begin t=A ts=20,0
+  put t=A v=v10
+----
+put: lock acquisition = {k5 id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+>> at end:
+txn: "A" meta={id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+data: "k1"/20.000000000,0 -> /BYTES/v2
+data: "k1"/10.000000000,0 -> /BYTES/v1
+data: "k2"/20.000000000,0 -> /BYTES/v4
+data: "k2"/10.000000000,0? -> /BYTES/v3
+data: "k3"/20.000000000,0? -> /BYTES/v6
+data: "k3"/10.000000000,0 -> /BYTES/v5
+data: "k4"/20.000000000,0? -> /BYTES/v8
+data: "k4"/10.000000000,0? -> /BYTES/v7
+meta: "k5"/0,0 -> txn={id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k5"/20.000000000,0 -> /BYTES/v10
+data: "k5"/10.000000000,0 -> /BYTES/v9
+
+run ok
+with k=k6
+  put v=v11 ts=10,0?
+  txn_begin t=B ts=20,0
+  put t=B v=v12
+----
+put: lock acquisition = {k6 id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+>> at end:
+txn: "B" meta={id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+data: "k1"/20.000000000,0 -> /BYTES/v2
+data: "k1"/10.000000000,0 -> /BYTES/v1
+data: "k2"/20.000000000,0 -> /BYTES/v4
+data: "k2"/10.000000000,0? -> /BYTES/v3
+data: "k3"/20.000000000,0? -> /BYTES/v6
+data: "k3"/10.000000000,0 -> /BYTES/v5
+data: "k4"/20.000000000,0? -> /BYTES/v8
+data: "k4"/10.000000000,0? -> /BYTES/v7
+meta: "k5"/0,0 -> txn={id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k5"/20.000000000,0 -> /BYTES/v10
+data: "k5"/10.000000000,0 -> /BYTES/v9
+meta: "k6"/0,0 -> txn={id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k6"/20.000000000,0 -> /BYTES/v12
+data: "k6"/10.000000000,0? -> /BYTES/v11
+
+run ok
+with k=k7
+  put v=v13 ts=10,0
+  txn_begin t=C ts=20,0?
+  put t=C v=v14
+----
+put: lock acquisition = {k7 id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0? min=0,0 seq=0 Replicated Intent []}
+>> at end:
+txn: "C" meta={id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0? min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0? wto=false gul=0,0
+data: "k1"/20.000000000,0 -> /BYTES/v2
+data: "k1"/10.000000000,0 -> /BYTES/v1
+data: "k2"/20.000000000,0 -> /BYTES/v4
+data: "k2"/10.000000000,0? -> /BYTES/v3
+data: "k3"/20.000000000,0? -> /BYTES/v6
+data: "k3"/10.000000000,0 -> /BYTES/v5
+data: "k4"/20.000000000,0? -> /BYTES/v8
+data: "k4"/10.000000000,0? -> /BYTES/v7
+meta: "k5"/0,0 -> txn={id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k5"/20.000000000,0 -> /BYTES/v10
+data: "k5"/10.000000000,0 -> /BYTES/v9
+meta: "k6"/0,0 -> txn={id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k6"/20.000000000,0 -> /BYTES/v12
+data: "k6"/10.000000000,0? -> /BYTES/v11
+meta: "k7"/0,0 -> txn={id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0? min=0,0 seq=0} ts=20.000000000,0? del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k7"/20.000000000,0? -> /BYTES/v14
+data: "k7"/10.000000000,0 -> /BYTES/v13
+
+run ok
+with k=k8
+  put v=v15 ts=10,0?
+  txn_begin t=D ts=20,0?
+  put t=D v=v16
+----
+put: lock acquisition = {k8 id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0? min=0,0 seq=0 Replicated Intent []}
+>> at end:
+txn: "D" meta={id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0? min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0? wto=false gul=0,0
+data: "k1"/20.000000000,0 -> /BYTES/v2
+data: "k1"/10.000000000,0 -> /BYTES/v1
+data: "k2"/20.000000000,0 -> /BYTES/v4
+data: "k2"/10.000000000,0? -> /BYTES/v3
+data: "k3"/20.000000000,0? -> /BYTES/v6
+data: "k3"/10.000000000,0 -> /BYTES/v5
+data: "k4"/20.000000000,0? -> /BYTES/v8
+data: "k4"/10.000000000,0? -> /BYTES/v7
+meta: "k5"/0,0 -> txn={id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k5"/20.000000000,0 -> /BYTES/v10
+data: "k5"/10.000000000,0 -> /BYTES/v9
+meta: "k6"/0,0 -> txn={id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k6"/20.000000000,0 -> /BYTES/v12
+data: "k6"/10.000000000,0? -> /BYTES/v11
+meta: "k7"/0,0 -> txn={id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0? min=0,0 seq=0} ts=20.000000000,0? del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k7"/20.000000000,0? -> /BYTES/v14
+data: "k7"/10.000000000,0 -> /BYTES/v13
+meta: "k8"/0,0 -> txn={id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0? min=0,0 seq=0} ts=20.000000000,0? del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "k8"/20.000000000,0? -> /BYTES/v16
+data: "k8"/10.000000000,0? -> /BYTES/v15
+
+# Test cases:
+#
+# for ts in (5, 10, 15, 20, 25):
+#   for localUncertaintyLimit in (5, 10, 15, 20, 25):
+#     if localUncertaintyLimit < ts: continue
+#     for globalUncertaintyLimit in (5, 10, 15, 20, 25):
+#       if globalUncertaintyLimit < ts: continue
+#       if globalUncertaintyLimit <= localUncertaintyLimit: continue
+#       for k in (k1, k2, k3, k4, k5, k6, k7, k8):
+#         for op in (get, scan):
+#           testCase()
+#
+
+run ok
+txn_begin t=txn1 ts=5,0 globalUncertaintyLimit=10,0
+----
+>> at end:
+txn: "txn1" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=10.000000000,0
+
+run ok
+get t=txn1 k=k1 localUncertaintyLimit=5,0
+----
+get: "k1" -> <no data>
+
+run ok
+scan t=txn1 k=k1 localUncertaintyLimit=5,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+
+run error
+get t=txn1 k=k2 localUncertaintyLimit=5,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn1 k=k2 localUncertaintyLimit=5,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn1 k=k3 localUncertaintyLimit=5,0
+----
+get: "k3" -> <no data>
+
+run ok
+scan t=txn1 k=k3 localUncertaintyLimit=5,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+
+run error
+get t=txn1 k=k4 localUncertaintyLimit=5,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn1 k=k4 localUncertaintyLimit=5,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn1 k=k5 localUncertaintyLimit=5,0
+----
+get: "k5" -> <no data>
+
+run ok
+scan t=txn1 k=k5 localUncertaintyLimit=5,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+
+run error
+get t=txn1 k=k6 localUncertaintyLimit=5,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn1 k=k6 localUncertaintyLimit=5,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn1 k=k7 localUncertaintyLimit=5,0
+----
+get: "k7" -> <no data>
+
+run ok
+scan t=txn1 k=k7 localUncertaintyLimit=5,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+
+run error
+get t=txn1 k=k8 localUncertaintyLimit=5,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn1 k=k8 localUncertaintyLimit=5,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn2 ts=5,0 globalUncertaintyLimit=15,0
+----
+>> at end:
+txn: "txn2" meta={id=00000006 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=15.000000000,0
+
+run ok
+get t=txn2 k=k1 localUncertaintyLimit=5,0
+----
+get: "k1" -> <no data>
+
+run ok
+scan t=txn2 k=k1 localUncertaintyLimit=5,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+
+run error
+get t=txn2 k=k2 localUncertaintyLimit=5,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn2 k=k2 localUncertaintyLimit=5,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn2 k=k3 localUncertaintyLimit=5,0
+----
+get: "k3" -> <no data>
+
+run ok
+scan t=txn2 k=k3 localUncertaintyLimit=5,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+
+run error
+get t=txn2 k=k4 localUncertaintyLimit=5,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn2 k=k4 localUncertaintyLimit=5,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn2 k=k5 localUncertaintyLimit=5,0
+----
+get: "k5" -> <no data>
+
+run ok
+scan t=txn2 k=k5 localUncertaintyLimit=5,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+
+run error
+get t=txn2 k=k6 localUncertaintyLimit=5,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn2 k=k6 localUncertaintyLimit=5,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn2 k=k7 localUncertaintyLimit=5,0
+----
+get: "k7" -> <no data>
+
+run ok
+scan t=txn2 k=k7 localUncertaintyLimit=5,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+
+run error
+get t=txn2 k=k8 localUncertaintyLimit=5,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn2 k=k8 localUncertaintyLimit=5,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn3 ts=5,0 globalUncertaintyLimit=20,0
+----
+>> at end:
+txn: "txn3" meta={id=00000007 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=20.000000000,0
+
+run ok
+get t=txn3 k=k1 localUncertaintyLimit=5,0
+----
+get: "k1" -> <no data>
+
+run ok
+scan t=txn3 k=k1 localUncertaintyLimit=5,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+
+run error
+get t=txn3 k=k2 localUncertaintyLimit=5,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn3 k=k2 localUncertaintyLimit=5,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn3 k=k3 localUncertaintyLimit=5,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn3 k=k3 localUncertaintyLimit=5,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn3 k=k4 localUncertaintyLimit=5,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn3 k=k4 localUncertaintyLimit=5,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn3 k=k5 localUncertaintyLimit=5,0
+----
+get: "k5" -> <no data>
+
+run ok
+scan t=txn3 k=k5 localUncertaintyLimit=5,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+
+run error
+get t=txn3 k=k6 localUncertaintyLimit=5,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn3 k=k6 localUncertaintyLimit=5,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn3 k=k7 localUncertaintyLimit=5,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn3 k=k7 localUncertaintyLimit=5,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn3 k=k8 localUncertaintyLimit=5,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn3 k=k8 localUncertaintyLimit=5,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn4 ts=5,0 globalUncertaintyLimit=25,0
+----
+>> at end:
+txn: "txn4" meta={id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=25.000000000,0
+
+run ok
+get t=txn4 k=k1 localUncertaintyLimit=5,0
+----
+get: "k1" -> <no data>
+
+run ok
+scan t=txn4 k=k1 localUncertaintyLimit=5,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+
+run error
+get t=txn4 k=k2 localUncertaintyLimit=5,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn4 k=k2 localUncertaintyLimit=5,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn4 k=k3 localUncertaintyLimit=5,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn4 k=k3 localUncertaintyLimit=5,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn4 k=k4 localUncertaintyLimit=5,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn4 k=k4 localUncertaintyLimit=5,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn4 k=k5 localUncertaintyLimit=5,0
+----
+get: "k5" -> <no data>
+
+run ok
+scan t=txn4 k=k5 localUncertaintyLimit=5,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+
+run error
+get t=txn4 k=k6 localUncertaintyLimit=5,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn4 k=k6 localUncertaintyLimit=5,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn4 k=k7 localUncertaintyLimit=5,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn4 k=k7 localUncertaintyLimit=5,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn4 k=k8 localUncertaintyLimit=5,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn4 k=k8 localUncertaintyLimit=5,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn5 ts=5,0 globalUncertaintyLimit=15,0
+----
+>> at end:
+txn: "txn5" meta={id=00000009 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=15.000000000,0
+
+run error
+get t=txn5 k=k1 localUncertaintyLimit=10,0
+----
+get: "k1" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn5 k=k1 localUncertaintyLimit=10,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn5 k=k2 localUncertaintyLimit=10,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn5 k=k2 localUncertaintyLimit=10,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn5 k=k3 localUncertaintyLimit=10,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn5 k=k3 localUncertaintyLimit=10,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn5 k=k4 localUncertaintyLimit=10,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn5 k=k4 localUncertaintyLimit=10,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn5 k=k5 localUncertaintyLimit=10,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn5 k=k5 localUncertaintyLimit=10,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn5 k=k6 localUncertaintyLimit=10,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn5 k=k6 localUncertaintyLimit=10,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn5 k=k7 localUncertaintyLimit=10,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn5 k=k7 localUncertaintyLimit=10,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn5 k=k8 localUncertaintyLimit=10,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn5 k=k8 localUncertaintyLimit=10,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn6 ts=5,0 globalUncertaintyLimit=20,0
+----
+>> at end:
+txn: "txn6" meta={id=0000000a key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=20.000000000,0
+
+run error
+get t=txn6 k=k1 localUncertaintyLimit=10,0
+----
+get: "k1" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn6 k=k1 localUncertaintyLimit=10,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn6 k=k2 localUncertaintyLimit=10,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn6 k=k2 localUncertaintyLimit=10,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn6 k=k3 localUncertaintyLimit=10,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn6 k=k3 localUncertaintyLimit=10,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn6 k=k4 localUncertaintyLimit=10,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn6 k=k4 localUncertaintyLimit=10,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn6 k=k5 localUncertaintyLimit=10,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn6 k=k5 localUncertaintyLimit=10,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn6 k=k6 localUncertaintyLimit=10,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn6 k=k6 localUncertaintyLimit=10,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn6 k=k7 localUncertaintyLimit=10,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn6 k=k7 localUncertaintyLimit=10,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn6 k=k8 localUncertaintyLimit=10,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn6 k=k8 localUncertaintyLimit=10,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn7 ts=5,0 globalUncertaintyLimit=25,0
+----
+>> at end:
+txn: "txn7" meta={id=0000000b key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=25.000000000,0
+
+run error
+get t=txn7 k=k1 localUncertaintyLimit=10,0
+----
+get: "k1" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn7 k=k1 localUncertaintyLimit=10,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn7 k=k2 localUncertaintyLimit=10,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn7 k=k2 localUncertaintyLimit=10,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn7 k=k3 localUncertaintyLimit=10,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn7 k=k3 localUncertaintyLimit=10,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn7 k=k4 localUncertaintyLimit=10,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn7 k=k4 localUncertaintyLimit=10,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn7 k=k5 localUncertaintyLimit=10,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn7 k=k5 localUncertaintyLimit=10,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn7 k=k6 localUncertaintyLimit=10,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn7 k=k6 localUncertaintyLimit=10,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn7 k=k7 localUncertaintyLimit=10,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn7 k=k7 localUncertaintyLimit=10,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn7 k=k8 localUncertaintyLimit=10,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn7 k=k8 localUncertaintyLimit=10,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn8 ts=5,0 globalUncertaintyLimit=20,0
+----
+>> at end:
+txn: "txn8" meta={id=0000000c key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=20.000000000,0
+
+run error
+get t=txn8 k=k1 localUncertaintyLimit=15,0
+----
+get: "k1" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn8 k=k1 localUncertaintyLimit=15,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn8 k=k2 localUncertaintyLimit=15,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn8 k=k2 localUncertaintyLimit=15,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn8 k=k3 localUncertaintyLimit=15,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn8 k=k3 localUncertaintyLimit=15,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn8 k=k4 localUncertaintyLimit=15,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn8 k=k4 localUncertaintyLimit=15,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn8 k=k5 localUncertaintyLimit=15,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn8 k=k5 localUncertaintyLimit=15,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn8 k=k6 localUncertaintyLimit=15,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn8 k=k6 localUncertaintyLimit=15,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn8 k=k7 localUncertaintyLimit=15,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn8 k=k7 localUncertaintyLimit=15,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn8 k=k8 localUncertaintyLimit=15,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn8 k=k8 localUncertaintyLimit=15,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn9 ts=5,0 globalUncertaintyLimit=25,0
+----
+>> at end:
+txn: "txn9" meta={id=0000000d key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=25.000000000,0
+
+run error
+get t=txn9 k=k1 localUncertaintyLimit=15,0
+----
+get: "k1" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn9 k=k1 localUncertaintyLimit=15,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn9 k=k2 localUncertaintyLimit=15,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn9 k=k2 localUncertaintyLimit=15,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn9 k=k3 localUncertaintyLimit=15,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn9 k=k3 localUncertaintyLimit=15,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn9 k=k4 localUncertaintyLimit=15,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn9 k=k4 localUncertaintyLimit=15,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn9 k=k5 localUncertaintyLimit=15,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn9 k=k5 localUncertaintyLimit=15,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn9 k=k6 localUncertaintyLimit=15,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn9 k=k6 localUncertaintyLimit=15,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn9 k=k7 localUncertaintyLimit=15,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn9 k=k7 localUncertaintyLimit=15,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn9 k=k8 localUncertaintyLimit=15,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn9 k=k8 localUncertaintyLimit=15,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn10 ts=5,0 globalUncertaintyLimit=25,0
+----
+>> at end:
+txn: "txn10" meta={id=0000000e key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=25.000000000,0
+
+run error
+get t=txn10 k=k1 localUncertaintyLimit=20,0
+----
+get: "k1" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn10 k=k1 localUncertaintyLimit=20,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn10 k=k2 localUncertaintyLimit=20,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn10 k=k2 localUncertaintyLimit=20,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn10 k=k3 localUncertaintyLimit=20,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn10 k=k3 localUncertaintyLimit=20,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn10 k=k4 localUncertaintyLimit=20,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn10 k=k4 localUncertaintyLimit=20,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn10 k=k5 localUncertaintyLimit=20,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn10 k=k5 localUncertaintyLimit=20,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn10 k=k6 localUncertaintyLimit=20,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn10 k=k6 localUncertaintyLimit=20,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn10 k=k7 localUncertaintyLimit=20,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn10 k=k7 localUncertaintyLimit=20,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn10 k=k8 localUncertaintyLimit=20,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn10 k=k8 localUncertaintyLimit=20,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn11 ts=10,0 globalUncertaintyLimit=15,0
+----
+>> at end:
+txn: "txn11" meta={id=0000000f key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=15.000000000,0
+
+run ok
+get t=txn11 k=k1 localUncertaintyLimit=10,0
+----
+get: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+scan t=txn11 k=k1 localUncertaintyLimit=10,0
+----
+scan: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+get t=txn11 k=k2 localUncertaintyLimit=10,0
+----
+get: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run ok
+scan t=txn11 k=k2 localUncertaintyLimit=10,0
+----
+scan: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run ok
+get t=txn11 k=k3 localUncertaintyLimit=10,0
+----
+get: "k3" -> /BYTES/v5 @10.000000000,0
+
+run ok
+scan t=txn11 k=k3 localUncertaintyLimit=10,0
+----
+scan: "k3" -> /BYTES/v5 @10.000000000,0
+
+run ok
+get t=txn11 k=k4 localUncertaintyLimit=10,0
+----
+get: "k4" -> /BYTES/v7 @10.000000000,0?
+
+run ok
+scan t=txn11 k=k4 localUncertaintyLimit=10,0
+----
+scan: "k4" -> /BYTES/v7 @10.000000000,0?
+
+run ok
+get t=txn11 k=k5 localUncertaintyLimit=10,0
+----
+get: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+scan t=txn11 k=k5 localUncertaintyLimit=10,0
+----
+scan: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+get t=txn11 k=k6 localUncertaintyLimit=10,0
+----
+get: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run ok
+scan t=txn11 k=k6 localUncertaintyLimit=10,0
+----
+scan: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run ok
+get t=txn11 k=k7 localUncertaintyLimit=10,0
+----
+get: "k7" -> /BYTES/v13 @10.000000000,0
+
+run ok
+scan t=txn11 k=k7 localUncertaintyLimit=10,0
+----
+scan: "k7" -> /BYTES/v13 @10.000000000,0
+
+run ok
+get t=txn11 k=k8 localUncertaintyLimit=10,0
+----
+get: "k8" -> /BYTES/v15 @10.000000000,0?
+
+run ok
+scan t=txn11 k=k8 localUncertaintyLimit=10,0
+----
+scan: "k8" -> /BYTES/v15 @10.000000000,0?
+
+
+run ok
+txn_begin t=txn12 ts=10,0 globalUncertaintyLimit=20,0
+----
+>> at end:
+txn: "txn12" meta={id=00000010 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=20.000000000,0
+
+run ok
+get t=txn12 k=k1 localUncertaintyLimit=10,0
+----
+get: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+scan t=txn12 k=k1 localUncertaintyLimit=10,0
+----
+scan: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+get t=txn12 k=k2 localUncertaintyLimit=10,0
+----
+get: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run ok
+scan t=txn12 k=k2 localUncertaintyLimit=10,0
+----
+scan: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run error
+get t=txn12 k=k3 localUncertaintyLimit=10,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn12 k=k3 localUncertaintyLimit=10,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn12 k=k4 localUncertaintyLimit=10,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn12 k=k4 localUncertaintyLimit=10,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn12 k=k5 localUncertaintyLimit=10,0
+----
+get: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+scan t=txn12 k=k5 localUncertaintyLimit=10,0
+----
+scan: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+get t=txn12 k=k6 localUncertaintyLimit=10,0
+----
+get: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run ok
+scan t=txn12 k=k6 localUncertaintyLimit=10,0
+----
+scan: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run error
+get t=txn12 k=k7 localUncertaintyLimit=10,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn12 k=k7 localUncertaintyLimit=10,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn12 k=k8 localUncertaintyLimit=10,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn12 k=k8 localUncertaintyLimit=10,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn13 ts=10,0 globalUncertaintyLimit=25,0
+----
+>> at end:
+txn: "txn13" meta={id=00000011 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=25.000000000,0
+
+run ok
+get t=txn13 k=k1 localUncertaintyLimit=10,0
+----
+get: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+scan t=txn13 k=k1 localUncertaintyLimit=10,0
+----
+scan: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+get t=txn13 k=k2 localUncertaintyLimit=10,0
+----
+get: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run ok
+scan t=txn13 k=k2 localUncertaintyLimit=10,0
+----
+scan: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run error
+get t=txn13 k=k3 localUncertaintyLimit=10,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn13 k=k3 localUncertaintyLimit=10,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn13 k=k4 localUncertaintyLimit=10,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn13 k=k4 localUncertaintyLimit=10,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn13 k=k5 localUncertaintyLimit=10,0
+----
+get: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+scan t=txn13 k=k5 localUncertaintyLimit=10,0
+----
+scan: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+get t=txn13 k=k6 localUncertaintyLimit=10,0
+----
+get: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run ok
+scan t=txn13 k=k6 localUncertaintyLimit=10,0
+----
+scan: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run error
+get t=txn13 k=k7 localUncertaintyLimit=10,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn13 k=k7 localUncertaintyLimit=10,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn13 k=k8 localUncertaintyLimit=10,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn13 k=k8 localUncertaintyLimit=10,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn14 ts=10,0 globalUncertaintyLimit=20,0
+----
+>> at end:
+txn: "txn14" meta={id=00000012 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=20.000000000,0
+
+run ok
+get t=txn14 k=k1 localUncertaintyLimit=15,0
+----
+get: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+scan t=txn14 k=k1 localUncertaintyLimit=15,0
+----
+scan: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+get t=txn14 k=k2 localUncertaintyLimit=15,0
+----
+get: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run ok
+scan t=txn14 k=k2 localUncertaintyLimit=15,0
+----
+scan: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run error
+get t=txn14 k=k3 localUncertaintyLimit=15,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn14 k=k3 localUncertaintyLimit=15,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn14 k=k4 localUncertaintyLimit=15,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn14 k=k4 localUncertaintyLimit=15,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn14 k=k5 localUncertaintyLimit=15,0
+----
+get: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+scan t=txn14 k=k5 localUncertaintyLimit=15,0
+----
+scan: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+get t=txn14 k=k6 localUncertaintyLimit=15,0
+----
+get: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run ok
+scan t=txn14 k=k6 localUncertaintyLimit=15,0
+----
+scan: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run error
+get t=txn14 k=k7 localUncertaintyLimit=15,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn14 k=k7 localUncertaintyLimit=15,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn14 k=k8 localUncertaintyLimit=15,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn14 k=k8 localUncertaintyLimit=15,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn15 ts=10,0 globalUncertaintyLimit=25,0
+----
+>> at end:
+txn: "txn15" meta={id=00000013 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=25.000000000,0
+
+run ok
+get t=txn15 k=k1 localUncertaintyLimit=15,0
+----
+get: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+scan t=txn15 k=k1 localUncertaintyLimit=15,0
+----
+scan: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+get t=txn15 k=k2 localUncertaintyLimit=15,0
+----
+get: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run ok
+scan t=txn15 k=k2 localUncertaintyLimit=15,0
+----
+scan: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run error
+get t=txn15 k=k3 localUncertaintyLimit=15,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn15 k=k3 localUncertaintyLimit=15,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn15 k=k4 localUncertaintyLimit=15,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn15 k=k4 localUncertaintyLimit=15,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn15 k=k5 localUncertaintyLimit=15,0
+----
+get: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+scan t=txn15 k=k5 localUncertaintyLimit=15,0
+----
+scan: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+get t=txn15 k=k6 localUncertaintyLimit=15,0
+----
+get: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run ok
+scan t=txn15 k=k6 localUncertaintyLimit=15,0
+----
+scan: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run error
+get t=txn15 k=k7 localUncertaintyLimit=15,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn15 k=k7 localUncertaintyLimit=15,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn15 k=k8 localUncertaintyLimit=15,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn15 k=k8 localUncertaintyLimit=15,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn16 ts=10,0 globalUncertaintyLimit=25,0
+----
+>> at end:
+txn: "txn16" meta={id=00000014 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=25.000000000,0
+
+run error
+get t=txn16 k=k1 localUncertaintyLimit=20,0
+----
+get: "k1" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn16 k=k1 localUncertaintyLimit=20,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn16 k=k2 localUncertaintyLimit=20,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn16 k=k2 localUncertaintyLimit=20,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn16 k=k3 localUncertaintyLimit=20,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn16 k=k3 localUncertaintyLimit=20,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn16 k=k4 localUncertaintyLimit=20,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn16 k=k4 localUncertaintyLimit=20,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn16 k=k5 localUncertaintyLimit=20,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn16 k=k5 localUncertaintyLimit=20,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn16 k=k6 localUncertaintyLimit=20,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn16 k=k6 localUncertaintyLimit=20,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn16 k=k7 localUncertaintyLimit=20,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn16 k=k7 localUncertaintyLimit=20,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn16 k=k8 localUncertaintyLimit=20,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn16 k=k8 localUncertaintyLimit=20,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn17 ts=15,0 globalUncertaintyLimit=20,0
+----
+>> at end:
+txn: "txn17" meta={id=00000015 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 wto=false gul=20.000000000,0
+
+run ok
+get t=txn17 k=k1 localUncertaintyLimit=15,0
+----
+get: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+scan t=txn17 k=k1 localUncertaintyLimit=15,0
+----
+scan: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+get t=txn17 k=k2 localUncertaintyLimit=15,0
+----
+get: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run ok
+scan t=txn17 k=k2 localUncertaintyLimit=15,0
+----
+scan: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run error
+get t=txn17 k=k3 localUncertaintyLimit=15,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn17 k=k3 localUncertaintyLimit=15,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn17 k=k4 localUncertaintyLimit=15,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn17 k=k4 localUncertaintyLimit=15,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn17 k=k5 localUncertaintyLimit=15,0
+----
+get: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+scan t=txn17 k=k5 localUncertaintyLimit=15,0
+----
+scan: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+get t=txn17 k=k6 localUncertaintyLimit=15,0
+----
+get: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run ok
+scan t=txn17 k=k6 localUncertaintyLimit=15,0
+----
+scan: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run error
+get t=txn17 k=k7 localUncertaintyLimit=15,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn17 k=k7 localUncertaintyLimit=15,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn17 k=k8 localUncertaintyLimit=15,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn17 k=k8 localUncertaintyLimit=15,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn18 ts=15,0 globalUncertaintyLimit=25,0
+----
+>> at end:
+txn: "txn18" meta={id=00000016 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 wto=false gul=25.000000000,0
+
+run ok
+get t=txn18 k=k1 localUncertaintyLimit=15,0
+----
+get: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+scan t=txn18 k=k1 localUncertaintyLimit=15,0
+----
+scan: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+get t=txn18 k=k2 localUncertaintyLimit=15,0
+----
+get: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run ok
+scan t=txn18 k=k2 localUncertaintyLimit=15,0
+----
+scan: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run error
+get t=txn18 k=k3 localUncertaintyLimit=15,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn18 k=k3 localUncertaintyLimit=15,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn18 k=k4 localUncertaintyLimit=15,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn18 k=k4 localUncertaintyLimit=15,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run ok
+get t=txn18 k=k5 localUncertaintyLimit=15,0
+----
+get: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+scan t=txn18 k=k5 localUncertaintyLimit=15,0
+----
+scan: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+get t=txn18 k=k6 localUncertaintyLimit=15,0
+----
+get: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run ok
+scan t=txn18 k=k6 localUncertaintyLimit=15,0
+----
+scan: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run error
+get t=txn18 k=k7 localUncertaintyLimit=15,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn18 k=k7 localUncertaintyLimit=15,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn18 k=k8 localUncertaintyLimit=15,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn18 k=k8 localUncertaintyLimit=15,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn19 ts=15,0 globalUncertaintyLimit=25,0
+----
+>> at end:
+txn: "txn19" meta={id=00000017 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 wto=false gul=25.000000000,0
+
+run error
+get t=txn19 k=k1 localUncertaintyLimit=20,0
+----
+get: "k1" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn19 k=k1 localUncertaintyLimit=20,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn19 k=k2 localUncertaintyLimit=20,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn19 k=k2 localUncertaintyLimit=20,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn19 k=k3 localUncertaintyLimit=20,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn19 k=k3 localUncertaintyLimit=20,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn19 k=k4 localUncertaintyLimit=20,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn19 k=k4 localUncertaintyLimit=20,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn19 k=k5 localUncertaintyLimit=20,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn19 k=k5 localUncertaintyLimit=20,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn19 k=k6 localUncertaintyLimit=20,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn19 k=k6 localUncertaintyLimit=20,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn19 k=k7 localUncertaintyLimit=20,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn19 k=k7 localUncertaintyLimit=20,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+get t=txn19 k=k8 localUncertaintyLimit=20,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+run error
+scan t=txn19 k=k8 localUncertaintyLimit=20,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+
+
+run ok
+txn_begin t=txn20 ts=20,0 globalUncertaintyLimit=25,0
+----
+>> at end:
+txn: "txn20" meta={id=00000018 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=25.000000000,0
+
+run ok
+get t=txn20 k=k1 localUncertaintyLimit=20,0
+----
+get: "k1" -> /BYTES/v2 @20.000000000,0
+
+run ok
+scan t=txn20 k=k1 localUncertaintyLimit=20,0
+----
+scan: "k1" -> /BYTES/v2 @20.000000000,0
+
+run ok
+get t=txn20 k=k2 localUncertaintyLimit=20,0
+----
+get: "k2" -> /BYTES/v4 @20.000000000,0
+
+run ok
+scan t=txn20 k=k2 localUncertaintyLimit=20,0
+----
+scan: "k2" -> /BYTES/v4 @20.000000000,0
+
+run ok
+get t=txn20 k=k3 localUncertaintyLimit=20,0
+----
+get: "k3" -> /BYTES/v6 @20.000000000,0?
+
+run ok
+scan t=txn20 k=k3 localUncertaintyLimit=20,0
+----
+scan: "k3" -> /BYTES/v6 @20.000000000,0?
+
+run ok
+get t=txn20 k=k4 localUncertaintyLimit=20,0
+----
+get: "k4" -> /BYTES/v8 @20.000000000,0?
+
+run ok
+scan t=txn20 k=k4 localUncertaintyLimit=20,0
+----
+scan: "k4" -> /BYTES/v8 @20.000000000,0?
+
+run error
+get t=txn20 k=k5 localUncertaintyLimit=20,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k5"
+
+run error
+scan t=txn20 k=k5 localUncertaintyLimit=20,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k5"
+
+run error
+get t=txn20 k=k6 localUncertaintyLimit=20,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k6"
+
+run error
+scan t=txn20 k=k6 localUncertaintyLimit=20,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k6"
+
+run error
+get t=txn20 k=k7 localUncertaintyLimit=20,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k7"
+
+run error
+scan t=txn20 k=k7 localUncertaintyLimit=20,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k7"
+
+run error
+get t=txn20 k=k8 localUncertaintyLimit=20,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k8"
+
+run error
+scan t=txn20 k=k8 localUncertaintyLimit=20,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k8"
+
+# A subset of the previous test cases, but with non-transactional reads:
+#
+# for ts in (5, 15, 25):
+#   for localUncertaintyLimit in (5, 15, 25):
+#     if localUncertaintyLimit < ts: continue
+#     for globalUncertaintyLimit in (5, 15, 25):
+#       if globalUncertaintyLimit < ts: continue
+#       if globalUncertaintyLimit < localUncertaintyLimit: continue
+#       for k in (k1, k2, k3, k4, k5, k6, k7, k8):
+#         for op in (get, scan):
+#           testCase()
+#
+
+run ok
+get k=k1 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+get: "k1" -> <no data>
+
+run ok
+scan k=k1 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+
+run ok
+get k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+get: "k2" -> <no data>
+
+run ok
+scan k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+
+run ok
+get k=k3 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+get: "k3" -> <no data>
+
+run ok
+scan k=k3 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+
+run ok
+get k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+get: "k4" -> <no data>
+
+run ok
+scan k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+
+run ok
+get k=k5 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+get: "k5" -> <no data>
+
+run ok
+scan k=k5 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+
+run ok
+get k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+get: "k6" -> <no data>
+
+run ok
+scan k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+
+run ok
+get k=k7 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+get: "k7" -> <no data>
+
+run ok
+scan k=k7 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+
+run ok
+get k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+get: "k8" -> <no data>
+
+run ok
+scan k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=5,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+
+run ok
+get k=k1 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+get: "k1" -> <no data>
+
+run ok
+scan k=k1 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+
+run error
+get k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run ok
+get k=k3 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+get: "k3" -> <no data>
+
+run ok
+scan k=k3 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+
+run error
+get k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run ok
+get k=k5 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+get: "k5" -> <no data>
+
+run ok
+scan k=k5 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+
+run error
+get k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run ok
+get k=k7 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+get: "k7" -> <no data>
+
+run ok
+scan k=k7 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+
+run error
+get k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run ok
+get k=k1 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+get: "k1" -> <no data>
+
+run ok
+scan k=k1 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+
+run error
+get k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k3 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k3 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run ok
+get k=k5 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+get: "k5" -> <no data>
+
+run ok
+scan k=k5 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+
+run error
+get k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k7 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k7 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k1 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k1" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k1 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k2 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k2 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k3 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k3 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k4 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k4 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k5 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k5 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k6 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k6 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k7 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k7 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k8 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k8 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k1 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k1" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k1 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k2 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k2 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k3 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k3 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k4 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k4 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k5 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k5 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k6 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k6 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k7 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k7 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k8 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k8 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k1 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k1" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k1 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k2 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k2 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k3 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k3 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k4 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k4 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k5 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k5 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k6 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k6 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k7 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k7 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k8 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k8 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run ok
+get k=k1 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+scan k=k1 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+get k=k2 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run ok
+scan k=k2 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run ok
+get k=k3 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k3" -> /BYTES/v5 @10.000000000,0
+
+run ok
+scan k=k3 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k3" -> /BYTES/v5 @10.000000000,0
+
+run ok
+get k=k4 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k4" -> /BYTES/v7 @10.000000000,0?
+
+run ok
+scan k=k4 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k4" -> /BYTES/v7 @10.000000000,0?
+
+run ok
+get k=k5 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+scan k=k5 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+get k=k6 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run ok
+scan k=k6 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run ok
+get k=k7 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k7" -> /BYTES/v13 @10.000000000,0
+
+run ok
+scan k=k7 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k7" -> /BYTES/v13 @10.000000000,0
+
+run ok
+get k=k8 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+get: "k8" -> /BYTES/v15 @10.000000000,0?
+
+run ok
+scan k=k8 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
+----
+scan: "k8" -> /BYTES/v15 @10.000000000,0?
+
+run ok
+get k=k1 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+scan k=k1 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k1" -> /BYTES/v1 @10.000000000,0
+
+run ok
+get k=k2 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run ok
+scan k=k2 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k2" -> /BYTES/v3 @10.000000000,0?
+
+run error
+get k=k3 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k3 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k4 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k4 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run ok
+get k=k5 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+scan k=k5 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k5" -> /BYTES/v9 @10.000000000,0
+
+run ok
+get k=k6 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run ok
+scan k=k6 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k6" -> /BYTES/v11 @10.000000000,0?
+
+run error
+get k=k7 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k7 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k8 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k8 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k1 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k1" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k1 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k1"-"k1\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k2 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k2" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k2 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k2"-"k2\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k3 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k3" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k3 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k3"-"k3\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k4 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k4" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k4 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k4"-"k4\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k5 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k5 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k6 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k6 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k7 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k7 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=k8 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run error
+scan k=k8 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+
+run ok
+get k=k1 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k1" -> /BYTES/v2 @20.000000000,0
+
+run ok
+scan k=k1 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k1" -> /BYTES/v2 @20.000000000,0
+
+run ok
+get k=k2 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k2" -> /BYTES/v4 @20.000000000,0
+
+run ok
+scan k=k2 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k2" -> /BYTES/v4 @20.000000000,0
+
+run ok
+get k=k3 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k3" -> /BYTES/v6 @20.000000000,0?
+
+run ok
+scan k=k3 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k3" -> /BYTES/v6 @20.000000000,0?
+
+run ok
+get k=k4 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k4" -> /BYTES/v8 @20.000000000,0?
+
+run ok
+scan k=k4 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k4" -> /BYTES/v8 @20.000000000,0?
+
+run error
+get k=k5 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k5" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k5"
+
+run error
+scan k=k5 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k5"-"k5\x00" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k5"
+
+run error
+get k=k6 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k6" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k6"
+
+run error
+scan k=k6 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k6"-"k6\x00" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k6"
+
+run error
+get k=k7 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k7" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k7"
+
+run error
+scan k=k7 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k7"-"k7\x00" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k7"
+
+run error
+get k=k8 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+get: "k8" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k8"
+
+run error
+scan k=k8 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
+----
+scan: "k8"-"k8\x00" -> <no data>
+error: (*kvpb.LockConflictError:) conflicting locks on "k8"


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/117302.
Alternative to #117304 for `release-23.2`.

This commit reverts #105523 for the release-23.2 branch while retaining the two commits on master. In doing so, it resolves the replica inconsistency false-positive described in #117302 between v23.1 and v23.2 binaries.

Master will still need a change like #117304 as part of #101938, but this allows us to avoid spreading the migration to remove synthetic timestamps over two releases (which was not the intention). I'm concerned that there may be other unknown consequences of remaining in this mid-migration state, where we don't encode or decode synthetic timestamps, but where the field is still part of the timestamp proto. Pulling the entire migration forward into v24.1 feels safer.

Release note: None
Release justification: Resolves replica inconsistency false-positive.