### PR TITLE
workload/schemachange: avoid concurrent use of RNG

### DIFF
--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -244,11 +244,15 @@ func (s *schemaChange) Ops(
 
 	for i := 0; i < s.connFlags.Concurrency; i++ {
 
+		// Different worker goroutines are not allowed to share RNGs. We use a
+		// different seed for each worker so that each one generates different
+		// operations.
+		workerRng := randutil.NewTestRandWithSeed(seed + int64(i))
 		opGeneratorParams := operationGeneratorParams{
 			seqNum:             seqNum,
 			errorRate:          s.errorRate,
 			enumPct:            s.enumPct,
-			rng:                rng,
+			rng:                workerRng,
 			ops:                ops,
 			declarativeOps:     declarativeOps,
 			maxSourceTables:    s.maxSourceTables,


### PR DESCRIPTION
Previously the workload would use the same RNG across different goroutines, which is not allowed. Now it's updated to make an RNG for each goroutine.

See an example error at: https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Ci_Tests_LocalRoachtest/13399302?buildTab=overview&expandBuildProblemsSection=true&hideProblemsFromDependencies=false&expandBuildTestsSection=true&hideTestsFromDependencies=false&expandBuildChangesSection=true#%2Facceptance%2Fversion-upgrade%2Frun_1%2Fartifacts.zip
Epic: None
Release note: None