### PR TITLE
sql: skip tests under race that may trigger a fixed race in conn executor

### DIFF
--- a/pkg/ccl/testccl/sqlccl/temp_table_clean_test.go
+++ b/pkg/ccl/testccl/sqlccl/temp_table_clean_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -28,6 +29,7 @@ import (
 func TestTenantTempTableCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "May cause a conn executor race fixed by #114783")
 
 	ctx := context.Background()
 	t.Helper()

--- a/pkg/sql/sessionprotectedts/BUILD.bazel
+++ b/pkg/sql/sessionprotectedts/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//pkg/sql/isql",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/sql/sessionprotectedts/session_protected_ts_test.go
+++ b/pkg/sql/sessionprotectedts/session_protected_ts_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionprotectedts"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -62,6 +63,7 @@ func createSessionAndProtect(
 
 func TestSessionProtectedTimestampReconciler(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderRace(t, "May cause a conn executor race fixed by #114783")
 
 	ctx := context.Background()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
This PR skips TestSessionProtectedTimestampReconciler and TestTenantTempTableCleanup under race, since they can trigger a race in conn executor that has been mostly fixed.

Epic: None
Fixes: #117104

Release note: None