### PR TITLE
stress: tag relevant EngFlow nightlies with `deadlock` or `race`

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 export RUNS_PER_TEST=3
 export EXTRA_TEST_ARGS="--define gotags=bazel,gss,deadlock --test_timeout=1800,3600,5395,5395"
-export EXTRA_ISSUE_PARAMS=deadlock=true
+export EXTRA_ISSUE_PARAMS=deadlock
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 

--- a/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
@@ -11,11 +11,18 @@ ENGFLOW_FLAGS="--config engflow --config crosslinux \
 --tls_client_key=/home/agent/engflow/engflow.key"
 INVOCATION_ID=$(uuidgen)
 
+BES_KEYWORDS_ARGS=
+if [ ! -z "${EXTRA_ISSUE_PARAMS:+$EXTRA_ISSUE_PARAMS}" ]
+then
+    BES_KEYWORDS_ARGS=$(echo "$EXTRA_ISSUE_PARAMS" | sed 's/,/\n/g' | sed 's/^/--bes_keywords /g' | tr '\n' ' ')
+fi
+
 status=0
 bazel test //pkg:all_tests $ENGFLOW_FLAGS --remote_download_minimal \
       --runs_per_test ${RUNS_PER_TEST=30} --verbose_failures --build_event_binary_file=artifacts/eventstream \
       --profile=artifacts/profile.json.gz --invocation_id=$INVOCATION_ID \
       ${EXTRA_TEST_ARGS:+$EXTRA_TEST_ARGS} \
+      $BES_KEYWORDS_ARGS \
     || status=$?
 
 # Upload results to GitHub.

--- a/build/teamcity/cockroach/nightlies/stress_engflow_race.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_race.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 export RUNS_PER_TEST=3
 export EXTRA_TEST_ARGS="--config=race --test_timeout=1800,3600,5395,5395"
-export EXTRA_ISSUE_PARAMS=race=true
+export EXTRA_ISSUE_PARAMS=race
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 

--- a/pkg/cmd/bazci/process-bep-file/main.go
+++ b/pkg/cmd/bazci/process-bep-file/main.go
@@ -63,7 +63,7 @@ var (
 	tlsClientCert = flag.String("cert", "", "TLS client certificate for accessing EngFlow, probably a .crt file")
 	tlsClientKey  = flag.String("key", "", "TLS client key for accessing EngFlow")
 
-	extraParams = flag.String("extra", "", "comma-separated list of KEY=VALUE pairs like a=b,c=d")
+	extraParams = flag.String("extra", "", "comma-separated list of keys to mark as 'true' in the produced GitHub issue")
 
 	githubApiToken = os.Getenv("GITHUB_API_TOKEN")
 )
@@ -116,14 +116,8 @@ func failurePoster(res *testResultWithXml, sha string) githubpost.FailurePoster 
 			req.ExtraParams["attempt"] = fmt.Sprintf("%d", res.attempt)
 		}
 		if *extraParams != "" {
-			for _, kv := range strings.Split(*extraParams, ",") {
-				split := strings.SplitN(kv, "=", 2)
-				key := split[0]
-				var value string
-				if len(split) > 1 {
-					value = split[1]
-				}
-				req.ExtraParams[key] = value
+			for _, key := range strings.Split(*extraParams, ",") {
+				req.ExtraParams[key] = "true"
 			}
 		}
 		return fmter, req


### PR DESCRIPTION
Epic: CRDB-8308
Release note: None