### PR TITLE
backupccl: disable tenant in fast drop test

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-fast-drop
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-fast-drop
@@ -1,4 +1,4 @@
-new-cluster name=s1 nodes=1
+new-cluster name=s1 nodes=1 disable-tenant
 ----
 
 subtest restore-cleanup-with-range-tombstones
@@ -16,7 +16,7 @@ exec-sql
 BACKUP INTO 'nodelocal://1/cluster_backup';
 ----
 
-new-cluster name=s2 nodes=1 share-io-dir=s1
+new-cluster name=s2 nodes=1 share-io-dir=s1 disable-tenant
 ----
 
 # Restore's OnFailOrCancel deletes descriptors which requires us to wait for no


### PR DESCRIPTION
We recently enabled this test under tenants. However, it seems that occasionally we time out waiting for GC to complete. Why we time out needs investigation, but skipping this for now will stop this from causing CI failures.

Epic: none

Release note: None