### PR TITLE
gossip: when redirecting / forwarding connection requests, consider l…

### DIFF
--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -31,11 +31,14 @@ import (
 type client struct {
 	log.AmbientContext
 
-	createdAt             time.Time
-	peerID                roachpb.NodeID           // Peer node ID; 0 until first gossip response
-	resolvedPlaceholder   bool                     // Whether we've resolved the nodeSet's placeholder for this client
-	addr                  net.Addr                 // Peer node network address
-	forwardAddr           *util.UnresolvedAddr     // Set if disconnected with an alternate addr
+	createdAt           time.Time
+	peerID              roachpb.NodeID // Peer node ID; 0 until first gossip response
+	resolvedPlaceholder bool           // Whether we've resolved the nodeSet's placeholder for this client
+	addr                net.Addr       // Peer node network address
+	// If redirected to an alternative node, these are the address and
+	// locality-advertise-addr of that node.
+	forwardAddr           *util.UnresolvedAddr
+	forwardLocalityAddrs  []roachpb.LocalityAddress
 	remoteHighWaterStamps map[roachpb.NodeID]int64 // Remote server's high water timestamps
 	closer                chan struct{}            // Client shutdown channel
 	clientMetrics         Metrics
@@ -160,10 +163,11 @@ func (c *client) requestGossip(g *Gossip, stream Gossip_GossipClient) error {
 		return g.mu.is.NodeAddr, g.mu.is.getHighWaterStamps()
 	}()
 	args := &Request{
-		NodeID:          g.NodeID.Get(),
-		Addr:            nodeAddr,
-		HighWaterStamps: highWaterStamps,
-		ClusterID:       g.clusterID.Get(),
+		NodeID:            g.NodeID.Get(),
+		Addr:              nodeAddr,
+		LocalityAddresses: g.localityAddresses,
+		HighWaterStamps:   highWaterStamps,
+		ClusterID:         g.clusterID.Get(),
 	}
 
 	bytesSent := int64(args.Size())
@@ -190,7 +194,8 @@ func (c *client) sendGossip(g *Gossip, stream Gossip_GossipClient, firstReq bool
 		}
 
 		args := Request{
-			NodeID:          g.NodeID.Get(),
+			NodeID: g.NodeID.Get(),
+			// TODO(shralex): seems wasteful to send the address with every request.
 			Addr:            g.mu.is.NodeAddr,
 			Delta:           delta,
 			HighWaterStamps: g.mu.is.getHighWaterStamps(),
@@ -261,12 +266,15 @@ func (c *client) handleResponse(ctx context.Context, g *Gossip, reply *Response)
 	if reply.AlternateAddr != nil {
 		if g.hasIncomingLocked(reply.AlternateNodeID) || g.hasOutgoingLocked(reply.AlternateNodeID) {
 			return errors.Errorf(
-				"received forward from n%d to n%d (%s); already have active connection, skipping",
-				reply.NodeID, reply.AlternateNodeID, reply.AlternateAddr)
+				"received forward from n%d to n%d (address: %s, locality advertised "+
+					"addresses: %s); already have active connection, skipping", reply.NodeID,
+				reply.AlternateNodeID, reply.AlternateAddr, reply.AlternateLocalityAddresses)
 		}
 		c.forwardAddr = reply.AlternateAddr
-		return errors.Errorf("received forward from n%d to n%d (%s)",
-			reply.NodeID, reply.AlternateNodeID, reply.AlternateAddr)
+		c.forwardLocalityAddrs = reply.AlternateLocalityAddresses
+		return errors.Errorf("received forward from n%d to n%d (address: %s, "+
+			"locality advertised addresses: %s)", reply.NodeID, reply.AlternateNodeID,
+			reply.AlternateAddr, reply.AlternateLocalityAddresses)
 	}
 
 	// Check whether we're connected at this point.

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -518,15 +518,23 @@ func TestClientForwardUnresolved(t *testing.T) {
 
 	client := newClient(log.MakeTestingAmbientCtxWithNewTracer(), addr, makeMetrics()) // never started
 
-	newAddr := util.UnresolvedAddr{
-		NetworkField: "tcp",
-		AddressField: "localhost:2345",
+	makeAddr := func(name string) util.UnresolvedAddr {
+		return util.UnresolvedAddr{
+			NetworkField: "tcp",
+			AddressField: name,
+		}
+	}
+	newAddr := makeAddr("localhost:2345")
+	LocalityAddress := []roachpb.LocalityAddress{
+		{Address: makeAddr("2"), LocalityTier: roachpb.Tier{Key: "region", Value: "east"}},
+		{Address: makeAddr("3"), LocalityTier: roachpb.Tier{Key: "zone", Value: "a"}},
 	}
 	reply := &Response{
-		NodeID:          nodeID,
-		Addr:            *addr,
-		AlternateNodeID: nodeID + 1,
-		AlternateAddr:   &newAddr,
+		NodeID:                     nodeID,
+		Addr:                       *addr,
+		AlternateNodeID:            nodeID + 1,
+		AlternateAddr:              &newAddr,
+		AlternateLocalityAddresses: LocalityAddress,
 	}
 	local.mu.Lock()
 	local.outgoing.addPlaceholder() // so that the resolvePlaceholder in handleResponse doesn't fail
@@ -538,5 +546,84 @@ func TestClientForwardUnresolved(t *testing.T) {
 	}
 	if !client.forwardAddr.Equal(&newAddr) {
 		t.Fatalf("unexpected forward address %v, expected %v", client.forwardAddr, &newAddr)
+	}
+	if len(client.forwardLocalityAddrs) != 2 ||
+		!client.forwardLocalityAddrs[0].Equal(LocalityAddress[0]) ||
+		!client.forwardLocalityAddrs[1].Equal(LocalityAddress[1]) {
+		t.Fatalf("unexpected forward locality address %v, expected %v", client.forwardLocalityAddrs,
+			LocalityAddress)
+	}
+}
+
+// Tests that Gossip.getLocalFwdAddress does the right thing based on client locality and
+// the returned forward address and list of locality address for an alternative node.
+func TestAlternativeAddressLocality1(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	makeAddr := func(name string) util.UnresolvedAddr {
+		return util.UnresolvedAddr{
+			NetworkField: "tcp",
+			AddressField: name,
+		}
+	}
+
+	// Make a client that's never started.
+	local, _ := startGossip(uuid.Nil, 10, stopper, t, metric.NewRegistry())
+	client := newClient(log.MakeTestingAmbientCtxWithNewTracer(), local.GetNodeAddr(), makeMetrics())
+
+	// Let's assume that the client tried to connect to a server and got a Response
+	// including the following redirect (forward) info, corresponding to an
+	// alternative node.
+	addr := makeAddr("1")
+	client.forwardAddr = &addr
+	client.forwardLocalityAddrs = []roachpb.LocalityAddress{
+		{Address: makeAddr("2"), LocalityTier: roachpb.Tier{Key: "region", Value: "east"}},
+		{Address: makeAddr("3"), LocalityTier: roachpb.Tier{Key: "zone", Value: "a"}},
+	}
+
+	// Make sure that the client chooses the correct locality address for the
+	// alternative node, based on the client's locality string.
+	for _, tc := range []struct {
+		clientLocality roachpb.Locality
+		expected       util.UnresolvedAddr
+	}{
+		{
+			// When the locality string is empty the base address is chosen.
+			clientLocality: roachpb.Locality{},
+			expected:       makeAddr("1"),
+		},
+		{
+			// No overlap with forwardLocalityAddr, base address is chosen.
+			clientLocality: roachpb.Locality{Tiers: []roachpb.Tier{
+				{Key: "region", Value: "west"},
+				{Key: "zone", Value: "b"},
+			}},
+			expected: makeAddr("1"),
+		},
+		{
+			// region=east is in common, use address 2.
+			clientLocality: roachpb.Locality{Tiers: []roachpb.Tier{
+				{Key: "region", Value: "east"},
+				{Key: "zone", Value: "b"},
+			}},
+			expected: makeAddr("2"),
+		},
+		{
+			// zone=a is in common, use address 3.
+			clientLocality: roachpb.Locality{Tiers: []roachpb.Tier{
+				{Key: "region", Value: "west"},
+				{Key: "zone", Value: "a"},
+			}},
+			expected: makeAddr("3"),
+		},
+	} {
+		testName := "client locality: " + tc.clientLocality.String()
+		g := Gossip{locality: tc.clientLocality}
+		t.Run(testName, func(t *testing.T) {
+			addr := g.getLocalFwdAddress(client)
+			require.Equal(t, tc.expected, *addr)
+		})
 	}
 }

--- a/pkg/gossip/gossip.proto
+++ b/pkg/gossip/gossip.proto
@@ -13,6 +13,7 @@ package cockroach.gossip;
 option go_package = "github.com/cockroachdb/cockroach/pkg/gossip";
 
 import "roachpb/data.proto";
+import "roachpb/metadata.proto";
 import "util/hlc/timestamp.proto";
 import "util/unresolved_addr.proto";
 import "gogoproto/gogo.proto";
@@ -42,6 +43,9 @@ message Request {
   bytes cluster_id = 5 [(gogoproto.nullable) = false,
                         (gogoproto.customname) = "ClusterID",
                         (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"];
+  // locality-advertise-addr of the requesting node. Sent only with initial
+  // connection Request.
+  repeated roachpb.LocalityAddress locality_addresses = 6 [(gogoproto.nullable) = false];
 }
 
 // Response is returned from the Gossip.Gossip RPC.
@@ -63,6 +67,8 @@ message Response {
   // Map of high water timestamps from infos originating at other
   // nodes, as seen by the responder.
   map<int32, int64> high_water_stamps = 6 [(gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID", (gogoproto.nullable) = false];
+  // locality-advertise-addr of the alternative node.
+  repeated roachpb.LocalityAddress alternate_locality_addresses = 7 [(gogoproto.nullable) = false];
 }
 
 message ConnStatus {
@@ -72,6 +78,9 @@ message ConnStatus {
       (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"];
   string address = 2;
   int64 age_nanos = 3;
+  // locality-advertise-addr of the node.
+  repeated roachpb.LocalityAddress locality_address = 4 [(gogoproto.customname) =
+    "LocalityAddresses", (gogoproto.nullable) = false];
 }
 
 message MetricSnap {

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -172,7 +172,8 @@ func TestGossipLocalityResolver(t *testing.T) {
 	var node2LocalityList []roachpb.LocalityAddress
 	node2LocalityList = append(node2LocalityList, nodeLocalityAddress2)
 
-	g := NewTestWithLocality(1, stopper, metric.NewRegistry(), gossipLocalityAdvertiseList)
+	g := NewTestWithLocality(1, stopper, metric.NewRegistry(), gossipLocalityAdvertiseList,
+		node1LocalityList)
 	node1 := &roachpb.NodeDescriptor{
 		NodeID:          1,
 		Address:         node1PublicAddressRPC,

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -30,8 +30,9 @@ import (
 )
 
 type serverInfo struct {
-	createdAt time.Time
-	peerID    roachpb.NodeID
+	createdAt         time.Time
+	peerID            roachpb.NodeID
+	localityAddresses []roachpb.LocalityAddress
 }
 
 // server maintains an array of connected peers to which it gossips
@@ -249,8 +250,9 @@ func (s *server) gossipReceiver(
 
 				s.mu.incoming.addNode(args.NodeID)
 				s.mu.nodeMap[args.Addr] = serverInfo{
-					peerID:    args.NodeID,
-					createdAt: timeutil.Now(),
+					peerID:            args.NodeID,
+					createdAt:         timeutil.Now(),
+					localityAddresses: args.LocalityAddresses,
 				}
 
 				defer func(nodeID roachpb.NodeID, addr util.UnresolvedAddr) {
@@ -259,28 +261,33 @@ func (s *server) gossipReceiver(
 					delete(s.mu.nodeMap, addr)
 				}(args.NodeID, args.Addr)
 			} else {
-				// If we don't have any space left, forward the client along to a peer.
+				// If we don't have any space left, redirect the client to a random peer.
 				var alternateAddr util.UnresolvedAddr
 				var alternateNodeID roachpb.NodeID
+				var alternateLocalityAddresses []roachpb.LocalityAddress
 				// Choose a random peer for forwarding.
 				altIdx := rand.Intn(len(s.mu.nodeMap))
 				for addr, info := range s.mu.nodeMap {
 					if altIdx == 0 {
 						alternateAddr = addr
 						alternateNodeID = info.peerID
+						alternateLocalityAddresses = info.localityAddresses
 						break
 					}
 					altIdx--
 				}
 
 				s.nodeMetrics.ConnectionsRefused.Inc(1)
-				log.Infof(ctx, "refusing gossip from n%d (max %d conns); forwarding to n%d (%s)",
-					args.NodeID, s.mu.incoming.maxSize, alternateNodeID, alternateAddr)
+				log.Infof(ctx, "refusing gossip from n%d (max %d conns); forwarding to "+
+					"n%d (address: %s, locality advertised addresses: %s)", args.NodeID,
+					s.mu.incoming.maxSize, alternateNodeID, alternateAddr,
+					alternateLocalityAddresses)
 
 				*reply = Response{
-					NodeID:          s.NodeID.Get(),
-					AlternateAddr:   &alternateAddr,
-					AlternateNodeID: alternateNodeID,
+					NodeID:                     s.NodeID.Get(),
+					AlternateAddr:              &alternateAddr,
+					AlternateNodeID:            alternateNodeID,
+					AlternateLocalityAddresses: alternateLocalityAddresses,
 				}
 
 				s.mu.Unlock()
@@ -292,6 +299,7 @@ func (s *server) gossipReceiver(
 				// process this message, which instructs it to hang up anyway.
 				// Instead, we send the message and proceed to gossip
 				// normally, depending on the client to end the connection.
+				// We hang up if sending a reply fails.
 				if err != nil {
 					return err
 				}
@@ -412,9 +420,10 @@ func (s *server) status() ServerStatus {
 
 	for addr, info := range s.mu.nodeMap {
 		status.ConnStatus = append(status.ConnStatus, ConnStatus{
-			NodeID:   info.peerID,
-			Address:  addr.String(),
-			AgeNanos: timeutil.Since(info.createdAt).Nanoseconds(),
+			NodeID:            info.peerID,
+			Address:           addr.String(),
+			LocalityAddresses: info.localityAddresses,
+			AgeNanos:          timeutil.Since(info.createdAt).Nanoseconds(),
 		})
 	}
 	return status

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -319,6 +319,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		stopper,
 		nodeRegistry,
 		cfg.Locality,
+		cfg.LocalityAddresses,
 	)
 
 	tenantCapabilitiesTestingKnobs, _ := cfg.TestingKnobs.TenantCapabilitiesTestingKnobs.(*tenantcapabilities.TestingKnobs)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -154,7 +154,8 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 
 	cfg.RPCContext.NodeID.Set(ctx, nodeID)
 	clusterID := cfg.RPCContext.StorageClusterID
-	ltc.Gossip = gossip.New(ambient, clusterID, nc, ltc.stopper, metric.NewRegistry(), roachpb.Locality{})
+	ltc.Gossip = gossip.New(ambient, clusterID, nc, ltc.stopper, metric.NewRegistry(),
+		roachpb.Locality{}, []roachpb.LocalityAddress{})
 	var err error
 	ltc.Eng, err = storage.Open(
 		ctx,


### PR DESCRIPTION
…ocality-advertise-addr

Previously,  when a gossip server rejects a connection request, it suggests an alternate node
to connect to, which is returned in the connection response. However, the address of that node
does not consider the locality of the connecting node. It is possible that the alternate
node has multiple addresses for multiple localities (locality-advertise-addr), and without
knowing them the client might not be able to connect.

With this PR, when a connection is refused, we now return both the base address and the
locality-advertise-addr in the Response to the connecting client. It the chooses the first
matching address from locality-advertise-addr based on the client's own locality, or,
if no match is found, uses the base address (this logic is in metadata.go, Locality.LookupAddress).

Release note (bug fix): when a gossip client attempts to connect to a server, but the connection
is refused and an alternative server is suggested, that server's locality-advertise-addr is provided. 
The client then picks an address from this list based on its own locality, and uses advertise-addr
as a fall-back. This fixes a bug where, upon being redirected, the client always used the alternative
node's advertise-addr.


Fixes: https://github.com/cockroachdb/cockroach/issues/114430