### PR TITLE
cluster-ui: enable statement bundles in tenant clusters

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -15,8 +15,6 @@ import { noop } from "lodash";
 import { StatementDetailsProps } from "./statementDetails";
 import { StatementDetailsResponse } from "../api";
 
-const history = createMemoryHistory({ initialEntries: ["/statements"] });
-
 const lastUpdated = moment("Nov 28 2022 01:30:00 GMT");
 
 const statementDetailsNoData: StatementDetailsResponse = {
@@ -817,55 +815,67 @@ const statementDetailsData: StatementDetailsResponse = {
 
 export const getStatementDetailsPropsFixture = (
   withData = true,
-): StatementDetailsProps => ({
-  history,
-  location: {
-    pathname: "/statement/true/4705782015019656142",
-    search: "",
-    hash: "",
-    state: null,
-  },
-  match: {
-    path: "/statement/:implicitTxn/:statement",
-    url: "/statement/true/4705782015019656142",
-    isExact: true,
-    params: {
-      implicitTxn: "true",
-      statement: "4705782015019656142",
+): StatementDetailsProps => {
+  const history = createMemoryHistory({ initialEntries: ["/statements"] });
+  return {
+    history,
+    location: {
+      pathname: "/statement/true/4705782015019656142",
+      search: "",
+      hash: "",
+      state: null,
     },
-  },
-  isLoading: false,
-  lastUpdated: lastUpdated,
-  timeScale: {
-    windowSize: moment.duration(5, "day"),
-    sampleSize: moment.duration(5, "minutes"),
-    fixedWindowEnd: moment.utc("2021.12.12"),
-    key: "Custom",
-  },
-  statementFingerprintID: "4705782015019656142",
-  statementDetails: withData ? statementDetailsData : statementDetailsNoData,
-  statementsError: null,
-  nodeRegions: {
-    "1": "gcp-us-east1",
-    "2": "gcp-us-east1",
-    "3": "gcp-us-west1",
-    "4": "gcp-europe-west1",
-  },
-  requestTime: moment.utc("2021.12.12"),
-  refreshStatementDetails: noop,
-  refreshStatementDiagnosticsRequests: noop,
-  refreshNodes: noop,
-  refreshNodesLiveness: noop,
-  refreshUserSQLRoles: noop,
-  refreshStatementFingerprintInsights: noop,
-  diagnosticsReports: [],
-  dismissStatementDiagnosticsAlertMessage: noop,
-  onTimeScaleChange: noop,
-  onRequestTimeChange: noop,
-  createStatementDiagnosticsReport: noop,
-  uiConfig: {
-    showStatementDiagnosticsLink: true,
-  },
-  isTenant: false,
-  hasViewActivityRedactedRole: false,
-});
+    match: {
+      path: "/statement/:implicitTxn/:statement",
+      url: "/statement/true/4705782015019656142",
+      isExact: true,
+      params: {
+        implicitTxn: "true",
+        statement: "4705782015019656142",
+      },
+    },
+    isLoading: false,
+    lastUpdated: lastUpdated,
+    timeScale: {
+      windowSize: moment.duration(5, "day"),
+      sampleSize: moment.duration(5, "minutes"),
+      fixedWindowEnd: moment.utc("2021.12.12"),
+      key: "Custom",
+    },
+    statementFingerprintID: "4705782015019656142",
+    statementDetails: withData ? statementDetailsData : statementDetailsNoData,
+    statementsError: null,
+    nodeRegions: {
+      "1": "gcp-us-east1",
+      "2": "gcp-us-east1",
+      "3": "gcp-us-west1",
+      "4": "gcp-europe-west1",
+    },
+    requestTime: moment.utc("2021.12.12"),
+    refreshStatementDetails: noop,
+    refreshStatementDiagnosticsRequests: noop,
+    refreshNodes: noop,
+    refreshNodesLiveness: noop,
+    refreshUserSQLRoles: noop,
+    refreshStatementFingerprintInsights: noop,
+    diagnosticsReports: [
+      {
+        id: "123",
+        statement_fingerprint: "SELECT x, y FROM xy",
+        completed: true,
+        requested_at: moment("2021-12-08T09:51:27Z"),
+        min_execution_latency: moment.duration("1ms"),
+        expires_at: moment("2021-12-08T10:06:00Z"),
+      },
+    ],
+    dismissStatementDiagnosticsAlertMessage: noop,
+    onTimeScaleChange: noop,
+    onRequestTimeChange: noop,
+    createStatementDiagnosticsReport: noop,
+    uiConfig: {
+      showStatementDiagnosticsLink: true,
+    },
+    isTenant: false,
+    hasViewActivityRedactedRole: false,
+  };
+};

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.spec.tsx
@@ -58,53 +58,87 @@ describe("StatementDetails page", () => {
     );
   });
 
-  it("calls onTabChanged prop when selected tab is changed", () => {
-    const onTabChangeSpy = jest.fn();
-    const wrapper = mount(
-      <Router>
-        <StatementDetails
-          {...statementDetailsProps}
-          onTabChanged={onTabChangeSpy}
-        />
-      </Router>,
-    );
-
-    wrapper
-      .find(StatementDetails)
-      .find("div.ant-tabs-tab")
-      .last()
-      .simulate("click");
-
-    expect(onTabChangeSpy).toHaveBeenCalledWith("diagnostics");
-  });
-
-  describe("Diagnostics tab", () => {
+  // Repeat this test for dedicated vs. tenant clusters.
+  describe.each([true, true])("Diagnostics tab, isTenant = %p", isTenant => {
     beforeEach(() => {
-      statementDetailsProps.history.location.search = new URLSearchParams([
-        ["tab", "diagnostics"],
-      ]).toString();
+      statementDetailsProps.isTenant = isTenant;
     });
 
-    it("calls createStatementDiagnosticsReport callback on Activate button click", () => {
+    it("switches to the Diagnostics tab and triggers the activation modal", () => {
+      const onTabChangeSpy = jest.fn();
+      const refreshNodesClickSpy = sandbox.spy();
+      const refreshNodesLivenessClickSpy = sandbox.spy();
+      const refreshStatementDiagnosticsRequestsClickSpy = sandbox.spy();
       const onDiagnosticsActivateClickSpy = sandbox.spy();
 
       const wrapper = mount(
         <Router>
           <StatementDetails
             {...statementDetailsProps}
+            onTabChanged={onTabChangeSpy}
             createStatementDiagnosticsReport={onDiagnosticsActivateClickSpy}
+            refreshNodes={refreshNodesClickSpy}
+            refreshNodesLiveness={refreshNodesLivenessClickSpy}
+            refreshStatementDiagnosticsRequests={
+              refreshStatementDiagnosticsRequestsClickSpy
+            }
           />
         </Router>,
       );
 
+      // Click on the Diagnostics tab.
+      wrapper
+        .find(StatementDetails)
+        .find("div.ant-tabs-tab")
+        .last()
+        .simulate("click");
+      expect(onTabChangeSpy).toHaveBeenCalledWith("diagnostics");
+
+      // Click on the "Activate diagnostics" button in the tab.
       wrapper
         .find(DiagnosticsView)
-        .findWhere(n => n.prop("children") === "Activate Diagnostics")
+        .findWhere(n => n.prop("children") === "Activate diagnostics")
         .first()
         .simulate("click");
-
       onDiagnosticsActivateClickSpy.calledOnceWith(
         statementDetailsProps.statementDetails.statement.metadata.query,
+      );
+
+      // Expect calls to refresh page information on load and update events. Node
+      // and liveness refreshes should not happen for tenants.
+      assert.equal(
+        refreshNodesClickSpy.callCount,
+        isTenant ? 0 : 2,
+        "refresh nodes",
+      );
+      assert.equal(
+        refreshNodesLivenessClickSpy.callCount,
+        isTenant ? 0 : 2,
+        "refresh liveness",
+      );
+      assert.isTrue(
+        refreshStatementDiagnosticsRequestsClickSpy.calledTwice,
+        "refresh diagnostics requests",
+      );
+    });
+
+    it("shows completed diagnostics report", () => {
+      // Navigate to correct tab.
+      statementDetailsProps.history.location.search = new URLSearchParams([
+        ["tab", "diagnostics"],
+      ]).toString();
+
+      const wrapper = mount(
+        <Router>
+          <StatementDetails {...statementDetailsProps} />
+        </Router>,
+      );
+
+      assert.isTrue(
+        wrapper
+          .find(DiagnosticsView)
+          .findWhere(n => n.text() === "Dec 08, 2021 at 9:51 UTC")
+          .exists(),
       );
     });
   });

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -313,9 +313,9 @@ export class StatementDetails extends React.Component<
     if (!this.props.isTenant) {
       this.props.refreshNodes();
       this.props.refreshNodesLiveness();
-      if (!this.props.hasViewActivityRedactedRole) {
-        this.props.refreshStatementDiagnosticsRequests();
-      }
+    }
+    if (!this.props.hasViewActivityRedactedRole) {
+      this.props.refreshStatementDiagnosticsRequests();
     }
   }
 
@@ -332,9 +332,9 @@ export class StatementDetails extends React.Component<
     if (!this.props.isTenant) {
       this.props.refreshNodes();
       this.props.refreshNodesLiveness();
-      if (!this.props.hasViewActivityRedactedRole) {
-        this.props.refreshStatementDiagnosticsRequests();
-      }
+    }
+    if (!this.props.hasViewActivityRedactedRole) {
+      this.props.refreshStatementDiagnosticsRequests();
     }
 
     // If a new, non-empty-string query text is available
@@ -474,7 +474,7 @@ export class StatementDetails extends React.Component<
         <TabPane tab="Explain Plans" key="explain-plan">
           {this.renderExplainPlanTabContent(hasTimeout, hasData)}
         </TabPane>
-        {!this.props.isTenant && !this.props.hasViewActivityRedactedRole && (
+        {!this.props.hasViewActivityRedactedRole && (
           <TabPane
             tab={`Diagnostics${
               this.hasDiagnosticReports()

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -66,13 +66,12 @@ const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
     lastUpdated: lastUpdated,
     timeScale: selectTimeScale(state),
     nodeRegions: nodeRegionsByIDSelector(state),
-    diagnosticsReports:
-      selectIsTenant(state) || selectHasViewActivityRedactedRole(state)
-        ? []
-        : selectDiagnosticsReportsByStatementFingerprint(
-            state,
-            statementFingerprint,
-          ),
+    diagnosticsReports: selectHasViewActivityRedactedRole(state)
+      ? []
+      : selectDiagnosticsReportsByStatementFingerprint(
+          state,
+          statementFingerprint,
+        ),
     uiConfig: selectStatementDetailsUiConfig(state),
     isTenant: selectIsTenant(state),
     hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -355,9 +355,9 @@ export class StatementsPage extends React.Component<
     this.props.refreshUserSQLRoles();
     if (!this.props.isTenant) {
       this.props.refreshNodes();
-      if (!this.props.hasViewActivityRedactedRole) {
-        this.props.refreshStatementDiagnosticsRequests();
-      }
+    }
+    if (!this.props.hasViewActivityRedactedRole) {
+      this.props.refreshStatementDiagnosticsRequests();
     }
   }
 
@@ -397,9 +397,9 @@ export class StatementsPage extends React.Component<
     this.updateQueryParams();
     if (!this.props.isTenant) {
       this.props.refreshNodes();
-      if (!this.props.hasViewActivityRedactedRole) {
-        this.props.refreshStatementDiagnosticsRequests();
-      }
+    }
+    if (!this.props.hasViewActivityRedactedRole) {
+      this.props.refreshStatementDiagnosticsRequests();
     }
   };
 


### PR DESCRIPTION
Statement bundles were never enabled in tenant clusters, despite appearing to work just fine. There were explicit checks that disabled the "Diagnostics" tag in the Statement Fingerprint page. This commit removes those checks and enables statement bundles for tenants..

Release note (ui change): Statement bundles are now enabled for tenant clusters.