### PR TITLE
testcluster,server: copy test settings to shared proc settings

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -549,6 +549,8 @@ type TestSharedProcessTenantArgs struct {
 
 	// Skip check for tenant existence when running the test.
 	SkipTenantCheck bool
+
+	Settings *cluster.Settings
 }
 
 // TestTenantArgs are the arguments to TestServer.StartTenant.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -651,6 +651,7 @@ func (ts *testServer) getSharedProcessDefaultTenantArgs() base.TestSharedProcess
 		TenantID:    serverutils.TestTenantID(),
 		Knobs:       ts.params.Knobs,
 		UseDatabase: ts.params.UseDatabase,
+		Settings:    ts.params.Settings,
 	}
 	// See comment above on separate process tenant regarding the testing knobs.
 	args.Knobs.Server = &TestingKnobs{}

--- a/pkg/settings/values.go
+++ b/pkg/settings/values.go
@@ -265,6 +265,11 @@ func (sv *Values) TestingCopyForVirtualCluster(input *Values) {
 		if s.Class() != ApplicationLevel && s.Class() != SystemVisible {
 			continue
 		}
+		// This test-only method is used when creating new virtual clusters which
+		// initialize their own version and thus do not want an existing version.
+		if s.Typ() == VersionSettingValueType {
+			continue
+		}
 
 		// Copy the value.
 		sv.container.intVals[slot] = input.container.intVals[slot]


### PR DESCRIPTION
Release note: none.
Epic: none.