### PR TITLE
rpc: add raft connection class

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2288,7 +2288,7 @@ func (ds *DistSender) sendToReplicas(
 	}
 
 	opts := SendOptions{
-		class:                  rpc.ConnectionClassForKey(desc.RSpan().Key),
+		class:                  rpc.ConnectionClassForKey(desc.RSpan().Key, rpc.DefaultClass),
 		metrics:                &ds.metrics,
 		dontConsiderConnHealth: ds.dontConsiderConnHealth,
 	}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -4266,7 +4266,7 @@ func TestConnectionClass(t *testing.T) {
 			// Verify that the request carries the class we expect it to for its span.
 			span, err := keys.Range(ba.Requests)
 			require.NoError(t, err)
-			require.Equalf(t, rpc.ConnectionClassForKey(span.Key), class,
+			require.Equalf(t, rpc.ConnectionClassForKey(span.Key, rpc.DefaultClass), class,
 				"unexpected class for span key %v", span.Key)
 		})
 	}

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -177,6 +177,9 @@ type RaftTransport struct {
 	// level. When new raftSendQueues are instantiated, or old ones deleted, we
 	// also maintain kvflowControl.mu.connectedTracker. So writing to this field
 	// is done while holding kvflowControl.mu.
+	//
+	// TODO(pav-kv): only SystemClass and "default" raft class slots are used.
+	// Find an efficient way to have only the necessary number of slots.
 	queues [rpc.NumConnectionClasses]syncutil.IntMap
 
 	dialer                  *nodedialer.Dialer

--- a/pkg/rpc/datadriven_test.go
+++ b/pkg/rpc/datadriven_test.go
@@ -327,6 +327,8 @@ func scanClass(t *testing.T, d *datadriven.TestData) ConnectionClass {
 		return SystemClass
 	case "rf":
 		return RangefeedClass
+	case "raft":
+		return RaftClass
 	default:
 		t.Fatalf("no such class: %s", s)
 	}

--- a/pkg/rpc/testdata/TestReconnection/single.txt
+++ b/pkg/rpc/testdata/TestReconnection/single.txt
@@ -1,7 +1,7 @@
 # This basic test operates against a single server. It establishes a healthy
 # DefaultClass connection, then interrupts the heartbeat, lets the peer reconnect,
-# then adds a SystemClass and RangeFeedClass connection, and interrupts heartbeats
-# again. At each step, metrics are verified via `soon`.
+# then adds SystemClass, RangefeedClass, and RaftClass connection, and
+# interrupts heartbeats again. At each step, metrics are verified via `soon`.
 dial n1 class=def
 ----
 ok
@@ -62,10 +62,18 @@ soon healthy=3
 ----
 ok
 
+connect n1 class=raft
+----
+ok
+
+soon healthy=4
+----
+ok
+
 set-hb-err n1
 ----
 ok
 
-soon n1 unhealthy=3
+soon n1 unhealthy=4
 ----
 ok


### PR DESCRIPTION
Resolves #111262

Release note (performance improvement): this change introduces a separate RPC connection class for most raft traffic. This improves isolation and reduces interference with the foreground SQL traffic, which reduces chances of head-of-line blocking caused by unrelated traffic under high load conditions. The new `COCKROACH_RAFT_USE_DEFAULT_CONNECTION_CLASS` env variable can be set to use the default connection class instead (the previous behaviour).