### PR TITLE
roachtest: skip `PostValidationReplicaDivergence` with loss of quorum

### DIFF
--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -69,29 +69,31 @@ func registerLOQRecovery(r registry.Registry) {
 	} {
 		testSpec := s
 		r.Add(registry.TestSpec{
-			Name:                s.testName(""),
-			Owner:               registry.OwnerReplication,
-			Benchmark:           true,
-			CompatibleClouds:    registry.AllExceptAWS,
-			Suites:              registry.Suites(registry.Nightly),
-			Cluster:             spec,
-			Leases:              registry.MetamorphicLeases,
-			SkipPostValidations: registry.PostValidationInvalidDescriptors | registry.PostValidationNoDeadNodes,
-			NonReleaseBlocker:   true,
+			Name:             s.testName(""),
+			Owner:            registry.OwnerReplication,
+			Benchmark:        true,
+			CompatibleClouds: registry.AllExceptAWS,
+			Suites:           registry.Suites(registry.Nightly),
+			Cluster:          spec,
+			Leases:           registry.MetamorphicLeases,
+			SkipPostValidations: registry.PostValidationReplicaDivergence |
+				registry.PostValidationInvalidDescriptors | registry.PostValidationNoDeadNodes,
+			NonReleaseBlocker: true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runRecoverLossOfQuorum(ctx, t, c, testSpec)
 			},
 		})
 		r.Add(registry.TestSpec{
-			Name:                s.testName("half-online"),
-			Owner:               registry.OwnerReplication,
-			Benchmark:           true,
-			CompatibleClouds:    registry.AllExceptAWS,
-			Suites:              registry.Suites(registry.Nightly),
-			Cluster:             spec,
-			Leases:              registry.MetamorphicLeases,
-			SkipPostValidations: registry.PostValidationInvalidDescriptors | registry.PostValidationNoDeadNodes,
-			NonReleaseBlocker:   true,
+			Name:             s.testName("half-online"),
+			Owner:            registry.OwnerReplication,
+			Benchmark:        true,
+			CompatibleClouds: registry.AllExceptAWS,
+			Suites:           registry.Suites(registry.Nightly),
+			Cluster:          spec,
+			Leases:           registry.MetamorphicLeases,
+			SkipPostValidations: registry.PostValidationReplicaDivergence |
+				registry.PostValidationInvalidDescriptors | registry.PostValidationNoDeadNodes,
+			NonReleaseBlocker: true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runHalfOnlineRecoverLossOfQuorum(ctx, t, c, testSpec)
 			},


### PR DESCRIPTION
The loss of quorum recovery roachtests are not guaranteed to recover quorum. If they don't, post-test assertions may fail due to range unavailability. This patch adds `PostValidationReplicaDivergence` to the set of skipped assertions.

Resolves #117317.
Epic: none
Release note: None