### PR TITLE
release-23.1: sql: skip tests under race that may trigger a fixed race in conn executor

### DIFF
--- a/pkg/ccl/testccl/sqlccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlccl/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//pkg/sql/tests",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",

--- a/pkg/ccl/testccl/sqlccl/temp_table_clean_test.go
+++ b/pkg/ccl/testccl/sqlccl/temp_table_clean_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -26,6 +27,7 @@ import (
 
 func TestTenantTempTableCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderRace(t, "May cause a conn executor race fixed by #114783")
 
 	ctx := context.Background()
 	t.Helper()


### PR DESCRIPTION
Backport 1/1 commits from #117336.

/cc @cockroachdb/release

---

This PR skips TestTenantTempTableCleanup under race, since they can trigger a race in conn executor that has been mostly fixed.

Epic: None
Fixes: #117104

Release note: None

--

Release justification: Test-only change to reduce noisy test failures under race that have been fixed in upcoming releases.