### PR TITLE
kvpb,storage: add ScanStats.BlockReadDuration

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2105,7 +2105,7 @@ func humanizeCount(n uint64) redact.SafeString {
 // SafeFormat implements redact.SafeFormatter.
 func (s *ScanStats) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("scan stats: stepped %s times (%s internal); seeked %s times (%s internal); "+
-		"block-bytes: (total %s, cached %s); "+
+		"block-bytes: (total %s, cached %s, duration %v); "+
 		"points: (count %s, key-bytes %s, value-bytes %s, tombstoned: %s) "+
 		"ranges: (count %s), (contained-points %s, skipped-points %s) "+
 		"evaluated requests: %s gets, %s scans, %s reverse scans",
@@ -2115,6 +2115,7 @@ func (s *ScanStats) SafeFormat(w redact.SafePrinter, _ rune) {
 		humanizeCount(s.NumInternalSeeks),
 		humanizeutil.IBytes(int64(s.BlockBytes)),
 		humanizeutil.IBytes(int64(s.BlockBytesInCache)),
+		s.BlockReadDuration,
 		humanizeCount(s.PointCount),
 		humanizeutil.IBytes(int64(s.KeyBytes)),
 		humanizeutil.IBytes(int64(s.ValueBytes)),

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3598,6 +3598,9 @@ message ScanStats {
   uint64 separated_point_count = 14;
   uint64 separated_point_value_bytes = 15;
   uint64 separated_point_value_bytes_fetched = 16;
+  google.protobuf.Duration block_read_duration = 20 [(gogoproto.nullable) = false,
+    (gogoproto.stdduration) = true];
+
 
   // NumGets, NumScans, and NumReverseScans tracks the number of Gets, Scans,
   // and ReverseScans, respectively, that were actually evaluated as part of the

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -4351,6 +4351,7 @@ func recordIteratorStats(iter iteratorWithStats, scanStats *kvpb.ScanStats) {
 	scanStats.SeparatedPointCount += stats.InternalStats.SeparatedPointValue.Count
 	scanStats.SeparatedPointValueBytes += stats.InternalStats.SeparatedPointValue.ValueBytes
 	scanStats.SeparatedPointValueBytesFetched += stats.InternalStats.SeparatedPointValue.ValueBytesFetched
+	scanStats.BlockReadDuration += stats.InternalStats.BlockReadDuration
 }
 
 // mvccScanInit performs some preliminary checks on the validity of options for


### PR DESCRIPTION
This is not plumbed into SQL's execstats.ScanStats, and there is an existing TODO there to add fields that are in kvpb.ScanStats that also subsumes the change in this PR. The change in this PR is sufficient to make the duration appear in traces.

Fixes #117389

Epic: none

Release note: None