### PR TITLE
release-23.1: roachtest: fix follower-reads backport skew

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -536,7 +536,7 @@ func initFollowerReadsDB(
 			const q2 = `
 			SELECT
 				count(distinct substring(unnest(replica_localities), 'region=([^,]*)'))
-			FROM [SHOW RANGES FROM TABLE test.test]`
+			FROM [SHOW RANGES FROM TABLE mr_db.test]`
 
 			var distinctRegions int
 			require.NoError(t, db.QueryRowContext(ctx, q2).Scan(&distinctRegions))


### PR DESCRIPTION
Fixes #117405.
Fixes #117404.
Fixes #117403.
Fixes #117402.
Fixes #117401.
Fixes #117400.
Fixes #117399.
Fixes #117398.
Fixes #117397.
Fixes #117396.
Fixes #117394.
Fixes #117392.

The backport in #117328 broken this test because it skewed with 5cc456bb.

Release note: None
Release justification: Testing only.