### PR TITLE
roachprod: update roachprod-gc-cronjob docker image

### DIFF
--- a/pkg/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/roachprod/k8s/roachprod-gc.yaml
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
             - name: roachprod-gc-cronjob
-              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:2b6e80e938e
+              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:5bf97e5bd7b
               args:
                 - gc
                 - --gce-project=cockroach-ephemeral,cockroach-roachstress


### PR DESCRIPTION
Epic: none

Release note: None