### PR TITLE
workload/schemachange: fix CREATE FUNCTION flakes

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -98,6 +98,16 @@ func (og *operationGenerator) schemaExists(
 	)`, schemaName)
 }
 
+func (og *operationGenerator) fnExists(
+	ctx context.Context, tx pgx.Tx, fnName string, argTypes string,
+) (bool, error) {
+	return og.scanBool(ctx, tx, `SELECT EXISTS (
+	SELECT proname
+		FROM pg_proc 
+   WHERE proname = $1 AND pg_get_function_identity_arguments(oid) ILIKE $2
+	)`, fnName, argTypes)
+}
+
 func (og *operationGenerator) tableHasDependencies(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
 ) (bool, error) {

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3921,7 +3921,7 @@ func (og *operationGenerator) createFunction(ctx context.Context, tx pgx.Tx) (*o
 			return PickOne(og.params.rng, droppingEnums)
 		},
 		"ParamRefs": func() (string, error) {
-			refs, err := PickAtLeast(og.params.rng, 1, possibleParamReferences)
+			refs, err := PickBetween(og.params.rng, 1, 99, possibleParamReferences)
 			if useParamRefs && err == nil {
 				return strings.Join(refs, ", "), nil
 			}


### PR DESCRIPTION
### workload/schemachange: limit amount of params generated by create fn
Previously, our schemachange workload flaked due to some `CREATE
FUNCTION`s 
randomly generated with >= 100 params; however, this is not
allowed and not a particularly useful edge case to test. This patch
prevents these types of functions from being generated by adding a
restriction to the max length of fn params.

Informs: #116649

Epic: none
Release note: None

---

### workload/schemachange: handle cases of duplicate functions
This patch ensures that our schemachange workload is able
to handle cases where we could generate duplicate functions
(same name, same param types). We will now detect whether
or not a duplicate function has been generated and add the
proper error to our expected errors list.

Fixes: #117421

Epic: none
Release note: None
