### PR TITLE
sql: do not re-run optbuild before collecting index recommendations

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/index_recommendations
+++ b/pkg/sql/logictest/testdata/logic_test/index_recommendations
@@ -1,0 +1,107 @@
+# LogicTest: local
+
+# Regression test for #117307.
+
+statement ok
+SET CLUSTER SETTING sql.metrics.statement_details.index_recommendation_collection.enabled = true
+
+statement ok
+SET enable_insert_fast_path = true
+
+statement ok
+CREATE TABLE b (b INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE c (c INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE d (d INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE abcd (
+  a INT NOT NULL PRIMARY KEY,
+  b INT NULL REFERENCES b (b),
+  c INT NULL REFERENCES c (c),
+  d INT NULL REFERENCES d (d),
+  INDEX (b),
+  INDEX (c),
+  INDEX (d)
+)
+
+statement ok
+INSERT INTO b VALUES (0), (1), (2), (3), (4), (5)
+
+statement ok
+INSERT INTO c VALUES (0), (1), (2), (3), (4), (5)
+
+statement ok
+INSERT INTO d VALUES (0), (1), (2), (3), (4)
+
+# We need 5 previous executions to turn on index recommendation collection.
+
+statement ok
+PREPARE p0 AS INSERT INTO abcd VALUES ($1, $2, $3, $4)
+
+statement ok
+EXECUTE p0(0, 0, 0, 0)
+
+statement ok
+DEALLOCATE p0
+
+statement ok
+PREPARE p1 AS INSERT INTO abcd VALUES ($1, $2, $3, $4)
+
+statement ok
+EXECUTE p1(1, 1, 1, 1)
+
+statement ok
+DEALLOCATE p1
+
+statement ok
+PREPARE p2 AS INSERT INTO abcd VALUES ($1, $2, $3, $4)
+
+statement ok
+EXECUTE p2(2, 2, 2, 2)
+
+statement ok
+DEALLOCATE p2
+
+statement ok
+PREPARE p3 AS INSERT INTO abcd VALUES ($1, $2, $3, $4)
+
+statement ok
+EXECUTE p3(3, 3, 3, 3)
+
+statement ok
+DEALLOCATE p3
+
+statement ok
+PREPARE p4 AS INSERT INTO abcd VALUES ($1, $2, $3, $4)
+
+statement ok
+EXECUTE p4(4, 4, 4, 4)
+
+statement ok
+DEALLOCATE p4
+
+# To hit the bug, we need a combination of:
+# - index recommendation collection
+# - prepared statement
+# - insert fast path with multiple FK checks
+# - one FK check can be skipped due to NULL value
+# - last FK check fails
+
+statement ok
+PREPARE p5 AS INSERT INTO abcd VALUES ($1, $2, $3, $4)
+
+statement error pq: insert on table "abcd" violates foreign key constraint "abcd_d_fkey"\nDETAIL: Key \(d\)=\(5\) is not present in table "d"
+EXECUTE p5(5, 5, NULL, 5)
+
+statement ok
+DEALLOCATE p5
+
+statement ok
+RESET CLUSTER SETTING sql.metrics.statement_details.index_recommendation_collection.enabled
+
+statement ok
+RESET enable_insert_fast_path

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1082,6 +1082,13 @@ func TestLogic_index_join(
 	runLogicTest(t, "index_join")
 }
 
+func TestLogic_index_recommendations(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "index_recommendations")
+}
+
 func TestLogic_inet(
 	t *testing.T,
 ) {

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -818,6 +818,11 @@ func TestSchemaChangeComparator_index_join(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/index_join"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
+func TestSchemaChangeComparator_index_recommendations(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/index_recommendations"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_inet(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/inet"


### PR DESCRIPTION
In #85343 for 22.2 we added automatic collection of index recommendations for DML statements. This collection occurred after execution, and initially re-ran optbuild for the query, before doing the usual index recommendation generation steps of (1) detaching the memo, (2) optimizing with hypothetical indexes, and then (3) restoring the detached memo.

In #99081 for 23.2 we moved collection of index recommendations from after execution to between planning and execution, which simplified some things. But this revealed that some queries refer to the memo (and its metadata) during execution, and re-running optbuild can change the contents of the memo (and its metadata) from how they were after planning, especially if the original memo was cached and re-used.

I think this initial optbuild step was added to ensure we always have a root expression in the memo. This commit changes index recommendation collection to only run optbuild if the memo is empty, and otherwise use the memo that comes out of planning.

Fixes: #117307

Release note (bug fix): Fix a bug introduced in 23.2 that causes internal errors and panics when certain queries run with automatic index recommendation collection enabled.