### PR TITLE
sql: move jobs table auth checks out of hot path

### DIFF
--- a/pkg/bench/rttanalysis/cluster.go
+++ b/pkg/bench/rttanalysis/cluster.go
@@ -27,7 +27,7 @@ type ClusterConstructor func(testing.TB) *Cluster
 // function. The intention is that the caller will use the provided knobs when
 // constructing the cluster and will return a handle to the SQL database.
 func MakeClusterConstructor(
-	f func(testing.TB, base.TestingKnobs) (_ *gosql.DB, cleanup func()),
+	f func(testing.TB, base.TestingKnobs) (_, _ *gosql.DB, cleanup func()),
 ) ClusterConstructor {
 	return func(t testing.TB) *Cluster {
 		c := &Cluster{}
@@ -36,7 +36,7 @@ func MakeClusterConstructor(
 				c.stmtToKVBatchRequests.Store(stmt, trace)
 			}
 		}
-		c.sql, c.cleanup = f(t, base.TestingKnobs{
+		c.adminSQLConn, c.nonAdminSQLConn, c.cleanup = f(t, base.TestingKnobs{
 			SQLExecutor: &sql.ExecutorTestingKnobs{
 				WithStatementTrace: beforePlan,
 			},
@@ -49,11 +49,22 @@ func MakeClusterConstructor(
 type Cluster struct {
 	stmtToKVBatchRequests sync.Map
 	cleanup               func()
-	sql                   *gosql.DB
+
+	// adminSQLConn should be the default connection for tests. It specifies a
+	// user with admin privileges.
+	adminSQLConn *gosql.DB
+
+	// nonAdminSQLConn should be used for tests that require a non-admin user.
+	// It may be unset for tests that don't need it.
+	nonAdminSQLConn *gosql.DB
 }
 
-func (c *Cluster) conn() *gosql.DB {
-	return c.sql
+func (c *Cluster) adminConn() *gosql.DB {
+	return c.adminSQLConn
+}
+
+func (c *Cluster) nonAdminConn() *gosql.DB {
+	return c.nonAdminSQLConn
 }
 
 func (c *Cluster) clearStatementTrace(stmt string) {

--- a/pkg/bench/rttanalysis/jobs_test.go
+++ b/pkg/bench/rttanalysis/jobs_test.go
@@ -111,6 +111,13 @@ func init() {
 			Stmt:    "SHOW JOBS",
 		},
 		{
+			SetupEx:      setupQueries,
+			Reset:        cleanupQuery,
+			Name:         "non admin show jobs",
+			Stmt:         "SHOW JOBS",
+			NonAdminUser: true,
+		},
+		{
 			SetupEx:  setupQueries,
 			Reset:    cleanupQuery,
 			Name:     "jobs page default",
@@ -143,6 +150,13 @@ func init() {
 			Reset:   cleanupQuery,
 			Name:    "crdb_internal.system_jobs",
 			Stmt:    "SELECT * FROM crdb_internal.system_jobs",
+		},
+		{
+			SetupEx:      setupQueries,
+			Reset:        cleanupQuery,
+			Name:         "non admin crdb_internal.system_jobs",
+			Stmt:         "SELECT * FROM crdb_internal.system_jobs",
+			NonAdminUser: true,
 		},
 	})
 }

--- a/pkg/bench/rttanalysis/rtt_analysis_test.go
+++ b/pkg/bench/rttanalysis/rtt_analysis_test.go
@@ -23,7 +23,7 @@ import (
 
 var reg = NewRegistry(1 /* numNodes */, MakeClusterConstructor(func(
 	t testing.TB, knobs base.TestingKnobs,
-) (_ *gosql.DB, cleanup func()) {
+) (_, _ *gosql.DB, cleanup func()) {
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
 		UseDatabase: "bench",
 		Knobs:       knobs,
@@ -32,19 +32,34 @@ var reg = NewRegistry(1 /* numNodes */, MakeClusterConstructor(func(
 	if _, err := db.Exec("SET CLUSTER SETTING server.eventlog.enabled = false"); err != nil {
 		t.Fatal(err)
 	}
+	// Create a user with admin privileges.
 	if _, err := db.Exec("CREATE USER testuser"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec("GRANT admin TO testuser"); err != nil {
 		t.Fatal(err)
 	}
-	url, testuserCleanup := sqlutils.PGUrl(t, s.ApplicationLayer().AdvSQLAddr(), "rttanalysis", url.User("testuser"))
-	conn, err := gosql.Open("postgres", url.String())
+	adminUserURL, adminUserCleanup := sqlutils.PGUrl(
+		t, s.ApplicationLayer().AdvSQLAddr(), "rttanalysis", url.User("testuser"),
+	)
+	adminUserConn, err := gosql.Open("postgres", adminUserURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}
-	return conn, func() {
+	// Create a user with no privileges.
+	if _, err := db.Exec("CREATE USER testuser2"); err != nil {
+		t.Fatal(err)
+	}
+	nonAdminUserURL, nonAdminUserCleanup := sqlutils.PGUrl(
+		t, s.ApplicationLayer().AdvSQLAddr(), "rttanalysis", url.User("testuser2"),
+	)
+	nonAdminUserConn, err := gosql.Open("postgres", nonAdminUserURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return adminUserConn, nonAdminUserConn, func() {
 		s.Stopper().Stop(context.Background())
-		testuserCleanup()
+		adminUserCleanup()
+		nonAdminUserCleanup()
 	}
 }))

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -63,6 +63,7 @@ exp,benchmark
 25,GrantRole/grant_2_roles
 6,Jobs/cancel_job
 3,Jobs/crdb_internal.system_jobs
+83,Jobs/non_admin_crdb_internal.system_jobs
 3,Jobs/jobs_page_default
 3,Jobs/jobs_page_latest_50
 3,Jobs/jobs_page_type_filtered
@@ -71,6 +72,7 @@ exp,benchmark
 6,Jobs/resume_job
 3,Jobs/show_job
 3,Jobs/show_jobs
+83,Jobs/non_admin_show_jobs
 3,ORMQueries/activerecord_type_introspection_query
 0,ORMQueries/asyncpg_types
 0,ORMQueries/column_descriptions_json_agg

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -63,7 +63,7 @@ exp,benchmark
 25,GrantRole/grant_2_roles
 6,Jobs/cancel_job
 3,Jobs/crdb_internal.system_jobs
-83,Jobs/non_admin_crdb_internal.system_jobs
+4,Jobs/non_admin_crdb_internal.system_jobs
 3,Jobs/jobs_page_default
 3,Jobs/jobs_page_latest_50
 3,Jobs/jobs_page_type_filtered
@@ -72,7 +72,7 @@ exp,benchmark
 6,Jobs/resume_job
 3,Jobs/show_job
 3,Jobs/show_jobs
-83,Jobs/non_admin_show_jobs
+4,Jobs/non_admin_show_jobs
 3,ORMQueries/activerecord_type_introspection_query
 0,ORMQueries/asyncpg_types
 0,ORMQueries/column_descriptions_json_agg

--- a/pkg/ccl/benchccl/rttanalysisccl/multi_region_bench_test.go
+++ b/pkg/ccl/benchccl/rttanalysisccl/multi_region_bench_test.go
@@ -25,7 +25,7 @@ const numNodes = 4
 // and counts how many round trips the Stmt specified by the test case performs.
 var reg = rttanalysis.NewRegistry(numNodes, rttanalysis.MakeClusterConstructor(func(
 	tb testing.TB, knobs base.TestingKnobs,
-) (*gosql.DB, func()) {
+) (*gosql.DB, *gosql.DB, func()) {
 	cluster, _, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
 		tb, numNodes, knobs,
 	)
@@ -47,7 +47,7 @@ var reg = rttanalysis.NewRegistry(numNodes, rttanalysis.MakeClusterConstructor(f
 	if err != nil {
 		tb.Fatal(err)
 	}
-	return conn, func() {
+	return conn, nil, func() {
 		cleanup()
 		testuserCleanup()
 	}

--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -109,7 +109,14 @@ func alterChangefeedPlanHook(
 
 		jobPayload := job.Payload()
 
-		if err := jobsauth.Authorize(ctx, p, jobID, &jobPayload, jobsauth.ControlAccess); err != nil {
+		globalPrivileges, err := jobsauth.GetGlobalJobPrivileges(ctx, p)
+		if err != nil {
+			return err
+		}
+		err = jobsauth.Authorize(
+			ctx, p, jobID, &jobPayload, jobsauth.ControlAccess, globalPrivileges,
+		)
+		if err != nil {
 			return err
 		}
 

--- a/pkg/jobs/jobsauth/BUILD.bazel
+++ b/pkg/jobs/jobsauth/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/privilege",
         "//pkg/sql/roleoption",
-        "//pkg/sql/syntheticprivilege",
     ],
 )
 

--- a/pkg/jobs/jobsauth/authorization.go
+++ b/pkg/jobs/jobsauth/authorization.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
-	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 )
 
 // An AccessLevel is used to indicate how strict an authorization check should
@@ -80,6 +79,32 @@ type AuthorizationAccessor interface {
 	User() username.SQLUsername
 }
 
+// GlobalJobPrivileges is used in conjunction with GetGlobalJobPrivileges to
+// avoid unnecessary work in Authorize.
+type GlobalJobPrivileges struct {
+	// hasControl and hasView indicate whether the current user has the global
+	// CONTROLJOB and VIEWJOB privileges respectively.
+	hasControl, hasView bool
+}
+
+// GetGlobalJobPrivileges is a helper used to check whether the current user
+// has the global CONTROLJOB and VIEWJOB privileges respectively. It is separate
+// from Authorize so that it can be called once, and its result repeatedly
+// passed to Authorize.
+func GetGlobalJobPrivileges(
+	ctx context.Context, a AuthorizationAccessor,
+) (GlobalJobPrivileges, error) {
+	hasControlJob, err := a.HasGlobalPrivilegeOrRoleOption(ctx, privilege.CONTROLJOB)
+	if err != nil {
+		return GlobalJobPrivileges{}, err
+	}
+	hasViewJob, err := a.HasGlobalPrivilegeOrRoleOption(ctx, privilege.VIEWJOB)
+	if err != nil {
+		return GlobalJobPrivileges{}, err
+	}
+	return GlobalJobPrivileges{hasControl: hasControlJob, hasView: hasViewJob}, nil
+}
+
 // Authorize returns nil if the user is authorized to access the job.
 // If the user is not authorized, then a pgcode.InsufficientPrivilege
 // error will be returned.
@@ -98,6 +123,7 @@ func Authorize(
 	jobID jobspb.JobID,
 	payload *jobspb.Payload,
 	accessLevel AccessLevel,
+	global GlobalJobPrivileges,
 ) error {
 	callerIsAdmin, err := a.UserHasAdminRole(ctx, a.User())
 	if err != nil {
@@ -106,22 +132,11 @@ func Authorize(
 	if callerIsAdmin {
 		return nil
 	}
-	hasControlJob, err := a.HasGlobalPrivilegeOrRoleOption(ctx, privilege.CONTROLJOB)
-	if err != nil {
-		return err
-	}
 
 	jobOwnerUser := payload.UsernameProto.Decode()
 
 	if accessLevel == ViewAccess {
-		if a.User() == jobOwnerUser || hasControlJob {
-			return nil
-		}
-		hasViewJob, err := a.HasPrivilege(ctx, &syntheticprivilege.GlobalPrivilege{}, privilege.VIEWJOB, a.User())
-		if err != nil {
-			return err
-		}
-		if hasViewJob {
+		if global.hasControl || global.hasView || a.User() == jobOwnerUser {
 			return nil
 		}
 	}
@@ -134,7 +149,7 @@ func Authorize(
 		return pgerror.Newf(pgcode.InsufficientPrivilege,
 			"only admins can control jobs owned by other admins")
 	}
-	if hasControlJob {
+	if global.hasControl {
 		return nil
 	}
 

--- a/pkg/jobs/jobsauth/authorization_test.go
+++ b/pkg/jobs/jobsauth/authorization_test.go
@@ -326,7 +326,11 @@ func TestAuthorization(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			err := jobsauth.Authorize(ctx, testAuth, 0, tc.payload, tc.accessLevel)
+			globalPrivileges, err := jobsauth.GetGlobalJobPrivileges(ctx, testAuth)
+			assert.NoError(t, err)
+			err = jobsauth.Authorize(
+				ctx, testAuth, 0, tc.payload, tc.accessLevel, globalPrivileges,
+			)
 			assert.Equal(t, pgerror.GetPGCode(tc.userErr), pgerror.GetPGCode(err))
 		})
 	}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1103,6 +1103,11 @@ func populateSystemJobsTableRows(
 	}
 	defer cleanup(ctx)
 
+	globalPrivileges, err := jobsauth.GetGlobalJobPrivileges(ctx, p)
+	if err != nil {
+		return matched, err
+	}
+
 	for {
 		hasNext, err := it.Next(ctx)
 		if !hasNext || err != nil {
@@ -1120,7 +1125,10 @@ func populateSystemJobsTableRows(
 			return matched, wrapPayloadUnMarshalError(err, currentRow[jobIdIdx])
 		}
 
-		if err := jobsauth.Authorize(ctx, p, jobspb.JobID(jobID), payload, jobsauth.ViewAccess); err != nil {
+		err = jobsauth.Authorize(
+			ctx, p, jobspb.JobID(jobID), payload, jobsauth.ViewAccess, globalPrivileges,
+		)
+		if err != nil {
 			// Filter out jobs which the user is not allowed to see.
 			if IsInsufficientPrivilegeError(err) {
 				continue


### PR DESCRIPTION
Previously, the `crdb_internal.system_jobs` internal table performed an authorization check for every row, to ensure that it was visible to the current user. This could cause a large slow down when there were many rows for any query that touches `crdb_internal.system_jobs`.

This commit moves part of the authorization check outside the loop. Now, checking that the current user has `CONTROLJOB` and `VIEWJOB` global privileges only happens once per jobs table scan.

Fixes #117416

Release note (performance improvement): Some privilege checks when scanning the `crdb_internal.system_jobs` internal table now happen once before the scan, instead of once for each row. This will improve performance for queries that read from `crdb_internal.system_jobs`.