### PR TITLE
colinfo: optimize and refactor ResultColumns.NodeFormatter

### DIFF
--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -95,7 +95,7 @@ func (r ResultColumns) TypesEqual(other ResultColumns) bool {
 // NodeFormatter returns a tree.NodeFormatter that, when formatted,
 // represents the column at the input column index.
 func (r ResultColumns) NodeFormatter(colIdx int) tree.NodeFormatter {
-	return &varFormatter{ColumnName: tree.Name(r[colIdx].Name)}
+	return (*tree.Name)(&r[colIdx].Name)
 }
 
 // String formats result columns to a string.

--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -92,10 +92,9 @@ func (r ResultColumns) TypesEqual(other ResultColumns) bool {
 	return true
 }
 
-// NodeFormatter returns a tree.NodeFormatter that, when formatted,
-// represents the column at the input column index.
-func (r ResultColumns) NodeFormatter(colIdx int) tree.NodeFormatter {
-	return (*tree.Name)(&r[colIdx].Name)
+// Name returns the name of the column at the given index.
+func (r ResultColumns) Name(idx int) *tree.Name {
+	return (*tree.Name)(&r[idx].Name)
 }
 
 // String formats result columns to a string.

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -45,7 +45,7 @@ func (f *filterNode) IndexedVarResolvedType(idx int) *types.T {
 
 // IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
 func (f *filterNode) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return f.source.columns.NodeFormatter(idx)
+	return f.source.columns.Name(idx)
 }
 
 func (f *filterNode) startExec(runParams) error {

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -127,9 +127,9 @@ func (p *joinPredicate) IndexedVarResolvedType(idx int) *types.T {
 // IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
 func (p *joinPredicate) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 	if idx < p.numLeftCols {
-		return p.leftCols.NodeFormatter(idx)
+		return p.leftCols.Name(idx)
 	}
-	return p.rightCols.NodeFormatter(idx - p.numLeftCols)
+	return p.rightCols.Name(idx - p.numLeftCols)
 }
 
 // eval for joinPredicate runs the on condition across the columns that do

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -74,7 +74,7 @@ func (r *renderNode) IndexedVarResolvedType(idx int) *types.T {
 
 // IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
 func (r *renderNode) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return r.source.columns.NodeFormatter(idx)
+	return r.source.columns.Name(idx)
 }
 
 func (r *renderNode) startExec(runParams) error {

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -138,18 +138,21 @@ func (p *planner) Scan() *scanNode {
 // scanNode implements eval.IndexedVarContainer.
 var _ eval.IndexedVarContainer = &scanNode{}
 
+// IndexedVarEval implements the eval.IndexedVarContainer interface.
 func (n *scanNode) IndexedVarEval(
 	ctx context.Context, idx int, e tree.ExprEvaluator,
 ) (tree.Datum, error) {
 	panic("scanNode can't be run in local mode")
 }
 
+// IndexedVarResolvedType implements the tree.IndexedVarContainer interface.
 func (n *scanNode) IndexedVarResolvedType(idx int) *types.T {
 	return n.resultColumns[idx].Typ
 }
 
+// IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
 func (n *scanNode) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return (*tree.Name)(&n.resultColumns[idx].Name)
+	return n.resultColumns.Name(idx)
 }
 
 func (n *scanNode) startExec(params runParams) error {


### PR DESCRIPTION
#### colinfo: eliminate allocations in ResultColumns.NodeFormatter

This commit eliminates allocations in `ResultColumns.NodeFormatter` by
returning an already-allocated `*string` casted to a `*tree.Name`.

Release notes: None

#### colinfo: refactor and rename ResultColumns.NodeFormatter

This commit replaces `ResultColumns.NodeFormatter` with
`ResultColumns.Name` with the return type of `*tree.Name` instead of
`tree.NodeFormatter`. `scanNode.IndexedVarNodeFormatter` has been
updated to use this new `Name` method.

Epic: None

Release note: None
