### PR TITLE
sql: set session data search path when created

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -980,6 +980,7 @@ func newSessionData(args SessionArgs) *sessiondata.SessionData {
 			sd.CustomOptions[k] = v
 		}
 	}
+	sd.SearchPath = sessiondata.DefaultSearchPathForUser(sd.User())
 	populateMinimalSessionData(sd)
 	return sd
 }
@@ -992,9 +993,6 @@ func populateMinimalSessionData(sd *sessiondata.SessionData) {
 	}
 	if sd.Location == nil {
 		sd.Location = time.UTC
-	}
-	if len(sd.SearchPath.GetPathArray()) == 0 {
-		sd.SearchPath = sessiondata.DefaultSearchPathForUser(sd.User())
 	}
 }
 

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1668,6 +1668,7 @@ func (ief *InternalDB) newInternalExecutorWithTxn(
 	if sd == nil {
 		sd = NewInternalSessionData(ctx, settings, "" /* opName */)
 		sd.UserProto = username.RootUserName().EncodeProto()
+		sd.SearchPath = sessiondata.DefaultSearchPathForUser(sd.User())
 	}
 
 	schemaChangerState := &SchemaChangerState{


### PR DESCRIPTION
Previously, if a search path was empty when populating minimal session data, the session data search path would be overridden with the user's default search path. This can override legitimate empty search paths which were enabled in #117318 for compatibility with postgres. This PR moves setting the search path to callers that create new session data so that it is not mistakenly overwritten.

No release note, since this bug was introduced by #117318 and only exists on master.

Epic: None
Fixes: #117377

Release note: None