### PR TITLE
roachtest: skip multitenant/distsql for now

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -42,6 +42,8 @@ func registerMultiTenantDistSQL(r registry.Registry) {
 				CompatibleClouds: registry.AllExceptAWS,
 				Suites:           registry.Suites(registry.Nightly),
 				Leases:           registry.MetamorphicLeases,
+				// TODO(#117150): unskip when #117150 is fixed.
+				Skip: "#117150",
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runMultiTenantDistSQL(ctx, t, c, numInstances, b == "on", to)
 				},


### PR DESCRIPTION
This test is flaking with some infra issue.

Informs: #117150.
Fixes: #117461.
Fixes: #117462.
Fixes: #117463.
Fixes: #117464.

Release note: None