### PR TITLE
kv: shallow copy BatchRequest on mutate in applyTimestampCache

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -13480,7 +13480,8 @@ func TestReplicaTelemetryCounterForPushesDueToClosedTimestamp(t *testing.T) {
 				ba.Add(putReq(keyA))
 				minReadTS := r.store.Clock().Now()
 				ba.Timestamp = minReadTS.Next()
-				require.False(t, r.applyTimestampCache(ctx, ba, minReadTS))
+				_, bumped := r.applyTimestampCache(ctx, ba, minReadTS)
+				require.False(t, bumped)
 				require.Equal(t, int32(0), telemetry.Read(batchesPushedDueToClosedTimestamp))
 			},
 		},
@@ -13491,7 +13492,8 @@ func TestReplicaTelemetryCounterForPushesDueToClosedTimestamp(t *testing.T) {
 				ba.Add(putReq(keyA))
 				ba.Timestamp = r.store.Clock().Now()
 				minReadTS := ba.Timestamp.Next()
-				require.True(t, r.applyTimestampCache(ctx, ba, minReadTS))
+				_, bumped := r.applyTimestampCache(ctx, ba, minReadTS)
+				require.True(t, bumped)
 				require.Equal(t, int32(1), telemetry.Read(batchesPushedDueToClosedTimestamp))
 			},
 		},
@@ -13503,7 +13505,8 @@ func TestReplicaTelemetryCounterForPushesDueToClosedTimestamp(t *testing.T) {
 				ba.Timestamp = r.store.Clock().Now()
 				minReadTS := ba.Timestamp.Next()
 				r.store.tsCache.Add(ctx, keyA, keyA, minReadTS.Next(), uuid.MakeV4())
-				require.True(t, r.applyTimestampCache(ctx, ba, minReadTS))
+				_, bumped := r.applyTimestampCache(ctx, ba, minReadTS)
+				require.True(t, bumped)
 				require.Equal(t, int32(0), telemetry.Read(batchesPushedDueToClosedTimestamp))
 			},
 		},
@@ -13518,7 +13521,8 @@ func TestReplicaTelemetryCounterForPushesDueToClosedTimestamp(t *testing.T) {
 				minReadTS := ba.Timestamp.Next()
 				t.Log(ba.Timestamp, minReadTS, minReadTS.Next())
 				r.store.tsCache.Add(ctx, keyAA, keyAA, minReadTS.Next(), uuid.MakeV4())
-				require.True(t, r.applyTimestampCache(ctx, ba, minReadTS))
+				_, bumped := r.applyTimestampCache(ctx, ba, minReadTS)
+				require.True(t, bumped)
 				require.Equal(t, int32(0), telemetry.Read(batchesPushedDueToClosedTimestamp))
 			},
 		},

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -144,7 +144,8 @@ func (r *Replica) executeWriteBatch(
 	// Examine the timestamp cache for preceding commands which require this
 	// command to move its timestamp forward. Or, in the case of a transactional
 	// write, the txn timestamp and possible write-too-old bool.
-	if bumped := r.applyTimestampCache(ctx, ba, minTS); bumped {
+	var bumped bool
+	if ba, bumped = r.applyTimestampCache(ctx, ba, minTS); bumped {
 		// If we bump the transaction's timestamp, we must absolutely
 		// tell the client in a response transaction (for otherwise it
 		// doesn't know about the incremented timestamp). Response


### PR DESCRIPTION
Fixes #117489.
Fixes #117491.

This avoids a data race between applyTimestampCache and waitForSignal, which was fallout from the new logging introduced in ba13697a.

Release note: None