### PR TITLE
opt: add rule to merge GroupBy and Window operators

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -74,7 +74,7 @@ exp,benchmark
 3,Jobs/show_job
 3-5,Jobs/show_jobs
 3,ORMQueries/activerecord_type_introspection_query
-0,ORMQueries/asyncpg_types
+4,ORMQueries/asyncpg_types
 6,ORMQueries/column_descriptions_json_agg
 4,ORMQueries/django_column_introspection_1_table
 4,ORMQueries/django_column_introspection_4_tables

--- a/pkg/sql/colexec/colexecwindow/window_aggregator.eg.go
+++ b/pkg/sql/colexec/colexecwindow/window_aggregator.eg.go
@@ -311,11 +311,26 @@ func (a *slidingWindowAggregator) processBatch(batch coldata.Batch, startIdx, en
 	})
 }
 
+// INVARIANT: the rows within a window frame are always processed in the same
+// order, regardless of whether the user specified an ordering. This means that
+// two rows with the exact same frame will produce the same result for a given
+// aggregation.
+//
 // execgen:inline
 const _ = "template_aggregateOverIntervals"
 
+// INVARIANT: the rows within a window frame are always processed in the same
+// order, regardless of whether the user specified an ordering. This means that
+// two rows with the exact same frame will produce the same result for a given
+// aggregation.
+//
 // execgen:inline
 const _ = "inlined_aggregateOverIntervals_false"
 
+// INVARIANT: the rows within a window frame are always processed in the same
+// order, regardless of whether the user specified an ordering. This means that
+// two rows with the exact same frame will produce the same result for a given
+// aggregation.
+//
 // execgen:inline
 const _ = "inlined_aggregateOverIntervals_true"

--- a/pkg/sql/colexec/colexecwindow/window_aggregator_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/window_aggregator_tmpl.go
@@ -247,6 +247,11 @@ func (a *slidingWindowAggregator) processBatch(batch coldata.Batch, startIdx, en
 	})
 }
 
+// INVARIANT: the rows within a window frame are always processed in the same
+// order, regardless of whether the user specified an ordering. This means that
+// two rows with the exact same frame will produce the same result for a given
+// aggregation.
+//
 // execgen:inline
 // execgen:template<removeRows>
 func aggregateOverIntervals(intervals []windowInterval, removeRows bool) {

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4490,6 +4490,7 @@ FROM (
     WHERE c.relname = 'indexes_table'
 ) s2
 GROUP BY indexname, indisunique, indisprimary, amname, exprdef, attoptions
+ORDER BY indexname
 ----
 indexname            array_agg  indisunique  indisprimary  array_agg      amname  exprdef  attoptions
 indexes_include_idx  {a,c,d}    false        false         {ASC,ASC,ASC}  prefix  NULL     NULL

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -560,7 +560,8 @@ vectorized: true
     └── • group (hash)
         │ group by: column_name, ordinal_position, column_default, is_nullable, generation_expression, is_hidden, crdb_sql_type
         │
-        └── • window
+        └── • sort
+            │ order: +index_name
             │
             └── • hash join (left outer)
                 │ equality: (column_name) = (column_name)
@@ -734,39 +735,41 @@ vectorized: true
             │ estimated row count: 3
             │ order: +"role"
             │
-            └── • hash join (left outer)
+            └── • merge join (right outer)
                 │ estimated row count: 3
-                │ equality: (username) = (member)
-                │ left cols are key
+                │ equality: (member) = (username)
+                │ right cols are key
                 │
-                ├── • group (hash)
-                │   │ estimated row count: 3
-                │   │ group by: username
-                │   │
-                │   └── • window
-                │       │ estimated row count: 3
-                │       │
-                │       └── • render
-                │           │
-                │           └── • hash join (left outer)
-                │               │ estimated row count: 3
-                │               │ equality: (username) = (username)
-                │               │ left cols are key
-                │               │
-                │               ├── • scan
-                │               │     estimated row count: 3 (100% of the table; stats collected <hidden> ago)
-                │               │     table: users@users_user_id_idx
-                │               │     spans: FULL SCAN
-                │               │
-                │               └── • scan
-                │                     estimated row count: 1 (100% of the table; stats collected <hidden> ago)
-                │                     table: role_options@primary
-                │                     spans: FULL SCAN
+                ├── • scan
+                │     estimated row count: 1 (100% of the table; stats collected <hidden> ago)
+                │     table: role_members@role_members_member_idx
+                │     spans: FULL SCAN
                 │
-                └── • scan
-                      estimated row count: 1 (100% of the table; stats collected <hidden> ago)
-                      table: role_members@role_members_role_idx
-                      spans: FULL SCAN
+                └── • group (streaming)
+                    │ estimated row count: 3
+                    │ group by: username
+                    │ ordered: +username
+                    │
+                    └── • sort
+                        │ estimated row count: 3
+                        │ order: +username,+option
+                        │
+                        └── • render
+                            │
+                            └── • hash join (left outer)
+                                │ estimated row count: 3
+                                │ equality: (username) = (username)
+                                │ left cols are key
+                                │
+                                ├── • scan
+                                │     estimated row count: 3 (100% of the table; stats collected <hidden> ago)
+                                │     table: users@users_user_id_idx
+                                │     spans: FULL SCAN
+                                │
+                                └── • scan
+                                      estimated row count: 1 (100% of the table; stats collected <hidden> ago)
+                                      table: role_options@primary
+                                      spans: FULL SCAN
 
 # EXPLAIN selecting from a sequence.
 statement ok

--- a/pkg/sql/opt/memo/testdata/logprops/window
+++ b/pkg/sql/opt/memo/testdata/logprops/window
@@ -30,7 +30,7 @@ project
       ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) rank:10(int)
       ├── cardinality: [0 - 10]
       ├── key: (1)
-      ├── fd: (1)-->(2-7)
+      ├── fd: (1)-->(2-7,10)
       ├── prune: (1-7,10)
       ├── limit
       │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
@@ -70,7 +70,7 @@ project
       ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) rank:10(int)
       ├── cardinality: [0 - 10]
       ├── key: (1)
-      ├── fd: (1)-->(2-7)
+      ├── fd: (1)-->(2-7,10)
       ├── prune: (1,3,5-7,10)
       ├── limit
       │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
@@ -138,7 +138,7 @@ project
                      │    ├── outer: (1)
                      │    ├── cardinality: [1 - 1]
                      │    ├── key: ()
-                     │    ├── fd: ()-->(10)
+                     │    ├── fd: ()-->(10,11)
                      │    ├── prune: (10,11)
                      │    ├── project
                      │    │    ├── columns: x:10(int)
@@ -171,7 +171,7 @@ project
       ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid) lag:10(string) lag:11(int) lag_1_arg1:12(string!null) lag_1_arg2:13(int!null) lag_1_arg3:14(string) lag_2_arg3:15(int)
       ├── immutable
       ├── key: (1)
-      ├── fd: ()-->(12-15), (1)-->(2-9)
+      ├── fd: ()-->(12-15), (1)-->(2-11)
       ├── prune: (1-11)
       ├── project
       │    ├── columns: lag_1_arg1:12(string!null) lag_1_arg2:13(int!null) lag_1_arg3:14(string) lag_2_arg3:15(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid)
@@ -202,3 +202,306 @@ project
                 ├── variable: lag_1_arg2:13 [type=int]
                 ├── variable: lag_1_arg2:13 [type=int]
                 └── variable: lag_2_arg3:15 [type=int]
+
+# Given an unbounded window frame, aggregates, first_value, and last_value
+# are functionally determined by the partition column(s).
+build
+SELECT
+  sum(v) OVER w,
+  array_agg(s) OVER w,
+  first_value(d) OVER w,
+  last_value(f) OVER w
+FROM kv
+WINDOW w AS (
+  PARTITION BY w ORDER BY v, s, d, f
+  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+)
+----
+project
+ ├── columns: sum:10(decimal) array_agg:11(string[]) first_value:12(decimal) last_value:13(float)
+ ├── prune: (10-13)
+ └── window partition=(3) ordering=+2,+6,+5,+4
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid) sum:10(decimal) array_agg:11(string[]) first_value:12(decimal) last_value:13(float)
+      ├── key: (1)
+      ├── fd: (1)-->(2-9), (3)-->(10-13)
+      ├── prune: (1,7-13)
+      ├── scan kv
+      │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-9)
+      │    ├── prune: (1-9)
+      │    └── interesting orderings: (+1)
+      └── windows
+           ├── sum [as=sum:10, frame="rows from unbounded to unbounded", type=decimal, outer=(2)]
+           │    └── variable: v:2 [type=int]
+           ├── array-agg [as=array_agg:11, frame="rows from unbounded to unbounded", type=string[], outer=(6)]
+           │    └── variable: s:6 [type=string]
+           ├── first-value [as=first_value:12, frame="rows from unbounded to unbounded", type=decimal, outer=(5)]
+           │    └── variable: d:5 [type=decimal]
+           └── last-value [as=last_value:13, frame="rows from unbounded to unbounded", type=float, outer=(4)]
+                └── variable: f:4 [type=float]
+
+# Case with no partition columns.
+build
+SELECT
+  sum(v) OVER w,
+  array_agg(s) OVER w,
+  first_value(d) OVER w,
+  last_value(f) OVER w
+FROM kv
+WINDOW w AS (
+  ORDER BY v, s, d, f
+  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+)
+----
+project
+ ├── columns: sum:10(decimal) array_agg:11(string[]) first_value:12(decimal) last_value:13(float)
+ ├── fd: ()-->(10-13)
+ ├── prune: (10-13)
+ └── window partition=() ordering=+2,+6,+5,+4
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid) sum:10(decimal) array_agg:11(string[]) first_value:12(decimal) last_value:13(float)
+      ├── key: (1)
+      ├── fd: ()-->(10-13), (1)-->(2-9)
+      ├── prune: (1,3,7-13)
+      ├── scan kv
+      │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-9)
+      │    ├── prune: (1-9)
+      │    └── interesting orderings: (+1)
+      └── windows
+           ├── sum [as=sum:10, frame="rows from unbounded to unbounded", type=decimal, outer=(2)]
+           │    └── variable: v:2 [type=int]
+           ├── array-agg [as=array_agg:11, frame="rows from unbounded to unbounded", type=string[], outer=(6)]
+           │    └── variable: s:6 [type=string]
+           ├── first-value [as=first_value:12, frame="rows from unbounded to unbounded", type=decimal, outer=(5)]
+           │    └── variable: d:5 [type=decimal]
+           └── last-value [as=last_value:13, frame="rows from unbounded to unbounded", type=float, outer=(4)]
+                └── variable: f:4 [type=float]
+
+# Case with multiple partition columns.
+build
+SELECT
+  sum(v) OVER w,
+  array_agg(s) OVER w,
+  first_value(d) OVER w,
+  last_value(f) OVER w
+FROM kv
+WINDOW w AS (
+  PARTITION BY b, w ORDER BY v, s, d, f
+  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+)
+----
+project
+ ├── columns: sum:10(decimal) array_agg:11(string[]) first_value:12(decimal) last_value:13(float)
+ ├── prune: (10-13)
+ └── window partition=(3,7) ordering=+2,+6,+5,+4
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid) sum:10(decimal) array_agg:11(string[]) first_value:12(decimal) last_value:13(float)
+      ├── key: (1)
+      ├── fd: (1)-->(2-9), (3,7)-->(10-13)
+      ├── prune: (1,8-13)
+      ├── scan kv
+      │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-9)
+      │    ├── prune: (1-9)
+      │    └── interesting orderings: (+1)
+      └── windows
+           ├── sum [as=sum:10, frame="rows from unbounded to unbounded", type=decimal, outer=(2)]
+           │    └── variable: v:2 [type=int]
+           ├── array-agg [as=array_agg:11, frame="rows from unbounded to unbounded", type=string[], outer=(6)]
+           │    └── variable: s:6 [type=string]
+           ├── first-value [as=first_value:12, frame="rows from unbounded to unbounded", type=decimal, outer=(5)]
+           │    └── variable: d:5 [type=decimal]
+           └── last-value [as=last_value:13, frame="rows from unbounded to unbounded", type=float, outer=(4)]
+                └── variable: f:4 [type=float]
+
+# The frame must be unbounded in order to infer an FD from partition columns to
+# window function output.
+build
+SELECT
+  sum(v) OVER w,
+  array_agg(s) OVER w,
+  first_value(d) OVER w,
+  last_value(f) OVER w
+FROM kv
+WINDOW w AS (
+  PARTITION BY w ORDER BY v, s, d, f
+)
+----
+project
+ ├── columns: sum:10(decimal) array_agg:11(string[]) first_value:12(decimal) last_value:13(float)
+ ├── prune: (10-13)
+ └── window partition=(3) ordering=+2,+6,+5,+4
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid) sum:10(decimal) array_agg:11(string[]) first_value:12(decimal) last_value:13(float)
+      ├── key: (1)
+      ├── fd: (1)-->(2-13)
+      ├── prune: (1,7-13)
+      ├── scan kv
+      │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-9)
+      │    ├── prune: (1-9)
+      │    └── interesting orderings: (+1)
+      └── windows
+           ├── sum [as=sum:10, type=decimal, outer=(2)]
+           │    └── variable: v:2 [type=int]
+           ├── array-agg [as=array_agg:11, type=string[], outer=(6)]
+           │    └── variable: s:6 [type=string]
+           ├── first-value [as=first_value:12, type=decimal, outer=(5)]
+           │    └── variable: d:5 [type=decimal]
+           └── last-value [as=last_value:13, type=float, outer=(4)]
+                └── variable: f:4 [type=float]
+
+# The default window frame is unbounded in the absence of ORDER BY.
+# Currently, we cannot see that this is the case, because the window
+# frame is not normalized to unbounded preceding and following.
+# This is tracked in #117716.
+build
+SELECT
+  sum(v) OVER w,
+  array_agg(s) OVER w,
+  first_value(d) OVER w,
+  last_value(f) OVER w
+FROM kv
+WINDOW w AS (
+  PARTITION BY w
+)
+----
+project
+ ├── columns: sum:10(decimal) array_agg:11(string[]) first_value:12(decimal) last_value:13(float)
+ ├── prune: (10-13)
+ └── window partition=(3)
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid) sum:10(decimal) array_agg:11(string[]) first_value:12(decimal) last_value:13(float)
+      ├── key: (1)
+      ├── fd: (1)-->(2-13)
+      ├── prune: (1,7-13)
+      ├── scan kv
+      │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-9)
+      │    ├── prune: (1-9)
+      │    └── interesting orderings: (+1)
+      └── windows
+           ├── sum [as=sum:10, type=decimal, outer=(2)]
+           │    └── variable: v:2 [type=int]
+           ├── array-agg [as=array_agg:11, type=string[], outer=(6)]
+           │    └── variable: s:6 [type=string]
+           ├── first-value [as=first_value:12, type=decimal, outer=(5)]
+           │    └── variable: d:5 [type=decimal]
+           └── last-value [as=last_value:13, type=float, outer=(4)]
+                └── variable: f:4 [type=float]
+
+# The results of other window functions can depend on things other than the
+# window frame (e.g. position for rank, or the value of a column for nth_value).
+build
+SELECT
+  rank() OVER w,
+  row_number() OVER w,
+  nth_value(v, 2) OVER w,
+  lead(v, 2) OVER w
+FROM kv
+WINDOW w AS (
+  PARTITION BY w ORDER BY v, s, d, f
+  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+)
+----
+project
+ ├── columns: rank:10(int) row_number:11(int) nth_value:12(int) lead:13(int)
+ ├── immutable
+ ├── prune: (10-13)
+ └── window partition=(3) ordering=+2,+6,+5,+4
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid) rank:10(int) row_number:11(int) nth_value:12(int) lead:13(int) nth_value_3_arg2:14(int!null) lead_4_arg3:15(int)
+      ├── immutable
+      ├── key: (1)
+      ├── fd: ()-->(14,15), (1)-->(2-13)
+      ├── prune: (1,7-13)
+      ├── project
+      │    ├── columns: nth_value_3_arg2:14(int!null) lead_4_arg3:15(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid)
+      │    ├── immutable
+      │    ├── key: (1)
+      │    ├── fd: ()-->(14,15), (1)-->(2-9)
+      │    ├── prune: (1-9,14,15)
+      │    ├── interesting orderings: (+1 opt(14,15))
+      │    ├── scan kv
+      │    │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-9)
+      │    │    ├── prune: (1-9)
+      │    │    └── interesting orderings: (+1)
+      │    └── projections
+      │         ├── const: 2 [as=nth_value_3_arg2:14, type=int]
+      │         └── cast: INT8 [as=lead_4_arg3:15, type=int, immutable]
+      │              └── null [type=unknown]
+      └── windows
+           ├── rank [as=rank:10, frame="rows from unbounded to unbounded", type=int]
+           ├── row-number [as=row_number:11, frame="rows from unbounded to unbounded", type=int]
+           ├── nth-value [as=nth_value:12, frame="rows from unbounded to unbounded", type=int, outer=(2,14)]
+           │    ├── variable: v:2 [type=int]
+           │    └── variable: nth_value_3_arg2:14 [type=int]
+           └── lead [as=lead:13, frame="rows from unbounded to unbounded", type=int, outer=(2,14,15)]
+                ├── variable: v:2 [type=int]
+                ├── variable: nth_value_3_arg2:14 [type=int]
+                └── variable: lead_4_arg3:15 [type=int]
+
+# If the partition columns are a strict key over the input, then window frames
+# and functions don't matter - the partition columns are also a strict key over
+# the output.
+build
+SELECT
+  sum(v) OVER w,
+  array_agg(s) OVER w,
+  first_value(d) OVER w,
+  last_value(f) OVER w,
+  rank() OVER w,
+  row_number() OVER w,
+  nth_value(v, 2) OVER w,
+  lead(v, 2) OVER w
+FROM kv
+WINDOW w AS (PARTITION BY k ORDER BY s, d)
+----
+project
+ ├── columns: sum:10(decimal) array_agg:11(string[]) first_value:12(decimal) last_value:13(float) rank:14(int) row_number:15(int) nth_value:16(int) lead:17(int)
+ ├── immutable
+ ├── prune: (10-17)
+ └── window partition=(1) ordering=+6,+5
+      ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid) sum:10(decimal) array_agg:11(string[]) first_value:12(decimal) last_value:13(float) rank:14(int) row_number:15(int) nth_value:16(int) lead:17(int) nth_value_7_arg2:18(int!null) lead_8_arg3:19(int)
+      ├── immutable
+      ├── key: (1)
+      ├── fd: ()-->(18,19), (1)-->(2-17)
+      ├── prune: (3,7-17)
+      ├── project
+      │    ├── columns: nth_value_7_arg2:18(int!null) lead_8_arg3:19(int) k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid)
+      │    ├── immutable
+      │    ├── key: (1)
+      │    ├── fd: ()-->(18,19), (1)-->(2-9)
+      │    ├── prune: (1-9,18,19)
+      │    ├── interesting orderings: (+1 opt(18,19))
+      │    ├── scan kv
+      │    │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool) crdb_internal_mvcc_timestamp:8(decimal) tableoid:9(oid)
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-9)
+      │    │    ├── prune: (1-9)
+      │    │    └── interesting orderings: (+1)
+      │    └── projections
+      │         ├── const: 2 [as=nth_value_7_arg2:18, type=int]
+      │         └── cast: INT8 [as=lead_8_arg3:19, type=int, immutable]
+      │              └── null [type=unknown]
+      └── windows
+           ├── sum [as=sum:10, type=decimal, outer=(2)]
+           │    └── variable: v:2 [type=int]
+           ├── array-agg [as=array_agg:11, type=string[], outer=(6)]
+           │    └── variable: s:6 [type=string]
+           ├── first-value [as=first_value:12, type=decimal, outer=(5)]
+           │    └── variable: d:5 [type=decimal]
+           ├── last-value [as=last_value:13, type=float, outer=(4)]
+           │    └── variable: f:4 [type=float]
+           ├── rank [as=rank:14, type=int]
+           ├── row-number [as=row_number:15, type=int]
+           ├── nth-value [as=nth_value:16, type=int, outer=(2,18)]
+           │    ├── variable: v:2 [type=int]
+           │    └── variable: nth_value_7_arg2:18 [type=int]
+           └── lead [as=lead:17, type=int, outer=(2,18,19)]
+                ├── variable: v:2 [type=int]
+                ├── variable: nth_value_7_arg2:18 [type=int]
+                └── variable: lead_8_arg3:19 [type=int]

--- a/pkg/sql/opt/memo/testdata/stats/window
+++ b/pkg/sql/opt/memo/testdata/stats/window
@@ -27,7 +27,7 @@ project
       ├── cardinality: [0 - 10]
       ├── stats: [rows=10, distinct(10)=10, null(10)=0]
       ├── key: (1)
-      ├── fd: (1)-->(2-7)
+      ├── fd: (1)-->(2-7,10)
       ├── limit
       │    ├── columns: k:1(int!null) v:2(int) w:3(int) f:4(float) d:5(decimal) s:6(string) b:7(bool)
       │    ├── cardinality: [0 - 10]

--- a/pkg/sql/opt/norm/groupby_funcs.go
+++ b/pkg/sql/opt/norm/groupby_funcs.go
@@ -382,6 +382,82 @@ func (c *CustomFuncs) MergeAggs(
 	return newAggs
 }
 
+// CanMergeAggsAndWindow returns true if all the given aggregations satisfy one
+// of the following conditions:
+//  1. Reference only columns from the input of the Window operator.
+//  2. Is a ConstAgg (or similar) that references an input aggregate window
+//     function.
+//
+// CanMergeAggsAndWindow expects that all the window functions have been
+// verified to be aggregate functions.
+func (c *CustomFuncs) CanMergeAggsAndWindow(
+	aggs memo.AggregationsExpr, windows memo.WindowsExpr, inputCols opt.ColSet,
+) bool {
+	// Collect the columns produced by the window functions.
+	var windowCols opt.ColSet
+	for i := range windows {
+		windowCols.Add(windows[i].Col)
+	}
+	for i := range aggs {
+		if memo.ExtractAggInputColumns(aggs[i].Agg).SubsetOf(inputCols) {
+			// Condition 1: the aggregate function only references columns from the
+			// input of the Window operator. It will not be affected by a merge.
+			// In this case, it doesn't matter what the aggregate is, since it won't
+			// be modified in any way.
+			//
+			// Note that unlike for CanMergeAggs, it is not necessary to check for
+			// duplicate sensitivity. This is because window operators do not group or
+			// duplicate rows.
+			continue
+		}
+		// Condition 2: the aggregate function must be a AnyNotNullAgg, ConstAgg,
+		// ConstNotNullAgg, or FirstAggOp that references a window function.
+		switch aggs[i].Agg.Op() {
+		case opt.AnyNotNullAggOp, opt.ConstAggOp, opt.ConstNotNullAggOp, opt.FirstAggOp:
+			// Ensure that the input to the aggregation is a direct reference to a
+			// window function, with no intervening logic.
+			ref, ok := aggs[i].Agg.Child(0).(*memo.VariableExpr)
+			if !ok {
+				return false
+			}
+			if !windowCols.Contains(ref.Col) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// MergeAggsAndWindow returns an AggregationsExpr that is equivalent to the
+// combination of the given (outer) aggregations and (inner) window functions.
+// ConstAgg-like outer aggregations that reference a window function are
+// replaced with that window function.
+//
+// MergeAggs will panic if CanMergeAggs is false. It also expects the given
+// window functions to all be aggregate functions.
+func (c *CustomFuncs) MergeAggsAndWindow(
+	aggs memo.AggregationsExpr, windows memo.WindowsExpr, inputCols opt.ColSet,
+) memo.AggregationsExpr {
+	// Create a mapping from column IDs to the window functions that produce them.
+	colsToWindowFuncs := map[opt.ColumnID]opt.ScalarExpr{}
+	for i := range windows {
+		colsToWindowFuncs[windows[i].Col] = windows[i].Function
+	}
+	newAggs := make(memo.AggregationsExpr, len(aggs))
+	for i := range aggs {
+		aggCols := memo.ExtractAggInputColumns(aggs[i].Agg)
+		if aggCols.SubsetOf(inputCols) {
+			newAggs[i] = aggs[i]
+			continue
+		}
+		windowFunc := colsToWindowFuncs[aggCols.SingleColumn()]
+		newAggs[i] = c.f.ConstructAggregationsItem(windowFunc, aggs[i].Col)
+	}
+	return newAggs
+}
+
 // CanEliminateJoinUnderGroupByLeft returns true if the given join can be
 // eliminated and replaced by its left input. It should be called only when the
 // join is under a grouping operator that is only using columns from the join's

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -587,3 +587,83 @@
     (MergeAggs $innerAggs $outerAggs $innerGroupingCols)
     (MakeGrouping $outerGroupingCols (EmptyOrdering))
 )
+
+# FoldGroupByAndWindow merges a GroupBy operator with an input Window operator.
+# This is possible when the following conditions are satisfied:
+#
+#   1. The GroupBy is unordered. This may not technically be necessary, but
+#      avoids complication in determining the correctness of ordering-sensitive
+#      aggregations.
+#
+#   2. The window function output cols are functionally determined by the
+#      partition-by cols. This means that the window function outputs the
+#      same value for every row in the partition (group).
+#
+#   3. The Window operator partition-by cols and grouping cols are the same.
+#      This ensures that an aggregate operator will act on the same set of rows,
+#      whether it is part of the Window operator or the GroupBy operator.
+#
+#   4. The window functions are all aggregate functions. This ensures they are
+#      compatible with GroupBy operators.
+#
+#   5. Finally, all of the GroupBy's aggregations must satisfy one of two cases:
+#      a. The aggregate only references cols from the Window operator's input.
+#      b. The aggregate is a ConstAgg (or ConstNotNull, AnyNotNull, or FirstAgg)
+#         that passes through the result of a window function.
+# 
+# Assuming all of the above are satisfied, each GroupBy aggregate that only
+# references the Window's input can be left alone (5a). Then, each ConstAgg
+# referencing a window function can be replaced by that function (5b).
+#
+# Here's an example with slightly altered SQL syntax:
+#
+#   SELECT max(b), const_agg(foo), const_agg(bar)
+#   FROM
+#     (
+#       SELECT *, count(c) OVER w AS foo, array_agg(d) OVER w AS bar
+#       FROM abcd
+#       WINDOW w AS (
+#         PARTITION BY a ORDER BY d
+#         RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+#       )
+#     )
+#   GROUP BY a;
+#   =>
+#   SELECT max(b), count(c), array_agg(d ORDER BY d) FROM abcd GROUP BY a;
+#
+# Note also that the Window's ordering should be preserved by the GroupBy to
+# ensure that ordering-sensitive aggregates produce correct results.
+[FoldGroupByAndWindow, Normalize]
+(GroupBy | ScalarGroupBy
+    $window:(Window
+            $input:*
+            $windows:* & (WindowsAreAggregations $windows)
+            $windowPrivate:*
+        ) &
+        (ColsAreDeterminedBy
+            (WindowFuncOutputCols $windows)
+            $partitionByCols:(WindowPartition $windowPrivate)
+            $window
+        )
+    $aggs:* &
+        (CanMergeAggsAndWindow
+            $aggs
+            $windows
+            $inputCols:(OutputCols $input)
+        )
+    $groupingPrivate:* &
+        (IsUnorderedGrouping $groupingPrivate) &
+        (ColsAreEqual
+            $groupingCols:(GroupingCols $groupingPrivate)
+            $partitionByCols
+        )
+)
+=>
+((OpName)
+    $input
+    (MergeAggsAndWindow $aggs $windows $inputCols)
+    (MakeGrouping
+        (GroupingCols $groupingPrivate)
+        (WindowOrdering $windowPrivate)
+    )
+)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -277,12 +277,12 @@ WHERE i = 3
 ----
 project
  ├── columns: u:1!null v:2 rank:12 i:6!null
- ├── key: (1,12)
- ├── fd: ()-->(6), (1)-->(2)
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2,12)
  └── window partition=(1)
       ├── columns: u:1!null v:2 k:5!null i:6!null rank:12
       ├── key: (5)
-      ├── fd: ()-->(6), (1)-->(2), (1)==(5), (5)==(1)
+      ├── fd: ()-->(6), (1)-->(2,5,12), (1)==(5), (5)==(1)
       ├── inner-join (hash)
       │    ├── columns: u:1!null v:2 k:5!null i:6!null
       │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
@@ -377,7 +377,7 @@ project
       ├── columns: column1:1!null k:2!null i:3 row_number:9 rownum:10!null
       ├── cardinality: [0 - 3]
       ├── key: (10)
-      ├── fd: (10)-->(1), (2)-->(3), (1)==(2), (2)==(1)
+      ├── fd: (10)-->(1-3,9), (2)-->(3), (1)==(2), (2)==(1)
       ├── inner-join (hash)
       │    ├── columns: column1:1!null k:2!null i:3 rownum:10!null
       │    ├── cardinality: [0 - 3]
@@ -460,7 +460,7 @@ project
       ├── columns: column1:1!null i:3 row_number:9 rownum:11!null
       ├── cardinality: [0 - 3]
       ├── key: (11)
-      ├── fd: (11)-->(1), (1)-->(3)
+      ├── fd: (11)-->(1,3,9), (1)-->(3)
       ├── project
       │    ├── columns: column1:1!null i:3 rownum:11!null
       │    ├── cardinality: [0 - 3]
@@ -507,7 +507,7 @@ project
       ├── columns: column1:1!null column2:2!null i:4 row_number:10 rownum:13!null
       ├── cardinality: [0 - 3]
       ├── key: (13)
-      ├── fd: (13)-->(1,2), (1)-->(4)
+      ├── fd: (13)-->(1,2,4,10), (1)-->(4)
       ├── project
       │    ├── columns: column1:1!null column2:2!null i:4 rownum:13!null
       │    ├── cardinality: [0 - 3]
@@ -549,7 +549,7 @@ FROM
 window partition=(1)
  ├── columns: u:1!null v:2 row_number:12 i:6
  ├── key: (1)
- ├── fd: (1)-->(2,6)
+ ├── fd: (1)-->(2,6,12)
  ├── project
  │    ├── columns: u:1!null v:2 i:6
  │    ├── key: (1)
@@ -581,12 +581,12 @@ FROM
 ----
 project
  ├── columns: u:1!null v:2 row_number:12 i:6
- ├── key: (1,12)
- ├── fd: (1)-->(2,6)
+ ├── key: (1)
+ ├── fd: (1)-->(2,6,12)
  └── window partition=(1)
       ├── columns: u:1!null v:2 k:5!null i:6 row_number:12
       ├── key: (5)
-      ├── fd: (1)-->(2), (5)-->(6), (1)==(5), (5)==(1)
+      ├── fd: (1)-->(2,5,6,12), (5)-->(6), (1)==(5), (5)==(1)
       ├── inner-join (hash)
       │    ├── columns: u:1!null v:2 k:5!null i:6
       │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
@@ -3234,11 +3234,11 @@ group-by (hash)
  ├── select
  │    ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:8!null u:12!null v:13!null row_num:16!null
  │    ├── key: (1,12)
- │    ├── fd: (1)-->(2-5), (12)-->(13), (2)==(13), (13)==(2), (8)==(12), (12)==(8), (1,12)-->(16)
+ │    ├── fd: (1)-->(2-5), (12)-->(13), (2)==(13), (13)==(2), (1,8,12)-->(16), (8)==(12), (12)==(8)
  │    ├── window partition=(1,8)
  │    │    ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:8!null u:12!null v:13!null row_num:16
  │    │    ├── key: (1,8,12)
- │    │    ├── fd: (1)-->(2-5), (12)-->(13), (2)==(13), (13)==(2)
+ │    │    ├── fd: (1)-->(2-5), (12)-->(13), (2)==(13), (13)==(2), (1,8,12)-->(16)
  │    │    ├── inner-join (cross)
  │    │    │    ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:8!null u:12!null v:13!null
  │    │    │    ├── key: (1,8,12)
@@ -3299,7 +3299,7 @@ project
  │    ├── left-join-apply
  │    │    ├── columns: x:1!null u:5 uv.v:6 k:9 i:10 f:11 row_num:16
  │    │    ├── key: (1,9)
- │    │    ├── fd: (1,5)-->(6), (1,9)-->(10,11,16), (5)==(9), (9)==(5)
+ │    │    ├── fd: (1,5)-->(6), (1,9)-->(10,11), (1,5,9)-->(16), (5)==(9), (9)==(5)
  │    │    ├── scan xy
  │    │    │    ├── columns: x:1!null
  │    │    │    └── key: (1)
@@ -3308,18 +3308,18 @@ project
  │    │    │    ├── outer: (1)
  │    │    │    ├── cardinality: [0 - 3]
  │    │    │    ├── key: (9)
- │    │    │    ├── fd: ()-->(10), (5)-->(6), (9)-->(11,16), (5)==(9), (9)==(5)
+ │    │    │    ├── fd: ()-->(10), (5)-->(6), (9)-->(11), (5,9)-->(16), (5)==(9), (9)==(5)
  │    │    │    ├── select
  │    │    │    │    ├── columns: u:5!null uv.v:6 k:9!null i:10!null f:11 row_num:16!null
  │    │    │    │    ├── outer: (1)
  │    │    │    │    ├── key: (9)
- │    │    │    │    ├── fd: ()-->(10), (5)-->(6), (9)-->(11,16), (5)==(9), (9)==(5)
+ │    │    │    │    ├── fd: ()-->(10), (5)-->(6), (9)-->(11), (5,9)-->(16), (5)==(9), (9)==(5)
  │    │    │    │    ├── limit hint: 3.00
  │    │    │    │    ├── window partition=(5) ordering=+11 opt(5-8,10)
  │    │    │    │    │    ├── columns: u:5!null uv.v:6 k:9!null i:10!null f:11 row_num:16
  │    │    │    │    │    ├── outer: (1)
  │    │    │    │    │    ├── key: (5,9)
- │    │    │    │    │    ├── fd: ()-->(10), (5)-->(6), (9)-->(11)
+ │    │    │    │    │    ├── fd: ()-->(10), (5)-->(6), (9)-->(11), (5,9)-->(16)
  │    │    │    │    │    ├── limit hint: 8999.57
  │    │    │    │    │    ├── inner-join (cross)
  │    │    │    │    │    │    ├── columns: u:5!null uv.v:6 k:9!null i:10!null f:11
@@ -3479,12 +3479,12 @@ project
       ├── columns: x:1!null y:2 xy.crdb_internal_mvcc_timestamp:3 xy.tableoid:4 u:5!null v:6 foo:9 row_num:10!null
       ├── immutable
       ├── key: (5)
-      ├── fd: (1)-->(2-4), (5)-->(6,10), (2,6)-->(9), (1)==(5), (5)==(1)
+      ├── fd: (1)-->(2-4), (5)-->(6), (2,6)-->(9), (1,5)-->(10), (1)==(5), (5)==(1)
       ├── window partition=(1)
       │    ├── columns: x:1!null y:2 xy.crdb_internal_mvcc_timestamp:3 xy.tableoid:4 u:5!null v:6 foo:9 row_num:10
       │    ├── immutable
       │    ├── key: (1,5)
-      │    ├── fd: (1)-->(2-4), (5)-->(6), (2,6)-->(9)
+      │    ├── fd: (1)-->(2-4), (5)-->(6), (2,6)-->(9), (1,5)-->(10)
       │    ├── project
       │    │    ├── columns: foo:9 x:1!null y:2 xy.crdb_internal_mvcc_timestamp:3 xy.tableoid:4 u:5!null v:6
       │    │    ├── immutable

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -4408,3 +4408,470 @@ scalar-group-by
  └── aggregations
       └── sum [as=sum:6, outer=(1)]
            └── a:1
+
+# --------------------------------------------------
+# FoldGroupByAndWindow
+# --------------------------------------------------
+
+# Case with one partition column and an aggregate that references an input col.
+# NOTE: the "foo" and "bar" grouping columns are simplified to ConstAgg.
+norm expect=FoldGroupByAndWindow
+SELECT sum(v), foo, bar
+FROM (
+  SELECT *, count(w) OVER w AS foo, array_agg(z) OVER w AS bar
+  FROM uvwz
+  WINDOW w AS (
+    PARTITION BY u ORDER BY z
+    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+  )
+)
+GROUP BY u, foo, bar;
+----
+project
+ ├── columns: sum:10!null foo:8!null bar:9!null
+ └── group-by (hash)
+      ├── columns: u:1!null count:8!null array_agg:9!null sum:10!null
+      ├── grouping columns: u:1!null
+      ├── internal-ordering: +4 opt(1)
+      ├── key: (1)
+      ├── fd: (1)-->(8-10)
+      ├── sort
+      │    ├── columns: u:1!null v:2!null z:4!null
+      │    ├── key: (1,2)
+      │    ├── fd: (1,2)-->(4)
+      │    ├── ordering: +4 opt(1) [actual: +4]
+      │    └── scan uvwz
+      │         ├── columns: u:1!null v:2!null z:4!null
+      │         ├── key: (1,2)
+      │         └── fd: (1,2)-->(4)
+      └── aggregations
+           ├── sum [as=sum:10, outer=(2)]
+           │    └── v:2
+           ├── count-rows [as=count:8]
+           └── array-agg [as=array_agg:9, outer=(4)]
+                └── z:4
+
+# Case with a ConstAgg referencing an input column.
+norm expect=FoldGroupByAndWindow
+SELECT sum(v), foo, bar
+FROM (
+  SELECT *, count(w) OVER w AS foo
+  FROM (SELECT *, 100 AS bar FROM uvwz)
+  WINDOW w AS (
+    PARTITION BY u ORDER BY z
+    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+  )
+)
+GROUP BY u, foo, bar;
+----
+project
+ ├── columns: sum:10!null foo:9!null bar:8!null
+ ├── fd: ()-->(8)
+ └── group-by (hash)
+      ├── columns: u:1!null bar:8!null count:9!null sum:10!null
+      ├── grouping columns: u:1!null
+      ├── internal-ordering: +4 opt(1,8)
+      ├── key: (1)
+      ├── fd: ()-->(8), (1)-->(8-10)
+      ├── project
+      │    ├── columns: bar:8!null u:1!null v:2!null z:4!null
+      │    ├── key: (1,2)
+      │    ├── fd: ()-->(8), (1,2)-->(4)
+      │    ├── ordering: +4 opt(1,8) [actual: +4]
+      │    ├── sort
+      │    │    ├── columns: u:1!null v:2!null z:4!null
+      │    │    ├── key: (1,2)
+      │    │    ├── fd: (1,2)-->(4)
+      │    │    ├── ordering: +4 opt(1) [actual: +4]
+      │    │    └── scan uvwz
+      │    │         ├── columns: u:1!null v:2!null z:4!null
+      │    │         ├── key: (1,2)
+      │    │         └── fd: (1,2)-->(4)
+      │    └── projections
+      │         └── 100 [as=bar:8]
+      └── aggregations
+           ├── sum [as=sum:10, outer=(2)]
+           │    └── v:2
+           ├── const-agg [as=bar:8, outer=(8)]
+           │    └── bar:8
+           └── count-rows [as=count:9]
+
+# Case with no partition columns.
+norm expect=FoldGroupByAndWindow
+SELECT sum(v), foo, bar
+FROM (
+  SELECT *, count(w) OVER w AS foo, array_agg(z) OVER w AS bar
+  FROM uvwz
+  WINDOW w AS (
+    ORDER BY z
+    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+  )
+)
+GROUP BY foo, bar;
+----
+group-by (streaming)
+ ├── columns: sum:10!null foo:8!null bar:9!null
+ ├── internal-ordering: +4
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(8-10)
+ ├── sort
+ │    ├── columns: v:2!null z:4!null
+ │    ├── ordering: +4
+ │    └── scan uvwz
+ │         └── columns: v:2!null z:4!null
+ └── aggregations
+      ├── sum [as=sum:10, outer=(2)]
+      │    └── v:2
+      ├── count-rows [as=count:8]
+      └── array-agg [as=array_agg:9, outer=(4)]
+           └── z:4
+
+# Case with multiple partition columns.
+norm expect=FoldGroupByAndWindow
+SELECT sum(v), foo, bar
+FROM (
+  SELECT *, count(v) OVER w AS foo, array_agg(z) OVER w AS bar
+  FROM uvwz
+  WINDOW w AS (
+    PARTITION BY u, w ORDER BY z
+    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+  )
+)
+GROUP BY u, w, foo, bar;
+----
+project
+ ├── columns: sum:10!null foo:8!null bar:9!null
+ └── group-by (hash)
+      ├── columns: u:1!null w:3!null count:8!null array_agg:9!null sum:10!null
+      ├── grouping columns: u:1!null w:3!null
+      ├── internal-ordering: +4 opt(1,3)
+      ├── key: (1,3)
+      ├── fd: (1,3)-->(8-10)
+      ├── sort
+      │    ├── columns: u:1!null v:2!null w:3!null z:4!null
+      │    ├── key: (2,3)
+      │    ├── fd: (1,2)-->(3,4), (2,3)-->(1,4)
+      │    ├── ordering: +4 opt(1,3) [actual: +4]
+      │    └── scan uvwz
+      │         ├── columns: u:1!null v:2!null w:3!null z:4!null
+      │         ├── key: (2,3)
+      │         └── fd: (1,2)-->(3,4), (2,3)-->(1,4)
+      └── aggregations
+           ├── sum [as=sum:10, outer=(2)]
+           │    └── v:2
+           ├── count-rows [as=count:8]
+           └── array-agg [as=array_agg:9, outer=(4)]
+                └── z:4
+
+# Case with grouping/partitioning on key columns.
+norm expect=FoldGroupByAndWindow
+SELECT sum(w), foo, bar
+FROM (
+  SELECT *, count(w) OVER w AS foo, array_agg(z) OVER w AS bar
+  FROM uvwz
+  WINDOW w AS (
+    PARTITION BY u, v ORDER BY z
+    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+  )
+)
+GROUP BY u, v, foo, bar;
+----
+project
+ ├── columns: sum:10!null foo:8!null bar:9!null
+ └── group-by (hash)
+      ├── columns: u:1!null v:2!null count:8!null array_agg:9!null sum:10!null
+      ├── grouping columns: u:1!null v:2!null
+      ├── key: (1,2)
+      ├── fd: (1,2)-->(8-10)
+      ├── scan uvwz
+      │    ├── columns: u:1!null v:2!null w:3!null z:4!null
+      │    ├── key: (2,3)
+      │    └── fd: (1,2)-->(3,4), (2,3)-->(1,4)
+      └── aggregations
+           ├── sum [as=sum:10, outer=(3)]
+           │    └── w:3
+           ├── count-rows [as=count:8]
+           └── array-agg [as=array_agg:9, outer=(4)]
+                └── z:4
+
+# No-op because of an ordered GroupBy.
+norm expect-not=FoldGroupByAndWindow
+SELECT array_agg(v), foo, bar
+FROM (
+  SELECT * FROM (
+    SELECT *, count(w) OVER w AS foo, array_agg(z) OVER w AS bar
+    FROM uvwz
+    WINDOW w AS (
+      PARTITION BY u ORDER BY z
+      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+    )
+  )
+  ORDER BY v DESC
+)
+GROUP BY u, foo, bar;
+----
+project
+ ├── columns: array_agg:10!null foo:8 bar:9
+ └── group-by (hash)
+      ├── columns: u:1!null count:8 array_agg:9 array_agg:10!null
+      ├── grouping columns: u:1!null
+      ├── internal-ordering: -2 opt(1,8,9)
+      ├── key: (1)
+      ├── fd: (1)-->(8-10)
+      ├── sort
+      │    ├── columns: u:1!null v:2!null w:3!null z:4!null count:8 array_agg:9
+      │    ├── key: (2,3)
+      │    ├── fd: (1,2)-->(3,4), (2,3)-->(1,4), (1)-->(8,9)
+      │    ├── ordering: -2 opt(1,8,9) [actual: -2]
+      │    └── window partition=(1) ordering=+4 opt(1)
+      │         ├── columns: u:1!null v:2!null w:3!null z:4!null count:8 array_agg:9
+      │         ├── key: (2,3)
+      │         ├── fd: (1,2)-->(3,4), (2,3)-->(1,4), (1)-->(8,9)
+      │         ├── scan uvwz
+      │         │    ├── columns: u:1!null v:2!null w:3!null z:4!null
+      │         │    ├── key: (2,3)
+      │         │    └── fd: (1,2)-->(3,4), (2,3)-->(1,4)
+      │         └── windows
+      │              ├── count [as=count:8, frame="rows from unbounded to unbounded", outer=(3)]
+      │              │    └── w:3
+      │              └── array-agg [as=array_agg:9, frame="rows from unbounded to unbounded", outer=(4)]
+      │                   └── z:4
+      └── aggregations
+           ├── array-agg [as=array_agg:10, outer=(2)]
+           │    └── v:2
+           ├── const-agg [as=count:8, outer=(8)]
+           │    └── count:8
+           └── const-agg [as=array_agg:9, outer=(9)]
+                └── array_agg:9
+
+# No-op because the grouping columns reference a window function.
+norm expect-not=FoldGroupByAndWindow
+SELECT sum(v), foo, bar
+FROM (
+  SELECT *, count(w) OVER w AS foo, array_agg(z) OVER w AS bar, row_number() OVER w AS baz
+  FROM uvwz
+  WINDOW w AS (
+    PARTITION BY u ORDER BY z
+    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+  )
+)
+GROUP BY u, foo, bar, baz;
+----
+project
+ ├── columns: sum:11!null foo:8 bar:9
+ └── group-by (hash)
+      ├── columns: u:1!null count:8 array_agg:9 row_number:10 sum:11!null
+      ├── grouping columns: u:1!null row_number:10
+      ├── key: (1,10)
+      ├── fd: (1)-->(8,9), (1,10)-->(8,9,11)
+      ├── window partition=(1) ordering=+4 opt(1)
+      │    ├── columns: u:1!null v:2!null w:3!null z:4!null count:8 array_agg:9 row_number:10
+      │    ├── key: (2,3)
+      │    ├── fd: (1,2)-->(3,4), (2,3)-->(1,4,10), (1)-->(8,9)
+      │    ├── scan uvwz
+      │    │    ├── columns: u:1!null v:2!null w:3!null z:4!null
+      │    │    ├── key: (2,3)
+      │    │    └── fd: (1,2)-->(3,4), (2,3)-->(1,4)
+      │    └── windows
+      │         ├── count [as=count:8, frame="rows from unbounded to unbounded", outer=(3)]
+      │         │    └── w:3
+      │         ├── array-agg [as=array_agg:9, frame="rows from unbounded to unbounded", outer=(4)]
+      │         │    └── z:4
+      │         └── row-number [as=row_number:10, frame="rows from unbounded to unbounded"]
+      └── aggregations
+           ├── sum [as=sum:11, outer=(2)]
+           │    └── v:2
+           ├── const-agg [as=count:8, outer=(8)]
+           │    └── count:8
+           └── const-agg [as=array_agg:9, outer=(9)]
+                └── array_agg:9
+
+# No-op because the grouping columns are not the same as the partition columns.
+norm expect-not=FoldGroupByAndWindow
+SELECT sum(u), foo, bar
+FROM (
+  SELECT *, count(w) OVER w AS foo, array_agg(z) OVER w AS bar
+  FROM uvwz
+  WINDOW w AS (
+    PARTITION BY u ORDER BY z
+    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+  )
+)
+GROUP BY v, foo, bar;
+----
+project
+ ├── columns: sum:10!null foo:8 bar:9
+ └── group-by (hash)
+      ├── columns: v:2!null count:8 array_agg:9 sum:10!null
+      ├── grouping columns: v:2!null count:8 array_agg:9
+      ├── key: (2,8,9)
+      ├── fd: (2,8,9)-->(10)
+      ├── window partition=(1) ordering=+4 opt(1)
+      │    ├── columns: u:1!null v:2!null w:3!null z:4!null count:8 array_agg:9
+      │    ├── key: (2,3)
+      │    ├── fd: (1,2)-->(3,4), (2,3)-->(1,4), (1)-->(8,9)
+      │    ├── scan uvwz
+      │    │    ├── columns: u:1!null v:2!null w:3!null z:4!null
+      │    │    ├── key: (2,3)
+      │    │    └── fd: (1,2)-->(3,4), (2,3)-->(1,4)
+      │    └── windows
+      │         ├── count [as=count:8, frame="rows from unbounded to unbounded", outer=(3)]
+      │         │    └── w:3
+      │         └── array-agg [as=array_agg:9, frame="rows from unbounded to unbounded", outer=(4)]
+      │              └── z:4
+      └── aggregations
+           └── sum [as=sum:10, outer=(1)]
+                └── u:1
+
+# No-op because the grouping columns are not the same as the partition columns.
+norm expect-not=FoldGroupByAndWindow
+SELECT sum(v), foo, bar
+FROM (
+  SELECT *, count(w) OVER w AS foo, array_agg(z) OVER w AS bar
+  FROM uvwz
+  WINDOW w AS (
+    ORDER BY z
+    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+  )
+)
+GROUP BY u, foo, bar;
+----
+project
+ ├── columns: sum:10!null foo:8 bar:9
+ ├── fd: ()-->(8,9)
+ └── group-by (hash)
+      ├── columns: u:1!null count:8 array_agg:9 sum:10!null
+      ├── grouping columns: u:1!null
+      ├── key: (1)
+      ├── fd: ()-->(8,9), (1)-->(8-10)
+      ├── window partition=() ordering=+4
+      │    ├── columns: u:1!null v:2!null w:3!null z:4!null count:8 array_agg:9
+      │    ├── key: (2,3)
+      │    ├── fd: ()-->(8,9), (1,2)-->(3,4), (2,3)-->(1,4)
+      │    ├── scan uvwz
+      │    │    ├── columns: u:1!null v:2!null w:3!null z:4!null
+      │    │    ├── key: (2,3)
+      │    │    └── fd: (1,2)-->(3,4), (2,3)-->(1,4)
+      │    └── windows
+      │         ├── count [as=count:8, frame="rows from unbounded to unbounded", outer=(3)]
+      │         │    └── w:3
+      │         └── array-agg [as=array_agg:9, frame="rows from unbounded to unbounded", outer=(4)]
+      │              └── z:4
+      └── aggregations
+           ├── sum [as=sum:10, outer=(2)]
+           │    └── v:2
+           ├── const-agg [as=count:8, outer=(8)]
+           │    └── count:8
+           └── const-agg [as=array_agg:9, outer=(9)]
+                └── array_agg:9
+
+# No-op because the window frame is not unbounded.
+norm expect-not=FoldGroupByAndWindow
+SELECT sum(v), foo, bar
+FROM (
+  SELECT *, count(w) OVER w AS foo, array_agg(z) OVER w AS bar
+  FROM uvwz
+  WINDOW w AS (
+    PARTITION BY u ORDER BY z
+  )
+)
+GROUP BY u, foo, bar;
+----
+project
+ ├── columns: sum:10!null foo:8 bar:9
+ └── group-by (hash)
+      ├── columns: u:1!null count:8 array_agg:9 sum:10!null
+      ├── grouping columns: u:1!null count:8 array_agg:9
+      ├── key: (1,8,9)
+      ├── fd: (1,8,9)-->(10)
+      ├── window partition=(1) ordering=+4 opt(1)
+      │    ├── columns: u:1!null v:2!null w:3!null z:4!null count:8 array_agg:9
+      │    ├── key: (2,3)
+      │    ├── fd: (1,2)-->(3,4), (2,3)-->(1,4,8,9)
+      │    ├── scan uvwz
+      │    │    ├── columns: u:1!null v:2!null w:3!null z:4!null
+      │    │    ├── key: (2,3)
+      │    │    └── fd: (1,2)-->(3,4), (2,3)-->(1,4)
+      │    └── windows
+      │         ├── count [as=count:8, outer=(3)]
+      │         │    └── w:3
+      │         └── array-agg [as=array_agg:9, outer=(4)]
+      │              └── z:4
+      └── aggregations
+           └── sum [as=sum:10, outer=(2)]
+                └── v:2
+
+# No-op because the (non ConstAgg-like) Sum GroupBy aggregate references a
+# Window aggregate.
+norm expect-not=FoldGroupByAndWindow
+SELECT sum(foo), foo, bar
+FROM (
+  SELECT *, count(w) OVER w AS foo, array_agg(z) OVER w AS bar
+  FROM uvwz
+  WINDOW w AS (
+    PARTITION BY u ORDER BY z
+    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+  )
+)
+GROUP BY u, foo, bar;
+----
+project
+ ├── columns: sum:10 foo:8 bar:9
+ └── group-by (hash)
+      ├── columns: u:1!null count:8 array_agg:9 sum:10
+      ├── grouping columns: u:1!null
+      ├── key: (1)
+      ├── fd: (1)-->(8-10)
+      ├── window partition=(1) ordering=+4 opt(1)
+      │    ├── columns: u:1!null w:3!null z:4!null count:8 array_agg:9
+      │    ├── fd: (1)-->(8,9)
+      │    ├── scan uvwz
+      │    │    └── columns: u:1!null w:3!null z:4!null
+      │    └── windows
+      │         ├── count [as=count:8, frame="rows from unbounded to unbounded", outer=(3)]
+      │         │    └── w:3
+      │         └── array-agg [as=array_agg:9, frame="rows from unbounded to unbounded", outer=(4)]
+      │              └── z:4
+      └── aggregations
+           ├── sum [as=sum:10, outer=(8)]
+           │    └── count:8
+           ├── const-agg [as=count:8, outer=(8)]
+           │    └── count:8
+           └── const-agg [as=array_agg:9, outer=(9)]
+                └── array_agg:9
+
+# No-op case with row_number, which can produce a different result for each row
+# in a window frame.
+norm expect-not=FoldGroupByAndWindow
+SELECT sum(v), foo
+FROM (
+  SELECT *, row_number() OVER w AS foo
+  FROM uvwz
+  WINDOW w AS (
+    PARTITION BY u ORDER BY z
+    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+  )
+)
+GROUP BY u, foo;
+----
+project
+ ├── columns: sum:9!null foo:8
+ └── group-by (hash)
+      ├── columns: u:1!null row_number:8 sum:9!null
+      ├── grouping columns: u:1!null row_number:8
+      ├── key: (1,8)
+      ├── fd: (1,8)-->(9)
+      ├── window partition=(1) ordering=+4 opt(1)
+      │    ├── columns: u:1!null v:2!null z:4!null row_number:8
+      │    ├── key: (1,2)
+      │    ├── fd: (1,2)-->(4,8)
+      │    ├── scan uvwz
+      │    │    ├── columns: u:1!null v:2!null z:4!null
+      │    │    ├── key: (1,2)
+      │    │    └── fd: (1,2)-->(4)
+      │    └── windows
+      │         └── row-number [as=row_number:8, frame="rows from unbounded to unbounded"]
+      └── aggregations
+           └── sum [as=sum:9, outer=(2)]
+                └── v:2

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -5382,47 +5382,39 @@ SELECT concat_agg(tab_1739.col3_7::STRING ORDER BY tab_1739.col3_7 DESC)::STRING
 FROM table86308@[0] AS tab_1739 GROUP BY tab_1739.col3_7 HAVING bool_and(false::BOOL)::BOOL
 ----
 project
- └── group-by (hash)
-      ├── select
-      │    ├── window partition=(8)
-      │    │    ├── window partition=(8)
-      │    │    │    ├── project
-      │    │    │    │    ├── scan table86308
-      │    │    │    │    │    ├── computed column expressions
-      │    │    │    │    │    │    ├── col3_9
-      │    │    │    │    │    │    │    └── col3_3 + 0.7530620098114014
-      │    │    │    │    │    │    ├── col3_10
-      │    │    │    │    │    │    │    └── lower(col3_0::STRING)
-      │    │    │    │    │    │    ├── col3_11
-      │    │    │    │    │    │    │    └── col3_3 + 0.8790965676307678
-      │    │    │    │    │    │    ├── col3_12
-      │    │    │    │    │    │    │    └── lower(col3_0::STRING)
-      │    │    │    │    │    │    ├── col3_13
-      │    │    │    │    │    │    │    └── lower(col3_6::STRING)
-      │    │    │    │    │    │    ├── col3_14
-      │    │    │    │    │    │    │    └── col3_3 + -0.27059364318847656
-      │    │    │    │    │    │    └── col3_15
-      │    │    │    │    │    │         └── lower(col3_5::STRING)
-      │    │    │    │    │    └── partial index predicates
-      │    │    │    │    │         └── table3_col3_4_col3_11_col3_1_col3_0_col3_3_key: filters
-      │    │    │    │    │              ├── ((col3_9 = 5e-324) OR (col3_1 = -32768)) OR (col3_15 = '')
-      │    │    │    │    │              ├── col3_3 > 3.4028234663852886e+38
-      │    │    │    │    │              └── lower(col3_0::STRING) != '""'
-      │    │    │    │    └── projections
-      │    │    │    │         ├── false
-      │    │    │    │         ├── col3_3 + 0.8790965676307678
-      │    │    │    │         └── lower(col3_0::STRING)
-      │    │    │    └── windows
-      │    │    │         └── concat-agg [frame="range from unbounded to unbounded"]
-      │    │    │              └── col3_7
-      │    │    └── windows
-      │    │         └── bool-and [frame="range from unbounded to unbounded"]
-      │    │              └── column21
-      │    └── filters
-      │         └── bool_and
-      └── aggregations
-           └── const-agg
-                └── concat_agg
+ └── select
+      ├── group-by (hash)
+      │    ├── project
+      │    │    ├── scan table86308
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── col3_9
+      │    │    │    │    │    └── col3_3 + 0.7530620098114014
+      │    │    │    │    ├── col3_10
+      │    │    │    │    │    └── lower(col3_0::STRING)
+      │    │    │    │    ├── col3_11
+      │    │    │    │    │    └── col3_3 + 0.8790965676307678
+      │    │    │    │    ├── col3_12
+      │    │    │    │    │    └── lower(col3_0::STRING)
+      │    │    │    │    ├── col3_13
+      │    │    │    │    │    └── lower(col3_6::STRING)
+      │    │    │    │    ├── col3_14
+      │    │    │    │    │    └── col3_3 + -0.27059364318847656
+      │    │    │    │    └── col3_15
+      │    │    │    │         └── lower(col3_5::STRING)
+      │    │    │    └── partial index predicates
+      │    │    │         └── table3_col3_4_col3_11_col3_1_col3_0_col3_3_key: filters
+      │    │    │              ├── ((col3_9 = 5e-324) OR (col3_1 = -32768)) OR (col3_15 = '')
+      │    │    │              ├── col3_3 > 3.4028234663852886e+38
+      │    │    │              └── lower(col3_0::STRING) != '""'
+      │    │    └── projections
+      │    │         └── false
+      │    └── aggregations
+      │         ├── concat-agg
+      │         │    └── col3_7
+      │         └── bool-and
+      │              └── column21
+      └── filters
+           └── bool_and
 
 exec-ddl
 CREATE TABLE p100478 (

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1938,7 +1938,7 @@ sort
       ├── window partition=(3) ordering=+4 opt(3)
       │    ├── columns: k:1!null f:3 s:4 avg:7
       │    ├── key: (1)
-      │    ├── fd: (1)-->(3,4)
+      │    ├── fd: (1)-->(3,4,7)
       │    ├── scan a
       │    │    ├── columns: k:1!null f:3 s:4
       │    │    ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/window
+++ b/pkg/sql/opt/norm/testdata/rules/window
@@ -14,6 +14,7 @@ project
  └── window partition=(1)
       ├── columns: k:1!null rank:8
       ├── key: (1)
+      ├── fd: (1)-->(8)
       ├── scan a
       │    ├── columns: k:1!null
       │    └── key: (1)
@@ -44,6 +45,7 @@ project
  └── window partition=() ordering=+1
       ├── columns: k:1!null rank:8
       ├── key: (1)
+      ├── fd: (1)-->(8)
       ├── scan a
       │    ├── columns: k:1!null
       │    └── key: (1)
@@ -62,6 +64,7 @@ project
  └── window partition=(1)
       ├── columns: k:1!null rank:8
       ├── key: (1)
+      ├── fd: (1)-->(8)
       ├── scan a
       │    ├── columns: k:1!null
       │    └── key: (1)
@@ -237,7 +240,7 @@ project
  └── window partition=(1)
       ├── columns: k:1!null i:2!null rank:8
       ├── key: (1)
-      ├── fd: ()-->(2)
+      ├── fd: ()-->(2), (1)-->(8)
       ├── select
       │    ├── columns: k:1!null i:2!null
       │    ├── key: (1)
@@ -261,7 +264,7 @@ project
       ├── columns: k:1!null i:2 f:3 rank:8
       ├── immutable
       ├── key: (1)
-      ├── fd: (1)-->(2,3)
+      ├── fd: (1)-->(2,3,8)
       ├── select
       │    ├── columns: k:1!null i:2 f:3
       │    ├── immutable
@@ -289,7 +292,7 @@ project
       ├── window partition=(1)
       │    ├── columns: k:1!null i:2 f:3 rank:8
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2,3)
+      │    ├── fd: (1)-->(2,3,8)
       │    ├── scan a
       │    │    ├── columns: k:1!null i:2 f:3
       │    │    ├── key: (1)
@@ -402,9 +405,11 @@ project
       ├── columns: k:1!null avg:8
       ├── cardinality: [0 - 10]
       ├── key: (1)
+      ├── fd: (1)-->(8)
       ├── window partition=()
       │    ├── columns: k:1!null avg:8
       │    ├── key: (1)
+      │    ├── fd: (1)-->(8)
       │    ├── limit hint: 10.00
       │    ├── scan a
       │    │    ├── columns: k:1!null
@@ -490,11 +495,11 @@ project
       ├── columns: k:1!null i:2 f:3 rank:8 avg:9
       ├── cardinality: [0 - 10]
       ├── key: (1)
-      ├── fd: (1)-->(2,3)
+      ├── fd: (1)-->(2,3,8,9)
       ├── window partition=(2) ordering=+3 opt(2)
       │    ├── columns: k:1!null i:2 f:3 rank:8 avg:9
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2,3)
+      │    ├── fd: (1)-->(2,3,8,9)
       │    ├── limit hint: 10.00
       │    ├── scan a
       │    │    ├── columns: k:1!null i:2 f:3
@@ -518,18 +523,18 @@ limit
  ├── internal-ordering: +3
  ├── cardinality: [0 - 2]
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-4,7)
  ├── ordering: +3
  ├── sort
  │    ├── columns: w:1!null x:2 y:3 z:4 rank:7
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4)
+ │    ├── fd: (1)-->(2-4,7)
  │    ├── ordering: +3
  │    ├── limit hint: 2.00
  │    └── window partition=(4) ordering=+3 opt(4)
  │         ├── columns: w:1!null x:2 y:3 z:4 rank:7
  │         ├── key: (1)
- │         ├── fd: (1)-->(2-4)
+ │         ├── fd: (1)-->(2-4,7)
  │         ├── scan wxyz
  │         │    ├── columns: w:1!null x:2 y:3 z:4
  │         │    ├── key: (1)
@@ -545,13 +550,13 @@ sort
  ├── columns: w:1!null x:2 y:3 z:4 rank:7
  ├── cardinality: [0 - 2]
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-4,7)
  ├── ordering: +3
  └── window partition=(1)
       ├── columns: w:1!null x:2 y:3 z:4 rank:7
       ├── cardinality: [0 - 2]
       ├── key: (1)
-      ├── fd: (1)-->(2-4)
+      ├── fd: (1)-->(2-4,7)
       ├── limit
       │    ├── columns: w:1!null x:2 y:3 z:4
       │    ├── internal-ordering: +3,+1
@@ -579,13 +584,13 @@ sort
  ├── columns: w:1!null x:2 y:3 z:4 rank:7
  ├── cardinality: [0 - 2]
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-4,7)
  ├── ordering: +1
  └── window partition=(1)
       ├── columns: w:1!null x:2 y:3 z:4 rank:7
       ├── cardinality: [0 - 2]
       ├── key: (1)
-      ├── fd: (1)-->(2-4)
+      ├── fd: (1)-->(2-4,7)
       ├── limit
       │    ├── columns: w:1!null x:2 y:3 z:4
       │    ├── internal-ordering: +1
@@ -609,13 +614,13 @@ sort
  ├── columns: w:1!null x:2 y:3 z:4 rank:7
  ├── cardinality: [0 - 2]
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-4,7)
  ├── ordering: +1
  └── window partition=(1)
       ├── columns: w:1!null x:2 y:3 z:4 rank:7
       ├── cardinality: [0 - 2]
       ├── key: (1)
-      ├── fd: (1)-->(2-4)
+      ├── fd: (1)-->(2-4,7)
       ├── limit
       │    ├── columns: w:1!null x:2 y:3 z:4
       │    ├── internal-ordering: +1
@@ -639,13 +644,13 @@ sort
  ├── columns: w:1!null x:2 y:3 z:4 rank:7
  ├── cardinality: [0 - 2]
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-4,7)
  ├── ordering: +3,+1
  └── window partition=(1)
       ├── columns: w:1!null x:2 y:3 z:4 rank:7
       ├── cardinality: [0 - 2]
       ├── key: (1)
-      ├── fd: (1)-->(2-4)
+      ├── fd: (1)-->(2-4,7)
       ├── limit
       │    ├── columns: w:1!null x:2 y:3 z:4
       │    ├── internal-ordering: +3,+1
@@ -673,13 +678,13 @@ sort
  ├── columns: w:1!null x:2 y:3 z:4 rank:7
  ├── cardinality: [0 - 2]
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-4,7)
  ├── ordering: +1
  └── window partition=(1)
       ├── columns: w:1!null x:2 y:3 z:4 rank:7
       ├── cardinality: [0 - 2]
       ├── key: (1)
-      ├── fd: (1)-->(2-4)
+      ├── fd: (1)-->(2-4,7)
       ├── limit
       │    ├── columns: w:1!null x:2 y:3 z:4
       │    ├── internal-ordering: +1
@@ -703,13 +708,13 @@ sort
  ├── columns: w:1!null x:2 y:3 z:4 rank:7
  ├── cardinality: [0 - 2]
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-4,7)
  ├── ordering: +4,+2
  └── window partition=(2,4) ordering=+3 opt(2,4)
       ├── columns: w:1!null x:2 y:3 z:4 rank:7
       ├── cardinality: [0 - 2]
       ├── key: (1)
-      ├── fd: (1)-->(2-4)
+      ├── fd: (1)-->(2-4,7)
       ├── limit
       │    ├── columns: w:1!null x:2 y:3 z:4
       │    ├── internal-ordering: +4,+2,+3
@@ -737,13 +742,13 @@ sort
  ├── columns: w:1!null x:2 y:3 z:4 rank:7
  ├── cardinality: [0 - 2]
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-4,7)
  ├── ordering: +4,+3
  └── window partition=(4) ordering=+3 opt(4)
       ├── columns: w:1!null x:2 y:3 z:4 rank:7
       ├── cardinality: [0 - 2]
       ├── key: (1)
-      ├── fd: (1)-->(2-4)
+      ├── fd: (1)-->(2-4,7)
       ├── limit
       │    ├── columns: w:1!null x:2 y:3 z:4
       │    ├── internal-ordering: +4,+3
@@ -772,18 +777,18 @@ limit
  ├── internal-ordering: +3
  ├── cardinality: [0 - 2]
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-4,7)
  ├── ordering: +3
  ├── sort
  │    ├── columns: w:1!null x:2 y:3 z:4 rank:7
  │    ├── key: (1)
- │    ├── fd: (1)-->(2-4)
+ │    ├── fd: (1)-->(2-4,7)
  │    ├── ordering: +3
  │    ├── limit hint: 2.00
  │    └── window partition=(4) ordering=+3 opt(4)
  │         ├── columns: w:1!null x:2 y:3 z:4 rank:7
  │         ├── key: (1)
- │         ├── fd: (1)-->(2-4)
+ │         ├── fd: (1)-->(2-4,7)
  │         ├── scan wxyz
  │         │    ├── columns: w:1!null x:2 y:3 z:4
  │         │    ├── key: (1)
@@ -799,13 +804,13 @@ sort
  ├── columns: w:1!null x:2 y:3 z:4 rank:7
  ├── cardinality: [0 - 2]
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-4,7)
  ├── ordering: +1
  └── window partition=(1)
       ├── columns: w:1!null x:2 y:3 z:4 rank:7
       ├── cardinality: [0 - 2]
       ├── key: (1)
-      ├── fd: (1)-->(2-4)
+      ├── fd: (1)-->(2-4,7)
       ├── limit
       │    ├── columns: w:1!null x:2 y:3 z:4
       │    ├── internal-ordering: +1
@@ -829,13 +834,13 @@ sort
  ├── columns: w:1!null x:2 y:3 z:4 rank:7
  ├── cardinality: [0 - 2]
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-4,7)
  ├── ordering: +4,+1
  └── window partition=(1)
       ├── columns: w:1!null x:2 y:3 z:4 rank:7
       ├── cardinality: [0 - 2]
       ├── key: (1)
-      ├── fd: (1)-->(2-4)
+      ├── fd: (1)-->(2-4,7)
       ├── limit
       │    ├── columns: w:1!null x:2 y:3 z:4
       │    ├── internal-ordering: +4,+1
@@ -863,13 +868,13 @@ sort
  ├── columns: w:1!null x:2 y:3 z:4 rank:7
  ├── cardinality: [0 - 2]
  ├── key: (1)
- ├── fd: (1)-->(2-4)
+ ├── fd: (1)-->(2-4,7)
  ├── ordering: +4
  └── window partition=(1)
       ├── columns: w:1!null x:2 y:3 z:4 rank:7
       ├── cardinality: [0 - 2]
       ├── key: (1)
-      ├── fd: (1)-->(2-4)
+      ├── fd: (1)-->(2-4,7)
       ├── limit
       │    ├── columns: w:1!null x:2 y:3 z:4
       │    ├── internal-ordering: +4,+1

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -1856,7 +1856,7 @@ project
  │         │    ├── columns: i:5!null sum:7
  │         │    ├── cardinality: [0 - 1]
  │         │    ├── key: ()
- │         │    ├── fd: ()-->(5)
+ │         │    ├── fd: ()-->(5,7)
  │         │    ├── select
  │         │    │    ├── columns: i:5!null
  │         │    │    ├── cardinality: [0 - 1]

--- a/pkg/sql/opt/norm/window_funcs.go
+++ b/pkg/sql/opt/norm/window_funcs.go
@@ -197,3 +197,24 @@ func (c *CustomFuncs) LimitToRowNumberFilter(
 		),
 	}
 }
+
+// WindowsAreAggregations returns true if all the window functions are aggregate
+// functions.
+func (c *CustomFuncs) WindowsAreAggregations(windows memo.WindowsExpr) bool {
+	for i := range windows {
+		if !opt.IsAggregateOp(windows[i].Function) {
+			return false
+		}
+	}
+	return true
+}
+
+// WindowFuncOutputCols collects all columns projected by the given set of
+// window functions.
+func (c *CustomFuncs) WindowFuncOutputCols(windows memo.WindowsExpr) opt.ColSet {
+	var cols opt.ColSet
+	for i := range windows {
+		cols.Add(windows[i].Col)
+	}
+	return cols
+}

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -929,6 +929,12 @@ func (f *FuncDepSet) AddEquivalency(a, b opt.ColumnID) {
 	f.tryToReduceKey(opt.ColSet{} /* notNullCols */)
 }
 
+// AddStrictDependency adds a new strict dependency to the set.
+func (f *FuncDepSet) AddStrictDependency(from, to opt.ColSet) {
+	f.addDependency(from, to, true /* strict */, false /* equiv */)
+	f.tryToReduceKey(opt.ColSet{} /* notNullCols */)
+}
+
 // AddConstants adds a strict FD to the set that declares each given column as
 // having the same constant value for all rows. If a column is nullable, then
 // its value may be NULL, but then the column must be NULL for all rows. For

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -4649,19 +4649,19 @@ left-join (cross)
  ├── cardinality: [0 - 50]
  ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  ├── immutable
- ├── key: (98,99,106)
- ├── fd: (99)-->(100-105,107,108), (103)-->(107,108), (98,99,106)-->(109-111)
+ ├── key: (99,106)
+ ├── fd: (99)-->(98,100-105,107,108), (103)-->(107,108), (99,106)-->(109-111)
  ├── project
  │    ├── columns: row_number:98 t_id:99!null t_dts:100!null st_name:101!null tt_name:102!null t_s_symb:103!null t_qty:104!null t_exec_name:105!null t_chrg:106!null s_name:107!null ex_name:108!null
  │    ├── cardinality: [0 - 50]
  │    ├── immutable
- │    ├── key: (98,99,106)
- │    ├── fd: (99)-->(100-105,107,108), (103)-->(107,108)
+ │    ├── key: (99,106)
+ │    ├── fd: (99)-->(98,100-105,107,108), (103)-->(107,108)
  │    ├── window partition=()
  │    │    ├── columns: trade.t_id:1!null trade.t_dts:2!null t_st_id:3!null t_tt_id:4!null trade.t_s_symb:6!null trade.t_qty:7!null t_ca_id:9!null trade.t_exec_name:10!null trade.t_chrg:12!null s_symb:18!null security.s_name:21!null s_ex_id:22!null ex_id:36!null exchange.ex_name:37!null st_id:45!null status_type.st_name:46!null tt_id:49!null trade_type.tt_name:50!null row_number:55
  │    │    ├── cardinality: [0 - 50]
  │    │    ├── key: (1)
- │    │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12), (18)-->(21,22), (6)==(18), (18)==(6), (36)-->(37), (22)==(36), (36)==(22), (45)-->(46), (3)==(45), (45)==(3), (49)-->(50), (4)==(49), (49)==(4)
+ │    │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12,55), (18)-->(21,22), (6)==(18), (18)==(6), (36)-->(37), (22)==(36), (36)==(22), (45)-->(46), (3)==(45), (45)==(3), (49)-->(50), (4)==(49), (49)==(4)
  │    │    ├── inner-join (hash)
  │    │    │    ├── columns: trade.t_id:1!null trade.t_dts:2!null t_st_id:3!null t_tt_id:4!null trade.t_s_symb:6!null trade.t_qty:7!null t_ca_id:9!null trade.t_exec_name:10!null trade.t_chrg:12!null s_symb:18!null security.s_name:21!null s_ex_id:22!null ex_id:36!null exchange.ex_name:37!null st_id:45!null status_type.st_name:46!null tt_id:49!null trade_type.tt_name:50!null
  │    │    │    ├── cardinality: [0 - 50]
@@ -4800,19 +4800,19 @@ left-join (cross)
  ├── cardinality: [0 - 50]
  ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  ├── immutable
- ├── key: (98,99,106)
- ├── fd: (99)-->(100-105,107,108), (103)-->(107,108), (98,99,106)-->(109-111)
+ ├── key: (99,106)
+ ├── fd: (99)-->(98,100-105,107,108), (103)-->(107,108), (99,106)-->(109-111)
  ├── project
  │    ├── columns: row_number:98 t_id:99!null t_dts:100!null st_name:101!null tt_name:102!null t_s_symb:103!null t_qty:104!null t_exec_name:105!null t_chrg:106!null s_name:107!null ex_name:108!null
  │    ├── cardinality: [0 - 50]
  │    ├── immutable
- │    ├── key: (98,99,106)
- │    ├── fd: (99)-->(100-105,107,108), (103)-->(107,108)
+ │    ├── key: (99,106)
+ │    ├── fd: (99)-->(98,100-105,107,108), (103)-->(107,108)
  │    ├── window partition=()
  │    │    ├── columns: trade.t_id:1!null trade.t_dts:2!null t_st_id:3!null t_tt_id:4!null trade.t_s_symb:6!null trade.t_qty:7!null t_ca_id:9!null trade.t_exec_name:10!null trade.t_chrg:12!null s_symb:18!null security.s_name:21!null s_ex_id:22!null ex_id:36!null exchange.ex_name:37!null st_id:45!null status_type.st_name:46!null tt_id:49!null trade_type.tt_name:50!null row_number:55
  │    │    ├── cardinality: [0 - 50]
  │    │    ├── key: (1)
- │    │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12), (18)-->(21,22), (6)==(18), (18)==(6), (36)-->(37), (22)==(36), (36)==(22), (45)-->(46), (3)==(45), (45)==(3), (49)-->(50), (4)==(49), (49)==(4)
+ │    │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12,55), (18)-->(21,22), (6)==(18), (18)==(6), (36)-->(37), (22)==(36), (36)==(22), (45)-->(46), (3)==(45), (45)==(3), (49)-->(50), (4)==(49), (49)==(4)
  │    │    ├── inner-join (hash)
  │    │    │    ├── columns: trade.t_id:1!null trade.t_dts:2!null t_st_id:3!null t_tt_id:4!null trade.t_s_symb:6!null trade.t_qty:7!null t_ca_id:9!null trade.t_exec_name:10!null trade.t_chrg:12!null s_symb:18!null security.s_name:21!null s_ex_id:22!null ex_id:36!null exchange.ex_name:37!null st_id:45!null status_type.st_name:46!null tt_id:49!null trade_type.tt_name:50!null
  │    │    │    ├── flags: force hash join (store right side)
@@ -6063,7 +6063,7 @@ project
       ├── window partition=()
       │    ├── columns: wi_wl_id:1!null wi_s_symb:2!null wl_id:5!null wl_c_id:6!null row_number:9
       │    ├── key: (2,5)
-      │    ├── fd: ()-->(6), (1)==(5), (5)==(1)
+      │    ├── fd: ()-->(6), (1)==(5), (5)==(1), (2,5)-->(9)
       │    ├── inner-join (lookup watch_item)
       │    │    ├── columns: wi_wl_id:1!null wi_s_symb:2!null wl_id:5!null wl_c_id:6!null
       │    │    ├── key columns: [5] = [1]

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -4679,19 +4679,19 @@ left-join (cross)
  ├── cardinality: [0 - 50]
  ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  ├── immutable
- ├── key: (98,99,106)
- ├── fd: (99)-->(100-105,107,108), (103)-->(107,108), (98,99,106)-->(109-111)
+ ├── key: (99,106)
+ ├── fd: (99)-->(98,100-105,107,108), (103)-->(107,108), (99,106)-->(109-111)
  ├── project
  │    ├── columns: row_number:98 t_id:99!null t_dts:100!null st_name:101!null tt_name:102!null t_s_symb:103!null t_qty:104!null t_exec_name:105!null t_chrg:106!null s_name:107!null ex_name:108!null
  │    ├── cardinality: [0 - 50]
  │    ├── immutable
- │    ├── key: (98,99,106)
- │    ├── fd: (99)-->(100-105,107,108), (103)-->(107,108)
+ │    ├── key: (99,106)
+ │    ├── fd: (99)-->(98,100-105,107,108), (103)-->(107,108)
  │    ├── window partition=()
  │    │    ├── columns: trade.t_id:1!null trade.t_dts:2!null t_st_id:3!null t_tt_id:4!null trade.t_s_symb:6!null trade.t_qty:7!null t_ca_id:9!null trade.t_exec_name:10!null trade.t_chrg:12!null s_symb:18!null security.s_name:21!null s_ex_id:22!null ex_id:36!null exchange.ex_name:37!null st_id:45!null status_type.st_name:46!null tt_id:49!null trade_type.tt_name:50!null row_number:55
  │    │    ├── cardinality: [0 - 50]
  │    │    ├── key: (1)
- │    │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12), (18)-->(21,22), (6)==(18), (18)==(6), (36)-->(37), (22)==(36), (36)==(22), (45)-->(46), (3)==(45), (45)==(3), (49)-->(50), (4)==(49), (49)==(4)
+ │    │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12,55), (18)-->(21,22), (6)==(18), (18)==(6), (36)-->(37), (22)==(36), (36)==(22), (45)-->(46), (3)==(45), (45)==(3), (49)-->(50), (4)==(49), (49)==(4)
  │    │    ├── inner-join (lookup trade_type)
  │    │    │    ├── columns: trade.t_id:1!null trade.t_dts:2!null t_st_id:3!null t_tt_id:4!null trade.t_s_symb:6!null trade.t_qty:7!null t_ca_id:9!null trade.t_exec_name:10!null trade.t_chrg:12!null s_symb:18!null security.s_name:21!null s_ex_id:22!null ex_id:36!null exchange.ex_name:37!null st_id:45!null status_type.st_name:46!null tt_id:49!null trade_type.tt_name:50!null
  │    │    │    ├── key columns: [4] = [49]
@@ -4818,19 +4818,19 @@ left-join (cross)
  ├── cardinality: [0 - 50]
  ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  ├── immutable
- ├── key: (98,99,106)
- ├── fd: (99)-->(100-105,107,108), (103)-->(107,108), (98,99,106)-->(109-111)
+ ├── key: (99,106)
+ ├── fd: (99)-->(98,100-105,107,108), (103)-->(107,108), (99,106)-->(109-111)
  ├── project
  │    ├── columns: row_number:98 t_id:99!null t_dts:100!null st_name:101!null tt_name:102!null t_s_symb:103!null t_qty:104!null t_exec_name:105!null t_chrg:106!null s_name:107!null ex_name:108!null
  │    ├── cardinality: [0 - 50]
  │    ├── immutable
- │    ├── key: (98,99,106)
- │    ├── fd: (99)-->(100-105,107,108), (103)-->(107,108)
+ │    ├── key: (99,106)
+ │    ├── fd: (99)-->(98,100-105,107,108), (103)-->(107,108)
  │    ├── window partition=()
  │    │    ├── columns: trade.t_id:1!null trade.t_dts:2!null t_st_id:3!null t_tt_id:4!null trade.t_s_symb:6!null trade.t_qty:7!null t_ca_id:9!null trade.t_exec_name:10!null trade.t_chrg:12!null s_symb:18!null security.s_name:21!null s_ex_id:22!null ex_id:36!null exchange.ex_name:37!null st_id:45!null status_type.st_name:46!null tt_id:49!null trade_type.tt_name:50!null row_number:55
  │    │    ├── cardinality: [0 - 50]
  │    │    ├── key: (1)
- │    │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12), (18)-->(21,22), (6)==(18), (18)==(6), (36)-->(37), (22)==(36), (36)==(22), (45)-->(46), (3)==(45), (45)==(3), (49)-->(50), (4)==(49), (49)==(4)
+ │    │    ├── fd: ()-->(9), (1)-->(2-4,6,7,10,12,55), (18)-->(21,22), (6)==(18), (18)==(6), (36)-->(37), (22)==(36), (36)==(22), (45)-->(46), (3)==(45), (45)==(3), (49)-->(50), (4)==(49), (49)==(4)
  │    │    ├── inner-join (hash)
  │    │    │    ├── columns: trade.t_id:1!null trade.t_dts:2!null t_st_id:3!null t_tt_id:4!null trade.t_s_symb:6!null trade.t_qty:7!null t_ca_id:9!null trade.t_exec_name:10!null trade.t_chrg:12!null s_symb:18!null security.s_name:21!null s_ex_id:22!null ex_id:36!null exchange.ex_name:37!null st_id:45!null status_type.st_name:46!null tt_id:49!null trade_type.tt_name:50!null
  │    │    │    ├── flags: force hash join (store right side)
@@ -6080,7 +6080,7 @@ project
       ├── window partition=()
       │    ├── columns: wi_wl_id:1!null wi_s_symb:2!null wl_id:5!null wl_c_id:6!null row_number:9
       │    ├── key: (2,5)
-      │    ├── fd: ()-->(6), (1)==(5), (5)==(1)
+      │    ├── fd: ()-->(6), (1)==(5), (5)==(1), (2,5)-->(9)
       │    ├── inner-join (lookup watch_item)
       │    │    ├── columns: wi_wl_id:1!null wi_s_symb:2!null wl_id:5!null wl_c_id:6!null
       │    │    ├── key columns: [5] = [1]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -2493,10 +2493,12 @@ SELECT *, row_number() OVER() FROM abc ORDER BY a
 sort
  ├── columns: a:1!null b:2!null c:3!null row_number:6
  ├── key: (1-3)
+ ├── fd: (1-3)-->(6)
  ├── ordering: +1
  └── window partition=()
       ├── columns: a:1!null b:2!null c:3!null row_number:6
       ├── key: (1-3)
+      ├── fd: (1-3)-->(6)
       ├── scan abc
       │    ├── columns: a:1!null b:2!null c:3!null
       │    └── key: (1-3)

--- a/pkg/sql/sem/builtins/window_builtins.go
+++ b/pkg/sql/sem/builtins/window_builtins.go
@@ -223,6 +223,11 @@ var _ eval.WindowFunc = &nthValueWindow{}
 
 // aggregateWindowFunc aggregates over the current row's window frame, using
 // the internal eval.AggregateFunc to perform the aggregation.
+//
+// INVARIANT: the rows within a window frame are always processed in the same
+// order, regardless of whether the user specified an ordering. This means that
+// two rows with the exact same frame will produce the same result for a given
+// aggregation.
 type aggregateWindowFunc struct {
 	agg     eval.AggregateFunc
 	peerRes tree.Datum


### PR DESCRIPTION
#### opt: add method to add strict dependency to FuncDepSet

This commit adds a new method, `AddStrictDependency`, to `FuncDepSet`.
This will be used in the following commit to add a dependency between
a Window operator's partition columns and its functions. Existing
methods don't work for this because the dependency is not a key.

Epic: None

Release note: None

#### opt: infer functional dependencies for window functions

This commit adds logic to infer strict functional dependencies from
a Window operator's partition column(s) to some or all of its window
functions when the following conditions are satisfied:
1. The window function must be an aggregate, or first_value or last_value.
2. The window frame must be unbounded.

The above conditions ensure that the window function always produces the
same result given the same window frame, as well as that every row in a
partition has the same window frame. This means that the window function
produces the same output for every row in the partition, and therefore,
the partition columns functionally determine the output of the window
function.

Epic: None

Release note: None

#### opt: add rule to merge GroupBy and Window

This commit adds a new norm rule, `FoldGroupByAndWindow`, which can
merge a Window operator with a parent GroupBy operator when the grouping
columns are the same as the partition columns. See the rule comment for
the complete list of conditions. In addition to removing a potentially
expensive Window operator, this transformation makes way for other rules
to match.

Fixes #113292

Release note: None