### PR TITLE
release-23.2: ttljob: fix job to handle composite PKs

### DIFF
--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -553,6 +553,7 @@ var (
 		},
 		types.FloatFamily: {
 			tree.NewDFloat(tree.DFloat(0)),
+			tree.NewDFloat(tree.DFloat(math.Copysign(0, -1))), // -0
 			tree.NewDFloat(tree.DFloat(1)),
 			tree.NewDFloat(tree.DFloat(-1)),
 			tree.NewDFloat(tree.DFloat(math.SmallestNonzeroFloat32)),
@@ -566,9 +567,12 @@ var (
 		types.DecimalFamily: func() []tree.Datum {
 			var res []tree.Datum
 			for _, s := range []string{
+				"-0",
 				"0",
 				"1",
+				"1.0",
 				"-1",
+				"-1.0",
 				"Inf",
 				"-Inf",
 				"NaN",

--- a/pkg/sql/rowenc/BUILD.bazel
+++ b/pkg/sql/rowenc/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/geo/geoindex",
         "//pkg/geo/geopb",
         "//pkg/keys",
+        "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkeys",

--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -96,6 +96,7 @@ go_test(
         "//pkg/sql/types",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/sql/ttl/ttljob/ttljob_processor_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor_test.go
@@ -12,11 +12,14 @@ package ttljob_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/replicationtestutils"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -167,6 +170,10 @@ func TestSpanToQueryBounds(t *testing.T) {
 				tableName,
 			)
 			primaryIndexDesc := tableDesc.GetPrimaryIndex().IndexDesc()
+			pkColIDs := catalog.TableColMap{}
+			for i, id := range primaryIndexDesc.KeyColumnIDs {
+				pkColIDs.Set(id, i)
+			}
 			pkColTypes, err := ttljob.GetPKColumnTypes(tableDesc, primaryIndexDesc)
 			require.NoError(t, err)
 			pkColDirs := primaryIndexDesc.KeyColumnDirections
@@ -182,8 +189,9 @@ func TestSpanToQueryBounds(t *testing.T) {
 				key := keyValue.Key
 				if truncateKey {
 					key = key[:len(key)-3]
+					kvKeyValues := []kv.KeyValue{{Key: key, Value: &keyValue.Value}}
 					// Ensure truncated key cannot be decoded.
-					_, err = rowenc.DecodeIndexKeyToDatums(codec, pkColTypes, pkColDirs, key, &alloc)
+					_, err = rowenc.DecodeIndexKeyToDatums(codec, pkColIDs, pkColTypes, pkColDirs, kvKeyValues, &alloc)
 					require.ErrorContainsf(t, err, "did not find terminator 0x0 in buffer", "pkValue=%s", pkValue)
 				}
 				return key
@@ -194,18 +202,10 @@ func TestSpanToQueryBounds(t *testing.T) {
 			endKey := createKey(tc.endPKValue, tc.truncateEndPKValue, primaryIndexSpan.EndKey)
 
 			// Run test function.
-			actualBounds, actualHasRows, err := ttljob.SpanToQueryBounds(
-				ctx,
-				kvDB,
-				codec,
-				pkColTypes,
-				pkColDirs,
-				roachpb.Span{
-					Key:    startKey,
-					EndKey: endKey,
-				},
-				&alloc,
-			)
+			actualBounds, actualHasRows, err := ttljob.SpanToQueryBounds(ctx, kvDB, codec, pkColIDs, pkColTypes, pkColDirs, 1, roachpb.Span{
+				Key:    startKey,
+				EndKey: endKey,
+			}, &alloc)
 
 			// Verify results.
 			require.NoError(t, err)
@@ -217,5 +217,230 @@ func TestSpanToQueryBounds(t *testing.T) {
 				require.Equalf(t, tc.expectedBoundsEnd, actualBoundsEnd, "end")
 			}
 		})
+	}
+}
+
+func TestSpanToQueryBoundsCompositeKeys(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		desc string
+		// tablePKValues are PK values initially inserted into the table.
+		tablePKValues [][]string
+		// startPKValue is the PK value used to create the span start key.
+		startPKValue []string
+		// truncateStartPKValue removes end bytes from startPKValue to cause a
+		// decoding error.
+		truncateStartPKValue bool
+		// endPKValue is the PK value used to create the span end key.
+		endPKValue []string
+		// truncateEndPKValue removes end bytes from endPKValue to cause a
+		// decoding error.
+		truncateEndPKValue  bool
+		expectedHasRows     bool
+		expectedBoundsStart []string
+		expectedBoundsEnd   []string
+	}{
+		{
+			desc:            "empty table",
+			tablePKValues:   [][]string{},
+			expectedHasRows: false,
+		},
+		{
+			desc:                "start key < table value",
+			tablePKValues:       [][]string{{"B", "2"}},
+			startPKValue:        []string{"A", "1"},
+			expectedHasRows:     true,
+			expectedBoundsStart: []string{"B", "2"},
+			expectedBoundsEnd:   []string{"B", "2"},
+		},
+		{
+			desc:                "start key = table value",
+			tablePKValues:       [][]string{{"A", "1"}},
+			startPKValue:        []string{"A", "1"},
+			expectedHasRows:     true,
+			expectedBoundsStart: []string{"A", "1"},
+			expectedBoundsEnd:   []string{"A", "1"},
+		},
+		{
+			desc:            "start key > table value",
+			tablePKValues:   [][]string{{"A", "1"}},
+			startPKValue:    []string{"B", "2"},
+			expectedHasRows: false,
+		},
+		{
+			desc:            "end key < table value",
+			tablePKValues:   [][]string{{"B", "2"}},
+			endPKValue:      []string{"A", "1"},
+			expectedHasRows: false,
+		},
+		{
+			desc:            "end key = table value",
+			tablePKValues:   [][]string{{"A", "1"}},
+			endPKValue:      []string{"A", "1"},
+			expectedHasRows: false,
+		},
+		{
+			desc:                "end key > table value",
+			tablePKValues:       [][]string{{"A", "1"}},
+			endPKValue:          []string{"B", "2"},
+			expectedHasRows:     true,
+			expectedBoundsStart: []string{"A", "1"},
+			expectedBoundsEnd:   []string{"A", "1"},
+		},
+		{
+			desc:                "start key between values",
+			tablePKValues:       [][]string{{"A", "1"}, {"B", "2"}, {"D", "4"}, {"E", "5"}},
+			startPKValue:        []string{"C", "3"},
+			expectedHasRows:     true,
+			expectedBoundsStart: []string{"D", "4"},
+			expectedBoundsEnd:   []string{"E", "5"},
+		},
+		{
+			desc:                "end key between values",
+			tablePKValues:       [][]string{{"A", "1"}, {"B", "2"}, {"D", "4"}, {"E", "5"}},
+			endPKValue:          []string{"C", "3"},
+			expectedHasRows:     true,
+			expectedBoundsStart: []string{"A", "1"},
+			expectedBoundsEnd:   []string{"B", "2"},
+		},
+		{
+			desc:                 "truncated start key",
+			tablePKValues:        [][]string{{"A", "1"}, {"B", "2"}, {"C", "3"}},
+			startPKValue:         []string{"B", "2"},
+			truncateStartPKValue: true,
+			expectedHasRows:      true,
+			expectedBoundsStart:  []string{"B", "2"},
+			expectedBoundsEnd:    []string{"C", "3"},
+		},
+		{
+			desc:                "truncated end key",
+			tablePKValues:       [][]string{{"A", "1"}, {"B", "2"}, {"C", "3"}},
+			endPKValue:          []string{"B", "2"},
+			truncateEndPKValue:  true,
+			expectedHasRows:     true,
+			expectedBoundsStart: []string{"A", "1"},
+			expectedBoundsEnd:   []string{"A", "1"},
+		},
+	}
+
+	// Test with different column families, since this affects how the primary
+	// key gets encoded.
+	familyClauses := []string{
+		"",
+		"FAMILY (a, b), FAMILY (c),",
+		"FAMILY (c), FAMILY (a, b),",
+		"FAMILY (a), FAMILY (b), FAMILY (c),",
+	}
+
+	for _, tc := range testCases {
+		for _, families := range familyClauses {
+			t.Run(tc.desc, func(t *testing.T) {
+
+				const tableName = "tbl"
+				ctx := context.Background()
+				srv, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+				defer srv.Stopper().Stop(ctx)
+				codec := srv.ApplicationLayer().Codec()
+
+				sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
+
+				// Create table.
+				sqlRunner.Exec(t, fmt.Sprintf(`
+				CREATE TABLE %s (
+					a string,
+					b string COLLATE en_US_u_ks_level2,
+					c STRING,
+					%s
+					PRIMARY KEY(a,b)
+				)`, tableName, families))
+
+				// Insert tablePKValues into table.
+				if len(tc.tablePKValues) > 0 {
+					insertValues := ""
+					for i, val := range tc.tablePKValues {
+						if i > 0 {
+							insertValues += ", "
+						}
+						insertValues += "('" + strings.Join(val, "','") + "')"
+					}
+					sqlRunner.Exec(t, fmt.Sprintf("INSERT INTO %s VALUES %s", tableName, insertValues))
+				}
+
+				// Get table descriptor.
+				tableDesc := desctestutils.TestingGetPublicTableDescriptor(
+					kvDB,
+					codec,
+					"defaultdb", /* database */
+					tableName,
+				)
+				primaryIndexDesc := tableDesc.GetPrimaryIndex().IndexDesc()
+				pkColIDs := catalog.TableColMap{}
+				for i, id := range primaryIndexDesc.KeyColumnIDs {
+					pkColIDs.Set(id, i)
+				}
+				pkColTypes, err := ttljob.GetPKColumnTypes(tableDesc, primaryIndexDesc)
+				require.NoError(t, err)
+				pkColDirs := primaryIndexDesc.KeyColumnDirections
+
+				var alloc tree.DatumAlloc
+				primaryIndexSpan := tableDesc.PrimaryIndexSpan(codec)
+
+				createKey := func(pkValue []string, truncateKey bool, defaultKey roachpb.Key) roachpb.Key {
+					if len(pkValue) == 0 {
+						return defaultKey
+					}
+					require.Equal(t, 2, len(pkValue))
+					dString := tree.NewDString(pkValue[0])
+					dCollatedString, err := alloc.NewDCollatedString(pkValue[1], "en_US_u_ks_level2")
+					require.NoError(t, err)
+
+					keyValues := replicationtestutils.EncodeKVs(t, codec, tableDesc, dString, dCollatedString)
+					key := keyValues[0].Key
+					if truncateKey {
+						key = key[:len(key)-3]
+						kvKeyValues := make([]kv.KeyValue, len(keyValues))
+						for i := range keyValues {
+							kvKeyValues[i] = kv.KeyValue{Key: key, Value: &keyValues[i].Value}
+						}
+						// Ensure truncated key cannot be decoded.
+						_, err = rowenc.DecodeIndexKeyToDatums(codec, pkColIDs, pkColTypes, pkColDirs, kvKeyValues, &alloc)
+						require.ErrorContainsf(t, err, "did not find terminator 0x0 in buffer", "pkValue=%s", pkValue)
+					}
+					return key
+				}
+
+				// Create keys for test.
+				startKey := createKey(tc.startPKValue, tc.truncateStartPKValue, primaryIndexSpan.Key)
+				endKey := createKey(tc.endPKValue, tc.truncateEndPKValue, primaryIndexSpan.EndKey)
+
+				// Run test function.
+				actualBounds, actualHasRows, err := ttljob.SpanToQueryBounds(
+					ctx, kvDB, codec, pkColIDs, pkColTypes, pkColDirs, tableDesc.NumFamilies(),
+					roachpb.Span{
+						Key:    startKey,
+						EndKey: endKey,
+					},
+					&alloc,
+				)
+
+				// Verify results.
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedHasRows, actualHasRows)
+				if actualHasRows {
+					actualBoundsStart := []string{
+						string(*actualBounds.Start[0].(*tree.DString)),
+						actualBounds.Start[1].(*tree.DCollatedString).Contents,
+					}
+					require.Equalf(t, tc.expectedBoundsStart, actualBoundsStart, "start")
+					actualBoundsEnd := []string{
+						string(*actualBounds.End[0].(*tree.DString)),
+						actualBounds.End[1].(*tree.DCollatedString).Contents,
+					}
+					require.Equalf(t, tc.expectedBoundsEnd, actualBoundsEnd, "end")
+				}
+			})
+		}
 	}
 }

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -571,10 +572,13 @@ func TestRowLevelTTLJobRandomEntries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderDuress(t, "this test is very slow")
+
 	rng, _ := randutil.NewTestRand()
 
+	collatedStringType := types.MakeCollatedString(types.String, "en" /* locale */)
 	var indexableTyps []*types.T
-	for _, typ := range types.Scalar {
+	for _, typ := range append(types.Scalar, collatedStringType) {
 		// TODO(#76419): DateFamily has a broken `-infinity` case.
 		// TODO(#99432): JsonFamily has broken cases. This is because the test is wrapping JSON
 		//   objects in multiple single quotes which causes parsing errors.
@@ -737,8 +741,29 @@ func TestRowLevelTTLJobRandomEntries(t *testing.T) {
 			},
 		},
 	}
-	// Also randomly generate random PKs.
+	// Also randomly generate random PKs and families.
+	generateFamilyClauses := func(colNames []string) string {
+		familyClauses := strings.Builder{}
+		numFamilies := rng.Intn(len(colNames))
+		for fam := 0; fam < numFamilies && len(colNames) > 0; fam++ {
+			rng.Shuffle(len(colNames), func(i, j int) {
+				colNames[i], colNames[j] = colNames[j], colNames[i]
+			})
+			familySize := 1 + rng.Intn(len(colNames))
+			familyClauses.WriteString(fmt.Sprintf("FAMILY fam%d (", fam))
+			for col := 0; col < familySize; col++ {
+				if col > 0 {
+					familyClauses.WriteString(", ")
+				}
+				familyClauses.WriteString(colNames[col])
+			}
+			colNames = colNames[familySize:]
+			familyClauses.WriteString("), ")
+		}
+		return familyClauses.String()
+	}
 	for i := 0; i < 5; i++ {
+		familyClauses := generateFamilyClauses([]string{"id", "rand_col_1", "rand_col_2", "t", "i"})
 		testCases = append(
 			testCases,
 			testCase{
@@ -748,11 +773,14 @@ func TestRowLevelTTLJobRandomEntries(t *testing.T) {
 	id UUID DEFAULT gen_random_uuid(),
 	rand_col_1 %s,
 	rand_col_2 %s,
-	text TEXT,
+	t TEXT NULL,
+	i INT8 NULL,
+	%s
 	PRIMARY KEY (id, rand_col_1, rand_col_2)
 ) WITH (ttl_expire_after = '30 days', ttl_select_batch_size = %d, ttl_delete_batch_size = %d)`,
 					randgen.RandTypeFromSlice(rng, indexableTyps).SQLString(),
 					randgen.RandTypeFromSlice(rng, indexableTyps).SQLString(),
+					familyClauses,
 					1+rng.Intn(100),
 					1+rng.Intn(100),
 				),
@@ -778,10 +806,15 @@ func TestRowLevelTTLJobRandomEntries(t *testing.T) {
 				lexbase.EncodeRestrictedSQLIdent(&b, string(def.Name), lexbase.EncNoFlags)
 				insertColumns = append(insertColumns, b.String())
 
-				d := randgen.RandDatum(rng, def.Type.(*types.T), false /* nullOk */)
-				f := tree.NewFmtCtx(tree.FmtBareStrings)
-				d.Format(f)
-				values = append(values, f.CloseAndGetString())
+				nullOK := def.Nullable.Nullability == tree.Null
+				d := randgen.RandDatum(rng, def.Type.(*types.T), nullOK)
+				if d == tree.DNull {
+					values = append(values, nil)
+				} else {
+					f := tree.NewFmtCtx(tree.FmtBareStrings)
+					d.Format(f)
+					values = append(values, f.CloseAndGetString())
+				}
 			}
 		}
 


### PR DESCRIPTION
Backport 2/2 commits from #116988 and #117510

/cc @cockroachdb/release

Release justification: high priority bug fix

---

Certain types, like decimals and collated strings, store their contents in the value of the encoded KeyValue. The ttljob code that decodes the span bounds into datums for the purpose of creating SQL query bounds previously did not take this into account.

fixes https://github.com/cockroachdb/cockroach/issues/116845
Release note (bug fix): Fixed a bug in the row-level TTL job that would
cause it to skip expired rows if the primary key of the table included
columns of the collated string type. This bug was present since the
initial release of row-level TTL in v22.2.0.
