### PR TITLE
logmetrics: code/cruft cleanup of LogMetricsRegistry

### DIFF
--- a/pkg/util/log/logmetrics/BUILD.bazel
+++ b/pkg/util/log/logmetrics/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/util/log",
         "//pkg/util/metric",
-        "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_prometheus_client_model//go",
     ],
@@ -21,7 +20,6 @@ go_test(
     deps = [
         "//pkg/util/leaktest",
         "//pkg/util/log",
-        "//pkg/util/metric",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/log/logmetrics/metrics.go
+++ b/pkg/util/log/logmetrics/metrics.go
@@ -13,50 +13,49 @@ package logmetrics
 import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
-	"github.com/prometheus/client_model/go"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 )
 
 var (
-	// logMetricsReg is a singleton instance of the LogMetricsRegistry.
+	// logMetricsReg is a singleton instance of the logMetricsRegistry.
 	logMetricsReg          = newLogMetricsRegistry()
-	FluentSinkConnAttempts = metric.Metadata{
+	fluentSinkConnAttempts = metric.Metadata{
 		Name:        "log.fluent.sink.conn.attempts",
 		Help:        "Number of connection attempts experienced by fluent-server logging sinks",
 		Measurement: "Attempts",
 		Unit:        metric.Unit_COUNT,
 		MetricType:  io_prometheus_client.MetricType_COUNTER,
 	}
-	FluentSinkConnErrors = metric.Metadata{
+	fluentSinkConnErrors = metric.Metadata{
 		Name:        "log.fluent.sink.conn.errors",
 		Help:        "Number of connection errors experienced by fluent-server logging sinks",
 		Measurement: "Errors",
 		Unit:        metric.Unit_COUNT,
 		MetricType:  io_prometheus_client.MetricType_COUNTER,
 	}
-	FluentSinkWriteAttempts = metric.Metadata{
+	fluentSinkWriteAttempts = metric.Metadata{
 		Name:        "log.fluent.sink.write.attempts",
 		Help:        "Number of write attempts experienced by fluent-server logging sinks",
 		Measurement: "Attempts",
 		Unit:        metric.Unit_COUNT,
 		MetricType:  io_prometheus_client.MetricType_COUNTER,
 	}
-	FluentSinkWriteErrors = metric.Metadata{
+	fluentSinkWriteErrors = metric.Metadata{
 		Name:        "log.fluent.sink.write.errors",
 		Help:        "Number of write errors experienced by fluent-server logging sinks",
 		Measurement: "Errors",
 		Unit:        metric.Unit_COUNT,
 		MetricType:  io_prometheus_client.MetricType_COUNTER,
 	}
-	BufferedSinkMessagesDropped = metric.Metadata{
+	bufferedSinkMessagesDropped = metric.Metadata{
 		Name:        "log.buffered.messages.dropped",
 		Help:        "Count of log messages that are dropped by buffered log sinks. When CRDB attempts to buffer a log message in a buffered log sink whose buffer is already full, it drops the oldest buffered messages to make space for the new message",
 		Measurement: "Messages",
 		Unit:        metric.Unit_COUNT,
 		MetricType:  io_prometheus_client.MetricType_COUNTER,
 	}
-	LogMessageCount = metric.Metadata{
+	logMessageCount = metric.Metadata{
 		Name:        "log.messages.count",
 		Help:        "Count of messages logged on the node since startup. Note that this does not measure the fan-out of single log messages to the various configured logging sinks.",
 		Measurement: "Messages",
@@ -65,110 +64,64 @@ var (
 	}
 )
 
-// Inject our singleton LogMetricsRegistry into the logging
+// Inject our singleton logMetricsRegistry into the logging
 // package. This ensures that the LogMetrics implementation within the
 // log package is always defined. This should only be called once from
 // a single init function.
 //
 // Since the primary user of the eventual metric.Registry's that come
-// from LogMetricsRegistry is the MetricsRecorder, we trigger this
+// from logMetricsRegistry is the MetricsRecorder, we trigger this
 // init function via an import in pkg/util/log/logmetrics/metrics.go.
 func init() {
 	log.SetLogMetrics(logMetricsReg)
 }
 
-// logMetricsStruct is a struct used to contain all metrics
-// tracked by the LogMetricsRegistry. This container is necessary
-// to register all the metrics with the Registry internal to the
-// LogMetricsRegistry.
-//
-// NB: If adding metrics to this struct, be sure to also add in
-// (*LogMetricsRegistry).registerCounters
-type logMetricsStruct struct {
-	FluentSinkConnAttempts      *metric.Counter
-	FluentSinkConnErrors        *metric.Counter
-	FluentSinkWriteAttempts     *metric.Counter
-	FluentSinkWriteErrors       *metric.Counter
-	BufferedSinkMessagesDropped *metric.Counter
-	LogMessageCount             *metric.Counter
-}
-
-// LogMetricsRegistry is a log.LogMetrics implementation used in the
+// logMetricsRegistry is a log.LogMetrics implementation used in the
 // logging package to give it access to metrics without introducing a
 // circular dependency.
 //
-// All metrics meant to be available to the logging package must be
-// registered at the time of initialization.
-//
-// LogMetricsRegistry is thread-safe.
-type LogMetricsRegistry struct {
-	// metricsStruct holds the same metrics as the below structures, but
-	// provides an easy way to inject them into metric.Registry's on demand
-	// in NewRegistry().
-	metricsStruct logMetricsStruct
-	mu            struct {
-		syncutil.Mutex
-		counters []*metric.Counter
-	}
+// logMetricsRegistry is thread-safe.
+type logMetricsRegistry struct {
+	// counters contains references to all the counters tracked by logMetricsRegistry,
+	// indexed by the log.Metric type.
+	counters []*metric.Counter
 }
 
-var _ log.LogMetrics = (*LogMetricsRegistry)(nil)
+var _ log.LogMetrics = (*logMetricsRegistry)(nil)
 
-func newLogMetricsRegistry() *LogMetricsRegistry {
-	registry := &LogMetricsRegistry{}
-	registry.registerCounters()
-	return registry
-}
-
-func (l *LogMetricsRegistry) registerCounters() {
-	l.mu.counters = make([]*metric.Counter, len(log.Metrics))
-	// Create the metrics struct for us to add to registries as they're
-	// requested.
-	l.metricsStruct = logMetricsStruct{
-		FluentSinkConnAttempts:      metric.NewCounter(FluentSinkConnAttempts),
-		FluentSinkConnErrors:        metric.NewCounter(FluentSinkConnErrors),
-		FluentSinkWriteAttempts:     metric.NewCounter(FluentSinkWriteAttempts),
-		FluentSinkWriteErrors:       metric.NewCounter(FluentSinkWriteErrors),
-		BufferedSinkMessagesDropped: metric.NewCounter(BufferedSinkMessagesDropped),
-		LogMessageCount:             metric.NewCounter(LogMessageCount),
-	}
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	// Be sure to also add the metrics to our internal store, for
-	// recall in functions such as IncrementCounter.
-	l.mu.counters[log.FluentSinkConnectionAttempt] = l.metricsStruct.FluentSinkConnAttempts
-	l.mu.counters[log.FluentSinkConnectionError] = l.metricsStruct.FluentSinkConnErrors
-	l.mu.counters[log.FluentSinkWriteAttempt] = l.metricsStruct.FluentSinkWriteAttempts
-	l.mu.counters[log.FluentSinkWriteError] = l.metricsStruct.FluentSinkWriteErrors
-	l.mu.counters[log.BufferedSinkMessagesDropped] = l.metricsStruct.BufferedSinkMessagesDropped
-	l.mu.counters[log.LogMessageCount] = l.metricsStruct.LogMessageCount
-	for _, c := range l.mu.counters {
-		if c == nil {
-			panic(errors.AssertionFailedf("Failed to register log metric in LogMetricsRegistry"))
-		}
+func newLogMetricsRegistry() *logMetricsRegistry {
+	return &logMetricsRegistry{
+		counters: []*metric.Counter{
+			log.FluentSinkConnectionAttempt: metric.NewCounter(fluentSinkConnAttempts),
+			log.FluentSinkConnectionError:   metric.NewCounter(fluentSinkConnErrors),
+			log.FluentSinkWriteAttempt:      metric.NewCounter(fluentSinkWriteAttempts),
+			log.FluentSinkWriteError:        metric.NewCounter(fluentSinkWriteErrors),
+			log.BufferedSinkMessagesDropped: metric.NewCounter(bufferedSinkMessagesDropped),
+			log.LogMessageCount:             metric.NewCounter(logMessageCount),
+		},
 	}
 }
 
 // NewRegistry initializes and returns a new metric.Registry, populated with metrics
-// tracked by the LogMetricsRegistry. While the metrics tracked by the logmetrics package
+// tracked by the logMetricsRegistry. While the metrics tracked by the logmetrics package
 // are global, they may be shared by multiple servers, test servers, etc. Therefore, we
 // need the means to label the metrics separately depending on the server, tenant, etc.
 // serving them. For this reason, we provide the ability to track the same log metrics
 // across multiple registries.
 func NewRegistry() *metric.Registry {
 	if logMetricsReg == nil {
-		panic(errors.AssertionFailedf("LogMetricsRegistry was not initialized"))
+		panic(errors.AssertionFailedf("logMetricsRegistry was not initialized"))
 	}
 	reg := metric.NewRegistry()
-	reg.AddMetricStruct(logMetricsReg.metricsStruct)
+	for _, c := range logMetricsReg.counters {
+		reg.AddMetric(c)
+	}
 	return reg
 }
 
-// IncrementCounter increments thegi Counter held by the given alias. If a log.MetricName
-// is provided as an argument, but is not registered with the LogMetricsRegistry, this function
+// IncrementCounter increments the Counter held by the given log.Metric type. If a log.Metric
+// is provided as an argument, but is not registered with the logMetricsRegistry, this function
 // panics.
-func (l *LogMetricsRegistry) IncrementCounter(metric log.Metric, amount int64) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.mu.counters[metric].Inc(amount)
+func (l *logMetricsRegistry) IncrementCounter(metric log.Metric, amount int64) {
+	l.counters[metric].Inc(amount)
 }

--- a/pkg/util/log/logmetrics/metrics_test.go
+++ b/pkg/util/log/logmetrics/metrics_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,33 +23,17 @@ func TestIncrementCounter(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	l := newLogMetricsRegistry()
-
-	metrics := map[log.Metric]*metric.Counter{
-		log.FluentSinkConnectionAttempt: l.metricsStruct.FluentSinkConnAttempts,
-		log.FluentSinkConnectionError:   l.metricsStruct.FluentSinkConnErrors,
-		log.FluentSinkWriteAttempt:      l.metricsStruct.FluentSinkWriteAttempts,
-		log.FluentSinkWriteError:        l.metricsStruct.FluentSinkWriteErrors,
-		log.BufferedSinkMessagesDropped: l.metricsStruct.BufferedSinkMessagesDropped,
-		log.LogMessageCount:             l.metricsStruct.LogMessageCount,
+	metrics := l.counters
+	for _, m := range metrics {
+		require.Zero(t, m.Count())
 	}
-	func() {
-		l.mu.Lock()
-		defer l.mu.Unlock()
-		for _, m := range metrics {
-			require.Zero(t, m.Count())
-		}
-	}()
-	for m := range metrics {
-		l.IncrementCounter(m, 1)
-		l.IncrementCounter(m, 2)
+	for i := range metrics {
+		l.IncrementCounter(log.Metric(i), 1)
+		l.IncrementCounter(log.Metric(i), 2)
 	}
-	func() {
-		l.mu.Lock()
-		defer l.mu.Unlock()
-		for _, m := range metrics {
-			require.Equal(t, int64(3), m.Count())
-		}
-	}()
+	for _, m := range l.counters {
+		require.Equal(t, int64(3), m.Count())
+	}
 }
 
 func TestNewRegistry(t *testing.T) {
@@ -60,15 +43,9 @@ func TestNewRegistry(t *testing.T) {
 	t.Run("panics when logMetricsReg is nil", func(t *testing.T) {
 		logMetricsReg = nil
 		require.PanicsWithErrorf(t,
-			"LogMetricsRegistry was not initialized",
+			"logMetricsRegistry was not initialized",
 			func() {
 				_ = NewRegistry()
 			}, "expected NewRegistry() to panic with nil logMetricsReg package-level var")
 	})
 }
-
-type fakeLogMetrics struct{}
-
-func (*fakeLogMetrics) IncrementCounter(_ log.Metric, _ int64) {}
-
-var _ log.LogMetrics = (*fakeLogMetrics)(nil)

--- a/pkg/util/log/metric.go
+++ b/pkg/util/log/metric.go
@@ -33,12 +33,8 @@ type LogMetrics interface {
 }
 
 // Metric is the enum representation of each metric supported within the log package.
-// NB: When adding a metric here, be sure to add to log.Metrics below.
 // NB: The metric also needs to be added to pkg/util/log/logmetrics, where we
 // need to register the metric and define its metadata.
-//
-// We use an enum representation as an optimization within LogMetrics implementations
-// when doing lookups for underlying metric counters.
 type Metric int
 
 const (
@@ -49,12 +45,3 @@ const (
 	BufferedSinkMessagesDropped
 	LogMessageCount
 )
-
-var Metrics = []Metric{
-	FluentSinkConnectionAttempt,
-	FluentSinkConnectionError,
-	FluentSinkWriteAttempt,
-	FluentSinkWriteError,
-	BufferedSinkMessagesDropped,
-	LogMessageCount,
-}


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/117502

The LogMetricsRegistry had a few unsightly bits to its code that deserved some cleanup. Among these are:

1. Unnecessary `logMetricsStruct` variable. This was likely added due to me missing the fact that you can add individual metrics to a `metric.Registry` using `.AddMetric()`, meaning we don't need a separate struct to use for the `.AddMetricsStruct()` function.
2. Unnecessary mutex guarding the list of counters tracked by LogMetricsRegistry. The underlying counters are backed by atomic integers, and we never modify the set of counters after initialization, meaning this mutex is unneeded.
3. Adding a new metric requires a developer to update many places. The more places that need to be touched, the more opportunity there are for mistakes.

This patch aims to clean up the items mentioned above.

Release note: none

Epic: CRDB-21266