### PR TITLE
streamingccl: don't complete producer job on cutover

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -263,7 +263,6 @@ func (c *TenantStreamingClusters) Cutover(
 
 	if !async {
 		jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
-		jobutils.WaitForJobToSucceed(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 	}
 }
 

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
@@ -343,9 +343,9 @@ INSERT INTO d.t2 VALUES (2);
 	require.True(t, testutils.IsError(err, "job with ID 999 does not exist"), err)
 
 	// Makes producer job exit quickly.
-	h.SysSQL.Exec(t, `
-SET CLUSTER SETTING stream_replication.stream_liveness_track_frequency = '200ms';
-`)
+	h.SysSQL.ExecMultiple(t, `
+SET CLUSTER SETTING stream_replication.stream_liveness_track_frequency = '200ms'`,
+		`SET CLUSTER SETTING stream_replication.job_liveness_timeout = '100ms'`)
 	rps, err = client.Create(ctx, testTenantName, streampb.ReplicationProducerRequest{})
 	require.NoError(t, err)
 	streamID = rps.StreamID

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -562,14 +562,13 @@ func TestCompleteStreamReplication(t *testing.T) {
 	// Make the producer job times out fast and fastly tracks ingestion cutover signal.
 	h.SysSQL.ExecMultiple(t,
 		"SET CLUSTER SETTING stream_replication.job_liveness.timeout = '2s';",
-		"SET CLUSTER SETTING stream_replication.stream_liveness_track_frequency = '2s';")
+		"SET CLUSTER SETTING stream_replication.stream_liveness_track_frequency = '2s';",
+		"SET CLUSTER SETTING stream_replication.job_liveness_timeout = '3s'")
 
 	replicationProducerSpec := h.StartReplicationStream(t, testTenantName)
 	timedOutStreamID := replicationProducerSpec.StreamID
 	jobutils.WaitForJobToFail(t, h.SysSQL, jobspb.JobID(timedOutStreamID))
 
-	// Makes the producer job not easily time out.
-	h.SysSQL.Exec(t, "SET CLUSTER SETTING stream_replication.job_liveness.timeout = '10m';")
 	testCompleteStreamReplication := func(t *testing.T, successfulIngestion bool) {
 		// Verify no error when completing a timed out replication stream.
 		h.SysSQL.Exec(t, "SELECT crdb_internal.complete_replication_stream($1, $2)",


### PR DESCRIPTION
Previously on cutover, the producer job would complete, removing the producer
side protected timestamp. To ensure a smooth fast failback to any timestamp
greater or equal to the cutover timestamp, however, the original producer side
should keep the pts around.

This patch retains the producer side timestamp by delaying the completion of
the producer job until `stream_replication.job_liveness_timeout` (default 3
days) elapses after the final heartbeat during the replication job. A future PR
will deprecate this setting and allow users to directly set this producer side
retention period.

Epic: none

Release note: none