### PR TITLE
changefeedccl: fix npe for nil metrics on aggregator shutdown

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -597,7 +597,12 @@ func (ca *changeAggregator) close() {
 		_ = ca.sink.Close()
 	}
 
-	ca.closeMetrics()
+	// The sliMetrics registry may hold on to some state for each aggregator
+	// (ex. last known resolved timestamp). De-register the aggregator so this
+	// data is deleted and not included in metrics.
+	if ca.sliMetrics != nil {
+		ca.sliMetrics.closeId(ca.sliMetricsID)
+	}
 
 	ca.memAcc.Close(ca.Ctx())
 
@@ -883,12 +888,6 @@ func (ca *changeAggregator) emitResolved(batch jobspb.ResolvedSpans) error {
 
 	ca.recentKVCount = 0
 	return nil
-}
-
-// closeMetrics de-registers the aggregator from the sliMetrics registry so that
-// it's no longer considered by the aggregator_progress gauge
-func (ca *changeAggregator) closeMetrics() {
-	ca.sliMetrics.closeId(ca.sliMetricsID)
 }
 
 // ConsumerClosed is part of the RowSource interface.


### PR DESCRIPTION
Previously, if a change aggregator shut down before it initialized metrics, the aggregator would encournter an NPE when trying to close metrics upon shutdown. This change fixes that by adding a nil check.

Release note: None
Epic: None
Closes: https://github.com/cockroachdb/cockroach/issues/117474
Closes: https://github.com/cockroachdb/cockroach/issues/117313