### PR TITLE
roachtest: fail the latency verifier immediately if latency is too high

### DIFF
--- a/pkg/cmd/roachtest/tests/latency_verifier.go
+++ b/pkg/cmd/roachtest/tests/latency_verifier.go
@@ -181,6 +181,10 @@ func (lv *latencyVerifier) pollLatencyUntilJobSucceeds(
 			lv.logger.Printf("unexpected status: %s, error: %s", status, info.GetError())
 			return errors.Errorf("unexpected status: %s", status)
 		}
+		if lv.targetSteadyLatency != 0 && lv.maxSeenSteadyLatency > lv.targetSteadyLatency {
+			return errors.Errorf("max latency was more than allowed: %s vs %s",
+				lv.maxSeenSteadyLatency, lv.targetSteadyLatency)
+		}
 	}
 }
 


### PR DESCRIPTION
Previously, the latency verifier used by c2c and cdc roachtests would not fail immediately if latency was too high. This patch fails the latency verifier immediately, as the roachtest is going to eventually fail anyway.

In addition, immediately after a latency verifier failure, this patch captures c2c debug zips to better understand the cause of the increased latency.

Fixes #117182

Release note: none