### PR TITLE
catalog/lease: Fix race condition inside TestSessionLeasingTable

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3490,7 +3490,8 @@ func TestSessionLeasingTable(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 	runner := sqlutils.MakeSQLRunner(sqlDB)
 
-	executor := srv.InternalExecutor().(isql.Executor)
+	idb := srv.InternalDB().(isql.DB)
+	executor := idb.Executor()
 	// Insert using a synthetic descriptor.
 	err := executor.WithSyntheticDescriptors(catalog.Descriptors{systemschema.LeaseTable_V24_1()}, func() error {
 		_, err := executor.Exec(ctx, "add-rows-for-test", nil,


### PR DESCRIPTION
Previously, TestSessionLeasingTable could run into a race condition because it used an internal executor that is shared within the server and setting the synthetic descriptors is not a thread safe operation (leading to a race condition for other users of this internal executor). To address this, this patch will create a new internal executor and modify it to set the synthetic descriptors for validating inserts with the session based format.

Epic: none
Fixes: #117390

Release note: None