### PR TITLE
server: take locality-addr into account for connHealth

### DIFF
--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -368,6 +368,8 @@ message NodeDescriptor {
   option (gogoproto.equal) = true;
   optional int32 node_id = 1 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "NodeID", (gogoproto.casttype) = "NodeID"];
+  // Address can not be used directly for dialing a node. It doesn't take into
+  // account the locality addresses. Use gossip.GetNodeIDAddress instead.
   optional util.UnresolvedAddr address = 2 [(gogoproto.nullable) = false];
   optional Attributes attrs = 3 [(gogoproto.nullable) = false];
   optional Locality locality = 4 [(gogoproto.nullable) = false];

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2031,7 +2031,13 @@ func (s *systemStatusServer) NetworkConnectivity(
 				peer.Error = errors.UnwrapAll(err).Error()
 				continue
 			}
-			if err = s.rpcCtx.ConnHealth(node.Address.AddressField, node.NodeID, rpc.SystemClass); err != nil {
+			addr, err := s.gossip.GetNodeIDAddress(targetNodeId)
+			if err != nil {
+				peer.Status = serverpb.NetworkConnectivityResponse_UNKNOWN
+				peer.Error = errors.UnwrapAll(err).Error()
+				continue
+			}
+			if err = s.rpcCtx.ConnHealth(addr.String(), targetNodeId, rpc.SystemClass); err != nil {
 				if errors.Is(rpc.ErrNotHeartbeated, err) {
 					peer.Status = serverpb.NetworkConnectivityResponse_ESTABLISHING
 				} else {
@@ -2041,7 +2047,7 @@ func (s *systemStatusServer) NetworkConnectivity(
 			} else {
 				peer.Status = serverpb.NetworkConnectivityResponse_ESTABLISHED
 			}
-			peer.Address = node.Address.AddressField
+			peer.Address = addr.String()
 			peer.Locality = &node.Locality
 
 			peers[targetNodeId] = peer

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1171,6 +1171,7 @@ func makeTenantSQLServerArgs(
 	if err != nil {
 		return sqlServerArgs{}, err
 	}
+	// TODO(baptist): This call does not take into account locality addresses.
 	resolver := kvtenant.AddressResolver(tenantConnect)
 	kvNodeDialer := nodedialer.New(rpcContext, resolver)
 


### PR DESCRIPTION
Previously the connHealth was always using the nodes address field. This did not work correctly if there was a locality address defined.

Fixes: #117418

Release note: None