### PR TITLE
multitenant: check service mode during authorization

### DIFF
--- a/pkg/multitenant/tenantcapabilities/interfaces.go
+++ b/pkg/multitenant/tenantcapabilities/interfaces.go
@@ -24,8 +24,12 @@ import (
 // Reader provides access to the global tenant capability state. The global
 // tenant capability state may be arbitrarily stale.
 type Reader interface {
+	// GetInfo returns the tenant information for the specified tenant.
+	GetInfo(id roachpb.TenantID) (_ Entry, _ <-chan struct{}, found bool)
+
 	// GetCapabilities returns the tenant capabilities for the specified tenant.
 	GetCapabilities(id roachpb.TenantID) (_ *tenantcapabilitiespb.TenantCapabilities, found bool)
+
 	// GetGlobalCapabilityState returns the capability state for all tenants.
 	GetGlobalCapabilityState() map[roachpb.TenantID]*tenantcapabilitiespb.TenantCapabilities
 }

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/BUILD.bazel
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/BUILD.bazel
@@ -11,8 +11,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvpb",
+        "//pkg/multitenant/mtinfopb",
         "//pkg/multitenant/tenantcapabilities",
-        "//pkg/multitenant/tenantcapabilities/tenantcapabilitiespb",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/authorizer_enabled
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/authorizer_enabled
@@ -81,3 +81,30 @@ client tenant does not have capability to query cluster node metadata
 has-tsdb-query-capability ten=10
 ----
 client tenant does not have capability to query timeseries data
+
+# Set the service state to none and make sure we can't send a batch.
+upsert ten=10 can_admin_scatter=false can_admin_split=false can_view_node_info=false can_view_tsdb_metrics=false service=none
+----
+ok
+
+has-capability-for-batch ten=10 cmds=(Scan)
+----
+operation not allowed when in service mode "none"
+
+# Set the service state to externa and make sure we can send a batch.
+upsert ten=10 can_admin_scatter=false can_admin_split=false can_view_node_info=false can_view_tsdb_metrics=false service=external
+----
+ok
+
+has-capability-for-batch ten=10 cmds=(Scan)
+----
+ok
+
+# Set the service state to externa and make sure we can send a batch.
+upsert ten=10 can_admin_scatter=false can_admin_split=false can_view_node_info=false can_view_tsdb_metrics=false service=shared
+----
+ok
+
+has-capability-for-batch ten=10 cmds=(Scan)
+----
+ok

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/system_tenant
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/system_tenant
@@ -24,3 +24,12 @@ ok
 has-capability-for-batch ten=system cmds=(AdminSplit)
 ----
 ok
+
+# service mode check does not apply to the system tenant.
+upsert ten=system can_admin_split=false service=none
+----
+ok
+
+has-capability-for-batch ten=system cmds=(AdminSplit)
+----
+ok

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher_test.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher_test.go
@@ -216,19 +216,19 @@ func TestDataDriven(t *testing.T) {
 
 			case "upsert":
 				t.Logf("%v: processing upsert", d.Pos)
-				tenID, caps, err := tenantcapabilitiestestutils.ParseTenantCapabilityUpsert(t, d)
+				entry, err := tenantcapabilitiestestutils.ParseTenantCapabilityUpsert(t, d)
 				require.NoError(t, err)
 				name, dataState, serviceMode, err := tenantcapabilitiestestutils.ParseTenantInfo(t, d)
 				require.NoError(t, err)
 				info := mtinfopb.ProtoInfo{
-					Capabilities: *caps,
+					Capabilities: *entry.TenantCapabilities,
 				}
 				buf, err := protoutil.Marshal(&info)
 				require.NoError(t, err)
 				tdb.Exec(
 					t,
 					fmt.Sprintf("UPSERT INTO %s (id, active, info, name, data_state, service_mode) VALUES ($1, $2, $3, $4, $5, $6)", dummyTableName),
-					tenID.ToUint64(),
+					entry.TenantID.ToUint64(),
 					true, /* active */
 					buf,
 					name, dataState, serviceMode,


### PR DESCRIPTION
When in service mode none, we do not expect to receive requests from
virtual cluster SQL nodes.

Note that during an `ALTER VIRTUAL CLUSTER <NAME> STOP SERVICE` we may
reject some requests from the graceful shutdown of a virtual cluster.
We are OK with this at the moment since service for a virtual cluster
is really only stopped if we expect to reset its data.

Epic: none

Release note: None