### PR TITLE
sql: fix erroneous benchmark regressions

### DIFF
--- a/pkg/sql/catalog/resolver/resolver_bench_test.go
+++ b/pkg/sql/catalog/resolver/resolver_bench_test.go
@@ -117,6 +117,7 @@ func BenchmarkResolveExistingObject(b *testing.B) {
 				require.NoError(b, err)
 				require.NotNil(b, desc)
 			}
+			b.StopTimer()
 		})
 	}
 }
@@ -208,6 +209,7 @@ func BenchmarkResolveFunction(b *testing.B) {
 				require.NoError(b, err)
 				require.NotNil(b, fd)
 			}
+			b.StopTimer()
 		})
 	}
 }

--- a/pkg/sql/colenc/bench_test.go
+++ b/pkg/sql/colenc/bench_test.go
@@ -134,6 +134,7 @@ func BenchmarkTCPHLineItem(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		err = enc.PrepareBatch(ctx, &noopPutter{}, 0, cb.Length())
 	}
+	b.StopTimer()
 	require.NoError(b, err)
 }
 

--- a/pkg/sql/opt/bench/fk_test.go
+++ b/pkg/sql/opt/bench/fk_test.go
@@ -49,6 +49,7 @@ func runFKBench(
 			setup(b, r, cfg.setupFKs)
 			b.ResetTimer()
 			run(b, r)
+			b.StopTimer()
 		})
 	}
 }

--- a/pkg/sql/plan_opt_test.go
+++ b/pkg/sql/plan_opt_test.go
@@ -629,6 +629,7 @@ func BenchmarkQueryCache(b *testing.B) {
 				b.Fatal(err)
 			}
 		}
+		b.StopTimer()
 	}
 
 	for workload, workloadName := range workloads {

--- a/pkg/sql/sequence_test.go
+++ b/pkg/sql/sequence_test.go
@@ -65,6 +65,7 @@ func BenchmarkSequenceIncrement(b *testing.B) {
 					b.Fatal(err)
 				}
 			})
+			b.StopTimer()
 		}
 		b.Run(fmt.Sprintf("Cache-%d-P-%d", cacheSize, parallelism), subBenchMark)
 	}


### PR DESCRIPTION
Several benchmarks incorrectly included cluster shutdown as part of the
benchmark timing. This caused major regressions in benchmarks
when #117116 was merged because it made cluster shutdown slower. The
benchmarks now stop the timer before initiating cluster shutdown to more
accurately measure the code in question.

Fixes #117494

Release note: None
