### PR TITLE
rpc: rm rangefeed RPC stream window special case

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1785,12 +1785,10 @@ func (rpcCtx *Context) dialOptsCommon(
 	dialOpts = append(dialOpts, grpc.WithDisableRetry())
 
 	// Configure the window sizes with optional env var overrides.
-	dialOpts = append(dialOpts, grpc.WithInitialConnWindowSize(rpcCtx.initialConnWindowSize(ctx)))
-	if class == RangefeedClass {
-		dialOpts = append(dialOpts, grpc.WithInitialWindowSize(rpcCtx.rangefeedInitialWindowSize(ctx)))
-	} else {
-		dialOpts = append(dialOpts, grpc.WithInitialWindowSize(rpcCtx.initialWindowSize(ctx)))
-	}
+	dialOpts = append(dialOpts,
+		grpc.WithInitialConnWindowSize(rpcCtx.initialConnWindowSize(ctx)),
+		grpc.WithInitialWindowSize(rpcCtx.initialWindowSize(ctx)),
+	)
 	unaryInterceptors := rpcCtx.clientUnaryInterceptors
 	unaryInterceptors = unaryInterceptors[:len(unaryInterceptors):len(unaryInterceptors)]
 	if rpcCtx.Knobs.UnaryClientInterceptor != nil {

--- a/pkg/rpc/settings.go
+++ b/pkg/rpc/settings.go
@@ -81,8 +81,6 @@ type windowSizeSettings struct {
 		initialWindowSize int32
 		// initialConnWindowSize is the initial window size for a connection.
 		initialConnWindowSize int32
-		// rangefeedInitialWindowSize is the initial window size for a RangeFeed RPC.
-		rangefeedInitialWindowSize int32
 	}
 }
 
@@ -94,8 +92,6 @@ func (s *windowSizeSettings) maybeInit(ctx context.Context) {
 		if s.values.initialConnWindowSize > maximumWindowSize {
 			s.values.initialConnWindowSize = maximumWindowSize
 		}
-		s.values.rangefeedInitialWindowSize = getWindowSize(ctx,
-			"COCKROACH_RANGEFEED_RPC_INITIAL_WINDOW_SIZE", RangefeedClass, 2*defaultWindowSize /* 128KB */)
 	})
 }
 
@@ -109,12 +105,6 @@ func (s *windowSizeSettings) initialWindowSize(ctx context.Context) int32 {
 func (s *windowSizeSettings) initialConnWindowSize(ctx context.Context) int32 {
 	s.maybeInit(ctx)
 	return s.values.initialConnWindowSize
-}
-
-// For a RangeFeed RPC.
-func (s *windowSizeSettings) rangefeedInitialWindowSize(ctx context.Context) int32 {
-	s.maybeInit(ctx)
-	return s.values.rangefeedInitialWindowSize
 }
 
 // sourceAddr is the environment-provided local address for outgoing


### PR DESCRIPTION
The rangefeed stream window size tuning was introduced to mitigate OOM in rangefeeds caused by the excessive number of streams (one per `Range`). Since we now use mux rangefeeds (which multiplexes all the rangefeed traffic into a single stream), this setting is no longer needed, so this commit removes it.

Part of #108992

Release note (ops change): `COCKROACH_RANGEFEED_RPC_INITIAL_WINDOW_SIZE` env variable has been removed, and rangefeed connection now uses the same window size as other RPC connections.