### PR TITLE
zip: explain redaction for span config boundary keys

### DIFF
--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -1236,7 +1236,13 @@ var zipSystemTables = DebugZipTableRegistry{
 	"system.span_configurations": {
 		nonSensitiveCols: NonSensitiveColumns{
 			"config",
+			// Boundary keys for span configs, which are derived from zone configs, are typically on
+			// metadata object boundaries (database, table, or index), and not arbitrary range boundaries
+			// and therefore do not contain sensitive information. Therefore they can remain unredacted.
 			"start_key",
+			// Boundary keys for span configs, which are derived from zone configs, are typically on
+			// metadata object boundaries (database, table, or index), and not arbitrary range boundaries
+			// and therefore do not contain sensitive information. Therefore they can remain unredacted.
 			"end_key",
 		},
 	},


### PR DESCRIPTION
Data deemed essential for debugging is considered acceptable to keep unredacted from a compliance perspective in dumps of debug data, such as a debug zip. Two instances where this applies are for range boundary keys, and span config boundary keys.

This isn't immediately obvious, so this patch adds a comment to the zip table registry for the `system.span_configurations` table to clarify why `start_key` and `end_key` are not considered sensitive.

Release note: none

Epic: CRDB-20791