### PR TITLE
util/log/logmetrics: simplify implementation

### DIFF
--- a/pkg/util/log/logmetrics/metrics_test.go
+++ b/pkg/util/log/logmetrics/metrics_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,33 +23,17 @@ func TestIncrementCounter(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	l := newLogMetricsRegistry()
-
-	metrics := map[log.Metric]*metric.Counter{
-		log.FluentSinkConnectionAttempt: l.metricsStruct.FluentSinkConnAttempts,
-		log.FluentSinkConnectionError:   l.metricsStruct.FluentSinkConnErrors,
-		log.FluentSinkWriteAttempt:      l.metricsStruct.FluentSinkWriteAttempts,
-		log.FluentSinkWriteError:        l.metricsStruct.FluentSinkWriteErrors,
-		log.BufferedSinkMessagesDropped: l.metricsStruct.BufferedSinkMessagesDropped,
-		log.LogMessageCount:             l.metricsStruct.LogMessageCount,
+	metrics := l.counters
+	for _, m := range metrics {
+		require.Zero(t, m.Count())
 	}
-	func() {
-		l.mu.Lock()
-		defer l.mu.Unlock()
-		for _, m := range metrics {
-			require.Zero(t, m.Count())
-		}
-	}()
-	for m := range metrics {
-		l.IncrementCounter(m, 1)
-		l.IncrementCounter(m, 2)
+	for i := range metrics {
+		l.IncrementCounter(log.Metric(i), 1)
+		l.IncrementCounter(log.Metric(i), 2)
 	}
-	func() {
-		l.mu.Lock()
-		defer l.mu.Unlock()
-		for _, m := range metrics {
-			require.Equal(t, int64(3), m.Count())
-		}
-	}()
+	for _, m := range metrics {
+		require.Equal(t, int64(3), m.Count())
+	}
 }
 
 func TestNewRegistry(t *testing.T) {
@@ -66,9 +49,3 @@ func TestNewRegistry(t *testing.T) {
 			}, "expected NewRegistry() to panic with nil logMetricsReg package-level var")
 	})
 }
-
-type fakeLogMetrics struct{}
-
-func (*fakeLogMetrics) IncrementCounter(_ log.Metric, _ int64) {}
-
-var _ log.LogMetrics = (*fakeLogMetrics)(nil)

--- a/pkg/util/log/metric.go
+++ b/pkg/util/log/metric.go
@@ -49,12 +49,3 @@ const (
 	BufferedSinkMessagesDropped
 	LogMessageCount
 )
-
-var Metrics = []Metric{
-	FluentSinkConnectionAttempt,
-	FluentSinkConnectionError,
-	FluentSinkWriteAttempt,
-	FluentSinkWriteError,
-	BufferedSinkMessagesDropped,
-	LogMessageCount,
-}


### PR DESCRIPTION
Simplify the `LogMetricsRegistry` implementation. Get rid of the
`logMetricsStruct` which was only adding complexity instead of making it
easier to register the log metrics. Get rid of `LogMetricsRegistry.mu`
which wasn't necessary because `metric.Counters` are internally
thread-safe and we never mutate the slice of counters after
creation. Get rid of `log.Metrics` which was only being used to
determine the number of log Metrics and instead rely on the index
slice-initialization technique to size `LogMetricsRegistry.counters`
correctly.

Epic: none
Release note: None
