### PR TITLE
release-23.2: sql: allow empty search path parameters

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -983,6 +983,7 @@ func newSessionData(args SessionArgs) *sessiondata.SessionData {
 			sd.CustomOptions[k] = v
 		}
 	}
+	sd.SearchPath = sessiondata.DefaultSearchPathForUser(sd.User())
 	populateMinimalSessionData(sd)
 	return sd
 }
@@ -995,9 +996,6 @@ func populateMinimalSessionData(sd *sessiondata.SessionData) {
 	}
 	if sd.Location == nil {
 		sd.Location = time.UTC
-	}
-	if len(sd.SearchPath.GetPathArray()) == 0 {
-		sd.SearchPath = sessiondata.DefaultSearchPathForUser(sd.User())
 	}
 }
 

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1660,6 +1660,7 @@ func (ief *InternalDB) newInternalExecutorWithTxn(
 	if sd == nil {
 		sd = NewInternalSessionData(ctx, settings, "" /* opName */)
 		sd.UserProto = username.RootUserName().EncodeProto()
+		sd.SearchPath = sessiondata.DefaultSearchPathForUser(sd.User())
 	}
 
 	schemaChangerState := &SchemaChangerState{

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -400,6 +400,21 @@ SELECT pg_catalog.set_config('woo', 'woo', false)
 query error configuration setting.*not supported
 SELECT set_config('vacuum_cost_delay', '0', false)
 
+# Regression test for #117316. Setting an empty search_path should succeed.
+query T
+SELECT pg_catalog.set_config('search_path', '', false)
+----
+·
+
+query T
+SHOW search_path
+----
+·
+
+# Reset the search paths for subsequent tests.
+statement ok
+RESET search_path
+
 # pg_my_temp_schema
 #
 # Before a temporary schema is created, it returns 0. Afterwards, it returns the

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -1701,9 +1701,9 @@ func TestParseSearchPathInConnectionString(t *testing.T) {
 			expectedErr: `option "Ghi" is invalid`,
 		},
 		{
-			desc:        "empty search_path is not allowed",
-			query:       `options=-c search_path=`,
-			expectedErr: `invalid value for parameter "search_path": ""`,
+			desc:               "empty search_path is allowed",
+			query:              `options=-c search_path=`,
+			expectedSearchPath: ``,
 		},
 		{
 			desc:        "unbalanced quotes in search_path are not allowed",

--- a/pkg/sql/sessiondata/parse_search_path.go
+++ b/pkg/sql/sessiondata/parse_search_path.go
@@ -143,6 +143,11 @@ func doParseSearchPathFromString(s string) ([]string, bool) {
 		result: make([]string, 0, strings.Count(s, ",")),
 	}
 
+	// Empty strings are valid search paths.
+	if parser.eof() {
+		return parser.result, true
+	}
+
 	parser.eatWhitespace()
 	if parser.eof() {
 		return nil, false

--- a/pkg/sql/sessiondata/search_path_test.go
+++ b/pkg/sql/sessiondata/search_path_test.go
@@ -399,7 +399,7 @@ func TestParseSearchPathEdgeCases(t *testing.T) {
 		expected    []string
 		expectedErr bool
 	}{
-		{input: ``, expectedErr: true},
+		{input: ``, expected: []string{}},
 		{input: `""`, expected: []string{""}},
 		{input: `  `, expectedErr: true},
 		{input: `a, `, expectedErr: true},


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: allow empty search path parameters" (#117318)
  * 1/1 commits from "sql: set session data search path when created" (#117457)

Please see individual PRs for details.

/cc @cockroachdb/release

--

Release justification: Fixes a bug introduced in 23.1 to allow setting empty search paths.