### PR TITLE
util/span: improve span frontier out of bounds check

### DIFF
--- a/pkg/util/span/llrb_frontier.go
+++ b/pkg/util/span/llrb_frontier.go
@@ -48,7 +48,7 @@ func (s *llrbFrontierEntry) Range() interval.Range {
 }
 
 func (s *llrbFrontierEntry) String() string {
-	return fmt.Sprintf("[%s @ %s]", s.span, s.ts)
+	return fmt.Sprintf("[%s@%s]", s.span, s.ts)
 }
 
 // llrbFrontierHeap implements heap.Interface and holds `llrbFrontierEntry`s. Entries
@@ -358,7 +358,8 @@ func (f *llrbFrontier) insert(span roachpb.Span, insertTS hlc.Timestamp) error {
 
 	if spanMustBeTracked {
 		if todoRange.Start.Compare(todoRange.End) < 0 {
-			return errors.Newf("span %s is not a sub-span of this frontier (remaining %s)", span, todoRange)
+			return errors.Newf("span %s is not a sub-span of this frontier (remaining {%s-%s}) (frontier %s)",
+				span, todoRange.Start, todoRange.End, f.String())
 		}
 	}
 


### PR DESCRIPTION
Previously, when the span frontier running in strict mode was forwarded using a span
which is out of bounds, the error did not include the frontier itself, making it hard
to debug such errors. Now the error message includes the frontier.

Also, this change updates the `String()` method on the llrb frontier, making it consistent
with the btree frontier. It also changes the error message in the llrb frontier to be
consistent with the b tree frontier error message.

Epic: None
Informs: https://github.com/cockroachdb/cockroach/issues/117476
Release note: None