### PR TITLE
*: Prep work for supporting CONFIGURE ZONE in declarative schema changer

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -2577,8 +2577,8 @@ func (r *restoreResumer) dropDescriptors(
 		// descriptors. To ensure that this happens quickly, we install a zone
 		// configuration for every table that we are going to drop with a small GC TTL.
 		canSetGCTTL := codec.ForSystemTenant() ||
-			(sql.SecondaryTenantZoneConfigsEnabled.Get(&r.execCfg.Settings.SV) &&
-				sql.SecondaryTenantsAllZoneConfigsEnabled.Get(&r.execCfg.Settings.SV))
+			(sqlclustersettings.SecondaryTenantZoneConfigsEnabled.Get(&r.execCfg.Settings.SV) &&
+				sqlclustersettings.SecondaryTenantsAllZoneConfigsEnabled.Get(&r.execCfg.Settings.SV))
 		if canSetGCTTL {
 			if err := setGCTTLForDroppingTable(
 				ctx, txn, descsCol, tableToDrop,

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -271,6 +271,7 @@ go_library(
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/sessioninit",
         "//pkg/sql/sessionprotectedts",
+        "//pkg/sql/sqlclustersettings",
         "//pkg/sql/sqlinstance",
         "//pkg/sql/sqlinstance/instancestorage",
         "//pkg/sql/sqlliveness",

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -58,6 +58,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -742,7 +743,7 @@ func (ts *testServer) grantDefaultTenantCapabilities(
 	for _, setting := range []settings.Setting{
 		sql.SecondaryTenantScatterEnabled,
 		sql.SecondaryTenantSplitAtEnabled,
-		sql.SecondaryTenantZoneConfigsEnabled,
+		sqlclustersettings.SecondaryTenantZoneConfigsEnabled,
 		sql.SecondaryTenantsMultiRegionAbstractionsEnabled,
 	} {
 		// Update the override for this setting. We need to do this

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -865,6 +865,7 @@ go_test(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/sessionphase",
+        "//pkg/sql/sqlclustersettings",
         "//pkg/sql/sqlinstance",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/sqllivenesstestutils",

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -140,6 +140,13 @@ func (p *planner) HasPrivilege(
 	privilegeKind privilege.Kind,
 	user username.SQLUsername,
 ) (bool, error) {
+	// Skip privilege checking if `privilegeKind == 0`. This exists to enable a
+	// more cohesive coding style in the caller where CheckPrivilege(priv=0)
+	// means "do not perform any privilege check".
+	if privilegeKind == 0 {
+		return true, nil
+	}
+
 	// Verify that the txn is valid in any case, so that
 	// we don't get the risk to say "OK" to root requests
 	// with an invalid API usage.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -217,18 +217,6 @@ var allowCrossDatabaseSeqReferences = settings.RegisterBoolSetting(
 	false,
 	settings.WithPublic)
 
-// SecondaryTenantZoneConfigsEnabled controls if secondary tenants are allowed
-// to set zone configurations. It has no effect for the system tenant.
-//
-// This setting has no effect on zone configurations that have already been set.
-var SecondaryTenantZoneConfigsEnabled = settings.RegisterBoolSetting(
-	settings.SystemVisible,
-	"sql.zone_configs.allow_for_secondary_tenant.enabled",
-	"enable the use of ALTER CONFIGURE ZONE in virtual clusters",
-	false,
-	settings.WithName("sql.virtual_cluster.feature_access.zone_configs.enabled"),
-)
-
 // SecondaryTenantSplitAtEnabled controls if secondary tenants are allowed to
 // run ALTER TABLE/INDEX ... SPLIT AT statements. It has no effect for the
 // system tenant.
@@ -3864,21 +3852,6 @@ func (cfg *ExecutorConfig) GetRowMetrics(internal bool) *rowinfra.Metrics {
 		return cfg.InternalRowMetrics
 	}
 	return cfg.RowMetrics
-}
-
-// requireSystemTenantOrClusterSetting returns a setting disabled error if
-// executed from inside a secondary tenant that does not have the specified
-// cluster setting.
-func requireSystemTenantOrClusterSetting(
-	codec keys.SQLCodec, settings *cluster.Settings, setting *settings.BoolSetting,
-) error {
-	if codec.ForSystemTenant() || setting.Get(&settings.SV) {
-		return nil
-	}
-	return errors.WithDetailf(errors.WithHint(
-		errors.New("operation is disabled within a virtual cluster"),
-		"Feature was disabled by the system operator."),
-		"Feature flag: %s", setting.Name())
 }
 
 // MaybeHashAppName returns the provided app name, possibly hashed.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treewindow"
 	"github.com/cockroachdb/cockroach/pkg/sql/span"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
@@ -1985,7 +1986,7 @@ func (ef *execFactory) ConstructAlterTableSplit(
 		return nil, err
 	}
 
-	if err := requireSystemTenantOrClusterSetting(execCfg.Codec, execCfg.Settings, SecondaryTenantSplitAtEnabled); err != nil {
+	if err := sqlclustersettings.RequireSystemTenantOrClusterSetting(execCfg.Codec, execCfg.Settings, SecondaryTenantSplitAtEnabled); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
@@ -36,7 +37,7 @@ type scatterNode struct {
 // Privileges: INSERT on table.
 func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error) {
 
-	if err := requireSystemTenantOrClusterSetting(p.ExecCfg().Codec, p.ExecCfg().Settings, SecondaryTenantScatterEnabled); err != nil {
+	if err := sqlclustersettings.RequireSystemTenantOrClusterSetting(p.ExecCfg().Codec, p.ExecCfg().Settings, SecondaryTenantScatterEnabled); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/sqlerrors",
+        "//pkg/sql/syntheticprivilege",
         "//pkg/sql/types",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/log/eventpb",

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/plpgsqltree/utils"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
@@ -328,6 +329,11 @@ func (b *builderState) checkPrivilege(id catid.DescID, priv privilege.Kind) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+// CheckGlobalPrivilege implements the scbuildstmt.PrivilegeChecker interface.
+func (b *builderState) CheckGlobalPrivilege(privilege privilege.Kind) error {
+	return b.auth.CheckPrivilege(b.ctx, syntheticprivilege.GlobalPrivilegeObject, privilege)
 }
 
 // HasGlobalPrivilegeOrRoleOption implements the scbuildstmt.PrivilegeChecker interface.

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -298,16 +298,16 @@ func (b *builderState) mustOwn(id catid.DescID) {
 }
 
 // CheckPrivilege implements the scbuildstmt.PrivilegeChecker interface.
-func (b *builderState) CheckPrivilege(e scpb.Element, privilege privilege.Kind) {
-	b.checkPrivilege(screl.GetDescID(e), privilege)
+func (b *builderState) CheckPrivilege(e scpb.Element, privilege privilege.Kind) error {
+	return b.checkPrivilege(screl.GetDescID(e), privilege)
 }
 
 // checkPrivilege checks if current user has privilege `priv` on descriptor with `id`.
-func (b *builderState) checkPrivilege(id catid.DescID, priv privilege.Kind) {
+func (b *builderState) checkPrivilege(id catid.DescID, priv privilege.Kind) error {
 	b.ensureDescriptor(id)
 	c := b.descCache[id]
 	if c.hasOwnership {
-		return
+		return nil
 	}
 	err, found := c.privileges[priv]
 	if !found {
@@ -318,7 +318,7 @@ func (b *builderState) checkPrivilege(id catid.DescID, priv privilege.Kind) {
 				b.QueryByID(id),
 				func(current scpb.Status, _ scpb.TargetStatus, e *scpb.SchemaParent) {
 					if current == scpb.Status_PUBLIC {
-						b.checkPrivilege(e.SchemaID, privilege.USAGE)
+						b.requirePrivilege(e.SchemaID, privilege.USAGE)
 					}
 				},
 			)
@@ -326,7 +326,12 @@ func (b *builderState) checkPrivilege(id catid.DescID, priv privilege.Kind) {
 		err = b.auth.CheckPrivilege(b.ctx, c.desc, priv)
 		c.privileges[priv] = err
 	}
-	if err != nil {
+	return err
+}
+
+// requirePrivilege is a must version of checkPrivilege where it panics if non-nil error.
+func (b *builderState) requirePrivilege(id catid.DescID, priv privilege.Kind) {
+	if err := b.checkPrivilege(id, priv); err != nil {
 		panic(err)
 	}
 }
@@ -876,7 +881,7 @@ func (b *builderState) ResolveDatabase(
 		panic(sqlerrors.NewUndefinedDatabaseError(name.String()))
 	}
 	b.ensureDescriptor(db.GetID())
-	b.checkPrivilege(db.GetID(), p.RequiredPrivilege)
+	b.requirePrivilege(db.GetID(), p.RequiredPrivilege)
 	return b.QueryByID(db.GetID())
 }
 
@@ -943,7 +948,7 @@ func (b *builderState) checkOwnershipOrPrivilegesOnSchemaDesc(
 		if p.RequireOwnership {
 			b.mustOwn(sc.GetID())
 		} else {
-			b.checkPrivilege(sc.GetID(), p.RequiredPrivilege)
+			b.requirePrivilege(sc.GetID(), p.RequiredPrivilege)
 		}
 	default:
 		panic(errors.AssertionFailedf("unknown schema kind %d", sc.SchemaKind()))
@@ -1020,7 +1025,9 @@ func (b *builderState) resolveRelation(
 	if rel.IsTemporary() {
 		panic(scerrors.NotImplementedErrorf(nil /* n */, "dropping a temporary table"))
 	}
-	// If we own the schema then we can manipulate the underlying relation.
+
+	// If we own the schema then we can manipulate the underlying relation,
+	// regardless what privilege is required on relation.
 	b.ensureDescriptor(rel.GetID())
 	c := b.descCache[rel.GetID()]
 	b.ensureDescriptor(rel.GetParentSchemaID())
@@ -1028,10 +1035,11 @@ func (b *builderState) resolveRelation(
 		c.hasOwnership = true
 		return c
 	}
+
 	err, found := c.privileges[p.RequiredPrivilege]
 	if !found {
 		// Validate if this descriptor can be resolved under the current schema.
-		b.checkPrivilege(rel.GetParentSchemaID(), privilege.USAGE)
+		b.requirePrivilege(rel.GetParentSchemaID(), privilege.USAGE)
 		err = b.auth.CheckPrivilege(b.ctx, rel, p.RequiredPrivilege)
 		c.privileges[p.RequiredPrivilege] = err
 	}
@@ -1108,7 +1116,7 @@ func (b *builderState) ResolveIndex(
 		panic(pgerror.Newf(pgcode.WrongObjectType,
 			"%q is not an indexable table or a materialized view", rel.GetName()))
 	}
-	b.checkPrivilege(rel.GetID(), p.RequiredPrivilege)
+	b.requirePrivilege(rel.GetID(), p.RequiredPrivilege)
 	elts := b.QueryByID(rel.GetID())
 	var indexID catid.IndexID
 	scpb.ForEachIndexName(elts, func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexName) {
@@ -1170,7 +1178,7 @@ func (b *builderState) ResolveColumn(
 	b.ensureDescriptor(relationID)
 	rel := b.descCache[relationID].desc.(catalog.TableDescriptor)
 	elts := b.QueryByID(rel.GetID())
-	b.checkPrivilege(rel.GetID(), p.RequiredPrivilege)
+	b.requirePrivilege(rel.GetID(), p.RequiredPrivilege)
 	var columnID catid.ColumnID
 	scpb.ForEachColumnName(elts, func(status scpb.Status, _ scpb.TargetStatus, e *scpb.ColumnName) {
 		if tree.Name(e.Name) == columnName {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -214,7 +214,16 @@ type PrivilegeChecker interface {
 
 	// CheckPrivilege panics if the current user does not have the specified
 	// privilege for the element.
+	//
+	// Note: This function is written on the assumption that privileges are tied
+	// to descriptors. However, privileges can also live in the
+	// `system.privileges` table (i.e. system-level privileges) and checking those
+	// global privileges are done by the CheckGlobalPrivilege method below.
 	CheckPrivilege(e scpb.Element, privilege privilege.Kind)
+
+	// CheckGlobalPrivilege panics if the current user does not have the specified
+	// global privilege.
+	CheckGlobalPrivilege(privilege privilege.Kind) error
 
 	// HasGlobalPrivilegeOrRoleOption returns a bool representing whether the current user
 	// has a global privilege or the corresponding legacy role option.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -219,7 +219,7 @@ type PrivilegeChecker interface {
 	// to descriptors. However, privileges can also live in the
 	// `system.privileges` table (i.e. system-level privileges) and checking those
 	// global privileges are done by the CheckGlobalPrivilege method below.
-	CheckPrivilege(e scpb.Element, privilege privilege.Kind)
+	CheckPrivilege(e scpb.Element, privilege privilege.Kind) error
 
 	// CheckGlobalPrivilege panics if the current user does not have the specified
 	// global privilege.
@@ -334,6 +334,7 @@ type ResolveParams struct {
 
 	// RequiredPrivilege defines the privilege required for the resolved
 	// descriptor.
+	// If 0, no privilege checking is performed.
 	RequiredPrivilege privilege.Kind
 
 	// RequireOwnership if set to true, requires current user be the owner of the

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -74,7 +74,9 @@ func dropRestrictDescriptor(b BuildCtx, id catid.DescID) (hasChanged bool) {
 		return false
 	}
 	undropped.ForEach(func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) {
-		b.CheckPrivilege(e, privilege.DROP)
+		if err := b.CheckPrivilege(e, privilege.DROP); err != nil {
+			panic(err)
+		}
 		b.Drop(e)
 	})
 	return true
@@ -187,7 +189,9 @@ func dropCascadeDescriptor(b BuildCtx, id catid.DescID) {
 		default:
 			return
 		}
-		b.CheckPrivilege(e, privilege.DROP)
+		if err := b.CheckPrivilege(e, privilege.DROP); err != nil {
+			panic(err)
+		}
 	})
 	// Mark element targets as ABSENT.
 	next := b.WithNewSourceElementID()

--- a/pkg/sql/sem/tree/zone.go
+++ b/pkg/sql/sem/tree/zone.go
@@ -118,6 +118,9 @@ func (node *SetZoneConfig) Format(ctx *FmtCtx) {
 	node.ZoneConfigSettings.Format(ctx)
 }
 
+// modifiesSchema implements the canModifySchema interface.
+func (*SetZoneConfig) modifiesSchema() bool { return true }
+
 // ZoneConfigSettings represents info needed for zone config setting.
 type ZoneConfigSettings struct {
 	SetDefault bool

--- a/pkg/sql/set_zone_config_test.go
+++ b/pkg/sql/set_zone_config_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -150,7 +151,7 @@ func TestValidateZoneAttrsAndLocalitiesForSecondaryTenants(t *testing.T) {
 	}
 
 	for _, anyConstraintAllowed := range []bool{false, true} {
-		SecondaryTenantsAllZoneConfigsEnabled.Override(ctx, &settings.SV, anyConstraintAllowed)
+		sqlclustersettings.SecondaryTenantsAllZoneConfigsEnabled.Override(ctx, &settings.SV, anyConstraintAllowed)
 		for _, tc := range testCases {
 			var zone zonepb.ZoneConfig
 			err := yaml.UnmarshalStrict([]byte(tc.cfg), &zone)

--- a/pkg/sql/sqlclustersettings/BUILD.bazel
+++ b/pkg/sql/sqlclustersettings/BUILD.bazel
@@ -5,5 +5,10 @@ go_library(
     srcs = ["clustersettings.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/settings"],
+    deps = [
+        "//pkg/keys",
+        "//pkg/settings",
+        "//pkg/settings/cluster",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
 )


### PR DESCRIPTION
This PR consists several preparation work that will be needed for properly supporting CONFIGURE ZONE stmts in declarative schema changer. They're separated out for easier review and bc I expect those to be a lot less controversial than the main work. See each commit for details.

Informs #117574
Epic: CRDB-31473