### PR TITLE
test: add datadriven tests to sql api

### DIFF
--- a/pkg/server/application_api/BUILD.bazel
+++ b/pkg/server/application_api/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "util_test.go",
         "zcfg_test.go",
     ],
+    data = glob(["testdata/**"]),
     exec_properties = select({
         "//build/toolchains:is_heavy": {"Pool": "heavy"},
         "//conditions:default": {"Pool": "default"},
@@ -89,6 +90,7 @@ go_test(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
+        "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//proto",
         "@com_github_kr_pretty//:pretty",

--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -11,6 +11,7 @@
 package application_api_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -42,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/datadriven"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,7 +51,7 @@ import (
 
 // additionalTimeoutUnderStress is the additional timeout to use for the http
 // client if under stress.
-const additionalTimeoutUnderStress = 30 * time.Second
+const additionalTimeoutUnderStress = 60 * time.Second
 
 func TestStatusAPICombinedTransactions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -390,6 +392,7 @@ func TestStatusAPITransactionStatementFingerprintIDsTruncation(t *testing.T) {
 func TestStatusAPIStatements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderRace(t, "test is too slow to run under race")
 
 	// Increase the timeout for the http client if under stress.
 	additionalTimeout := 0 * time.Second
@@ -504,16 +507,6 @@ func TestStatusAPIStatements(t *testing.T) {
 	testPath(fmt.Sprintf("statements?combined=true&start=%d", aggregatedTs+60), nil)
 }
 
-type testStatement struct {
-	query                  string
-	fingerprintID          appstatspb.StmtFingerprintID
-	aggregatedTs           time.Time
-	count                  int64
-	serviceLatency         appstatspb.NumericStat
-	addStatementStatistics bool
-	addStatementActivity   bool
-}
-
 func TestStatusAPICombinedStatementsTotalLatency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -526,148 +519,55 @@ func TestStatusAPICombinedStatementsTotalLatency(t *testing.T) {
 
 	sqlStatsKnobs := sqlstats.CreateTestingKnobs()
 	// Start the cluster.
-	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-		Insecure: true,
-		Knobs: base.TestingKnobs{
-			SQLStatsKnobs: sqlStatsKnobs,
+	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SQLStatsKnobs: sqlStatsKnobs,
+			},
 		},
 	})
 
-	defer srv.Stopper().Stop(context.Background())
+	defer testCluster.Stopper().Stop(context.Background())
+	sqlDB := testCluster.ServerConn(0)
 	defer sqlDB.Close()
-	ts := srv.ApplicationLayer()
+	ts := testCluster.Server(0).ApplicationLayer()
 	db := sqlutils.MakeSQLRunner(sqlDB)
 
-	// Disabled flush so no extra data is inserted to the system table.
-	db.Exec(t, "SET CLUSTER SETTING sql.stats.activity.flush.enabled = 'f'")
-	// Give permission to write to system tables.
-	db.Exec(t, "INSERT INTO system.users VALUES ('node', NULL, true, 3)")
-	db.Exec(t, "GRANT node TO root")
+	loadStatsFixtures(t, db, []string{"sql_stats_default"})
+	datadriven.RunTest(t, "testdata/combined_stmts_total_latency", func(t *testing.T, d *datadriven.TestData) string {
+		var buf bytes.Buffer
+		timeLayout := "2006-01-02 15:04:05"
+		switch d.Cmd {
+		case "check-total-latency":
+			var resp serverpb.StatementsResponse
+			var start string
+			var end string
 
-	stmts := []testStatement{
-		{
-			query:                  "SELECT * FROM foo",
-			fingerprintID:          appstatspb.StmtFingerprintID(1088747230083123385),
-			aggregatedTs:           timeutil.FromUnixMicros(1704103200000000), // January 1, 2024 10:00:00
-			count:                  1,
-			serviceLatency:         appstatspb.NumericStat{Mean: 3, SquaredDiffs: 0},
-			addStatementStatistics: true,
-			addStatementActivity:   false,
-		},
-		{
-			query:                  "SELECT * FROM bar",
-			fingerprintID:          appstatspb.StmtFingerprintID(2422963415274537466),
-			aggregatedTs:           timeutil.FromUnixMicros(1704106800000000), // January 1, 2024 11:00:00
-			count:                  5,
-			serviceLatency:         appstatspb.NumericStat{Mean: 7, SquaredDiffs: 0},
-			addStatementStatistics: true,
-			addStatementActivity:   false,
-		},
-		{
-			query:                  "SELECT * FROM abc",
-			fingerprintID:          appstatspb.StmtFingerprintID(8810317408726404693),
-			aggregatedTs:           timeutil.FromUnixMicros(1704110400000000), // January 1, 2024 12:00:00
-			count:                  11,
-			serviceLatency:         appstatspb.NumericStat{Mean: 13, SquaredDiffs: 0},
-			addStatementStatistics: true,
-			addStatementActivity:   true,
-		},
-		{
-			query:                  "SELECT * FROM xyz",
-			fingerprintID:          appstatspb.StmtFingerprintID(2759320105256699956),
-			aggregatedTs:           timeutil.FromUnixMicros(1704114000000000), // January 1, 2024 13:00:00
-			count:                  17,
-			serviceLatency:         appstatspb.NumericStat{Mean: 19, SquaredDiffs: 0},
-			addStatementStatistics: true,
-			addStatementActivity:   true,
-		},
-	}
-
-	for _, stmt := range stmts {
-		s := generateStatement()
-		s.AggregatedTs = stmt.aggregatedTs
-		s.ID = stmt.fingerprintID
-		s.Key.Query = stmt.query
-		s.Key.QuerySummary = stmt.query
-		s.Stats.Count = stmt.count
-		s.Stats.ServiceLat = stmt.serviceLatency
-
-		if stmt.addStatementStatistics {
-			insertStatementIntoSystemStmtStatsTable(t, db, s)
+			for _, arg := range d.CmdArgs {
+				switch arg.Key {
+				case "start":
+					time, err := time.Parse(timeLayout, arg.Vals[0])
+					require.NoError(t, err)
+					start = fmt.Sprint(time.Unix())
+				case "end":
+					time, err := time.Parse(timeLayout, arg.Vals[0])
+					require.NoError(t, err)
+					end = fmt.Sprint(time.Unix())
+				}
+			}
+			endpoint := fmt.Sprintf("combinedstmts?start=%s&end=%s", start, end)
+			err := srvtestutils.GetStatusJSONProtoWithAdminAndTimeoutOption(ts, endpoint, &resp, true, additionalTimeout)
+			errorMsg := ""
+			if err != nil {
+				errorMsg = err.Error()
+			}
+			fmt.Fprintf(&buf, "Error: %s\n", errorMsg)
+			fmt.Fprintf(&buf, "Source table: %s\n", resp.StmtsSourceTable)
+			fmt.Fprintf(&buf, "Statements count: %d\n", len(resp.Statements))
+			fmt.Fprintf(&buf, "Total latency: %v\n", resp.StmtsTotalRuntimeSecs)
 		}
-		if stmt.addStatementActivity {
-			insertStatementIntoSystemStmtActivityTable(t, db, s)
-		}
-	}
-
-	testCases := []struct {
-		testName     string
-		start        string
-		end          string
-		count        int
-		totalLatency float32
-		sourceTable  string
-	}{
-		{
-			testName:     "period with one statement on statement_statistics and none on statement_activity",
-			start:        "1704103200", // January 1, 2024 10:00:00
-			end:          "1704104400", // January 1, 2024 10:20:00
-			count:        1,
-			totalLatency: getTotalLatencyForStatements(stmts[0]),
-			sourceTable:  "crdb_internal.statement_statistics_persisted",
-		},
-		{
-			testName:     "period with 2 statements on statement_statistics and none on statement_activity",
-			start:        "1704103200", // January 1, 2024 10:00:00
-			end:          "1704109200", // January 1, 2024 11:40:00
-			count:        2,
-			totalLatency: getTotalLatencyForStatements(stmts[0], stmts[1]),
-			sourceTable:  "crdb_internal.statement_statistics_persisted",
-		},
-		{
-			testName:     "period with one statement on statement_activity",
-			start:        "1704110400", // January 1, 2024 12:00:00
-			end:          "1704112800", // January 1, 2024 12:40:00
-			count:        1,
-			totalLatency: getTotalLatencyForStatements(stmts[2]),
-			sourceTable:  "crdb_internal.statement_activity",
-		},
-		{
-			testName:     "period with 2 statements on statement_activity",
-			start:        "1704110400", // January 1, 2024 12:00:00
-			end:          "1704116400", // January 1, 2024 13:40:00
-			count:        2,
-			totalLatency: getTotalLatencyForStatements(stmts[2], stmts[3]),
-			sourceTable:  "crdb_internal.statement_activity",
-		},
-		{
-			testName:     "period with 2 statements on statement_activity and 4 statements on statement_statistics",
-			start:        "1704103200", // January 1, 2024 10:00:00
-			end:          "1704116400", // January 1, 2024 13:40:00
-			count:        4,
-			totalLatency: getTotalLatencyForStatements(stmts[0], stmts[1], stmts[2], stmts[3]),
-			sourceTable:  "crdb_internal.statement_statistics_persisted",
-		},
-	}
-
-	for _, tc := range testCases {
-		var resp serverpb.StatementsResponse
-		endpoint := fmt.Sprintf("combinedstmts?start=%s&end=%s", tc.start, tc.end)
-		err := srvtestutils.GetStatusJSONProtoWithAdminAndTimeoutOption(ts, endpoint, &resp, true, additionalTimeout)
-		require.NoError(t, err, fmt.Sprintf("server error on %s", tc.testName))
-		require.Equal(t, tc.sourceTable, resp.StmtsSourceTable, fmt.Sprintf("source table error on %s", tc.testName))
-		require.Equal(t, tc.count, len(resp.Statements), fmt.Sprintf("stmts length error on %s", tc.testName))
-		require.Equal(t, tc.totalLatency, resp.StmtsTotalRuntimeSecs, fmt.Sprintf("total latency on %s", tc.testName))
-	}
-
-}
-
-func getTotalLatencyForStatements(statements ...testStatement) float32 {
-	total := float32(0)
-	for _, statement := range statements {
-		total = total + float32(statement.count)*float32(statement.serviceLatency.Mean)
-	}
-	return total
+		return buf.String()
+	})
 }
 
 func TestStatusAPICombinedStatementsWithFullScans(t *testing.T) {
@@ -1573,305 +1473,18 @@ func createTxnFetchMode(
 	}
 }
 
-func generateStatement() appstatspb.CollectedStatementStatistics {
-	return appstatspb.CollectedStatementStatistics{
-		AggregatedTs:        timeutil.FromUnixNanos(1704103200), // January 1, 2024 10:00:00
-		ID:                  appstatspb.StmtFingerprintID(1088747230083123385),
-		AggregationInterval: time.Hour,
-		Key: appstatspb.StatementStatisticsKey{
-			App:                      "test_app",
-			Database:                 "test_database",
-			DistSQL:                  true,
-			FullScan:                 true,
-			Failed:                   false,
-			ImplicitTxn:              true,
-			PlanHash:                 uint64(200),
-			Query:                    "SELECT * FROM foo",
-			QuerySummary:             "SELECT * FROM foo",
-			TransactionFingerprintID: appstatspb.TransactionFingerprintID(50),
-			Vec:                      true,
-		},
-
-		Stats: appstatspb.StatementStatistics{
-			Count:         10,
-			Indexes:       []string{"15@4"},
-			LastErrorCode: "",
-			MaxRetries:    0,
-			Nodes:         []int64{1},
-			PlanGists:     []string{"AgEeCADnAwIAAAMHEgUUIR4AAA=="},
-			Regions:       []string{"us-east1"},
-			SQLType:       "TypeDDL",
-		},
+func loadStatsFixtures(t *testing.T, db *sqlutils.SQLRunner, fixtures []string) {
+	for _, fixture := range fixtures {
+		datadriven.RunTest(t, fmt.Sprintf("testdata/%s", fixture), func(t *testing.T, d *datadriven.TestData) string {
+			var buf bytes.Buffer
+			switch d.Cmd {
+			case "run-sql":
+				rows := db.QueryStr(t, d.Input)
+				for _, row := range rows {
+					fmt.Fprintf(&buf, "%s\n", strings.Join(row, ","))
+				}
+			}
+			return buf.String()
+		})
 	}
-}
-func generateStatisticsColumn(
-	t *testing.T, statement appstatspb.CollectedStatementStatistics,
-) string {
-	// Create execution Statistics JSON
-	executionStats := struct {
-		Cnt            int                    `json:"cnt"`
-		ContentionTime appstatspb.NumericStat `json:"contentionTime"`
-		CpuSQLNanos    appstatspb.NumericStat `json:"cpuSQLNanos"`
-		MaxDiskUsage   appstatspb.NumericStat `json:"maxDiskUsage"`
-		MaxMemUsage    appstatspb.NumericStat `json:"maxMemUsage"`
-		NetworkBytes   appstatspb.NumericStat `json:"networkBytes"`
-		NetworkMsgs    appstatspb.NumericStat `json:"networkMsgs"`
-	}{
-		Cnt: 3,
-		ContentionTime: appstatspb.NumericStat{
-			Mean:         0,
-			SquaredDiffs: 0,
-		},
-		CpuSQLNanos: appstatspb.NumericStat{
-			Mean:         5,
-			SquaredDiffs: 0,
-		},
-		MaxDiskUsage: appstatspb.NumericStat{
-			Mean:         10,
-			SquaredDiffs: 0,
-		},
-		MaxMemUsage: appstatspb.NumericStat{
-			Mean:         10,
-			SquaredDiffs: 0,
-		},
-		NetworkBytes: appstatspb.NumericStat{
-			Mean:         0,
-			SquaredDiffs: 0,
-		},
-		NetworkMsgs: appstatspb.NumericStat{
-			Mean:         0,
-			SquaredDiffs: 0,
-		},
-	}
-	executionStatsBytes, err := json.Marshal(executionStats)
-	require.NoError(t, err)
-
-	// Create stats JSON
-	stats := struct {
-		BytesRead       appstatspb.NumericStat `json:"bytesRead"`
-		Cnt             int64                  `json:"cnt"`
-		FirstAttemptCnt int64                  `json:"firstAttemptCnt"`
-		IdleLat         appstatspb.NumericStat `json:"idleLat"`
-		Indexes         []string               `json:"indexes"`
-		LastErrorCode   string                 `json:"lastErrorCode"`
-		LastExecAt      time.Time              `json:"lastExecAt"`
-		MaxRetries      int                    `json:"maxRetries"`
-		Nodes           []int64                `json:"nodes"`
-		NumRows         appstatspb.NumericStat `json:"numRows"`
-		OvhLat          appstatspb.NumericStat `json:"ovhLat"`
-		ParseLat        appstatspb.NumericStat `json:"parseLat"`
-		PlanGists       []string               `json:"planGists"`
-		PlanLat         appstatspb.NumericStat `json:"planLat"`
-		Regions         []string               `json:"regions"`
-		RowsRead        appstatspb.NumericStat `json:"rowsRead"`
-		RowsWritten     appstatspb.NumericStat `json:"rowsWritten"`
-		RunLat          appstatspb.NumericStat `json:"runLat"`
-		SvcLat          appstatspb.NumericStat `json:"svcLat"`
-	}{
-		BytesRead: appstatspb.NumericStat{
-			Mean:         0,
-			SquaredDiffs: 0,
-		},
-		Cnt:             statement.Stats.Count,
-		FirstAttemptCnt: statement.Stats.Count,
-		IdleLat: appstatspb.NumericStat{
-			Mean:         0,
-			SquaredDiffs: 0,
-		},
-		Indexes:       statement.Stats.Indexes,
-		LastErrorCode: statement.Stats.LastErrorCode,
-		LastExecAt:    statement.AggregatedTs.Add(time.Minute * 10),
-		MaxRetries:    0,
-		Nodes:         statement.Stats.Nodes,
-		NumRows: appstatspb.NumericStat{
-			Mean:         0,
-			SquaredDiffs: 0,
-		},
-		OvhLat: appstatspb.NumericStat{
-			Mean:         0,
-			SquaredDiffs: 0,
-		},
-		ParseLat: appstatspb.NumericStat{
-			Mean:         0,
-			SquaredDiffs: 0,
-		},
-		PlanGists: statement.Stats.PlanGists,
-		PlanLat: appstatspb.NumericStat{
-			Mean:         0,
-			SquaredDiffs: 0,
-		},
-		Regions: statement.Stats.Regions,
-		RowsRead: appstatspb.NumericStat{
-			Mean:         0,
-			SquaredDiffs: 0,
-		},
-		RowsWritten: appstatspb.NumericStat{
-			Mean:         0,
-			SquaredDiffs: 0,
-		},
-		RunLat: appstatspb.NumericStat{
-			Mean:         0,
-			SquaredDiffs: 0,
-		},
-		SvcLat: statement.Stats.ServiceLat,
-	}
-	statsBytes, err := json.Marshal(stats)
-	require.NoError(t, err)
-
-	return fmt.Sprintf("{\"execution_statistics\": %s, \"statistics\": %s"+
-		", \"index_recommendations\": []} ", string(executionStatsBytes), string(statsBytes))
-}
-
-func insertStatementIntoSystemStmtStatsTable(
-	t *testing.T, db *sqlutils.SQLRunner, statement appstatspb.CollectedStatementStatistics,
-) {
-	// Create metadata JSON
-	metadata := struct {
-		Database     string `json:"db"`
-		DistSQL      bool   `json:"distsql"`
-		Failed       bool   `json:"failed"`
-		FullScan     bool   `json:"fullScan"`
-		ImplicitTxn  bool   `json:"implicitTxn"`
-		Query        string `json:"query"`
-		QuerySummary string `json:"querySummary"`
-		StmtType     string `json:"stmtType"`
-		Vec          bool   `json:"vec"`
-	}{
-		Database:     statement.Key.Database,
-		DistSQL:      statement.Key.DistSQL,
-		Failed:       statement.Key.Failed,
-		FullScan:     statement.Key.FullScan,
-		ImplicitTxn:  statement.Key.ImplicitTxn,
-		Query:        statement.Key.Query,
-		QuerySummary: statement.Key.QuerySummary,
-		StmtType:     statement.Stats.SQLType,
-		Vec:          statement.Key.Vec,
-	}
-	metadataBytes, err := json.Marshal(metadata)
-	require.NoError(t, err)
-	statistics := generateStatisticsColumn(t, statement)
-
-	query := `INSERT INTO system.statement_statistics (
-  aggregated_ts,
-  fingerprint_id,
-  transaction_fingerprint_id,
-  plan_hash,
-  app_name,
-  node_id,
-  agg_interval,
-  metadata,
-  statistics,
-  plan,
-  index_recommendations
-)
-VALUES (
-  $1,
-  $2,
-  $3,
-  $4,
-  $5,
-  1,
-  $6,
-  $7,
-  $8::JSONB,
-  '{"Children": [], "Name": ""}',
-  ARRAY['creation : CREATE INDEX t3_k_i_f ON t3(k, i, f)']
-)`
-	args := []interface{}{
-		statement.AggregatedTs,
-		statement.ID,
-		statement.Key.TransactionFingerprintID,
-		statement.Key.PlanHash,
-		statement.Key.App,
-		statement.AggregationInterval,
-		string(metadataBytes),
-		statistics,
-	}
-
-	db.Exec(t, query, args...)
-}
-
-func insertStatementIntoSystemStmtActivityTable(
-	t *testing.T, db *sqlutils.SQLRunner, statement appstatspb.CollectedStatementStatistics,
-) {
-	// Create metadata JSON
-	metadata := struct {
-		AppNames      []string `json:"appNames"`
-		Database      []string `json:"db"`
-		DistSQLCount  int      `json:"distSQLCount"`
-		FailedCount   int      `json:"failedCount"`
-		FullScanCount int      `json:"fullScanCount"`
-		ImplicitTxn   bool     `json:"implicitTxn"`
-		Query         string   `json:"query"`
-		QuerySummary  string   `json:"querySummary"`
-		StmtType      string   `json:"stmtType"`
-		VecCount      int      `json:"vecCount"`
-	}{
-		AppNames:      []string{statement.Key.App},
-		Database:      []string{statement.Key.Database},
-		DistSQLCount:  1,
-		FailedCount:   0,
-		FullScanCount: 1,
-		ImplicitTxn:   statement.Key.ImplicitTxn,
-		Query:         statement.Key.Query,
-		QuerySummary:  statement.Key.QuerySummary,
-		StmtType:      statement.Stats.SQLType,
-		VecCount:      1,
-	}
-	metadataBytes, err := json.Marshal(metadata)
-	require.NoError(t, err)
-	statistics := generateStatisticsColumn(t, statement)
-
-	query := `INSERT INTO system.statement_activity (
-  aggregated_ts,
-  fingerprint_id,
-  transaction_fingerprint_id,
-  plan_hash,
-  app_name,
-  agg_interval,
-  metadata,
-  statistics,
-  plan,
-  index_recommendations,
-  execution_count,
-	execution_total_seconds,
-	execution_total_cluster_seconds,
-	contention_time_avg_seconds,
-	cpu_sql_avg_nanos,
-	service_latency_avg_seconds,
-	service_latency_p99_seconds
-)
-VALUES (
-  $1,
-  $2,
-  $3,
-  $4,
-  $5,
-  $6,
-  $7,
-  $8::JSONB,
-  '{"Children": [], "Name": ""}',
-  ARRAY['creation : CREATE INDEX t3_k_i_f ON t3(k, i, f)'],
-	$9,
-	$10,
-	$10,
-	0,
-	5,
-	10,
-	7
-)`
-
-	args := []interface{}{
-		statement.AggregatedTs,
-		statement.ID,
-		statement.Key.TransactionFingerprintID,
-		statement.Key.PlanHash,
-		statement.Key.App,
-		statement.AggregationInterval,
-		string(metadataBytes),
-		statistics,
-		statement.Stats.Count,
-		float64(statement.Stats.Count) * statement.Stats.ServiceLat.Mean,
-	}
-	db.Exec(t, query, args...)
 }

--- a/pkg/server/application_api/testdata/combined_stmts_total_latency
+++ b/pkg/server/application_api/testdata/combined_stmts_total_latency
@@ -1,0 +1,39 @@
+# Period with one statement on statement_statistics and none on statement_activity
+check-total-latency start=(2024-01-01 10:00:00) end=(2024-01-01 10:20:00)
+----
+Error: 
+Source table: crdb_internal.statement_statistics_persisted
+Statements count: 1
+Total latency: 3
+
+# Period with 2 statements on statement_statistics and none on statement_activity
+check-total-latency start=(2024-01-01 10:00:00) end=(2024-01-01 11:40:00)
+----
+Error: 
+Source table: crdb_internal.statement_statistics_persisted
+Statements count: 2
+Total latency: 38
+
+# Period with one statement on statement_activity
+check-total-latency start=(2024-01-01 12:00:00) end=(2024-01-01 12:40:00)
+----
+Error: 
+Source table: crdb_internal.statement_activity
+Statements count: 1
+Total latency: 143
+
+# Period with 2 statements on statement_activity
+check-total-latency start=(2024-01-01 12:00:00) end=(2024-01-01 13:40:00)
+----
+Error: 
+Source table: crdb_internal.statement_activity
+Statements count: 2
+Total latency: 466
+
+# Period with 2 statements on statement_activity and 4 statements on statement_statistics
+check-total-latency start=(2024-01-01 10:00:00) end=(2024-01-01 13:40:00)
+----
+Error: 
+Source table: crdb_internal.statement_statistics_persisted
+Statements count: 4
+Total latency: 504

--- a/pkg/server/application_api/testdata/sql_stats_default
+++ b/pkg/server/application_api/testdata/sql_stats_default
@@ -1,0 +1,157 @@
+# Disabled flush so no extra data is inserted to the system table.
+run-sql
+SET CLUSTER SETTING sql.stats.activity.flush.enabled = 'f'
+----
+
+# Give permission to write to system tables.
+run-sql
+INSERT INTO system.users VALUES ('node', NULL, true, 3)
+----
+
+
+run-sql
+GRANT node TO root
+----
+
+
+# Insert Data to system.statement_statistics
+run-sql
+INSERT INTO system.statement_statistics (
+  aggregated_ts,
+  fingerprint_id,
+  transaction_fingerprint_id,
+  plan_hash,
+  app_name,
+  node_id,
+  agg_interval,
+  metadata,
+  statistics,
+  plan,
+  index_recommendations
+)
+VALUES (
+  '2024-01-01 10:00:00 +0000',
+  '\x0f1c01d65b4b88b9',
+  '\xa07fbc9add4a3f66',
+  '\xbff951ae7cecdd4b',
+  'test_app',
+  1,
+  '01:00:00',
+  '{"db":"test_database","distsql":true,"failed":false,"fullScan":true,"implicitTxn":true,"query":"SELECT * FROM foo","querySummary":"SELECT * FROM foo","stmtType":"TypeDDL","vec":true}',
+  '{"execution_statistics": {"cnt":3,"contentionTime":{"mean":0,"squared_diffs":0},"cpuSQLNanos":{"mean":5,"squared_diffs":0},"maxDiskUsage":{"mean":10,"squared_diffs":0},"maxMemUsage":{"mean":10,"squared_diffs":0},"networkBytes":{"mean":0,"squared_diffs":0},"networkMsgs":{"mean":0,"squared_diffs":0}}, "statistics": {"bytesRead":{"mean":0,"squared_diffs":0},"cnt":1,"firstAttemptCnt":1,"idleLat":{"mean":0,"squared_diffs":0},"indexes":["15@4"],"lastErrorCode":"","lastExecAt":"2024-01-01T10:10:00Z","maxRetries":0,"nodes":[1],"numRows":{"mean":0,"squared_diffs":0},"ovhLat":{"mean":0,"squared_diffs":0},"parseLat":{"mean":0,"squared_diffs":0},"planGists":["AgEeCADnAwIAAAMHEgUUIR4AAA=="],"planLat":{"mean":0,"squared_diffs":0},"regions":["us-east1"],"rowsRead":{"mean":0,"squared_diffs":0},"rowsWritten":{"mean":0,"squared_diffs":0},"runLat":{"mean":0,"squared_diffs":0},"svcLat":{"mean":3,"squared_diffs":0}}, "index_recommendations": []}'::JSONB,
+  '{"Children": [], "Name": ""}',
+  ARRAY[]
+),
+(
+  '2024-01-01 11:00:00 +0000',
+  '\x21a018638734c1fa',
+  '\x8ec3a52f01357625',
+  '\xa3ca652fbc7ba181',
+  'test_app',
+  1,
+  '01:00:00',
+  '{"db":"test_database","distsql":true,"failed":false,"fullScan":true,"implicitTxn":true,"query":"SELECT * FROM bar","querySummary":"SELECT * FROM bar","stmtType":"TypeDDL","vec":true}',
+  '{"execution_statistics": {"cnt":3,"contentionTime":{"mean":0,"squared_diffs":0},"cpuSQLNanos":{"mean":5,"squared_diffs":0},"maxDiskUsage":{"mean":10,"squared_diffs":0},"maxMemUsage":{"mean":10,"squared_diffs":0},"networkBytes":{"mean":0,"squared_diffs":0},"networkMsgs":{"mean":0,"squared_diffs":0}}, "statistics": {"bytesRead":{"mean":0,"squared_diffs":0},"cnt":5,"firstAttemptCnt":5,"idleLat":{"mean":0,"squared_diffs":0},"indexes":["15@4"],"lastErrorCode":"","lastExecAt":"2024-01-01T11:10:00Z","maxRetries":0,"nodes":[1],"numRows":{"mean":0,"squared_diffs":0},"ovhLat":{"mean":0,"squared_diffs":0},"parseLat":{"mean":0,"squared_diffs":0},"planGists":["AgEeCADnAwIAAAMHEgUUIR4AAA=="],"planLat":{"mean":0,"squared_diffs":0},"regions":["us-east1"],"rowsRead":{"mean":0,"squared_diffs":0},"rowsWritten":{"mean":0,"squared_diffs":0},"runLat":{"mean":0,"squared_diffs":0},"svcLat":{"mean":7,"squared_diffs":0}}, "index_recommendations": []}'::JSONB,
+  '{"Children": [], "Name": ""}',
+  ARRAY[]
+),
+(
+  '2024-01-01 12:00:00 +0000',
+  '\x7a4489011193ce55',
+  '\xd527344d9792798a',
+  '\x2324d56cb507f877',
+  'test_app',
+  1,
+  '01:00:00',
+  '{"db":"test_database","distsql":true,"failed":false,"fullScan":true,"implicitTxn":true,"query":"SELECT * FROM abc","querySummary":"SELECT * FROM abc","stmtType":"TypeDDL","vec":true}',
+  '{"execution_statistics": {"cnt":3,"contentionTime":{"mean":0,"squared_diffs":0},"cpuSQLNanos":{"mean":5,"squared_diffs":0},"maxDiskUsage":{"mean":10,"squared_diffs":0},"maxMemUsage":{"mean":10,"squared_diffs":0},"networkBytes":{"mean":0,"squared_diffs":0},"networkMsgs":{"mean":0,"squared_diffs":0}}, "statistics": {"bytesRead":{"mean":0,"squared_diffs":0},"cnt":11,"firstAttemptCnt":11,"idleLat":{"mean":0,"squared_diffs":0},"indexes":["15@4"],"lastErrorCode":"","lastExecAt":"2024-01-01T12:10:00Z","maxRetries":0,"nodes":[1],"numRows":{"mean":0,"squared_diffs":0},"ovhLat":{"mean":0,"squared_diffs":0},"parseLat":{"mean":0,"squared_diffs":0},"planGists":["AgEeCADnAwIAAAMHEgUUIR4AAA=="],"planLat":{"mean":0,"squared_diffs":0},"regions":["us-east1"],"rowsRead":{"mean":0,"squared_diffs":0},"rowsWritten":{"mean":0,"squared_diffs":0},"runLat":{"mean":0,"squared_diffs":0},"svcLat":{"mean":13,"squared_diffs":0}}, "index_recommendations": []}'::JSONB,
+  '{"Children": [], "Name": ""}',
+  ARRAY[]
+),
+(
+  '2024-01-01 13:00:00 +0000',
+  '\x264b1304276b4834',
+  '\x8928ae48a16affeb',
+  '\x0586d2c686ef8add',
+  'test_app',
+  1,
+  '01:00:00',
+  '{"db":"test_database","distsql":true,"failed":false,"fullScan":true,"implicitTxn":true,"query":"SELECT * FROM xyz","querySummary":"SELECT * FROM xyz","stmtType":"TypeDDL","vec":true}',
+  '{"execution_statistics": {"cnt":3,"contentionTime":{"mean":0,"squared_diffs":0},"cpuSQLNanos":{"mean":5,"squared_diffs":0},"maxDiskUsage":{"mean":10,"squared_diffs":0},"maxMemUsage":{"mean":10,"squared_diffs":0},"networkBytes":{"mean":0,"squared_diffs":0},"networkMsgs":{"mean":0,"squared_diffs":0}}, "statistics": {"bytesRead":{"mean":0,"squared_diffs":0},"cnt":17,"firstAttemptCnt":17,"idleLat":{"mean":0,"squared_diffs":0},"indexes":["15@4"],"lastErrorCode":"","lastExecAt":"2024-01-01T13:10:00Z","maxRetries":0,"nodes":[1],"numRows":{"mean":0,"squared_diffs":0},"ovhLat":{"mean":0,"squared_diffs":0},"parseLat":{"mean":0,"squared_diffs":0},"planGists":["AgEeCADnAwIAAAMHEgUUIR4AAA=="],"planLat":{"mean":0,"squared_diffs":0},"regions":["us-east1"],"rowsRead":{"mean":0,"squared_diffs":0},"rowsWritten":{"mean":0,"squared_diffs":0},"runLat":{"mean":0,"squared_diffs":0},"svcLat":{"mean":19,"squared_diffs":0}}, "index_recommendations": []}'::JSONB,
+  '{"Children": [], "Name": ""}',
+  ARRAY[]
+)
+----
+
+
+run-sql
+SELECT count(*) FROM system.statement_statistics
+----
+4
+
+# Insert Data to system.statement_activity
+run-sql
+INSERT INTO system.statement_activity (
+  aggregated_ts,
+  fingerprint_id,
+  transaction_fingerprint_id,
+  plan_hash,
+  app_name,
+  agg_interval,
+  metadata,
+  statistics,
+  plan,
+  index_recommendations,
+  execution_count,
+	execution_total_seconds,
+	execution_total_cluster_seconds,
+	contention_time_avg_seconds,
+	cpu_sql_avg_nanos,
+	service_latency_avg_seconds,
+	service_latency_p99_seconds
+)
+VALUES (
+  '2024-01-01 12:00:00 +0000',
+  '\x7a4489011193ce55',
+  '\xd527344d9792798a',
+  '\x2324d56cb507f877',
+  'test_app',
+  '01:00:00',
+  '{"appNames":["test_app"],"db":["test_database"],"distSQLCount":1,"failedCount":0,"fullScanCount":1,"implicitTxn":true,"query":"SELECT * FROM abc","querySummary":"SELECT * FROM abc","stmtType":"TypeDDL","vecCount":1}',
+  '{"execution_statistics": {"cnt":3,"contentionTime":{"mean":0,"squared_diffs":0},"cpuSQLNanos":{"mean":5,"squared_diffs":0},"maxDiskUsage":{"mean":10,"squared_diffs":0},"maxMemUsage":{"mean":10,"squared_diffs":0},"networkBytes":{"mean":0,"squared_diffs":0},"networkMsgs":{"mean":0,"squared_diffs":0}}, "statistics": {"bytesRead":{"mean":0,"squared_diffs":0},"cnt":11,"firstAttemptCnt":11,"idleLat":{"mean":0,"squared_diffs":0},"indexes":["15@4"],"lastErrorCode":"","lastExecAt":"2024-01-01T12:10:00Z","maxRetries":0,"nodes":[1],"numRows":{"mean":0,"squared_diffs":0},"ovhLat":{"mean":0,"squared_diffs":0},"parseLat":{"mean":0,"squared_diffs":0},"planGists":["AgEeCADnAwIAAAMHEgUUIR4AAA=="],"planLat":{"mean":0,"squared_diffs":0},"regions":["us-east1"],"rowsRead":{"mean":0,"squared_diffs":0},"rowsWritten":{"mean":0,"squared_diffs":0},"runLat":{"mean":0,"squared_diffs":0},"svcLat":{"mean":13,"squared_diffs":0}}, "index_recommendations": []}'::JSONB,
+  '{"Children": [], "Name": ""}',
+  ARRAY['creation : CREATE INDEX t3_k_i_f ON t3(k, i, f)'],
+	11,
+	143,
+	143,
+	0,
+	5,
+	10,
+	7
+),
+(
+  '2024-01-01 13:00:00 +0000',
+  '\x264b1304276b4834',
+  '\x8928ae48a16affeb',
+  '\x0586d2c686ef8add',
+  'test_app',
+  '01:00:00',
+  '{"appNames":["test_app"],"db":["test_database"],"distSQLCount":1,"failedCount":0,"fullScanCount":1,"implicitTxn":true,"query":"SELECT * FROM xyz","querySummary":"SELECT * FROM xyz","stmtType":"TypeDDL","vecCount":1}',
+  '{"execution_statistics": {"cnt":3,"contentionTime":{"mean":0,"squared_diffs":0},"cpuSQLNanos":{"mean":5,"squared_diffs":0},"maxDiskUsage":{"mean":10,"squared_diffs":0},"maxMemUsage":{"mean":10,"squared_diffs":0},"networkBytes":{"mean":0,"squared_diffs":0},"networkMsgs":{"mean":0,"squared_diffs":0}}, "statistics": {"bytesRead":{"mean":0,"squared_diffs":0},"cnt":17,"firstAttemptCnt":17,"idleLat":{"mean":0,"squared_diffs":0},"indexes":["15@4"],"lastErrorCode":"","lastExecAt":"2024-01-01T13:10:00Z","maxRetries":0,"nodes":[1],"numRows":{"mean":0,"squared_diffs":0},"ovhLat":{"mean":0,"squared_diffs":0},"parseLat":{"mean":0,"squared_diffs":0},"planGists":["AgEeCADnAwIAAAMHEgUUIR4AAA=="],"planLat":{"mean":0,"squared_diffs":0},"regions":["us-east1"],"rowsRead":{"mean":0,"squared_diffs":0},"rowsWritten":{"mean":0,"squared_diffs":0},"runLat":{"mean":0,"squared_diffs":0},"svcLat":{"mean":19,"squared_diffs":0}}, "index_recommendations": []}'::JSONB,
+  '{"Children": [], "Name": ""}',
+  ARRAY['creation : CREATE INDEX t3_k_i_f ON t3(k, i, f)'],
+	17,
+	323,
+	323,
+	0,
+	5,
+	10,
+	7
+)
+----
+
+
+run-sql
+SELECT count(*) FROM system.statement_activity
+----
+2


### PR DESCRIPTION
Previously, the tests for the sql api was not using data driven tests, making the test itself hard to read.
This commit replace the total latency test with a data driven one. It creates a default file to insert data which can be used be the other tests on the same file.

A following PR will update the remaining tests on this file.

Part Of CRDB-35217

Release note: None