### PR TITLE
workload,randgen: make schema object names more deterministic

### DIFF
--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -16,6 +16,7 @@ import (
 	"math/rand"
 	"net/http/httptest"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -221,7 +222,7 @@ func (s *Smither) name(prefix string) tree.Name {
 		s.nameGens[prefix] = g
 	}
 	g.count++
-	return tree.Name(g.g.GenerateOne(g.count))
+	return tree.Name(g.g.GenerateOne(strconv.Itoa(g.count)))
 }
 
 // SmitherOption is an option for the Smither client.

--- a/pkg/server/application_api/util_test.go
+++ b/pkg/server/application_api/util_test.go
@@ -28,5 +28,5 @@ func generateRandomName() string {
 		rand,
 		"a b%s-c.d",
 	)
-	return ng.GenerateOne(42)
+	return ng.GenerateOne("42")
 }

--- a/pkg/sql/catalog/randgen/tables.go
+++ b/pkg/sql/catalog/randgen/tables.go
@@ -106,9 +106,9 @@ func (g *testSchemaGenerator) selectNamesAndTemplates(
 			tbNamePat := g.models.tb[i].namePat
 			cfg := g.cfg.NameGen
 			if namesPerTemplate == 1 {
-				cfg.Number = false
+				cfg.Suffix = false
 				if !cfg.HasVariability() {
-					cfg.Number = true
+					cfg.Suffix = true
 				}
 			}
 			ng := randident.NewNameGenerator(&cfg, g.rand, tbNamePat)
@@ -181,10 +181,10 @@ func (g *testSchemaGenerator) genOneTable(
 	tmpl.desc.Temporary = sc.SchemaKind() == catalog.SchemaTemporary
 	if g.cfg.RandomizeColumns {
 		nameGenCfg := g.cfg.NameGen
-		nameGenCfg.Number = false
+		nameGenCfg.Suffix = false
 		for i, cPat := range tmpl.baseColumnNames {
 			ng := randident.NewNameGenerator(&nameGenCfg, g.rand, cPat)
-			colName := ng.GenerateOne(0)
+			colName := ng.GenerateOne("0")
 			tmpl.desc.Columns[i+1].Name = colName
 			tmpl.desc.Families[0].ColumnNames[i+1] = colName
 			for j := range tmpl.desc.PrimaryIndex.KeyColumnNames {
@@ -199,7 +199,7 @@ func (g *testSchemaGenerator) genOneTable(
 			}
 		}
 		ng := randident.NewNameGenerator(&nameGenCfg, g.rand, "primary")
-		idxName := ng.GenerateOne(0)
+		idxName := ng.GenerateOne("0")
 		tmpl.desc.PrimaryIndex.Name = idxName
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/gen_test_objects
+++ b/pkg/sql/logictest/testdata/logic_test/gen_test_objects
@@ -49,15 +49,15 @@ SELECT quote_ident(database_name), quote_ident(schema_name), quote_ident(name)
 FROM "".crdb_internal.tables WHERE database_name LIKE '%z%z%'
 ORDER BY database_name, schema_name, name
 ----
-"""z z1"  b1      c1
-"""z z1"  b1      c2
-"""z z1"  b̷2     c1
-"""z z1"  b̷2     c2
-"zz%q2"   "b%p2"  "%c'2"
-"zz%q2"   "b%p2"  "c""
-1"
-"zz%q2"  b1  c1
-"zz%q2"  b1  c̕2
+"""z z_1"  b_1      c_1
+"""z z_1"  b_1      c_2
+"""z z_1"  b̷_2     c_1
+"""z z_1"  b̷_2     c_2
+"zz%q_2"   "b%p_2"  "%c'_2"
+"zz%q_2"   "b%p_2"  "c""
+_1"
+"zz%q_2"  b_1  c_1
+"zz%q_2"  b_1  c̕_2
 
 # Show number placement inside the output identifier, without added noise.
 query T
@@ -69,14 +69,14 @@ query TTT rowsort
 SELECT quote_ident(database_name), quote_ident(schema_name), quote_ident(name)
 FROM "".crdb_internal.tables WHERE database_name LIKE '%z%y%'
 ----
-z1y  b1  c1
-z1y  b1  c2
-z1y  b2  c1
-z1y  b2  c2
-z2y  b1  c1
-z2y  b1  c2
-z2y  b2  c1
-z2y  b2  c2
+z1y  b_1  c_1
+z1y  b_1  c_2
+z1y  b_2  c_1
+z1y  b_2  c_2
+z2y  b_1  c_1
+z2y  b_1  c_2
+z2y  b_2  c_1
+z2y  b_2  c_2
 
 subtest randomize_columns
 
@@ -90,15 +90,15 @@ SELECT quote_ident(descriptor_name), quote_ident(column_name) FROM crdb_internal
 WHERE descriptor_name ILIKE '%t%e%s%t%'
 ORDER BY descriptor_name, column_name
 ----
-"test(3"  address
-"test(3"  name
-"test(3"  rowid
-test1     "ad""dress%"
-test1     name😤
-test1     rowid
-test2     address
-test2     "name%80"
-test2     rowid
+"test(_3"  address
+"test(_3"  name
+"test(_3"  rowid
+test_1     "ad""dress%"
+test_1     name😤
+test_1     rowid
+test_2     address
+test_2     "name%80"
+test_2     rowid
 
 subtest templates/more_tables_generated_than_templates
 
@@ -119,26 +119,26 @@ SELECT quote_ident(table_name), quote_ident(column_name), data_type FROM "".info
 WHERE table_catalog = 'newdb' AND table_schema = 'public'
 ORDER BY table_name, column_name
 ----
-"                u3"      rowid    bigint
-"                u3"      y        text
-"*t""1"          "%56x"   numeric
-"*t""1"          rowid    bigint
-"\\U00051024u4"  rowid    bigint
-"\\U00051024u4"  "y "     text
-"t%q3"           rowid    bigint
-"t%q3"           x        numeric
-t2               rowid    bigint
-t2               "x""%q"  numeric
-t4               """%vx"  numeric
-t4               rowid    bigint
-t̷5              "%vx"    numeric
-t̷5              rowid    bigint
-u1               rowid    bigint
-u1               y        text
-u2               rowid    bigint
-u2               "|y"     text
-u5               rowid    bigint
-u5               y        text
+"                 u_3"     rowid    bigint
+"                 u_3"     y        text
+"*t""_1"          "%56x"   numeric
+"*t""_1"          rowid    bigint
+"\\U00051024u_4"  rowid    bigint
+"\\U00051024u_4"  "y "     text
+"t%q_3"           rowid    bigint
+"t%q_3"           x        numeric
+t_2               rowid    bigint
+t_2               "x""%q"  numeric
+t_4               """%vx"  numeric
+t_4               rowid    bigint
+t̷_5              "%vx"    numeric
+t̷_5              rowid    bigint
+u_1               rowid    bigint
+u_1               y        text
+u_2               rowid    bigint
+u_2               "|y"     text
+u_5               rowid    bigint
+u_5               y        text
 
 # As well as index names.
 query TT
@@ -146,16 +146,16 @@ SELECT quote_ident(table_name), quote_ident(constraint_name) FROM "".information
 WHERE table_catalog = 'newdb' AND table_schema = 'public' AND constraint_type = 'PRIMARY KEY'
 ORDER BY table_name, constraint_name
 ----
-"                u3"          pr̫imary
-"*t""1"          "PrimaRy̧"
-"\\U00051024u4"  "primary"
-"t%q3"           "primary"
-t2               "primary"
-t4               "primar'y"
-t̷5              primary̕
-u1               "primary"
-u2               "primary"
-u5               "primar%vy"
+"                 u_3"         pr̫imary
+"*t""_1"          "PrimaRy̧"
+"\\U00051024u_4"  "primary"
+"t%q_3"           "primary"
+t_2               "primary"
+t_4               "primar'y"
+t̷_5              primary̕
+u_1               "primary"
+u_2               "primary"
+u_5               "primar%vy"
 
 subtest templates/fewer_tables_generated_than_templates
 
@@ -236,15 +236,15 @@ SELECT quote_ident(database_name), quote_ident(schema_name), quote_ident(name)
 FROM "".crdb_internal.tables WHERE database_name ILIKE '%d%b%t%'
 ORDER BY database_name, schema_name, name
 ----
-"d%qbt1"  public  span_stats_samples
-"d%qbt1"  public  "t abLe_statistics"
-"d%qbt1"  public  "transaction_execut%ion_insights"
-"d%qbt2"  public  "r\\x0fegion_liveness"
-"d%qbt2"  public  span_stats_buckets
-"d%qbt2"  public  "transaction_statisTics"
-dbt3      public  "extern'al_connections"
-dbt3      public  "te\\x64nant_i""d_se q"
-dbt3      public  "tenant_setting%vs"
+"d%qbt_1"  public  span_stats_samples
+"d%qbt_1"  public  "t abLe_statistics"
+"d%qbt_1"  public  "transaction_execut%ion_insights"
+"d%qbt_2"  public  "r\\x0fegion_liveness"
+"d%qbt_2"  public  span_stats_buckets
+"d%qbt_2"  public  "transaction_statisTics"
+dbt_3      public  "extern'al_connections"
+dbt_3      public  "te\\x64nant_i""d_se q"
+dbt_3      public  "tenant_setting%vs"
 
 
 statement ok
@@ -259,46 +259,46 @@ subtest show_config
 query T
 SELECT crdb_internal.generate_test_objects('{"dry_run":true}'::JSONB)#-array['seed']
 ----
-{"batch_size": 1000, "counts": [10], "dry_run": true, "generated_counts": {"databases": 0, "schemas": 0, "tables": 10}, "name_gen": {"capitals": 0.08, "diacritic_depth": 1, "diacritics": 0.08, "emote": 0.08, "escapes": 0.08, "fmt": 0.08, "noise": true, "number": true, "punctuate": 0.08, "quote": 0.08, "space": 0.08, "whitespace": 0.08}, "names": "_", "randomize_columns": true}
+{"batch_size": 1000, "counts": [10], "dry_run": true, "generated_counts": {"databases": 0, "schemas": 0, "tables": 10}, "name_gen": {"capitals": 0.08, "diacritic_depth": 1, "diacritics": 0.08, "emote": 0.08, "escapes": 0.08, "fmt": 0.08, "noise": true, "punctuate": 0.08, "quote": 0.08, "space": 0.08, "suffix": true, "whitespace": 0.08}, "names": "_", "randomize_columns": true}
 
 # Manual seed.
 query T
 SELECT crdb_internal.generate_test_objects('{"dry_run":true,"seed":123}'::JSONB)#-array['generated_counts']
 ----
-{"batch_size": 1000, "counts": [10], "dry_run": true, "name_gen": {"capitals": 0.08, "diacritic_depth": 1, "diacritics": 0.08, "emote": 0.08, "escapes": 0.08, "fmt": 0.08, "noise": true, "number": true, "punctuate": 0.08, "quote": 0.08, "space": 0.08, "whitespace": 0.08}, "names": "_", "randomize_columns": true, "seed": 123}
+{"batch_size": 1000, "counts": [10], "dry_run": true, "name_gen": {"capitals": 0.08, "diacritic_depth": 1, "diacritics": 0.08, "emote": 0.08, "escapes": 0.08, "fmt": 0.08, "noise": true, "punctuate": 0.08, "quote": 0.08, "space": 0.08, "suffix": true, "whitespace": 0.08}, "names": "_", "randomize_columns": true, "seed": 123}
 
 # Noise disabled.
 query T
 SELECT crdb_internal.generate_test_objects('{"dry_run":true,"seed":123,"name_gen":{"noise":false}}'::JSONB)#-array['generated_counts']
 ----
-{"batch_size": 1000, "counts": [10], "dry_run": true, "name_gen": {"noise": false, "number": true}, "names": "_", "randomize_columns": true, "seed": 123}
+{"batch_size": 1000, "counts": [10], "dry_run": true, "name_gen": {"noise": false, "suffix": true}, "names": "_", "randomize_columns": true, "seed": 123}
 
 # Numbers disabled.
 query T
-SELECT crdb_internal.generate_test_objects('{"dry_run":true,"seed":123,"name_gen":{"number":false}}'::JSONB)#-array['generated_counts']
+SELECT crdb_internal.generate_test_objects('{"dry_run":true,"seed":123,"name_gen":{"suffix":false}}'::JSONB)#-array['generated_counts']
 ----
-{"batch_size": 1000, "counts": [10], "dry_run": true, "name_gen": {"capitals": 0.08, "diacritic_depth": 1, "diacritics": 0.08, "emote": 0.08, "escapes": 0.08, "fmt": 0.08, "noise": true, "number": false, "punctuate": 0.08, "quote": 0.08, "space": 0.08, "whitespace": 0.08}, "names": "_", "randomize_columns": true, "seed": 123}
+{"batch_size": 1000, "counts": [10], "dry_run": true, "name_gen": {"capitals": 0.08, "diacritic_depth": 1, "diacritics": 0.08, "emote": 0.08, "escapes": 0.08, "fmt": 0.08, "noise": true, "punctuate": 0.08, "quote": 0.08, "space": 0.08, "suffix": false, "whitespace": 0.08}, "names": "_", "randomize_columns": true, "seed": 123}
 
 # Numbers and noise disabled.
 query error name generation needs variability to generate objects
-SELECT crdb_internal.generate_test_objects('{"dry_run":true,"seed":123,"name_gen":{"number":false,"noise":false}}'::JSONB)#-array['generated_counts']
+SELECT crdb_internal.generate_test_objects('{"dry_run":true,"seed":123,"name_gen":{"suffix":false,"noise":false}}'::JSONB)#-array['generated_counts']
 
 # Numbers and noise disabled, but some extra variability.
 query T
-SELECT crdb_internal.generate_test_objects('{"dry_run":true,"seed":123,"name_gen":{"number":false,"noise":false,"quote":1}}'::JSONB)#-array['generated_counts']
+SELECT crdb_internal.generate_test_objects('{"dry_run":true,"seed":123,"name_gen":{"suffix":false,"noise":false,"quote":1}}'::JSONB)#-array['generated_counts']
 ----
-{"batch_size": 1000, "counts": [10], "dry_run": true, "name_gen": {"noise": false, "number": false, "quote": 1}, "names": "_", "randomize_columns": true, "seed": 123}
+{"batch_size": 1000, "counts": [10], "dry_run": true, "name_gen": {"noise": false, "quote": 1, "suffix": false}, "names": "_", "randomize_columns": true, "seed": 123}
 
 # Zalgo mode enabled.
 query T
 SELECT crdb_internal.generate_test_objects('{"dry_run":true,"seed":123,"name_gen":{"noise":false,"zalgo":true}}'::JSONB)#-array['generated_counts']
 ----
-{"batch_size": 1000, "counts": [10], "dry_run": true, "name_gen": {"diacritic_depth": 20, "diacritics": 1000, "noise": false, "number": true, "zalgo": true}, "names": "_", "randomize_columns": true, "seed": 123}
+{"batch_size": 1000, "counts": [10], "dry_run": true, "name_gen": {"diacritic_depth": 20, "diacritics": 1000, "noise": false, "suffix": true, "zalgo": true}, "names": "_", "randomize_columns": true, "seed": 123}
 
 query T
 SELECT crdb_internal.generate_test_objects('{"dry_run":true,"seed":123,"name_gen":{"noise":true,"zalgo":true}}'::JSONB)#-array['generated_counts']
 ----
-{"batch_size": 1000, "counts": [10], "dry_run": true, "name_gen": {"capitals": 0.08, "diacritic_depth": 20, "diacritics": 1000, "emote": 0.08, "escapes": 0.08, "fmt": 0.08, "noise": true, "number": true, "punctuate": 0.08, "quote": 0.08, "space": 0.08, "whitespace": 0.08, "zalgo": true}, "names": "_", "randomize_columns": true, "seed": 123}
+{"batch_size": 1000, "counts": [10], "dry_run": true, "name_gen": {"capitals": 0.08, "diacritic_depth": 20, "diacritics": 1000, "emote": 0.08, "escapes": 0.08, "fmt": 0.08, "noise": true, "punctuate": 0.08, "quote": 0.08, "space": 0.08, "suffix": true, "whitespace": 0.08, "zalgo": true}, "names": "_", "randomize_columns": true, "seed": 123}
 
 subtest zero_dbs
 
@@ -320,12 +320,12 @@ SELECT crdb_internal.generate_test_objects('{"names":"dba.bar.baz", "counts":[2,
 {"databases": 2, "schemas": 2, "tables": 0}
 
 query I
-SELECT count(*) FROM [SHOW TABLES FROM dba1]
+SELECT count(*) FROM [SHOW TABLES FROM dba_1]
 ----
 0
 
 query I
-SELECT count(*) FROM [SHOW TABLES FROM dba2]
+SELECT count(*) FROM [SHOW TABLES FROM dba_2]
 ----
 0
 
@@ -341,9 +341,9 @@ SELECT crdb_internal.generate_test_objects('{"names":"dbb.bar.baz", "counts":[1,
 {"databases": 1, "schemas": 2, "tables": 0}
 
 query T rowsort
-SELECT schema_name FROM [SHOW SCHEMAS FROM dbb1]
+SELECT schema_name FROM [SHOW SCHEMAS FROM dbb_1]
 ----
-bar1
+bar_1
 public
 crdb_internal
 information_schema
@@ -351,7 +351,7 @@ pg_catalog
 pg_extension
 
 query I
-SELECT count(*) FROM [SHOW TABLES FROM dbb1.bar1]
+SELECT count(*) FROM [SHOW TABLES FROM dbb_1.bar_1]
 ----
 0
 
@@ -371,8 +371,8 @@ SELECT crdb_internal.generate_test_objects('{"names":"myschema.foo", "counts":[2
 query TT rowsort
 SELECT schema_name, table_name FROM [SHOW TABLES FROM test.myschema]
 ----
-myschema  foo1
-myschema  foo2
+myschema  foo_1
+myschema  foo_2
 
 subtest implicit_db/zero_schemas
 
@@ -398,16 +398,16 @@ SELECT crdb_internal.generate_test_objects('{"names":"scgen.foo", "counts":[2,0]
 query T rowsort
 SELECT schema_name FROM [SHOW SCHEMAS] WHERE schema_name LIKE 'scgen%'
 ----
-scgen1
-scgen2
+scgen_1
+scgen_2
 
 query I
-SELECT count(*) FROM [SHOW TABLES FROM scgen1]
+SELECT count(*) FROM [SHOW TABLES FROM scgen_1]
 ----
 0
 
 query I
-SELECT count(*) FROM [SHOW TABLES FROM scgen2]
+SELECT count(*) FROM [SHOW TABLES FROM scgen_2]
 ----
 0
 
@@ -428,8 +428,8 @@ SELECT crdb_internal.generate_test_objects('{"names":"foo", "counts":[2], "name_
 query TT rowsort
 SELECT schema_name, table_name FROM [SHOW TABLES FROM test.otherschema]
 ----
-otherschema  foo2
-otherschema  foo1
+otherschema  foo_1
+otherschema  foo_2
 
 statement ok
 RESET search_path
@@ -446,10 +446,10 @@ SELECT crdb_internal.generate_test_objects('{"names":"dbfoo.baz", "counts":[1,0,
 {"databases": 1, "schemas": 1, "tables": 2}
 
 query TT rowsort
-SELECT schema_name, table_name FROM [SHOW TABLES FROM dbfoo1]
+SELECT schema_name, table_name FROM [SHOW TABLES FROM dbfoo_1]
 ----
-public  baz1
-public  baz2
+public  baz_1
+public  baz_2
 
 subtest missing_pattern
 
@@ -600,7 +600,7 @@ SELECT crdb_internal.generate_test_objects('{"names":"pg_temp.foo", "counts":[3]
 query T rowsort
 SELECT table_name FROM [SHOW TABLES FROM pg_temp]
 ----
-foo1
-foo2
-foo3
 test
+foo_1
+foo_2
+foo_3

--- a/pkg/sql/logictest/testdata/logic_test/rand_ident
+++ b/pkg/sql/logictest/testdata/logic_test/rand_ident
@@ -11,19 +11,19 @@ SELECT count(*) FROM crdb_internal.gen_rand_ident('hello', 10)
 query T nosort
 SELECT crdb_internal.gen_rand_ident('helloworld', 10, '{"seed":123}')
 ----
-helloworld1
-heLlowor%pld   2
-hell😆oworld3
-helloworld4
-helloworld5
-helloworld6
-helloWorld7
-helloworld8
-h%velloworld9
-hellowo        rld10
+helloworld_1
+heLlowor%pld    _2
+hell😆oworld_3
+helloworld_4
+helloworld_5
+helloworld_6
+helloWorld_7
+helloworld_8
+h%velloworld_9
+hellowo         rld_10
 
 query T nosort
-SELECT crdb_internal.gen_rand_ident('helloworld', 10, '{"seed":123,"number":false}')
+SELECT crdb_internal.gen_rand_ident('helloworld', 10, '{"seed":123,"suffix":false}')
 ----
 helloworld
 heLlowor%pld
@@ -40,130 +40,130 @@ hellowo       rld
 query T nosort
 SELECT crdb_internal.gen_rand_ident('helloworld', 10, '{"seed":123,"noise":true,"emote":-1}')
 ----
-helloworld1
-hell\roworld%562
-he"llowo rld3
-helloworld4
-helloworld5
-helloworld6
-helloworld7
+helloworld_1
+hell\roworld%56_2
+he"llowo rld_3
+helloworld_4
+helloworld_5
+helloworld_6
+helloworld_7
 hel
-loworld8
-helloworld9
-h elloworld10
+loworld_8
+helloworld_9
+h elloworld_10
 
 query T nosort
 SELECT crdb_internal.gen_rand_ident('helloworld', 10, '{"seed":123,"noise":false}')
 ----
-helloworld1
-helloworld2
-helloworld3
-helloworld4
-helloworld5
-helloworld6
-helloworld7
-helloworld8
-helloworld9
-helloworld10
+helloworld_1
+helloworld_2
+helloworld_3
+helloworld_4
+helloworld_5
+helloworld_6
+helloworld_7
+helloworld_8
+helloworld_9
+helloworld_10
 
 query T nosort
 SELECT crdb_internal.gen_rand_ident('helloworld', 10, '{"seed":123,"noise":false,"punctuate":1}')
 ----
-h*ello}world&1
-helloworld2
-helloworld3
-hell(oworld-4
-hellowo/rld5
-helloworld6
-hell.ow!orld7
-helloworld8
-he}lloworld9
-h%elloworld10
+h*ello}world&_1
+helloworld_2
+helloworld_3
+hell(oworld-_4
+hellowo/rld_5
+helloworld_6
+hell.ow!orld_7
+helloworld_8
+he}lloworld_9
+h%elloworld_10
 
 query T nosort
 SELECT crdb_internal.gen_rand_ident('helloworld', 10, '{"seed":123,"noise":false,"quote":1}')
 ----
-h"ello"world"1
-helloworld2
-helloworld3
-hell'oworld"4
-hellowo'rld5
-helloworld6
-hell"ow'orld7
-helloworld8
-he'lloworld9
-h'elloworld10
+h"ello"world"_1
+helloworld_2
+helloworld_3
+hell'oworld"_4
+hellowo'rld_5
+helloworld_6
+hell"ow'orld_7
+helloworld_8
+he'lloworld_9
+h'elloworld_10
 
 query T nosort
 SELECT crdb_internal.gen_rand_ident('helloworld', 10, '{"seed":123,"noise":false,"space":1}')
 ----
-h ellow orld1
-h elloworld2
-helloworld3
-hellowo rld4
-hel loworld5
-h e lloworld6
-helloworld 7
-he lloworld8
-helloworld 9
-helloworld 10
+h ellow orld_1
+h elloworld_2
+helloworld_3
+hellowo rld_4
+hel loworld_5
+h e lloworld_6
+helloworld _7
+he lloworld_8
+helloworld _9
+helloworld _10
 
 query T nosort
 SELECT quote_ident(crdb_internal.gen_rand_ident('helloworld', 10, '{"seed":123,"noise":false,"whitespace":1}'))
 ----
-"h  ello  world  1"
-helloworld2
-helloworld3
+"h  ello  world  _1"
+helloworld_2
+helloworld_3
 "hell
-oworld           4"
+oworld           _4"
 "hellowo
-rld5"
-helloworld6
+rld_5"
+helloworld_6
 "hell
-ow orld7"
-helloworld8
+ow orld_7"
+helloworld_8
 "he
-lloworld9"
-"h elloworld10"
+lloworld_9"
+"h elloworld_10"
 
 query T nosort
 SELECT crdb_internal.gen_rand_ident('helloworld', 10, '{"seed":123,"noise":false,"emote":1}')
 ----
-h😟ello😺world😋1
-helloworld2
-helloworld3
-hell😅oworld😵4
-hellowo😓rld5
-helloworld6
-hell😉ow😉orld7
-helloworld8
-he😙lloworld9
-h😞elloworld10
+h😟ello😺world😋_1
+helloworld_2
+helloworld_3
+hell😅oworld😵_4
+hellowo😓rld_5
+helloworld_6
+hell😉ow😉orld_7
+helloworld_8
+he😙lloworld_9
+h😞elloworld_10
 
 query T nosort
 SELECT crdb_internal.gen_rand_ident('aeaeiao', 10, '{"seed":123,"noise":false,"diacritics":3,"diacritic_depth":4}')
 ----
-aẹͫae̩͇iao̅͘1
-ā̞e͠a̶̓eia̲o2
-a̲̾e̙̺ae̴ͥia͍͟o3
-aea͎ḙͭi͖͞aͪo4
-ae͌aei̷͓a̺o5
-a͔ͪeaeiaͧo̦6
-aeͨä̯́ei̒a̸o7
-aeaeͮi̪ͅa͚̓o8
-aeaeǐ̉aͭ͜o̩̚9
-aeaeĩ͊ã̓o10
+aẹͫae̩͇iao̅͘_1
+ā̞e͠a̶̓eia̲o_2
+a̲̾e̙̺ae̴ͥia͍͟o_3
+aea͎ḙͭi͖͞aͪo_4
+ae͌aei̷͓a̺o_5
+a͔ͪeaeiaͧo̦_6
+aeͨä̯́ei̒a̸o_7
+aeaeͮi̪ͅa͚̓o_8
+aeaeǐ̉aͭ͜o̩̚_9
+aeaeĩ͊ã̓o_10
 
 query T nosort
 SELECT crdb_internal.gen_rand_ident('aeaeiao', 10, '{"seed":123,"noise":false,"zalgo":true}')
 ----
-a̫̣̳̟̩͇̻͎ͫ̇e̶͍̞̝̅̄̊ͦ́͘͟͠ă̢͔̲͙̲͙̙̺̼̍̾̃͑͢è̴̸̛͍̠̥͎̰̭ͣͥͭ̚͟͠i͖͇̦͑ͪͪ͋͌͜͞ȁ̷͓̗̺̻̣̽ͪ͛ő̳̭ͯͬ̐ͧͤ͌1
-a̠̯̿ͨ̐ͧ̈́ͬ́̔̒ě̸̛ͮ̚͟͢a̷e̵͚̰̖ͭ̓̑̃̓̏̌̕i̴̱̩̹̇ͭͨͮ͐̍̃̚͘͜ã̡̡̼̓͂̉͟ͅͅo̡̖̹̓͞2
-a̵̦͋̈́͒ͦ̽̇͌e̡ͧ̊a̷̢̢̟̯͕͒̓͋̃̋͊ͨ͟e̸̡͎̥̺͙̓̂̚i̍ͦ͊͏̴̷ͩ̄̆̽̃ͥ͜͡ͅͅͅḁ̖̭͚̘̗̠͈̬̔̿̐o̧̪̬̗̳͑ͮͩ̂͘3
-á̢̌e͓͒̒ͥ͠͏̝̳̈́̀̕ã̸̱̻̥̻̩̒ͧͨͨ̔͆̀̊ͦ͊͝ẽi̶̢̛̠̜̣̘̋̽́͑̅̏̇̋̈́͡ȧ̻ǫ̬̩̳͈̍̌̈̈́͞͞4
-a̸̛̦̝̰̠̖̺ͫ̍͑͂̀̊̽͠e͏̰̘͚͙̙̣͕͔̝̋ͨ͋̀̓̏͘͜a̯̭̯͕̲ͣ̓̈́ͥ͌ͧͬ̚͝e̢̖̫̯͔̽ͯ̐͐̇̊̾͂ͬi̙͗͋̄̇͝͞͡͏̼̗̱̃́a̙̩̔͏͈̫̣̍́ỡ̱̞̒͆́ͯͦ͑͠5
-a̷̫̥̣̦̦̭͗͆̅͐ͬ̓ͥ̚ḙ̶̛̲̳̻̯̙̺̅ͪͦ̎͌͟ạ̷̢̤̤͗͊ͧͩ̑͋͡e̘͉̜̮͍̰͔̊ͨ̆̄̅i̙͚͇̳͕̺̰ͮ̃̋͂̂ͮͣậ̫̞̜̱̌ͭ̋ͬ̎͛͠ȯ̞̻̘̐̌6
-áe̷̷̙̟̜̮͕̋͘͝a͓͖ẹ͉͈̦͛ͩ̔͋ͫ̽̊i̻̫̋̍ͬ͆̒̌a̮̬̼̳͉ͦͩ͋ͣͥͧ̐͂ͩ̓ͭ̕o̯͛͢͏̝̬͎̬̘̥͈̯ͫ̅̆͛̚͡7
-ǎ͎͎͙̬͓̫̮͙ͮ̈ͣeͩ͜ȃ̢̧͓̣͕̭ͤe̦̝̤̲̭ͬ̒͊̊͆͜͏̚͞i͉͈͍͚̿̊ͬ̑̚ā̵̜̪͕͕̼̘͂̿́̀͠͝ớ͖͓̳̯̍ͮ͒͑̔ͩ̋̒͡8
-ȧ̢̙̝͕͕̘̦́̋ͫ̀̔͘̚͢͞͠è̵̫̰̾̔͌͂͘͜͝a̸̳̦͂̒ͥ͗e̴̢͕̋̑̄ͪ̊͋́̕i͖̹̟͘͞ą̙͋͊̀ͬọ̬̩͗̈́9
-ȃ̒̉̃͢͝ͅe͡a͖͖̩̦͆̇̽̅͌̃͡e̶̸͙͚̣̩̓͂̿̈̀ͬͤ̌̐̚i̬̲̩͊́̐̀̚a̧͍̞̜̓͒́̅o̯͕̗̹͔̘ͫ̅ͯ̒ͭ͒̐̀̔̿͢͞10
+a̫̣̳̟̩͇̻͎ͫ̇e̶͍̞̝̅̄̊ͦ́͘͟͠ă̢͔̲͙̲͙̙̺̼̍̾̃͑͢è̴̸̛͍̠̥͎̰̭ͣͥͭ̚͟͠i͖͇̦͑ͪͪ͋͌͜͞ȁ̷͓̗̺̻̣̽ͪ͛ő̳̭ͯͬ̐ͧͤ͌_1
+a̠̯̿ͨ̐ͧ̈́ͬ́̔̒ě̸̛ͮ̚͟͢a̷e̵͚̰̖ͭ̓̑̃̓̏̌̕i̴̱̩̹̇ͭͨͮ͐̍̃̚͘͜ã̡̡̼̓͂̉͟ͅͅo̡̖̹̓͞_2
+a̵̦͋̈́͒ͦ̽̇͌e̡ͧ̊a̷̢̢̟̯͕͒̓͋̃̋͊ͨ͟e̸̡͎̥̺͙̓̂̚i̍ͦ͊͏̴̷ͩ̄̆̽̃ͥ͜͡ͅͅͅḁ̖̭͚̘̗̠͈̬̔̿̐o̧̪̬̗̳͑ͮͩ̂͘_3
+á̢̌e͓͒̒ͥ͠͏̝̳̈́̀̕ã̸̱̻̥̻̩̒ͧͨͨ̔͆̀̊ͦ͊͝ẽi̶̢̛̠̜̣̘̋̽́͑̅̏̇̋̈́͡ȧ̻ǫ̬̩̳͈̍̌̈̈́͞͞_4
+a̸̛̦̝̰̠̖̺ͫ̍͑͂̀̊̽͠e͏̰̘͚͙̙̣͕͔̝̋ͨ͋̀̓̏͘͜a̯̭̯͕̲ͣ̓̈́ͥ͌ͧͬ̚͝e̢̖̫̯͔̽ͯ̐͐̇̊̾͂ͬi̙͗͋̄̇͝͞͡͏̼̗̱̃́a̙̩̔͏͈̫̣̍́ỡ̱̞̒͆́ͯͦ͑͠_5
+a̷̫̥̣̦̦̭͗͆̅͐ͬ̓ͥ̚ḙ̶̛̲̳̻̯̙̺̅ͪͦ̎͌͟ạ̷̢̤̤͗͊ͧͩ̑͋͡e̘͉̜̮͍̰͔̊ͨ̆̄̅i̙͚͇̳͕̺̰ͮ̃̋͂̂ͮͣậ̫̞̜̱̌ͭ̋ͬ̎͛͠ȯ̞̻̘̐̌_6
+áe̷̷̙̟̜̮͕̋͘͝a͓͖ẹ͉͈̦͛ͩ̔͋ͫ̽̊i̻̫̋̍ͬ͆̒̌a̮̬̼̳͉ͦͩ͋ͣͥͧ̐͂ͩ̓ͭ̕o̯͛͢͏̝̬͎̬̘̥͈̯ͫ̅̆͛̚͡_7
+ǎ͎͎͙̬͓̫̮͙ͮ̈ͣeͩ͜ȃ̢̧͓̣͕̭ͤe̦̝̤̲̭ͬ̒͊̊͆͜͏̚͞i͉͈͍͚̿̊ͬ̑̚ā̵̜̪͕͕̼̘͂̿́̀͠͝ớ͖͓̳̯̍ͮ͒͑̔ͩ̋̒͡_8
+ȧ̢̙̝͕͕̘̦́̋ͫ̀̔͘̚͢͞͠è̵̫̰̾̔͌͂͘͜͝a̸̳̦͂̒ͥ͗e̴̢͕̋̑̄ͪ̊͋́̕i͖̹̟͘͞ą̙͋͊̀ͬọ̬̩͗̈́_9
+ȃ̒̉̃͢͝ͅe͡a͖͖̩̦͆̇̽̅͌̃͡e̶̸͙͚̣̩̓͂̿̈̀ͬͤ̌̐̚i̬̲̩͊́̐̀̚a̧͍̞̜̓͒́̅o̯͕̗̹͔̘ͫ̅ͯ̒ͭ͒̐̀̔̿͢͞_10

--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"strconv"
 	"strings"
 
 	apd "github.com/cockroachdb/apd/v3"
@@ -118,12 +119,12 @@ func RandCreateTableWithColumnIndexNumberGenerator(
 	tableIdx int,
 	isMultiRegion bool,
 	allowPartiallyVisibleIndex bool,
-	generateColumnIndexNumber func() int64,
+	generateColumnIndexSuffix func() string,
 ) *tree.CreateTable {
 	g := randident.NewNameGenerator(&nameGenCfg, rng, prefix)
-	name := g.GenerateOne(tableIdx)
+	name := g.GenerateOne(strconv.Itoa(tableIdx))
 	return RandCreateTableWithColumnIndexNumberGeneratorAndName(
-		rng, name, tableIdx, isMultiRegion, allowPartiallyVisibleIndex, generateColumnIndexNumber,
+		rng, name, tableIdx, isMultiRegion, allowPartiallyVisibleIndex, generateColumnIndexSuffix,
 	)
 }
 
@@ -141,7 +142,7 @@ func RandCreateTableWithColumnIndexNumberGeneratorAndName(
 	tableIdx int,
 	isMultiRegion bool,
 	allowPartiallyVisibleIndex bool,
-	generateColumnIndexNumber func() int64,
+	generateColumnIndexSuffix func() string,
 ) *tree.CreateTable {
 	// columnDefs contains the list of Columns we'll add to our table.
 	nColumns := randutil.RandIntInRange(rng, 1, 20)
@@ -151,18 +152,18 @@ func RandCreateTableWithColumnIndexNumberGeneratorAndName(
 	defs := make(tree.TableDefs, 0, len(columnDefs))
 
 	// colIdx generates numbers that are incorporated into column names.
-	colIdx := func(ordinal int) int {
-		if generateColumnIndexNumber != nil {
-			return int(generateColumnIndexNumber())
+	colSuffix := func(ordinal int) string {
+		if generateColumnIndexSuffix != nil {
+			return generateColumnIndexSuffix()
 		}
-		return ordinal
+		return strconv.Itoa(ordinal)
 	}
 
 	// Make new defs from scratch.
 	nComputedColumns := randutil.RandIntInRange(rng, 0, (nColumns+1)/2)
 	nNormalColumns := nColumns - nComputedColumns
 	for i := 0; i < nNormalColumns; i++ {
-		columnDef := randColumnTableDef(rng, tableIdx, colIdx(i))
+		columnDef := randColumnTableDef(rng, tableIdx, colSuffix(i))
 		columnDefs = append(columnDefs, columnDef)
 		defs = append(defs, columnDef)
 	}
@@ -170,7 +171,7 @@ func RandCreateTableWithColumnIndexNumberGeneratorAndName(
 	// Make defs for computed columns.
 	normalColDefs := columnDefs
 	for i := nNormalColumns; i < nColumns; i++ {
-		columnDef := randComputedColumnTableDef(rng, normalColDefs, tableIdx, colIdx(i))
+		columnDef := randComputedColumnTableDef(rng, normalColDefs, tableIdx, colSuffix(i))
 		columnDefs = append(columnDefs, columnDef)
 		defs = append(defs, columnDef)
 	}
@@ -462,9 +463,9 @@ func GenerateRandInterestingTable(db *gosql.DB, dbName, tableName string) error 
 
 // randColumnTableDef produces a random ColumnTableDef for a non-computed
 // column, with a random type and nullability.
-func randColumnTableDef(rng *rand.Rand, tableIdx int, colIdx int) *tree.ColumnTableDef {
+func randColumnTableDef(rng *rand.Rand, tableIdx int, colSuffix string) *tree.ColumnTableDef {
 	g := randident.NewNameGenerator(&nameGenCfg, rng, fmt.Sprintf("col%d_", tableIdx))
-	colName := g.GenerateOne(colIdx)
+	colName := g.GenerateOne(colSuffix)
 	columnDef := &tree.ColumnTableDef{
 		// We make a unique name for all columns by prefixing them with the table
 		// index to make it easier to reference columns from different tables.
@@ -654,7 +655,7 @@ func randIndexTableDefFromCols(
 		numExpressions := rng.Intn(10) + 1
 		for i := 0; i < numPartitions; i++ {
 			var partition tree.ListPartition
-			partition.Name = tree.Name(g.GenerateOne(i))
+			partition.Name = tree.Name(g.GenerateOne(strconv.Itoa(i)))
 			// Add up to 10 expressions in each partition.
 			for j := 0; j < numExpressions; j++ {
 				// Use a tuple to contain the expressions in case there are multiple

--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -491,9 +491,9 @@ func randColumnTableDef(rng *rand.Rand, tableIdx int, colSuffix string) *tree.Co
 // column (either STORED or VIRTUAL). The computed expressions refer to columns
 // in normalColDefs.
 func randComputedColumnTableDef(
-	rng *rand.Rand, normalColDefs []*tree.ColumnTableDef, tableIdx int, colIdx int,
+	rng *rand.Rand, normalColDefs []*tree.ColumnTableDef, tableIdx int, colSuffix string,
 ) *tree.ColumnTableDef {
-	newDef := randColumnTableDef(rng, tableIdx, colIdx)
+	newDef := randColumnTableDef(rng, tableIdx, colSuffix)
 	newDef.Computed.Computed = true
 	newDef.Computed.Virtual = rng.Intn(2) == 0
 

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -16,6 +16,7 @@ import (
 	gojson "encoding/json"
 	"math/rand"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -2993,7 +2994,7 @@ func (s *identGenerator) Next(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	name := s.gen.GenerateOne(s.idx)
+	name := s.gen.GenerateOne(strconv.Itoa(s.idx))
 	if err := s.acc.Grow(ctx, int64(len(name))); err != nil {
 		return false, err
 	}

--- a/pkg/util/randident/api.go
+++ b/pkg/util/randident/api.go
@@ -24,9 +24,9 @@ type NameGeneratorConfig = randidentcfg.Config
 type NameGenerator interface {
 	// GenerateOne generates one name.
 	//
-	// The specified number is included in the name if Number is true
+	// The specified suffix is included in the name if Suffix is true
 	// in the attached NameGeneratorConfig.
-	GenerateOne(number int) string
+	GenerateOne(suffix string) string
 
 	// GenerateMultiple generates count names, guaranteed to not be
 	// present in the conflictNames map.
@@ -47,7 +47,7 @@ func DefaultNameGeneratorConfig() NameGeneratorConfig {
 		DiacriticDepth: 1,
 
 		// Number the objects by default and add some noise.
-		Number: true,
+		Suffix: true,
 		Noise:  true,
 	}
 }

--- a/pkg/util/randident/namegen.go
+++ b/pkg/util/randident/namegen.go
@@ -33,7 +33,7 @@ func NewNameGenerator(cfg *NameGeneratorConfig, rand *rand.Rand, pattern string)
 		cfg:           cfg,
 		rand:          rand,
 		pattern:       pattern,
-		numberReplace: strings.Contains(pattern, "#"),
+		suffixReplace: strings.Contains(pattern, "#"),
 	}
 }
 
@@ -41,7 +41,7 @@ type nameGenerator struct {
 	cfg           *NameGeneratorConfig
 	rand          *rand.Rand
 	pattern       string
-	numberReplace bool
+	suffixReplace bool
 }
 
 var _ NameGenerator = (*nameGenerator)(nil)
@@ -63,7 +63,7 @@ var escGenerators = []func(s *strings.Builder, r *rand.Rand){
 }
 
 // GenerateOne generates one random name.
-func (g *nameGenerator) GenerateOne(number int) string {
+func (g *nameGenerator) GenerateOne(suffix string) string {
 	var s strings.Builder
 
 	// We want to consider every character position, including the start
@@ -147,14 +147,13 @@ func (g *nameGenerator) GenerateOne(number int) string {
 		insertNoise()
 	}
 
-	if g.cfg.Number {
-		if g.numberReplace {
-			is := strconv.Itoa(number)
-			r := strings.ReplaceAll(s.String(), "#", is)
+	if g.cfg.Suffix {
+		if g.suffixReplace {
+			r := strings.ReplaceAll(s.String(), "#", suffix)
 			r = lexbase.NormalizeString(r)
 			return r
 		}
-		fmt.Fprintf(&s, "%d", number)
+		fmt.Fprintf(&s, "_%s", suffix)
 	}
 	// The introduction of special unicode characters above may result
 	// in combined runes that should be reduced to NFC to form a valid
@@ -173,7 +172,7 @@ func (g *nameGenerator) GenerateMultiple(
 			return nil, ctx.Err()
 		default:
 		}
-		candidateName := g.GenerateOne(i)
+		candidateName := g.GenerateOne(strconv.Itoa(i))
 		if _, ok := conflictNames[candidateName]; ok {
 			continue
 		}

--- a/pkg/util/randident/namegen_test.go
+++ b/pkg/util/randident/namegen_test.go
@@ -13,6 +13,7 @@ package randident
 import (
 	"context"
 	"math/rand"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -92,7 +93,7 @@ func TestNameGen(t *testing.T) {
 			t.Run(tname+"/one", func(t *testing.T) {
 				names := make([]string, 100)
 				for i := 0; i < 100; i++ {
-					names[i] = g.GenerateOne(i)
+					names[i] = g.GenerateOne(strconv.Itoa(i))
 				}
 				validate(t, names, ps)
 			})
@@ -104,7 +105,7 @@ func TestNameGen(t *testing.T) {
 		})
 	}
 
-	cfg := NameGeneratorConfig{Number: true}
+	cfg := NameGeneratorConfig{Suffix: true}
 	testNameGen("base", &cfg, "hello",
 		preds{
 			always: []pred{func(n string) bool { return strings.HasPrefix(n, "hello") }},

--- a/pkg/util/randident/randidentcfg/config.go
+++ b/pkg/util/randident/randidentcfg/config.go
@@ -40,9 +40,9 @@ const ConfigDoc = `
 // The caller is responsible for calling the Finalize() method
 // before using a config object.
 type Config struct {
-	// Number adds an identifying number to the name.
-	// The pattern name can contain '#' to indicate where the number should go.
-	Number bool `json:"number"`
+	// Suffix adds an identifying suffix to the name.
+	// The pattern name can contain '#' to indicate where the suffix should go.
+	Suffix bool `json:"suffix"`
 
 	// Noise indicates that non-zero name generation options get
 	// a non-zero value.
@@ -146,7 +146,7 @@ func (cfg *Config) Finalize() {
 // is guaranteed to return different names with the same config
 // and name number.
 func (cfg *Config) HasVariability() bool {
-	return cfg.Number ||
+	return cfg.Suffix ||
 		cfg.Punctuate > 0 ||
 		cfg.Quote > 0 ||
 		cfg.Emote > 0 ||

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -16,9 +16,9 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"regexp"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"text/template"
 	"time"
 
@@ -41,10 +41,11 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// seqNum may be shared across multiple instances of this, so it should only
-// be change atomically.
+// All of the fields of operationGeneratorParams should only be accessed by
+// one goroutine.
 type operationGeneratorParams struct {
-	seqNum             *atomic.Int64
+	workerID           int
+	seqNum             int
 	errorRate          int
 	enumPct            int
 	rng                *rand.Rand
@@ -672,7 +673,7 @@ func (og *operationGenerator) alterDatabaseAddSuperRegion(
 			return PickAtLeast(og.params.rng, 1, nonSuperRegionRegions)
 		},
 		"UniqueName": func() *tree.Name {
-			name := tree.Name(fmt.Sprintf("super_region_%d", og.newUniqueSeqNum()))
+			name := tree.Name(fmt.Sprintf("super_region_%s", og.newUniqueSeqNumSuffix()))
 			return &name
 		},
 		"RegionsNotPartOfDatabase": func() (Values, error) {
@@ -1191,13 +1192,16 @@ func (og *operationGenerator) createSequence(ctx context.Context, tx pgx.Tx) (*o
 	return stmt, nil
 }
 
+var trailingDigits = regexp.MustCompile(`\d+$`)
+
 func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opStmt, error) {
 	tableName, err := og.randTable(ctx, tx, og.pctExisting(false), "")
 	if err != nil {
 		return nil, err
 	}
 
-	tableIdx, err := strconv.Atoi(strings.TrimPrefix(tableName.Table(), "table"))
+	tableIdxStr := trailingDigits.FindString(tableName.Table())
+	tableIdx, err := strconv.Atoi(tableIdxStr)
 	if err != nil {
 		return nil, err
 	}
@@ -1214,7 +1218,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	}
 	stmt := randgen.RandCreateTableWithColumnIndexNumberGenerator(
 		og.params.rng, "table", tableIdx, databaseHasMultiRegion,
-		!partiallyVisibleIndexNotSupported, og.newUniqueSeqNum,
+		!partiallyVisibleIndexNotSupported, og.newUniqueSeqNumSuffix,
 	)
 	stmt.Table = *tableName
 	stmt.IfNotExists = og.randIntn(2) == 0
@@ -3247,8 +3251,8 @@ func (og *operationGenerator) randColumn(
 	if og.randIntn(100) >= pctExisting {
 		// We make a unique name for all columns by prefixing them with the table
 		// index to make it easier to reference columns from different tables.
-		return fmt.Sprintf("col%s_%d",
-			strings.TrimPrefix(tableName.Table(), "table"), og.newUniqueSeqNum()), nil
+		return fmt.Sprintf("col%s_%s",
+			strings.TrimPrefix(tableName.Table(), "table"), og.newUniqueSeqNumSuffix()), nil
 	}
 	q := fmt.Sprintf(`
   SELECT column_name
@@ -3274,8 +3278,8 @@ func (og *operationGenerator) randColumnWithMeta(
 		// We make a unique name for all columns by prefixing them with the table
 		// index to make it easier to reference columns from different tables.
 		return column{
-			name: fmt.Sprintf("col%s_%d",
-				strings.TrimPrefix(tableName.Table(), "table"), og.newUniqueSeqNum()),
+			name: fmt.Sprintf("col%s_%s",
+				strings.TrimPrefix(tableName.Table(), "table"), og.newUniqueSeqNumSuffix()),
 		}, nil
 	}
 	q := fmt.Sprintf(`
@@ -3452,8 +3456,8 @@ func (og *operationGenerator) randIndex(
 	if og.randIntn(100) >= pctExisting {
 		// We make a unique name for all indices by prefixing them with the table
 		// index to make it easier to reference columns from different tables.
-		return fmt.Sprintf("index%s_%d",
-			strings.TrimPrefix(tableName.Table(), "table"), og.newUniqueSeqNum()), nil
+		return fmt.Sprintf("index%s_%s",
+			strings.TrimPrefix(tableName.Table(), "table"), og.newUniqueSeqNumSuffix()), nil
 	}
 	q := fmt.Sprintf(`
   SELECT index_name
@@ -3479,7 +3483,7 @@ func (og *operationGenerator) randSequence(
 			treeSeqName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
 				SchemaName:     tree.Name(desiredSchema),
 				ExplicitSchema: true,
-			}, tree.Name(fmt.Sprintf("seq%d", og.newUniqueSeqNum())))
+			}, tree.Name(fmt.Sprintf("seq_%s", og.newUniqueSeqNumSuffix())))
 			return &treeSeqName, nil
 		}
 		q := fmt.Sprintf(`
@@ -3515,7 +3519,7 @@ func (og *operationGenerator) randSequence(
 		treeSeqName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
 			SchemaName:     tree.Name(randSchema),
 			ExplicitSchema: true,
-		}, tree.Name(fmt.Sprintf("seq%d", og.newUniqueSeqNum())))
+		}, tree.Name(fmt.Sprintf("seq_%s", og.newUniqueSeqNumSuffix())))
 		return &treeSeqName, nil
 	}
 
@@ -3552,7 +3556,7 @@ func (og *operationGenerator) randEnum(
 		if err != nil {
 			return nil, false, err
 		}
-		typeName := tree.MakeSchemaQualifiedTypeName(randSchema, fmt.Sprintf("enum%d", og.newUniqueSeqNum()))
+		typeName := tree.MakeSchemaQualifiedTypeName(randSchema, fmt.Sprintf("enum_%s", og.newUniqueSeqNumSuffix()))
 		return &typeName, false, nil
 	}
 	const q = `
@@ -3581,7 +3585,7 @@ func (og *operationGenerator) randTable(
 			treeTableName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
 				SchemaName:     tree.Name(desiredSchema),
 				ExplicitSchema: true,
-			}, tree.Name(fmt.Sprintf("table%d", og.newUniqueSeqNum())))
+			}, tree.Name(fmt.Sprintf("table_%s", og.newUniqueSeqNumSuffix())))
 			return &treeTableName, nil
 		}
 		q := fmt.Sprintf(`
@@ -3618,7 +3622,7 @@ func (og *operationGenerator) randTable(
 		treeTableName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
 			SchemaName:     tree.Name(randSchema),
 			ExplicitSchema: true,
-		}, tree.Name(fmt.Sprintf("table%d", og.newUniqueSeqNum())))
+		}, tree.Name(fmt.Sprintf("table_%s", og.newUniqueSeqNumSuffix())))
 		return &treeTableName, nil
 	}
 
@@ -3651,7 +3655,7 @@ func (og *operationGenerator) randView(
 			treeViewName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
 				SchemaName:     tree.Name(desiredSchema),
 				ExplicitSchema: true,
-			}, tree.Name(fmt.Sprintf("view%d", og.newUniqueSeqNum())))
+			}, tree.Name(fmt.Sprintf("view_%s", og.newUniqueSeqNumSuffix())))
 			return &treeViewName, nil
 		}
 
@@ -3687,7 +3691,7 @@ func (og *operationGenerator) randView(
 		treeViewName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
 			SchemaName:     tree.Name(randSchema),
 			ExplicitSchema: true,
-		}, tree.Name(fmt.Sprintf("view%d", og.newUniqueSeqNum())))
+		}, tree.Name(fmt.Sprintf("view_%s", og.newUniqueSeqNumSuffix())))
 		return &treeViewName, nil
 	}
 	const q = `
@@ -3801,7 +3805,7 @@ func (og *operationGenerator) randSchema(
 	ctx context.Context, tx pgx.Tx, pctExisting int,
 ) (string, error) {
 	if og.randIntn(100) >= pctExisting {
-		return fmt.Sprintf("schema%d", og.newUniqueSeqNum()), nil
+		return fmt.Sprintf("schema_%s", og.newUniqueSeqNumSuffix()), nil
 	}
 	const q = `
   SELECT schema_name
@@ -3914,7 +3918,7 @@ func (og *operationGenerator) createFunction(ctx context.Context, tx pgx.Tx) (*o
 		{pgcode.UndefinedTable, `CREATE FUNCTION { UniqueName } (IN p1 { DroppingEnum }) RETURNS VOID LANGUAGE SQL AS $$ SELECT NULL $$`},
 	}, template.FuncMap{
 		"UniqueName": func() *tree.Name {
-			name := tree.Name(fmt.Sprintf("udf_%d", og.newUniqueSeqNum()))
+			name := tree.Name(fmt.Sprintf("udf_%s", og.newUniqueSeqNumSuffix()))
 			return &name
 		},
 		"DroppingEnum": func() (string, error) {
@@ -4027,7 +4031,7 @@ func (og *operationGenerator) alterFunctionRename(ctx context.Context, tx pgx.Tx
 		{pgcode.SuccessfulCompletion, `ALTER FUNCTION { (ExistingFunction).qualified_name } RENAME TO { UniqueName }`},
 	}, template.FuncMap{
 		"UniqueName": func() *tree.Name {
-			name := tree.Name(fmt.Sprintf("udf_%d", og.newUniqueSeqNum()))
+			name := tree.Name(fmt.Sprintf("udf_%s", og.newUniqueSeqNumSuffix()))
 			return &name
 		},
 		"ExistingFunction": func() (map[string]any, error) {
@@ -4254,8 +4258,9 @@ func (og *operationGenerator) randIntn(topBound int) int {
 	return og.params.rng.Intn(topBound)
 }
 
-func (og *operationGenerator) newUniqueSeqNum() int64 {
-	return og.params.seqNum.Add(1)
+func (og *operationGenerator) newUniqueSeqNumSuffix() string {
+	og.params.seqNum++
+	return fmt.Sprintf("w%d_%d", og.params.workerID, og.params.seqNum)
 }
 
 // typeFromTypeName resolves a type string to a types.T struct so that it can be

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -321,7 +321,8 @@ SELECT max(regexp_extract(name, '[0-9]+$')::INT8)
 						 (SELECT name FROM [SHOW ENUMS]) UNION
 	           (SELECT schema_name FROM [SHOW SCHEMAS]) UNION
 						 (SELECT column_name FROM information_schema.columns) UNION
-						 (SELECT index_name FROM information_schema.statistics)
+						 (SELECT index_name FROM information_schema.statistics) UNION
+						 (SELECT function_name FROM [SHOW FUNCTIONS])
            ) AS obj (name)
        )
  WHERE name ~ '^(table|view|seq|enum|schema|udf)_w%[1]d_[0-9]+$'

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -195,10 +195,6 @@ func (s *schemaChange) Ops(
 	if err := s.setClusterSettings(ctx, pool); err != nil {
 		return workload.QueryLoad{}, err
 	}
-	seqNum, err := s.initSeqNum(ctx, pool)
-	if err != nil {
-		return workload.QueryLoad{}, err
-	}
 	stdoutLog := makeAtomicLog(os.Stdout)
 	rng, seed := randutil.NewTestRand()
 	stdoutLog.printLn(fmt.Sprintf("using random seed: %d", seed))
@@ -248,7 +244,16 @@ func (s *schemaChange) Ops(
 		// different seed for each worker so that each one generates different
 		// operations.
 		workerRng := randutil.NewTestRandWithSeed(seed + int64(i))
+
+		// Each worker needs its own sequence number generator so that the names of
+		// generated objects are deterministic across runs.
+		seqNum, err := s.initSeqNum(ctx, pool, i)
+		if err != nil {
+			return workload.QueryLoad{}, err
+		}
+
 		opGeneratorParams := operationGeneratorParams{
+			workerID:           i,
 			seqNum:             seqNum,
 			errorRate:          s.errorRate,
 			enumPct:            s.enumPct,
@@ -304,11 +309,9 @@ func (s *schemaChange) setClusterSettings(ctx context.Context, pool *workload.Mu
 // It's not obvious how the workloads will behave when accessing the same
 // cluster.
 func (s *schemaChange) initSeqNum(
-	ctx context.Context, pool *workload.MultiConnPool,
-) (*atomic.Int64, error) {
-	var seqNum atomic.Int64
-
-	const q = `
+	ctx context.Context, pool *workload.MultiConnPool, workerID int,
+) (int, error) {
+	var q = fmt.Sprintf(`
 SELECT max(regexp_extract(name, '[0-9]+$')::INT8)
   FROM (
     SELECT name
@@ -321,18 +324,19 @@ SELECT max(regexp_extract(name, '[0-9]+$')::INT8)
 						 (SELECT index_name FROM information_schema.statistics)
            ) AS obj (name)
        )
- WHERE name ~ '^(table|view|seq|enum|schema)[0-9]+$'
-    OR name ~ '^(col|index)[0-9]+_[0-9]+$';
-`
-	var max gosql.NullInt64
-	if err := pool.Get().QueryRow(ctx, q).Scan(&max); err != nil {
-		return nil, err
-	}
-	if max.Valid {
-		seqNum.Store(max.Int64 + 1)
+ WHERE name ~ '^(table|view|seq|enum|schema|udf)_w%[1]d_[0-9]+$'
+    OR name ~ '^(col|index)[0-9]+_w%[1]d_[0-9]+$';
+`, workerID)
+	var maxID gosql.NullInt64
+	if err := pool.Get().QueryRow(ctx, q).Scan(&maxID); err != nil {
+		return 0, err
 	}
 
-	return &seqNum, nil
+	var seqNum int
+	if maxID.Valid {
+		seqNum = int(maxID.Int64 + 1)
+	}
+	return seqNum, nil
 }
 
 type schemaChangeWorker struct {


### PR DESCRIPTION
Now each worker of the schema change workload has its own sequence number. This makes it so the names that are generated are now deterministic for each worker, rather than depending on how the worker execution is interleaved.

fixes https://github.com/cockroachdb/cockroach/issues/117422
Release note: None