### PR TITLE
kvclient: remove speculative leases

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2383,9 +2383,8 @@ func (ds *DistSender) sendToReplicas(
 			// is correct, we want the serve to return an update, at which point
 			// the cached entry will no longer be "speculative".
 			DescriptorGeneration: desc.Generation,
-			// The LeaseSequence will be 0 if the cache doesn't have lease info,
-			// or has a speculative lease. Like above, this asks the server to
-			// return an update.
+			// The LeaseSequence will be 0 if the cache doesn't have lease info.
+			// Like above, this asks the server to return an update.
 			LeaseSequence: routing.LeaseSeq(),
 			// The ClosedTimestampPolicy will be the default if the cache
 			// doesn't have info. Like above, this asks the server to return an
@@ -2552,7 +2551,7 @@ func (ds *DistSender) sendToReplicas(
 				ds.metrics.NotLeaseHolderErrCount.Inc(1)
 				// If we got some lease information, we use it. If not, we loop around
 				// and try the next replica.
-				if tErr.Lease != nil || tErr.DeprecatedLeaseHolder != nil {
+				if tErr.Lease != nil {
 					// Update the leaseholder in the range cache. Naively this would also
 					// happen when the next RPC comes back, but we don't want to wait out
 					// the additional RPC latency.
@@ -2560,10 +2559,6 @@ func (ds *DistSender) sendToReplicas(
 					var updatedLeaseholder bool
 					if tErr.Lease != nil {
 						updatedLeaseholder = routing.SyncTokenAndMaybeUpdateCache(ctx, tErr.Lease, &tErr.RangeDesc)
-					} else if tErr.DeprecatedLeaseHolder != nil {
-						updatedLeaseholder = routing.SyncTokenAndMaybeUpdateCacheWithSpeculativeLease(
-							ctx, *tErr.DeprecatedLeaseHolder, &tErr.RangeDesc,
-						)
 					}
 					// Move the new leaseholder to the head of the queue for the next
 					// retry. Note that the leaseholder might not be the one indicated by

--- a/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
@@ -394,9 +394,6 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 					"actual lease info: %s",
 					expStoreID, desc, curLease)
 			}
-			if curLease.Speculative() {
-				return errors.Errorf("only had speculative lease for %s", desc)
-			}
 			if !kvserver.ExpirationLeasesOnly.Get(&tc.Server(0).ClusterSettings().SV) &&
 				curLease.Type() != roachpb.LeaseEpoch {
 				return errors.Errorf("awaiting upgrade to epoch-based lease for %s", desc)

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -656,18 +656,6 @@ func TestRetryOnNotLeaseHolderError(t *testing.T) {
 			expLease:       true,
 		},
 		{
-			// TODO(arul): This is only possible in 22.{1,2} mixed version clusters;
-			// remove once we get rid of the LeaseHolder field in 23.1.
-			name: "leaseholder in desc, no lease",
-			nlhe: kvpb.NotLeaseHolderError{
-				RangeID:               testUserRangeDescriptor3Replicas.RangeID,
-				DeprecatedLeaseHolder: &recognizedLeaseHolder,
-				RangeDesc:             testUserRangeDescriptor3Replicas,
-			},
-			expLeaseholder: &recognizedLeaseHolder,
-			expLease:       false,
-		},
-		{
 			name: "leaseholder not in desc",
 			nlhe: kvpb.NotLeaseHolderError{
 				RangeID:   testUserRangeDescriptor3Replicas.RangeID,
@@ -5779,123 +5767,116 @@ func TestDistSenderNLHEFromUninitializedReplicaDoesNotCauseUnboundedBackoff(t *t
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	testutils.RunTrueAndFalse(t, "uninitialized-replica-returns-speculative-lease",
-		func(t *testing.T, returnSpeculativeLease bool) {
+	// We'll set things up such that the first replica on the range descriptor of
+	// the client has an uninitialized replica. We'll mimic this by returning an
+	// empty range descriptor as part of the NotLeaseHolderError it returns.
+	// We expect the client to simply reroute to the next replica.
+	//
+	// For the returnsSpeculativeLease=true version of the test the NLHE error
+	// will include a speculative lease that points to a replica that isn't
+	// part of the client's range descriptor. This is only possible in
+	// versions <= 22.1 as NLHE errors from uninitialized replicas no longer
+	// return speculative leases by populating the (Deprecated)LeaseHolder
+	// field. Effectively, this acts as a mixed (22.1, 22.2) version test.
+	// TODO(arul): remove the speculative lease version of this test in 23.1.
 
-			// We'll set things up such that the first replica on the range descriptor of
-			// the client has an uninitialized replica. We'll mimic this by returning an
-			// empty range descriptor as part of the NotLeaseHolderError it returns.
-			// We expect the client to simply reroute to the next replica.
-			//
-			// For the returnsSpeculativeLease=true version of the test the NLHE error
-			// will include a speculative lease that points to a replica that isn't
-			// part of the client's range descriptor. This is only possible in
-			// versions <= 22.1 as NLHE errors from uninitialized replicas no longer
-			// return speculative leases by populating the (Deprecated)LeaseHolder
-			// field. Effectively, this acts as a mixed (22.1, 22.2) version test.
-			// TODO(arul): remove the speculative lease version of this test in 23.1.
+	clock := hlc.NewClockForTesting(nil)
+	ns := &mockNodeStore{nodes: []roachpb.NodeDescriptor{
+		{NodeID: 1, Address: util.UnresolvedAddr{}},
+		{NodeID: 2, Address: util.UnresolvedAddr{}},
+		{NodeID: 3, Address: util.UnresolvedAddr{}},
+		{NodeID: 4, Address: util.UnresolvedAddr{}},
+	}}
 
-			clock := hlc.NewClockForTesting(nil)
-			ns := &mockNodeStore{nodes: []roachpb.NodeDescriptor{
-				{NodeID: 1, Address: util.UnresolvedAddr{}},
-				{NodeID: 2, Address: util.UnresolvedAddr{}},
-				{NodeID: 3, Address: util.UnresolvedAddr{}},
-				{NodeID: 4, Address: util.UnresolvedAddr{}},
-			}}
+	// Actual view of the range (descriptor + lease). The client doesn't have
+	// any knowledge about the lease, so it routes its request to the first
+	// replica on the range descriptor.
+	var desc = roachpb.RangeDescriptor{
+		RangeID:    roachpb.RangeID(1),
+		Generation: 1,
+		StartKey:   roachpb.RKeyMin,
+		EndKey:     roachpb.RKeyMax,
+		InternalReplicas: []roachpb.ReplicaDescriptor{
+			{NodeID: 1, StoreID: 1, ReplicaID: 1},
+			{NodeID: 2, StoreID: 2, ReplicaID: 2},
+			{NodeID: 3, StoreID: 3, ReplicaID: 3},
+			{NodeID: 4, StoreID: 4, ReplicaID: 4},
+		},
+	}
+	leaseResp := roachpb.Lease{
+		Replica: roachpb.ReplicaDescriptor{NodeID: 4, StoreID: 4, ReplicaID: 4},
+	}
 
-			// Actual view of the range (descriptor + lease). The client doesn't have
-			// any knowledge about the lease, so it routes its request to the first
-			// replica on the range descriptor.
-			var desc = roachpb.RangeDescriptor{
-				RangeID:    roachpb.RangeID(1),
-				Generation: 1,
-				StartKey:   roachpb.RKeyMin,
-				EndKey:     roachpb.RKeyMax,
-				InternalReplicas: []roachpb.ReplicaDescriptor{
-					{NodeID: 1, StoreID: 1, ReplicaID: 1},
-					{NodeID: 2, StoreID: 2, ReplicaID: 2},
-					{NodeID: 3, StoreID: 3, ReplicaID: 3},
-					{NodeID: 4, StoreID: 4, ReplicaID: 4},
-				},
+	call := 0
+	var transportFn = func(_ context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
+		br := &kvpb.BatchResponse{}
+		switch call {
+		case 0:
+			// We return an empty range descriptor in the NLHE like an
+			// uninitialized replica would.
+			expRepl := desc.Replicas().Descriptors()[0]
+			require.Equal(t, expRepl, ba.Replica)
+			nlhe := &kvpb.NotLeaseHolderError{
+				RangeDesc: roachpb.RangeDescriptor{},
 			}
-			leaseResp := roachpb.Lease{
-				Replica: roachpb.ReplicaDescriptor{NodeID: 4, StoreID: 4, ReplicaID: 4},
+			br.Error = kvpb.NewError(nlhe)
+		case 1:
+			// We expect the client to discard information from the NLHE above and
+			// instead just try the next replica.
+			expRepl := desc.Replicas().Descriptors()[1]
+			require.Equal(t, expRepl, ba.Replica)
+			br.Error = kvpb.NewError(&kvpb.NotLeaseHolderError{
+				RangeDesc: desc,
+				Lease:     &leaseResp,
+			})
+		case 2:
+			// We expect the client to route to the leaseholder given it's now
+			// known.
+			expRepl := desc.Replicas().Descriptors()[3]
+			require.Equal(t, expRepl, ba.Replica)
+			br = ba.CreateReply()
+		default:
+			t.Fatal("unexpected")
+		}
+		call++
+		return br, nil
+	}
+
+	rangeLookups := 0
+	cfg := DistSenderConfig{
+		AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
+		Clock:      clock,
+		NodeDescs:  ns,
+		Stopper:    stopper,
+		RangeDescriptorDB: MockRangeDescriptorDB(func(key roachpb.RKey, reverse bool) (
+			[]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error,
+		) {
+			switch rangeLookups {
+			case 0:
+				rangeLookups++
+				return []roachpb.RangeDescriptor{desc}, nil, nil
+			default:
+				// This doesn't run on the test's goroutine.
+				panic("unexpected")
 			}
+		}),
+		TransportFactory: adaptSimpleTransport(transportFn),
+		TestingKnobs: ClientTestingKnobs{
+			DontReorderReplicas: true,
+		},
+		Settings: cluster.MakeTestingClusterSettings(),
+	}
 
-			call := 0
-			var transportFn = func(_ context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
-				br := &kvpb.BatchResponse{}
-				switch call {
-				case 0:
-					// We return an empty range descriptor in the NLHE like an
-					// uninitialized replica would.
-					expRepl := desc.Replicas().Descriptors()[0]
-					require.Equal(t, expRepl, ba.Replica)
-					nlhe := &kvpb.NotLeaseHolderError{
-						RangeDesc: roachpb.RangeDescriptor{},
-					}
-					if returnSpeculativeLease {
-						nlhe.DeprecatedLeaseHolder = &roachpb.ReplicaDescriptor{NodeID: 5, StoreID: 5, ReplicaID: 5}
-					}
-					br.Error = kvpb.NewError(nlhe)
-				case 1:
-					// We expect the client to discard information from the NLHE above and
-					// instead just try the next replica.
-					expRepl := desc.Replicas().Descriptors()[1]
-					require.Equal(t, expRepl, ba.Replica)
-					br.Error = kvpb.NewError(&kvpb.NotLeaseHolderError{
-						RangeDesc: desc,
-						Lease:     &leaseResp,
-					})
-				case 2:
-					// We expect the client to route to the leaseholder given it's now
-					// known.
-					expRepl := desc.Replicas().Descriptors()[3]
-					require.Equal(t, expRepl, ba.Replica)
-					br = ba.CreateReply()
-				default:
-					t.Fatal("unexpected")
-				}
-				call++
-				return br, nil
-			}
+	ds := NewDistSender(cfg)
+	ba := &kvpb.BatchRequest{}
+	get := &kvpb.GetRequest{}
+	get.Key = roachpb.Key("a")
+	ba.Add(get)
 
-			rangeLookups := 0
-			cfg := DistSenderConfig{
-				AmbientCtx: log.MakeTestingAmbientCtxWithNewTracer(),
-				Clock:      clock,
-				NodeDescs:  ns,
-				Stopper:    stopper,
-				RangeDescriptorDB: MockRangeDescriptorDB(func(key roachpb.RKey, reverse bool) (
-					[]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error,
-				) {
-					switch rangeLookups {
-					case 0:
-						rangeLookups++
-						return []roachpb.RangeDescriptor{desc}, nil, nil
-					default:
-						// This doesn't run on the test's goroutine.
-						panic("unexpected")
-					}
-				}),
-				TransportFactory: adaptSimpleTransport(transportFn),
-				TestingKnobs: ClientTestingKnobs{
-					DontReorderReplicas: true,
-				},
-				Settings: cluster.MakeTestingClusterSettings(),
-			}
-
-			ds := NewDistSender(cfg)
-			ba := &kvpb.BatchRequest{}
-			get := &kvpb.GetRequest{}
-			get.Key = roachpb.Key("a")
-			ba.Add(get)
-
-			_, err := ds.Send(ctx, ba)
-			require.NoError(t, err.GoError())
-			require.Equal(t, 3, call)
-			require.Equal(t, 1, rangeLookups)
-		})
+	_, err := ds.Send(ctx, ba)
+	require.NoError(t, err.GoError())
+	require.Equal(t, 3, call)
+	require.Equal(t, 1, rangeLookups)
 }
 
 // TestOptimisticRangeDescriptorLookups tests the integration of optimistic

--- a/pkg/kv/kvclient/rangecache/range_cache_test.go
+++ b/pkg/kv/kvclient/rangecache/range_cache_test.go
@@ -1914,33 +1914,6 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				require.Equal(t, l, entries[0].lease)
 			},
 		},
-		{
-			name: "speculative lease coming from a replica with a non-stale view",
-			testFn: func(t *testing.T, cache *RangeCache) {
-				// Check that trying to update the cache with a speculative lease coming
-				// from a replica that has a non-stale view of the world is persisted.
-				cache.Insert(ctx, roachpb.RangeInfo{
-					Desc: desc2,
-					Lease: roachpb.Lease{
-						Replica:  rep3,
-						Sequence: 2,
-					},
-					ClosedTimestampPolicy: lead,
-				})
-				tok, err := cache.LookupWithEvictionToken(
-					ctx, startKey, EvictionToken{}, false, /* useReverseScan */
-				)
-				require.NoError(t, err)
-
-				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCacheWithSpeculativeLease(
-					ctx, rep2, &desc2,
-				)
-				require.True(t, updatedLeaseholder)
-				require.Equal(t, &desc2, tok.Desc())
-				require.Equal(t, &rep2, tok.Leaseholder())
-				require.Equal(t, roachpb.LeaseSequence(0), tok.Lease().Sequence)
-			},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -488,8 +488,6 @@ func (e *NotLeaseHolderError) printError(s Printer) {
 	}
 	if e.Lease != nil {
 		s.Printf("current lease is %s", e.Lease)
-	} else if e.DeprecatedLeaseHolder != nil {
-		s.Printf("replica %s is", *e.DeprecatedLeaseHolder)
 	} else {
 		s.Printf("lease holder unknown")
 	}
@@ -1634,10 +1632,6 @@ func NewNotLeaseHolderError(
 		if stillMember {
 			err.Lease = new(roachpb.Lease)
 			*err.Lease = l
-			// TODO(arul): We only need to return this for the 22.1 <-> 22.2 mixed
-			// version state, as v22.1 use this field to log NLHE messages. We can
-			// get rid of this, and the field, in v23.1.
-			err.DeprecatedLeaseHolder = &err.Lease.Replica
 		}
 	}
 	return err

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -45,15 +45,6 @@ message NotLeaseHolderError {
   // The replica the error originated from. Used in the error's string
   // representation, if known.
   optional roachpb.ReplicaDescriptor replica = 1 [(gogoproto.nullable) = false];
-  // The lease holder, if known.
-  //
-  // This field was only ever meaningful if the full lease was not known, but
-  // when constructing this error there was a guess about who the leaseholder
-  // may be. The same idea applied to speculative leases (which have unset
-  // sequence numbers). In a bid to unify these two cases, from v22.2, we stop
-  // making use of this field.
-  // TODO(arul): remove this field in 23.1.
-  optional roachpb.ReplicaDescriptor deprecated_lease_holder = 2;
   // The current lease, if known.
   //
   // It's possible for leases returned here to represent speculative leases, not
@@ -73,6 +64,8 @@ message NotLeaseHolderError {
   // because the lease under which its application was attempted is different
   // than the lease under which it had been proposed.
   optional string custom_msg = 5 [(gogoproto.nullable) = false];
+
+  reserved 2;
 }
 
 // A NodeUnavailableError indicates that the sending gateway can

--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -384,13 +384,6 @@ func TestNotLeaseholderError(t *testing.T) {
 		err *NotLeaseHolderError
 	}{
 		{
-			exp: `[NotLeaseHolderError] r1: replica not lease holder; replica (n1,s1):1 is`,
-			err: &NotLeaseHolderError{
-				RangeID:               1,
-				DeprecatedLeaseHolder: rd,
-			},
-		},
-		{
 			exp: `[NotLeaseHolderError] r1: replica not lease holder; current lease is repl=(n1,s1):1 seq=2 start=0.000000001,0 epo=1`,
 			err: &NotLeaseHolderError{
 				RangeID: 1,

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1865,15 +1865,6 @@ func (l Lease) Type() LeaseType {
 	return LeaseEpoch
 }
 
-// Speculative returns true if this lease instance doesn't correspond to a
-// committed lease (or at least to a lease that's *known* to have committed).
-// For example, nodes sometimes guess who a leaseholder might be and synthesize
-// a more or less complete lease struct. Such cases are identified by an empty
-// Sequence.
-func (l Lease) Speculative() bool {
-	return l.Sequence == 0
-}
-
 // Equivalent determines whether ol is considered the same lease
 // for the purposes of matching leases when executing a command.
 // For expiration-based leases, extensions are allowed.


### PR DESCRIPTION
Speculative leases where introduced for compabitility between 22.1 and 22.2. They are no longer needed and removing them simplifies the DistSender code as preparation for removing instances of NLHE.

Epic: none

Release note: None