### PR TITLE
tracingpb: do not emit default protobuf values

### DIFF
--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -294,7 +294,7 @@ func TestSpanRecordStructured(t *testing.T) {
 		`))
 	checkRecording(t, rec, `
 		=== operation:root
-structured:‹{"@type":"type.googleapis.com/cockroach.util.tracing.tracingpb.OperationMetadata","duration":"3s","count":"0","containsUnfinished":false}›
+structured:‹{"@type":"type.googleapis.com/cockroach.util.tracing.tracingpb.OperationMetadata","duration":"3s"}›
 structured:‹{"@type":"type.googleapis.com/google.protobuf.Int32Value","value":4}›`)
 }
 

--- a/pkg/util/tracing/tracingpb/recording.go
+++ b/pkg/util/tracing/tracingpb/recording.go
@@ -307,7 +307,7 @@ func (r Recording) visitSpan(sp RecordedSpan, depth int) []traceLogData {
 	// the Logs above. We conservatively serialize the structured events again
 	// here, for the case when the span had not been verbose at the time.
 	sp.Structured(func(sr *types.Any, t time.Time) {
-		str, err := MessageToJSONString(sr, true /* emitDefaults */)
+		str, err := MessageToJSONString(sr, false /* emitDefaults */)
 		if err != nil {
 			return
 		}
@@ -497,7 +497,7 @@ func (r Recording) ToJaegerJSON(stmt, comment, nodeStr string) (string, error) {
 		if !(sp.Verbose || sp.RecordingMode == RecordingMode_VERBOSE) {
 			sp.Structured(func(sr *types.Any, t time.Time) {
 				jl := jaegerjson.Log{Timestamp: uint64(t.UnixNano() / 1000)}
-				jsonStr, err := MessageToJSONString(sr, true /* emitDefaults */)
+				jsonStr, err := MessageToJSONString(sr, false /* emitDefaults */)
 				if err != nil {
 					return
 				}


### PR DESCRIPTION
This commit makes it so that we no longer "emit defaults" when marshaling protobuf messages into JSON format. That information is very often useless and only pollutes the output. For example, `ComponentStats` object would previously get serialized as:
```
structured:{"@type":"type.googleapis.com/cockroach.sql.distsqlrun.ComponentStats","component":{"flowId":"fc41a36f-c823-45f6-99d2-c29adf2f38ee","type":"PROCESSOR","id":2,"sqlInstanceId":1,"region":""},"netRx":{"latency":{"valuePlusOne":"0s"},"waitTime":{"valuePlusOne":"0s"},"deserializationTime":{"valuePlusOne":"0s"},"tuplesReceived":{"valuePlusOne":"0"},"bytesReceived":{"valuePlusOne":"0"},"messagesReceived":{"valuePlusOne":"0"}},"netTx":{"tuplesSent":{"valuePlusOne":"0"},"bytesSent":{"valuePlusOne":"0"},"messagesSent":{"valuePlusOne":"0"}},"kv":{"bytesRead":{"valuePlusOne":"0"},"kvPairsRead":{"valuePlusOne":"0"},"tuplesRead":{"valuePlusOne":"0"},"batchRequestsIssued":{"valuePlusOne":"0"},"kvTime":{"valuePlusOne":"0s"},"contentionTime":{"valuePlusOne":"0s"},"numInterfaceSteps":{"valuePlusOne":"0"},"numInternalSteps":{"valuePlusOne":"0"},"numInterfaceSeeks":{"valuePlusOne":"0"},"numInternalSeeks":{"valuePlusOne":"0"},"blockBytes":{"valuePlusOne":"0"},"blockBytesInCache":{"valuePlusOne":"0"},"keyBytes":{"valuePlusOne":"0"},"valueBytes":{"valuePlusOne":"0"},"pointCount":{"valuePlusOne":"0"},"pointsCoveredByRangeTombstones":{"valuePlusOne":"0"},"rangeKeyCount":{"valuePlusOne":"0"},"rangeKeyContainedPoints":{"valuePlusOne":"0"},"rangeKeySkippedPoints":{"valuePlusOne":"0"},"kvCpuTime":{"valuePlusOne":"0s"},"numGets":{"valuePlusOne":"0"},"numScans":{"valuePlusOne":"0"},"numReverseScans":{"valuePlusOne":"0"},"usedStreamer":false},"exec":{"execTime":{"valuePlusOne":"0.000005460s"},"maxAllocatedMem":{"valuePlusOne":"40961"},"maxAllocatedDisk":{"valuePlusOne":"1"},"consumedRu":{"valuePlusOne":"0"},"cpuTime":{"valuePlusOne":"0.000005291s"}},"output":{"numBatches":{"valuePlusOne":"2"},"numTuples":{"valuePlusOne":"2"}},"inputs":[],"flowStats":{"maxMemUsage":{"valuePlusOne":"0"},"maxDiskUsage":{"valuePlusOne":"0"},"consumedRu":{"valuePlusOne":"0"}}}
```
and now it'll be shown as:
```
structured:{"@type":"type.googleapis.com/cockroach.sql.distsqlrun.ComponentStats","component":{"flowId":"21bacea2-3da7-41d9-bdcf-14a69383f402","type":"PROCESSOR","id":2,"sqlInstanceId":1},"netRx":{"latency":{},"waitTime":{},"deserializationTime":{},"tuplesReceived":{},"bytesReceived":{},"messagesReceived":{}},"netTx":{"tuplesSent":{},"bytesSent":{},"messagesSent":{}},"kv":{"bytesRead":{},"kvPairsRead":{},"tuplesRead":{},"batchRequestsIssued":{},"kvTime":{},"contentionTime":{},"numInterfaceSteps":{},"numInternalSteps":{},"numInterfaceSeeks":{},"numInternalSeeks":{},"blockBytes":{},"blockBytesInCache":{},"keyBytes":{},"valueBytes":{},"pointCount":{},"pointsCoveredByRangeTombstones":{},"rangeKeyCount":{},"rangeKeyContainedPoints":{},"rangeKeySkippedPoints":{},"kvCpuTime":{},"numGets":{},"numScans":{},"numReverseScans":{}},"exec":{"execTime":{"valuePlusOne":"0.000005543s"},"maxAllocatedMem":{"valuePlusOne":"40961"},"maxAllocatedDisk":{"valuePlusOne":"1"},"consumedRu":{},"cpuTime":{"valuePlusOne":"0.000005501s"}},"output":{"numBatches":{"valuePlusOne":"2"},"numTuples":{"valuePlusOne":"2"}},"flowStats":{"maxMemUsage":{},"maxDiskUsage":{},"consumedRu":{}}}
```
For a single stmt bundle I tried this on, this change reduces the size of the zip file from 997KiB to 906KiB.

Fixes: #117495.

Release note: None