### PR TITLE
sql: include stringified expression for each stmt into distsql diagram

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -255,7 +255,8 @@ func (a *applyJoinNode) runNextRightSideIteration(params runParams, leftRow tree
 	plan := p.(*planComponents)
 	rowResultWriter := NewRowResultWriter(&a.run.rightRows)
 	if err := runPlanInsidePlan(
-		ctx, params, plan, rowResultWriter, nil, /* deferredRoutineSender */
+		ctx, params, plan, rowResultWriter,
+		nil /* deferredRoutineSender */, "", /* stmtForDistSQLDiagram */
 	); err != nil {
 		return err
 	}
@@ -271,6 +272,7 @@ func runPlanInsidePlan(
 	plan *planComponents,
 	resultWriter rowResultWriter,
 	deferredRoutineSender eval.DeferredRoutineSender,
+	stmtForDistSQLDiagram string,
 ) error {
 	defer plan.close(ctx)
 	execCfg := params.ExecCfg()
@@ -350,6 +352,7 @@ func runPlanInsidePlan(
 	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, &plannerCopy, plannerCopy.txn, distributeType)
 	planCtx.stmtType = recv.stmtType
 	planCtx.mustUseLeafTxn = params.p.mustUseLeafTxn()
+	planCtx.stmtForDistSQLDiagram = stmtForDistSQLDiagram
 
 	// Wrap PlanAndRun in a function call so that we clean up immediately.
 	func() {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -873,6 +873,10 @@ type PlanningCtx struct {
 	// other ways to get the diagram.
 	skipDistSQLDiagramGeneration bool
 
+	// stmtForDistSQLDiagram, if set, will be used when generating the DistSQL
+	// diagram to specify the SQL stmt that this plan corresponds to.
+	stmtForDistSQLDiagram string
+
 	// If set, the flows for the physical plan will be passed to this function.
 	// The flows are not safe for use past the lifetime of the saveFlows function.
 	saveFlows func(_ map[base.SQLInstanceID]*execinfrapb.FlowSpec, _ execopnode.OpChains, _ []execinfra.LocalProcessor, vectorized bool) error

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -802,7 +802,9 @@ func (dsp *DistSQLPlanner) Run(
 
 	if !planCtx.skipDistSQLDiagramGeneration && log.ExpensiveLogEnabled(ctx, 2) {
 		var stmtStr string
-		if planCtx.planner != nil && planCtx.planner.stmt.AST != nil {
+		if planCtx.stmtForDistSQLDiagram != "" {
+			stmtStr = planCtx.stmtForDistSQLDiagram
+		} else if planCtx.planner != nil && planCtx.planner.stmt.AST != nil {
 			stmtStr = planCtx.planner.stmt.String()
 		}
 		_, url, err := execinfrapb.GeneratePlanDiagramURL(stmtStr, flows, execinfrapb.DiagramFlags{})

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3190,6 +3190,7 @@ func (b *Builder) buildCall(c *memo.CallExpr) (execPlan, error) {
 		udf.Def.Params,
 		udf.Def.Body,
 		udf.Def.BodyProps,
+		udf.Def.BodyStmts,
 		false, /* allowOuterWithRefs */
 		nil,   /* wrapRootExpr */
 	)

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -729,6 +729,10 @@ type UDFDefinition struct {
 	// at the same position in Body.
 	BodyProps []*physical.Required
 
+	// BodyStmts, if set, is the string representation of each statement in
+	// Body. It is only populated when verbose tracing is enabled.
+	BodyStmts []string
+
 	// ExceptionBlock contains information needed for exception-handling when the
 	// body of this routine returns an error. It can be unset.
 	ExceptionBlock *ExceptionBlock

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -94,11 +94,14 @@ type Builder struct {
 	factory *norm.Factory
 	stmt    tree.Statement
 
-	ctx        context.Context
-	semaCtx    *tree.SemaContext
-	evalCtx    *eval.Context
-	catalog    cat.Catalog
-	scopeAlloc []scope
+	ctx context.Context
+	// verboseTracing is set if expensive logging is enabled on ctx. If false,
+	// then some work can be omitted.
+	verboseTracing bool
+	semaCtx        *tree.SemaContext
+	evalCtx        *eval.Context
+	catalog        cat.Catalog
+	scopeAlloc     []scope
 
 	// stmtTree tracks the hierarchy of statements to ensure that multiple
 	// modifications to the same table cannot corrupt indexes (see #70731).
@@ -189,12 +192,13 @@ func New(
 	stmt tree.Statement,
 ) *Builder {
 	return &Builder{
-		factory: factory,
-		stmt:    stmt,
-		ctx:     ctx,
-		semaCtx: semaCtx,
-		evalCtx: evalCtx,
-		catalog: catalog,
+		factory:        factory,
+		stmt:           stmt,
+		ctx:            ctx,
+		verboseTracing: log.ExpensiveLogEnabled(ctx, 2),
+		semaCtx:        semaCtx,
+		evalCtx:        evalCtx,
+		catalog:        catalog,
 	}
 }
 

--- a/pkg/sql/recursive_cte.go
+++ b/pkg/sql/recursive_cte.go
@@ -149,7 +149,8 @@ func (n *recursiveCTENode) Next(params runParams) (bool, error) {
 	ctx, sp := tracing.ChildSpan(params.ctx, opName)
 	defer sp.Finish()
 	if err := runPlanInsidePlan(
-		ctx, params, newPlan.(*planComponents), rowResultWriter(n), nil, /* deferredRoutineSender */
+		ctx, params, newPlan.(*planComponents), rowResultWriter(n),
+		nil /* deferredRoutineSender */, "", /* stmtForDistSQLDiagram */
 	); err != nil {
 		return false, err
 	}

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -236,7 +236,7 @@ func (g *routineGenerator) startInternal(ctx context.Context, txn *kv.Txn) (err 
 	ef := newExecFactory(ctx, g.p)
 	rrw := NewRowResultWriter(&g.rch)
 	var cursorHelper *plpgsqlCursorHelper
-	err = g.expr.ForEachPlan(ctx, ef, g.args, func(plan tree.RoutinePlan, isFinalPlan bool) error {
+	err = g.expr.ForEachPlan(ctx, ef, g.args, func(plan tree.RoutinePlan, stmtForDistSQLDiagram string, isFinalPlan bool) error {
 		stmtIdx++
 		opName := "udf-stmt-" + g.expr.Name + "-" + strconv.Itoa(stmtIdx)
 		ctx, sp := tracing.ChildSpan(ctx, opName)
@@ -273,7 +273,7 @@ func (g *routineGenerator) startInternal(ctx context.Context, txn *kv.Txn) (err 
 		}
 
 		// Run the plan.
-		err = runPlanInsidePlan(ctx, g.p.RunParams(ctx), plan.(*planComponents), w, g)
+		err = runPlanInsidePlan(ctx, g.p.RunParams(ctx), plan.(*planComponents), w, g, stmtForDistSQLDiagram)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/sem/tree/routine.go
+++ b/pkg/sql/sem/tree/routine.go
@@ -28,9 +28,12 @@ type RoutinePlanGenerator func(
 ) error
 
 // RoutinePlanGeneratedFunc is the function type that is called for each plan
-// enumerated by a RoutinePlanGenerator. isFinalPlan is true if no more plans
-// will be generated after the current plan.
-type RoutinePlanGeneratedFunc func(plan RoutinePlan, isFinalPlan bool) error
+// enumerated by a RoutinePlanGenerator.
+// - stmtForDistSQLDiagram, if set, will be used when generating DistSQL diagram
+// to specify the SQL stmt corresponding to the plan.
+// - isFinalPlan is true if no more plans will be generated after the current
+// plan.
+type RoutinePlanGeneratedFunc func(plan RoutinePlan, stmtForDistSQLDiagram string, isFinalPlan bool) error
 
 // RoutinePlan represents a plan for a statement in a routine. It currently maps
 // to exec.Plan. We use the empty interface here rather than exec.Plan to avoid


### PR DESCRIPTION
sql: include SQL for each stmt into distsql diagram This commit adjusts the code that generates DistSQL diagrams for each plan within routine invocation to use the "child" stmt itself as the SQL string (rather than "parent" query like `SELECT f(1)`). This might come in handy.

Here are all diagrams logged in the trace in the bundle from the example in #114827 (for two INSERTs and final VALUES within the UDF):
- https://cockroachdb.github.io/distsqlplan/decode.html#eJyMj09P4zAQxe_7KaxRD7uS07X7j9Y3pPYQCVrUFi4oQo49KRZuHGxHBVX57igJCMSpx3nvzfzmnSG8WhCQrner7Z6k6_2GaCxkbaPOh1WdW6OGkTxc39yvduTvgFMyGP0DCqXTuJZHDCAegUNGofJOYQjOt9K5C6T6DQSjYMqqjq2cUVDOI4gzRBMtggDrlLREubqMhP1nQEFjlMZ28YaCq-P3cojygCD4D1q6BMEaejlwi6FyZcCLSOwXKeFNRgH1AfuWwdVe4Z13qsv246Y71AkaQ-xd3g9p-WWF6FEe-_czCoV1pyejQcBonE_5eDJJJOcymczZVZJPuU4WrJgv9GxW4GIG7YI8hLbY7tmdurP796p9q5A2IIVb-YJLjOiPpjQhGvXpNM2fjwAAAP__3tqh9g==
- https://cockroachdb.github.io/distsqlplan/decode.html#eJyMj0FPAjEQhe_-imbCQZMutgqL9GYCh00UDKAXszGlncXGsl3bbtCQ_e9mdzUaTxznvTfzzTtCeLcgIFus56sNyRabJdFYyNpGvR1W9dYaNVTk6fbucb4m5wNOyeDqAiiUTuNC7jGAeAYOOYXKO4UhON9Kxy6Q6Q8QjIIpqzq2ck5BOY8gjhBNtAgCrFPSEuXqMhJ2yYCCxiiN7eINBVfH3-UQ5Q5B8D-0bAaCNfR04ApD5cqAJ5HYP1LCm5wC6h32LYOrvcIH71SX7cdld6gTNIbYu7wfsvLHCtGj3Pfv5xQK6w4vRoMA5DdbzpVM2CRlyShNJ8mUXatkNB6NkaeswMkU2gW5C22x9as7dGc3n1X7ViFtQAr38g1nGNHvTWlCNOrbaZqzrwAAAP__t46hsg==
- https://cockroachdb.github.io/distsqlplan/decode.html#eJyMj0FL-0AQxe__T1He6S9sMGlqafYm1EOhVrHWiwTZ7k5qcJuNOxurlHx3SaIonnqc997Mb94R_Goh8XC53FytR_9Xm-XyDAKVM7RSe2LIRyTIBWrvNDE730nHPrAw75CxQFnVTejkXEA7T5BHhDJYgoR1WtnRm7IN8Sg-jyFgKKjS9vlWwDXhZ5uD2hFk8gu3mEPGrTideEdcu4rpJFL8hxQlbS5AZkdDTXaN13Trne6zw3jTH-oFQxwGNxmGRfVtcfCk9sP7uUBh3eGpNJAYZxdZmiYmmlK2jSY6nUazSULRzBTjItPbdDvT6BbUjrti62d36M_ef9TdW4WyTALX6oXmFMjvy6rkUOovp23_fQYAAP__bmeY1w==

Epic CRDB-34181

Release note: None