### PR TITLE
sql: add client time to top-level execution stats

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2065,6 +2065,7 @@ func populateQueryLevelStats(
 				}
 			}
 		}
+		ih.queryLevelStatsWithErr.Stats.ClientTime = topLevelStats.clientTime
 	}
 	if ih.traceMetadata != nil && ih.explainPlan != nil {
 		ih.traceMetadata.annotateExplain(
@@ -2325,6 +2326,10 @@ type topLevelQueryStats struct {
 	// networkEgressEstimate is an estimate for the number of bytes sent to the
 	// client. It is used for estimating the number of RUs consumed by a query.
 	networkEgressEstimate int64
+	// clientTime is the amount of time query execution was blocked on the
+	// client receiving the PGWire protocol messages (as well as construcing
+	// those messages).
+	clientTime time.Duration
 }
 
 func (s *topLevelQueryStats) add(other *topLevelQueryStats) {
@@ -2332,6 +2337,7 @@ func (s *topLevelQueryStats) add(other *topLevelQueryStats) {
 	s.rowsRead += other.rowsRead
 	s.rowsWritten += other.rowsWritten
 	s.networkEgressEstimate += other.networkEgressEstimate
+	s.clientTime += other.clientTime
 }
 
 // execWithDistSQLEngine converts a plan to a distributed SQL physical plan and
@@ -2356,6 +2362,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 		ex.server.cfg.Clock,
 		&ex.sessionTracing,
 	)
+	recv.measureClientTime = planner.instrumentation.ShouldCollectExecStats()
 	recv.progressAtomic = progressAtomic
 	if ex.server.cfg.TestingKnobs.DistSQLReceiverPushCallbackFactory != nil {
 		recv.testingKnobs.pushCallback = ex.server.cfg.TestingKnobs.DistSQLReceiverPushCallbackFactory(planner.stmt.SQL)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -995,6 +995,10 @@ type DistSQLReceiver struct {
 	// a query with EXPLAIN ANALYZE.
 	isTenantExplainAnalyze bool
 
+	// If set, client time will be measured (result will be stored in
+	// stats.clientTime).
+	measureClientTime bool
+
 	egressCounter TenantNetworkEgressCounter
 
 	expectedRowsRead int64
@@ -1508,6 +1512,11 @@ func (r *DistSQLReceiver) Push(
 		}
 	}
 	r.tracing.TraceExecRowsResult(r.ctx, r.row)
+	if r.measureClientTime {
+		defer func(start time.Time) {
+			r.stats.clientTime += timeutil.Since(start)
+		}(timeutil.Now())
+	}
 	if commErr := r.resultWriter.AddRow(r.ctx, r.row); commErr != nil {
 		r.handleCommErr(commErr)
 	}
@@ -1564,6 +1573,11 @@ func (r *DistSQLReceiver) PushBatch(
 		panic("unsupported exists mode for PushBatch")
 	}
 	r.tracing.TraceExecBatchResult(r.ctx, batch)
+	if r.measureClientTime {
+		defer func(start time.Time) {
+			r.stats.clientTime += timeutil.Since(start)
+		}(timeutil.Now())
+	}
 	if commErr := r.batchWriter.AddBatch(r.ctx, batch); commErr != nil {
 		r.handleCommErr(commErr)
 	}

--- a/pkg/sql/execstats/traceanalyzer.go
+++ b/pkg/sql/execstats/traceanalyzer.go
@@ -162,6 +162,7 @@ type QueryLevelStats struct {
 	CPUTime                            time.Duration
 	SqlInstanceIds                     map[base.SQLInstanceID]struct{}
 	Regions                            []string
+	ClientTime                         time.Duration
 }
 
 // QueryLevelStatsWithErr is the same as QueryLevelStats, but also tracks
@@ -219,8 +220,8 @@ func (s *QueryLevelStats) Accumulate(other QueryLevelStats) {
 			s.SqlInstanceIds[id] = struct{}{}
 		}
 	}
-
 	s.Regions = util.CombineUnique(s.Regions, other.Regions)
+	s.ClientTime += other.ClientTime
 }
 
 // TraceAnalyzer is a struct that helps calculate top-level statistics from a

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -284,6 +284,7 @@ func TestQueryLevelStatsAccumulate(t *testing.T) {
 		MvccRangeKeySkippedPoints:          23,
 		SqlInstanceIds:                     aSQLInstanceIds,
 		Regions:                            []string{"east-usA"},
+		ClientTime:                         time.Second,
 	}
 	bEvent := kvpb.ContentionEvent{Duration: 14 * time.Second}
 	bSQLInstanceIds := map[base.SQLInstanceID]struct{}{}
@@ -317,6 +318,7 @@ func TestQueryLevelStatsAccumulate(t *testing.T) {
 		MvccRangeKeySkippedPoints:          30,
 		SqlInstanceIds:                     bSQLInstanceIds,
 		Regions:                            []string{"east-usB"},
+		ClientTime:                         2 * time.Second,
 	}
 	cSQLInstanceIds := map[base.SQLInstanceID]struct{}{}
 	cSQLInstanceIds[1] = struct{}{}
@@ -350,6 +352,7 @@ func TestQueryLevelStatsAccumulate(t *testing.T) {
 		MvccRangeKeySkippedPoints:          53,
 		SqlInstanceIds:                     cSQLInstanceIds,
 		Regions:                            []string{"east-usA", "east-usB"},
+		ClientTime:                         3 * time.Second,
 	}
 
 	aCopy := a

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -342,7 +342,7 @@ func (b *stmtBundleBuilder) addOptPlans(ctx context.Context) {
 // addExecPlan adds the EXPLAIN (VERBOSE) plan as file plan.txt.
 func (b *stmtBundleBuilder) addExecPlan(plan string) {
 	if plan == "" {
-		plan = "no plan"
+		plan = noPlan
 	}
 	b.z.AddFile("plan.txt", plan)
 }

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -832,6 +832,9 @@ func (ih *instrumentationHelper) emitExplainAnalyzePlanToOutputBuilder(
 			// vectorized plans.
 			ob.AddRUEstimate(queryStats.RUEstimate)
 		}
+		if queryStats.ClientTime != 0 {
+			ob.AddClientTime(queryStats.ClientTime)
+		}
 	}
 
 	qos := sessiondatapb.Normal

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -325,6 +325,15 @@ func (ob *OutputBuilder) AddExecutionTime(delta time.Duration) {
 	ob.AddTopLevelField("execution time", string(humanizeutil.Duration(delta)))
 }
 
+// AddClientTime adds a top-level client-level protocol time field. Cannot be
+// called while inside a node.
+func (ob *OutputBuilder) AddClientTime(delta time.Duration) {
+	if ob.flags.Deflake.Has(DeflakeVolatile) {
+		delta = time.Microsecond
+	}
+	ob.AddTopLevelField("client time", string(humanizeutil.Duration(delta)))
+}
+
 // AddKVReadStats adds a top-level field for the bytes/rows/KV pairs read from
 // KV as well as for the number of BatchRequests issued.
 func (ob *OutputBuilder) AddKVReadStats(rows, bytes, kvPairs, batchRequests int64) {


### PR DESCRIPTION
This commit adds "client time" execution statistic to `plan.txt` file of the stmt bundles which tracks the amount of time that was spent waiting for the client to consume the query result (as well as constructing the PGWire messages in the first place). This should be helpful when investigating some slow queries were the bottleneck is actually the client. Note, however, this new statistic is unlikely to help in explicit EXPLAIN ANALYZE cases since in that setup we discard the output rows, so there is nothing for the client to consume.

An example output of `plan.txt` from the test added in this commit (where we inject 1s of sleep between reading messages corresponding to two rows):
```
        planning time: 104µs
        execution time: 1s
        distribution: full
        vectorized: true
        rows decoded from KV: 2 (48 B, 1 gRPC calls)
        cumulative time spent in KV: 434µs
        maximum memory usage: 10 KiB
        network usage: 0 B (0 messages)
        sql cpu time: 4µs
        client time: 1s
        isolation level: serializable
        priority: normal
        quality of service: regular

        • scan
          nodes: n1
          actual row count: 2
          KV time: 434µs
          KV contention time: 0µs
          KV rows decoded: 2
          KV bytes read: 48 B
          KV gRPC calls: 1
          estimated max memory allocated: 10 KiB
          sql cpu time: 4µs
          missing stats
          table: t@t_pkey
          spans: FULL SCAN
```

Fixes: #115110.

Release note (sql change): Additional execution statistic that measures "client time" is now included into `plan.txt` files of the stmt bundles. This client time tracks how long the query execution was blocked on the client receiving the PGWire protocol messages. Note that in EXPLAIN ANALYZE context it doesn't make much sense because in that variant the output rows are discarded and are not communicated to the client.