### PR TITLE
sql: make intervalstyle hint deterministic

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -216,7 +216,7 @@ SET intervalstyle = 'iso_8601'
 statement ok
 SET intervalstyle = 'sql_standard'
 
-statement error invalid value for parameter "IntervalStyle": "other"
+statement error invalid value for parameter "IntervalStyle": "other"\nHINT: Available values: postgres,iso_8601,sql_standard
 SET intervalstyle = 'other'
 
 statement ok

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1028,9 +1028,10 @@ var varGen = map[string]sessionVar{
 		Set: func(ctx context.Context, m sessionDataMutator, s string) error {
 			styleVal, ok := duration.IntervalStyle_value[strings.ToUpper(s)]
 			if !ok {
-				validIntervalStyles := make([]string, 0, len(duration.IntervalStyle_value))
-				for k := range duration.IntervalStyle_value {
-					validIntervalStyles = append(validIntervalStyles, strings.ToLower(k))
+				validIntervalStyles := make([]string, 0, len(duration.IntervalStyle_name))
+				for k := 0; k < len(duration.IntervalStyle_name); k++ {
+					name := duration.IntervalStyle_name[int32(k)]
+					validIntervalStyles = append(validIntervalStyles, strings.ToLower(name))
 				}
 				return newVarValueError(`IntervalStyle`, s, validIntervalStyles...)
 			}


### PR DESCRIPTION
Sorts the valid interval styles before providing them as a hint.

Epic: none

Release note: None