### PR TITLE
sql: change pg io builtins volatility to immutable

### DIFF
--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -265,7 +265,7 @@ func makeTypeIOBuiltin(paramTypes tree.TypeList, returnType *types.T) builtinDef
 				return nil, errUnimplemented
 			},
 			Info:       notUsableInfo,
-			Volatility: volatility.Volatile,
+			Volatility: volatility.Stable,
 			// Ignore validity checks for typeio builtins. We don't
 			// implement these anyway, and they are very hard to special
 			// case.


### PR DESCRIPTION
The IO builtins (e.g., int2send) were previously marked as volatile, while they are immutable in postgres. We don't implement these builtins in CRDB, but fixing this helps reduce noise in the pg_regress test.

Epic: None

Release note: None