### PR TITLE
plpgsql: improve block formatting and unimplemented errors

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_procedures
+++ b/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_procedures
@@ -65,7 +65,6 @@ db1 sc2 p2 function false
 query-sql
 SELECT create_statement FROM [SHOW CREATE PROCEDURE sc1.p1]
 ----
-----
 CREATE PROCEDURE sc1.p1(IN a db1.sc1.enum1)
 	LANGUAGE plpgsql
 	AS $$
@@ -75,11 +74,8 @@ CREATE PROCEDURE sc1.p1(IN a db1.sc1.enum1)
 	SELECT a FROM db1.sc1.tbl1;
 	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
-	END
-
+	END;
 $$
-----
-----
 
 exec-sql
 CALL sc1.p1('Good'::sc1.enum1)
@@ -109,7 +105,6 @@ USE db1_new
 query-sql
 SELECT create_statement FROM [SHOW CREATE PROCEDURE sc1.p1]
 ----
-----
 CREATE PROCEDURE sc1.p1(IN a db1_new.sc1.enum1)
 	LANGUAGE plpgsql
 	AS $$
@@ -119,11 +114,8 @@ CREATE PROCEDURE sc1.p1(IN a db1_new.sc1.enum1)
 	SELECT a FROM db1_new.sc1.tbl1;
 	SELECT 'Good':::db1_new.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
-	END
-
+	END;
 $$
-----
-----
 
 # Make sure procedure signature is rewritten in schema descriptor so that
 # procedure can be resolved and executed.
@@ -252,7 +244,6 @@ db1 sc2 p2 function true
 query-sql
 SELECT create_statement FROM [SHOW CREATE PROCEDURE sc1.p1]
 ----
-----
 CREATE PROCEDURE sc1.p1(IN a db1.sc1.enum1)
 	LANGUAGE plpgsql
 	AS $$
@@ -262,11 +253,8 @@ CREATE PROCEDURE sc1.p1(IN a db1.sc1.enum1)
 	SELECT a FROM db1.sc1.tbl1;
 	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
-	END
-
+	END;
 $$
-----
-----
 
 query-sql
 CALL sc1.p1('Good'::sc1.enum1)
@@ -297,7 +285,6 @@ USE db1
 query-sql
 SELECT create_statement FROM [SHOW CREATE PROCEDURE sc1.p1]
 ----
-----
 CREATE PROCEDURE sc1.p1(IN a db1.sc1.enum1)
 	LANGUAGE plpgsql
 	AS $$
@@ -307,11 +294,8 @@ CREATE PROCEDURE sc1.p1(IN a db1.sc1.enum1)
 	SELECT a FROM db1.sc1.tbl1;
 	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS);
-	END
-
+	END;
 $$
-----
-----
 
 # Make sure procedure signature is rewritten in schema descriptor so that
 # procedure can be resolved and executed.

--- a/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_user_defined_functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/plpgsql_user_defined_functions
@@ -70,7 +70,6 @@ db1 sc2 f2 function false
 query-sql
 SELECT create_statement FROM [SHOW CREATE FUNCTION sc1.f1]
 ----
-----
 CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	RETURNS INT8
 	VOLATILE
@@ -85,11 +84,8 @@ CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	SELECT a FROM db1.sc1.tbl1;
 	SELECT 'Good':::db1.sc1.enum1;
 	RETURN nextval('sc1.sq1'::REGCLASS);
-	END
-
+	END;
 $$
-----
-----
 
 query-sql
 SELECT sc1.f1('Good'::sc1.enum1)
@@ -115,7 +111,6 @@ USE db1_new
 query-sql
 SELECT create_statement FROM [SHOW CREATE FUNCTION sc1.f1]
 ----
-----
 CREATE FUNCTION sc1.f1(IN a db1_new.sc1.enum1)
 	RETURNS INT8
 	VOLATILE
@@ -130,11 +125,8 @@ CREATE FUNCTION sc1.f1(IN a db1_new.sc1.enum1)
 	SELECT a FROM db1_new.sc1.tbl1;
 	SELECT 'Good':::db1_new.sc1.enum1;
 	RETURN nextval('sc1.sq1'::REGCLASS);
-	END
-
+	END;
 $$
-----
-----
 
 # Make sure function signature is rewritten in schema descriptor so that
 # function can be resolved and executed.
@@ -255,7 +247,6 @@ db1 sc2 f2 function true
 query-sql
 SELECT create_statement FROM [SHOW CREATE FUNCTION sc1.f1]
 ----
-----
 CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	RETURNS INT8
 	VOLATILE
@@ -271,11 +262,8 @@ CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS) INTO x;
 	RETURN x;
-	END
-
+	END;
 $$
-----
-----
 
 query-sql
 SELECT sc1.f1('Good'::sc1.enum1)
@@ -302,7 +290,6 @@ USE db1
 query-sql
 SELECT create_statement FROM [SHOW CREATE FUNCTION sc1.f1]
 ----
-----
 CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	RETURNS INT8
 	VOLATILE
@@ -318,11 +305,8 @@ CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
 	SELECT 'Good':::db1.sc1.enum1;
 	SELECT nextval('sc1.sq1'::REGCLASS) INTO x;
 	RETURN x;
-	END
-
+	END;
 $$
-----
-----
 
 # Make sure function signature is rewritten in schema descriptor so that
 # function can be resolved and executed.

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_unsupported
@@ -7,4 +7,12 @@ CREATE OR REPLACE PROCEDURE foo() AS $$
   BEGIN
     RAISE NOTICE 'x: %', x;
   END
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 0A000 pq: unimplemented: block labels are not yet supported
+CREATE OR REPLACE PROCEDURE foo() AS $$
+  <<bar>>
+  BEGIN
+    RAISE NOTICE 'baz';
+  END
+$$ LANGUAGE PLpgSQL;

--- a/pkg/ccl/logictestccl/testdata/logic_test/show_create
+++ b/pkg/ccl/logictestccl/testdata/logic_test/show_create
@@ -186,5 +186,5 @@ f112134  CREATE FUNCTION sc.f112134()
            i := i + 1;
            END LOOP;
            RETURN x;
-           END
+           END;
          $$

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
@@ -77,7 +77,7 @@ $$ LANGUAGE PLPGSQL;
 query T
 SELECT get_body_str('f_rewrite');
 ----
-"DECLARE\ni INT8 := nextval(106:::REGCLASS);\nj INT8 := nextval(106:::REGCLASS);\ncurs REFCURSOR := nextval(106:::REGCLASS)::STRING;\ncurs2 CURSOR FOR SELECT nextval(106:::REGCLASS);\nBEGIN\nRAISE notice\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nRAISE notice 'val1: %, val2: %', nextval(106:::REGCLASS), nextval(106:::REGCLASS);\nWHILE nextval(106:::REGCLASS) < 10:::INT8 LOOP\ni := nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nIF nextval(106:::REGCLASS) = 1:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\n\tCONTINUE;\nELSIF nextval(106:::REGCLASS) = 2:::INT8 THEN\n\tSELECT v FROM ROWS FROM (nextval(106:::REGCLASS)) AS v (\"int\") INTO i;\nELSIF nextval(106:::REGCLASS) = 3:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT nextval(106:::REGCLASS);\nRETURN nextval(106:::REGCLASS);\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE notice\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nWHEN not_null_violation THEN\nSELECT nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nRAISE notice\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nEND\n;"
+"DECLARE\ni INT8 := nextval(106:::REGCLASS);\nj INT8 := nextval(106:::REGCLASS);\ncurs REFCURSOR := nextval(106:::REGCLASS)::STRING;\ncurs2 CURSOR FOR SELECT nextval(106:::REGCLASS);\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nRAISE NOTICE 'val1: %, val2: %', nextval(106:::REGCLASS), nextval(106:::REGCLASS);\nWHILE nextval(106:::REGCLASS) < 10:::INT8 LOOP\ni := nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nIF nextval(106:::REGCLASS) = 1:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\n\tCONTINUE;\nELSIF nextval(106:::REGCLASS) = 2:::INT8 THEN\n\tSELECT v FROM ROWS FROM (nextval(106:::REGCLASS)) AS v (\"int\") INTO i;\nELSIF nextval(106:::REGCLASS) = 3:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT nextval(106:::REGCLASS);\nRETURN nextval(106:::REGCLASS);\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nWHEN not_null_violation THEN\nSELECT nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nEND;\n"
 
 query TT
 SHOW CREATE FUNCTION f_rewrite;
@@ -95,9 +95,9 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              curs REFCURSOR := nextval('public.seq'::REGCLASS)::STRING;
              curs2 CURSOR FOR SELECT nextval('public.seq'::REGCLASS);
              BEGIN
-             RAISE notice
+             RAISE NOTICE
              USING MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
-             RAISE notice 'val1: %, val2: %', nextval('public.seq'::REGCLASS), nextval('public.seq'::REGCLASS);
+             RAISE NOTICE 'val1: %, val2: %', nextval('public.seq'::REGCLASS), nextval('public.seq'::REGCLASS);
              WHILE nextval('public.seq'::REGCLASS) < 10:::INT8 LOOP
              i := nextval('public.seq'::REGCLASS);
              SELECT nextval('public.seq'::REGCLASS);
@@ -116,14 +116,14 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              RETURN nextval('public.seq'::REGCLASS);
              EXCEPTION
              WHEN division_by_zero THEN
-             RAISE notice
+             RAISE NOTICE
              USING MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
              WHEN not_null_violation THEN
              SELECT nextval('public.seq'::REGCLASS);
              SELECT nextval('public.seq'::REGCLASS);
-             RAISE notice
+             RAISE NOTICE
              USING MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
-             END
+             END;
            $$
 
 statement ok
@@ -132,7 +132,7 @@ ALTER SEQUENCE seq RENAME TO renamed;
 query T
 SELECT get_body_str('f_rewrite');
 ----
-"DECLARE\ni INT8 := nextval(106:::REGCLASS);\nj INT8 := nextval(106:::REGCLASS);\ncurs REFCURSOR := nextval(106:::REGCLASS)::STRING;\ncurs2 CURSOR FOR SELECT nextval(106:::REGCLASS);\nBEGIN\nRAISE notice\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nRAISE notice 'val1: %, val2: %', nextval(106:::REGCLASS), nextval(106:::REGCLASS);\nWHILE nextval(106:::REGCLASS) < 10:::INT8 LOOP\ni := nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nIF nextval(106:::REGCLASS) = 1:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\n\tCONTINUE;\nELSIF nextval(106:::REGCLASS) = 2:::INT8 THEN\n\tSELECT v FROM ROWS FROM (nextval(106:::REGCLASS)) AS v (\"int\") INTO i;\nELSIF nextval(106:::REGCLASS) = 3:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT nextval(106:::REGCLASS);\nRETURN nextval(106:::REGCLASS);\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE notice\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nWHEN not_null_violation THEN\nSELECT nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nRAISE notice\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nEND\n;"
+"DECLARE\ni INT8 := nextval(106:::REGCLASS);\nj INT8 := nextval(106:::REGCLASS);\ncurs REFCURSOR := nextval(106:::REGCLASS)::STRING;\ncurs2 CURSOR FOR SELECT nextval(106:::REGCLASS);\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nRAISE NOTICE 'val1: %, val2: %', nextval(106:::REGCLASS), nextval(106:::REGCLASS);\nWHILE nextval(106:::REGCLASS) < 10:::INT8 LOOP\ni := nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nIF nextval(106:::REGCLASS) = 1:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\n\tCONTINUE;\nELSIF nextval(106:::REGCLASS) = 2:::INT8 THEN\n\tSELECT v FROM ROWS FROM (nextval(106:::REGCLASS)) AS v (\"int\") INTO i;\nELSIF nextval(106:::REGCLASS) = 3:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT nextval(106:::REGCLASS);\nRETURN nextval(106:::REGCLASS);\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nWHEN not_null_violation THEN\nSELECT nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nEND;\n"
 
 query TT
 SHOW CREATE FUNCTION f_rewrite;
@@ -150,9 +150,9 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              curs REFCURSOR := nextval('public.renamed'::REGCLASS)::STRING;
              curs2 CURSOR FOR SELECT nextval('public.renamed'::REGCLASS);
              BEGIN
-             RAISE notice
+             RAISE NOTICE
              USING MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
-             RAISE notice 'val1: %, val2: %', nextval('public.renamed'::REGCLASS), nextval('public.renamed'::REGCLASS);
+             RAISE NOTICE 'val1: %, val2: %', nextval('public.renamed'::REGCLASS), nextval('public.renamed'::REGCLASS);
              WHILE nextval('public.renamed'::REGCLASS) < 10:::INT8 LOOP
              i := nextval('public.renamed'::REGCLASS);
              SELECT nextval('public.renamed'::REGCLASS);
@@ -171,14 +171,14 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              RETURN nextval('public.renamed'::REGCLASS);
              EXCEPTION
              WHEN division_by_zero THEN
-             RAISE notice
+             RAISE NOTICE
              USING MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
              WHEN not_null_violation THEN
              SELECT nextval('public.renamed'::REGCLASS);
              SELECT nextval('public.renamed'::REGCLASS);
-             RAISE notice
+             RAISE NOTICE
              USING MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
-             END
+             END;
            $$
 
 # Reset sequence name for subtest.
@@ -227,7 +227,7 @@ $$ LANGUAGE PLPGSQL;
 query T
 SELECT get_body_str('f_rewrite');
 ----
-"DECLARE\nday @100107 := b'\\x80':::@100107;\ntoday @100107 := b'\\xa0':::@100107;\ncurs REFCURSOR := b' ':::@100107::STRING;\ncurs2 CURSOR FOR SELECT b'@':::@100107;\nBEGIN\nRAISE notice\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nRAISE notice 'val1: %, val2: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nWHILE day != b'\\x80':::@100107 LOOP\nday := b'\\xc0':::@100107;\nSELECT b'\\x80':::@100107;\nIF day = b'\\x80':::@100107 THEN\n\tday := b'\\xa0':::@100107;\n\tSELECT b'@':::@100107;\n\tCONTINUE;\nELSIF day = b' ':::@100107 THEN\n\tSELECT b'@':::@100107 INTO day;\nELSIF day = b'@':::@100107 THEN\n\tSELECT b'\\x80':::@100107 INTO day;\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT b'\\x80':::@100107;\nRETURN b'\\x80':::@100107;\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE notice\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nWHEN not_null_violation THEN\nSELECT b'\\x80':::@100107;\nRAISE notice 'val: %', b'\\x80':::@100107;\nEND\n;"
+"DECLARE\nday @100107 := b'\\x80':::@100107;\ntoday @100107 := b'\\xa0':::@100107;\ncurs REFCURSOR := b' ':::@100107::STRING;\ncurs2 CURSOR FOR SELECT b'@':::@100107;\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nRAISE NOTICE 'val1: %, val2: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nWHILE day != b'\\x80':::@100107 LOOP\nday := b'\\xc0':::@100107;\nSELECT b'\\x80':::@100107;\nIF day = b'\\x80':::@100107 THEN\n\tday := b'\\xa0':::@100107;\n\tSELECT b'@':::@100107;\n\tCONTINUE;\nELSIF day = b' ':::@100107 THEN\n\tSELECT b'@':::@100107 INTO day;\nELSIF day = b'@':::@100107 THEN\n\tSELECT b'\\x80':::@100107 INTO day;\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT b'\\x80':::@100107;\nRETURN b'\\x80':::@100107;\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nWHEN not_null_violation THEN\nSELECT b'\\x80':::@100107;\nRAISE NOTICE 'val: %', b'\\x80':::@100107;\nEND;\n"
 
 query TT
 SHOW CREATE FUNCTION f_rewrite;
@@ -245,9 +245,9 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              curs REFCURSOR := 'monday':::test.public.weekday::STRING;
              curs2 CURSOR FOR SELECT 'tuesday':::test.public.weekday;
              BEGIN
-             RAISE notice
+             RAISE NOTICE
              USING MESSAGE = format('val: %d':::STRING, 'wednesday':::test.public.weekday);
-             RAISE notice 'val1: %, val2: %', 'wednesday':::test.public.weekday, 'thursday':::test.public.weekday;
+             RAISE NOTICE 'val1: %, val2: %', 'wednesday':::test.public.weekday, 'thursday':::test.public.weekday;
              WHILE day != 'wednesday':::test.public.weekday LOOP
              day := 'friday':::test.public.weekday;
              SELECT 'wednesday':::test.public.weekday;
@@ -266,12 +266,12 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              RETURN 'wednesday':::test.public.weekday;
              EXCEPTION
              WHEN division_by_zero THEN
-             RAISE notice
+             RAISE NOTICE
              USING MESSAGE = format('val: %d':::STRING, 'wednesday':::test.public.weekday);
              WHEN not_null_violation THEN
              SELECT 'wednesday':::test.public.weekday;
-             RAISE notice 'val: %', 'wednesday':::test.public.weekday;
-             END
+             RAISE NOTICE 'val: %', 'wednesday':::test.public.weekday;
+             END;
            $$
 
 statement ok
@@ -283,7 +283,7 @@ ALTER TYPE weekday RENAME TO workday;
 query T
 SELECT get_body_str('f_rewrite');
 ----
-"DECLARE\nday @100107 := b'\\x80':::@100107;\ntoday @100107 := b'\\xa0':::@100107;\ncurs REFCURSOR := b' ':::@100107::STRING;\ncurs2 CURSOR FOR SELECT b'@':::@100107;\nBEGIN\nRAISE notice\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nRAISE notice 'val1: %, val2: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nWHILE day != b'\\x80':::@100107 LOOP\nday := b'\\xc0':::@100107;\nSELECT b'\\x80':::@100107;\nIF day = b'\\x80':::@100107 THEN\n\tday := b'\\xa0':::@100107;\n\tSELECT b'@':::@100107;\n\tCONTINUE;\nELSIF day = b' ':::@100107 THEN\n\tSELECT b'@':::@100107 INTO day;\nELSIF day = b'@':::@100107 THEN\n\tSELECT b'\\x80':::@100107 INTO day;\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT b'\\x80':::@100107;\nRETURN b'\\x80':::@100107;\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE notice\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nWHEN not_null_violation THEN\nSELECT b'\\x80':::@100107;\nRAISE notice 'val: %', b'\\x80':::@100107;\nEND\n;"
+"DECLARE\nday @100107 := b'\\x80':::@100107;\ntoday @100107 := b'\\xa0':::@100107;\ncurs REFCURSOR := b' ':::@100107::STRING;\ncurs2 CURSOR FOR SELECT b'@':::@100107;\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nRAISE NOTICE 'val1: %, val2: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nWHILE day != b'\\x80':::@100107 LOOP\nday := b'\\xc0':::@100107;\nSELECT b'\\x80':::@100107;\nIF day = b'\\x80':::@100107 THEN\n\tday := b'\\xa0':::@100107;\n\tSELECT b'@':::@100107;\n\tCONTINUE;\nELSIF day = b' ':::@100107 THEN\n\tSELECT b'@':::@100107 INTO day;\nELSIF day = b'@':::@100107 THEN\n\tSELECT b'\\x80':::@100107 INTO day;\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT b'\\x80':::@100107;\nRETURN b'\\x80':::@100107;\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nWHEN not_null_violation THEN\nSELECT b'\\x80':::@100107;\nRAISE NOTICE 'val: %', b'\\x80':::@100107;\nEND;\n"
 
 query TT
 SHOW CREATE FUNCTION f_rewrite;
@@ -301,9 +301,9 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              curs REFCURSOR := 'monday':::test.public.workday::STRING;
              curs2 CURSOR FOR SELECT 'tuesday':::test.public.workday;
              BEGIN
-             RAISE notice
+             RAISE NOTICE
              USING MESSAGE = format('val: %d':::STRING, 'humpday':::test.public.workday);
-             RAISE notice 'val1: %, val2: %', 'humpday':::test.public.workday, 'thursday':::test.public.workday;
+             RAISE NOTICE 'val1: %, val2: %', 'humpday':::test.public.workday, 'thursday':::test.public.workday;
              WHILE day != 'humpday':::test.public.workday LOOP
              day := 'friday':::test.public.workday;
              SELECT 'humpday':::test.public.workday;
@@ -322,12 +322,12 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              RETURN 'humpday':::test.public.workday;
              EXCEPTION
              WHEN division_by_zero THEN
-             RAISE notice
+             RAISE NOTICE
              USING MESSAGE = format('val: %d':::STRING, 'humpday':::test.public.workday);
              WHEN not_null_violation THEN
              SELECT 'humpday':::test.public.workday;
-             RAISE notice 'val: %', 'humpday':::test.public.workday;
-             END
+             RAISE NOTICE 'val: %', 'humpday':::test.public.workday;
+             END;
            $$
 
 # Reset types for subtest.
@@ -355,7 +355,7 @@ $$ LANGUAGE PLPGSQL
 query T
 SELECT get_body_str('p_rewrite');
 ----
-"BEGIN\nINSERT INTO test.public.t_rewrite(v) VALUES (nextval(106:::REGCLASS)) RETURNING v;\nEND\n;"
+"BEGIN\nINSERT INTO test.public.t_rewrite(v) VALUES (nextval(106:::REGCLASS)) RETURNING v;\nEND;\n"
 
 statement ok
 DROP PROCEDURE p_rewrite();
@@ -371,6 +371,6 @@ $$ LANGUAGE PLPGSQL
 query T
 SELECT get_body_str('p_rewrite');
 ----
-"BEGIN\nUPDATE test.public.t_rewrite SET w = b'\\xa0':::@100107 WHERE w = b'\\x80':::@100107 RETURNING w;\nEND\n;"
+"BEGIN\nUPDATE test.public.t_rewrite SET w = b'\\xa0':::@100107 WHERE w = b'\\x80':::@100107 RETURNING w;\nEND;\n"
 
 subtest end

--- a/pkg/sql/catalog/redact/redact_test.go
+++ b/pkg/sql/catalog/redact/redact_test.go
@@ -57,7 +57,7 @@ y TEXT := 'bar';
 BEGIN
 SELECT k FROM kv WHERE v != 'foo';
 RETURN x + 3;
-END
+END;
 $$`)
 
 	t.Run("view", func(t *testing.T) {
@@ -95,7 +95,7 @@ y STRING := '_';
 BEGIN
 SELECT k FROM defaultdb.public.kv WHERE v != '_';
 RETURN x + _;
-END
+END;
 `, mut.FunctionBody)
 	})
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -3590,7 +3590,7 @@ func createRoutinePopulate(
 					if err != nil {
 						return err
 					}
-					bodyStr = "\n" + bodyStr + "\n"
+					bodyStr = strings.TrimSpace(bodyStr)
 					stmtStrs := strings.Split(bodyStr, "\n")
 					for i := range stmtStrs {
 						if stmtStrs[i] != "" {
@@ -3599,7 +3599,7 @@ func createRoutinePopulate(
 					}
 					p := &treeNode.Options[i]
 					// Add two new lines just for better formatting.
-					*p = tree.RoutineBodyStr(strings.Join(stmtStrs, "\n"))
+					*p = tree.RoutineBodyStr("\n" + strings.Join(stmtStrs, "\n") + "\n")
 				}
 			}
 

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -668,7 +668,6 @@ func serializeUserDefinedTypesLang(
 		v2 := utils.TypeRefVisitor{Fn: replaceTypeFunc}
 		newStmt = plpgsqltree.Walk(&v2, newStmt)
 		fmtCtx.FormatNode(newStmt)
-		fmtCtx.WriteString(";")
 	}
 
 	return fmtCtx.CloseAndGetString(), nil

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -244,7 +244,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 			checkStmtVolatility(targetVolatility, stmtScope, stmt.AST)
 
 			// Format the statements with qualified datasource names.
-			formatFuncBodyStmt(fmtCtx, stmt.AST, i > 0 /* newLine */)
+			formatFuncBodyStmt(fmtCtx, stmt.AST, language, i > 0 /* newLine */)
 			afterBuildStmt()
 		}
 	case tree.RoutineLangPLpgSQL:
@@ -272,7 +272,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		checkStmtVolatility(targetVolatility, stmtScope, stmt)
 
 		// Format the statements with qualified datasource names.
-		formatFuncBodyStmt(fmtCtx, stmt.AST, false /* newLine */)
+		formatFuncBodyStmt(fmtCtx, stmt.AST, language, false /* newLine */)
 		afterBuildStmt()
 	default:
 		panic(errors.AssertionFailedf("unexpected language: %v", language))
@@ -319,12 +319,17 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 	return outScope
 }
 
-func formatFuncBodyStmt(fmtCtx *tree.FmtCtx, ast tree.NodeFormatter, newLine bool) {
+func formatFuncBodyStmt(
+	fmtCtx *tree.FmtCtx, ast tree.NodeFormatter, lang tree.RoutineLanguage, newLine bool,
+) {
 	if newLine {
 		fmtCtx.WriteString("\n")
 	}
 	fmtCtx.FormatNode(ast)
-	fmtCtx.WriteString(";")
+	if lang != tree.RoutineLangPLpgSQL {
+		// PL/pgSQL body statements handle semicolons.
+		fmtCtx.WriteString(";")
+	}
 }
 
 func validateReturnType(

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -382,6 +382,10 @@ opt_semi:
 
 pl_block: opt_block_label decl_sect BEGIN proc_sect exception_sect END opt_label
   {
+    blockLabel, blockEndLabel := $1, $7
+    if err := checkLoopLabels(blockLabel, blockEndLabel); err != nil {
+      return setErr(plpgsqllex, err)
+    }
     $$.val = &plpgsqltree.Block{
       Label: $1,
       Decls: $2.statements(),

--- a/pkg/sql/plpgsql/parser/testdata/combo
+++ b/pkg/sql/plpgsql/parser/testdata/combo
@@ -35,7 +35,7 @@ IF i >= n THEN
 END IF;
 END LOOP;
 RETURN res;
-END
+END;
  -- normalized!
 DECLARE
 i INT8;
@@ -55,7 +55,7 @@ IF ((i) >= (n)) THEN
 END IF;
 END LOOP;
 RETURN (res);
-END
+END;
  -- fully parenthesized
 DECLARE
 i INT8;
@@ -75,7 +75,7 @@ IF i >= n THEN
 END IF;
 END LOOP;
 RETURN res;
-END
+END;
  -- literals removed
 DECLARE
 i INT8;
@@ -95,5 +95,5 @@ IF _ >= _ THEN
 END IF;
 END LOOP;
 RETURN _;
-END
+END;
  -- identifiers removed

--- a/pkg/sql/plpgsql/parser/testdata/decl_header
+++ b/pkg/sql/plpgsql/parser/testdata/decl_header
@@ -7,22 +7,22 @@ END
 DECLARE
 var1 INT8 := 30;
 BEGIN
-END
+END;
  -- normalized!
 DECLARE
 var1 INT8 := (30);
 BEGIN
-END
+END;
  -- fully parenthesized
 DECLARE
 var1 INT8 := _;
 BEGIN
-END
+END;
  -- literals removed
 DECLARE
 var1 INT8 := 30;
 BEGIN
-END
+END;
  -- identifiers removed
 
 parse
@@ -34,22 +34,22 @@ END
 DECLARE
 var1 CONSTANT INT8 COLLATE collation_name NOT NULL := 30;
 BEGIN
-END
+END;
  -- normalized!
 DECLARE
 var1 CONSTANT INT8 COLLATE collation_name NOT NULL := (30);
 BEGIN
-END
+END;
  -- fully parenthesized
 DECLARE
 var1 CONSTANT INT8 COLLATE collation_name NOT NULL := _;
 BEGIN
-END
+END;
  -- literals removed
 DECLARE
 var1 CONSTANT INT8 COLLATE _ NOT NULL := 30;
 BEGIN
-END
+END;
  -- identifiers removed
 
 parse
@@ -61,22 +61,22 @@ END
 DECLARE
 var1 CONSTANT INT8 COLLATE collation_name NOT NULL := 30;
 BEGIN
-END
+END;
  -- normalized!
 DECLARE
 var1 CONSTANT INT8 COLLATE collation_name NOT NULL := (30);
 BEGIN
-END
+END;
  -- fully parenthesized
 DECLARE
 var1 CONSTANT INT8 COLLATE collation_name NOT NULL := _;
 BEGIN
-END
+END;
  -- literals removed
 DECLARE
 var1 CONSTANT INT8 COLLATE _ NOT NULL := 30;
 BEGIN
-END
+END;
  -- identifiers removed
 
 error
@@ -115,22 +115,22 @@ END
 DECLARE
 var1 CURSOR FOR SELECT * FROM t1 WHERE id = arg1;
 BEGIN
-END
+END;
  -- normalized!
 DECLARE
 var1 CURSOR FOR SELECT (*) FROM t1 WHERE ((id) = (arg1));
 BEGIN
-END
+END;
  -- fully parenthesized
 DECLARE
 var1 CURSOR FOR SELECT * FROM t1 WHERE id = arg1;
 BEGIN
-END
+END;
  -- literals removed
 DECLARE
 var1 CURSOR FOR SELECT * FROM _ WHERE _ = _;
 BEGIN
-END
+END;
  -- identifiers removed
 
 error

--- a/pkg/sql/plpgsql/parser/testdata/decl_header
+++ b/pkg/sql/plpgsql/parser/testdata/decl_header
@@ -1,55 +1,65 @@
 parse
+<<foo>>
 DECLARE
   var1 integer := 30;
 BEGIN
 END
 ----
+<<foo>>
 DECLARE
 var1 INT8 := 30;
 BEGIN
-END;
+END foo;
  -- normalized!
+<<foo>>
 DECLARE
 var1 INT8 := (30);
 BEGIN
-END;
+END foo;
  -- fully parenthesized
+<<foo>>
 DECLARE
 var1 INT8 := _;
 BEGIN
-END;
+END foo;
  -- literals removed
+<<_>>
 DECLARE
 var1 INT8 := 30;
 BEGIN
-END;
+END _;
  -- identifiers removed
 
 parse
+<<foo>>
 DECLARE
   var1 CONSTANT INTEGER COLLATE collation_name NOT NULL := 30;
 BEGIN
-END
+END foo
 ----
+<<foo>>
 DECLARE
 var1 CONSTANT INT8 COLLATE collation_name NOT NULL := 30;
 BEGIN
-END;
+END foo;
  -- normalized!
+<<foo>>
 DECLARE
 var1 CONSTANT INT8 COLLATE collation_name NOT NULL := (30);
 BEGIN
-END;
+END foo;
  -- fully parenthesized
+<<foo>>
 DECLARE
 var1 CONSTANT INT8 COLLATE collation_name NOT NULL := _;
 BEGIN
-END;
+END foo;
  -- literals removed
+<<_>>
 DECLARE
 var1 CONSTANT INT8 COLLATE _ NOT NULL := 30;
 BEGIN
-END;
+END _;
  -- identifiers removed
 
 parse
@@ -192,3 +202,29 @@ DECLARE
   var1 one.two.three.four := 0;
                      ^
 HINT: try \h SET SESSION
+
+error
+<<foo>>
+BEGIN
+  SELECT 1;
+END bar
+----
+at or near "bar": syntax error: end label "bar" differs from block's label "foo"
+DETAIL: source SQL:
+<<foo>>
+BEGIN
+  SELECT 1;
+END bar
+    ^
+
+error
+BEGIN
+  SELECT 1;
+END foo
+----
+at or near "foo": syntax error: end label "foo" specified for unlabeled block
+DETAIL: source SQL:
+BEGIN
+  SELECT 1;
+END foo
+    ^

--- a/pkg/sql/plpgsql/parser/testdata/exception_sect
+++ b/pkg/sql/plpgsql/parser/testdata/exception_sect
@@ -15,7 +15,7 @@ RETURN x;
 EXCEPTION
 WHEN division_by_zero THEN
 RETURN 0;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
@@ -24,7 +24,7 @@ RETURN (x);
 EXCEPTION
 WHEN division_by_zero THEN
 RETURN (0);
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
@@ -33,7 +33,7 @@ RETURN x;
 EXCEPTION
 WHEN _ THEN
 RETURN _;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
@@ -42,7 +42,7 @@ RETURN _;
 EXCEPTION
 WHEN division_by_zero THEN
 RETURN 0;
-END
+END;
  -- identifiers removed
 
 
@@ -66,7 +66,7 @@ EXCEPTION
 WHEN SQLSTATE '22012' THEN
 x := 22012;
 RETURN x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
@@ -76,7 +76,7 @@ EXCEPTION
 WHEN SQLSTATE '22012' THEN
 x := (22012);
 RETURN (x);
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
@@ -86,7 +86,7 @@ EXCEPTION
 WHEN SQLSTATE '_' THEN
 x := _;
 RETURN x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
@@ -96,7 +96,7 @@ EXCEPTION
 WHEN SQLSTATE '22012' THEN
 _ := 22012;
 RETURN _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -118,7 +118,7 @@ EXCEPTION
 WHEN SQLSTATE '22012' OR SQLSTATE '22005' THEN
 x := 100;
 RETURN x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
@@ -128,7 +128,7 @@ EXCEPTION
 WHEN SQLSTATE '22012' OR SQLSTATE '22005' THEN
 x := (100);
 RETURN (x);
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
@@ -138,7 +138,7 @@ EXCEPTION
 WHEN SQLSTATE '_' OR SQLSTATE '_' THEN
 x := _;
 RETURN x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
@@ -148,7 +148,7 @@ EXCEPTION
 WHEN SQLSTATE '22012' OR SQLSTATE '22005' THEN
 _ := 100;
 RETURN _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -170,7 +170,7 @@ EXCEPTION
 WHEN SQLSTATE '22012' OR SQLSTATE '22005' OR feature_not_supported THEN
 x := 100;
 RETURN x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
@@ -180,7 +180,7 @@ EXCEPTION
 WHEN SQLSTATE '22012' OR SQLSTATE '22005' OR feature_not_supported THEN
 x := (100);
 RETURN (x);
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
@@ -190,7 +190,7 @@ EXCEPTION
 WHEN SQLSTATE '_' OR SQLSTATE '_' OR _ THEN
 x := _;
 RETURN x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
@@ -200,7 +200,7 @@ EXCEPTION
 WHEN SQLSTATE '22012' OR SQLSTATE '22005' OR feature_not_supported THEN
 _ := 100;
 RETURN _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -228,7 +228,7 @@ RETURN x;
 WHEN feature_not_supported THEN
 x := 12345;
 RETURN x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
@@ -241,7 +241,7 @@ RETURN (x);
 WHEN feature_not_supported THEN
 x := (12345);
 RETURN (x);
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
@@ -254,7 +254,7 @@ RETURN x;
 WHEN _ THEN
 x := _;
 RETURN x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
@@ -267,7 +267,7 @@ RETURN _;
 WHEN feature_not_supported THEN
 _ := 12345;
 RETURN _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -295,7 +295,7 @@ RETURN x;
 WHEN feature_not_supported OR SQLSTATE '22005' THEN
 x := 12345;
 RETURN x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
@@ -308,7 +308,7 @@ RETURN (x);
 WHEN feature_not_supported OR SQLSTATE '22005' THEN
 x := (12345);
 RETURN (x);
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
@@ -321,7 +321,7 @@ RETURN x;
 WHEN _ OR SQLSTATE '_' THEN
 x := _;
 RETURN x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
@@ -334,5 +334,5 @@ RETURN _;
 WHEN feature_not_supported OR SQLSTATE '22005' THEN
 _ := 12345;
 RETURN _;
-END
+END;
  -- identifiers removed

--- a/pkg/sql/plpgsql/parser/testdata/stmt_assign
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_assign
@@ -9,25 +9,25 @@ DECLARE
 BEGIN
 johnny := NULL;
 gyro := 7 + 7;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 johnny := (NULL);
 gyro := ((7) + (7));
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 johnny := _;
 gyro := _ + _;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 _ := NULL;
 _ := 7 + 7;
-END
+END;
  -- identifiers removed
 
 parse
@@ -39,22 +39,22 @@ END
 DECLARE
 BEGIN
 a := NULL;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 a := (NULL);
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 a := _;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 _ := NULL;
-END
+END;
  -- identifiers removed
 
 error

--- a/pkg/sql/plpgsql/parser/testdata/stmt_block
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_block
@@ -280,7 +280,7 @@ BEGIN
   RAISE NOTICE '%', x;
 END
 ----
-at or near "notice": syntax error
+at or near "raise": syntax error: end label "raise" specified for unlabeled block
 DETAIL: source SQL:
 DECLARE
   x INT;
@@ -288,4 +288,4 @@ BEGIN
   BEGIN
   END
   RAISE NOTICE '%', x;
-        ^
+  ^

--- a/pkg/sql/plpgsql/parser/testdata/stmt_block
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_block
@@ -5,17 +5,287 @@ END
 ----
 DECLARE
 BEGIN
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
-END
+END;
  -- identifiers removed
+
+parse
+DECLARE
+BEGIN
+  DECLARE
+  BEGIN
+  END;
+END
+----
+DECLARE
+BEGIN
+DECLARE
+BEGIN
+END;
+END;
+ -- normalized!
+DECLARE
+BEGIN
+DECLARE
+BEGIN
+END;
+END;
+ -- fully parenthesized
+DECLARE
+BEGIN
+DECLARE
+BEGIN
+END;
+END;
+ -- literals removed
+DECLARE
+BEGIN
+DECLARE
+BEGIN
+END;
+END;
+ -- identifiers removed
+
+parse
+DECLARE
+BEGIN
+  BEGIN
+  END;
+END
+----
+DECLARE
+BEGIN
+BEGIN
+END;
+END;
+ -- normalized!
+DECLARE
+BEGIN
+BEGIN
+END;
+END;
+ -- fully parenthesized
+DECLARE
+BEGIN
+BEGIN
+END;
+END;
+ -- literals removed
+DECLARE
+BEGIN
+BEGIN
+END;
+END;
+ -- identifiers removed
+
+parse
+DECLARE
+  x INT;
+BEGIN
+  DECLARE
+    y INT;
+  BEGIN
+    RAISE NOTICE '% %', x, y;
+  END;
+  RAISE NOTICE '%', x;
+END
+----
+DECLARE
+x INT8;
+BEGIN
+DECLARE
+y INT8;
+BEGIN
+RAISE NOTICE '% %', x, y;
+END;
+RAISE NOTICE '%', x;
+END;
+ -- normalized!
+DECLARE
+x INT8;
+BEGIN
+DECLARE
+y INT8;
+BEGIN
+RAISE NOTICE '% %', (x), (y);
+END;
+RAISE NOTICE '%', (x);
+END;
+ -- fully parenthesized
+DECLARE
+x INT8;
+BEGIN
+DECLARE
+y INT8;
+BEGIN
+RAISE NOTICE '_', x, y;
+END;
+RAISE NOTICE '_', x;
+END;
+ -- literals removed
+DECLARE
+x INT8;
+BEGIN
+DECLARE
+y INT8;
+BEGIN
+RAISE NOTICE '% %', _, _;
+END;
+RAISE NOTICE '%', _;
+END;
+ -- identifiers removed
+
+parse
+DECLARE
+  x INT;
+BEGIN
+  BEGIN
+    x := 100;
+  END;
+  RAISE NOTICE '%', x;
+END
+----
+DECLARE
+x INT8;
+BEGIN
+BEGIN
+x := 100;
+END;
+RAISE NOTICE '%', x;
+END;
+ -- normalized!
+DECLARE
+x INT8;
+BEGIN
+BEGIN
+x := (100);
+END;
+RAISE NOTICE '%', (x);
+END;
+ -- fully parenthesized
+DECLARE
+x INT8;
+BEGIN
+BEGIN
+x := _;
+END;
+RAISE NOTICE '_', x;
+END;
+ -- literals removed
+DECLARE
+x INT8;
+BEGIN
+BEGIN
+_ := 100;
+END;
+RAISE NOTICE '%', _;
+END;
+ -- identifiers removed
+
+parse
+DECLARE
+  x INT;
+BEGIN
+  BEGIN
+    x := 1 // 0;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      x := 0;
+  END;
+  RAISE NOTICE '%', x;
+END
+----
+DECLARE
+x INT8;
+BEGIN
+BEGIN
+x := 1 // 0;
+EXCEPTION
+WHEN division_by_zero THEN
+x := 0;
+END;
+RAISE NOTICE '%', x;
+END;
+ -- normalized!
+DECLARE
+x INT8;
+BEGIN
+BEGIN
+x := ((1) // (0));
+EXCEPTION
+WHEN division_by_zero THEN
+x := (0);
+END;
+RAISE NOTICE '%', (x);
+END;
+ -- fully parenthesized
+DECLARE
+x INT8;
+BEGIN
+BEGIN
+x := _ // _;
+EXCEPTION
+WHEN _ THEN
+x := _;
+END;
+RAISE NOTICE '_', x;
+END;
+ -- literals removed
+DECLARE
+x INT8;
+BEGIN
+BEGIN
+_ := 1 // 0;
+EXCEPTION
+WHEN division_by_zero THEN
+_ := 0;
+END;
+RAISE NOTICE '%', _;
+END;
+ -- identifiers removed
+
+error
+DECLARE
+BEGIN
+  BEGIN
+  END
+END
+----
+at or near "end": syntax error
+DETAIL: source SQL:
+DECLARE
+BEGIN
+  BEGIN
+  END
+END
+^
+
+error
+DECLARE
+  x INT;
+BEGIN
+  BEGIN
+  END
+  RAISE NOTICE '%', x;
+END
+----
+at or near "notice": syntax error
+DETAIL: source SQL:
+DECLARE
+  x INT;
+BEGIN
+  BEGIN
+  END
+  RAISE NOTICE '%', x;
+        ^

--- a/pkg/sql/plpgsql/parser/testdata/stmt_close
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_close
@@ -7,20 +7,20 @@ END
 DECLARE
 BEGIN
 CLOSE some_cursor;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 CLOSE some_cursor;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 CLOSE some_cursor;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 CLOSE _;
-END
+END;
  -- identifiers removed

--- a/pkg/sql/plpgsql/parser/testdata/stmt_exec_sql
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_exec_sql
@@ -9,22 +9,22 @@ END
 DECLARE
 BEGIN
 IMPORT TABLE foo FROM PGDUMP 'userfile://defaultdb.public.userfiles_root/db.sql' WITH OPTIONS (max_row_size = '524288');
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 IMPORT TABLE foo FROM PGDUMP ('userfile://defaultdb.public.userfiles_root/db.sql') WITH OPTIONS (max_row_size = ('524288'));
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 IMPORT TABLE foo FROM PGDUMP '_' WITH OPTIONS (max_row_size = '_');
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 IMPORT TABLE _ FROM PGDUMP 'userfile://defaultdb.public.userfiles_root/db.sql' WITH OPTIONS (_ = '524288');
-END
+END;
  -- identifiers removed
 
 parse
@@ -36,22 +36,22 @@ END
 DECLARE
 BEGIN
 INSERT INTO t1 VALUES (1, 2);
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 INSERT INTO t1 VALUES ((1), (2));
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 INSERT INTO t1 VALUES (_, _);
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 INSERT INTO _ VALUES (1, 2);
-END
+END;
  -- identifiers removed
 
 parse
@@ -63,22 +63,22 @@ END
 DECLARE
 BEGIN
 INSERT INTO t1 VALUES (1, 2) RETURNING x INTO y;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 INSERT INTO t1 VALUES ((1), (2)) RETURNING (x) INTO y;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 INSERT INTO t1 VALUES (_, _) RETURNING x INTO y;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 INSERT INTO _ VALUES (1, 2) RETURNING _ INTO _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -90,22 +90,22 @@ END
 DECLARE
 BEGIN
 INSERT INTO t1 VALUES (1, 2) RETURNING x INTO STRICT y;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 INSERT INTO t1 VALUES ((1), (2)) RETURNING (x) INTO STRICT y;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 INSERT INTO t1 VALUES (_, _) RETURNING x INTO STRICT y;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 INSERT INTO _ VALUES (1, 2) RETURNING _ INTO STRICT _;
-END
+END;
  -- identifiers removed
 
 error
@@ -130,22 +130,22 @@ END
 DECLARE
 BEGIN
 IMPORT INTO foo(k, v) CSV DATA ($1, $2);
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 IMPORT INTO foo(k, v) CSV DATA (($1), ($2));
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 IMPORT INTO foo(k, v) CSV DATA ($1, $1);
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 IMPORT INTO _(_, _) CSV DATA ($1, $2);
-END
+END;
  -- identifiers removed
 
 parse
@@ -157,22 +157,22 @@ END
 DECLARE
 BEGIN
 SELECT x, y FROM xy;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 SELECT (x), (y) FROM xy;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 SELECT x, y FROM xy;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 SELECT _, _ FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -184,22 +184,22 @@ END
 DECLARE
 BEGIN
 SELECT x, y FROM xy INTO a, b;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 SELECT (x), (y) FROM xy INTO a, b;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 SELECT x, y FROM xy INTO a, b;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 SELECT _, _ FROM _ INTO _, _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -211,22 +211,22 @@ END
 DECLARE
 BEGIN
 SELECT x, y FROM xy INTO a, b;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 SELECT (x), (y) FROM xy INTO a, b;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 SELECT x, y FROM xy INTO a, b;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 SELECT _, _ FROM _ INTO _, _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -238,22 +238,22 @@ END
 DECLARE
 BEGIN
 SET testing_optimizer_disable_rule_probability = 0;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 SET testing_optimizer_disable_rule_probability = (0);
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 SET testing_optimizer_disable_rule_probability = _;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 SET testing_optimizer_disable_rule_probability = 0;
-END
+END;
  -- identifiers removed
 
 parse
@@ -279,7 +279,7 @@ SELECT 100 INTO i;
 SELECT max(x) FROM xy INTO i;
 INSERT INTO xy VALUES (10, 10) RETURNING x INTO i;
 RETURN i;
-END
+END;
  -- normalized!
 DECLARE
 i INT8;
@@ -291,7 +291,7 @@ SELECT (100) INTO i;
 SELECT (max((x))) FROM xy INTO i;
 INSERT INTO xy VALUES ((10), (10)) RETURNING (x) INTO i;
 RETURN (i);
-END
+END;
  -- fully parenthesized
 DECLARE
 i INT8;
@@ -303,7 +303,7 @@ SELECT _ INTO i;
 SELECT max(x) FROM xy INTO i;
 INSERT INTO xy VALUES (_, _) RETURNING x INTO i;
 RETURN i;
-END
+END;
  -- literals removed
 DECLARE
 i INT8;
@@ -315,7 +315,7 @@ SELECT 100 INTO _;
 SELECT _(_) FROM _ INTO _;
 INSERT INTO _ VALUES (10, 10) RETURNING _ INTO _;
 RETURN _;
-END
+END;
  -- identifiers removed
 
 error
@@ -369,22 +369,22 @@ END
 DECLARE
 BEGIN
 UPSERT INTO t1 VALUES (1, 2) RETURNING x INTO y;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 UPSERT INTO t1 VALUES ((1), (2)) RETURNING (x) INTO y;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 UPSERT INTO t1 VALUES (_, _) RETURNING x INTO y;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 UPSERT INTO _ VALUES (1, 2) RETURNING _ INTO _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -396,22 +396,22 @@ END
 DECLARE
 BEGIN
 UPSERT INTO t1 VALUES (1, 2) RETURNING x INTO STRICT y;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 UPSERT INTO t1 VALUES ((1), (2)) RETURNING (x) INTO STRICT y;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 UPSERT INTO t1 VALUES (_, _) RETURNING x INTO STRICT y;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 UPSERT INTO _ VALUES (1, 2) RETURNING _ INTO STRICT _;
-END
+END;
  -- identifiers removed
 
 error

--- a/pkg/sql/plpgsql/parser/testdata/stmt_exit
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_exit
@@ -9,25 +9,25 @@ DECLARE
 BEGIN
 EXIT some_label;
 EXIT some_label WHEN some_condition;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 EXIT some_label;
 EXIT some_label WHEN (some_condition);
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 EXIT some_label;
 EXIT some_label WHEN some_condition;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 EXIT _;
 EXIT _ WHEN _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -41,23 +41,23 @@ DECLARE
 BEGIN
 CONTINUE some_label;
 CONTINUE some_label WHEN some_condition;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 CONTINUE some_label;
 CONTINUE some_label WHEN (some_condition);
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 CONTINUE some_label;
 CONTINUE some_label WHEN some_condition;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 CONTINUE _;
 CONTINUE _ WHEN _;
-END
+END;
  -- identifiers removed

--- a/pkg/sql/plpgsql/parser/testdata/stmt_fetch_move
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_fetch_move
@@ -7,22 +7,22 @@ END
 DECLARE
 BEGIN
 MOVE 1 FROM emp_cur;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 MOVE 1 FROM emp_cur;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 MOVE 1 FROM emp_cur;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 MOVE 1 FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -34,22 +34,22 @@ END
 DECLARE
 BEGIN
 MOVE -1 FROM var;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 MOVE -1 FROM var;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 MOVE -1 FROM var;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 MOVE -1 FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -61,22 +61,22 @@ END
 DECLARE
 BEGIN
 FETCH 1 FROM emp_cur INTO x, y;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH 1 FROM emp_cur INTO x, y;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH 1 FROM emp_cur INTO x, y;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH 1 FROM _ INTO _, _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -88,22 +88,22 @@ END
 DECLARE
 BEGIN
 FETCH 1 FROM emp_cur INTO x, y;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH 1 FROM emp_cur INTO x, y;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH 1 FROM emp_cur INTO x, y;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH 1 FROM _ INTO _, _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -115,22 +115,22 @@ END
 DECLARE
 BEGIN
 FETCH ABSOLUTE 2 FROM emp_cur INTO x, y;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH ABSOLUTE 2 FROM emp_cur INTO x, y;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH ABSOLUTE 2 FROM emp_cur INTO x, y;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH ABSOLUTE 2 FROM _ INTO _, _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -142,22 +142,22 @@ END
 DECLARE
 BEGIN
 FETCH 1 FROM emp_cur INTO x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH 1 FROM emp_cur INTO x;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH 1 FROM emp_cur INTO x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH 1 FROM _ INTO _;
-END
+END;
  -- identifiers removed
 
 error
@@ -212,22 +212,22 @@ END
 DECLARE
 BEGIN
 MOVE 1 FROM emp_cur;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 MOVE 1 FROM emp_cur;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 MOVE 1 FROM emp_cur;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 MOVE 1 FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -239,22 +239,22 @@ END
 DECLARE
 BEGIN
 MOVE -1 FROM emp_cur;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 MOVE -1 FROM emp_cur;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 MOVE -1 FROM emp_cur;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 MOVE -1 FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -266,22 +266,22 @@ END
 DECLARE
 BEGIN
 MOVE FIRST FROM emp_cur;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 MOVE FIRST FROM emp_cur;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 MOVE FIRST FROM emp_cur;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 MOVE FIRST FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -293,22 +293,22 @@ END
 DECLARE
 BEGIN
 MOVE LAST FROM emp_cur;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 MOVE LAST FROM emp_cur;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 MOVE LAST FROM emp_cur;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 MOVE LAST FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -320,22 +320,22 @@ END
 DECLARE
 BEGIN
 MOVE ABSOLUTE 5 FROM emp_cur;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 MOVE ABSOLUTE 5 FROM emp_cur;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 MOVE ABSOLUTE 5 FROM emp_cur;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 MOVE ABSOLUTE 5 FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -347,22 +347,22 @@ END
 DECLARE
 BEGIN
 MOVE FIRST FROM emp_cur;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 MOVE FIRST FROM emp_cur;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 MOVE FIRST FROM emp_cur;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 MOVE FIRST FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -374,22 +374,22 @@ END
 DECLARE
 BEGIN
 MOVE RELATIVE 3 FROM emp_cur;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 MOVE RELATIVE 3 FROM emp_cur;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 MOVE RELATIVE 3 FROM emp_cur;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 MOVE RELATIVE 3 FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -401,22 +401,22 @@ END
 DECLARE
 BEGIN
 MOVE 3 FROM emp_cur;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 MOVE 3 FROM emp_cur;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 MOVE 3 FROM emp_cur;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 MOVE 3 FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -428,22 +428,22 @@ END
 DECLARE
 BEGIN
 MOVE -3 FROM emp_cur;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 MOVE -3 FROM emp_cur;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 MOVE -3 FROM emp_cur;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 MOVE -3 FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -455,22 +455,22 @@ END
 DECLARE
 BEGIN
 MOVE ALL FROM emp_cur;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 MOVE ALL FROM emp_cur;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 MOVE ALL FROM emp_cur;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 MOVE ALL FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -482,22 +482,22 @@ END
 DECLARE
 BEGIN
 MOVE BACKWARD ALL FROM emp_cur;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 MOVE BACKWARD ALL FROM emp_cur;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 MOVE BACKWARD ALL FROM emp_cur;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 MOVE BACKWARD ALL FROM _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -509,22 +509,22 @@ END
 DECLARE
 BEGIN
 FETCH 1 FROM emp_cur INTO x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH 1 FROM emp_cur INTO x;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH 1 FROM emp_cur INTO x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH 1 FROM _ INTO _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -536,22 +536,22 @@ END
 DECLARE
 BEGIN
 FETCH -1 FROM emp_cur INTO x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH -1 FROM emp_cur INTO x;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH -1 FROM emp_cur INTO x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH -1 FROM _ INTO _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -563,22 +563,22 @@ END
 DECLARE
 BEGIN
 FETCH FIRST FROM emp_cur INTO x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH FIRST FROM emp_cur INTO x;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH FIRST FROM emp_cur INTO x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH FIRST FROM _ INTO _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -590,22 +590,22 @@ END
 DECLARE
 BEGIN
 FETCH LAST FROM emp_cur INTO x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH LAST FROM emp_cur INTO x;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH LAST FROM emp_cur INTO x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH LAST FROM _ INTO _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -617,22 +617,22 @@ END
 DECLARE
 BEGIN
 FETCH ABSOLUTE 5 FROM emp_cur INTO x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH ABSOLUTE 5 FROM emp_cur INTO x;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH ABSOLUTE 5 FROM emp_cur INTO x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH ABSOLUTE 5 FROM _ INTO _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -644,22 +644,22 @@ END
 DECLARE
 BEGIN
 FETCH FIRST FROM emp_cur INTO x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH FIRST FROM emp_cur INTO x;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH FIRST FROM emp_cur INTO x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH FIRST FROM _ INTO _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -671,22 +671,22 @@ END
 DECLARE
 BEGIN
 FETCH RELATIVE 3 FROM emp_cur INTO x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH RELATIVE 3 FROM emp_cur INTO x;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH RELATIVE 3 FROM emp_cur INTO x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH RELATIVE 3 FROM _ INTO _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -698,22 +698,22 @@ END
 DECLARE
 BEGIN
 FETCH 3 FROM emp_cur INTO x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH 3 FROM emp_cur INTO x;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH 3 FROM emp_cur INTO x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH 3 FROM _ INTO _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -725,22 +725,22 @@ END
 DECLARE
 BEGIN
 FETCH -3 FROM emp_cur INTO x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH -3 FROM emp_cur INTO x;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH -3 FROM emp_cur INTO x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH -3 FROM _ INTO _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -752,22 +752,22 @@ END
 DECLARE
 BEGIN
 FETCH ALL FROM emp_cur INTO x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH ALL FROM emp_cur INTO x;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH ALL FROM emp_cur INTO x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH ALL FROM _ INTO _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -779,20 +779,20 @@ END
 DECLARE
 BEGIN
 FETCH BACKWARD ALL FROM emp_cur INTO x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 FETCH BACKWARD ALL FROM emp_cur INTO x;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 FETCH BACKWARD ALL FROM emp_cur INTO x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 FETCH BACKWARD ALL FROM _ INTO _;
-END
+END;
  -- identifiers removed

--- a/pkg/sql/plpgsql/parser/testdata/stmt_if
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_if
@@ -21,7 +21,7 @@ ELSIF hihotpants THEN
 ELSE
 	diego := 0;
 END IF;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
@@ -33,7 +33,7 @@ ELSIF (hihotpants) THEN
 ELSE
 	diego := (0);
 END IF;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
@@ -45,7 +45,7 @@ ELSIF hihotpants THEN
 ELSE
 	diego := _;
 END IF;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
@@ -57,7 +57,7 @@ ELSIF _ THEN
 ELSE
 	_ := 0;
 END IF;
-END
+END;
  -- identifiers removed
 
 
@@ -72,25 +72,25 @@ DECLARE
 BEGIN
 IF johnnygyro THEN
 END IF;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 IF (johnnygyro) THEN
 END IF;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 IF johnnygyro THEN
 END IF;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 IF _ THEN
 END IF;
-END
+END;
  -- identifiers removed
 
 feature-count

--- a/pkg/sql/plpgsql/parser/testdata/stmt_loop
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_loop
@@ -15,7 +15,7 @@ LOOP
 EXIT WHEN x = 10;
 x := x + 1;
 END LOOP;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
@@ -24,7 +24,7 @@ LOOP
 EXIT WHEN ((x) = (10));
 x := ((x) + (1));
 END LOOP;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
@@ -33,7 +33,7 @@ LOOP
 EXIT WHEN x = _;
 x := x + _;
 END LOOP;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
@@ -42,7 +42,7 @@ LOOP
 EXIT WHEN _ = 10;
 _ := _ + 1;
 END LOOP;
-END
+END;
  -- identifiers removed
 
 
@@ -65,7 +65,7 @@ LOOP
 EXIT WHEN x = 10;
 x := x + 1;
 END LOOP mathing;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
@@ -75,7 +75,7 @@ LOOP
 EXIT WHEN ((x) = (10));
 x := ((x) + (1));
 END LOOP mathing;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
@@ -85,7 +85,7 @@ LOOP
 EXIT WHEN x = _;
 x := x + _;
 END LOOP mathing;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
@@ -95,7 +95,7 @@ LOOP
 EXIT WHEN _ = 10;
 _ := _ + 1;
 END LOOP _;
-END
+END;
  -- identifiers removed
 
 # The end label can be omitted.
@@ -118,7 +118,7 @@ LOOP
 EXIT WHEN x = 10;
 x := x + 1;
 END LOOP mathing;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
@@ -128,7 +128,7 @@ LOOP
 EXIT WHEN ((x) = (10));
 x := ((x) + (1));
 END LOOP mathing;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
@@ -138,7 +138,7 @@ LOOP
 EXIT WHEN x = _;
 x := x + _;
 END LOOP mathing;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
@@ -148,7 +148,7 @@ LOOP
 EXIT WHEN _ = 10;
 _ := _ + 1;
 END LOOP _;
-END
+END;
  -- identifiers removed
 
 # The start and end labels must be the same.

--- a/pkg/sql/plpgsql/parser/testdata/stmt_open
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_open
@@ -7,22 +7,22 @@ END
 DECLARE
 BEGIN
 OPEN curs1;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 OPEN curs1;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 OPEN curs1;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 OPEN _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -34,22 +34,22 @@ END
 DECLARE
 BEGIN
 OPEN curs1 FOR SELECT * FROM foo WHERE key = mykey;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 OPEN curs1 FOR SELECT (*) FROM foo WHERE ((key) = (mykey));
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 OPEN curs1 FOR SELECT * FROM foo WHERE key = mykey;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 OPEN _ FOR SELECT * FROM _ WHERE _ = _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -61,22 +61,22 @@ END
 DECLARE
 BEGIN
 OPEN curs1 SCROLL FOR SELECT * FROM foo WHERE key = mykey;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 OPEN curs1 SCROLL FOR SELECT (*) FROM foo WHERE ((key) = (mykey));
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 OPEN curs1 SCROLL FOR SELECT * FROM foo WHERE key = mykey;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 OPEN _ SCROLL FOR SELECT * FROM _ WHERE _ = _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -88,22 +88,22 @@ END
 DECLARE
 BEGIN
 OPEN curs1 NO SCROLL FOR SELECT * FROM foo WHERE key = mykey;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 OPEN curs1 NO SCROLL FOR SELECT (*) FROM foo WHERE ((key) = (mykey));
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 OPEN curs1 NO SCROLL FOR SELECT * FROM foo WHERE key = mykey;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 OPEN _ NO SCROLL FOR SELECT * FROM _ WHERE _ = _;
-END
+END;
  -- identifiers removed
 
 error

--- a/pkg/sql/plpgsql/parser/testdata/stmt_raise
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_raise
@@ -32,27 +32,27 @@ END
 ----
 DECLARE
 BEGIN
-RAISE exception
+RAISE EXCEPTION
 USING MESSAGE = "why is this so involved?";
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
-RAISE exception
+RAISE EXCEPTION
 USING MESSAGE = ("why is this so involved?");
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
-RAISE exception
+RAISE EXCEPTION
 USING MESSAGE = "why is this so involved?";
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
-RAISE exception
+RAISE EXCEPTION
 USING MESSAGE = _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -63,27 +63,27 @@ END
 ----
 DECLARE
 BEGIN
-RAISE log
+RAISE LOG
 USING HINT = "Insert HINT";
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
-RAISE log
+RAISE LOG
 USING HINT = ("Insert HINT");
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
-RAISE log
+RAISE LOG
 USING HINT = "Insert HINT";
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
-RAISE log
+RAISE LOG
 USING HINT = _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -94,23 +94,23 @@ END
 ----
 DECLARE
 BEGIN
-RAISE log 'Nonexistent ID --> %', user_id;
-END
+RAISE LOG 'Nonexistent ID --> %', user_id;
+END;
  -- normalized!
 DECLARE
 BEGIN
-RAISE log 'Nonexistent ID --> %', (user_id);
-END
+RAISE LOG 'Nonexistent ID --> %', (user_id);
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
-RAISE log '_', user_id;
-END
+RAISE LOG '_', user_id;
+END;
  -- literals removed
 DECLARE
 BEGIN
-RAISE log 'Nonexistent ID --> %', _;
-END
+RAISE LOG 'Nonexistent ID --> %', _;
+END;
  -- identifiers removed
 
 parse
@@ -122,27 +122,27 @@ END
 ----
 DECLARE
 BEGIN
-RAISE log 'Nonexistent ID --> %', user_id
+RAISE LOG 'Nonexistent ID --> %', user_id
 USING HINT = "check...userid?";
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
-RAISE log 'Nonexistent ID --> %', (user_id)
+RAISE LOG 'Nonexistent ID --> %', (user_id)
 USING HINT = ("check...userid?");
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
-RAISE log '_', user_id
+RAISE LOG '_', user_id
 USING HINT = "check...userid?";
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
-RAISE log 'Nonexistent ID --> %', _
+RAISE LOG 'Nonexistent ID --> %', _
 USING HINT = _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -154,22 +154,22 @@ END
 DECLARE
 BEGIN
 RAISE 'foo %', 'bar';
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 RAISE 'foo %', ('bar');
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 RAISE '_', '_';
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 RAISE 'foo %', 'bar';
-END
+END;
  -- identifiers removed
 
 parse
@@ -183,25 +183,25 @@ DECLARE
 i INT8 := 0;
 BEGIN
 RAISE 'foo %', i;
-END
+END;
  -- normalized!
 DECLARE
 i INT8 := (0);
 BEGIN
 RAISE 'foo %', (i);
-END
+END;
  -- fully parenthesized
 DECLARE
 i INT8 := _;
 BEGIN
 RAISE '_', i;
-END
+END;
  -- literals removed
 DECLARE
 i INT8 := 0;
 BEGIN
 RAISE 'foo %', _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -215,25 +215,25 @@ DECLARE
 i INT8 := 0;
 BEGIN
 RAISE 'foo %, %, %.', i, i * 2, i * 100;
-END
+END;
  -- normalized!
 DECLARE
 i INT8 := (0);
 BEGIN
 RAISE 'foo %, %, %.', (i), ((i) * (2)), ((i) * (100));
-END
+END;
  -- fully parenthesized
 DECLARE
 i INT8 := _;
 BEGIN
 RAISE '_', i, i * _, i * _;
-END
+END;
  -- literals removed
 DECLARE
 i INT8 := 0;
 BEGIN
 RAISE 'foo %, %, %.', _, _ * 2, _ * 100;
-END
+END;
  -- identifiers removed
 
 parse
@@ -247,25 +247,25 @@ DECLARE
 i INT8 := 0;
 BEGIN
 RAISE 'foo %', (SELECT count(*) FROM xy WHERE x = i);
-END
+END;
  -- normalized!
 DECLARE
 i INT8 := (0);
 BEGIN
 RAISE 'foo %', ((SELECT (count((*))) FROM xy WHERE ((x) = (i))));
-END
+END;
  -- fully parenthesized
 DECLARE
 i INT8 := _;
 BEGIN
 RAISE '_', (SELECT count(*) FROM xy WHERE x = i);
-END
+END;
  -- literals removed
 DECLARE
 i INT8 := 0;
 BEGIN
 RAISE 'foo %', (SELECT _(*) FROM _ WHERE _ = _);
-END
+END;
  -- identifiers removed
 
 parse
@@ -278,25 +278,25 @@ DECLARE
 BEGIN
 RAISE SQLSTATE '222222'
 USING HINT = hm;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 RAISE SQLSTATE '222222'
 USING HINT = (hm);
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 RAISE SQLSTATE '_'
 USING HINT = hm;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 RAISE SQLSTATE '222222'
 USING HINT = _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -308,22 +308,22 @@ END
 DECLARE
 BEGIN
 RAISE internal_screaming;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 RAISE internal_screaming;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 RAISE _;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 RAISE internal_screaming;
-END
+END;
  -- identifiers removed
 
 parse
@@ -339,26 +339,26 @@ BEGIN
 RAISE internal_screaming
 USING MESSAGE = 'blah blah blah',
 COLUMN = 'foo';
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 RAISE internal_screaming
 USING MESSAGE = ('blah blah blah'),
 COLUMN = ('foo');
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 RAISE _
 USING MESSAGE = '_',
 COLUMN = '_';
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 RAISE internal_screaming
 USING MESSAGE = 'blah blah blah',
 COLUMN = 'foo';
-END
+END;
  -- identifiers removed

--- a/pkg/sql/plpgsql/parser/testdata/stmt_return
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_return
@@ -7,22 +7,22 @@ END
 DECLARE
 BEGIN
 RETURN 1 + 2;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 RETURN ((1) + (2));
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 RETURN _ + _;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 RETURN 1 + 2;
-END
+END;
  -- identifiers removed
 
 parse
@@ -36,25 +36,25 @@ DECLARE
 BEGIN
 x := 1 + 2;
 RETURN x;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 x := ((1) + (2));
 RETURN (x);
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 x := _ + _;
 RETURN x;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 _ := 1 + 2;
 RETURN _;
-END
+END;
  -- identifiers removed
 
 parse
@@ -66,22 +66,22 @@ END
 DECLARE
 BEGIN
 RETURN (1, 'string');
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
 RETURN (((1), ('string')));
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
 RETURN (_, '_');
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
 RETURN (1, 'string');
-END
+END;
  -- identifiers removed
 
 error

--- a/pkg/sql/plpgsql/parser/testdata/stmt_while
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_while
@@ -13,7 +13,7 @@ x := 10;
 WHILE x > 0 LOOP
 x := x - 1;
 END LOOP;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
@@ -21,7 +21,7 @@ x := (10);
 WHILE ((x) > (0)) LOOP
 x := ((x) - (1));
 END LOOP;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
@@ -29,7 +29,7 @@ x := _;
 WHILE x > _ LOOP
 x := x - _;
 END LOOP;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
@@ -37,7 +37,7 @@ _ := 10;
 WHILE _ > 0 LOOP
 _ := _ - 1;
 END LOOP;
-END
+END;
  -- identifiers removed
 
 parse
@@ -57,7 +57,7 @@ WHILE (x > 0) AND (x < 100) LOOP
 x := x - 1;
 x := x - 2;
 END LOOP;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
@@ -66,7 +66,7 @@ WHILE ((((x) > (0))) AND (((x) < (100)))) LOOP
 x := ((x) - (1));
 x := ((x) - (2));
 END LOOP;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
@@ -75,7 +75,7 @@ WHILE (x > _) AND (x < _) LOOP
 x := x - _;
 x := x - _;
 END LOOP;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
@@ -84,7 +84,7 @@ WHILE (_ > 0) AND (_ < 100) LOOP
 _ := _ - 1;
 _ := _ - 2;
 END LOOP;
-END
+END;
  -- identifiers removed
 
 parse
@@ -104,7 +104,7 @@ x := 10;
 WHILE x > 0 LOOP
 x := x - 1;
 END LOOP labeled;
-END
+END;
  -- normalized!
 DECLARE
 BEGIN
@@ -113,7 +113,7 @@ x := (10);
 WHILE ((x) > (0)) LOOP
 x := ((x) - (1));
 END LOOP labeled;
-END
+END;
  -- fully parenthesized
 DECLARE
 BEGIN
@@ -122,7 +122,7 @@ x := _;
 WHILE x > _ LOOP
 x := x - _;
 END LOOP labeled;
-END
+END;
  -- literals removed
 DECLARE
 BEGIN
@@ -131,5 +131,5 @@ _ := 10;
 WHILE _ > 0 LOOP
 _ := _ - 1;
 END LOOP _;
-END
+END;
  -- identifiers removed

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1739,7 +1739,6 @@ func (b *builderState) serializeUserDefinedTypes(
 		v2 := utils.TypeRefVisitor{Fn: replaceTypeFunc}
 		newStmt = plpgsqltree.Walk(&v2, newStmt)
 		fmtCtx.FormatNode(newStmt)
-		fmtCtx.WriteString(";")
 	default:
 		panic(errors.AssertionFailedf("unexpected function language: %s", lang))
 	}

--- a/pkg/sql/schemachanger/scbuild/testdata/create_function
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_function
@@ -70,4 +70,4 @@ $$;
 - [[UserPrivileges:{DescID: 111, Name: root}, PUBLIC], ABSENT]
   {descriptorId: 111, privileges: "2", userName: root, withGrantOption: "2"}
 - [[FunctionBody:{DescID: 111}, PUBLIC], ABSENT]
-  {body: "BEGIN\nSELECT a FROM t;\nSELECT b FROM t@t_idx_b;\nSELECT c FROM t@t_idx_c;\nSELECT a FROM v;\nSELECT b'@':::@100108;\nRETURN nextval(105:::REGCLASS);\nEND\n;", functionId: 111, lang: {lang: PLPGSQL}, usesSequenceIds: [105], usesTables: [{columnIds: [1], tableId: 104}, {columnIds: [2], indexId: 2, tableId: 104}, {columnIds: [3], indexId: 3, tableId: 104}], usesTypeIds: [108, 109], usesViews: [{columnIds: [1], viewId: 107}]}
+  {body: "BEGIN\nSELECT a FROM t;\nSELECT b FROM t@t_idx_b;\nSELECT c FROM t@t_idx_c;\nSELECT a FROM v;\nSELECT b'@':::@100108;\nRETURN nextval(105:::REGCLASS);\nEND;\n", functionId: 111, lang: {lang: PLPGSQL}, usesSequenceIds: [105], usesTables: [{columnIds: [1], tableId: 104}, {columnIds: [2], indexId: 2, tableId: 104}, {columnIds: [3], indexId: 3, tableId: 104}], usesTypeIds: [108, 109], usesViews: [{columnIds: [1], viewId: 107}]}

--- a/pkg/sql/schemachanger/scbuild/testdata/create_procedure
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_procedure
@@ -66,4 +66,4 @@ $$;
 - [[UserPrivileges:{DescID: 111, Name: root}, PUBLIC], ABSENT]
   {descriptorId: 111, privileges: "2", userName: root, withGrantOption: "2"}
 - [[FunctionBody:{DescID: 111}, PUBLIC], ABSENT]
-  {body: "BEGIN\nSELECT a FROM t;\nSELECT b FROM t@t_idx_b;\nSELECT c FROM t@t_idx_c;\nSELECT a FROM v;\nSELECT b'@':::@100108;\nSELECT nextval(105:::REGCLASS);\nEND\n;", functionId: 111, lang: {lang: PLPGSQL}, usesSequenceIds: [105], usesTables: [{columnIds: [1], tableId: 104}, {columnIds: [2], indexId: 2, tableId: 104}, {columnIds: [3], indexId: 3, tableId: 104}], usesTypeIds: [108, 109], usesViews: [{columnIds: [1], viewId: 107}]}
+  {body: "BEGIN\nSELECT a FROM t;\nSELECT b FROM t@t_idx_b;\nSELECT c FROM t@t_idx_c;\nSELECT a FROM v;\nSELECT b'@':::@100108;\nSELECT nextval(105:::REGCLASS);\nEND;\n", functionId: 111, lang: {lang: PLPGSQL}, usesSequenceIds: [105], usesTables: [{columnIds: [1], tableId: 104}, {columnIds: [2], indexId: 2, tableId: 104}, {columnIds: [3], indexId: 3, tableId: 104}], usesTypeIds: [108, 109], usesViews: [{columnIds: [1], viewId: 107}]}

--- a/pkg/sql/schemachanger/scplan/testdata/create_function
+++ b/pkg/sql/schemachanger/scplan/testdata/create_function
@@ -459,7 +459,7 @@ StatementPhase stage 1 of 1 with 12 MutationType ops
         WithGrantOption: 2
     *scop.SetFunctionBody
       Body:
-        Body: |-
+        Body: |
           BEGIN
           SELECT a FROM t;
           SELECT b FROM t@t_idx_b;
@@ -467,8 +467,7 @@ StatementPhase stage 1 of 1 with 12 MutationType ops
           SELECT a FROM v;
           SELECT b'@':::@100107;
           RETURN nextval(105:::REGCLASS);
-          END
-          ;
+          END;
         FunctionID: 111
         Lang:
           Lang: 2
@@ -608,7 +607,7 @@ PreCommitPhase stage 2 of 2 with 12 MutationType ops
         WithGrantOption: 2
     *scop.SetFunctionBody
       Body:
-        Body: |-
+        Body: |
           BEGIN
           SELECT a FROM t;
           SELECT b FROM t@t_idx_b;
@@ -616,8 +615,7 @@ PreCommitPhase stage 2 of 2 with 12 MutationType ops
           SELECT a FROM v;
           SELECT b'@':::@100107;
           RETURN nextval(105:::REGCLASS);
-          END
-          ;
+          END;
         FunctionID: 111
         Lang:
           Lang: 2

--- a/pkg/sql/schemachanger/scplan/testdata/create_procedure
+++ b/pkg/sql/schemachanger/scplan/testdata/create_procedure
@@ -438,7 +438,7 @@ StatementPhase stage 1 of 1 with 11 MutationType ops
         WithGrantOption: 2
     *scop.SetFunctionBody
       Body:
-        Body: |-
+        Body: |
           BEGIN
           SELECT a FROM t;
           SELECT b FROM t@t_idx_b;
@@ -446,8 +446,7 @@ StatementPhase stage 1 of 1 with 11 MutationType ops
           SELECT a FROM v;
           SELECT b'@':::@100107;
           SELECT nextval(105:::REGCLASS);
-          END
-          ;
+          END;
         FunctionID: 111
         Lang:
           Lang: 2
@@ -582,7 +581,7 @@ PreCommitPhase stage 2 of 2 with 11 MutationType ops
         WithGrantOption: 2
     *scop.SetFunctionBody
       Body:
-        Body: |-
+        Body: |
           BEGIN
           SELECT a FROM t;
           SELECT b FROM t@t_idx_b;
@@ -590,8 +589,7 @@ PreCommitPhase stage 2 of 2 with 11 MutationType ops
           SELECT a FROM v;
           SELECT b'@':::@100107;
           SELECT nextval(105:::REGCLASS);
-          END
-          ;
+          END;
         FunctionID: 111
         Lang:
           Lang: 2

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -72,8 +72,12 @@ func (s *Block) CopyNode() *Block {
 	return &copyNode
 }
 
-// TODO(drewk): format Label and Exceptions fields.
 func (s *Block) Format(ctx *tree.FmtCtx) {
+	if s.Label != "" {
+		ctx.WriteString("<<")
+		ctx.FormatNameP(&s.Label)
+		ctx.WriteString(">>\n")
+	}
 	if s.Decls != nil {
 		ctx.WriteString("DECLARE\n")
 		for _, dec := range s.Decls {
@@ -92,7 +96,12 @@ func (s *Block) Format(ctx *tree.FmtCtx) {
 			ctx.FormatNode(&e)
 		}
 	}
-	ctx.WriteString("END\n")
+	ctx.WriteString("END")
+	if s.Label != "" {
+		ctx.WriteString(" ")
+		ctx.FormatNameP(&s.Label)
+	}
+	ctx.WriteString(";\n")
 }
 
 func (s *Block) PlpgSQLStatementTag() string {
@@ -863,7 +872,7 @@ func (s *Raise) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString("RAISE")
 	if s.LogLevel != "" {
 		ctx.WriteString(" ")
-		ctx.WriteString(s.LogLevel)
+		ctx.WriteString(strings.ToUpper(s.LogLevel))
 	}
 	if s.Code != "" {
 		ctx.WriteString(" SQLSTATE ")


### PR DESCRIPTION
#### plpgsql: misc formatting fixes

This commit makes a few fixes to formatting for PL/pgSQL routines in
preparation for nested blocks support, as well as a few misc fixes:
1. Blocks now print a semicolon after `END`. While the semicolon is
   optional for the root block, it is non-optional for nested blocks.
2. Block labels are now correctly displayed (previously, they were ignored).
3. An extra newline has been removed from the output of `SHOW CREATE FUNCTION`
   and `SHOW CREATE PROCEDURE`.
4. RAISE statements now capitalize the log level (e.g. `notice` -> `NOTICE`).

Informs #114775
Informs #112136

Release note: None

#### plpgsql: return errors for block labels

This commit adds a parse-time check that the labels on a PLpgSQL block
(if any) match. If the labels do not match, an expected syntax error is
returned. This commit also adds an "unimplemented" error for block labels.
Finally, errors that don't use formatting arguments have been moved to the
bottom of the file for clarity.

Informs #114775

Release note (bug fix): Incorrectly labeled PL/pgSQL blocks now return
an expected syntax error.