### PR TITLE
streamingccl: change retention default to 4 hours

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -35,7 +35,7 @@ import (
 
 // defaultRetentionTTLSeconds is the default value for how long
 // replicated data will be retained.
-const defaultRetentionTTLSeconds = int32(25 * 60 * 60)
+const defaultRetentionTTLSeconds = int32(4 * 60 * 60)
 
 func streamIngestionJobDescription(
 	p sql.PlanHookState, sourceAddr string, streamIngestion *tree.CreateTenantFromReplication,


### PR DESCRIPTION
This changes the default retention from 25 hours to 4 hours. Users who need a longer retention can still manually set a longer retention.

The long retention on the destination side isn't necessarily a problem, but it does mean that shortly after cutover we will be running a cluster in which we've allowed substantially more garbage to accumulate than normal, which could affect post-cutover query performance until the GC queue catches up.

Epic: none

Release note: None