### PR TITLE
roachtest: pass RunOptions to RunWithDetails(SingleNode)

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2302,11 +2302,7 @@ func (c *clusterImpl) RunE(ctx context.Context, options install.RunOptions, args
 	if len(args) == 0 {
 		return errors.New("No command passed")
 	}
-	nodes := option.NodeListOption{}
-	for _, n := range options.Nodes {
-		nodes = append(nodes, int(n))
-	}
-
+	nodes := option.FromInstallNodes(options.Nodes)
 	l, logFile, err := c.loggerForCmd(nodes, args...)
 	if err != nil {
 		return err
@@ -2344,12 +2340,7 @@ func (c *clusterImpl) RunE(ctx context.Context, options install.RunOptions, args
 func (c *clusterImpl) RunWithDetailsSingleNode(
 	ctx context.Context, testLogger *logger.Logger, options install.RunOptions, args ...string,
 ) (install.RunResultDetails, error) {
-
-	nodes := option.NodeListOption{}
-	for _, n := range options.Nodes {
-		nodes = append(nodes, int(n))
-	}
-
+	nodes := option.FromInstallNodes(options.Nodes)
 	if len(nodes) != 1 {
 		return install.RunResultDetails{}, errors.Newf("RunWithDetailsSingleNode received %d nodes. Use RunWithDetails if you need to run on multiple nodes.", len(nodes))
 	}
@@ -2369,10 +2360,7 @@ func (c *clusterImpl) RunWithDetails(
 	if len(args) == 0 {
 		return nil, errors.New("No command passed")
 	}
-	nodes := option.NodeListOption{}
-	for _, n := range options.Nodes {
-		nodes = append(nodes, int(n))
-	}
+	nodes := option.FromInstallNodes(options.Nodes)
 	l, logFile, err := c.loggerForCmd(nodes, args...)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -94,11 +94,13 @@ type Cluster interface {
 
 	// Running commands on nodes.
 
-	// RunWithDetails runs a command on the specified nodes and returns results details and an error.
-	// The returned error is only for a major failure in roachprod run command so the caller needs
-	// to check for individual node errors in `[]install.RunResultDetails`.
+	// RunWithDetails runs a command on the specified nodes (option.WithNodes) and
+	// returns results details and an error. The returned error is only for a
+	// major failure in roachprod run command so the caller needs to check for
+	// individual node errors in `[]install.RunResultDetails`.
 	// Use it when you need output details such as stdout or stderr, or remote exit status.
-	RunWithDetails(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string) ([]install.RunResultDetails, error)
+	// See install.RunOptions for more details on available options.
+	RunWithDetails(ctx context.Context, testLogger *logger.Logger, options install.RunOptions, args ...string) ([]install.RunResultDetails, error)
 
 	// Run is just like RunE, except it is fatal on errors.
 	// Use it when an error means the test should fail.
@@ -119,7 +121,7 @@ type Cluster interface {
 	// on a single node AND 2) an error from roachprod itself would be treated the same way
 	// you treat an error from the command. This makes error checking easier / friendlier
 	// and helps us avoid code replication.
-	RunWithDetailsSingleNode(ctx context.Context, testLogger *logger.Logger, nodes option.NodeListOption, args ...string) (install.RunResultDetails, error)
+	RunWithDetailsSingleNode(ctx context.Context, testLogger *logger.Logger, options install.RunOptions, args ...string) (install.RunResultDetails, error)
 
 	// Metadata about the provisioned nodes.
 

--- a/pkg/cmd/roachtest/option/node_list_option.go
+++ b/pkg/cmd/roachtest/option/node_list_option.go
@@ -132,3 +132,12 @@ func (n NodeListOption) InstallNodes() install.Nodes {
 	}
 	return installNodes
 }
+
+// FromInstallNodes converts install.Nodes to NodeListOption
+func FromInstallNodes(installNodes install.Nodes) NodeListOption {
+	nodes := NodeListOption{}
+	for _, n := range installNodes {
+		nodes = append(nodes, int(n))
+	}
+	return nodes
+}

--- a/pkg/cmd/roachtest/roachtestutil/disk_usage.go
+++ b/pkg/cmd/roachtest/roachtestutil/disk_usage.go
@@ -149,7 +149,7 @@ func GetDiskUsageInBytes(
 		result, err = c.RunWithDetailsSingleNode(
 			ctx,
 			logger,
-			c.Node(nodeIdx),
+			option.WithNodes(c.Node(nodeIdx)),
 			"du -sk {store-dir} 2>/dev/null | grep -oE '^[0-9]+'",
 		)
 		if err != nil {

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -874,7 +874,7 @@ elif [[ -e "${ARTIFACTS_DIR}" ]]; then
 else
     echo false
 fi'`
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(node), "bash", "-c", testCmd)
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(node)), "bash", "-c", testCmd)
 		if err != nil {
 			return errors.Wrapf(err, "failed to check for artifacts in %q", srcDirOnNode)
 		}

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -177,7 +177,7 @@ func registerActiveRecord(r registry.Registry) {
 
 		t.Status("running activerecord test suite")
 
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node,
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node),
 			fmt.Sprintf(
 				`cd /mnt/data1/activerecord-cockroachdb-adapter/ && `+
 					`sudo RAILS_VERSION=%s RUBYOPT="-W0" TESTOPTS="-v" bundle exec rake test`, supportedRailsVersion),

--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -133,7 +133,7 @@ func registerAsyncpg(r registry.Registry) {
 
 		t.Status("Running asyncpg tests ")
 		result, err := c.RunWithDetailsSingleNode(
-			ctx, t.L(), node, asyncpgRunTestCmd)
+			ctx, t.L(), option.WithNodes(node), asyncpgRunTestCmd)
 		if err != nil {
 			t.L().Printf("error during asyncpg run (may be ok): %v\n", err)
 		}

--- a/pkg/cmd/roachtest/tests/build_info.go
+++ b/pkg/cmd/roachtest/tests/build_info.go
@@ -86,7 +86,7 @@ func RunBuildAnalyze(ctx context.Context, t test.Test, c cluster.Cluster) {
 	c.Run(ctx, option.WithNodes(c.Node(1)), "sudo apt-get update")
 	c.Run(ctx, option.WithNodes(c.Node(1)), "sudo apt-get -qqy install pax-utils")
 
-	result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(1), "scanelf -qe cockroach")
+	result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(1)), "scanelf -qe cockroach")
 	if err != nil {
 		t.Fatalf("scanelf failed: %s", err)
 	}

--- a/pkg/cmd/roachtest/tests/canary.go
+++ b/pkg/cmd/roachtest/tests/canary.go
@@ -145,7 +145,7 @@ func repeatRunWithDetailsSingleNode(
 		}
 		attempt++
 		t.L().Printf("attempt %d - %s", attempt, operation)
-		lastResult, lastError = c.RunWithDetailsSingleNode(ctx, t.L(), node, args...)
+		lastResult, lastError = c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node), args...)
 		if lastError != nil {
 			t.L().Printf("error - retrying: %s", lastError)
 			continue

--- a/pkg/cmd/roachtest/tests/cdc_filtering.go
+++ b/pkg/cmd/roachtest/tests/cdc_filtering.go
@@ -243,7 +243,7 @@ func checkCDCEvents[S any](
 
 	// Collect the events from the file-based sink on n1.
 	cmd := fmt.Sprintf("find {store-dir}/extern/%s -name '*.ndjson' | xargs cat", nodeLocalSinkDir)
-	d, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(1), cmd)
+	d, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(1)), cmd)
 	require.NoError(t, err)
 
 	var events []changefeedSinkEvent[S]

--- a/pkg/cmd/roachtest/tests/cli.go
+++ b/pkg/cmd/roachtest/tests/cli.go
@@ -47,7 +47,7 @@ func runCLINodeStatus(ctx context.Context, t test.Test, c cluster.Cluster) {
 	}
 
 	nodeStatus := func() (_ string, _ []string, err error) {
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(1), "./cockroach node status --insecure -p {pgport:1}")
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(1)), "./cockroach node status --insecure -p {pgport:1}")
 		if err != nil {
 			return "", nil, err
 		}

--- a/pkg/cmd/roachtest/tests/cluster_init.go
+++ b/pkg/cmd/roachtest/tests/cluster_init.go
@@ -162,7 +162,7 @@ func runClusterInit(ctx context.Context, t test.Test, c cluster.Cluster) {
 			args = append(args, extraArgs...)
 			args = append(args, "--insecure")
 			args = append(args, fmt.Sprintf("--port={pgport:%d}", runNode))
-			result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(runNode), args...)
+			result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(runNode)), args...)
 			combinedOutput := result.Stdout + result.Stderr
 			t.L().Printf("%s\n", combinedOutput)
 			return combinedOutput, err

--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -89,7 +89,7 @@ func runTest(ctx context.Context, t test.Test, c cluster.Cluster, pg string) {
 	succeeded := false
 	for r.Next() {
 		start = timeutil.Now()
-		det, err = c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(1), fmt.Sprintf(`cat /tmp/lineitem-table.csv | %s -c "COPY lineitem FROM STDIN WITH CSV DELIMITER '|';"`, pg))
+		det, err = c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(1)), fmt.Sprintf(`cat /tmp/lineitem-table.csv | %s -c "COPY lineitem FROM STDIN WITH CSV DELIMITER '|';"`, pg))
 		if err == nil {
 			succeeded = true
 			break
@@ -112,7 +112,7 @@ func runTest(ctx context.Context, t test.Test, c cluster.Cluster, pg string) {
 	require.NoError(t, err)
 	rate := int(float64(rows) / dur.Seconds())
 
-	det, err = c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(1), "wc -c /tmp/lineitem-table.csv")
+	det, err = c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(1)), "wc -c /tmp/lineitem-table.csv")
 	require.NoError(t, err)
 	var bytes float64
 	_, err = fmt.Sscan(det.Stdout, &bytes)

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -1485,7 +1485,7 @@ func execCLI(
 		t.Fatal(err)
 	}
 	args = append(args, fmt.Sprintf("--url=%s", pgurl))
-	result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(runNode), args...)
+	result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(runNode)), args...)
 	t.L().Printf("%s\n", result.Stdout)
 	return result.Stdout, err
 }

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -1107,7 +1107,7 @@ func logLSMHealth(ctx context.Context, l *logger.Logger, c cluster.Cluster, targ
 	if err != nil {
 		return err
 	}
-	result, err := c.RunWithDetailsSingleNode(ctx, l, c.Node(target),
+	result, err := c.RunWithDetailsSingleNode(ctx, l, option.WithNodes(c.Node(target)),
 		"curl", "-s", fmt.Sprintf("http://%s/debug/lsm",
 			adminAddrs[0]))
 	if err == nil {

--- a/pkg/cmd/roachtest/tests/disk_full.go
+++ b/pkg/cmd/roachtest/tests/disk_full.go
@@ -117,7 +117,7 @@ func registerDiskFull(r registry.Registry) {
 					// propagated from roachprod, obscures the Cockroach
 					// exit code. There should still be a record of it
 					// in the systemd logs.
-					result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(n), fmt.Sprintf(
+					result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(n)), fmt.Sprintf(
 						`systemctl status %s | grep 'Main PID' | grep -oE '\((.+)\)'`,
 						roachtestutil.SystemInterfaceSystemdUnitName(),
 					))

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -256,7 +256,7 @@ func getProcessExitMonotonic(
 func getProcessMonotonicTimestamp(
 	ctx context.Context, t test.Test, c cluster.Cluster, nodeID int, prop string,
 ) (time.Duration, bool) {
-	details, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(nodeID), fmt.Sprintf(
+	details, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(nodeID)), fmt.Sprintf(
 		"systemctl show %s --property=%s", roachtestutil.SystemInterfaceSystemdUnitName(), prop))
 	require.NoError(t, err)
 	require.NoError(t, details.Err)

--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -186,7 +186,7 @@ func registerDjango(r registry.Registry) {
 		var fullTestResults []byte
 		for _, testName := range enabledDjangoTests {
 			t.Status("Running django test app ", testName)
-			result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node, fmt.Sprintf(djangoRunTestCmd, testName))
+			result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node), fmt.Sprintf(djangoRunTestCmd, testName))
 
 			// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.
 			// Proceed for any other (command) errors

--- a/pkg/cmd/roachtest/tests/drain.go
+++ b/pkg/cmd/roachtest/tests/drain.go
@@ -134,7 +134,7 @@ func runEarlyExitInConnectionWait(ctx context.Context, t test.Test, c cluster.Cl
 		results, err := c.RunWithDetailsSingleNode(
 			ctx,
 			t.L(),
-			c.Node(nodeToDrain),
+			option.WithNodes(c.Node(nodeToDrain)),
 			// --drain-wait is set to a low value so that we can confirm that it
 			// gets automatically upgraded to use a higher value larger than the sum
 			// of server.shutdown.initial_wait, server.shutdown.connections.timeout,
@@ -349,7 +349,7 @@ func runClusterNotAtQuorum(ctx context.Context, t test.Test, c cluster.Cluster) 
 	results, _ := c.RunWithDetailsSingleNode(
 		ctx,
 		t.L(),
-		c.Node(3), fmt.Sprintf("./cockroach node drain --self --insecure --drain-wait=10s --url=%s", pgurl))
+		option.WithNodes(c.Node(3)), fmt.Sprintf("./cockroach node drain --self --insecure --drain-wait=10s --url=%s", pgurl))
 	t.L().Printf("drain output:\n%s\n%s\n", results.Stdout, results.Stderr)
 	require.Regexp(t, "(cluster settings require a value of at least|could not check drain related cluster settings)", results.Stderr)
 }

--- a/pkg/cmd/roachtest/tests/gopg.go
+++ b/pkg/cmd/roachtest/tests/gopg.go
@@ -104,7 +104,7 @@ func registerGopg(r registry.Registry) {
 		// code escape sequences.
 		const removeColorCodes = `sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g"`
 
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node,
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node),
 			fmt.Sprintf(
 				`cd %s && PGPORT={pgport:1} PGUSER=root PGSSLMODE=disable PGDATABASE=postgres go test -v ./... 2>&1 | %s | tee %s`,
 				destPath, removeColorCodes, resultsFilePath),
@@ -132,7 +132,7 @@ func registerGopg(r registry.Registry) {
 
 		// Now we parse the output of top-level tests.
 
-		result, err = c.RunWithDetailsSingleNode(ctx, t.L(), node,
+		result, err = c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node),
 			// We pipe the test output into go-junit-report tool which will output
 			// it in XML format.
 			fmt.Sprintf(`cd %s &&

--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -157,7 +157,7 @@ func initJepsen(ctx context.Context, t test.Test, c cluster.Cluster, j jepsenCon
 
 	// Install Jepsen's prereqs on the controller.
 	if result, err := c.RunWithDetailsSingleNode(
-		ctx, t.L(), controller, "sh", "-c",
+		ctx, t.L(), option.WithNodes(controller), "sh", "-c",
 		`"sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install openjdk-8-jre openjdk-8-jre-headless libjna-java gnuplot > /dev/null 2>&1"`,
 	); err != nil {
 		if result.RemoteExitStatus == 100 {
@@ -412,7 +412,7 @@ func runJepsen(ctx context.Context, t test.Test, c cluster.Cluster, testName, ne
 		}
 
 		if result, err := c.RunWithDetailsSingleNode(
-			ctx, t.L(), controller,
+			ctx, t.L(), option.WithNodes(controller),
 			// -h causes tar to follow symlinks; needed by the "latest" symlink.
 			// -f- sends the output to stdout, we read it and save it to a local file.
 			"tar -chj --ignore-failed-read -C /mnt/data1/jepsen/cockroachdb -f- store/latest invoke.log",

--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -125,7 +125,7 @@ echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.co
 		result, err := c.RunWithDetailsSingleNode(
 			ctx,
 			t.L(),
-			node,
+			option.WithNodes(node),
 			`cd /mnt/data1/knex/ && DB='cockroachdb' npm test`,
 		)
 		rawResultsStr := result.Stdout + result.Stderr

--- a/pkg/cmd/roachtest/tests/libpq.go
+++ b/pkg/cmd/roachtest/tests/libpq.go
@@ -103,7 +103,7 @@ func registerLibPQ(r registry.Registry) {
 		testListRegex := "^(Test|Example)"
 		result, err := c.RunWithDetailsSingleNode(
 			ctx, t.L(),
-			node,
+			option.WithNodes(node),
 			fmt.Sprintf(`cd %s && PGPORT={pgport:1} PGUSER=root PGSSLMODE=disable PGDATABASE=postgres go test -list "%s"`, libPQPath, testListRegex),
 		)
 		require.NoError(t, err)

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -481,7 +481,7 @@ func runHalfOnlineRecoverLossOfQuorum(
 		if err = timeutil.RunWithTimeout(ctx, "wait-for-restart", 2*time.Minute,
 			func(ctx context.Context) error {
 				for {
-					res, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(controller), verifyCommand)
+					res, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(controller)), verifyCommand)
 					if res.RemoteExitStatus == 0 {
 						if ctx.Err() != nil {
 							return &recoveryImpossibleError{testOutcome: restartFailed}

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -849,7 +849,7 @@ func (sc *systemTableContents) loadShowResults(
 		String()
 
 	node := sc.cluster.Node(sc.roachNode)
-	result, err := sc.cluster.RunWithDetailsSingleNode(ctx, l, node, showCmd)
+	result, err := sc.cluster.RunWithDetailsSingleNode(ctx, l, option.WithNodes(node), showCmd)
 	if err != nil {
 		return fmt.Errorf("error running command (%s): %w", showCmd, err)
 	}
@@ -1951,7 +1951,7 @@ func (u *CommonTestUtils) sentinelFilePath(
 	ctx context.Context, l *logger.Logger, node int,
 ) (string, error) {
 	result, err := u.cluster.RunWithDetailsSingleNode(
-		ctx, l, u.cluster.Node(node), "echo -n {store-dir}",
+		ctx, l, option.WithNodes(u.cluster.Node(node)), "echo -n {store-dir}",
 	)
 	if err != nil {
 		return "", fmt.Errorf("failed to retrieve store directory from node %d: %w", node, err)

--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -95,7 +95,7 @@ func validateCorpusFile(
 ) {
 	details, err := c.RunWithDetailsSingleNode(ctx,
 		t.L(),
-		c.Node(1),
+		option.WithNodes(c.Node(1)),
 		fmt.Sprintf("%s debug declarative-corpus-validate %s",
 			binaryName,
 			corpusPath))

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -61,7 +61,7 @@ func runMultiTenantTPCH(
 			cmd := fmt.Sprintf("./workload run tpch %s --secure "+
 				"--concurrency=1 --db=tpch --max-ops=%d --queries=%d {pgurl:1}",
 				url, numRunsPerQuery, queryNum)
-			result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(1), cmd)
+			result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(1)), cmd)
 			workloadOutput := result.Stdout + result.Stderr
 			t.L().Printf(workloadOutput)
 			if err != nil {

--- a/pkg/cmd/roachtest/tests/mvcc_gc.go
+++ b/pkg/cmd/roachtest/tests/mvcc_gc.go
@@ -646,7 +646,7 @@ func sendBatchRequest(
 		Flag("host", fmt.Sprintf("localhost:{pgport:%d}", node)).
 		String()
 	res, err := c.RunWithDetailsSingleNode(
-		ctx, t.L(), c.Node(node), debugEnv+cmd)
+		ctx, t.L(), option.WithNodes(c.Node(node)), debugEnv+cmd)
 	if err != nil {
 		return kvpb.BatchResponse{}, err
 	}

--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -207,7 +207,7 @@ SELECT $1::INT = ALL (
 				// Attempt a client connection to that server.
 				t.L().Printf("server %d, attempt %d; url: %s\n", server, attempt, url)
 
-				b, err := c.RunWithDetailsSingleNode(ctx, t.L(), clientNode, "time", "-p", "./cockroach", "sql",
+				b, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(clientNode), "time", "-p", "./cockroach", "sql",
 					"--url", url, "--certs-dir", certsDir, "-e", "'SELECT 1'")
 
 				// Report the results of execution.
@@ -323,7 +323,7 @@ func runClientNetworkConnectionTimeout(ctx context.Context, t test.Test, c clust
 		}
 		commandThatWillDisconnect := fmt.Sprintf(`./cockroach sql --certs-dir %s --url "postgres://root@%s:26257" -e "SELECT pg_sleep(600)"`, certsDir, ips[0])
 		t.L().Printf("Executing long running query: %s", commandThatWillDisconnect)
-		output, err := c.RunWithDetails(ctx, t.L(), clientNode, commandThatWillDisconnect)
+		output, err := c.RunWithDetails(ctx, t.L(), option.WithNodes(clientNode), commandThatWillDisconnect)
 		runOutput = output[0]
 		return err
 	})

--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -145,7 +145,7 @@ echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.co
 		require.NoError(t, err)
 
 		t.Status("running node-postgres tests")
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node,
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node),
 			fmt.Sprintf(
 				`cd /mnt/data1/node-postgres/ && sudo \
 PGPORT={pgport:1} PGUSER=%s PGSSLMODE=require PGDATABASE=postgres_node_test \

--- a/pkg/cmd/roachtest/tests/npgsql.go
+++ b/pkg/cmd/roachtest/tests/npgsql.go
@@ -105,7 +105,7 @@ sudo ln -s /snap/dotnet-sdk/current/dotnet /usr/local/bin/dotnet`,
 		t.L().Printf("Latest npgsql release is %s.", latestTag)
 		t.L().Printf("Supported release is %s.", npgsqlSupportedTag)
 
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Nodes(1), "echo -n {pgport:1}")
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Nodes(1)), "echo -n {pgport:1}")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -134,7 +134,7 @@ echo '%s' | git apply --ignore-whitespace -`, fmt.Sprintf(npgsqlPatch, result.St
 		t.Status("running npgsql test suite")
 		// Running the test suite is expected to error out, so swallow the error.
 		result, err = c.RunWithDetailsSingleNode(
-			ctx, t.L(), node,
+			ctx, t.L(), option.WithNodes(node),
 			`cd /mnt/data1/npgsql && dotnet test test/Npgsql.Tests --logger trx`,
 		)
 

--- a/pkg/cmd/roachtest/tests/process_lock.go
+++ b/pkg/cmd/roachtest/tests/process_lock.go
@@ -84,7 +84,7 @@ func registerProcessLock(r registry.Registry) {
 					// grepping for `./cockroach start` in ps's output, and
 					// grabbing the first field after stripping leading
 					// whitespace. Then, use this pid cat /proc/<pid>/cmdline.
-					result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(n),
+					result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(n)),
 						"cat /proc/`ps -eo pid,args | grep -E '([0-9]+) ./cockroach start' |  sed 's/^ *//' | cut -d ' ' -f 1`/cmdline")
 					if err != nil {
 						return err

--- a/pkg/cmd/roachtest/tests/psycopg.go
+++ b/pkg/cmd/roachtest/tests/psycopg.go
@@ -108,7 +108,7 @@ func registerPsycopg(r registry.Registry) {
 
 		t.Status("running psycopg test suite")
 
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node,
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node),
 			`cd /mnt/data1/psycopg/ &&
 			export PSYCOPG2_TESTDB=defaultdb &&
 			export PSYCOPG2_TESTDB_USER=root &&

--- a/pkg/cmd/roachtest/tests/quit.go
+++ b/pkg/cmd/roachtest/tests/quit.go
@@ -257,7 +257,7 @@ func (q *quitTest) checkNoLeases(ctx context.Context, nodeID int) {
 			if err != nil {
 				q.Fatal(err)
 			}
-			result, err := q.c.RunWithDetailsSingleNode(ctx, q.t.L(), q.c.Node(i),
+			result, err := q.c.RunWithDetailsSingleNode(ctx, q.t.L(), option.WithNodes(q.c.Node(i)),
 				"curl", "-s", fmt.Sprintf("http://%s/_status/ranges/local",
 					adminAddrs[0]))
 			if err != nil {
@@ -389,7 +389,7 @@ func registerQuitTransfersLeases(r registry.Registry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(nodeID),
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(nodeID)),
 			"./cockroach", "node", "drain", "--insecure", "--logtostderr=INFO",
 			fmt.Sprintf("--url=%s", pgurl),
 		)
@@ -436,7 +436,7 @@ func registerQuitTransfersLeases(r registry.Registry) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(otherNodeID),
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(otherNodeID)),
 			"./cockroach", "node", "drain", "--insecure", "--logtostderr=INFO",
 			fmt.Sprintf("--url=%s", pgurl),
 			fmt.Sprintf("%d", nodeID),

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -158,7 +158,7 @@ func registerRubyPG(r registry.Registry) {
 		t.Status("running ruby-pg test suite")
 		// Note that this is expected to return an error, since the test suite
 		// will fail. And it is safe to swallow it here.
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node,
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node),
 			`cd /mnt/data1/ruby-pg/ && bundle exec rake compile test`,
 		)
 

--- a/pkg/cmd/roachtest/tests/rust_postgres.go
+++ b/pkg/cmd/roachtest/tests/rust_postgres.go
@@ -130,7 +130,7 @@ func registerRustPostgres(r registry.Registry) {
 		result, err := c.RunWithDetailsSingleNode(
 			ctx,
 			t.L(),
-			node,
+			option.WithNodes(node),
 			`cd /mnt/data1/rust-postgres && /home/ubuntu/.cargo/bin/cargo test 2>&1 > rustpostgres.stdout --no-fail-fast`)
 		if err != nil {
 			t.L().Printf("error during rust postgres run (may be ok): %v\n", err)
@@ -138,7 +138,7 @@ func registerRustPostgres(r registry.Registry) {
 
 		t.L().Printf("Test stdout for rust-postgres")
 		result, err = c.RunWithDetailsSingleNode(
-			ctx, t.L(), node, "cd /mnt/data1/rust-postgres && cat rustpostgres.stdout",
+			ctx, t.L(), option.WithNodes(node), "cd /mnt/data1/rust-postgres && cat rustpostgres.stdout",
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -104,7 +104,7 @@ func runSchemaChangeRandomLoad(
 	}
 	c.Run(ctx, option.WithNodes(loadNode), fmt.Sprintf("./workload init schemachange '%s'", pgurl))
 
-	result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(1), "echo", "-n", "{store-dir}")
+	result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(1)), "echo", "-n", "{store-dir}")
 	if err != nil {
 		t.L().Printf("Failed to retrieve store directory from node 1: %v\n", err.Error())
 	}

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -153,7 +153,7 @@ echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.co
 
 		// Version telemetry is already disabled in the sequelize-cockroachdb test suite.
 		t.Status("running Sequelize test suite")
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node,
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node),
 			fmt.Sprintf(`cd /mnt/data1/sequelize/ && npm test --crdb_version=%s`, version),
 		)
 		rawResultsStr := result.Stdout + result.Stderr

--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -144,7 +144,7 @@ func runSQLAlchemy(ctx context.Context, t test.Test, c cluster.Cluster) {
 	t.Status("running sqlalchemy test suite")
 	// Note that this is expected to return an error, since the test suite
 	// will fail. And it is safe to swallow it here.
-	result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node,
+	result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node),
 		`source venv/bin/activate && cd /mnt/data1/sqlalchemy-cockroachdb/ && pytest --maxfail=0 \
 		--dburi='cockroachdb://root@localhost:{pgport:1}/defaultdb?sslmode=disable&disable_cockroachdb_telemetry=true' \
 		test/test_suite_sqlalchemy.py

--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -129,7 +129,7 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 
 		t.Status("running workload")
 		cmd := opts.cmd(true /* haproxy */) + " run"
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), loadNode, cmd)
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(loadNode), cmd)
 
 		// Sysbench occasionally segfaults. When that happens, don't fail the
 		// test.

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -1326,7 +1326,7 @@ func loadTPCCBench(
 	cmd = fmt.Sprintf("./cockroach workload run tpcc --warehouses=%d --workers=%d --max-rate=%d "+
 		"--wait=false --ramp=%s --duration=%s --scatter --tolerate-errors {pgurl%s%s}",
 		b.LoadWarehouses(c.Cloud()), b.LoadWarehouses(c.Cloud()), maxRate, rampTime, loadTime, roachNodes, tenantSuffix)
-	if _, err := c.RunWithDetailsSingleNode(ctx, t.L(), loadNode, cmd); err != nil {
+	if _, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(loadNode), cmd); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -97,7 +97,7 @@ func (ts *tpceSpec) run(
 	ctx context.Context, t test.Test, c cluster.Cluster, o tpceCmdOptions,
 ) (install.RunResultDetails, error) {
 	cmd := fmt.Sprintf("%s %s", ts.newCmd(o), strings.Join(ts.roachNodeIPFlags, " "))
-	return c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(ts.loadNode), cmd)
+	return c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(ts.loadNode)), cmd)
 }
 
 type tpceOptions struct {

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -278,7 +278,7 @@ func (p *tpchVecPerfTest) postTestRunHook(
 			for setupIdx, setup := range runConfig.clusterSetups {
 				performClusterSetup(t, conn, setup)
 				result, err := c.RunWithDetailsSingleNode(
-					ctx, t.L(), c.Node(1),
+					ctx, t.L(), option.WithNodes(c.Node(1)),
 					getTPCHVecWorkloadCmd(runConfig.numRunsPerQuery, queryNum, p.sharedProcess),
 				)
 				workloadOutput := result.Stdout + result.Stderr
@@ -515,7 +515,7 @@ func baseTestRun(
 		for setupIdx, setup := range runConfig.clusterSetups {
 			tc.preQueryRunHook(t, conn, setup)
 			result, err := c.RunWithDetailsSingleNode(
-				ctx, t.L(), c.Node(1),
+				ctx, t.L(), option.WithNodes(c.Node(1)),
 				getTPCHVecWorkloadCmd(runConfig.numRunsPerQuery, queryNum, tc.sharedProcessMT()),
 			)
 			workloadOutput := result.Stdout + result.Stderr

--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -177,7 +177,7 @@ echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.co
 		}
 
 		t.Status("running TypeORM test suite - approx 12 mins")
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node,
+		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(node),
 			`cd /mnt/data1/typeorm/ && npm test`,
 		)
 		rawResults := result.Stdout + result.Stderr


### PR DESCRIPTION
This change updates the `RunWithDetails` and `RunWithDetailsSingleNode` cluster interface methods to take `install.RunOptions` as a parameter instead of `option.NodeListOption` to expose the additional available options to `roachtest`.

Epic: None
Release Note: None