### PR TITLE
kvserver: don't report failure on in-flight initial snapshot

### DIFF
--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -129,19 +129,6 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 				repDesc,
 			)
 			log.VEventf(ctx, 2, "%v", err)
-			// TODO(dan): This is super brittle and non-obvious. In the common case,
-			// this check avoids duplicate work, but in rare cases, we send the
-			// learner snap at an index before the one raft wanted here. The raft
-			// leader should be able to use logs to get the rest of the way, but it
-			// doesn't try. In this case, skipping the raft snapshot would mean that
-			// we have to wait for the next scanner cycle of the raft snapshot queue
-			// to pick it up again. So, punt the responsibility back to raft by
-			// telling it that the snapshot failed. If the learner snap ends up being
-			// sufficient, this message will be ignored, but if we hit the case
-			// described above, this will cause raft to keep asking for a snap and at
-			// some point the snapshot lock above will be released and we'll fall
-			// through to the logic below.
-			repl.reportSnapshotStatus(ctx, repDesc.ReplicaID, err)
 			return false, nil
 		}
 	}


### PR DESCRIPTION
With https://github.com/etcd-io/raft/commit/d87942f5, Raft will no longer reject initial snapshots below its `PendingSnapshot` index. This commit removes a TODO for this scenario.

Epic: none
Release note: None