### PR TITLE
roachtest/cdc: rename cdc/tpcc-1000 to cdc/tpcc-1000/sink=kafka

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1087,7 +1087,7 @@ func registerCDC(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:             "cdc/tpcc-1000",
+		Name:             "cdc/tpcc-1000/sink=kafka",
 		Owner:            registry.OwnerCDC,
 		Benchmark:        true,
 		Cluster:          r.MakeClusterSpec(4, spec.CPU(16)),


### PR DESCRIPTION
This patch renames cdc/tpcc-1000 to cdc/tpcc-1000/sink=kafka to distinguish it from cdc/tpcc-1000/sink=null.

Epic: None
Release Note: None