### PR TITLE
roachtest: unskip follower-reads/mixed-version/survival=region/locality=global/reads=strong

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -113,7 +113,6 @@ func registerFollowerReads(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:            "follower-reads/mixed-version/survival=region/locality=global/reads=strong",
-		Skip:            "#117302",
 		Owner:           registry.OwnerKV,
 		RequiresLicense: true,
 		Cluster: r.MakeClusterSpec(


### PR DESCRIPTION
Informs #117302.

Now that #117302 is fixed on master, we can unskip this test.

Release note: None