### PR TITLE
kvclient: remove deprecated NLHE field

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2552,7 +2552,7 @@ func (ds *DistSender) sendToReplicas(
 				ds.metrics.NotLeaseHolderErrCount.Inc(1)
 				// If we got some lease information, we use it. If not, we loop around
 				// and try the next replica.
-				if tErr.Lease != nil || tErr.DeprecatedLeaseHolder != nil {
+				if tErr.Lease != nil {
 					// Update the leaseholder in the range cache. Naively this would also
 					// happen when the next RPC comes back, but we don't want to wait out
 					// the additional RPC latency.
@@ -2560,10 +2560,6 @@ func (ds *DistSender) sendToReplicas(
 					var updatedLeaseholder bool
 					if tErr.Lease != nil {
 						updatedLeaseholder = routing.SyncTokenAndMaybeUpdateCache(ctx, tErr.Lease, &tErr.RangeDesc)
-					} else if tErr.DeprecatedLeaseHolder != nil {
-						updatedLeaseholder = routing.SyncTokenAndMaybeUpdateCacheWithSpeculativeLease(
-							ctx, *tErr.DeprecatedLeaseHolder, &tErr.RangeDesc,
-						)
 					}
 					// Move the new leaseholder to the head of the queue for the next
 					// retry. Note that the leaseholder might not be the one indicated by

--- a/pkg/kv/kvclient/rangecache/range_cache_test.go
+++ b/pkg/kv/kvclient/rangecache/range_cache_test.go
@@ -1932,8 +1932,8 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCacheWithSpeculativeLease(
-					ctx, rep2, &desc2,
+				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCache(
+					ctx, &roachpb.Lease{Replica: rep2}, &desc2,
 				)
 				require.True(t, updatedLeaseholder)
 				require.Equal(t, &desc2, tok.Desc())

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -488,8 +488,6 @@ func (e *NotLeaseHolderError) printError(s Printer) {
 	}
 	if e.Lease != nil {
 		s.Printf("current lease is %s", e.Lease)
-	} else if e.DeprecatedLeaseHolder != nil {
-		s.Printf("replica %s is", *e.DeprecatedLeaseHolder)
 	} else {
 		s.Printf("lease holder unknown")
 	}
@@ -1634,10 +1632,6 @@ func NewNotLeaseHolderError(
 		if stillMember {
 			err.Lease = new(roachpb.Lease)
 			*err.Lease = l
-			// TODO(arul): We only need to return this for the 22.1 <-> 22.2 mixed
-			// version state, as v22.1 use this field to log NLHE messages. We can
-			// get rid of this, and the field, in v23.1.
-			err.DeprecatedLeaseHolder = &err.Lease.Replica
 		}
 	}
 	return err

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -45,15 +45,6 @@ message NotLeaseHolderError {
   // The replica the error originated from. Used in the error's string
   // representation, if known.
   optional roachpb.ReplicaDescriptor replica = 1 [(gogoproto.nullable) = false];
-  // The lease holder, if known.
-  //
-  // This field was only ever meaningful if the full lease was not known, but
-  // when constructing this error there was a guess about who the leaseholder
-  // may be. The same idea applied to speculative leases (which have unset
-  // sequence numbers). In a bid to unify these two cases, from v22.2, we stop
-  // making use of this field.
-  // TODO(arul): remove this field in 23.1.
-  optional roachpb.ReplicaDescriptor deprecated_lease_holder = 2;
   // The current lease, if known.
   //
   // It's possible for leases returned here to represent speculative leases, not
@@ -73,6 +64,8 @@ message NotLeaseHolderError {
   // because the lease under which its application was attempted is different
   // than the lease under which it had been proposed.
   optional string custom_msg = 5 [(gogoproto.nullable) = false];
+
+  reserved 2;
 }
 
 // A NodeUnavailableError indicates that the sending gateway can

--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -384,13 +384,6 @@ func TestNotLeaseholderError(t *testing.T) {
 		err *NotLeaseHolderError
 	}{
 		{
-			exp: `[NotLeaseHolderError] r1: replica not lease holder; replica (n1,s1):1 is`,
-			err: &NotLeaseHolderError{
-				RangeID:               1,
-				DeprecatedLeaseHolder: rd,
-			},
-		},
-		{
 			exp: `[NotLeaseHolderError] r1: replica not lease holder; current lease is repl=(n1,s1):1 seq=2 start=0.000000001,0 epo=1`,
 			err: &NotLeaseHolderError{
 				RangeID: 1,


### PR DESCRIPTION
The speculative leases field on the NLHE was introduced for compabitility between 22.1 and 22.2. It is no longer needed and removing the field cleans up some exisiting code.

Epic: none

Release note: None