### PR TITLE
release-23.1.14-rc: sql: fix an exported gist out of bounds error

### DIFF
--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -258,7 +258,9 @@ func groupByColumns(
 	columns := make(colinfo.ResultColumns, 0, len(groupCols)+len(aggregations))
 	if inputCols != nil {
 		for _, col := range groupCols {
-			columns = append(columns, inputCols[col])
+			if len(inputCols) > int(col) {
+				columns = append(columns, inputCols[col])
+			}
 		}
 	}
 	for _, agg := range aggregations {

--- a/pkg/sql/opt/exec/explain/testdata/gists
+++ b/pkg/sql/opt/exec/explain/testdata/gists
@@ -1122,3 +1122,33 @@ explain(shape):
   syntax: "select 123"
 explain(gist):
 • show completions
+
+# Regression for #111346
+explain-plan-gist
+AgFWBgCPAQIAABNWCgsGBwwHHA0UAXoCBgEFUCJ6AQ==
+----
+• upsert
+│ into: ?()
+│ auto commit
+│
+└── • lookup join (left outer)
+    │ table: ?@?
+    │ equality: (_, _, _) = (?,?,?)
+    │ equality cols are key
+    │
+    └── • distinct
+        │ distinct on
+        │
+        └── • render
+            │
+            └── • render
+                │
+                └── • group (hash)
+                    │ group by: _, _, _
+                    │
+                    └── • index join
+                        │ table: ?@?
+                        │
+                        └── • scan
+                              table: ?@?
+                              spans: 1 span


### PR DESCRIPTION
Backport 1/1 commits from #111347.

/cc @cockroachdb/release

---

Fixes: #111346
Release note: None
Epic: None

---

Release justification: low risk bug fix for a panic