### PR TITLE
roachtest: update cdc/filtering tests to work with duplicate events

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -290,6 +290,7 @@ go_library(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_x_exp//slices",
         "@org_golang_x_oauth2//clientcredentials",
         "@org_golang_x_sync//errgroup",
     ],


### PR DESCRIPTION
This patch updates the `cdc/filtering` tests to not fail when
duplicate events are emitted by the changefeed.

Fixes #117590

Release note: None