### PR TITLE
roachprod: set DisableRetries in WithRetryDisabled

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2836,6 +2836,10 @@ func (c *SyncedCluster) ParallelE(
 	if config.MaxConcurrency > 0 && options.Concurrency > config.MaxConcurrency {
 		options.Concurrency = config.MaxConcurrency
 	}
+	retryOptions := options.RetryOptions
+	if options.DisableRetries {
+		retryOptions = nil
+	}
 
 	completed := make(chan ParallelResult, count)
 	errorChannel := make(chan error)
@@ -2856,7 +2860,7 @@ func (c *SyncedCluster) ParallelE(
 			// This is rarely expected to return an error, but we fail fast in case.
 			// Command errors, which are far more common, will be contained within the result.
 			res, err := runWithMaybeRetry(
-				groupCtx, l, options.RetryOptions, options.ShouldRetryFn,
+				groupCtx, l, retryOptions, options.ShouldRetryFn,
 				func(ctx context.Context) (*RunResultDetails, error) { return fn(ctx, options.Nodes[i]) },
 			)
 			if err != nil {

--- a/pkg/roachprod/install/run_options.go
+++ b/pkg/roachprod/install/run_options.go
@@ -13,8 +13,11 @@ package install
 import "github.com/cockroachdb/cockroach/pkg/util/retry"
 
 type RunOptions struct {
-	// RetryOptions are the retry options
+	// RetryOptions are the retry options. The default roachprod retry
+	// options (DefaultRetryOpt) will be used, if left nil.
 	RetryOptions *retry.Options
+	// DisableRetries will disable retries. The default behaviour is to retry.
+	DisableRetries bool
 	// ShouldRetryFn is only applicable when RetryOptions is not nil
 	// and specifies a function to be called in the case that a retry
 	// is about to be performed. A user can provide a function which, for
@@ -59,7 +62,7 @@ func (r RunOptions) WithRetryOpts(retryOpts retry.Options) RunOptions {
 }
 
 func (r RunOptions) WithRetryDisabled() RunOptions {
-	r.RetryOptions = nil
+	r.DisableRetries = true
 	return r
 }
 


### PR DESCRIPTION
Previously, `WithRetryDisabled` operated on setting the RetryOptions on RunOptions to nil. This was however a part of how the functional options worked before a refactor (see #112411) and no longer works with a default struct. This change updates the RunOptions to explicitly set retries to disabled via WithRetriesDisabled.

See: #112411
Fixes: #117635

Epic: None
Release Note: None