### PR TITLE
release-23.1: changfeedccl: Fix schema feed test flake

### DIFF
--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -522,26 +522,16 @@ func (tf *schemaFeed) highWater() hlc.Timestamp {
 // `validateFn` is deterministic and the ingested descriptors are read
 // transactionally).
 func (tf *schemaFeed) waitForTS(ctx context.Context, ts hlc.Timestamp) error {
-	var errCh chan error
+	waitCh, feedErr := tf.tryWaitForTS(ts)
+	if feedErr != nil {
+		return feedErr
+	}
 
-	tf.mu.Lock()
-	highWater := tf.mu.highWater
-	var err error
-	if !tf.mu.errTS.IsEmpty() && tf.mu.errTS.LessEq(ts) {
-		err = tf.mu.err
-	}
-	fastPath := err != nil || ts.LessEq(highWater)
-	if !fastPath {
-		// non-fastPath is when we need to prove the invariant holds from [`high_water`, `ts].
-		errCh = make(chan error, 1)
-		tf.mu.waiters = append(tf.mu.waiters, tableHistoryWaiter{ts: ts, errCh: errCh})
-	}
-	tf.mu.Unlock()
-	if fastPath {
+	if waitCh == nil {
 		if log.V(1) {
-			log.Infof(ctx, "fastpath for %s: %v", ts, err)
+			log.Infof(ctx, "fastpath for %s", ts)
 		}
-		return err
+		return nil
 	}
 
 	if log.V(1) {
@@ -551,7 +541,7 @@ func (tf *schemaFeed) waitForTS(ctx context.Context, ts hlc.Timestamp) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case err := <-errCh:
+	case err := <-waitCh:
 		if log.V(1) {
 			log.Infof(ctx, "waited %s for %s highwater: err=%v", timeutil.Since(start), ts, err)
 		}
@@ -560,6 +550,27 @@ func (tf *schemaFeed) waitForTS(ctx context.Context, ts hlc.Timestamp) error {
 		}
 		return err
 	}
+}
+
+// tryWaitForTS is a fast path for waitForTS.  Returns non-nil channel
+// if the fast path not available.
+func (tf *schemaFeed) tryWaitForTS(ts hlc.Timestamp) (chan error, error) {
+	tf.mu.Lock()
+	defer tf.mu.Unlock()
+
+	if !tf.mu.errTS.IsEmpty() && tf.mu.errTS.LessEq(ts) {
+		// Schema feed error occurred.
+		return nil, tf.mu.err
+	}
+
+	if ts.LessEq(tf.mu.highWater) {
+		return nil, nil // Fast path.
+	}
+
+	// non-fastPath is when we need to prove the invariant holds from [`high_water`, `ts].
+	waitCh := make(chan error, 1)
+	tf.mu.waiters = append(tf.mu.waiters, tableHistoryWaiter{ts: ts, errCh: waitCh})
+	return waitCh, nil
 }
 
 // descLess orders descriptors by (modificationTime, id).


### PR DESCRIPTION
Backport 1/1 commits from #116101.

/cc @cockroachdb/release

---

Fixes #116011

Release notes: None

---

Release justification: Correctness fix
