### PR TITLE
release-23.1: storage: fix a series of intent resolution bugs with ignored seq nums

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -4244,30 +4244,30 @@ func MVCCResolveWriteIntent(
 	ctx context.Context,
 	rw ReadWriter,
 	ms *enginepb.MVCCStats,
-	intent roachpb.LockUpdate,
+	update roachpb.LockUpdate,
 	opts MVCCResolveWriteIntentOptions,
 ) (ok bool, numBytes int64, resumeSpan *roachpb.Span, err error) {
-	if len(intent.Key) == 0 {
+	if len(update.Key) == 0 {
 		return false, 0, nil, emptyKeyError()
 	}
-	if len(intent.EndKey) > 0 {
+	if len(update.EndKey) > 0 {
 		return false, 0, nil, errors.Errorf("can't resolve range intent as point intent")
 	}
 	if opts.TargetBytes < 0 {
-		return false, 0, &roachpb.Span{Key: intent.Key}, nil
+		return false, 0, &roachpb.Span{Key: update.Key}, nil
 	}
 
 	iterAndBuf := GetBufUsingIter(rw.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
 		KeyTypes: IterKeyTypePointsAndRanges,
 		Prefix:   true,
 	}))
-	iterAndBuf.iter.SeekIntentGE(intent.Key, intent.Txn.ID)
+	iterAndBuf.iter.SeekIntentGE(update.Key, update.Txn.ID)
 	// Production code will use a buffered writer, which makes the numBytes
 	// calculation accurate. Note that an inaccurate numBytes (e.g. 0 in the
 	// case of an unbuffered writer) does not affect any safety properties of
 	// the database.
 	beforeBytes := rw.BufferedSize()
-	ok, err = mvccResolveWriteIntent(ctx, rw, iterAndBuf.iter, ms, intent, iterAndBuf.buf)
+	ok, err = mvccResolveWriteIntent(ctx, rw, iterAndBuf.iter, ms, update, iterAndBuf.buf)
 	numBytes = int64(rw.BufferedSize() - beforeBytes)
 	// Using defer would be more convenient, but it is measurably slower.
 	iterAndBuf.Cleanup()
@@ -4552,7 +4552,7 @@ func (h singleDelOptimizationHelper) onAbortIntent() bool {
 }
 
 // mvccResolveWriteIntent is the core logic for resolving an intent.
-// REQUIRES: iter is already seeked to intent.Key.
+// REQUIRES: iter is already seeked to update.Key.
 // REQUIRES: iter surfaces range keys via IterKeyTypePointsAndRanges.
 // Returns whether an intent was found and resolved, false otherwise.
 func mvccResolveWriteIntent(
@@ -4560,52 +4560,52 @@ func mvccResolveWriteIntent(
 	rw ReadWriter,
 	iter iterForKeyVersions,
 	ms *enginepb.MVCCStats,
-	intent roachpb.LockUpdate,
+	update roachpb.LockUpdate,
 	buf *putBuffer,
 ) (bool, error) {
-	metaKey := MakeMVCCMetadataKey(intent.Key)
+	metaKey := MakeMVCCMetadataKey(update.Key)
 	meta := &buf.meta
 	ok, origMetaKeySize, origMetaValSize, err :=
 		mvccGetIntent(iter, metaKey, meta)
 	if err != nil {
 		return false, err
 	}
-	if !ok || meta.Txn == nil || intent.Txn.ID != meta.Txn.ID {
+	if !ok || meta.Txn == nil || update.Txn.ID != meta.Txn.ID {
 		return false, nil
 	}
 	metaTimestamp := meta.Timestamp.ToTimestamp()
 	canSingleDelHelper := singleDelOptimizationHelper{
 		_didNotUpdateMeta: meta.TxnDidNotUpdateMeta,
-		_hasIgnoredSeqs:   len(intent.IgnoredSeqNums) > 0,
+		_hasIgnoredSeqs:   len(update.IgnoredSeqNums) > 0,
 		// NB: the value is only used if epochs match, so it doesn't
 		// matter if we use the one from meta or incoming request here.
-		_epoch: intent.Txn.Epoch,
+		_epoch: update.Txn.Epoch,
 	}
 
-	// A commit with a newer epoch than the intent effectively means that we
+	// An update with a newer epoch than the intent effectively means that we
 	// wrote this intent before an earlier retry, but didn't write it again
 	// after. We treat such intents as uncommitted.
 	//
-	// A commit with a newer timestamp than the intent means that our timestamp
+	// An update with a newer timestamp than the intent means that our timestamp
 	// was pushed during the course of an epoch. We treat such intents as
 	// committed after moving their timestamp forward. This is possible if a
 	// transaction writes an intent and then successfully refreshes its
 	// timestamp to avoid a restart.
 	//
-	// A commit with an older epoch than the intent should never happen because
+	// An update with an older epoch than the intent should never happen because
 	// epoch increments require client action. This means that they can't be
 	// caused by replays.
 	//
-	// A commit with an older timestamp than the intent should not happen under
+	// An update with an older timestamp than the intent should not happen under
 	// normal circumstances because a client should never bump its timestamp
 	// after issuing an EndTxn request. Replays of intent writes that are pushed
 	// forward due to WriteTooOld errors without client action combined with
 	// replays of intent resolution make this configuration a possibility. We
 	// treat such intents as uncommitted.
-	epochsMatch := meta.Txn.Epoch == intent.Txn.Epoch
-	timestampsValid := metaTimestamp.LessEq(intent.Txn.WriteTimestamp)
-	timestampChanged := metaTimestamp.Less(intent.Txn.WriteTimestamp)
-	commit := intent.Status == roachpb.COMMITTED && epochsMatch && timestampsValid
+	epochsMatch := meta.Txn.Epoch == update.Txn.Epoch
+	timestampsValid := metaTimestamp.LessEq(update.Txn.WriteTimestamp)
+	timestampChanged := metaTimestamp.Less(update.Txn.WriteTimestamp)
+	commit := update.Status == roachpb.COMMITTED && epochsMatch && timestampsValid
 
 	// Note the small difference to commit epoch handling here: We allow
 	// a push from a previous epoch to move a newer intent. That's not
@@ -4632,9 +4632,9 @@ func mvccResolveWriteIntent(
 	// used for resolving), but that costs latency.
 	// TODO(tschottdorf): various epoch-related scenarios here deserve more
 	// testing.
-	inProgress := !intent.Status.IsFinalized() && meta.Txn.Epoch >= intent.Txn.Epoch
+	inProgress := !update.Status.IsFinalized() && meta.Txn.Epoch >= update.Txn.Epoch
 	pushed := inProgress && timestampChanged
-	latestKey := MVCCKey{Key: intent.Key, Timestamp: metaTimestamp}
+	latestKey := MVCCKey{Key: update.Key, Timestamp: metaTimestamp}
 
 	// Handle partial txn rollbacks. If the current txn sequence
 	// is part of a rolled back (ignored) seqnum range, we're going
@@ -4646,7 +4646,7 @@ func mvccResolveWriteIntent(
 	var rolledBackVal *MVCCValue
 	buf.newMeta = *meta
 	newMeta := &buf.newMeta
-	if len(intent.IgnoredSeqNums) > 0 {
+	if len(update.IgnoredSeqNums) > 0 {
 		// NOTE: mvccMaybeRewriteIntentHistory mutates its meta argument.
 		// TODO(nvanbenschoten): this is an awkward interface. We shouldn't
 		// be mutating meta and we shouldn't be restoring the previous value
@@ -4657,7 +4657,7 @@ func mvccResolveWriteIntent(
 		// intact and corresponding to the stats in ms to ensure that later on (in
 		// updateStatsOnResolve) the stats will be updated correctly based on the
 		// old meta (meta) and the new meta (newMeta).
-		removeIntent, rolledBackVal, err = mvccMaybeRewriteIntentHistory(ctx, rw, intent.IgnoredSeqNums, newMeta, latestKey)
+		removeIntent, rolledBackVal, err = mvccMaybeRewriteIntentHistory(ctx, rw, update.IgnoredSeqNums, newMeta, latestKey)
 		if err != nil {
 			return false, err
 		}
@@ -4677,7 +4677,7 @@ func mvccResolveWriteIntent(
 			// If we need to update the intent to roll back part of its intent
 			// history, make sure that we don't regress its timestamp, even if the
 			// caller provided an outdated timestamp.
-			intent.Txn.WriteTimestamp.Forward(metaTimestamp)
+			update.Txn.WriteTimestamp.Forward(metaTimestamp)
 		}
 	}
 
@@ -4701,7 +4701,7 @@ func mvccResolveWriteIntent(
 	if commit || pushed || rolledBackVal != nil {
 		// The intent might be committing at a higher timestamp, or it might be
 		// getting pushed.
-		newTimestamp := intent.Txn.WriteTimestamp
+		newTimestamp := update.Txn.WriteTimestamp
 
 		// Assert that the intent timestamp never regresses. The logic above should
 		// not allow this, regardless of the input to this function.
@@ -4761,7 +4761,7 @@ func mvccResolveWriteIntent(
 			// to the observed timestamp.
 			newValue := oldValue
 			newValue.LocalTimestamp = oldValue.GetLocalTimestamp(oldKey.Timestamp)
-			newValue.LocalTimestamp.Forward(intent.ClockWhilePending.Timestamp)
+			newValue.LocalTimestamp.Forward(update.ClockWhilePending.Timestamp)
 			if !newValue.LocalTimestampNeeded(newKey.Timestamp) || !rw.ShouldWriteLocalTimestamps(ctx) {
 				newValue.LocalTimestamp = hlc.ClockTimestamp{}
 			}
@@ -4828,7 +4828,7 @@ func mvccResolveWriteIntent(
 
 		// Update stat counters related to resolving the intent.
 		if ms != nil {
-			ms.Add(updateStatsOnResolve(intent.Key, prevIsValue, prevValSize, origMetaKeySize, origMetaValSize,
+			ms.Add(updateStatsOnResolve(update.Key, prevIsValue, prevValSize, origMetaKeySize, origMetaValSize,
 				metaKeySize, metaValSize, meta, newMeta, commit))
 		}
 
@@ -4838,9 +4838,9 @@ func mvccResolveWriteIntent(
 			logicalOp = MVCCUpdateIntentOpType
 		}
 		rw.LogLogicalOp(logicalOp, MVCCLogicalOpDetails{
-			Txn:       intent.Txn,
-			Key:       intent.Key,
-			Timestamp: intent.Txn.WriteTimestamp,
+			Txn:       update.Txn,
+			Key:       update.Key,
+			Timestamp: update.Txn.WriteTimestamp,
 		})
 
 		return true, nil
@@ -4850,7 +4850,7 @@ func mvccResolveWriteIntent(
 	// MVCCMetadata.
 	//
 	// Note that we have to support a somewhat unintuitive case - an ABORT with
-	// intent.Txn.Epoch < meta.Txn.Epoch:
+	// update.Txn.Epoch < meta.Txn.Epoch:
 	// - writer1 writes key0 at epoch 0
 	// - writer2 with higher priority encounters intent at key0 (epoch 0)
 	// - writer1 restarts, now at epoch one (txn record not updated)
@@ -4865,8 +4865,8 @@ func mvccResolveWriteIntent(
 
 	// Log the logical MVCC operation.
 	rw.LogLogicalOp(MVCCAbortIntentOpType, MVCCLogicalOpDetails{
-		Txn: intent.Txn,
-		Key: intent.Key,
+		Txn: update.Txn,
+		Key: update.Key,
 	})
 
 	ok = false
@@ -4931,7 +4931,7 @@ func mvccResolveWriteIntent(
 		// Clear stat counters attributable to the intent we're aborting.
 		if ms != nil {
 			ms.Add(updateStatsOnClear(
-				intent.Key, origMetaKeySize, origMetaValSize, 0, 0, meta, nil, 0))
+				update.Key, origMetaKeySize, origMetaValSize, 0, 0, meta, nil, 0))
 		}
 		return true, nil
 	}
@@ -4950,7 +4950,7 @@ func mvccResolveWriteIntent(
 
 	// Update stat counters with older version.
 	if ms != nil {
-		ms.Add(updateStatsOnClear(intent.Key, origMetaKeySize, origMetaValSize, metaKeySize,
+		ms.Add(updateStatsOnClear(update.Key, origMetaKeySize, origMetaValSize, metaKeySize,
 			metaValSize, meta, &buf.newMeta, unsafeNextKey.Timestamp.WallTime))
 	}
 
@@ -5052,13 +5052,13 @@ func MVCCResolveWriteIntentRange(
 	ctx context.Context,
 	rw ReadWriter,
 	ms *enginepb.MVCCStats,
-	intent roachpb.LockUpdate,
+	update roachpb.LockUpdate,
 	opts MVCCResolveWriteIntentRangeOptions,
 ) (numKeys, numBytes int64, resumeSpan *roachpb.Span, resumeReason kvpb.ResumeReason, err error) {
 	keysExceeded := opts.MaxKeys < 0
 	bytesExceeded := opts.TargetBytes < 0
 	if keysExceeded || bytesExceeded {
-		resumeSpan := intent.Span // don't inline or `intent` would escape to heap
+		resumeSpan := update.Span // don't inline or `update` would escape to heap
 		if keysExceeded {
 			resumeReason = kvpb.RESUME_KEY_LIMIT
 		} else if bytesExceeded {
@@ -5066,14 +5066,14 @@ func MVCCResolveWriteIntentRange(
 		}
 		return 0, 0, &resumeSpan, resumeReason, nil
 	}
-	ltStart, _ := keys.LockTableSingleKey(intent.Key, nil)
-	ltEnd, _ := keys.LockTableSingleKey(intent.EndKey, nil)
+	ltStart, _ := keys.LockTableSingleKey(update.Key, nil)
+	ltEnd, _ := keys.LockTableSingleKey(update.EndKey, nil)
 	engineIter := rw.NewEngineIterator(IterOptions{LowerBound: ltStart, UpperBound: ltEnd})
 	var mvccIter MVCCIterator
 	iterOpts := IterOptions{
 		KeyTypes:   IterKeyTypePointsAndRanges,
-		LowerBound: intent.Key,
-		UpperBound: intent.EndKey,
+		LowerBound: update.Key,
+		UpperBound: update.EndKey,
 	}
 	if rw.ConsistentIterators() {
 		// Production code should always have consistent iterators.
@@ -5096,8 +5096,8 @@ func MVCCResolveWriteIntentRange(
 	// only step the iterator and not seek.
 	sepIter.seekEngineKeyGE(EngineKey{Key: ltStart})
 
-	intentEndKey := intent.EndKey
-	intent.EndKey = nil
+	intentEndKey := update.EndKey
+	update.EndKey = nil
 
 	var lastResolvedKey roachpb.Key
 	for {
@@ -5126,7 +5126,7 @@ func MVCCResolveWriteIntentRange(
 		if meta.Txn == nil {
 			return 0, 0, nil, 0, errors.Errorf("intent with no txn")
 		}
-		if intent.Txn.ID != meta.Txn.ID {
+		if update.Txn.ID != meta.Txn.ID {
 			// Intent for a different txn, so ignore.
 			sepIter.nextEngineKey()
 			continue
@@ -5139,9 +5139,9 @@ func MVCCResolveWriteIntentRange(
 		// stability of the key passed to mvccResolveWriteIntent, and for the
 		// subsequent iteration to construct a resume span.
 		lastResolvedKey = append(lastResolvedKey[:0], sepIter.UnsafeKey().Key...)
-		intent.Key = lastResolvedKey
+		update.Key = lastResolvedKey
 		beforeBytes := rw.BufferedSize()
-		ok, err := mvccResolveWriteIntent(ctx, rw, sepIter, ms, intent, putBuf)
+		ok, err := mvccResolveWriteIntent(ctx, rw, sepIter, ms, update, putBuf)
 		if err != nil {
 			log.Warningf(ctx, "failed to resolve intent for key %q: %+v", lastResolvedKey, err)
 		} else if ok {

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -820,6 +820,11 @@ func cmdTxnRestart(e *evalCtx) error {
 	up := roachpb.NormalUserPriority
 	tp := enginepb.MinTxnPriority
 	txn.Restart(up, tp, ts)
+	if e.hasArg("epoch") {
+		var epoch int
+		e.scanArg("epoch", &epoch)
+		txn.Epoch = enginepb.TxnEpoch(epoch)
+	}
 	e.results.txn = txn
 	return nil
 }

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
@@ -639,8 +639,6 @@ clear_range k=k end=p
 # Try to update a pending intent with a lower epoch than the resolution.
 # The intent should be aborted because the new epoch may not write it again.
 
-# The test exposes a bug where the intent is updated instead of aborted.
-
 run ok
 with t=G k=p
   txn_begin    ts=50
@@ -668,8 +666,8 @@ with t=G k=p
 get: "p" -> <no data>
 >> at end:
 txn: "G" meta={id=00000000 key="p" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
-meta: "p"/0,0 -> txn={id=00000000 key="p" pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10} ts=50.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "p"/50.000000000,0 -> /BYTES/a
+<no data>
+
 
 run ok
 clear_range k=p end=-p
@@ -680,9 +678,6 @@ clear_range k=p end=-p
 # Try to update a pending intent with a higher epoch than the resolution's epoch.
 # The intent is not pushed, so it is not updated because the intent history
 # should be updated only when the epochs match.
-
-# The test exposes a bug where the intent is actually updated, as evident by the
-# changed intent history.
 
 run ok
 with t=H k=q
@@ -709,11 +704,11 @@ with t=H k=q
   resolve_intent status=PENDING
   check_intent
 ----
-meta: "q" -> txn={id=00000000 key="q" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=10} ts=50.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "q" -> txn={id=00000000 key="q" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 >> at end:
 txn: "H" meta={id=00000000 key="q" pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
-meta: "q"/0,0 -> txn={id=00000000 key="q" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=10} ts=50.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "q"/50.000000000,0 -> /BYTES/a
+meta: "q"/0,0 -> txn={id=00000000 key="q" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "q"/50.000000000,0 -> /BYTES/b
 
 run ok
 clear_range k=q end=-q
@@ -724,8 +719,6 @@ clear_range k=q end=-q
 # Update a pending intent with a higher epoch than the resolution's epoch.
 # The intent is pushed, so its timestamp is updated to help the pusher make progress.
 # The intent history is not updated because the epochs don't match.
-
-# The test exposes a bug where the intent history is actually updated.
 
 run ok
 with t=I k=r
@@ -753,8 +746,8 @@ with t=I k=r
   resolve_intent status=PENDING
   check_intent
 ----
-meta: "r" -> txn={id=00000000 key="r" pri=0.00000000 epo=1 ts=60.000000000,0 min=0,0 seq=10} ts=60.000000000,0 del=false klen=12 vlen=20 mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "r" -> txn={id=00000000 key="r" pri=0.00000000 epo=1 ts=60.000000000,0 min=0,0 seq=20} ts=60.000000000,0 del=false klen=12 vlen=20 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 >> at end:
 txn: "I" meta={id=00000000 key="r" pri=0.00000000 epo=0 ts=60.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
-meta: "r"/0,0 -> txn={id=00000000 key="r" pri=0.00000000 epo=1 ts=60.000000000,0 min=0,0 seq=10} ts=60.000000000,0 del=false klen=12 vlen=20 mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "r"/60.000000000,0 -> {localTs=50.000000000,0}/BYTES/a
+meta: "r"/0,0 -> txn={id=00000000 key="r" pri=0.00000000 epo=1 ts=60.000000000,0 min=0,0 seq=20} ts=60.000000000,0 del=false klen=12 vlen=20 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "r"/60.000000000,0 -> {localTs=50.000000000,0}/BYTES/b

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
@@ -629,3 +629,132 @@ data: "m"/30.000000000,0 -> /BYTES/a
 data: "n"/45.000000000,0 -> {localTs=40.000000000,0}/BYTES/c
 meta: "o"/0,0 -> txn={id=00000000 key="o" pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10} ts=50.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "o"/50.000000000,0 -> /BYTES/a
+
+run ok
+clear_range k=k end=p
+----
+>> at end:
+<no data>
+
+# Try to update a pending intent with a lower epoch than the resolution.
+# The intent should be aborted because the new epoch may not write it again.
+
+# The test exposes a bug where the intent is updated instead of aborted.
+
+run ok
+with t=G k=p
+  txn_begin    ts=50
+  txn_step     seq=10
+  put          v=a
+  txn_step     seq=20
+  put          v=b
+  check_intent
+  get
+----
+meta: "p" -> txn={id=00000000 key="p" pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
+get: "p" -> /BYTES/b @50.000000000,0
+>> at end:
+txn: "G" meta={id=00000000 key="p" pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
+meta: "p"/0,0 -> txn={id=00000000 key="p" pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "p"/50.000000000,0 -> /BYTES/b
+
+run ok
+with t=G k=p
+  txn_restart
+  txn_ignore_seqs seqs=(15-25)
+  resolve_intent status=PENDING
+  get
+----
+get: "p" -> <no data>
+>> at end:
+txn: "G" meta={id=00000000 key="p" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
+meta: "p"/0,0 -> txn={id=00000000 key="p" pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10} ts=50.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "p"/50.000000000,0 -> /BYTES/a
+
+run ok
+clear_range k=p end=-p
+----
+>> at end:
+<no data>
+
+# Try to update a pending intent with a higher epoch than the resolution's epoch.
+# The intent is not pushed, so it is not updated because the intent history
+# should be updated only when the epochs match.
+
+# The test exposes a bug where the intent is actually updated, as evident by the
+# changed intent history.
+
+run ok
+with t=H k=q
+  txn_begin    ts=50
+  txn_restart  epoch=1
+  txn_step     seq=10
+  put          v=a
+  txn_step     seq=20
+  put          v=b
+  check_intent
+  get
+----
+meta: "q" -> txn={id=00000000 key="q" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
+get: "q" -> /BYTES/b @50.000000000,0
+>> at end:
+txn: "H" meta={id=00000000 key="q" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
+meta: "q"/0,0 -> txn={id=00000000 key="q" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "q"/50.000000000,0 -> /BYTES/b
+
+run ok
+with t=H k=q
+  txn_restart epoch=0
+  txn_ignore_seqs seqs=(15-25)
+  resolve_intent status=PENDING
+  check_intent
+----
+meta: "q" -> txn={id=00000000 key="q" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=10} ts=50.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
+>> at end:
+txn: "H" meta={id=00000000 key="q" pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
+meta: "q"/0,0 -> txn={id=00000000 key="q" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=10} ts=50.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "q"/50.000000000,0 -> /BYTES/a
+
+run ok
+clear_range k=q end=-q
+----
+>> at end:
+<no data>
+
+# Update a pending intent with a higher epoch than the resolution's epoch.
+# The intent is pushed, so its timestamp is updated to help the pusher make progress.
+# The intent history is not updated because the epochs don't match.
+
+# The test exposes a bug where the intent history is actually updated.
+
+run ok
+with t=I k=r
+  txn_begin    ts=50
+  txn_restart  epoch=1
+  txn_step     seq=10
+  put          v=a
+  txn_step     seq=20
+  put          v=b
+  check_intent
+  get
+----
+meta: "r" -> txn={id=00000000 key="r" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
+get: "r" -> /BYTES/b @50.000000000,0
+>> at end:
+txn: "I" meta={id=00000000 key="r" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
+meta: "r"/0,0 -> txn={id=00000000 key="r" pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "r"/50.000000000,0 -> /BYTES/b
+
+run ok
+with t=I k=r
+  txn_restart epoch=0
+  txn_advance ts=60
+  txn_ignore_seqs seqs=(15-25)
+  resolve_intent status=PENDING
+  check_intent
+----
+meta: "r" -> txn={id=00000000 key="r" pri=0.00000000 epo=1 ts=60.000000000,0 min=0,0 seq=10} ts=60.000000000,0 del=false klen=12 vlen=20 mergeTs=<nil> txnDidNotUpdateMeta=false
+>> at end:
+txn: "I" meta={id=00000000 key="r" pri=0.00000000 epo=0 ts=60.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
+meta: "r"/0,0 -> txn={id=00000000 key="r" pri=0.00000000 epo=1 ts=60.000000000,0 min=0,0 seq=10} ts=60.000000000,0 del=false klen=12 vlen=20 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "r"/60.000000000,0 -> {localTs=50.000000000,0}/BYTES/a

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_abort
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_abort
@@ -1,0 +1,24 @@
+# Abort an intent whose history includes ignored seq nums.
+# The test exposes a bug where even though the transaction is aborted, its
+# intent is updated instead of aborted.
+
+# The test exposes a bug where even though the transaction is aborted, its
+# intent is updated instead of aborted.
+
+run ok
+with t=A k=k
+  txn_begin ts=11
+  txn_step  seq=10
+  put       v=a
+  txn_step  seq=20
+  put       v=b
+  txn_step  seq=30
+  txn_ignore_seqs seqs=(15-25)
+  resolve_intent status=ABORTED
+  get
+----
+get: "k" -> /BYTES/a @11.000000000,0
+>> at end:
+txn: "A" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "k"/11.000000000,0 -> /BYTES/a

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_abort
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_abort
@@ -2,9 +2,6 @@
 # The test exposes a bug where even though the transaction is aborted, its
 # intent is updated instead of aborted.
 
-# The test exposes a bug where even though the transaction is aborted, its
-# intent is updated instead of aborted.
-
 run ok
 with t=A k=k
   txn_begin ts=11
@@ -17,8 +14,7 @@ with t=A k=k
   resolve_intent status=ABORTED
   get
 ----
-get: "k" -> /BYTES/a @11.000000000,0
+get: "k" -> <no data>
 >> at end:
 txn: "A" meta={id=00000000 key="k" pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
-meta: "k"/0,0 -> txn={id=00000000 key="k" pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "k"/11.000000000,0 -> /BYTES/a
+<no data>

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
@@ -117,3 +117,46 @@ get  k=k
 ----
 scan: "k"-"l" -> <no data>
 get: "k" -> <no data>
+
+
+# Commit an intent with a lower epoch than the resolution.
+# The intent should be aborted because the new epoch may not write it again.
+
+# The test exposes a bug where the intent is updated instead of aborted.
+
+run ok
+with t=B k=b
+  txn_begin    ts=12
+  txn_step     seq=10
+  put          v=a
+  txn_step     seq=20
+  put          v=b
+  check_intent
+  get
+----
+meta: "b" -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20} ts=12.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
+get: "b" -> /BYTES/b @12.000000000,0
+>> at end:
+txn: "B" meta={id=00000000 key="b" pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=12.000000000,0 wto=false gul=0,0
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20} ts=12.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "b"/12.000000000,0 -> /BYTES/b
+data: "k"/11.000000000,0 -> /BYTES/c
+data: "k/10"/11.000000000,0 -> /BYTES/10
+data: "k/30"/11.000000000,0 -> /BYTES/30
+
+
+run ok
+with t=B k=b
+  txn_restart
+  txn_ignore_seqs seqs=(15-25)
+  resolve_intent status=COMMITTED
+  get
+----
+get: "b" -> <no data>
+>> at end:
+txn: "B" meta={id=00000000 key="b" pri=0.00000000 epo=1 ts=12.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,0 wto=false gul=0,0 isn=1
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=10} ts=12.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "b"/12.000000000,0 -> /BYTES/a
+data: "k"/11.000000000,0 -> /BYTES/c
+data: "k/10"/11.000000000,0 -> /BYTES/10
+data: "k/30"/11.000000000,0 -> /BYTES/30

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
@@ -122,8 +122,6 @@ get: "k" -> <no data>
 # Commit an intent with a lower epoch than the resolution.
 # The intent should be aborted because the new epoch may not write it again.
 
-# The test exposes a bug where the intent is updated instead of aborted.
-
 run ok
 with t=B k=b
   txn_begin    ts=12
@@ -155,8 +153,6 @@ with t=B k=b
 get: "b" -> <no data>
 >> at end:
 txn: "B" meta={id=00000000 key="b" pri=0.00000000 epo=1 ts=12.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,0 wto=false gul=0,0 isn=1
-meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=10} ts=12.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
-data: "b"/12.000000000,0 -> /BYTES/a
 data: "k"/11.000000000,0 -> /BYTES/c
 data: "k/10"/11.000000000,0 -> /BYTES/10
 data: "k/30"/11.000000000,0 -> /BYTES/30


### PR DESCRIPTION
Backport 3/3 commits from #117541.

/cc @cockroachdb/release

---

Previously, the logic in mvccResolveWriteIntent was structured in such a
way that if an intent contained both ignored and non-ignored seq nums
in its intent history, the intent may end up being updated instead of
aborted or unmodified (see examples in 644be59).

This commit fixes the bugs by ensuring that the intent history is
modified only when an intent resolution update is not aborted, and the
update and the actual intent have the same epoch.

Fixes: https://github.com/cockroachdb/cockroach/issues/117553

Release note: None

---

Release justification: Fixes an unexpected behavior in intent resolution.
