### PR TITLE
colexecagg: share agg func allocs between different functions if possible

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -988,12 +988,16 @@ func TestAggregatorRandom(t *testing.T) {
 	}
 }
 
-// benchmarkAggregateFunction runs aggregator microbenchmarks. numGroupCol is
-// the number of grouping columns. groupSize is the number of tuples to target
-// in each distinct aggregation group. chunkSize is the number of tuples to
-// target in each distinct partially ordered group column, and is intended for
-// use with partial order. Limit is the number of rows to retrieve from the
-// aggregation function before ending the microbenchmark.
+// benchmarkAggregateFunction runs aggregator micro benchmarks.
+// - numGroupCol is the number of grouping columns.
+// - groupSize is the number of tuples to target in each distinct aggregation
+// group.
+// - chunkSize is the number of tuples to target in each distinct partially
+// ordered group column, and is intended for use with partial order.
+// - limit is the number of rows to retrieve from the aggregation function
+// before ending the microbenchmark.
+// - numSameAggs, if positive, indicates the number of times that the provided
+// aggregate function should be evaluated.
 func benchmarkAggregateFunction(
 	b *testing.B,
 	agg aggType,
@@ -1005,6 +1009,7 @@ func benchmarkAggregateFunction(
 	numInputRows int,
 	chunkSize int,
 	limit int,
+	numSameAggs int,
 ) {
 	defer log.Scope(b).Close(b)
 	if groupSize > numInputRows {
@@ -1096,9 +1101,14 @@ func benchmarkAggregateFunction(
 	tc := aggregatorTestCase{
 		typs:           typs,
 		groupCols:      groupCols,
-		aggCols:        [][]uint32{aggCols},
-		aggFns:         []execinfrapb.AggregatorSpec_Func{aggFn},
 		unorderedInput: agg.order == unordered,
+	}
+	if numSameAggs < 1 {
+		numSameAggs = 1
+	}
+	for i := 0; i < numSameAggs; i++ {
+		tc.aggCols = append(tc.aggCols, aggCols)
+		tc.aggFns = append(tc.aggFns, aggFn)
 	}
 	if distinctProb > 0 {
 		if !typs[0].Identical(types.Int) {
@@ -1148,9 +1158,13 @@ func benchmarkAggregateFunction(
 	if distinctProb > 0 {
 		distinctProbString = fmt.Sprintf("/distinctProb=%.2f", distinctProb)
 	}
+	numSameAggsSuffix := ""
+	if numSameAggs != 1 {
+		numSameAggsSuffix = fmt.Sprintf("/numSameAggs=%d", numSameAggs)
+	}
 	b.Run(fmt.Sprintf(
-		"%s/%s/%s/groupSize=%d%s/numInputRows=%d",
-		fName, agg.name, inputTypesString, groupSize, distinctProbString, numInputRows),
+		"%s/%s/%s%s/groupSize=%d%s/numInputRows=%d",
+		fName, agg.name, inputTypesString, numSameAggsSuffix, groupSize, distinctProbString, numInputRows),
 		func(b *testing.B) {
 			b.SetBytes(int64(argumentsSize * numInputRows))
 			b.ResetTimer()
@@ -1201,12 +1215,15 @@ func BenchmarkAggregator(b *testing.B) {
 	// when benchmarking the aggregator logic.
 	aggFn := execinfrapb.AnyNotNull
 	for _, agg := range aggTypes {
-		for _, numInputRows := range numRows {
-			for _, groupSize := range groupSizes {
-				benchmarkAggregateFunction(
-					b, agg, aggFn, []*types.T{types.Int}, 1, /* numGroupCol */
-					groupSize, 0 /* distinctProb */, numInputRows,
-					0 /* chunkSize */, 0 /* limit */)
+		for _, numSameAggs := range []int{1, 4} {
+			for _, numInputRows := range numRows {
+				for _, groupSize := range groupSizes {
+					benchmarkAggregateFunction(
+						b, agg, aggFn, []*types.T{types.Int}, 1, /* numGroupCol */
+						groupSize, 0 /* distinctProb */, numInputRows,
+						0 /* chunkSize */, 0 /* limit */, numSameAggs,
+					)
+				}
 			}
 		}
 	}
@@ -1243,7 +1260,8 @@ func BenchmarkAllOptimizedAggregateFunctions(b *testing.B) {
 				benchmarkAggregateFunction(b, agg, aggFn, aggInputTypes,
 					1 /* numGroupCol */, groupSize,
 					0 /* distinctProb */, numInputRows,
-					0 /* chunkSize */, 0 /* limit */)
+					0 /* chunkSize */, 0 /* limit */, 0, /* numSameAggs */
+				)
 			}
 		}
 	}
@@ -1267,7 +1285,8 @@ func BenchmarkDistinctAggregation(b *testing.B) {
 					benchmarkAggregateFunction(b, agg, aggFn, []*types.T{types.Int},
 						1 /* numGroupCol */, groupSize,
 						0 /* distinctProb */, numInputRows,
-						0 /* chunkSize */, 0 /* limit */)
+						0 /* chunkSize */, 0 /* limit */, 0, /* numSameAggs */
+					)
 				}
 			}
 		}

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -915,8 +915,8 @@ func TestAggregatorRandom(t *testing.T) {
 							expNulls[curGroup] = false
 							expCounts[curGroup]++
 							expSums[curGroup] += aggCol[i]
-							expMins[curGroup] = min64(aggCol[i], expMins[curGroup])
-							expMaxs[curGroup] = max64(aggCol[i], expMaxs[curGroup])
+							expMins[curGroup] = min(aggCol[i], expMins[curGroup])
+							expMaxs[curGroup] = max(aggCol[i], expMaxs[curGroup])
 						}
 						groups[i] = int64(curGroup)
 					}
@@ -1272,18 +1272,4 @@ func BenchmarkDistinctAggregation(b *testing.B) {
 			}
 		}
 	}
-}
-
-func min64(a, b float64) float64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max64(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/pkg/sql/colexec/colexecagg/BUILD.bazel
+++ b/pkg/sql/colexec/colexecagg/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/buildutil",
         "//pkg/util/duration",
         "//pkg/util/json",  # keep
         "//pkg/util/mon",

--- a/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
@@ -60,7 +60,19 @@ const _CANONICAL_TYPE_FAMILY = types.UnknownFamily
 // _TYPE_WIDTH is the template variable.
 const _TYPE_WIDTH = 0
 
+// _ALLOC_CODE is the template variable that is replaced in agg_gen_util.go by
+// the template code for sharing allocator objects.
+const _ALLOC_CODE = 0
+
 // */}}
+
+// {{if eq "_AGGKIND" "Ordered"}}
+
+const anyNotNullNumOverloads = 11
+
+// {{end}}
+
+var _ = _ALLOC_CODE
 
 func newAnyNotNull_AGGKINDAggAlloc(
 	allocator *colmem.Allocator, t *types.T, allocSize int64,

--- a/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -41,6 +42,7 @@ var (
 	_ tree.AggType
 	_ apd.Context
 	_ duration.Duration
+	_ = typeconv.TypeFamilyToCanonicalTypeFamily
 )
 
 // {{/*
@@ -65,7 +67,19 @@ func _ASSIGN_SUBTRACT(_, _, _, _, _, _ string) {
 	colexecerror.InternalError(errors.AssertionFailedf(""))
 }
 
+// _ALLOC_CODE is the template variable that is replaced in agg_gen_util.go by
+// the template code for sharing allocator objects.
+const _ALLOC_CODE = 0
+
 // */}}
+
+// {{if eq "_AGGKIND" "Ordered"}}
+
+const avgNumOverloads = 6
+
+// {{end}}
+
+var _ = _ALLOC_CODE
 
 func newAvg_AGGKINDAggAlloc(
 	allocator *colmem.Allocator, t *types.T, allocSize int64,
@@ -73,7 +87,7 @@ func newAvg_AGGKINDAggAlloc(
 	allocBase := aggAllocBase{allocator: allocator, allocSize: allocSize}
 	switch t.Family() {
 	// {{range .}}
-	case _TYPE_FAMILY:
+	case _CANONICAL_TYPE_FAMILY:
 		switch t.Width() {
 		// {{range .WidthOverloads}}
 		case _TYPE_WIDTH:

--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -30,6 +31,7 @@ var (
 	_ tree.AggType
 	_ apd.Context
 	_ duration.Duration
+	_ = typeconv.TypeFamilyToCanonicalTypeFamily
 )
 
 func newAvgHashAggAlloc(

--- a/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -30,6 +31,7 @@ var (
 	_ tree.AggType
 	_ apd.Context
 	_ duration.Duration
+	_ = typeconv.TypeFamilyToCanonicalTypeFamily
 )
 
 func newSumHashAggAlloc(

--- a/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -30,6 +31,7 @@ var (
 	_ tree.AggType
 	_ apd.Context
 	_ duration.Duration
+	_ = typeconv.TypeFamilyToCanonicalTypeFamily
 )
 
 func newSumIntHashAggAlloc(

--- a/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/min_max_agg_tmpl.go
@@ -61,7 +61,33 @@ func _ASSIGN_CMP(_, _, _, _, _, _ string) bool {
 	colexecerror.InternalError(errors.AssertionFailedf(""))
 }
 
+// _ALLOC_CODE is the template variable that is replaced in agg_gen_util.go by
+// the template code for sharing allocator objects.
+const _ALLOC_CODE = 0
+
 // */}}
+
+// {{if eq "_AGGKIND" "Ordered"}}
+
+const minMaxNumOverloads = 11
+
+// {{end}}
+
+// {{range .}}
+// {{with .Overloads}}
+
+var _ = _ALLOC_CODE
+
+// {{/*
+//      The range loop is over an array of two items corresponding to min
+//      and max functions, but we want to generate the code for sharing
+//      allocators only once, so we break out of the loop.
+// */}}
+
+// {{break}}
+
+// {{end}}
+// {{end}}
 
 // {{range .}}
 // {{$agg := .Agg}}

--- a/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
@@ -37,6 +37,82 @@ var (
 	_ colexecerror.StorageError
 )
 
+const anyNotNullNumOverloads = 11
+
+func init() {
+	// Sanity check the hard-coded number of overloads.
+	var numOverloads int
+	numOverloads++
+	numOverloads++
+	numOverloads++
+	numOverloads++
+	numOverloads++
+	numOverloads++
+	numOverloads++
+	numOverloads++
+	numOverloads++
+	numOverloads++
+	numOverloads++
+	if numOverloads != anyNotNullNumOverloads {
+		colexecerror.InternalError(errors.AssertionFailedf(
+			"anyNotNullNumOverloads should be updated: expected %d, found %d", numOverloads, anyNotNullNumOverloads,
+		))
+	}
+}
+
+// anyNotNullOverloadOffset returns the offset for this particular type overload
+// within contiguous slice of allocators for this aggregate function.
+func anyNotNullOverloadOffset(t *types.T) int {
+	var offset int
+	canonicalTypeFamily := typeconv.TypeFamilyToCanonicalTypeFamily(t.Family())
+	if canonicalTypeFamily == types.BoolFamily {
+		return offset
+	}
+	offset += 1
+	if canonicalTypeFamily == types.BytesFamily {
+		return offset
+	}
+	offset += 1
+	if canonicalTypeFamily == types.DecimalFamily {
+		return offset
+	}
+	offset += 1
+	if canonicalTypeFamily == types.IntFamily {
+		if t.Width() == 16 {
+			return offset
+		}
+		offset++
+		if t.Width() == 32 {
+			return offset
+		}
+		offset++
+		return offset
+	}
+	offset += 3
+	if canonicalTypeFamily == types.FloatFamily {
+		return offset
+	}
+	offset += 1
+	if canonicalTypeFamily == types.TimestampTZFamily {
+		return offset
+	}
+	offset += 1
+	if canonicalTypeFamily == types.IntervalFamily {
+		return offset
+	}
+	offset += 1
+	if canonicalTypeFamily == types.JsonFamily {
+		return offset
+	}
+	offset += 1
+	if canonicalTypeFamily == typeconv.DatumVecCanonicalTypeFamily {
+		return offset
+	}
+	offset += 1
+	colexecerror.InternalError(errors.AssertionFailedf("didn't find overload offset for %s", t.SQLStringForError()))
+	return 0
+}
+
 func newAnyNotNullOrderedAggAlloc(
 	allocator *colmem.Allocator, t *types.T, allocSize int64,
 ) (aggregateFuncAlloc, error) {

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -30,7 +31,59 @@ var (
 	_ tree.AggType
 	_ apd.Context
 	_ duration.Duration
+	_ = typeconv.TypeFamilyToCanonicalTypeFamily
 )
+
+const avgNumOverloads = 6
+
+func init() {
+	// Sanity check the hard-coded number of overloads.
+	var numOverloads int
+	numOverloads++
+	numOverloads++
+	numOverloads++
+	numOverloads++
+	numOverloads++
+	numOverloads++
+	if numOverloads != avgNumOverloads {
+		colexecerror.InternalError(errors.AssertionFailedf(
+			"avgNumOverloads should be updated: expected %d, found %d", numOverloads, avgNumOverloads,
+		))
+	}
+}
+
+// avgOverloadOffset returns the offset for this particular type overload
+// within contiguous slice of allocators for this aggregate function.
+func avgOverloadOffset(t *types.T) int {
+	var offset int
+	canonicalTypeFamily := typeconv.TypeFamilyToCanonicalTypeFamily(t.Family())
+	if canonicalTypeFamily == types.IntFamily {
+		if t.Width() == 16 {
+			return offset
+		}
+		offset++
+		if t.Width() == 32 {
+			return offset
+		}
+		offset++
+		return offset
+	}
+	offset += 3
+	if canonicalTypeFamily == types.DecimalFamily {
+		return offset
+	}
+	offset += 1
+	if canonicalTypeFamily == types.FloatFamily {
+		return offset
+	}
+	offset += 1
+	if canonicalTypeFamily == types.IntervalFamily {
+		return offset
+	}
+	offset += 1
+	colexecerror.InternalError(errors.AssertionFailedf("didn't find overload offset for %s", t.SQLStringForError()))
+	return 0
+}
 
 func newAvgOrderedAggAlloc(
 	allocator *colmem.Allocator, t *types.T, allocSize int64,

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/execgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -41,6 +42,7 @@ var (
 	_ tree.AggType
 	_ apd.Context
 	_ duration.Duration
+	_ = typeconv.TypeFamilyToCanonicalTypeFamily
 )
 
 // {{/*
@@ -58,7 +60,27 @@ func _ASSIGN_SUBTRACT(_, _, _, _, _, _ string) {
 	colexecerror.InternalError(errors.AssertionFailedf(""))
 }
 
+// _ALLOC_CODE is the template variable that is replaced in agg_gen_util.go by
+// the template code for sharing allocator objects.
+const _ALLOC_CODE = 0
+
 // */}}
+
+// {{if eq "_AGGKIND" "Ordered"}}
+// {{if eq .SumKind "Int"}}
+const sumIntNumOverloads = 3
+
+// {{else}}
+const sumNumOverloads = 6
+
+// {{end}}
+// {{end}}
+
+// {{with .Infos}}
+
+var _ = _ALLOC_CODE
+
+// {{end}}
 
 func newSum_SUMKIND_AGGKINDAggAlloc(
 	allocator *colmem.Allocator, t *types.T, allocSize int64,
@@ -66,7 +88,7 @@ func newSum_SUMKIND_AGGKINDAggAlloc(
 	allocBase := aggAllocBase{allocator: allocator, allocSize: allocSize}
 	switch t.Family() {
 	// {{range .Infos}}
-	case _TYPE_FAMILY:
+	case _CANONICAL_TYPE_FAMILY:
 		switch t.Width() {
 		// {{range .WidthOverloads}}
 		case _TYPE_WIDTH:

--- a/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -30,6 +31,7 @@ var (
 	_ tree.AggType
 	_ apd.Context
 	_ duration.Duration
+	_ = typeconv.TypeFamilyToCanonicalTypeFamily
 )
 
 func newAvgWindowAggAlloc(

--- a/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -30,6 +31,7 @@ var (
 	_ tree.AggType
 	_ apd.Context
 	_ duration.Duration
+	_ = typeconv.TypeFamilyToCanonicalTypeFamily
 )
 
 func newSumWindowAggAlloc(

--- a/pkg/sql/colexec/colexecagg/window_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_sum_int_agg.eg.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -30,6 +31,7 @@ var (
 	_ tree.AggType
 	_ apd.Context
 	_ duration.Duration
+	_ = typeconv.TypeFamilyToCanonicalTypeFamily
 )
 
 func newSumIntWindowAggAlloc(

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -174,7 +174,8 @@ func BenchmarkDefaultAggregateFunction(b *testing.B) {
 					b, agg, aggFn, []*types.T{types.String, types.String},
 					1 /* numGroupCol */, groupSize,
 					0 /* distinctProb */, numInputRows,
-					0 /* chunkSize */, 0 /* limit */)
+					0 /* chunkSize */, 0 /* limit */, 0, /* numSameAggs */
+				)
 			}
 		}
 	}

--- a/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/any_not_null_agg_gen.go
@@ -46,5 +46,7 @@ func genAnyNotNullAgg(inputFileContents string, wr io.Writer) error {
 
 func init() {
 	registerAggGenerator(
-		genAnyNotNullAgg, "any_not_null_agg.eg.go", anyNotNullAggTmpl, false /* genWindowVariant */)
+		genAnyNotNullAgg, "any_not_null_agg.eg.go", /* filenameSuffix */
+		anyNotNullAggTmpl, "anyNotNull" /* aggName */, false, /* genWindowVariant */
+	)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
@@ -107,7 +107,7 @@ const avgAggTmpl = "pkg/sql/colexec/colexecagg/avg_agg_tmpl.go"
 
 func genAvgAgg(inputFileContents string, wr io.Writer) error {
 	r := strings.NewReplacer(
-		"_TYPE_FAMILY", "{{.TypeFamily}}",
+		"_CANONICAL_TYPE_FAMILY", "{{.TypeFamily}}",
 		"_TYPE_WIDTH", typeWidthReplacement,
 		"_RET_GOTYPESLICE", `{{.RetGoTypeSlice}}`,
 		"_RET_GOTYPE", `{{.RetGoType}}`,
@@ -174,5 +174,8 @@ func genAvgAgg(inputFileContents string, wr io.Writer) error {
 }
 
 func init() {
-	registerAggGenerator(genAvgAgg, "avg_agg.eg.go", avgAggTmpl, true /* genWindowVariant */)
+	registerAggGenerator(
+		genAvgAgg, "avg_agg.eg.go", /* filenameSuffix */
+		avgAggTmpl, "avg" /* aggName */, true, /* genWindowVariant */
+	)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/bool_and_or_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/bool_and_or_agg_gen.go
@@ -96,5 +96,7 @@ func genBooleanAgg(inputFileContents string, wr io.Writer) error {
 
 func init() {
 	registerAggGenerator(
-		genBooleanAgg, "bool_and_or_agg.eg.go", boolAggTmpl, true /* genWindowVariant */)
+		genBooleanAgg, "bool_and_or_agg.eg.go", /* filenameSuffix */
+		boolAggTmpl, "boolAndOr", true, /* genWindowVariant */
+	)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/concat_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/concat_agg_gen.go
@@ -34,5 +34,7 @@ func genConcatAgg(inputFileContents string, wr io.Writer) error {
 
 func init() {
 	registerAggGenerator(
-		genConcatAgg, "concat_agg.eg.go", concatAggTmpl, true /* genWindowVariant */)
+		genConcatAgg, "concat_agg.eg.go", /* filenameSuffix */
+		concatAggTmpl, "concat" /* aggName */, true, /* genWindowVariant */
+	)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/count_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/count_agg_gen.go
@@ -56,5 +56,8 @@ func genCountAgg(inputFileContents string, wr io.Writer) error {
 }
 
 func init() {
-	registerAggGenerator(genCountAgg, "count_agg.eg.go", countAggTmpl, true /* genWindowVariant */)
+	registerAggGenerator(
+		genCountAgg, "count_agg.eg.go", /* filenameSuffix */
+		countAggTmpl, "count" /* aggName */, true, /* genWindowVariant */
+	)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/default_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/default_agg_gen.go
@@ -35,5 +35,7 @@ func genDefaultAgg(inputFileContents string, wr io.Writer) error {
 
 func init() {
 	registerAggGenerator(
-		genDefaultAgg, "default_agg.eg.go", defaultAggTmpl, false /* genWindowVariant */)
+		genDefaultAgg, "default_agg.eg.go", /* filenameSuffix */
+		defaultAggTmpl, "defaultAgg" /* aggName */, false, /* genWindowVariant */
+	)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/min_max_agg_gen.go
@@ -65,5 +65,7 @@ func genMinMaxAgg(inputFileContents string, wr io.Writer) error {
 
 func init() {
 	registerAggGenerator(
-		genMinMaxAgg, "min_max_agg.eg.go", minMaxAggTmpl, true /* genWindowVariant */)
+		genMinMaxAgg, "min_max_agg.eg.go", /* filenameSuffix */
+		minMaxAggTmpl, "minMax" /* aggName */, true, /* genWindowVariant */
+	)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/sum_agg_gen.go
@@ -112,7 +112,7 @@ const sumAggTmpl = "pkg/sql/colexec/colexecagg/sum_agg_tmpl.go"
 
 func genSumAgg(inputFileContents string, wr io.Writer, isSumInt bool) error {
 	r := strings.NewReplacer(
-		"_TYPE_FAMILY", "{{.TypeFamily}}",
+		"_CANONICAL_TYPE_FAMILY", "{{.TypeFamily}}",
 		"_TYPE_WIDTH", typeWidthReplacement,
 		"_SUMKIND", "{{.SumKind}}",
 		"_RET_GOTYPESLICE", `{{.RetGoTypeSlice}}`,
@@ -207,9 +207,11 @@ func init() {
 		}
 	}
 	registerAggGenerator(
-		sumAggGenerator(false /* isSumInt */), "sum_agg.eg.go",
-		sumAggTmpl, true /* genWindowVariant */)
+		sumAggGenerator(false /* isSumInt */), "sum_agg.eg.go", /* filenameSuffix */
+		sumAggTmpl, "sum" /* aggName */, true, /* genWindowVariant */
+	)
 	registerAggGenerator(
-		sumAggGenerator(true /* isSumInt */), "sum_int_agg.eg.go",
-		sumAggTmpl, true /* genWindowVariant */)
+		sumAggGenerator(true /* isSumInt */), "sum_int_agg.eg.go", /* filenameSuffix */
+		sumAggTmpl, "sumInt" /* aggName */, true, /* genWindowVariant */
+	)
 }

--- a/pkg/sql/colexec/external_hash_aggregator_test.go
+++ b/pkg/sql/colexec/external_hash_aggregator_test.go
@@ -218,7 +218,9 @@ func BenchmarkExternalHashAggregator(b *testing.B) {
 						order: unordered,
 					},
 					aggFn, []*types.T{types.Int}, 1 /* numGroupCol */, groupSize,
-					0 /* distinctProb */, numInputRows, 0 /* chunkSize */, 0 /* limit */)
+					0 /* distinctProb */, numInputRows, 0, /* chunkSize */
+					0 /* limit */, 0, /* numSameAggs */
+				)
 			}
 		}
 	}

--- a/pkg/sql/colexec/hash_aggregator_test.go
+++ b/pkg/sql/colexec/hash_aggregator_test.go
@@ -528,7 +528,9 @@ func BenchmarkHashAggregatorInputTuplesTracking(b *testing.B) {
 			} {
 				benchmarkAggregateFunction(
 					b, agg, aggFn, []*types.T{types.Int}, 1 /* numGroupCol */, groupSize,
-					0 /* distinctProb */, numInputRows, 0 /* chunkSize */, 0 /* limit */)
+					0 /* distinctProb */, numInputRows, 0, /* chunkSize */
+					0 /* limit */, 0, /* numSameAggs */
+				)
 			}
 		}
 	}
@@ -617,7 +619,10 @@ func BenchmarkHashAggregatorPartialOrder(b *testing.B) {
 							// so we can skip all but one case.
 							continue
 						}
-						benchmarkAggregateFunction(b, agg, aggFn, []*types.T{types.Int}, 2, groupSize, 0, numInputRows, chunkSize, limit)
+						benchmarkAggregateFunction(
+							b, agg, aggFn, []*types.T{types.Int}, 2 /* numGroupCol */, groupSize,
+							0 /* distinctProb */, numInputRows, chunkSize, limit, 0, /* numSameAggs */
+						)
 					}
 				}
 			}


### PR DESCRIPTION
Previously, for every aggregate function we would always create a fresh `aggregateFuncAlloc` struct. That allocator is used to batch-allocate buckets. However, we would never share the alloc between different output columns even if the same aggregate function type overload is used. This commit addresses that inefficiency by enumerating all possible aggregate overloads for optimized aggregate functions and storing them in a single stack-allocated slice for reuse. This slice first stores 11 anyNotNull aggregates, then 6 avg aggregates, then 1 boolAnd aggregate, etc. In other words, each aggregate overload has a fixed spot in the array. This scheme was chosen over two dimensional array to remove any unused slots (we could have a separate slice for each aggregate type, and that slice would be up to 11 - the maximum number of type overloads any aggregate can have right now).

The main observation that allows us to easily reuse these allocs is the fact that there is no concurrency when allocating buckets.

For hash aggregation we currently use 128 allocation size in these allocators whereas for ordered / window aggregation we use just 1. This commit additionally extends `aggregateFuncAlloc` interface to add a method to increment the alloc size by 1. Namely, we don't change anything in case of the hash aggregation (meaning the same pool of 128 size can now be shared among multiple functions), but for ordered and window aggregations we increment the alloc size every time we reuse the allocator - this will make it so that for ordered / window aggs we batch-allocate all necessary objects at once.

Still, by far the main benefit of this change will be observed in case of the hash aggregation with small number of groups (buckets).

Addresses: #117546.

Epic: None.

Release note: None