### PR TITLE
build: add TestMetaTwoInstance nightly run scripts

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# This script is run by the Pebble Nightly Metamorphic Two Instance - TeamCity
+# build configuration.
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+mkdir -p artifacts
+
+# Pull in the latest version of Pebble from upstream. The benchmarks run
+# against the tip of the 'master' branch. We do this by `go get`ting the
+# latest version of the module, and then running `mirror` to update `DEPS.bzl`
+# accordingly.
+bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
+# Just dump the diff to see what, if anything, has changed.
+git diff
+NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
+echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
+
+# Use the Pebble SHA from the version in the modified go.mod file.
+# Note that we need to pluck the Git SHA from the go.sum-style version, i.e.
+# v0.0.0-20220214174839-6af77d5598c9SUM => 6af77d5598c9
+PEBBLE_SHA=$(grep 'github\.com/cockroachdb/pebble' go.mod | cut -d'-' -f3)
+echo "Pebble module Git SHA: $PEBBLE_SHA"
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_VCS_NUMBER=$PEBBLE_SHA -e GITHUB_API_TOKEN -e GITHUB_REPO -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+                               run_bazel build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance_impl.sh

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance_impl.sh
@@ -16,13 +16,12 @@ exit_status=0
 # NB: If adjusting the metamorphic test flags below, be sure to also update
 # pkg/cmd/github-post/main.go to ensure the GitHub issue poster includes the
 # correct flags in the reproduction command.
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --formatter=pebble-metamorphic -- test --config=race --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --formatter=pebble-metamorphic -- test --config=ci \
                                       @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test \
                                       --test_env TC_SERVER_URL=$TC_SERVER_URL \
-                                      --test_timeout=14400 \
-                                      --test_sharding_strategy=disabled \
+                                      --test_timeout=25200 '--test_filter=TestMetaTwoInstance$' \
                                       --define gotags=bazel,invariants \
-                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 3h -maxfails 1 -timeout 30m -stderr -p 1" \
+                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 3h -maxfails 1 -timeout 20m -stderr -p 1" \
                                       --test_arg -dir --test_arg $ARTIFACTS_DIR \
                                       --test_arg -ops --test_arg "uniform:5000-10000" \
                                       --test_output streamed \

--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -704,8 +704,8 @@ func formatPebbleMetamorphicIssue(
 			s := f.testMessage[i+len(seedHeader):]
 			s = strings.TrimSpace(s)
 			s = strings.TrimSpace(s[:strings.Index(s, "\n")])
-			repro = fmt.Sprintf("go test -tags 'invariants' -exec 'stress -p 1' "+
-				`-timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed %s -ops "uniform:5000-10000"`, s)
+			repro = fmt.Sprintf(`go test -tags 'invariants' -exec 'stress -p 1' `+
+				`-timeout 0 -test.v -run '%s$' ./internal/metamorphic -seed %s -ops "uniform:5000-10000"`, f.testName, s)
 		}
 	}
 	return issues.UnitTestFormatter, issues.PostRequest{

--- a/pkg/cmd/bazci/githubpost/githubpost_test.go
+++ b/pkg/cmd/bazci/githubpost/githubpost_test.go
@@ -334,7 +334,7 @@ TestXXA - 1.00s
 					testName: "TestMeta",
 					title:    "internal/metamorphic: TestMeta failed",
 					message:  "panic: induced panic",
-					expRepro: `go test -tags 'invariants' -exec 'stress -p 1' -timeout 0 -test.v -run TestMeta$ ./internal/metamorphic -seed 1600209371838097000 -ops "uniform:5000-10000"`,
+					expRepro: `go test -tags 'invariants' -exec 'stress -p 1' -timeout 0 -test.v -run 'TestMeta$' ./internal/metamorphic -seed 1600209371838097000 -ops "uniform:5000-10000"`,
 					labels:   []string{"metamorphic-failure", "C-test-failure", "release-blocker"},
 				},
 			},


### PR DESCRIPTION
We also change the race build to run both flavors.

Fixes: https://github.com/cockroachdb/pebble/issues/3175
Release note: None