### PR TITLE
ci: migrate CI docker images to GCP

### DIFF
--- a/build/.bazelbuilderversion
+++ b/build/.bazelbuilderversion
@@ -1,1 +1,1 @@
-cockroachdb/bazel:20231202-060338
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20231202-060338

--- a/build/.bazelbuilderversion-fips
+++ b/build/.bazelbuilderversion-fips
@@ -1,1 +1,1 @@
-cockroachdb/bazel-fips:20230815-175543
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel-fips:20230815-175543

--- a/build/README.md
+++ b/build/README.md
@@ -16,7 +16,7 @@ There are development and deploy images available.
 
 ### `bazel`/`bazelbuilder`
 
-`cockroachdb/bazel` is a Docker image containing basic requirements for
+`us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel` is a Docker image containing basic requirements for
 building the Cockroach binary using Bazel. It can be run using `./dev builder`.
 
 Note that if you use this image, you should ensure that your Docker installation
@@ -100,9 +100,9 @@ published both for `amd64` and `arm64` platforms. To update the image, perform
 the following steps:
 
 - Edit `build/bazelbuilder/Dockerfile` as desired.
-- Build the image by triggering the `Build and Push Bazel Builder Image` build in TeamCity. The generated image will be published to https://hub.docker.com/r/cockroachdb/bazel.
+- Build the image by triggering the `Build and Push Bazel Builder Image` build in TeamCity. The generated image will be published to `us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel`.
 - Update `build/.bazelbuilderversion` with the new tag and commit all your changes.
-- Build the FIPS image by triggering the `Build and Push FIPS Bazel Builder Image` build in TeamCity. The generated image will be published to https://hub.docker.com/r/cockroachdb/bazel-fips.
+- Build the FIPS image by triggering the `Build and Push FIPS Bazel Builder Image` build in TeamCity. The generated image will be published to `us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel-fips`.
 - Update `build/.bazelbuilderversion-fips` with the new tag and commit all your changes.
 - Ensure the "Bazel CI" job passes on your PR before merging.
 

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -175,7 +175,7 @@ if [ $ARCH = x86_64 ]; then
     do
         git checkout "$branch"
         # TODO(benesch): store the acceptanceversion somewhere more accessible.
-        docker pull $(git grep cockroachdb/acceptance -- '*.go' | sed -E 's/.*"([^"]*).*"/\1/') || true
+        docker pull $(git grep us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance -- '*.go' | sed -E 's/.*"([^"]*).*"/\1/') || true
     done
     cd -
 fi

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -22,7 +22,8 @@ BAZEL_IMAGE=$(cat $root/build/.bazelbuilderversion)
 DOCKER_EXPORT_COCKROACH_VARS=$(env | grep '^COCKROACH_' | cut -d= -f1 | sed -e 's/\(.*\)/-e \1/' | tr '\n' ' ') || true
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
-# container with the `cockroachdb/bazel` image running the given script.
+# container with the `us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel`
+# image running the given script.
 # BAZEL_SUPPORT_EXTRA_DOCKER_ARGS will be passed on to `docker run` unchanged.
 run_bazel() {
     # Set up volumes.

--- a/build/teamcity/internal/cockroach/build/ci/build-and-push-bazel-builder-image.sh
+++ b/build/teamcity/internal/cockroach/build/ci/build-and-push-bazel-builder-image.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
+source "$dir/release/teamcity-support.sh"
+
+gar_repository="us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel"
+docker_login_gcr "$gar_repository" "$IMAGE_BUILDER_GOOGLE_CREDENTIALS"
+
 TAG=$(date +%Y%m%d-%H%M%S)
 docker buildx create --name "builder-$TAG" --use
-docker buildx build --push --platform linux/amd64,linux/arm64 -t "cockroachdb/bazel:$TAG" -t "cockroachdb/bazel:latest-do-not-use" build/bazelbuilder
+docker buildx build --push --platform linux/amd64,linux/arm64 -t "$gar_repository:$TAG" -t "$gar_repository:latest-do-not-use" build/bazelbuilder
 
 if [[ "$open_pr_on_success" == "true" ]]; then
     # Trigger "Open New Bazel Builder Image PR".
@@ -16,7 +22,7 @@ if [[ "$open_pr_on_success" == "true" ]]; then
       <buildType id="Internal_Cockroach_Build_Ci_OpenNewBazelBuilderImagePr"/>
        <properties>
             <property name="env.BRANCH" value="'"bazel-builder-update-$TAG"'"/>
-            <property name="env.VERSION" value="'"cockroachdb/bazel:$TAG"'"/>
+            <property name="env.VERSION" value="'"$gar_repository:$TAG"'"/>
         </properties>
     </build>'
 else

--- a/build/teamcity/internal/cockroach/build/ci/nightly-bazel-builder-update-check.sh
+++ b/build/teamcity/internal/cockroach/build/ci/nightly-bazel-builder-update-check.sh
@@ -2,7 +2,7 @@
 set -xeuo pipefail
 
 BASE_IMAGE="ubuntu:focal"
-BAZEL_IMAGE="cockroachdb/bazel:latest-do-not-use"
+BAZEL_IMAGE="us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:latest-do-not-use"
 
 docker pull $BASE_IMAGE && docker pull $BAZEL_IMAGE
 LATEST_BASE_IMAGE_CREATE_DT="$(docker inspect $BASE_IMAGE -f '{{.Created}}')"

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -32,7 +32,7 @@ platform(
         "@platforms//cpu:x86_64",
     ],
     exec_properties = {
-        "container-image": "docker://cockroachdb/bazel@sha256:b46188e6376c291d23fe57befd806a13f68c7d596979ab0b3edb9eb3c329ba00",
+        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:d32b7199b97b493d4dbf7b354f7f12f894c06538d9ac4a3ef75fcdd94c16bfe4",
         "dockerReuse": "True",
         "Pool": "default",
     },
@@ -137,7 +137,7 @@ platform(
         "@platforms//cpu:arm64",
     ],
     exec_properties = {
-        "container-image": "docker://cockroachdb/bazel@sha256:c992a22b54a8667686d9ed65a48d10af10fe9210ef18b18421016cac95dc0983",
+        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:d32b7199b97b493d4dbf7b354f7f12f894c06538d9ac4a3ef75fcdd94c16bfe4",
         "dockerReuse": "True",
         "Pool": "default",
     },

--- a/build/toolchains/toolchainbuild/crosstool-ng/buildtoolchains.sh
+++ b/build/toolchains/toolchainbuild/crosstool-ng/buildtoolchains.sh
@@ -7,8 +7,7 @@ toplevel="$(dirname $(dirname $(dirname $(dirname $this_dir))))"
 
 mkdir -p "${toplevel}"/artifacts
 
-# note: the Docker image should match the base image of
-# `cockroachdb/builder` and `cockroachdb/bazel`.
+# note: the Docker image should match the base image of `us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel`.
 docker run --rm -i ${tty-} -v $this_dir:/bootstrap \
        -v "${toplevel}"/artifacts:/artifacts \
        ubuntu:focal-20210119 /bootstrap/perform-build.sh

--- a/build/toolchains/toolchainbuild/osxcross/buildtoolchains.sh
+++ b/build/toolchains/toolchainbuild/osxcross/buildtoolchains.sh
@@ -7,8 +7,7 @@ toplevel="$(dirname $(dirname $(dirname $(dirname $this_dir))))"
 
 mkdir -p "${toplevel}"/artifacts
 
-# note: the Docker image should match the base image of
-# `cockroachdb/builder` and `cockroachdb/bazel`.
+# note: the Docker image should match the base image of `us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel`.
 docker run --rm -i ${tty-} -v $this_dir:/bootstrap \
        -v "${toplevel}"/artifacts:/artifacts \
        ubuntu:focal-20210119 /bootstrap/perform-build.sh

--- a/pkg/acceptance/cluster/docker.go
+++ b/pkg/acceptance/cluster/docker.go
@@ -80,7 +80,11 @@ func hasImage(ctx context.Context, l *DockerCluster, ref string) error {
 	if err != nil {
 		return err
 	}
-	path := reference.Path(distributionRef)
+	path := distributionRef.Name()
+	// Images hosted on docker.io have local name without the domain name
+	if strings.HasPrefix(path, "docker.io") {
+		path = reference.Path(distributionRef)
+	}
 	// Correct for random docker stupidity:
 	//
 	// https://github.com/moby/moby/blob/7248742/registry/service.go#L207:L215
@@ -113,7 +117,7 @@ func hasImage(ctx context.Context, l *DockerCluster, ref string) error {
 	var imageList []string
 	for _, image := range images {
 		for _, tag := range image.RepoTags {
-			imageList = append(imageList, "%s %s", tag, image.ID)
+			imageList = append(imageList, fmt.Sprintf("%s %s", tag, image.ID))
 		}
 	}
 	return errors.Errorf("%s not found in:\n%s", wanted, strings.Join(imageList, "\n"))

--- a/pkg/acceptance/compose/gss/build-push-gss.sh
+++ b/pkg/acceptance/compose/gss/build-push-gss.sh
@@ -4,4 +4,4 @@ set -xeuo pipefail
 TARGET=$1
 TAG=$(date +%Y%m%d-%H%M%S)
 docker buildx create --use
-docker buildx build --push --platform linux/amd64,linux/arm64 -t cockroachdb/acceptance-gss-$TARGET:$TAG ./$TARGET
+docker buildx build --push --platform linux/amd64,linux/arm64 -t us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-$TARGET:$TAG ./$TARGET

--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   kdc:
-    image: cockroachdb/acceptance-gss-kdc:20221214-131000
+    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-kdc:20221214-131000
     volumes:
       - ./kdc/start.sh:/start.sh
       - keytab:/keytab
@@ -17,7 +17,7 @@ services:
       - keytab:/keytab
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach
   python:
-    image: cockroachdb/acceptance-gss-python:20221214-141947
+    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-python:20221214-141947
     user: "${UID}:${GID}"
     depends_on:
       - cockroach

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   kdc:
-    image: cockroachdb/acceptance-gss-kdc:20221214-131000
+    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-kdc:20221214-131000
     volumes:
       - ./kdc/start.sh:/start.sh
       - keytab:/keytab
@@ -17,7 +17,7 @@ services:
       - keytab:/keytab
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach
   psql:
-    image: cockroachdb/acceptance-gss-psql:20230907-113902
+    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-psql:20230907-113902
     user: "${UID}:${GID}"
     depends_on:
       - cockroach

--- a/pkg/acceptance/testdata/README.md
+++ b/pkg/acceptance/testdata/README.md
@@ -1,10 +1,11 @@
 # Acceptance Test Harnesses
 
-The Dockerfile in this directory builds an image, `cockroachdb/acceptance`, in
-which we run our language-specific acceptance tests. For each language we
-support, we install the compiler or runtime, and typically the Postgres driver,
-into the image. Where possible, we use packages provided by Debian; otherwise we
-invoke the language's package manager while building the image.
+The Dockerfile in this directory builds an image,
+`us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance`, in which we run
+our language-specific acceptance tests. For each language we support, we
+install the compiler or runtime, and typically the Postgres driver, into the
+image. Where possible, we use packages provided by Debian; otherwise we invoke
+the language's package manager while building the image.
 
 In all cases, the language's package manager is removed or put into offline mode
 before the image is fully baked to ensure that we don't accidentally introduce a
@@ -19,7 +20,7 @@ need to update the image.
 ```
     TAG=$(date +%Y%m%d-%H%M%S)
     docker buildx create --use
-    docker buildx build --push --platform linux/amd64,linux/arm64 -t cockroachdb/acceptance:$TAG .
+    docker buildx build --push --platform linux/amd64,linux/arm64 -t us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance:$TAG .
 ```
 
 No need to have your changes reviewed before you push an image, as we pin the

--- a/pkg/acceptance/util_docker.go
+++ b/pkg/acceptance/util_docker.go
@@ -66,7 +66,7 @@ func testDockerSuccess(ctx context.Context, t *testing.T, name string, cmd []str
 const (
 	// Iterating against a locally built version of the docker image can be done
 	// by changing acceptanceImage to the hash of the container.
-	acceptanceImage = "docker.io/cockroachdb/acceptance:20221005-223354"
+	acceptanceImage = "us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance:20221005-223354"
 )
 
 func testDocker(

--- a/pkg/cmd/dev/testdata/recorderdriven/builder
+++ b/pkg/cmd/dev/testdata/recorderdriven/builder
@@ -10,7 +10,7 @@ git rev-parse --git-dir
 git rev-parse --git-common-dir
 mkdir crdb-checkout/artifacts
 chmod crdb-checkout/artifacts 0777
-docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220328-163955
+docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20220328-163955
 
 dev builder echo hi
 ----
@@ -24,4 +24,4 @@ git rev-parse --git-dir
 git rev-parse --git-common-dir
 mkdir crdb-checkout/artifacts
 chmod crdb-checkout/artifacts 0777
-docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220328-163955 echo hi
+docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20220328-163955 echo hi

--- a/pkg/cmd/dev/testdata/recorderdriven/builder.rec
+++ b/pkg/cmd/dev/testdata/recorderdriven/builder.rec
@@ -9,7 +9,7 @@ id
 cat crdb-checkout/build/.bazelbuilderversion
 ----
 ----
-cockroachdb/bazel:20220328-163955
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20220328-163955
 ----
 ----
 
@@ -42,7 +42,7 @@ mkdir crdb-checkout/artifacts
 chmod crdb-checkout/artifacts 0777
 ----
 
-docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220328-163955
+docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20220328-163955
 ----
 
 which docker
@@ -56,7 +56,7 @@ id
 cat crdb-checkout/build/.bazelbuilderversion
 ----
 ----
-cockroachdb/bazel:20220328-163955
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20220328-163955
 ----
 ----
 
@@ -89,6 +89,6 @@ mkdir crdb-checkout/artifacts
 chmod crdb-checkout/artifacts 0777
 ----
 
-docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220328-163955 echo hi
+docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20220328-163955 echo hi
 ----
 


### PR DESCRIPTION
Previously, we used Docker Hub to host our CI docker images.

To improve service reliability, this PR moves the used docker images to GAR.

Part of: DEVINF-915
Epic: RE-539
Release note: None