### PR TITLE
streamingccl: deflake TestPartitionedStreamClient

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
@@ -345,7 +345,7 @@ INSERT INTO d.t2 VALUES (2);
 	// Makes producer job exit quickly.
 	h.SysSQL.ExecMultiple(t, `
 SET CLUSTER SETTING stream_replication.stream_liveness_track_frequency = '200ms'`,
-		`SET CLUSTER SETTING stream_replication.job_liveness_timeout = '100ms'`)
+		`SET CLUSTER SETTING stream_replication.job_liveness_timeout = '1s'`)
 	rps, err = client.Create(ctx, testTenantName, streampb.ReplicationProducerRequest{})
 	require.NoError(t, err)
 	streamID = rps.StreamID


### PR DESCRIPTION
A previous pr #117515 lowered the producer job liveness timout in the test to allow the producer job to succeed quickly on completion. The PR lowered it to 100ms which is too low, causing the job to fail on liveness timeouts. This patch bumps the timout to 1s, preventing the liveness timeout.

Fixes #117605

Release note: none