### PR TITLE
roachtest: pull tpc-e image from GAR

### DIFF
--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -80,7 +80,7 @@ func initTPCESpec(
 }
 
 func (ts *tpceSpec) newCmd(o tpceCmdOptions) *roachtestutil.Command {
-	cmd := roachtestutil.NewCommand(`sudo docker run cockroachdb/tpc-e:latest`)
+	cmd := roachtestutil.NewCommand(`sudo docker run us-east1-docker.pkg.dev/crl-ci-images/cockroach/tpc-e:latest`)
 	o.AddCommandOptions(cmd)
 	return cmd
 }


### PR DESCRIPTION
Previously, we pulled the tpc-e image from Docker Hub. Now that we move most of our CI images to GAR, this image will be pulled from GAR as well

Epic: RE-539
Release note: None