### PR TITLE
changefeedccl: introduce quota to parallelio

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -142,6 +142,7 @@ go_library(
         "//pkg/util/mon",
         "//pkg/util/parquet",
         "//pkg/util/protoutil",
+        "//pkg/util/quotapool",
         "//pkg/util/randutil",
         "//pkg/util/retry",
         "//pkg/util/span",

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -244,7 +244,8 @@ func getSink(
 			if WebhookV2Enabled.Get(&serverCfg.Settings.SV) {
 				return validateOptionsAndMakeSink(changefeedbase.WebhookValidOptions, func() (Sink, error) {
 					return makeWebhookSink(ctx, sinkURL{URL: u}, encodingOpts, webhookOpts,
-						numSinkIOWorkers(serverCfg), newCPUPacerFactory(ctx, serverCfg), timeutil.DefaultTimeSource{}, metricsBuilder)
+						numSinkIOWorkers(serverCfg), newCPUPacerFactory(ctx, serverCfg), timeutil.DefaultTimeSource{},
+						metricsBuilder, serverCfg.Settings)
 				})
 			} else {
 				return validateOptionsAndMakeSink(changefeedbase.WebhookValidOptions, func() (Sink, error) {
@@ -258,8 +259,10 @@ func getSink(
 				testingKnobs = knobs
 			}
 			if PubsubV2Enabled.Get(&serverCfg.Settings.SV) {
-				return makePubsubSink(ctx, u, encodingOpts, opts.GetPubsubConfigJSON(), AllTargets(feedCfg), opts.IsSet(changefeedbase.OptUnordered),
-					numSinkIOWorkers(serverCfg), newCPUPacerFactory(ctx, serverCfg), timeutil.DefaultTimeSource{}, metricsBuilder, testingKnobs)
+				return makePubsubSink(ctx, u, encodingOpts, opts.GetPubsubConfigJSON(), AllTargets(feedCfg),
+					opts.IsSet(changefeedbase.OptUnordered), numSinkIOWorkers(serverCfg),
+					newCPUPacerFactory(ctx, serverCfg), timeutil.DefaultTimeSource{},
+					metricsBuilder, serverCfg.Settings, testingKnobs)
 			} else {
 				return makeDeprecatedPubsubSink(ctx, u, encodingOpts, AllTargets(feedCfg), opts.IsSet(changefeedbase.OptUnordered), metricsBuilder, testingKnobs)
 			}

--- a/pkg/ccl/changefeedccl/sink_pubsub_v2.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub_v2.go
@@ -19,6 +19,7 @@ import (
 	pb "cloud.google.com/go/pubsub/apiv1/pubsubpb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
@@ -420,6 +421,7 @@ func makePubsubSink(
 	pacerFactory func() *admission.Pacer,
 	source timeutil.TimeSource,
 	mb metricsRecorderBuilder,
+	settings *cluster.Settings,
 	knobs *TestingKnobs,
 ) (Sink, error) {
 	batchCfg, retryOpts, err := getSinkConfigFromJson(jsonConfig, sinkJSONConfig{
@@ -463,5 +465,6 @@ func makePubsubSink(
 		pacerFactory,
 		source,
 		mb(requiresResourceAccounting),
+		settings,
 	), nil
 }

--- a/pkg/ccl/changefeedccl/sink_webhook_test.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -85,7 +86,7 @@ func setupWebhookSinkWithDetails(
 	if err != nil {
 		return nil, err
 	}
-	sinkSrc, err := makeWebhookSink(ctx, sinkURL{URL: u}, encodingOpts, sinkOpts, parallelism, nilPacerFactory, source, nilMetricsRecorderBuilder)
+	sinkSrc, err := makeWebhookSink(ctx, sinkURL{URL: u}, encodingOpts, sinkOpts, parallelism, nilPacerFactory, source, nilMetricsRecorderBuilder, cluster.MakeClusterSettings())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/sink_webhook_v2.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_v2.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -349,6 +350,7 @@ func makeWebhookSink(
 	pacerFactory func() *admission.Pacer,
 	source timeutil.TimeSource,
 	mb metricsRecorderBuilder,
+	settings *cluster.Settings,
 ) (Sink, error) {
 	batchCfg, retryOpts, err := getSinkConfigFromJson(opts.JSONConfig, sinkJSONConfig{})
 	if err != nil {
@@ -371,5 +373,6 @@ func makeWebhookSink(
 		pacerFactory,
 		source,
 		mb(requiresResourceAccounting),
+		settings,
 	), nil
 }


### PR DESCRIPTION
Problem:

In this (https://github.com/cockroachdb/cockroach/issues/111829) investigation, it was observed that there was a lot of wasted CPU
performing unions in intsets. This is caused by the `parallelIO` struct which relies
on performing unions to check for conflicting keys. The problem is not with intsets being
slow, but it has to do with how they are used:

`parallelIO` uses a goroutine to both process incoming requests and emit outgoing results.
It accepts incoming requests unconditionally, enqueing them if they cannot be emitted
due to conflicting in flight requests. As outgoing results are processed, each outgoing result
is cross checked with, in the worst case, all enqueued requests to see if they can be emitted.
The cross checking requires unions.

```
incoming request -> request queue -> request handler -> result
                        ^                                 ^
                        | cross check all entries to see  |
                        | if a new request can be emitted |
```

A problem arises when the incoming request queue grows to some critical length where
it significantly slows down the cross checking. This slows down result processing and
ultimately slows down consumption from the request queue. This creates a negative feedback loop
which causes the request queue to grow so large that results take very long to process. This
creates a bottle neck, which throttles the entire changefeed.

See comments https://github.com/cockroachdb/cockroach/issues/115536 for more details.

The request queue is unbounded. The only reason it doesn't cause an OOM is because the incoming
requests are bounded (by the per-changefeed memory limit).

Solution:

This change solves this problem by setting a quota for the maximum events being processed by the
library at the same time. This change sets a size of 128 requests by default. This setting can be
changed using a new cluster setting `changefeed.parallel_io.request_quota`.

Before this change, the API for the parallelio library was very bad. It required the caller to
select on both the request channel and result channel to prevent deadlock. There were also no
public methods. This made it unclear how to properly use the API. This change makes an explicit
API with public methods. However, it keeps the same 2-channel scheme because removing that would
require a larger refactor. This is left as a TODO.

Closes: https://github.com/cockroachdb/cockroach/issues/115536
Release note: None
Epic: None