### PR TITLE
roachtest: add limit_capacity roachtests 

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -97,6 +97,7 @@ go_library(
         "ledger.go",
         "libpq.go",
         "libpq_blocklist.go",
+        "limit_capacity.go",
         "liquibase.go",
         "liquibase_blocklist.go",
         "loss_of_quorum_recovery.go",

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -413,7 +413,7 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 	_, err := conn.ExecContext(ctx, `CREATE DATABASE kv`)
 	require.NoError(t, err)
 	configureZone(t, ctx, conn, `DATABASE kv`, zoneConfig{
-		replicas: 5, onlyNodes: []int{2, 3, 4, 5, 6}, leaseNode: 4})
+		replicas: 5, onlyNodes: []int{2, 3, 4, 5, 6}, leasePreference: "[+node4]"})
 
 	c.Run(ctx, option.WithNodes(c.Node(6)), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
 
@@ -672,7 +672,7 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 	// Place all ranges on n1-n3, and an extra liveness leaseholder replica on n4.
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 	configureZone(t, ctx, conn, `RANGE liveness`, zoneConfig{
-		replicas: 4, onlyNodes: []int{1, 2, 3, 4}, leaseNode: 4})
+		replicas: 4, onlyNodes: []int{1, 2, 3, 4}, leasePreference: "[+node4]"})
 
 	// Wait for upreplication.
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
@@ -900,7 +900,7 @@ func runFailoverLiveness(
 	configureAllZones(t, ctx, conn, zoneConfig{replicas: 3, onlyNodes: []int{1, 2, 3}})
 
 	// Constrain the liveness range to n1-n4, with leaseholder preference on n4.
-	configureZone(t, ctx, conn, `RANGE liveness`, zoneConfig{replicas: 4, leaseNode: 4})
+	configureZone(t, ctx, conn, `RANGE liveness`, zoneConfig{replicas: 4, leasePreference: "[+node4]"})
 
 	// Wait for upreplication.
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
@@ -1699,9 +1699,9 @@ func relocateLeases(t test.Test, ctx context.Context, conn *gosql.DB, predicate 
 }
 
 type zoneConfig struct {
-	replicas  int
-	onlyNodes []int
-	leaseNode int
+	replicas        int
+	onlyNodes       []int
+	leasePreference string
 }
 
 // configureZone sets the zone config for the given target.
@@ -1734,14 +1734,9 @@ func configureZone(
 		}
 	}
 
-	var leaseString string
-	if cfg.leaseNode > 0 {
-		leaseString += fmt.Sprintf("[+node%d]", cfg.leaseNode)
-	}
-
 	_, err := conn.ExecContext(ctx, fmt.Sprintf(
 		`ALTER %s CONFIGURE ZONE USING num_replicas = %d, constraints = '[%s]', lease_preferences = '[%s]'`,
-		target, cfg.replicas, constraintsString, leaseString))
+		target, cfg.replicas, constraintsString, cfg.leasePreference))
 	require.NoError(t, err)
 }
 

--- a/pkg/cmd/roachtest/tests/limit_capacity.go
+++ b/pkg/cmd/roachtest/tests/limit_capacity.go
@@ -1,0 +1,153 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/stretchr/testify/require"
+)
+
+func registerLimitCapacity(r registry.Registry) {
+	spec := func(subtest string, cfg limitCapacityOpts) registry.TestSpec {
+		return registry.TestSpec{
+			Name:             "limit_capacity/" + subtest,
+			Owner:            registry.OwnerKV,
+			Timeout:          1 * time.Hour,
+			CompatibleClouds: registry.OnlyGCE,
+			Suites:           registry.ManualOnly,
+			Cluster:          r.MakeClusterSpec(5, spec.CPU(8)),
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runLimitCapacity(ctx, t, c, cfg)
+			},
+		}
+	}
+
+	r.Add(spec("write_b=25mb", newAllocatorOverloadOpts().limitWriteCap(26214400)))
+	r.Add(spec("compact=0", newAllocatorOverloadOpts().limitCompaction(0)))
+}
+
+type limitCapacityOpts struct {
+	writeCapBytes      int
+	compactConcurrency int
+}
+
+func newAllocatorOverloadOpts() limitCapacityOpts {
+	return limitCapacityOpts{
+		writeCapBytes:      -1,
+		compactConcurrency: -1,
+	}
+}
+
+func (a limitCapacityOpts) limitCompaction(concurrency int) limitCapacityOpts {
+	a.compactConcurrency = concurrency
+	return a
+}
+
+func (a limitCapacityOpts) limitWriteCap(bytes int) limitCapacityOpts {
+	a.writeCapBytes = bytes
+	return a
+}
+
+// runLimitCapacity sets up a kv50 fixed rate workload running against the
+// first n-1 nodes, the last node is used for the workload. The n-1'th node has
+// any defined capacity limitations applied to it. The test initially runs for
+// 10 minutes to establish a baseline level of workload throughput, the
+// capacity constraint is applied and after another 2 minutes the throughput is
+// measured relative to the baseline QPS.
+func runLimitCapacity(ctx context.Context, t test.Test, c cluster.Cluster, cfg limitCapacityOpts) {
+	require.False(t, c.IsLocal())
+
+	appNodeID := c.Spec().NodeCount
+	limitedNodeID := c.Spec().NodeCount - 1
+	nodes := c.Range(1, limitedNodeID)
+	appNode := c.Node(appNodeID)
+	limitedNode := c.Node(limitedNodeID)
+
+	initialDuration := 10 * time.Minute
+	limitDuration := 2 * time.Minute
+
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), nodes)
+	conn := c.Conn(ctx, t.L(), 1)
+	defer conn.Close()
+
+	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
+	var cancels []func()
+
+	c.Run(ctx, option.WithNodes(appNode), "./cockroach workload init kv --splits=1000 {pgurl:1}")
+
+	m := c.NewMonitor(ctx, nodes)
+	cancels = append(cancels, m.GoWithCancel(func(ctx context.Context) error {
+		t.L().Printf("starting load generator\n")
+		// NB: kv50 with 4kb block size at 5k rate will incur approx. 500mb/s write
+		// bandwidth after 10 minutes across the cluster. Spread across 4 CRDB
+		// nodes, expect approx. 125 mb/s write bandwidth each and 30-50% CPU
+		// utilization.
+		err := c.RunE(ctx, option.WithNodes(appNode), fmt.Sprintf(
+			"./cockroach workload run kv --read-percent=50 --tolerate-errors --concurrency=400 "+
+				"--min-block-bytes=4096 --max-block-bytes=4096 --max-rate=5000 "+
+				"--duration=30m {pgurl:1-%d}", c.Spec().NodeCount-2))
+		return err
+	}))
+
+	t.Status(fmt.Sprintf("waiting %s for baseline workload throughput", initialDuration))
+	wait(c.NewMonitor(ctx, nodes), initialDuration)
+	qpsInitial := measureQPS(ctx, t, 10*time.Second, conn)
+	t.Status(fmt.Sprintf("initial (single node) qps: %.0f", qpsInitial))
+
+	if cfg.writeCapBytes >= 0 {
+		c.Run(ctx, option.WithNodes(limitedNode), "sudo", "systemctl", "set-property", "cockroach-system",
+			fmt.Sprintf("'IOWriteBandwidthMax=/mnt/data1 %d'", cfg.writeCapBytes))
+	}
+
+	if cfg.compactConcurrency >= 0 {
+		cancels = append(cancels, m.GoWithCancel(func(ctx context.Context) error {
+			t.Status(fmt.Sprintf("setting compaction concurrency on n%d to %d", limitedNodeID, cfg.compactConcurrency))
+			limitedConn := c.Conn(ctx, t.L(), limitedNodeID)
+			defer limitedConn.Close()
+
+			// Execution will be blocked on setting the compaction concurrency. The
+			// execution is cancelled below after measuring the final QPS below.
+			_, err := limitedConn.ExecContext(ctx,
+				fmt.Sprintf(`SELECT crdb_internal.set_compaction_concurrency(%d,%d,%d)`,
+					limitedNodeID, limitedNodeID, cfg.compactConcurrency,
+				))
+			return err
+		}))
+	}
+
+	wait(c.NewMonitor(ctx, nodes), limitDuration)
+	qpsFinal := measureQPS(ctx, t, 10*time.Second, conn)
+	qpsRelative := qpsFinal / qpsInitial
+	t.Status(fmt.Sprintf("initial qps=%f final qps=%f (%f%%)", qpsInitial, qpsFinal, 100*qpsRelative))
+	for _, cancel := range cancels {
+		cancel()
+	}
+	// We should be able to assert on the throughput not dropping beyond a
+	// certain % of the throughput prior to limiting a node's capacity.
+	//
+	// TODO(kvoli): Currently this test will fail an assertion that the final QPS
+	// will be >50% of the pre-limit QPS. Once we begin shedding leases off the
+	// limited node, this assertion would pass. Add in these assertions once
+	// shedding is done, or alternatively enable the test weekly and export the
+	// relative QPS to roachperf. Two potential assertions are:
+	//
+	//   (a) expect throughput to not drop by more than X%
+	//   (b) measure the throughput at set marks (10s, 30s, 1m, 5m) and assert.
+}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -19,6 +19,7 @@ func RegisterTests(r registry.Registry) {
 	registerActiveRecord(r)
 	registerAdmission(r)
 	registerAllocator(r)
+	registerLimitCapacity(r)
 	registerAllocationBench(r)
 	registerAlterPK(r)
 	registerAsyncpg(r)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -7941,7 +7941,7 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 				nodeID := int32(tree.MustBeDInt(args[0]))
 				storeID := int32(tree.MustBeDInt(args[1]))
 				compactionConcurrency := tree.MustBeDInt(args[2])
-				if compactionConcurrency <= 0 {
+				if compactionConcurrency < 0 {
 					return nil, errors.AssertionFailedf("compaction_concurrency must be > 0")
 				}
 				if err = evalCtx.SetCompactionConcurrency(


### PR DESCRIPTION
There were no roachtests which limited the capacity of a node in a
cluster where better allocation decisions would have an impact.
Introduce two roachtests

- `limit_capacity/write_b=25mbs`
- `limit_capacity/compact=0`

The test uses a 4 node cluster running a fixed rate kv50 workload
consuming 20-30% CPU and approx 100mb/s write bandwidth after 10
minutes. After 10 minutes, a node's capacity is limited.

In `write_b=25mbs`, the write bandwidth is limited to 25mb/s, or 1/4 of
the current write bandwidth usage. In `compact=0`, non-flush compactions
are disabled.

These tests are manual only and should be enabled either once the work
needed to maintain the steady state QPS is merged, or without assertions
using roachperf.

Resolves: https://github.com/cockroachdb/cockroach/issues/116640
Resolves: https://github.com/cockroachdb/cockroach/issues/116823

Release note: None