### PR TITLE
release-23.1: ci: migrate CI docker images to GCP

### DIFF
--- a/build/.bazelbuilderversion
+++ b/build/.bazelbuilderversion
@@ -1,1 +1,1 @@
-cockroachdb/bazel:20230815-141035
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20230815-141035

--- a/build/.bazelbuilderversion-fips
+++ b/build/.bazelbuilderversion-fips
@@ -1,1 +1,1 @@
-cockroachdb/bazel-fips:20230815-141035
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel-fips:20230815-141035

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -173,7 +173,7 @@ if [ $ARCH = x86_64 ]; then
     do
         git checkout "$branch"
         # TODO(benesch): store the acceptanceversion somewhere more accessible.
-        docker pull $(git grep cockroachdb/acceptance -- '*.go' | sed -E 's/.*"([^"]*).*"/\1/') || true
+        docker pull $(git grep us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance -- '*.go' | sed -E 's/.*"([^"]*).*"/\1/') || true
     done
     cd -
 fi

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -8,7 +8,8 @@ fi
 BAZEL_IMAGE=$(cat $root/build/.bazelbuilderversion)
 
 # Call `run_bazel $NAME_OF_SCRIPT` to start an appropriately-configured Docker
-# container with the `cockroachdb/bazel` image running the given script.
+# container with the `us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel`
+# image running the given script.
 # BAZEL_SUPPORT_EXTRA_DOCKER_ARGS will be passed on to `docker run` unchanged.
 run_bazel() {
     # Set up volumes.

--- a/build/teamcity/internal/cockroach/build/ci/build-and-push-bazel-builder-image.sh
+++ b/build/teamcity/internal/cockroach/build/ci/build-and-push-bazel-builder-image.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
+source "$dir/release/teamcity-support.sh"
+
+gar_repository="us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel"
+docker_login_gcr "$gar_repository" "$IMAGE_BUILDER_GOOGLE_CREDENTIALS"
+
 TAG=$(date +%Y%m%d-%H%M%S)
 docker buildx create --name "builder-$TAG" --use
-docker buildx build --push --platform linux/amd64,linux/arm64 -t "cockroachdb/bazel:$TAG" -t "cockroachdb/bazel:latest-do-not-use" build/bazelbuilder
+docker buildx build --push --platform linux/amd64,linux/arm64 -t "$gar_repository:$TAG" -t "$gar_repository:latest-do-not-use" build/bazelbuilder
 
 if [[ "$open_pr_on_success" == "true" ]]; then
     # Trigger "Open New Bazel Builder Image PR".
@@ -16,7 +22,7 @@ if [[ "$open_pr_on_success" == "true" ]]; then
       <buildType id="Internal_Cockroach_Build_Ci_OpenNewBazelBuilderImagePr"/>
        <properties>
             <property name="env.BRANCH" value="'"bazel-builder-update-$TAG"'"/>
-            <property name="env.VERSION" value="'"cockroachdb/bazel:$TAG"'"/>
+            <property name="env.VERSION" value="'"$gar_repository:$TAG"'"/>
         </properties>
     </build>'
 else

--- a/build/teamcity/internal/cockroach/build/ci/nightly-bazel-builder-update-check.sh
+++ b/build/teamcity/internal/cockroach/build/ci/nightly-bazel-builder-update-check.sh
@@ -2,7 +2,7 @@
 set -xeuo pipefail
 
 BASE_IMAGE="ubuntu:focal"
-BAZEL_IMAGE="cockroachdb/bazel:latest-do-not-use"
+BAZEL_IMAGE="us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:latest-do-not-use"
 
 docker pull $BASE_IMAGE && docker pull $BAZEL_IMAGE
 LATEST_BASE_IMAGE_CREATE_DT="$(docker inspect $BASE_IMAGE -f '{{.Created}}')"

--- a/build/toolchains/toolchainbuild/crosstool-ng/buildtoolchains.sh
+++ b/build/toolchains/toolchainbuild/crosstool-ng/buildtoolchains.sh
@@ -7,8 +7,7 @@ toplevel="$(dirname $(dirname $(dirname $(dirname $this_dir))))"
 
 mkdir -p "${toplevel}"/artifacts
 
-# note: the Docker image should match the base image of
-# `cockroachdb/builder` and `cockroachdb/bazel`.
+# note: the Docker image should match the base image of `us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel`.
 docker run --rm -i ${tty-} -v $this_dir:/bootstrap \
        -v "${toplevel}"/artifacts:/artifacts \
        ubuntu:focal-20210119 /bootstrap/perform-build.sh

--- a/build/toolchains/toolchainbuild/osxcross/buildtoolchains.sh
+++ b/build/toolchains/toolchainbuild/osxcross/buildtoolchains.sh
@@ -7,8 +7,7 @@ toplevel="$(dirname $(dirname $(dirname $(dirname $this_dir))))"
 
 mkdir -p "${toplevel}"/artifacts
 
-# note: the Docker image should match the base image of
-# `cockroachdb/builder` and `cockroachdb/bazel`.
+# note: the Docker image should match the base image of `us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel`.
 docker run --rm -i ${tty-} -v $this_dir:/bootstrap \
        -v "${toplevel}"/artifacts:/artifacts \
        ubuntu:focal-20210119 /bootstrap/perform-build.sh

--- a/pkg/acceptance/cluster/docker.go
+++ b/pkg/acceptance/cluster/docker.go
@@ -80,7 +80,11 @@ func hasImage(ctx context.Context, l *DockerCluster, ref string) error {
 	if err != nil {
 		return err
 	}
-	path := reference.Path(distributionRef)
+	path := distributionRef.Name()
+	// Images hosted on docker.io have local name without the domain name
+	if strings.HasPrefix(path, "docker.io") {
+		path = reference.Path(distributionRef)
+	}
 	// Correct for random docker stupidity:
 	//
 	// https://github.com/moby/moby/blob/7248742/registry/service.go#L207:L215
@@ -113,7 +117,7 @@ func hasImage(ctx context.Context, l *DockerCluster, ref string) error {
 	var imageList []string
 	for _, image := range images {
 		for _, tag := range image.RepoTags {
-			imageList = append(imageList, "%s %s", tag, image.ID)
+			imageList = append(imageList, fmt.Sprintf("%s %s", tag, image.ID))
 		}
 	}
 	return errors.Errorf("%s not found in:\n%s", wanted, strings.Join(imageList, "\n"))

--- a/pkg/acceptance/compose/gss/build-push-gss.sh
+++ b/pkg/acceptance/compose/gss/build-push-gss.sh
@@ -4,4 +4,4 @@ set -xeuo pipefail
 TARGET=$1
 TAG=$(date +%Y%m%d-%H%M%S)
 docker buildx create --use
-docker buildx build --push --platform linux/amd64,linux/arm64 -t cockroachdb/acceptance-gss-$TARGET:$TAG ./$TARGET
+docker buildx build --push --platform linux/amd64,linux/arm64 -t us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-$TARGET:$TAG ./$TARGET

--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   kdc:
-    image: cockroachdb/acceptance-gss-kdc:20221214-131000
+    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-kdc:20221214-131000
     volumes:
       - ./kdc/start.sh:/start.sh
       - keytab:/keytab
@@ -17,7 +17,7 @@ services:
       - keytab:/keytab
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach
   python:
-    image: cockroachdb/acceptance-gss-python:20221214-141947
+    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-python:20221214-141947
     user: "${UID}:${GID}"
     depends_on:
       - cockroach

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   kdc:
-    image: cockroachdb/acceptance-gss-kdc:20221214-131000
+    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-kdc:20221214-131000
     volumes:
       - ./kdc/start.sh:/start.sh
       - keytab:/keytab
@@ -17,7 +17,7 @@ services:
       - keytab:/keytab
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach
   psql:
-    image: cockroachdb/acceptance-gss-psql:20221215-102339
+    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-psql:20221215-102339
     user: "${UID}:${GID}"
     depends_on:
       - cockroach

--- a/pkg/acceptance/testdata/README.md
+++ b/pkg/acceptance/testdata/README.md
@@ -1,10 +1,11 @@
 # Acceptance Test Harnesses
 
-The Dockerfile in this directory builds an image, `cockroachdb/acceptance`, in
-which we run our language-specific acceptance tests. For each language we
-support, we install the compiler or runtime, and typically the Postgres driver,
-into the image. Where possible, we use packages provided by Debian; otherwise we
-invoke the language's package manager while building the image.
+The Dockerfile in this directory builds an image,
+`us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance`, in which we run
+our language-specific acceptance tests. For each language we support, we
+install the compiler or runtime, and typically the Postgres driver, into the
+image. Where possible, we use packages provided by Debian; otherwise we invoke
+the language's package manager while building the image.
 
 In all cases, the language's package manager is removed or put into offline mode
 before the image is fully baked to ensure that we don't accidentally introduce a
@@ -19,7 +20,7 @@ need to update the image.
 ```
     TAG=$(date +%Y%m%d-%H%M%S)
     docker buildx create --use
-    docker buildx build --push --platform linux/amd64,linux/arm64 -t cockroachdb/acceptance:$TAG .
+    docker buildx build --push --platform linux/amd64,linux/arm64 -t us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance:$TAG .
 ```
 
 No need to have your changes reviewed before you push an image, as we pin the

--- a/pkg/acceptance/util_docker.go
+++ b/pkg/acceptance/util_docker.go
@@ -62,7 +62,7 @@ func testDockerSuccess(ctx context.Context, t *testing.T, name string, cmd []str
 const (
 	// Iterating against a locally built version of the docker image can be done
 	// by changing acceptanceImage to the hash of the container.
-	acceptanceImage = "docker.io/cockroachdb/acceptance:20221005-223354"
+	acceptanceImage = "us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance:20221005-223354"
 )
 
 func testDocker(

--- a/pkg/cmd/dev/testdata/recorderdriven/builder
+++ b/pkg/cmd/dev/testdata/recorderdriven/builder
@@ -6,7 +6,7 @@ bazel info workspace --color=no
 cat crdb-checkout/build/.bazelbuilderversion
 docker volume inspect bzlhome
 mkdir crdb-checkout/artifacts
-docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220328-163955
+docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20220328-163955
 
 dev builder echo hi
 ----
@@ -16,4 +16,4 @@ bazel info workspace --color=no
 cat crdb-checkout/build/.bazelbuilderversion
 docker volume inspect bzlhome
 mkdir crdb-checkout/artifacts
-docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220328-163955 echo hi
+docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20220328-163955 echo hi

--- a/pkg/cmd/dev/testdata/recorderdriven/builder.rec
+++ b/pkg/cmd/dev/testdata/recorderdriven/builder.rec
@@ -9,7 +9,7 @@ id
 cat crdb-checkout/build/.bazelbuilderversion
 ----
 ----
-cockroachdb/bazel:20220328-163955
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20220328-163955
 ----
 ----
 
@@ -30,7 +30,7 @@ docker volume inspect bzlhome
 mkdir crdb-checkout/artifacts
 ----
 
-docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220328-163955
+docker run --rm -it -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20220328-163955
 ----
 
 which docker
@@ -44,7 +44,7 @@ id
 cat crdb-checkout/build/.bazelbuilderversion
 ----
 ----
-cockroachdb/bazel:20220328-163955
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20220328-163955
 ----
 ----
 
@@ -65,6 +65,6 @@ docker volume inspect bzlhome
 mkdir crdb-checkout/artifacts
 ----
 
-docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 cockroachdb/bazel:20220328-163955 echo hi
+docker run --rm -i -v crdb-checkout:/cockroach --workdir=/cockroach -v crdb-checkout/build/bazelutil/empty.bazelrc:/cockroach/.bazelrc.user -v crdb-checkout/artifacts:/artifacts -v bzlhome:/home/roach:delegated -u 502:502 us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20220328-163955 echo hi
 ----
 


### PR DESCRIPTION
Backport 1/1 commits from #117663.

/cc @cockroachdb/release

---

Previously, we used Docker Hub to host our CI docker images.

To improve service reliability, this PR moves the used docker images to GAR.

Part of: DEVINF-915
Epic: RE-539
Release note: None
Release justification: CI changes