### PR TITLE
plpgsql: add support for nested blocks

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_block
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_block
@@ -1,0 +1,479 @@
+# LogicTest: !local-mixed-23.1
+
+statement ok
+CREATE TABLE ab (a INT, b INT);
+
+subtest nested_block
+
+# Verify the following:
+# * variables from outer blocks are visible in nested blocks
+# * nested blocks can assign to variables from outer blocks
+# * assignments made in nested blocks should be visible after control returns
+statement ok
+CREATE PROCEDURE p(x INT) AS $$
+  DECLARE
+    y INT := 10;
+  BEGIN
+    x := x + 1;
+    y := y + 1;
+    RAISE NOTICE '% %', x, y;
+    DECLARE
+      z INT := 100;
+    BEGIN
+      x := x + 1;
+      y := y + 1;
+      z := z + 1;
+      RAISE NOTICE '% % %', x, y, z;
+    END;
+    x := x + 1;
+    y := y + 1;
+    RAISE NOTICE '% %', x, y;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+CALL p(1);
+----
+NOTICE: 2 11
+NOTICE: 3 12 101
+NOTICE: 4 13
+
+# Case with mutually nested blocks and IF statements, as well as RETURN
+# statements within nested blocks.
+statement ok
+CREATE FUNCTION f(x INT) RETURNS TEXT AS $$
+  BEGIN
+    IF x = 0 THEN
+      RETURN 'a';
+    ELSIF x = 1 THEN
+      DECLARE
+        y TEXT;
+      BEGIN
+        y := 'b';
+        RETURN y;
+      END;
+    END IF;
+    DECLARE
+      y INT := x * 2;
+    BEGIN
+      IF y >= 10 THEN
+        RETURN y::TEXT;
+      END IF;
+    END;
+    RETURN 'c';
+  END
+$$ LANGUAGE PLpgSQL;
+
+query TTTT
+SELECT f(0), f(1), f(2), f(5);
+----
+a  b  c  10
+
+# Case with nested block with a loop.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p(x INT) AS $$
+  BEGIN
+    DECLARE
+      i INT := 0;
+    BEGIN
+      WHILE i < x LOOP
+        DECLARE
+          j INT := 0;
+        BEGIN
+          WHILE j < i LOOP
+            RAISE NOTICE '%, %', i, j;
+            j := j + 1;
+          END LOOP;
+          RAISE NOTICE 'final j: %', j;
+        END;
+        i := i + 1;
+      END LOOP;
+      RAISE NOTICE 'final i: %', i;
+    END;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+CALL p(0);
+----
+NOTICE: final i: 0
+
+query T noticetrace
+CALL p(1);
+----
+NOTICE: final j: 0
+NOTICE: final i: 1
+
+query T noticetrace
+CALL p(3);
+----
+NOTICE: final j: 0
+NOTICE: 1, 0
+NOTICE: final j: 1
+NOTICE: 2, 0
+NOTICE: 2, 1
+NOTICE: final j: 2
+NOTICE: final i: 3
+
+subtest nested_block_cursors
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() AS $$
+  DECLARE
+    curs1 CURSOR FOR SELECT 1 FROM generate_series(1, 10);
+    curs2 CURSOR FOR SELECT 2 FROM generate_series(1, 10);
+    curs3 REFCURSOR;
+    curs4 REFCURSOR;
+    scratch INT;
+  BEGIN
+    OPEN curs1;
+    OPEN curs3 FOR SELECT 3 FROM generate_series(1, 10);
+    RAISE NOTICE 'a%', scratch;
+    FETCH curs1 INTO scratch;
+    RAISE NOTICE 'a%', scratch;
+    FETCH curs3 INTO scratch;
+    RAISE NOTICE 'a%', scratch;
+    DECLARE
+      curs5 CURSOR FOR SELECT 5 FROM generate_series(1, 10);
+      curs6 REFCURSOR;
+    BEGIN
+      OPEN curs2;
+      OPEN curs4 FOR SELECT 4 FROM generate_series(1, 10);
+      OPEN curs5;
+      OPEN curs6 FOR SELECT 6 FROM generate_series(1, 10);
+      FETCH curs1 INTO scratch;
+      RAISE NOTICE 'a%', scratch;
+      FETCH curs2 INTO scratch;
+      RAISE NOTICE 'a%', scratch;
+      FETCH curs3 INTO scratch;
+      RAISE NOTICE 'a%', scratch;
+      FETCH curs4 INTO scratch;
+      RAISE NOTICE 'a%', scratch;
+      FETCH curs5 INTO scratch;
+      RAISE NOTICE 'a%', scratch;
+      FETCH curs6 INTO scratch;
+      RAISE NOTICE 'a%', scratch;
+    END;
+    BEGIN
+      FETCH curs1 INTO scratch;
+      RAISE NOTICE 'a%', scratch;
+      FETCH curs2 INTO scratch;
+      RAISE NOTICE 'a%', scratch;
+      FETCH curs3 INTO scratch;
+      RAISE NOTICE 'a%', scratch;
+      FETCH curs4 INTO scratch;
+      RAISE NOTICE 'a%', scratch;
+    END;
+    FETCH curs1 INTO scratch;
+    RAISE NOTICE 'a%', scratch;
+    FETCH curs2 INTO scratch;
+    RAISE NOTICE 'a%', scratch;
+    FETCH curs3 INTO scratch;
+    RAISE NOTICE 'a%', scratch;
+    FETCH curs4 INTO scratch;
+    RAISE NOTICE 'a%', scratch;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: a<NULL>
+NOTICE: a1
+NOTICE: a3
+NOTICE: a1
+NOTICE: a2
+NOTICE: a3
+NOTICE: a4
+NOTICE: a5
+NOTICE: a6
+NOTICE: a1
+NOTICE: a2
+NOTICE: a3
+NOTICE: a4
+NOTICE: a1
+NOTICE: a2
+NOTICE: a3
+NOTICE: a4
+
+subtest nested_block_exceptions
+
+# Don't catch an exception thrown from the variable declarations.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() AS $$
+  DECLARE
+    x INT := 0;
+  BEGIN
+    RAISE NOTICE '%', x;
+    DECLARE
+      y INT := 1 // x;
+    BEGIN
+      RAISE NOTICE '% %', x, y;
+    EXCEPTION
+      WHEN division_by_zero THEN
+        RAISE NOTICE 'oops!';
+    END;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 22012 pq: division by zero
+CALL p();
+
+# Catch an exception thrown from the nested block's body statements.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() AS $$
+  DECLARE
+    x INT := 0;
+  BEGIN
+    RAISE NOTICE '%', x;
+    DECLARE
+      y INT;
+    BEGIN
+      y := 1 // x;
+      RAISE NOTICE '% %', x, y;
+    EXCEPTION
+      WHEN division_by_zero THEN
+        RAISE NOTICE 'oops!';
+    END;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: 0
+NOTICE: oops!
+
+# If an exception is thrown and caught within an inner block, the outer block
+# is not rolled back, and execution can continue.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() AS $$
+  BEGIN
+    INSERT INTO ab VALUES (1, 2);
+    BEGIN
+      INSERT INTO ab VALUES (3, 4);
+      SELECT 1 // 0;
+      INSERT INTO ab VALUES (5, 6);
+    EXCEPTION WHEN division_by_zero THEN
+      RAISE NOTICE 'saw exception';
+    END;
+    INSERT INTO ab VALUES (7, 8);
+    RAISE NOTICE 'finished execution of outer block';
+  END
+$$ LANGUAGE PLpgSQL;
+
+query II rowsort
+SELECT * FROM ab;
+----
+
+query T noticetrace
+CALL p()
+----
+NOTICE: saw exception
+NOTICE: finished execution of outer block
+
+query II rowsort
+SELECT * FROM ab;
+----
+1  2
+7  8
+
+# A variable assignment within a nested block's exception handler should be
+# visible when control returns to the outer block.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() AS $$
+  DECLARE
+    x INT := 0;
+  BEGIN
+    RAISE NOTICE '%', x;
+    BEGIN
+      SELECT 1 // 0;
+    EXCEPTION
+      WHEN division_by_zero THEN
+        x := 100;
+    END;
+    RAISE NOTICE '%', x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: 0
+NOTICE: 100
+
+# Cursors opened in a nested block should be closed when the block handles an
+# exception. Cursors opened in the outer block should remain open.
+# A cursor opened in a nested block's exception handler should be visible
+# in the outer block.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p(x INT) AS $$
+  DECLARE
+    curs1 REFCURSOR;
+    curs2 REFCURSOR;
+    curs3 REFCURSOR;
+  BEGIN
+    OPEN curs1 FOR SELECT 1;
+    BEGIN
+      OPEN curs2 FOR SELECT 2;
+      SELECT 1 // 0;
+    EXCEPTION
+      WHEN division_by_zero THEN
+        OPEN curs3 FOR SELECT 3;
+    END;
+    IF x = 1 THEN
+      FETCH curs1 INTO x;
+    ELSIF x = 2 THEN
+      FETCH curs2 INTO x;
+    ELSE
+      FETCH curs3 INTO x;
+    END IF;
+    RAISE NOTICE '%', x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+CALL p(1);
+----
+NOTICE: 1
+
+statement error pgcode 34000 pq: cursor \"<unnamed portal 11>\" does not exist
+CALL p(2);
+
+query T noticetrace
+CALL p(3);
+----
+NOTICE: 3
+
+# A block can be nested in an exception handler.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() AS $$
+  BEGIN
+    BEGIN
+      SELECT 1 // 0;
+    EXCEPTION
+      WHEN division_by_zero THEN
+        RAISE NOTICE 'outer handler';
+        DECLARE
+          x INT := 100;
+        BEGIN
+          RAISE NOTICE 'inner block x=%', x;
+        END;
+    END;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: outer handler
+NOTICE: inner block 100
+
+# A block nested in an exception handler can have its own exception handler.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p() AS $$
+  BEGIN
+    BEGIN
+      SELECT 1 // 0;
+    EXCEPTION
+      WHEN division_by_zero THEN
+        RAISE NOTICE 'outer handler';
+        DECLARE
+          x INT := 100;
+        BEGIN
+          RAISE NOTICE 'inner block';
+          SELECT 1 // 0;
+        EXCEPTION WHEN division_by_zero THEN
+          RAISE NOTICE 'inner handler x=%', x;
+        END;
+    END;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: outer handler
+NOTICE: inner block
+NOTICE: inner handler 100
+
+subtest error
+
+statement ok
+DROP PROCEDURE IF EXISTS p();
+DROP FUNCTION IF EXISTS f();
+
+# Detect duplicate declarations in a block.
+statement error pgcode 42601 pq: duplicate declaration at or near \"x\"
+CREATE PROCEDURE p() AS $$
+  DECLARE
+    x INT := 0;
+    x INT := 1;
+  BEGIN
+    RAISE NOTICE '%', x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# A variable declared in an inner block falls out of scope when control returns
+# to the outer block.
+statement error pgcode 42703 pq: column \"y\" does not exist
+CREATE PROCEDURE p() AS $$
+  DECLARE
+    x INT := 0;
+  BEGIN
+    DECLARE
+      y INT := 1;
+    BEGIN
+      RAISE NOTICE '% %', x, y;
+    END;
+    RAISE NOTICE '% %', x, y;
+  END
+$$ LANGUAGE PLpgSQL;
+
+subtest unimplemented
+
+statement ok
+DROP PROCEDURE IF EXISTS p;
+
+# Variable shadowing is not yet allowed (tracked in #117508).
+statement error pgcode 0A000 pq: unimplemented: variable shadowing is not yet implemented
+CREATE PROCEDURE p() AS $$
+  DECLARE
+    x INT := 0;
+  BEGIN
+    DECLARE
+      x INT := 1;
+    BEGIN
+      RAISE NOTICE '%', x;
+    END;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# A block cannot currently be nested in a block with an exception handler
+# (tracked in #118551).
+statement error pgcode 0A000 pq: unimplemented: PL/pgSQL blocks cannot yet be nested within a block that has an exception handler
+CREATE PROCEDURE p() AS $$
+  DECLARE
+    x INT := 0;
+  BEGIN
+    RAISE NOTICE '%', x;
+    DECLARE
+      y INT := 1 // x;
+    BEGIN
+      RAISE NOTICE '% %', x, y;
+    END;
+  EXCEPTION
+    WHEN division_by_zero THEN
+      RAISE NOTICE 'oops!';
+  END
+$$ LANGUAGE PLpgSQL;
+
+subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_rewrite
@@ -48,6 +48,21 @@ $$
   BEGIN
     RAISE NOTICE USING MESSAGE = format('next val: %d',nextval('seq'));
     RAISE NOTICE 'val1: %, val2: %', nextval('seq'), nextval('seq');
+    DECLARE
+      k INT := nextval('seq');
+    BEGIN
+      RAISE NOTICE 'k: %, nextval: %', k, nextval('seq');
+      IF k > 0 THEN
+        SELECT nextval('seq');
+      END IF;
+    EXCEPTION
+      WHEN division_by_zero THEN
+        RAISE NOTICE USING MESSAGE = format('next val: %d',nextval('seq'));
+      WHEN not_null_violation THEN
+        SELECT nextval('seq');
+        SELECT nextval('seq');
+        RAISE NOTICE USING MESSAGE = format('next val: %d',nextval('seq'));
+    END;
     WHILE nextval('seq') < 10 LOOP
       i = nextval('seq');
       SELECT nextval('seq');
@@ -64,20 +79,13 @@ $$
     END LOOP;
     OPEN curs FOR SELECT nextval('seq');
     RETURN nextval('seq');
-  EXCEPTION
-    WHEN division_by_zero THEN
-      RAISE NOTICE USING MESSAGE = format('next val: %d',nextval('seq'));
-    WHEN not_null_violation THEN
-      SELECT nextval('seq');
-      SELECT nextval('seq');
-      RAISE NOTICE USING MESSAGE = format('next val: %d',nextval('seq'));
   END
 $$ LANGUAGE PLPGSQL;
 
 query T
 SELECT get_body_str('f_rewrite');
 ----
-"DECLARE\ni INT8 := nextval(106:::REGCLASS);\nj INT8 := nextval(106:::REGCLASS);\ncurs REFCURSOR := nextval(106:::REGCLASS)::STRING;\ncurs2 CURSOR FOR SELECT nextval(106:::REGCLASS);\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nRAISE NOTICE 'val1: %, val2: %', nextval(106:::REGCLASS), nextval(106:::REGCLASS);\nWHILE nextval(106:::REGCLASS) < 10:::INT8 LOOP\ni := nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nIF nextval(106:::REGCLASS) = 1:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\n\tCONTINUE;\nELSIF nextval(106:::REGCLASS) = 2:::INT8 THEN\n\tSELECT v FROM ROWS FROM (nextval(106:::REGCLASS)) AS v (\"int\") INTO i;\nELSIF nextval(106:::REGCLASS) = 3:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT nextval(106:::REGCLASS);\nRETURN nextval(106:::REGCLASS);\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nWHEN not_null_violation THEN\nSELECT nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nEND;\n"
+"DECLARE\ni INT8 := nextval(106:::REGCLASS);\nj INT8 := nextval(106:::REGCLASS);\ncurs REFCURSOR := nextval(106:::REGCLASS)::STRING;\ncurs2 CURSOR FOR SELECT nextval(106:::REGCLASS);\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nRAISE NOTICE 'val1: %, val2: %', nextval(106:::REGCLASS), nextval(106:::REGCLASS);\nDECLARE\nk INT8 := nextval(106:::REGCLASS);\nBEGIN\nRAISE NOTICE 'k: %, nextval: %', k, nextval(106:::REGCLASS);\nIF k > 0 THEN\n\tSELECT nextval(106:::REGCLASS);\nEND IF;\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nWHEN not_null_violation THEN\nSELECT nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nEND;\nWHILE nextval(106:::REGCLASS) < 10:::INT8 LOOP\ni := nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nIF nextval(106:::REGCLASS) = 1:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\n\tCONTINUE;\nELSIF nextval(106:::REGCLASS) = 2:::INT8 THEN\n\tSELECT v FROM ROWS FROM (nextval(106:::REGCLASS)) AS v (\"int\") INTO i;\nELSIF nextval(106:::REGCLASS) = 3:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT nextval(106:::REGCLASS);\nRETURN nextval(106:::REGCLASS);\nEND;\n"
 
 query TT
 SHOW CREATE FUNCTION f_rewrite;
@@ -98,6 +106,23 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              RAISE NOTICE
              USING MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
              RAISE NOTICE 'val1: %, val2: %', nextval('public.seq'::REGCLASS), nextval('public.seq'::REGCLASS);
+             DECLARE
+             k INT8 := nextval('public.seq'::REGCLASS);
+             BEGIN
+             RAISE NOTICE 'k: %, nextval: %', k, nextval('public.seq'::REGCLASS);
+             IF k > 0 THEN
+               SELECT nextval('public.seq'::REGCLASS);
+             END IF;
+             EXCEPTION
+             WHEN division_by_zero THEN
+             RAISE NOTICE
+             USING MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
+             WHEN not_null_violation THEN
+             SELECT nextval('public.seq'::REGCLASS);
+             SELECT nextval('public.seq'::REGCLASS);
+             RAISE NOTICE
+             USING MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
+             END;
              WHILE nextval('public.seq'::REGCLASS) < 10:::INT8 LOOP
              i := nextval('public.seq'::REGCLASS);
              SELECT nextval('public.seq'::REGCLASS);
@@ -114,15 +139,6 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              END LOOP;
              OPEN curs FOR SELECT nextval('public.seq'::REGCLASS);
              RETURN nextval('public.seq'::REGCLASS);
-             EXCEPTION
-             WHEN division_by_zero THEN
-             RAISE NOTICE
-             USING MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
-             WHEN not_null_violation THEN
-             SELECT nextval('public.seq'::REGCLASS);
-             SELECT nextval('public.seq'::REGCLASS);
-             RAISE NOTICE
-             USING MESSAGE = format('next val: %d':::STRING, nextval('public.seq'::REGCLASS));
              END;
            $$
 
@@ -132,7 +148,7 @@ ALTER SEQUENCE seq RENAME TO renamed;
 query T
 SELECT get_body_str('f_rewrite');
 ----
-"DECLARE\ni INT8 := nextval(106:::REGCLASS);\nj INT8 := nextval(106:::REGCLASS);\ncurs REFCURSOR := nextval(106:::REGCLASS)::STRING;\ncurs2 CURSOR FOR SELECT nextval(106:::REGCLASS);\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nRAISE NOTICE 'val1: %, val2: %', nextval(106:::REGCLASS), nextval(106:::REGCLASS);\nWHILE nextval(106:::REGCLASS) < 10:::INT8 LOOP\ni := nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nIF nextval(106:::REGCLASS) = 1:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\n\tCONTINUE;\nELSIF nextval(106:::REGCLASS) = 2:::INT8 THEN\n\tSELECT v FROM ROWS FROM (nextval(106:::REGCLASS)) AS v (\"int\") INTO i;\nELSIF nextval(106:::REGCLASS) = 3:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT nextval(106:::REGCLASS);\nRETURN nextval(106:::REGCLASS);\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nWHEN not_null_violation THEN\nSELECT nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nEND;\n"
+"DECLARE\ni INT8 := nextval(106:::REGCLASS);\nj INT8 := nextval(106:::REGCLASS);\ncurs REFCURSOR := nextval(106:::REGCLASS)::STRING;\ncurs2 CURSOR FOR SELECT nextval(106:::REGCLASS);\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nRAISE NOTICE 'val1: %, val2: %', nextval(106:::REGCLASS), nextval(106:::REGCLASS);\nDECLARE\nk INT8 := nextval(106:::REGCLASS);\nBEGIN\nRAISE NOTICE 'k: %, nextval: %', k, nextval(106:::REGCLASS);\nIF k > 0 THEN\n\tSELECT nextval(106:::REGCLASS);\nEND IF;\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nWHEN not_null_violation THEN\nSELECT nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nRAISE NOTICE\nUSING MESSAGE = format('next val: %d':::STRING, nextval(106:::REGCLASS));\nEND;\nWHILE nextval(106:::REGCLASS) < 10:::INT8 LOOP\ni := nextval(106:::REGCLASS);\nSELECT nextval(106:::REGCLASS);\nIF nextval(106:::REGCLASS) = 1:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\n\tCONTINUE;\nELSIF nextval(106:::REGCLASS) = 2:::INT8 THEN\n\tSELECT v FROM ROWS FROM (nextval(106:::REGCLASS)) AS v (\"int\") INTO i;\nELSIF nextval(106:::REGCLASS) = 3:::INT8 THEN\n\tSELECT nextval(106:::REGCLASS);\n\tSELECT nextval(106:::REGCLASS);\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT nextval(106:::REGCLASS);\nRETURN nextval(106:::REGCLASS);\nEND;\n"
 
 query TT
 SHOW CREATE FUNCTION f_rewrite;
@@ -153,6 +169,23 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              RAISE NOTICE
              USING MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
              RAISE NOTICE 'val1: %, val2: %', nextval('public.renamed'::REGCLASS), nextval('public.renamed'::REGCLASS);
+             DECLARE
+             k INT8 := nextval('public.renamed'::REGCLASS);
+             BEGIN
+             RAISE NOTICE 'k: %, nextval: %', k, nextval('public.renamed'::REGCLASS);
+             IF k > 0 THEN
+               SELECT nextval('public.renamed'::REGCLASS);
+             END IF;
+             EXCEPTION
+             WHEN division_by_zero THEN
+             RAISE NOTICE
+             USING MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
+             WHEN not_null_violation THEN
+             SELECT nextval('public.renamed'::REGCLASS);
+             SELECT nextval('public.renamed'::REGCLASS);
+             RAISE NOTICE
+             USING MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
+             END;
              WHILE nextval('public.renamed'::REGCLASS) < 10:::INT8 LOOP
              i := nextval('public.renamed'::REGCLASS);
              SELECT nextval('public.renamed'::REGCLASS);
@@ -169,15 +202,6 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              END LOOP;
              OPEN curs FOR SELECT nextval('public.renamed'::REGCLASS);
              RETURN nextval('public.renamed'::REGCLASS);
-             EXCEPTION
-             WHEN division_by_zero THEN
-             RAISE NOTICE
-             USING MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
-             WHEN not_null_violation THEN
-             SELECT nextval('public.renamed'::REGCLASS);
-             SELECT nextval('public.renamed'::REGCLASS);
-             RAISE NOTICE
-             USING MESSAGE = format('next val: %d':::STRING, nextval('public.renamed'::REGCLASS));
              END;
            $$
 
@@ -199,6 +223,20 @@ $$
   BEGIN
     RAISE NOTICE USING MESSAGE = format('val: %d','wednesday'::weekday);
     RAISE NOTICE 'val1: %, val2: %', 'wednesday'::weekday, 'thursday'::weekday;
+    DECLARE
+      yesterday weekday := 'wednesday'::weekday;
+    BEGIN
+      RAISE NOTICE 'val3: %, val4: %', 'wednesday'::weekday, 'thursday'::weekday;
+      IF yesterday IS NOT NULL THEN
+        SELECT 'wednesday'::weekday;
+      END IF;
+    EXCEPTION
+      WHEN division_by_zero THEN
+        RAISE NOTICE USING MESSAGE = format('val: %d','wednesday'::weekday);
+      WHEN not_null_violation THEN
+        SELECT 'wednesday'::weekday;
+        RAISE NOTICE 'val: %', 'wednesday'::weekday;
+    END;
     WHILE day != 'wednesday'::weekday LOOP
       day = 'friday'::weekday;
       SELECT 'wednesday'::weekday;
@@ -215,19 +253,13 @@ $$
     END LOOP;
     OPEN curs FOR SELECT 'wednesday'::weekday;
     RETURN 'wednesday'::weekday;
-  EXCEPTION
-    WHEN division_by_zero THEN
-      RAISE NOTICE USING MESSAGE = format('val: %d','wednesday'::weekday);
-    WHEN not_null_violation THEN
-      SELECT 'wednesday'::weekday;
-      RAISE NOTICE 'val: %', 'wednesday'::weekday;
   END
 $$ LANGUAGE PLPGSQL;
 
 query T
 SELECT get_body_str('f_rewrite');
 ----
-"DECLARE\nday @100107 := b'\\x80':::@100107;\ntoday @100107 := b'\\xa0':::@100107;\ncurs REFCURSOR := b' ':::@100107::STRING;\ncurs2 CURSOR FOR SELECT b'@':::@100107;\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nRAISE NOTICE 'val1: %, val2: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nWHILE day != b'\\x80':::@100107 LOOP\nday := b'\\xc0':::@100107;\nSELECT b'\\x80':::@100107;\nIF day = b'\\x80':::@100107 THEN\n\tday := b'\\xa0':::@100107;\n\tSELECT b'@':::@100107;\n\tCONTINUE;\nELSIF day = b' ':::@100107 THEN\n\tSELECT b'@':::@100107 INTO day;\nELSIF day = b'@':::@100107 THEN\n\tSELECT b'\\x80':::@100107 INTO day;\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT b'\\x80':::@100107;\nRETURN b'\\x80':::@100107;\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nWHEN not_null_violation THEN\nSELECT b'\\x80':::@100107;\nRAISE NOTICE 'val: %', b'\\x80':::@100107;\nEND;\n"
+"DECLARE\nday @100107 := b'\\x80':::@100107;\ntoday @100107 := b'\\xa0':::@100107;\ncurs REFCURSOR := b' ':::@100107::STRING;\ncurs2 CURSOR FOR SELECT b'@':::@100107;\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nRAISE NOTICE 'val1: %, val2: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nDECLARE\nyesterday @100107 := b'\\x80':::@100107;\nBEGIN\nRAISE NOTICE 'val3: %, val4: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nIF yesterday IS NOT NULL THEN\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nWHEN not_null_violation THEN\nSELECT b'\\x80':::@100107;\nRAISE NOTICE 'val: %', b'\\x80':::@100107;\nEND;\nWHILE day != b'\\x80':::@100107 LOOP\nday := b'\\xc0':::@100107;\nSELECT b'\\x80':::@100107;\nIF day = b'\\x80':::@100107 THEN\n\tday := b'\\xa0':::@100107;\n\tSELECT b'@':::@100107;\n\tCONTINUE;\nELSIF day = b' ':::@100107 THEN\n\tSELECT b'@':::@100107 INTO day;\nELSIF day = b'@':::@100107 THEN\n\tSELECT b'\\x80':::@100107 INTO day;\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT b'\\x80':::@100107;\nRETURN b'\\x80':::@100107;\nEND;\n"
 
 query TT
 SHOW CREATE FUNCTION f_rewrite;
@@ -248,6 +280,21 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              RAISE NOTICE
              USING MESSAGE = format('val: %d':::STRING, 'wednesday':::test.public.weekday);
              RAISE NOTICE 'val1: %, val2: %', 'wednesday':::test.public.weekday, 'thursday':::test.public.weekday;
+             DECLARE
+             yesterday test.public.weekday := 'wednesday':::test.public.weekday;
+             BEGIN
+             RAISE NOTICE 'val3: %, val4: %', 'wednesday':::test.public.weekday, 'thursday':::test.public.weekday;
+             IF yesterday IS NOT NULL THEN
+               SELECT 'wednesday':::test.public.weekday;
+             END IF;
+             EXCEPTION
+             WHEN division_by_zero THEN
+             RAISE NOTICE
+             USING MESSAGE = format('val: %d':::STRING, 'wednesday':::test.public.weekday);
+             WHEN not_null_violation THEN
+             SELECT 'wednesday':::test.public.weekday;
+             RAISE NOTICE 'val: %', 'wednesday':::test.public.weekday;
+             END;
              WHILE day != 'wednesday':::test.public.weekday LOOP
              day := 'friday':::test.public.weekday;
              SELECT 'wednesday':::test.public.weekday;
@@ -264,13 +311,6 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              END LOOP;
              OPEN curs FOR SELECT 'wednesday':::test.public.weekday;
              RETURN 'wednesday':::test.public.weekday;
-             EXCEPTION
-             WHEN division_by_zero THEN
-             RAISE NOTICE
-             USING MESSAGE = format('val: %d':::STRING, 'wednesday':::test.public.weekday);
-             WHEN not_null_violation THEN
-             SELECT 'wednesday':::test.public.weekday;
-             RAISE NOTICE 'val: %', 'wednesday':::test.public.weekday;
              END;
            $$
 
@@ -283,7 +323,7 @@ ALTER TYPE weekday RENAME TO workday;
 query T
 SELECT get_body_str('f_rewrite');
 ----
-"DECLARE\nday @100107 := b'\\x80':::@100107;\ntoday @100107 := b'\\xa0':::@100107;\ncurs REFCURSOR := b' ':::@100107::STRING;\ncurs2 CURSOR FOR SELECT b'@':::@100107;\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nRAISE NOTICE 'val1: %, val2: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nWHILE day != b'\\x80':::@100107 LOOP\nday := b'\\xc0':::@100107;\nSELECT b'\\x80':::@100107;\nIF day = b'\\x80':::@100107 THEN\n\tday := b'\\xa0':::@100107;\n\tSELECT b'@':::@100107;\n\tCONTINUE;\nELSIF day = b' ':::@100107 THEN\n\tSELECT b'@':::@100107 INTO day;\nELSIF day = b'@':::@100107 THEN\n\tSELECT b'\\x80':::@100107 INTO day;\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT b'\\x80':::@100107;\nRETURN b'\\x80':::@100107;\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nWHEN not_null_violation THEN\nSELECT b'\\x80':::@100107;\nRAISE NOTICE 'val: %', b'\\x80':::@100107;\nEND;\n"
+"DECLARE\nday @100107 := b'\\x80':::@100107;\ntoday @100107 := b'\\xa0':::@100107;\ncurs REFCURSOR := b' ':::@100107::STRING;\ncurs2 CURSOR FOR SELECT b'@':::@100107;\nBEGIN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nRAISE NOTICE 'val1: %, val2: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nDECLARE\nyesterday @100107 := b'\\x80':::@100107;\nBEGIN\nRAISE NOTICE 'val3: %, val4: %', b'\\x80':::@100107, b'\\xa0':::@100107;\nIF yesterday IS NOT NULL THEN\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEXCEPTION\nWHEN division_by_zero THEN\nRAISE NOTICE\nUSING MESSAGE = format('val: %d':::STRING, b'\\x80':::@100107);\nWHEN not_null_violation THEN\nSELECT b'\\x80':::@100107;\nRAISE NOTICE 'val: %', b'\\x80':::@100107;\nEND;\nWHILE day != b'\\x80':::@100107 LOOP\nday := b'\\xc0':::@100107;\nSELECT b'\\x80':::@100107;\nIF day = b'\\x80':::@100107 THEN\n\tday := b'\\xa0':::@100107;\n\tSELECT b'@':::@100107;\n\tCONTINUE;\nELSIF day = b' ':::@100107 THEN\n\tSELECT b'@':::@100107 INTO day;\nELSIF day = b'@':::@100107 THEN\n\tSELECT b'\\x80':::@100107 INTO day;\n\tSELECT b'\\x80':::@100107;\nEND IF;\nEND LOOP;\nOPEN curs FOR SELECT b'\\x80':::@100107;\nRETURN b'\\x80':::@100107;\nEND;\n"
 
 query TT
 SHOW CREATE FUNCTION f_rewrite;
@@ -304,6 +344,21 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              RAISE NOTICE
              USING MESSAGE = format('val: %d':::STRING, 'humpday':::test.public.workday);
              RAISE NOTICE 'val1: %, val2: %', 'humpday':::test.public.workday, 'thursday':::test.public.workday;
+             DECLARE
+             yesterday test.public.workday := 'humpday':::test.public.workday;
+             BEGIN
+             RAISE NOTICE 'val3: %, val4: %', 'humpday':::test.public.workday, 'thursday':::test.public.workday;
+             IF yesterday IS NOT NULL THEN
+               SELECT 'humpday':::test.public.workday;
+             END IF;
+             EXCEPTION
+             WHEN division_by_zero THEN
+             RAISE NOTICE
+             USING MESSAGE = format('val: %d':::STRING, 'humpday':::test.public.workday);
+             WHEN not_null_violation THEN
+             SELECT 'humpday':::test.public.workday;
+             RAISE NOTICE 'val: %', 'humpday':::test.public.workday;
+             END;
              WHILE day != 'humpday':::test.public.workday LOOP
              day := 'friday':::test.public.workday;
              SELECT 'humpday':::test.public.workday;
@@ -320,13 +375,6 @@ f_rewrite  CREATE FUNCTION public.f_rewrite()
              END LOOP;
              OPEN curs FOR SELECT 'humpday':::test.public.workday;
              RETURN 'humpday':::test.public.workday;
-             EXCEPTION
-             WHEN division_by_zero THEN
-             RAISE NOTICE
-             USING MESSAGE = format('val: %d':::STRING, 'humpday':::test.public.workday);
-             WHEN not_null_violation THEN
-             SELECT 'humpday':::test.public.workday;
-             RAISE NOTICE 'val: %', 'humpday':::test.public.workday;
              END;
            $$
 

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2615,6 +2615,13 @@ func TestTenantLogicCCL_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestTenantLogicCCL_plpgsql_block(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_block")
+}
+
 func TestTenantLogicCCL_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"Pool": "heavy"},
         "//conditions:default": {"Pool": "large"},
     }),
-    shard_count = 17,
+    shard_count = 18,
     tags = [
         "ccl_test",
         "cpu:2",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
@@ -106,6 +106,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_block(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_block")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"Pool": "heavy"},
         "//conditions:default": {"Pool": "large"},
     }),
-    shard_count = 17,
+    shard_count = 18,
     tags = [
         "ccl_test",
         "cpu:2",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
@@ -106,6 +106,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_block(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_block")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"Pool": "heavy"},
         "//conditions:default": {"Pool": "large"},
     }),
-    shard_count = 18,
+    shard_count = 19,
     tags = [
         "ccl_test",
         "cpu:2",

--- a/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
@@ -113,6 +113,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_block(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_block")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"Pool": "heavy"},
         "//conditions:default": {"Pool": "large"},
     }),
-    shard_count = 17,
+    shard_count = 18,
     tags = [
         "ccl_test",
         "cpu:1",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
@@ -106,6 +106,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_block(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_block")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-23.2/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-23.2/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"Pool": "heavy"},
         "//conditions:default": {"Pool": "large"},
     }),
-    shard_count = 17,
+    shard_count = 18,
     tags = [
         "ccl_test",
         "cpu:1",

--- a/pkg/ccl/logictestccl/tests/local-mixed-23.2/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-23.2/generated_test.go
@@ -106,6 +106,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_block(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_block")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"Pool": "heavy"},
         "//conditions:default": {"Pool": "large"},
     }),
-    shard_count = 17,
+    shard_count = 18,
     tags = [
         "ccl_test",
         "cpu:1",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
@@ -106,6 +106,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_block(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_block")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"Pool": "heavy"},
         "//conditions:default": {"Pool": "large"},
     }),
-    shard_count = 32,
+    shard_count = 33,
     tags = [
         "ccl_test",
         "cpu:1",

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -190,6 +190,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_block(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_block")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -303,9 +303,10 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		// volatility of stable functions. If folded, we only get a scalar and lose
 		// the volatility.
 		b.factory.FoldingControl().TemporarilyDisallowStableFolds(func() {
-			var plBuilder plpgsqlBuilder
-			plBuilder.init(b, nil /* colRefs */, paramTypes, stmt.AST, funcReturnType)
-			stmtScope = plBuilder.build(stmt.AST, bodyScope)
+			plBuilder := newPLpgSQLBuilder(
+				b, cf.Name.Object(), nil /* colRefs */, paramTypes, funcReturnType,
+			)
+			stmtScope = plBuilder.buildBlock(stmt.AST, bodyScope)
 		})
 		checkStmtVolatility(targetVolatility, stmtScope, stmt)
 

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -1508,7 +1508,7 @@ func newRecordTypeVisitor(
 
 var _ ast.StatementVisitor = &recordTypeVisitor{}
 
-func (r *recordTypeVisitor) Visit(stmt ast.Statement) (newStmt ast.Statement, changed bool) {
+func (r *recordTypeVisitor) Visit(stmt ast.Statement) (newStmt ast.Statement, recurse bool) {
 	if retStmt, ok := stmt.(*ast.Return); ok {
 		desired := types.Any
 		if r.typ != types.Unknown {
@@ -1534,7 +1534,7 @@ func (r *recordTypeVisitor) Visit(stmt ast.Statement) (newStmt ast.Statement, ch
 			panic(recordReturnErr)
 		}
 	}
-	return stmt, false
+	return stmt, true
 }
 
 var (

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -146,23 +146,6 @@ type plpgsqlBuilder struct {
 	// expressions.
 	colRefs *opt.ColSet
 
-	// params tracks the names and types for the original function parameters.
-	params []tree.ParamType
-
-	// decls is the set of variable declarations for a PL/pgSQL function.
-	decls []ast.Declaration
-
-	// varTypes maps from the name of each variable to its type.
-	varTypes map[tree.Name]*types.T
-
-	// constants tracks the variables that were declared as constant.
-	constants map[tree.Name]struct{}
-
-	// cursors is the set of cursor declarations for a PL/pgSQL routine. It is set
-	// for bound cursor declarations, which allow a query to be associated with a
-	// cursor before it is opened.
-	cursors map[tree.Name]ast.CursorDeclaration
-
 	// returnType is the return type of the PL/pgSQL function.
 	returnType *types.T
 
@@ -178,87 +161,151 @@ type plpgsqlBuilder struct {
 	// statements that follow the loop.
 	exitContinuations []continuation
 
-	// blockState is shared state for all routines that make up a PLpgSQL block,
-	// including the implicit block that surrounds the body statements.
-	blockState *tree.BlockState
+	// blocks is a stack containing every block in the path from the root block to
+	// the current block. It is necessary to track the entire stack because
+	// variables from a parent block can be referenced in a child block.
+	blocks []plBlock
 
-	hasExceptionBlock bool
-	identCounter      int
+	identCounter int
 }
 
-func (b *plpgsqlBuilder) init(
-	ob *Builder, colRefs *opt.ColSet, params []tree.ParamType, block *ast.Block, returnType *types.T,
-) {
-	if block.Label != "" {
+func newPLpgSQLBuilder(
+	ob *Builder,
+	routineName string,
+	colRefs *opt.ColSet,
+	params []tree.ParamType,
+	returnType *types.T,
+) *plpgsqlBuilder {
+	const initialBlocksCap = 2
+	b := &plpgsqlBuilder{
+		ob:         ob,
+		colRefs:    colRefs,
+		returnType: returnType,
+		blocks:     make([]plBlock, 0, initialBlocksCap),
+	}
+	// Build the initial block for the routine parameters, which are considered
+	// PL/pgSQL variables.
+	b.pushBlock(plBlock{
+		label:    routineName,
+		vars:     make([]ast.Variable, 0, len(params)),
+		varTypes: make(map[ast.Variable]*types.T),
+	})
+	for _, param := range params {
+		b.addVariable(ast.Variable(param.Name), param.Typ)
+	}
+	return b
+}
+
+// plBlock encapsulates the local state of a PL/pgSQL block, including cursor
+// and variable declarations, as well the exception handler and label.
+type plBlock struct {
+	// label is the label provided for the block, if any. It can be used when
+	// resolving a PL/pgSQL variable.
+	label string
+
+	// vars is an ordered list of variables declared in a PL/pgSQL block.
+	vars []ast.Variable
+
+	// varTypes maps from the name of each variable in the scope to its type.
+	varTypes map[ast.Variable]*types.T
+
+	// constants tracks the variables that were declared as constant.
+	constants map[ast.Variable]struct{}
+
+	// cursors is the set of cursor declarations for a PL/pgSQL block. It is set
+	// for bound cursor declarations, which allow a query to be associated with a
+	// cursor before it is opened.
+	cursors map[ast.Variable]ast.CursorDeclaration
+
+	// hasExceptionHandler tracks whether this block has an exception handler.
+	hasExceptionHandler bool
+
+	// state is shared for all sub-routines that make up a PLpgSQL block,
+	// including the implicit block that surrounds the body statements. It is used
+	// for exception handling and cursor declarations. Note that the state is not
+	// shared between parent and child or sibling blocks - it is unique within a
+	// given block.
+	state *tree.BlockState
+}
+
+// buildBlock constructs an expression that returns the result of executing a
+// PL/pgSQL block, including variable declarations and exception handlers.
+func (b *plpgsqlBuilder) buildBlock(astBlock *ast.Block, s *scope) *scope {
+	if len(b.blocks) == 0 {
+		// There should always be a root block for the routine parameters.
+		panic(errors.AssertionFailedf("expected at least one PLpgSQL block"))
+	}
+	if astBlock.Label != "" {
 		panic(blockLabelErr)
 	}
-	b.ob = ob
-	b.colRefs = colRefs
-	b.params = params
-	b.returnType = returnType
-	b.varTypes = make(map[tree.Name]*types.T)
-	b.cursors = make(map[tree.Name]ast.CursorDeclaration)
-	for i := range block.Decls {
-		switch dec := block.Decls[i].(type) {
-		case *ast.Declaration:
-			b.decls = append(b.decls, *dec)
-		case *ast.CursorDeclaration:
-			// Declaration of a bound cursor declares a variable of type refcursor.
-			b.decls = append(b.decls, ast.Declaration{Var: dec.Name, Typ: types.RefCursor})
-			b.cursors[dec.Name] = *dec
-		}
+	if b.block().hasExceptionHandler {
+		// The parent block has an exception handler. Exception handlers and nested
+		// blocks are not yet compatible.
+		panic(nestedBlockExceptionErr)
 	}
-	for _, param := range b.params {
-		b.addVariableType(tree.Name(param.Name), param.Typ)
-	}
-	for _, dec := range b.decls {
-		typ, err := tree.ResolveType(b.ob.ctx, dec.Typ, b.ob.semaCtx.TypeResolver)
-		if err != nil {
-			panic(err)
-		}
-		b.addVariableType(dec.Var, typ)
-		if dec.NotNull {
-			panic(notNullVarErr)
-		}
-		if dec.Collate != "" {
-			panic(collatedVarErr)
-		}
-		if types.IsRecordType(typ) {
-			panic(recordVarErr)
-		}
-	}
-}
-
-// build constructs an expression that returns the result of executing a
-// PL/pgSQL function. See buildPLpgSQLStatements for more details.
-func (b *plpgsqlBuilder) build(block *ast.Block, s *scope) *scope {
+	// Push the scope to ensure that routine parameters are not treated as
+	// passthrough columns.
 	s = s.push()
 	b.ensureScopeHasExpr(s)
-
-	b.constants = make(map[tree.Name]struct{})
-	for _, dec := range b.decls {
-		if dec.Expr != nil {
-			// Some variable declarations initialize the variable.
-			s = b.addPLpgSQLAssign(s, dec.Var, dec.Expr)
-		} else {
-			// Uninitialized variables are null.
-			s = b.addPLpgSQLAssign(s, dec.Var, &tree.CastExpr{Expr: tree.DNull, Type: dec.Typ})
-		}
-		if dec.Constant {
-			// Add to the constants map after initializing the variable, since
-			// constant variables only prevent assignment, not initialization.
-			b.constants[dec.Var] = struct{}{}
+	block := b.pushBlock(plBlock{
+		label:     astBlock.Label,
+		vars:      make([]ast.Variable, 0, len(astBlock.Decls)),
+		varTypes:  make(map[ast.Variable]*types.T),
+		constants: make(map[ast.Variable]struct{}),
+		cursors:   make(map[ast.Variable]ast.CursorDeclaration),
+	})
+	// First, handle the variable declarations.
+	defer b.popBlock()
+	for i := range astBlock.Decls {
+		switch dec := astBlock.Decls[i].(type) {
+		case *ast.Declaration:
+			if dec.NotNull {
+				panic(notNullVarErr)
+			}
+			if dec.Collate != "" {
+				panic(collatedVarErr)
+			}
+			typ, err := tree.ResolveType(b.ob.ctx, dec.Typ, b.ob.semaCtx.TypeResolver)
+			if err != nil {
+				panic(err)
+			}
+			if types.IsRecordType(typ) {
+				panic(recordVarErr)
+			}
+			b.addVariable(dec.Var, typ)
+			if dec.Expr != nil {
+				// Some variable declarations initialize the variable.
+				s = b.addPLpgSQLAssign(s, dec.Var, dec.Expr)
+			} else {
+				// Uninitialized variables are null.
+				s = b.addPLpgSQLAssign(s, dec.Var, &tree.CastExpr{Expr: tree.DNull, Type: typ})
+			}
+			if dec.Constant {
+				// Add to the constants map after initializing the variable, since
+				// constant variables only prevent assignment, not initialization.
+				block.constants[dec.Var] = struct{}{}
+			}
+		case *ast.CursorDeclaration:
+			// Declaration of a bound cursor declares a variable of type refcursor.
+			b.addVariable(dec.Name, types.RefCursor)
+			s = b.addPLpgSQLAssign(s, dec.Name, &tree.CastExpr{Expr: tree.DNull, Type: types.RefCursor})
+			block.cursors[dec.Name] = *dec
 		}
 	}
+	// Perform type-checking for RECORD-returning routines. This happens after
+	// building the variable declarations, so that expressions that reference
+	// those variables can be type-checked.
 	if types.IsRecordType(b.returnType) {
 		// Infer the concrete type by examining the RETURN statements. This has to
 		// happen after building the declaration block because RETURN statements can
 		// reference declared variables.
-		recordVisitor := newRecordTypeVisitor(b.ob.ctx, b.ob.semaCtx, s)
-		ast.Walk(recordVisitor, block)
+		recordVisitor := newRecordTypeVisitor(b.ob.ctx, b.ob.semaCtx, s, astBlock)
+		ast.Walk(recordVisitor, astBlock)
 		b.returnType = recordVisitor.typ
 	}
-	if exceptions := b.buildExceptions(block); exceptions != nil {
+	// Build the exception handler. This has to happen after building the variable
+	// declarations, since the exception handler can reference the block's vars.
+	if exceptions := b.buildExceptions(astBlock); exceptions != nil {
 		// There is an implicit block around the body statements, with an optional
 		// exception handler. Note that the variable declarations are not in block
 		// scope, and exceptions thrown during variable declaration are not caught.
@@ -266,14 +313,16 @@ func (b *plpgsqlBuilder) build(block *ast.Block, s *scope) *scope {
 		// The routine is volatile to prevent inlining. Only the block and
 		// variable-assignment routines need to be volatile; see the buildExceptions
 		// comment for details.
-		b.blockState = &tree.BlockState{}
+		block.state = &tree.BlockState{}
+		block.hasExceptionHandler = true
 		blockCon := b.makeContinuation("exception_block")
 		blockCon.def.ExceptionBlock = exceptions
 		blockCon.def.Volatility = volatility.Volatile
-		b.appendPlpgSQLStmts(&blockCon, block.Body)
+		b.appendPlpgSQLStmts(&blockCon, astBlock.Body)
 		return b.callContinuation(&blockCon, s)
 	}
-	return b.buildPLpgSQLStatements(block.Body, s)
+	// Finally, build the body statements for the block.
+	return b.buildPLpgSQLStatements(astBlock.Body, s)
 }
 
 // buildPLpgSQLStatements performs the majority of the work building a PL/pgSQL
@@ -295,7 +344,6 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			b.addBarrierIfVolatile(s, returnScalar)
 			returnColName := scopeColName("").WithMetadataName(b.makeIdentifier("stmt_return"))
 			returnScope := s.push()
-			b.ensureScopeHasExpr(returnScope)
 			b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, returnScalar)
 			b.ob.constructProjectForScope(s, returnScope)
 			return returnScope
@@ -304,7 +352,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			// Assignment (:=) is handled by projecting a new column with the same
 			// name as the variable being assigned.
 			s = b.addPLpgSQLAssign(s, t.Var, t.Value)
-			if b.hasExceptionBlock {
+			if b.hasExceptionHandler() {
 				// If exception handling is required, we have to start a new
 				// continuation after each variable assignment. This ensures that in the
 				// event of an error, the arguments of the currently executing routine
@@ -374,7 +422,6 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			// Return a single column that projects the result of the CASE statement.
 			returnColName := scopeColName("").WithMetadataName(b.makeIdentifier("stmt_if"))
 			returnScope := s.push()
-			b.ensureScopeHasExpr(returnScope)
 			scalar = b.coerceType(scalar, b.returnType)
 			b.addBarrierIfVolatile(s, scalar)
 			b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, scalar)
@@ -627,7 +674,6 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			)
 			closeColName := scopeColName("").WithMetadataName(b.makeIdentifier("stmt_close"))
 			closeScope := closeCon.s.push()
-			b.ensureScopeHasExpr(closeScope)
 			b.ob.synthesizeColumn(closeScope, closeColName, types.Int, nil /* expr */, closeCall)
 			b.ob.constructProjectForScope(closeCon.s, closeScope)
 			b.appendBodyStmt(&closeCon, closeScope)
@@ -696,11 +742,16 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 // resolveOpenQuery finds and validates the query that is bound to cursor for
 // the given OPEN statement.
 func (b *plpgsqlBuilder) resolveOpenQuery(open *ast.Open) tree.Statement {
+	// Search the blocks in reverse order to ensure that more recent declarations
+	// are encountered first.
 	var boundStmt tree.Statement
-	for name := range b.cursors {
-		if open.CurVar == name {
-			boundStmt = b.cursors[name].Query
-			break
+	for i := len(b.blocks) - 1; i >= 0; i-- {
+		block := &b.blocks[i]
+		for name := range block.cursors {
+			if open.CurVar == name {
+				boundStmt = block.cursors[name].Query
+				break
+			}
 		}
 	}
 	stmt := open.Query
@@ -764,7 +815,6 @@ func (b *plpgsqlBuilder) buildCursorNameGen(nameCon *continuation, nameVar ast.V
 func (b *plpgsqlBuilder) addPLpgSQLAssign(inScope *scope, ident ast.Variable, val ast.Expr) *scope {
 	typ := b.resolveVariableForAssign(ident)
 	assignScope := inScope.push()
-	b.ensureScopeHasExpr(assignScope)
 	for i := range inScope.cols {
 		col := &inScope.cols[i]
 		if col.name.ReferenceName() == ident {
@@ -850,7 +900,6 @@ func (b *plpgsqlBuilder) buildPLpgSQLRaise(inScope *scope, args memo.ScalarListE
 	)
 	raiseColName := scopeColName("").WithMetadataName(b.makeIdentifier("stmt_raise"))
 	raiseScope := inScope.push()
-	b.ensureScopeHasExpr(raiseScope)
 	b.ob.synthesizeColumn(raiseScope, raiseColName, types.Int, nil /* expr */, raiseCall)
 	b.ob.constructProjectForScope(inScope, raiseScope)
 	return raiseScope
@@ -1108,7 +1157,6 @@ func (b *plpgsqlBuilder) buildExceptions(block *ast.Block) *memo.ExceptionBlock 
 			}
 		}
 	}
-	b.hasExceptionBlock = true
 	return &memo.ExceptionBlock{
 		Codes:   codes,
 		Actions: handlers,
@@ -1244,12 +1292,13 @@ func (b *plpgsqlBuilder) projectRecordVar(s *scope, name ast.Variable) *scope {
 }
 
 // makeContinuation allocates a new continuation routine with an uninitialized
-// definition.
-func (b *plpgsqlBuilder) makeContinuation(name string) continuation {
+// definition. Note that the parameters of the continuation will be determined
+// by the current block; if a child block declares new variables, its
+// continuations will have more parameters than those of its parent.
+func (b *plpgsqlBuilder) makeContinuation(conName string) continuation {
 	s := b.ob.allocScope()
-	b.ensureScopeHasExpr(s)
-	params := make(opt.ColList, 0, len(b.decls)+len(b.params))
-	addParam := func(name tree.Name, typ *types.T) {
+	params := make(opt.ColList, 0, b.variableCount())
+	addParam := func(name ast.Variable, typ *types.T) {
 		colName := scopeColName(name)
 		col := b.ob.synthesizeColumn(s, colName, typ, nil /* expr */, nil /* scalar */)
 		// TODO(mgartner): Lift the 100 parameter restriction for synthesized
@@ -1257,19 +1306,24 @@ func (b *plpgsqlBuilder) makeContinuation(name string) continuation {
 		col.setParamOrd(len(params))
 		params = append(params, col.id)
 	}
-	for _, param := range b.params {
-		addParam(tree.Name(param.Name), param.Typ)
+	// Invariant: the variables of a child block always follow those of a parent
+	// block in a continuation's parameters. This ensures that a continuation
+	// from a parent block can be called in a child block simply by truncating the
+	// set of variables that are in scope for that block (see callContinuation).
+	for i := range b.blocks {
+		block := &b.blocks[i]
+		for _, name := range block.vars {
+			addParam(name, block.varTypes[name])
+		}
 	}
-	for _, dec := range b.decls {
-		addParam(dec.Var, b.varTypes[dec.Var])
-	}
+	b.ensureScopeHasExpr(s)
 	return continuation{
 		def: &memo.UDFDefinition{
 			Params:            params,
-			Name:              b.makeIdentifier(name),
+			Name:              b.makeIdentifier(conName),
 			Typ:               b.returnType,
 			CalledOnNullInput: true,
-			BlockState:        b.blockState,
+			BlockState:        b.block().state,
 			RoutineType:       tree.UDFRoutine,
 		},
 		s: s,
@@ -1318,19 +1372,31 @@ func (b *plpgsqlBuilder) callContinuation(con *continuation, s *scope) *scope {
 	if con == nil {
 		return b.buildEndOfFunctionRaise(s)
 	}
-	args := make(memo.ScalarListExpr, 0, len(b.decls)+len(b.params))
-	addArg := func(name tree.Name, typ *types.T) {
+	args := make(memo.ScalarListExpr, 0, len(con.def.Params))
+	addArg := func(name ast.Variable) {
 		_, source, _, err := s.FindSourceProvidingColumn(b.ob.ctx, name)
 		if err != nil {
 			panic(err)
 		}
 		args = append(args, b.ob.factory.ConstructVariable(source.(*scopeColumn).id))
 	}
-	for _, param := range b.params {
-		addArg(tree.Name(param.Name), param.Typ)
-	}
-	for _, dec := range b.decls {
-		addArg(dec.Var, b.varTypes[dec.Var])
+	for i := range b.blocks {
+		if len(args) == len(con.def.Params) {
+			// A continuation has parameters for every variable that is in scope for
+			// the block in which it was created. If we reach the end of those
+			// parameters early, the continuation must be from an ancestor block. Any
+			// remaining variables are out of scope because control has passed back to
+			// the ancestor block.
+			//
+			// NOTE: makeContinuation maintains an invariant that variables from a
+			// parent block precede those of a child block in a continuation's
+			// parameters.
+			break
+		}
+		block := &b.blocks[i]
+		for _, name := range block.vars {
+			addArg(name)
+		}
 	}
 	// PLpgSQL continuation routines are always in tail-call position.
 	call := b.ob.factory.ConstructUDFCall(args, &memo.UDFCallPrivate{Def: con.def, TailCall: true})
@@ -1338,7 +1404,6 @@ func (b *plpgsqlBuilder) callContinuation(con *continuation, s *scope) *scope {
 
 	returnColName := scopeColName("").WithMetadataName(con.def.Name)
 	returnScope := s.push()
-	b.ensureScopeHasExpr(returnScope)
 	b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, call)
 	b.ob.constructProjectForScope(s, returnScope)
 	return returnScope
@@ -1401,17 +1466,23 @@ func (b *plpgsqlBuilder) coerceType(scalar opt.ScalarExpr, typ *types.T) opt.Sca
 
 // resolveVariableForAssign attempts to retrieve the type of the variable with
 // the given name, throwing an error if no such variable exists.
-func (b *plpgsqlBuilder) resolveVariableForAssign(name tree.Name) *types.T {
-	typ, ok := b.varTypes[name]
-	if !ok {
-		panic(pgerror.Newf(pgcode.Syntax, "\"%s\" is not a known variable", name))
-	}
-	if b.constants != nil {
-		if _, ok := b.constants[name]; ok {
-			panic(pgerror.Newf(pgcode.ErrorInAssignment, "variable \"%s\" is declared CONSTANT", name))
+func (b *plpgsqlBuilder) resolveVariableForAssign(name ast.Variable) *types.T {
+	// Search the blocks in reverse order to ensure that more recent declarations
+	// are encountered first.
+	for i := len(b.blocks) - 1; i >= 0; i-- {
+		block := &b.blocks[i]
+		typ, ok := block.varTypes[name]
+		if !ok {
+			continue
 		}
+		if block.constants != nil {
+			if _, ok := block.constants[name]; ok {
+				panic(pgerror.Newf(pgcode.ErrorInAssignment, "variable \"%s\" is declared CONSTANT", name))
+			}
+		}
+		return typ
 	}
-	return typ
+	panic(pgerror.Newf(pgcode.Syntax, "\"%s\" is not a known variable", name))
 }
 
 func (b *plpgsqlBuilder) ensureScopeHasExpr(s *scope) {
@@ -1480,14 +1551,63 @@ func (b *plpgsqlBuilder) getLoopContinuation() *continuation {
 	return nil
 }
 
-func (b *plpgsqlBuilder) addVariableType(name tree.Name, typ *types.T) {
-	if _, ok := b.varTypes[name]; ok {
-		panic(errors.WithHintf(
-			unimplemented.NewWithIssue(117508, "variable shadowing is not yet implemented"),
-			"variable \"%s\" shadows a previously defined variable", name,
-		))
+// addVariable adds a variable with the given name and type to the current
+// PL/pgSQL block scope.
+func (b *plpgsqlBuilder) addVariable(name ast.Variable, typ *types.T) {
+	curBlock := b.block()
+	if _, ok := curBlock.varTypes[name]; ok {
+		panic(pgerror.Newf(pgcode.Syntax, "duplicate declaration at or near \"%s\"", name))
 	}
-	b.varTypes[name] = typ
+	for i := range b.blocks {
+		block := &b.blocks[i]
+		if _, ok := block.varTypes[name]; ok {
+			panic(errors.WithHintf(
+				unimplemented.NewWithIssue(117508, "variable shadowing is not yet implemented"),
+				"variable \"%s\" shadows a previously defined variable", name,
+			))
+		}
+	}
+	curBlock.vars = append(curBlock.vars, name)
+	curBlock.varTypes[name] = typ
+}
+
+// block returns the block for the current PL/pgSQL block.
+func (b *plpgsqlBuilder) block() *plBlock {
+	return &b.blocks[len(b.blocks)-1]
+}
+
+// pushBlock puts the given block on the stack. It is used when entering the
+// scope of a PL/pgSQL block.
+func (b *plpgsqlBuilder) pushBlock(bs plBlock) *plBlock {
+	b.blocks = append(b.blocks, bs)
+	return &b.blocks[len(b.blocks)-1]
+}
+
+// popBlock removes the current block from the stack. It is used when leaving
+// the scope of a PL/pgSQL block.
+func (b *plpgsqlBuilder) popBlock() {
+	b.blocks = b.blocks[:len(b.blocks)-1]
+}
+
+// hasExceptionHandler returns true if any block from the root to the current
+// block has an exception handler.
+func (b *plpgsqlBuilder) hasExceptionHandler() bool {
+	for i := range b.blocks {
+		if b.blocks[i].hasExceptionHandler {
+			return true
+		}
+	}
+	return false
+}
+
+// variableCount returns the number of PL/pgSQL variables that are in scope for
+// the current block.
+func (b *plpgsqlBuilder) variableCount() int {
+	var count int
+	for i := range b.blocks {
+		count += len(b.blocks[i].vars)
+	}
+	return count
 }
 
 // recordTypeVisitor is used to infer the concrete return type for a
@@ -1498,23 +1618,32 @@ type recordTypeVisitor struct {
 	semaCtx *tree.SemaContext
 	s       *scope
 	typ     *types.T
+	block   *ast.Block
 }
 
 func newRecordTypeVisitor(
-	ctx context.Context, semaCtx *tree.SemaContext, s *scope,
+	ctx context.Context, semaCtx *tree.SemaContext, s *scope, block *ast.Block,
 ) *recordTypeVisitor {
-	return &recordTypeVisitor{ctx: ctx, semaCtx: semaCtx, s: s, typ: types.Unknown}
+	return &recordTypeVisitor{ctx: ctx, semaCtx: semaCtx, s: s, typ: types.Unknown, block: block}
 }
 
 var _ ast.StatementVisitor = &recordTypeVisitor{}
 
 func (r *recordTypeVisitor) Visit(stmt ast.Statement) (newStmt ast.Statement, recurse bool) {
-	if retStmt, ok := stmt.(*ast.Return); ok {
+	switch t := stmt.(type) {
+	case *ast.Block:
+		if t != r.block {
+			// This is a nested block. We can't visit it yet, since we haven't built
+			// its variable declarations, and therefore can't type-check expressions
+			// that reference those variables.
+			return t, false
+		}
+	case *ast.Return:
 		desired := types.Any
 		if r.typ != types.Unknown {
 			desired = r.typ
 		}
-		expr, _ := tree.WalkExpr(r.s, retStmt.Expr)
+		expr, _ := tree.WalkExpr(r.s, t.Expr)
 		typedExpr, err := expr.TypeCheck(r.ctx, r.semaCtx, desired)
 		if err != nil {
 			panic(err)
@@ -1606,5 +1735,8 @@ var (
 	)
 	nonCompositeErr = pgerror.New(pgcode.DatatypeMismatch,
 		"cannot return non-composite value from function returning composite type",
+	)
+	nestedBlockExceptionErr = unimplemented.New("exception handler for nested blocks",
+		"PL/pgSQL blocks cannot yet be nested within a block that has an exception handler",
 	)
 )

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -1257,11 +1257,11 @@ func (b *plpgsqlBuilder) makeContinuation(name string) continuation {
 		col.setParamOrd(len(params))
 		params = append(params, col.id)
 	}
-	for _, dec := range b.decls {
-		addParam(dec.Var, b.varTypes[dec.Var])
-	}
 	for _, param := range b.params {
 		addParam(tree.Name(param.Name), param.Typ)
+	}
+	for _, dec := range b.decls {
+		addParam(dec.Var, b.varTypes[dec.Var])
 	}
 	return continuation{
 		def: &memo.UDFDefinition{
@@ -1326,11 +1326,11 @@ func (b *plpgsqlBuilder) callContinuation(con *continuation, s *scope) *scope {
 		}
 		args = append(args, b.ob.factory.ConstructVariable(source.(*scopeColumn).id))
 	}
-	for _, dec := range b.decls {
-		addArg(dec.Var, b.varTypes[dec.Var])
-	}
 	for _, param := range b.params {
 		addArg(tree.Name(param.Name), param.Typ)
+	}
+	for _, dec := range b.decls {
+		addArg(dec.Var, b.varTypes[dec.Var])
 	}
 	// PLpgSQL continuation routines are always in tail-call position.
 	call := b.ob.factory.ConstructUDFCall(args, &memo.UDFCallPrivate{Def: con.def, TailCall: true})

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -300,9 +300,8 @@ func (b *Builder) buildRoutine(
 		}
 		var expr memo.RelExpr
 		var physProps *physical.Required
-		var plBuilder plpgsqlBuilder
-		plBuilder.init(b, colRefs, o.Types.(tree.ParamTypes), stmt.AST, rtyp)
-		stmtScope := plBuilder.build(stmt.AST, bodyScope)
+		plBuilder := newPLpgSQLBuilder(b, def.Name, colRefs, o.Types.(tree.ParamTypes), rtyp)
+		stmtScope := plBuilder.buildBlock(stmt.AST, bodyScope)
 		rtyp = finishResolveType(stmtScope)
 		expr, physProps, isMultiColDataSource =
 			b.finishBuildLastStmt(stmtScope, bodyScope, isSetReturning, f)

--- a/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
@@ -203,3 +203,420 @@ call
                 │                                                                                                             └── cast: VOID [as=stmt_return_4:23]
                 │                                                                                                                  └── null
                 └── const: 1
+
+# Case with nested blocks.
+exec-ddl
+CREATE OR REPLACE PROCEDURE p(x INT) AS $$
+  DECLARE
+    y INT := 10;
+  BEGIN
+    x := x + 1;
+    y := y + 1;
+    RAISE NOTICE '% %', x, y;
+    DECLARE
+      z INT := 100;
+    BEGIN
+      x := x + 1;
+      y := y + 1;
+      z := z + 1;
+      RAISE NOTICE '% % %', x, y, z;
+    END;
+    x := x + 1;
+    y := y + 1;
+    RAISE NOTICE '% %', x, y;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+CALL p(5)
+----
+call
+ └── procedure: p
+      ├── args
+      │    └── const: 5
+      ├── params: x:1
+      └── body
+           └── limit
+                ├── columns: "_stmt_raise_1":27
+                ├── project
+                │    ├── columns: "_stmt_raise_1":27
+                │    ├── barrier
+                │    │    ├── columns: x:3 y:4!null
+                │    │    └── project
+                │    │         ├── columns: y:4!null x:3
+                │    │         ├── project
+                │    │         │    ├── columns: x:3 y:2!null
+                │    │         │    ├── project
+                │    │         │    │    ├── columns: y:2!null
+                │    │         │    │    ├── values
+                │    │         │    │    │    └── tuple
+                │    │         │    │    └── projections
+                │    │         │    │         └── const: 10 [as=y:2]
+                │    │         │    └── projections
+                │    │         │         └── plus [as=x:3]
+                │    │         │              ├── variable: x:1
+                │    │         │              └── const: 1
+                │    │         └── projections
+                │    │              └── plus [as=y:4]
+                │    │                   ├── variable: y:2
+                │    │                   └── const: 1
+                │    └── projections
+                │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":27]
+                │              ├── args
+                │              │    ├── variable: x:3
+                │              │    └── variable: y:4
+                │              ├── params: x:5 y:6
+                │              └── body
+                │                   ├── project
+                │                   │    ├── columns: stmt_raise_2:7
+                │                   │    ├── values
+                │                   │    │    └── tuple
+                │                   │    └── projections
+                │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:7]
+                │                   │              ├── const: 'NOTICE'
+                │                   │              ├── concat
+                │                   │              │    ├── concat
+                │                   │              │    │    ├── concat
+                │                   │              │    │    │    ├── concat
+                │                   │              │    │    │    │    ├── const: ''
+                │                   │              │    │    │    │    └── coalesce
+                │                   │              │    │    │    │         ├── cast: STRING
+                │                   │              │    │    │    │         │    └── variable: x:5
+                │                   │              │    │    │    │         └── const: '<NULL>'
+                │                   │              │    │    │    └── const: ' '
+                │                   │              │    │    └── coalesce
+                │                   │              │    │         ├── cast: STRING
+                │                   │              │    │         │    └── variable: y:6
+                │                   │              │    │         └── const: '<NULL>'
+                │                   │              │    └── const: ''
+                │                   │              ├── const: ''
+                │                   │              ├── const: ''
+                │                   │              └── const: '00000'
+                │                   └── project
+                │                        ├── columns: "_stmt_raise_7":26
+                │                        ├── barrier
+                │                        │    ├── columns: x:18 y:19 z:20!null
+                │                        │    └── project
+                │                        │         ├── columns: z:20!null x:18 y:19
+                │                        │         ├── project
+                │                        │         │    ├── columns: y:19 z:17!null x:18
+                │                        │         │    ├── project
+                │                        │         │    │    ├── columns: x:18 z:17!null
+                │                        │         │    │    ├── project
+                │                        │         │    │    │    ├── columns: z:17!null
+                │                        │         │    │    │    ├── values
+                │                        │         │    │    │    │    └── tuple
+                │                        │         │    │    │    └── projections
+                │                        │         │    │    │         └── const: 100 [as=z:17]
+                │                        │         │    │    └── projections
+                │                        │         │    │         └── plus [as=x:18]
+                │                        │         │    │              ├── variable: x:5
+                │                        │         │    │              └── const: 1
+                │                        │         │    └── projections
+                │                        │         │         └── plus [as=y:19]
+                │                        │         │              ├── variable: y:6
+                │                        │         │              └── const: 1
+                │                        │         └── projections
+                │                        │              └── plus [as=z:20]
+                │                        │                   ├── variable: z:17
+                │                        │                   └── const: 1
+                │                        └── projections
+                │                             └── udf: _stmt_raise_7 [as="_stmt_raise_7":26]
+                │                                  ├── args
+                │                                  │    ├── variable: x:18
+                │                                  │    ├── variable: y:19
+                │                                  │    └── variable: z:20
+                │                                  ├── params: x:21 y:22 z:23
+                │                                  └── body
+                │                                       ├── project
+                │                                       │    ├── columns: stmt_raise_8:24
+                │                                       │    ├── values
+                │                                       │    │    └── tuple
+                │                                       │    └── projections
+                │                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:24]
+                │                                       │              ├── const: 'NOTICE'
+                │                                       │              ├── concat
+                │                                       │              │    ├── concat
+                │                                       │              │    │    ├── concat
+                │                                       │              │    │    │    ├── concat
+                │                                       │              │    │    │    │    ├── concat
+                │                                       │              │    │    │    │    │    ├── concat
+                │                                       │              │    │    │    │    │    │    ├── const: ''
+                │                                       │              │    │    │    │    │    │    └── coalesce
+                │                                       │              │    │    │    │    │    │         ├── cast: STRING
+                │                                       │              │    │    │    │    │    │         │    └── variable: x:21
+                │                                       │              │    │    │    │    │    │         └── const: '<NULL>'
+                │                                       │              │    │    │    │    │    └── const: ' '
+                │                                       │              │    │    │    │    └── coalesce
+                │                                       │              │    │    │    │         ├── cast: STRING
+                │                                       │              │    │    │    │         │    └── variable: y:22
+                │                                       │              │    │    │    │         └── const: '<NULL>'
+                │                                       │              │    │    │    └── const: ' '
+                │                                       │              │    │    └── coalesce
+                │                                       │              │    │         ├── cast: STRING
+                │                                       │              │    │         │    └── variable: z:23
+                │                                       │              │    │         └── const: '<NULL>'
+                │                                       │              │    └── const: ''
+                │                                       │              ├── const: ''
+                │                                       │              ├── const: ''
+                │                                       │              └── const: '00000'
+                │                                       └── project
+                │                                            ├── columns: nested_block_3:25
+                │                                            ├── values
+                │                                            │    └── tuple
+                │                                            └── projections
+                │                                                 └── udf: nested_block_3 [as=nested_block_3:25]
+                │                                                      ├── args
+                │                                                      │    ├── variable: x:21
+                │                                                      │    └── variable: y:22
+                │                                                      ├── params: x:8 y:9
+                │                                                      └── body
+                │                                                           └── project
+                │                                                                ├── columns: "_stmt_raise_4":16
+                │                                                                ├── barrier
+                │                                                                │    ├── columns: x:10 y:11
+                │                                                                │    └── project
+                │                                                                │         ├── columns: y:11 x:10
+                │                                                                │         ├── project
+                │                                                                │         │    ├── columns: x:10
+                │                                                                │         │    ├── values
+                │                                                                │         │    │    └── tuple
+                │                                                                │         │    └── projections
+                │                                                                │         │         └── plus [as=x:10]
+                │                                                                │         │              ├── variable: x:8
+                │                                                                │         │              └── const: 1
+                │                                                                │         └── projections
+                │                                                                │              └── plus [as=y:11]
+                │                                                                │                   ├── variable: y:9
+                │                                                                │                   └── const: 1
+                │                                                                └── projections
+                │                                                                     └── udf: _stmt_raise_4 [as="_stmt_raise_4":16]
+                │                                                                          ├── args
+                │                                                                          │    ├── variable: x:10
+                │                                                                          │    └── variable: y:11
+                │                                                                          ├── params: x:12 y:13
+                │                                                                          └── body
+                │                                                                               ├── project
+                │                                                                               │    ├── columns: stmt_raise_5:14
+                │                                                                               │    ├── values
+                │                                                                               │    │    └── tuple
+                │                                                                               │    └── projections
+                │                                                                               │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_5:14]
+                │                                                                               │              ├── const: 'NOTICE'
+                │                                                                               │              ├── concat
+                │                                                                               │              │    ├── concat
+                │                                                                               │              │    │    ├── concat
+                │                                                                               │              │    │    │    ├── concat
+                │                                                                               │              │    │    │    │    ├── const: ''
+                │                                                                               │              │    │    │    │    └── coalesce
+                │                                                                               │              │    │    │    │         ├── cast: STRING
+                │                                                                               │              │    │    │    │         │    └── variable: x:12
+                │                                                                               │              │    │    │    │         └── const: '<NULL>'
+                │                                                                               │              │    │    │    └── const: ' '
+                │                                                                               │              │    │    └── coalesce
+                │                                                                               │              │    │         ├── cast: STRING
+                │                                                                               │              │    │         │    └── variable: y:13
+                │                                                                               │              │    │         └── const: '<NULL>'
+                │                                                                               │              │    └── const: ''
+                │                                                                               │              ├── const: ''
+                │                                                                               │              ├── const: ''
+                │                                                                               │              └── const: '00000'
+                │                                                                               └── project
+                │                                                                                    ├── columns: stmt_return_6:15
+                │                                                                                    ├── values
+                │                                                                                    │    └── tuple
+                │                                                                                    └── projections
+                │                                                                                         └── cast: VOID [as=stmt_return_6:15]
+                │                                                                                              └── null
+                └── const: 1
+
+# Nested blocks with an exception handler. Note that the exception handler
+# returns control to the outer block, so that the variable assignment is
+# visible in the outer block.
+exec-ddl
+CREATE OR REPLACE PROCEDURE p() AS $$
+  DECLARE
+    x INT := 0;
+  BEGIN
+    RAISE NOTICE '%', x;
+    BEGIN
+      SELECT 1 // 0;
+    EXCEPTION
+      WHEN division_by_zero THEN
+        x := 100;
+    END;
+    RAISE NOTICE '%', x;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+CALL p()
+----
+call
+ └── procedure: p
+      └── body
+           └── limit
+                ├── columns: "_stmt_raise_1":18
+                ├── project
+                │    ├── columns: "_stmt_raise_1":18
+                │    ├── barrier
+                │    │    ├── columns: x:1!null
+                │    │    └── project
+                │    │         ├── columns: x:1!null
+                │    │         ├── values
+                │    │         │    └── tuple
+                │    │         └── projections
+                │    │              └── const: 0 [as=x:1]
+                │    └── projections
+                │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":18]
+                │              ├── args
+                │              │    └── variable: x:1
+                │              ├── params: x:2
+                │              └── body
+                │                   ├── project
+                │                   │    ├── columns: stmt_raise_2:3
+                │                   │    ├── values
+                │                   │    │    └── tuple
+                │                   │    └── projections
+                │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:3]
+                │                   │              ├── const: 'NOTICE'
+                │                   │              ├── concat
+                │                   │              │    ├── concat
+                │                   │              │    │    ├── const: ''
+                │                   │              │    │    └── coalesce
+                │                   │              │    │         ├── cast: STRING
+                │                   │              │    │         │    └── variable: x:2
+                │                   │              │    │         └── const: '<NULL>'
+                │                   │              │    └── const: ''
+                │                   │              ├── const: ''
+                │                   │              ├── const: ''
+                │                   │              └── const: '00000'
+                │                   └── project
+                │                        ├── columns: exception_block_8:17
+                │                        ├── values
+                │                        │    └── tuple
+                │                        └── projections
+                │                             └── udf: exception_block_8 [as=exception_block_8:17]
+                │                                  ├── args
+                │                                  │    └── variable: x:2
+                │                                  ├── params: x:12
+                │                                  ├── body
+                │                                  │    └── project
+                │                                  │         ├── columns: "_stmt_exec_9":16
+                │                                  │         ├── values
+                │                                  │         │    └── tuple
+                │                                  │         └── projections
+                │                                  │              └── udf: _stmt_exec_9 [as="_stmt_exec_9":16]
+                │                                  │                   ├── args
+                │                                  │                   │    └── variable: x:12
+                │                                  │                   ├── params: x:13
+                │                                  │                   └── body
+                │                                  │                        ├── project
+                │                                  │                        │    ├── columns: "?column?":14!null
+                │                                  │                        │    ├── values
+                │                                  │                        │    │    └── tuple
+                │                                  │                        │    └── projections
+                │                                  │                        │         └── floor-div [as="?column?":14]
+                │                                  │                        │              ├── const: 1
+                │                                  │                        │              └── const: 0
+                │                                  │                        └── project
+                │                                  │                             ├── columns: nested_block_3:15
+                │                                  │                             ├── values
+                │                                  │                             │    └── tuple
+                │                                  │                             └── projections
+                │                                  │                                  └── udf: nested_block_3 [as=nested_block_3:15]
+                │                                  │                                       ├── args
+                │                                  │                                       │    └── variable: x:13
+                │                                  │                                       ├── params: x:4
+                │                                  │                                       └── body
+                │                                  │                                            └── project
+                │                                  │                                                 ├── columns: "_stmt_raise_4":8
+                │                                  │                                                 ├── values
+                │                                  │                                                 │    └── tuple
+                │                                  │                                                 └── projections
+                │                                  │                                                      └── udf: _stmt_raise_4 [as="_stmt_raise_4":8]
+                │                                  │                                                           ├── args
+                │                                  │                                                           │    └── variable: x:4
+                │                                  │                                                           ├── params: x:5
+                │                                  │                                                           └── body
+                │                                  │                                                                ├── project
+                │                                  │                                                                │    ├── columns: stmt_raise_5:6
+                │                                  │                                                                │    ├── values
+                │                                  │                                                                │    │    └── tuple
+                │                                  │                                                                │    └── projections
+                │                                  │                                                                │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_5:6]
+                │                                  │                                                                │              ├── const: 'NOTICE'
+                │                                  │                                                                │              ├── concat
+                │                                  │                                                                │              │    ├── concat
+                │                                  │                                                                │              │    │    ├── const: ''
+                │                                  │                                                                │              │    │    └── coalesce
+                │                                  │                                                                │              │    │         ├── cast: STRING
+                │                                  │                                                                │              │    │         │    └── variable: x:5
+                │                                  │                                                                │              │    │         └── const: '<NULL>'
+                │                                  │                                                                │              │    └── const: ''
+                │                                  │                                                                │              ├── const: ''
+                │                                  │                                                                │              ├── const: ''
+                │                                  │                                                                │              └── const: '00000'
+                │                                  │                                                                └── project
+                │                                  │                                                                     ├── columns: stmt_return_6:7
+                │                                  │                                                                     ├── values
+                │                                  │                                                                     │    └── tuple
+                │                                  │                                                                     └── projections
+                │                                  │                                                                          └── cast: VOID [as=stmt_return_6:7]
+                │                                  │                                                                               └── null
+                │                                  └── exception-handler
+                │                                       └── SQLSTATE '22012'
+                │                                            └── project
+                │                                                 ├── columns: nested_block_3:11
+                │                                                 ├── barrier
+                │                                                 │    ├── columns: x:10!null
+                │                                                 │    └── project
+                │                                                 │         ├── columns: x:10!null
+                │                                                 │         ├── values
+                │                                                 │         │    └── tuple
+                │                                                 │         └── projections
+                │                                                 │              └── const: 100 [as=x:10]
+                │                                                 └── projections
+                │                                                      └── udf: nested_block_3 [as=nested_block_3:11]
+                │                                                           ├── args
+                │                                                           │    └── variable: x:10
+                │                                                           ├── params: x:4
+                │                                                           └── body
+                │                                                                └── project
+                │                                                                     ├── columns: "_stmt_raise_4":8
+                │                                                                     ├── values
+                │                                                                     │    └── tuple
+                │                                                                     └── projections
+                │                                                                          └── udf: _stmt_raise_4 [as="_stmt_raise_4":8]
+                │                                                                               ├── args
+                │                                                                               │    └── variable: x:4
+                │                                                                               ├── params: x:5
+                │                                                                               └── body
+                │                                                                                    ├── project
+                │                                                                                    │    ├── columns: stmt_raise_5:6
+                │                                                                                    │    ├── values
+                │                                                                                    │    │    └── tuple
+                │                                                                                    │    └── projections
+                │                                                                                    │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_5:6]
+                │                                                                                    │              ├── const: 'NOTICE'
+                │                                                                                    │              ├── concat
+                │                                                                                    │              │    ├── concat
+                │                                                                                    │              │    │    ├── const: ''
+                │                                                                                    │              │    │    └── coalesce
+                │                                                                                    │              │    │         ├── cast: STRING
+                │                                                                                    │              │    │         │    └── variable: x:5
+                │                                                                                    │              │    │         └── const: '<NULL>'
+                │                                                                                    │              │    └── const: ''
+                │                                                                                    │              ├── const: ''
+                │                                                                                    │              ├── const: ''
+                │                                                                                    │              └── const: '00000'
+                │                                                                                    └── project
+                │                                                                                         ├── columns: stmt_return_6:7
+                │                                                                                         ├── values
+                │                                                                                         │    └── tuple
+                │                                                                                         └── projections
+                │                                                                                              └── cast: VOID [as=stmt_return_6:7]
+                │                                                                                                   └── null
+                └── const: 1

--- a/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
@@ -48,11 +48,11 @@ call
                 │    └── projections
                 │         └── udf: _stmt_exec_1 [as="_stmt_exec_1":59]
                 │              ├── args
-                │              │    ├── variable: c:4
                 │              │    ├── variable: arg_k:1
                 │              │    ├── variable: new_i:2
-                │              │    └── variable: new_s:3
-                │              ├── params: c:5 arg_k:6 new_i:7 new_s:8
+                │              │    ├── variable: new_s:3
+                │              │    └── variable: c:4
+                │              ├── params: arg_k:5 new_i:6 new_s:7 c:8
                 │              └── body
                 │                   └── project
                 │                        ├── columns: "_stmt_exec_ret_2":58
@@ -74,7 +74,7 @@ call
                 │                        │         │    │    │    │         └── filters
                 │                        │         │    │    │    │              └── eq
                 │                        │         │    │    │    │                   ├── variable: k:9
-                │                        │         │    │    │    │                   └── variable: arg_k:6
+                │                        │         │    │    │    │                   └── variable: arg_k:5
                 │                        │         │    │    │    └── aggregations
                 │                        │         │    │    │         └── count-rows [as=count_rows:14]
                 │                        │         │    │    └── const: 1
@@ -86,11 +86,11 @@ call
                 │                        └── projections
                 │                             └── udf: _stmt_exec_ret_2 [as="_stmt_exec_ret_2":58]
                 │                                  ├── args
-                │                                  │    ├── variable: c:57
-                │                                  │    ├── variable: arg_k:6
-                │                                  │    ├── variable: new_i:7
-                │                                  │    └── variable: new_s:8
-                │                                  ├── params: c:15 arg_k:16 new_i:17 new_s:18
+                │                                  │    ├── variable: arg_k:5
+                │                                  │    ├── variable: new_i:6
+                │                                  │    ├── variable: new_s:7
+                │                                  │    └── variable: c:57
+                │                                  ├── params: arg_k:15 new_i:16 new_s:17 c:18
                 │                                  └── body
                 │                                       └── project
                 │                                            ├── columns: stmt_if_7:56
@@ -101,7 +101,7 @@ call
                 │                                                      ├── true
                 │                                                      ├── when
                 │                                                      │    ├── gt
-                │                                                      │    │    ├── variable: c:15
+                │                                                      │    │    ├── variable: c:18
                 │                                                      │    │    └── const: 0
                 │                                                      │    └── subquery
                 │                                                      │         └── project
@@ -111,11 +111,11 @@ call
                 │                                                      │              └── projections
                 │                                                      │                   └── udf: _stmt_exec_5 [as="_stmt_exec_5":41]
                 │                                                      │                        ├── args
-                │                                                      │                        │    ├── variable: c:15
-                │                                                      │                        │    ├── variable: arg_k:16
-                │                                                      │                        │    ├── variable: new_i:17
-                │                                                      │                        │    └── variable: new_s:18
-                │                                                      │                        ├── params: c:24 arg_k:25 new_i:26 new_s:27
+                │                                                      │                        │    ├── variable: arg_k:15
+                │                                                      │                        │    ├── variable: new_i:16
+                │                                                      │                        │    ├── variable: new_s:17
+                │                                                      │                        │    └── variable: c:18
+                │                                                      │                        ├── params: arg_k:24 new_i:25 new_s:26 c:27
                 │                                                      │                        └── body
                 │                                                      │                             ├── update t
                 │                                                      │                             │    ├── columns: <none>
@@ -132,10 +132,10 @@ call
                 │                                                      │                             │         │    └── filters
                 │                                                      │                             │         │         └── eq
                 │                                                      │                             │         │              ├── variable: k:33
-                │                                                      │                             │         │              └── variable: arg_k:25
+                │                                                      │                             │         │              └── variable: arg_k:24
                 │                                                      │                             │         └── projections
-                │                                                      │                             │              ├── variable: new_i:26 [as=i_new:38]
-                │                                                      │                             │              └── variable: new_s:27 [as=s_new:39]
+                │                                                      │                             │              ├── variable: new_i:25 [as=i_new:38]
+                │                                                      │                             │              └── variable: new_s:26 [as=s_new:39]
                 │                                                      │                             └── project
                 │                                                      │                                  ├── columns: stmt_if_3:40
                 │                                                      │                                  ├── values
@@ -143,11 +143,11 @@ call
                 │                                                      │                                  └── projections
                 │                                                      │                                       └── udf: stmt_if_3 [as=stmt_if_3:40]
                 │                                                      │                                            ├── args
-                │                                                      │                                            │    ├── variable: c:24
-                │                                                      │                                            │    ├── variable: arg_k:25
-                │                                                      │                                            │    ├── variable: new_i:26
-                │                                                      │                                            │    └── variable: new_s:27
-                │                                                      │                                            ├── params: c:19 arg_k:20 new_i:21 new_s:22
+                │                                                      │                                            │    ├── variable: arg_k:24
+                │                                                      │                                            │    ├── variable: new_i:25
+                │                                                      │                                            │    ├── variable: new_s:26
+                │                                                      │                                            │    └── variable: c:27
+                │                                                      │                                            ├── params: arg_k:19 new_i:20 new_s:21 c:22
                 │                                                      │                                            └── body
                 │                                                      │                                                 └── project
                 │                                                      │                                                      ├── columns: stmt_return_4:23
@@ -164,11 +164,11 @@ call
                 │                                                                └── projections
                 │                                                                     └── udf: _stmt_exec_6 [as="_stmt_exec_6":55]
                 │                                                                          ├── args
-                │                                                                          │    ├── variable: c:15
-                │                                                                          │    ├── variable: arg_k:16
-                │                                                                          │    ├── variable: new_i:17
-                │                                                                          │    └── variable: new_s:18
-                │                                                                          ├── params: c:42 arg_k:43 new_i:44 new_s:45
+                │                                                                          │    ├── variable: arg_k:15
+                │                                                                          │    ├── variable: new_i:16
+                │                                                                          │    ├── variable: new_s:17
+                │                                                                          │    └── variable: c:18
+                │                                                                          ├── params: arg_k:42 new_i:43 new_s:44 c:45
                 │                                                                          └── body
                 │                                                                               ├── insert t
                 │                                                                               │    ├── columns: <none>
@@ -179,9 +179,9 @@ call
                 │                                                                               │    └── values
                 │                                                                               │         ├── columns: column1:51 column2:52 column3:53
                 │                                                                               │         └── tuple
-                │                                                                               │              ├── variable: arg_k:43
-                │                                                                               │              ├── variable: new_i:44
-                │                                                                               │              └── variable: new_s:45
+                │                                                                               │              ├── variable: arg_k:42
+                │                                                                               │              ├── variable: new_i:43
+                │                                                                               │              └── variable: new_s:44
                 │                                                                               └── project
                 │                                                                                    ├── columns: stmt_if_3:54
                 │                                                                                    ├── values
@@ -189,11 +189,11 @@ call
                 │                                                                                    └── projections
                 │                                                                                         └── udf: stmt_if_3 [as=stmt_if_3:54]
                 │                                                                                              ├── args
-                │                                                                                              │    ├── variable: c:42
-                │                                                                                              │    ├── variable: arg_k:43
-                │                                                                                              │    ├── variable: new_i:44
-                │                                                                                              │    └── variable: new_s:45
-                │                                                                                              ├── params: c:19 arg_k:20 new_i:21 new_s:22
+                │                                                                                              │    ├── variable: arg_k:42
+                │                                                                                              │    ├── variable: new_i:43
+                │                                                                                              │    ├── variable: new_s:44
+                │                                                                                              │    └── variable: c:45
+                │                                                                                              ├── params: arg_k:19 new_i:20 new_s:21 c:22
                 │                                                                                              └── body
                 │                                                                                                   └── project
                 │                                                                                                        ├── columns: stmt_return_4:23

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -250,17 +250,17 @@ project
                      │              │              └── projections
                      │              │                   └── udf: stmt_if_1 [as=stmt_if_1:9]
                      │              │                        ├── args
-                     │              │                        │    ├── variable: c:8
                      │              │                        │    ├── variable: a:1
-                     │              │                        │    └── variable: b:2
-                     │              │                        ├── params: c:4 a:5 b:6
+                     │              │                        │    ├── variable: b:2
+                     │              │                        │    └── variable: c:8
+                     │              │                        ├── params: a:4 b:5 c:6
                      │              │                        └── body
                      │              │                             └── project
                      │              │                                  ├── columns: stmt_return_2:7
                      │              │                                  ├── values
                      │              │                                  │    └── tuple
                      │              │                                  └── projections
-                     │              │                                       └── variable: c:4 [as=stmt_return_2:7]
+                     │              │                                       └── variable: c:6 [as=stmt_return_2:7]
                      │              └── subquery
                      │                   └── project
                      │                        ├── columns: stmt_if_1:10
@@ -269,17 +269,17 @@ project
                      │                        └── projections
                      │                             └── udf: stmt_if_1 [as=stmt_if_1:10]
                      │                                  ├── args
-                     │                                  │    ├── variable: c:3
                      │                                  │    ├── variable: a:1
-                     │                                  │    └── variable: b:2
-                     │                                  ├── params: c:4 a:5 b:6
+                     │                                  │    ├── variable: b:2
+                     │                                  │    └── variable: c:3
+                     │                                  ├── params: a:4 b:5 c:6
                      │                                  └── body
                      │                                       └── project
                      │                                            ├── columns: stmt_return_2:7
                      │                                            ├── values
                      │                                            │    └── tuple
                      │                                            └── projections
-                     │                                                 └── variable: c:4 [as=stmt_return_2:7]
+                     │                                                 └── variable: c:6 [as=stmt_return_2:7]
                      └── const: 1
 
 exec-ddl
@@ -341,17 +341,17 @@ project
                      │              │              └── projections
                      │              │                   └── udf: stmt_if_1 [as=stmt_if_1:9]
                      │              │                        ├── args
-                     │              │                        │    ├── variable: c:8
                      │              │                        │    ├── variable: a:1
-                     │              │                        │    └── variable: b:2
-                     │              │                        ├── params: c:4 a:5 b:6
+                     │              │                        │    ├── variable: b:2
+                     │              │                        │    └── variable: c:8
+                     │              │                        ├── params: a:4 b:5 c:6
                      │              │                        └── body
                      │              │                             └── project
                      │              │                                  ├── columns: stmt_return_2:7
                      │              │                                  ├── values
                      │              │                                  │    └── tuple
                      │              │                                  └── projections
-                     │              │                                       └── variable: c:4 [as=stmt_return_2:7]
+                     │              │                                       └── variable: c:6 [as=stmt_return_2:7]
                      │              └── subquery
                      │                   └── project
                      │                        ├── columns: stmt_if_1:11
@@ -364,17 +364,17 @@ project
                      │                        └── projections
                      │                             └── udf: stmt_if_1 [as=stmt_if_1:11]
                      │                                  ├── args
-                     │                                  │    ├── variable: c:10
                      │                                  │    ├── variable: a:1
-                     │                                  │    └── variable: b:2
-                     │                                  ├── params: c:4 a:5 b:6
+                     │                                  │    ├── variable: b:2
+                     │                                  │    └── variable: c:10
+                     │                                  ├── params: a:4 b:5 c:6
                      │                                  └── body
                      │                                       └── project
                      │                                            ├── columns: stmt_return_2:7
                      │                                            ├── values
                      │                                            │    └── tuple
                      │                                            └── projections
-                     │                                                 └── variable: c:4 [as=stmt_return_2:7]
+                     │                                                 └── variable: c:6 [as=stmt_return_2:7]
                      └── const: 1
 
 exec-ddl
@@ -436,17 +436,17 @@ project
                      │              │              └── projections
                      │              │                   └── udf: stmt_if_1 [as=stmt_if_1:9]
                      │              │                        ├── args
-                     │              │                        │    ├── variable: c:8
                      │              │                        │    ├── variable: a:1
-                     │              │                        │    └── variable: b:2
-                     │              │                        ├── params: c:4 a:5 b:6
+                     │              │                        │    ├── variable: b:2
+                     │              │                        │    └── variable: c:8
+                     │              │                        ├── params: a:4 b:5 c:6
                      │              │                        └── body
                      │              │                             └── project
                      │              │                                  ├── columns: stmt_return_2:7
                      │              │                                  ├── values
                      │              │                                  │    └── tuple
                      │              │                                  └── projections
-                     │              │                                       └── variable: c:4 [as=stmt_return_2:7]
+                     │              │                                       └── variable: c:6 [as=stmt_return_2:7]
                      │              └── subquery
                      │                   └── project
                      │                        ├── columns: stmt_return_3:10!null
@@ -522,17 +522,17 @@ project
                      │                        └── projections
                      │                             └── udf: stmt_if_1 [as=stmt_if_1:10]
                      │                                  ├── args
-                     │                                  │    ├── variable: c:9
                      │                                  │    ├── variable: a:1
-                     │                                  │    └── variable: b:2
-                     │                                  ├── params: c:4 a:5 b:6
+                     │                                  │    ├── variable: b:2
+                     │                                  │    └── variable: c:9
+                     │                                  ├── params: a:4 b:5 c:6
                      │                                  └── body
                      │                                       └── project
                      │                                            ├── columns: stmt_return_2:7
                      │                                            ├── values
                      │                                            │    └── tuple
                      │                                            └── projections
-                     │                                                 └── variable: c:4 [as=stmt_return_2:7]
+                     │                                                 └── variable: c:6 [as=stmt_return_2:7]
                      └── const: 1
 
 exec-ddl
@@ -636,10 +636,10 @@ project
                      │    └── projections
                      │         └── udf: stmt_loop_5 [as=stmt_loop_5:17]
                      │              ├── args
-                     │              │    ├── variable: i:3
                      │              │    ├── variable: a:1
-                     │              │    └── variable: b:2
-                     │              ├── params: i:13 a:14 b:15
+                     │              │    ├── variable: b:2
+                     │              │    └── variable: i:3
+                     │              ├── params: a:13 b:14 i:15
                      │              └── body
                      │                   └── project
                      │                        ├── columns: stmt_return_6:16!null
@@ -691,10 +691,10 @@ project
                      │    └── projections
                      │         └── udf: stmt_loop_5 [as=stmt_loop_5:23]
                      │              ├── args
-                     │              │    ├── variable: i:3
                      │              │    ├── variable: a:1
-                     │              │    └── variable: b:2
-                     │              ├── params: i:13 a:14 b:15
+                     │              │    ├── variable: b:2
+                     │              │    └── variable: i:3
+                     │              ├── params: a:13 b:14 i:15
                      │              └── body
                      │                   └── project
                      │                        ├── columns: stmt_if_9:22
@@ -705,8 +705,8 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── lt
-                     │                                  │    │    ├── variable: a:14
-                     │                                  │    │    └── variable: b:15
+                     │                                  │    │    ├── variable: a:13
+                     │                                  │    │    └── variable: b:14
                      │                                  │    └── subquery
                      │                                  │         └── project
                      │                                  │              ├── columns: stmt_return_8:20!null
@@ -722,10 +722,10 @@ project
                      │                                            └── projections
                      │                                                 └── udf: stmt_if_6 [as=stmt_if_6:21]
                      │                                                      ├── args
-                     │                                                      │    ├── variable: i:13
-                     │                                                      │    ├── variable: a:14
-                     │                                                      │    └── variable: b:15
-                     │                                                      ├── params: i:16 a:17 b:18
+                     │                                                      │    ├── variable: a:13
+                     │                                                      │    ├── variable: b:14
+                     │                                                      │    └── variable: i:15
+                     │                                                      ├── params: a:16 b:17 i:18
                      │                                                      └── body
                      │                                                           └── project
                      │                                                                ├── columns: stmt_return_7:19!null
@@ -777,10 +777,10 @@ project
                      │    └── projections
                      │         └── udf: stmt_loop_3 [as=stmt_loop_3:25]
                      │              ├── args
-                     │              │    ├── variable: i:3
                      │              │    ├── variable: a:1
-                     │              │    └── variable: b:2
-                     │              ├── params: i:8 a:9 b:10
+                     │              │    ├── variable: b:2
+                     │              │    └── variable: i:3
+                     │              ├── params: a:8 b:9 i:10
                      │              └── body
                      │                   └── project
                      │                        ├── columns: stmt_if_8:24
@@ -791,8 +791,8 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:8
-                     │                                  │    │    └── variable: b:10
+                     │                                  │    │    ├── variable: i:10
+                     │                                  │    │    └── variable: b:9
                      │                                  │    └── subquery
                      │                                  │         └── project
                      │                                  │              ├── columns: loop_exit_1:22
@@ -801,17 +801,17 @@ project
                      │                                  │              └── projections
                      │                                  │                   └── udf: loop_exit_1 [as=loop_exit_1:22]
                      │                                  │                        ├── args
-                     │                                  │                        │    ├── variable: i:8
-                     │                                  │                        │    ├── variable: a:9
-                     │                                  │                        │    └── variable: b:10
-                     │                                  │                        ├── params: i:4 a:5 b:6
+                     │                                  │                        │    ├── variable: a:8
+                     │                                  │                        │    ├── variable: b:9
+                     │                                  │                        │    └── variable: i:10
+                     │                                  │                        ├── params: a:4 b:5 i:6
                      │                                  │                        └── body
                      │                                  │                             └── project
                      │                                  │                                  ├── columns: stmt_return_2:7
                      │                                  │                                  ├── values
                      │                                  │                                  │    └── tuple
                      │                                  │                                  └── projections
-                     │                                  │                                       └── variable: i:4 [as=stmt_return_2:7]
+                     │                                  │                                       └── variable: i:6 [as=stmt_return_2:7]
                      │                                  └── subquery
                      │                                       └── project
                      │                                            ├── columns: stmt_if_4:23
@@ -820,10 +820,10 @@ project
                      │                                            └── projections
                      │                                                 └── udf: stmt_if_4 [as=stmt_if_4:23]
                      │                                                      ├── args
-                     │                                                      │    ├── variable: i:8
-                     │                                                      │    ├── variable: a:9
-                     │                                                      │    └── variable: b:10
-                     │                                                      ├── params: i:11 a:12 b:13
+                     │                                                      │    ├── variable: a:8
+                     │                                                      │    ├── variable: b:9
+                     │                                                      │    └── variable: i:10
+                     │                                                      ├── params: a:11 b:12 i:13
                      │                                                      └── body
                      │                                                           └── project
                      │                                                                ├── columns: stmt_if_7:21
@@ -834,7 +834,7 @@ project
                      │                                                                          ├── true
                      │                                                                          ├── when
                      │                                                                          │    ├── eq
-                     │                                                                          │    │    ├── variable: i:11
+                     │                                                                          │    │    ├── variable: i:13
                      │                                                                          │    │    └── const: 8
                      │                                                                          │    └── subquery
                      │                                                                          │         └── project
@@ -851,10 +851,10 @@ project
                      │                                                                                    └── projections
                      │                                                                                         └── udf: stmt_if_5 [as=stmt_if_5:20]
                      │                                                                                              ├── args
-                     │                                                                                              │    ├── variable: i:11
-                     │                                                                                              │    ├── variable: a:12
-                     │                                                                                              │    └── variable: b:13
-                     │                                                                                              ├── params: i:14 a:15 b:16
+                     │                                                                                              │    ├── variable: a:11
+                     │                                                                                              │    ├── variable: b:12
+                     │                                                                                              │    └── variable: i:13
+                     │                                                                                              ├── params: a:14 b:15 i:16
                      │                                                                                              └── body
                      │                                                                                                   └── project
                      │                                                                                                        ├── columns: stmt_loop_3:18
@@ -864,14 +864,14 @@ project
                      │                                                                                                        │    │    └── tuple
                      │                                                                                                        │    └── projections
                      │                                                                                                        │         └── plus [as=i:17]
-                     │                                                                                                        │              ├── variable: i:14
+                     │                                                                                                        │              ├── variable: i:16
                      │                                                                                                        │              └── const: 1
                      │                                                                                                        └── projections
                      │                                                                                                             └── udf: stmt_loop_3 [as=stmt_loop_3:18]
                      │                                                                                                                  ├── args
-                     │                                                                                                                  │    ├── variable: i:17
-                     │                                                                                                                  │    ├── variable: a:15
-                     │                                                                                                                  │    └── variable: b:16
+                     │                                                                                                                  │    ├── variable: a:14
+                     │                                                                                                                  │    ├── variable: b:15
+                     │                                                                                                                  │    └── variable: i:17
                      │                                                                                                                  └── recursive-call
                      └── const: 1
 
@@ -916,10 +916,10 @@ project
                      │    └── projections
                      │         └── udf: stmt_loop_3 [as=stmt_loop_3:19]
                      │              ├── args
-                     │              │    ├── variable: i:3
                      │              │    ├── variable: a:1
-                     │              │    └── variable: b:2
-                     │              ├── params: i:8 a:9 b:10
+                     │              │    ├── variable: b:2
+                     │              │    └── variable: i:3
+                     │              ├── params: a:8 b:9 i:10
                      │              └── body
                      │                   └── project
                      │                        ├── columns: stmt_if_5:18
@@ -930,8 +930,8 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:8
-                     │                                  │    │    └── variable: b:10
+                     │                                  │    │    ├── variable: i:10
+                     │                                  │    │    └── variable: b:9
                      │                                  │    └── subquery
                      │                                  │         └── project
                      │                                  │              ├── columns: loop_exit_1:16
@@ -940,17 +940,17 @@ project
                      │                                  │              └── projections
                      │                                  │                   └── udf: loop_exit_1 [as=loop_exit_1:16]
                      │                                  │                        ├── args
-                     │                                  │                        │    ├── variable: i:8
-                     │                                  │                        │    ├── variable: a:9
-                     │                                  │                        │    └── variable: b:10
-                     │                                  │                        ├── params: i:4 a:5 b:6
+                     │                                  │                        │    ├── variable: a:8
+                     │                                  │                        │    ├── variable: b:9
+                     │                                  │                        │    └── variable: i:10
+                     │                                  │                        ├── params: a:4 b:5 i:6
                      │                                  │                        └── body
                      │                                  │                             └── project
                      │                                  │                                  ├── columns: stmt_return_2:7
                      │                                  │                                  ├── values
                      │                                  │                                  │    └── tuple
                      │                                  │                                  └── projections
-                     │                                  │                                       └── variable: i:4 [as=stmt_return_2:7]
+                     │                                  │                                       └── variable: i:6 [as=stmt_return_2:7]
                      │                                  └── subquery
                      │                                       └── project
                      │                                            ├── columns: stmt_if_4:17
@@ -959,10 +959,10 @@ project
                      │                                            └── projections
                      │                                                 └── udf: stmt_if_4 [as=stmt_if_4:17]
                      │                                                      ├── args
-                     │                                                      │    ├── variable: i:8
-                     │                                                      │    ├── variable: a:9
-                     │                                                      │    └── variable: b:10
-                     │                                                      ├── params: i:11 a:12 b:13
+                     │                                                      │    ├── variable: a:8
+                     │                                                      │    ├── variable: b:9
+                     │                                                      │    └── variable: i:10
+                     │                                                      ├── params: a:11 b:12 i:13
                      │                                                      └── body
                      │                                                           └── project
                      │                                                                ├── columns: stmt_loop_3:15
@@ -972,14 +972,14 @@ project
                      │                                                                │    │    └── tuple
                      │                                                                │    └── projections
                      │                                                                │         └── plus [as=i:14]
-                     │                                                                │              ├── variable: i:11
+                     │                                                                │              ├── variable: i:13
                      │                                                                │              └── const: 1
                      │                                                                └── projections
                      │                                                                     └── udf: stmt_loop_3 [as=stmt_loop_3:15]
                      │                                                                          ├── args
-                     │                                                                          │    ├── variable: i:14
-                     │                                                                          │    ├── variable: a:12
-                     │                                                                          │    └── variable: b:13
+                     │                                                                          │    ├── variable: a:11
+                     │                                                                          │    ├── variable: b:12
+                     │                                                                          │    └── variable: i:14
                      │                                                                          └── recursive-call
                      └── const: 1
 
@@ -1048,11 +1048,11 @@ project
                      │              │              └── projections
                      │              │                   └── udf: stmt_loop_4 [as=stmt_loop_4:29]
                      │              │                        ├── args
-                     │              │                        │    ├── variable: sum:3
-                     │              │                        │    ├── variable: i:4
                      │              │                        │    ├── variable: a:1
-                     │              │                        │    └── variable: b:2
-                     │              │                        ├── params: sum:15 i:16 a:17 b:18
+                     │              │                        │    ├── variable: b:2
+                     │              │                        │    ├── variable: sum:3
+                     │              │                        │    └── variable: i:4
+                     │              │                        ├── params: a:15 b:16 sum:17 i:18
                      │              │                        └── body
                      │              │                             └── project
                      │              │                                  ├── columns: stmt_if_6:28
@@ -1063,8 +1063,8 @@ project
                      │              │                                            ├── true
                      │              │                                            ├── when
                      │              │                                            │    ├── ge
-                     │              │                                            │    │    ├── variable: i:16
-                     │              │                                            │    │    └── variable: b:18
+                     │              │                                            │    │    ├── variable: i:18
+                     │              │                                            │    │    └── variable: b:16
                      │              │                                            │    └── subquery
                      │              │                                            │         └── project
                      │              │                                            │              ├── columns: loop_exit_3:26
@@ -1073,11 +1073,11 @@ project
                      │              │                                            │              └── projections
                      │              │                                            │                   └── udf: loop_exit_3 [as=loop_exit_3:26]
                      │              │                                            │                        ├── args
-                     │              │                                            │                        │    ├── variable: sum:15
-                     │              │                                            │                        │    ├── variable: i:16
-                     │              │                                            │                        │    ├── variable: a:17
-                     │              │                                            │                        │    └── variable: b:18
-                     │              │                                            │                        ├── params: sum:10 i:11 a:12 b:13
+                     │              │                                            │                        │    ├── variable: a:15
+                     │              │                                            │                        │    ├── variable: b:16
+                     │              │                                            │                        │    ├── variable: sum:17
+                     │              │                                            │                        │    └── variable: i:18
+                     │              │                                            │                        ├── params: a:10 b:11 sum:12 i:13
                      │              │                                            │                        └── body
                      │              │                                            │                             └── project
                      │              │                                            │                                  ├── columns: stmt_if_1:14
@@ -1086,18 +1086,18 @@ project
                      │              │                                            │                                  └── projections
                      │              │                                            │                                       └── udf: stmt_if_1 [as=stmt_if_1:14]
                      │              │                                            │                                            ├── args
-                     │              │                                            │                                            │    ├── variable: sum:10
-                     │              │                                            │                                            │    ├── variable: i:11
-                     │              │                                            │                                            │    ├── variable: a:12
-                     │              │                                            │                                            │    └── variable: b:13
-                     │              │                                            │                                            ├── params: sum:5 i:6 a:7 b:8
+                     │              │                                            │                                            │    ├── variable: a:10
+                     │              │                                            │                                            │    ├── variable: b:11
+                     │              │                                            │                                            │    ├── variable: sum:12
+                     │              │                                            │                                            │    └── variable: i:13
+                     │              │                                            │                                            ├── params: a:5 b:6 sum:7 i:8
                      │              │                                            │                                            └── body
                      │              │                                            │                                                 └── project
                      │              │                                            │                                                      ├── columns: stmt_return_2:9
                      │              │                                            │                                                      ├── values
                      │              │                                            │                                                      │    └── tuple
                      │              │                                            │                                                      └── projections
-                     │              │                                            │                                                           └── variable: sum:5 [as=stmt_return_2:9]
+                     │              │                                            │                                                           └── variable: sum:7 [as=stmt_return_2:9]
                      │              │                                            └── subquery
                      │              │                                                 └── project
                      │              │                                                      ├── columns: stmt_if_5:27
@@ -1106,11 +1106,11 @@ project
                      │              │                                                      └── projections
                      │              │                                                           └── udf: stmt_if_5 [as=stmt_if_5:27]
                      │              │                                                                ├── args
-                     │              │                                                                │    ├── variable: sum:15
-                     │              │                                                                │    ├── variable: i:16
-                     │              │                                                                │    ├── variable: a:17
-                     │              │                                                                │    └── variable: b:18
-                     │              │                                                                ├── params: sum:19 i:20 a:21 b:22
+                     │              │                                                                │    ├── variable: a:15
+                     │              │                                                                │    ├── variable: b:16
+                     │              │                                                                │    ├── variable: sum:17
+                     │              │                                                                │    └── variable: i:18
+                     │              │                                                                ├── params: a:19 b:20 sum:21 i:22
                      │              │                                                                └── body
                      │              │                                                                     └── project
                      │              │                                                                          ├── columns: stmt_loop_4:25
@@ -1122,19 +1122,19 @@ project
                      │              │                                                                          │    │    │    └── tuple
                      │              │                                                                          │    │    └── projections
                      │              │                                                                          │    │         └── plus [as=sum:23]
-                     │              │                                                                          │    │              ├── variable: sum:19
-                     │              │                                                                          │    │              └── variable: i:20
+                     │              │                                                                          │    │              ├── variable: sum:21
+                     │              │                                                                          │    │              └── variable: i:22
                      │              │                                                                          │    └── projections
                      │              │                                                                          │         └── plus [as=i:24]
-                     │              │                                                                          │              ├── variable: i:20
+                     │              │                                                                          │              ├── variable: i:22
                      │              │                                                                          │              └── const: 1
                      │              │                                                                          └── projections
                      │              │                                                                               └── udf: stmt_loop_4 [as=stmt_loop_4:25]
                      │              │                                                                                    ├── args
+                     │              │                                                                                    │    ├── variable: a:19
+                     │              │                                                                                    │    ├── variable: b:20
                      │              │                                                                                    │    ├── variable: sum:23
-                     │              │                                                                                    │    ├── variable: i:24
-                     │              │                                                                                    │    ├── variable: a:21
-                     │              │                                                                                    │    └── variable: b:22
+                     │              │                                                                                    │    └── variable: i:24
                      │              │                                                                                    └── recursive-call
                      │              └── subquery
                      │                   └── project
@@ -1144,18 +1144,18 @@ project
                      │                        └── projections
                      │                             └── udf: stmt_if_1 [as=stmt_if_1:30]
                      │                                  ├── args
-                     │                                  │    ├── variable: sum:3
-                     │                                  │    ├── variable: i:4
                      │                                  │    ├── variable: a:1
-                     │                                  │    └── variable: b:2
-                     │                                  ├── params: sum:5 i:6 a:7 b:8
+                     │                                  │    ├── variable: b:2
+                     │                                  │    ├── variable: sum:3
+                     │                                  │    └── variable: i:4
+                     │                                  ├── params: a:5 b:6 sum:7 i:8
                      │                                  └── body
                      │                                       └── project
                      │                                            ├── columns: stmt_return_2:9
                      │                                            ├── values
                      │                                            │    └── tuple
                      │                                            └── projections
-                     │                                                 └── variable: sum:5 [as=stmt_return_2:9]
+                     │                                                 └── variable: sum:7 [as=stmt_return_2:9]
                      └── const: 1
 
 exec-ddl
@@ -1209,11 +1209,11 @@ project
                      │    └── projections
                      │         └── udf: stmt_loop_3 [as=stmt_loop_3:32]
                      │              ├── args
-                     │              │    ├── variable: sum:3
-                     │              │    ├── variable: i:4
                      │              │    ├── variable: a:1
-                     │              │    └── variable: b:2
-                     │              ├── params: sum:10 i:11 a:12 b:13
+                     │              │    ├── variable: b:2
+                     │              │    ├── variable: sum:3
+                     │              │    └── variable: i:4
+                     │              ├── params: a:10 b:11 sum:12 i:13
                      │              └── body
                      │                   └── project
                      │                        ├── columns: stmt_if_7:31
@@ -1224,8 +1224,8 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:11
-                     │                                  │    │    └── variable: b:13
+                     │                                  │    │    ├── variable: i:13
+                     │                                  │    │    └── variable: b:11
                      │                                  │    └── subquery
                      │                                  │         └── project
                      │                                  │              ├── columns: loop_exit_1:29
@@ -1234,18 +1234,18 @@ project
                      │                                  │              └── projections
                      │                                  │                   └── udf: loop_exit_1 [as=loop_exit_1:29]
                      │                                  │                        ├── args
-                     │                                  │                        │    ├── variable: sum:10
-                     │                                  │                        │    ├── variable: i:11
-                     │                                  │                        │    ├── variable: a:12
-                     │                                  │                        │    └── variable: b:13
-                     │                                  │                        ├── params: sum:5 i:6 a:7 b:8
+                     │                                  │                        │    ├── variable: a:10
+                     │                                  │                        │    ├── variable: b:11
+                     │                                  │                        │    ├── variable: sum:12
+                     │                                  │                        │    └── variable: i:13
+                     │                                  │                        ├── params: a:5 b:6 sum:7 i:8
                      │                                  │                        └── body
                      │                                  │                             └── project
                      │                                  │                                  ├── columns: stmt_return_2:9
                      │                                  │                                  ├── values
                      │                                  │                                  │    └── tuple
                      │                                  │                                  └── projections
-                     │                                  │                                       └── variable: sum:5 [as=stmt_return_2:9]
+                     │                                  │                                       └── variable: sum:7 [as=stmt_return_2:9]
                      │                                  └── subquery
                      │                                       └── project
                      │                                            ├── columns: stmt_if_4:30
@@ -1254,11 +1254,11 @@ project
                      │                                            └── projections
                      │                                                 └── udf: stmt_if_4 [as=stmt_if_4:30]
                      │                                                      ├── args
-                     │                                                      │    ├── variable: sum:10
-                     │                                                      │    ├── variable: i:11
-                     │                                                      │    ├── variable: a:12
-                     │                                                      │    └── variable: b:13
-                     │                                                      ├── params: sum:14 i:15 a:16 b:17
+                     │                                                      │    ├── variable: a:10
+                     │                                                      │    ├── variable: b:11
+                     │                                                      │    ├── variable: sum:12
+                     │                                                      │    └── variable: i:13
+                     │                                                      ├── params: a:14 b:15 sum:16 i:17
                      │                                                      └── body
                      │                                                           └── project
                      │                                                                ├── columns: stmt_if_6:28
@@ -1269,7 +1269,7 @@ project
                      │                                                                          ├── true
                      │                                                                          ├── when
                      │                                                                          │    ├── eq
-                     │                                                                          │    │    ├── variable: i:15
+                     │                                                                          │    │    ├── variable: i:17
                      │                                                                          │    │    └── const: 2
                      │                                                                          │    └── subquery
                      │                                                                          │         └── project
@@ -1280,15 +1280,15 @@ project
                      │                                                                          │              │    │    └── tuple
                      │                                                                          │              │    └── projections
                      │                                                                          │              │         └── plus [as=i:25]
-                     │                                                                          │              │              ├── variable: i:15
+                     │                                                                          │              │              ├── variable: i:17
                      │                                                                          │              │              └── const: 1
                      │                                                                          │              └── projections
                      │                                                                          │                   └── udf: stmt_loop_3 [as=stmt_loop_3:26]
                      │                                                                          │                        ├── args
-                     │                                                                          │                        │    ├── variable: sum:14
-                     │                                                                          │                        │    ├── variable: i:25
-                     │                                                                          │                        │    ├── variable: a:16
-                     │                                                                          │                        │    └── variable: b:17
+                     │                                                                          │                        │    ├── variable: a:14
+                     │                                                                          │                        │    ├── variable: b:15
+                     │                                                                          │                        │    ├── variable: sum:16
+                     │                                                                          │                        │    └── variable: i:25
                      │                                                                          │                        └── recursive-call
                      │                                                                          └── subquery
                      │                                                                               └── project
@@ -1298,11 +1298,11 @@ project
                      │                                                                                    └── projections
                      │                                                                                         └── udf: stmt_if_5 [as=stmt_if_5:27]
                      │                                                                                              ├── args
-                     │                                                                                              │    ├── variable: sum:14
-                     │                                                                                              │    ├── variable: i:15
-                     │                                                                                              │    ├── variable: a:16
-                     │                                                                                              │    └── variable: b:17
-                     │                                                                                              ├── params: sum:18 i:19 a:20 b:21
+                     │                                                                                              │    ├── variable: a:14
+                     │                                                                                              │    ├── variable: b:15
+                     │                                                                                              │    ├── variable: sum:16
+                     │                                                                                              │    └── variable: i:17
+                     │                                                                                              ├── params: a:18 b:19 sum:20 i:21
                      │                                                                                              └── body
                      │                                                                                                   └── project
                      │                                                                                                        ├── columns: stmt_loop_3:24
@@ -1314,19 +1314,19 @@ project
                      │                                                                                                        │    │    │    └── tuple
                      │                                                                                                        │    │    └── projections
                      │                                                                                                        │    │         └── plus [as=sum:22]
-                     │                                                                                                        │    │              ├── variable: sum:18
-                     │                                                                                                        │    │              └── variable: i:19
+                     │                                                                                                        │    │              ├── variable: sum:20
+                     │                                                                                                        │    │              └── variable: i:21
                      │                                                                                                        │    └── projections
                      │                                                                                                        │         └── plus [as=i:23]
-                     │                                                                                                        │              ├── variable: i:19
+                     │                                                                                                        │              ├── variable: i:21
                      │                                                                                                        │              └── const: 1
                      │                                                                                                        └── projections
                      │                                                                                                             └── udf: stmt_loop_3 [as=stmt_loop_3:24]
                      │                                                                                                                  ├── args
+                     │                                                                                                                  │    ├── variable: a:18
+                     │                                                                                                                  │    ├── variable: b:19
                      │                                                                                                                  │    ├── variable: sum:22
-                     │                                                                                                                  │    ├── variable: i:23
-                     │                                                                                                                  │    ├── variable: a:20
-                     │                                                                                                                  │    └── variable: b:21
+                     │                                                                                                                  │    └── variable: i:23
                      │                                                                                                                  └── recursive-call
                      └── const: 1
 
@@ -1388,12 +1388,12 @@ project
                      │    └── projections
                      │         └── udf: stmt_loop_3 [as=stmt_loop_3:50]
                      │              ├── args
+                     │              │    ├── variable: a:1
+                     │              │    ├── variable: b:2
                      │              │    ├── variable: sum:3
                      │              │    ├── variable: i:4
-                     │              │    ├── variable: j:5
-                     │              │    ├── variable: a:1
-                     │              │    └── variable: b:2
-                     │              ├── params: sum:12 i:13 j:14 a:15 b:16
+                     │              │    └── variable: j:5
+                     │              ├── params: a:12 b:13 sum:14 i:15 j:16
                      │              └── body
                      │                   └── project
                      │                        ├── columns: stmt_if_9:49
@@ -1404,8 +1404,8 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:13
-                     │                                  │    │    └── variable: b:16
+                     │                                  │    │    ├── variable: i:15
+                     │                                  │    │    └── variable: b:13
                      │                                  │    └── subquery
                      │                                  │         └── project
                      │                                  │              ├── columns: loop_exit_1:47
@@ -1414,19 +1414,19 @@ project
                      │                                  │              └── projections
                      │                                  │                   └── udf: loop_exit_1 [as=loop_exit_1:47]
                      │                                  │                        ├── args
-                     │                                  │                        │    ├── variable: sum:12
-                     │                                  │                        │    ├── variable: i:13
-                     │                                  │                        │    ├── variable: j:14
-                     │                                  │                        │    ├── variable: a:15
-                     │                                  │                        │    └── variable: b:16
-                     │                                  │                        ├── params: sum:6 i:7 j:8 a:9 b:10
+                     │                                  │                        │    ├── variable: a:12
+                     │                                  │                        │    ├── variable: b:13
+                     │                                  │                        │    ├── variable: sum:14
+                     │                                  │                        │    ├── variable: i:15
+                     │                                  │                        │    └── variable: j:16
+                     │                                  │                        ├── params: a:6 b:7 sum:8 i:9 j:10
                      │                                  │                        └── body
                      │                                  │                             └── project
                      │                                  │                                  ├── columns: stmt_return_2:11
                      │                                  │                                  ├── values
                      │                                  │                                  │    └── tuple
                      │                                  │                                  └── projections
-                     │                                  │                                       └── variable: sum:6 [as=stmt_return_2:11]
+                     │                                  │                                       └── variable: sum:8 [as=stmt_return_2:11]
                      │                                  └── subquery
                      │                                       └── project
                      │                                            ├── columns: stmt_if_4:48
@@ -1435,12 +1435,12 @@ project
                      │                                            └── projections
                      │                                                 └── udf: stmt_if_4 [as=stmt_if_4:48]
                      │                                                      ├── args
-                     │                                                      │    ├── variable: sum:12
-                     │                                                      │    ├── variable: i:13
-                     │                                                      │    ├── variable: j:14
-                     │                                                      │    ├── variable: a:15
-                     │                                                      │    └── variable: b:16
-                     │                                                      ├── params: sum:17 i:18 j:19 a:20 b:21
+                     │                                                      │    ├── variable: a:12
+                     │                                                      │    ├── variable: b:13
+                     │                                                      │    ├── variable: sum:14
+                     │                                                      │    ├── variable: i:15
+                     │                                                      │    └── variable: j:16
+                     │                                                      ├── params: a:17 b:18 sum:19 i:20 j:21
                      │                                                      └── body
                      │                                                           └── project
                      │                                                                ├── columns: stmt_loop_6:46
@@ -1453,12 +1453,12 @@ project
                      │                                                                └── projections
                      │                                                                     └── udf: stmt_loop_6 [as=stmt_loop_6:46]
                      │                                                                          ├── args
-                     │                                                                          │    ├── variable: sum:17
-                     │                                                                          │    ├── variable: i:18
-                     │                                                                          │    ├── variable: j:22
-                     │                                                                          │    ├── variable: a:20
-                     │                                                                          │    └── variable: b:21
-                     │                                                                          ├── params: sum:30 i:31 j:32 a:33 b:34
+                     │                                                                          │    ├── variable: a:17
+                     │                                                                          │    ├── variable: b:18
+                     │                                                                          │    ├── variable: sum:19
+                     │                                                                          │    ├── variable: i:20
+                     │                                                                          │    └── variable: j:22
+                     │                                                                          ├── params: a:30 b:31 sum:32 i:33 j:34
                      │                                                                          └── body
                      │                                                                               └── project
                      │                                                                                    ├── columns: stmt_if_8:45
@@ -1469,8 +1469,8 @@ project
                      │                                                                                              ├── true
                      │                                                                                              ├── when
                      │                                                                                              │    ├── ge
-                     │                                                                                              │    │    ├── variable: j:32
-                     │                                                                                              │    │    └── variable: i:31
+                     │                                                                                              │    │    ├── variable: j:34
+                     │                                                                                              │    │    └── variable: i:33
                      │                                                                                              │    └── subquery
                      │                                                                                              │         └── project
                      │                                                                                              │              ├── columns: loop_exit_5:43
@@ -1479,12 +1479,12 @@ project
                      │                                                                                              │              └── projections
                      │                                                                                              │                   └── udf: loop_exit_5 [as=loop_exit_5:43]
                      │                                                                                              │                        ├── args
-                     │                                                                                              │                        │    ├── variable: sum:30
-                     │                                                                                              │                        │    ├── variable: i:31
-                     │                                                                                              │                        │    ├── variable: j:32
-                     │                                                                                              │                        │    ├── variable: a:33
-                     │                                                                                              │                        │    └── variable: b:34
-                     │                                                                                              │                        ├── params: sum:23 i:24 j:25 a:26 b:27
+                     │                                                                                              │                        │    ├── variable: a:30
+                     │                                                                                              │                        │    ├── variable: b:31
+                     │                                                                                              │                        │    ├── variable: sum:32
+                     │                                                                                              │                        │    ├── variable: i:33
+                     │                                                                                              │                        │    └── variable: j:34
+                     │                                                                                              │                        ├── params: a:23 b:24 sum:25 i:26 j:27
                      │                                                                                              │                        └── body
                      │                                                                                              │                             └── project
                      │                                                                                              │                                  ├── columns: stmt_loop_3:29
@@ -1494,16 +1494,16 @@ project
                      │                                                                                              │                                  │    │    └── tuple
                      │                                                                                              │                                  │    └── projections
                      │                                                                                              │                                  │         └── plus [as=i:28]
-                     │                                                                                              │                                  │              ├── variable: i:24
+                     │                                                                                              │                                  │              ├── variable: i:26
                      │                                                                                              │                                  │              └── const: 1
                      │                                                                                              │                                  └── projections
                      │                                                                                              │                                       └── udf: stmt_loop_3 [as=stmt_loop_3:29]
                      │                                                                                              │                                            ├── args
-                     │                                                                                              │                                            │    ├── variable: sum:23
+                     │                                                                                              │                                            │    ├── variable: a:23
+                     │                                                                                              │                                            │    ├── variable: b:24
+                     │                                                                                              │                                            │    ├── variable: sum:25
                      │                                                                                              │                                            │    ├── variable: i:28
-                     │                                                                                              │                                            │    ├── variable: j:25
-                     │                                                                                              │                                            │    ├── variable: a:26
-                     │                                                                                              │                                            │    └── variable: b:27
+                     │                                                                                              │                                            │    └── variable: j:27
                      │                                                                                              │                                            └── recursive-call
                      │                                                                                              └── subquery
                      │                                                                                                   └── project
@@ -1513,12 +1513,12 @@ project
                      │                                                                                                        └── projections
                      │                                                                                                             └── udf: stmt_if_7 [as=stmt_if_7:44]
                      │                                                                                                                  ├── args
-                     │                                                                                                                  │    ├── variable: sum:30
-                     │                                                                                                                  │    ├── variable: i:31
-                     │                                                                                                                  │    ├── variable: j:32
-                     │                                                                                                                  │    ├── variable: a:33
-                     │                                                                                                                  │    └── variable: b:34
-                     │                                                                                                                  ├── params: sum:35 i:36 j:37 a:38 b:39
+                     │                                                                                                                  │    ├── variable: a:30
+                     │                                                                                                                  │    ├── variable: b:31
+                     │                                                                                                                  │    ├── variable: sum:32
+                     │                                                                                                                  │    ├── variable: i:33
+                     │                                                                                                                  │    └── variable: j:34
+                     │                                                                                                                  ├── params: a:35 b:36 sum:37 i:38 j:39
                      │                                                                                                                  └── body
                      │                                                                                                                       └── project
                      │                                                                                                                            ├── columns: stmt_loop_6:42
@@ -1530,20 +1530,20 @@ project
                      │                                                                                                                            │    │    │    └── tuple
                      │                                                                                                                            │    │    └── projections
                      │                                                                                                                            │    │         └── plus [as=sum:40]
-                     │                                                                                                                            │    │              ├── variable: sum:35
-                     │                                                                                                                            │    │              └── variable: j:37
+                     │                                                                                                                            │    │              ├── variable: sum:37
+                     │                                                                                                                            │    │              └── variable: j:39
                      │                                                                                                                            │    └── projections
                      │                                                                                                                            │         └── plus [as=j:41]
-                     │                                                                                                                            │              ├── variable: j:37
+                     │                                                                                                                            │              ├── variable: j:39
                      │                                                                                                                            │              └── const: 1
                      │                                                                                                                            └── projections
                      │                                                                                                                                 └── udf: stmt_loop_6 [as=stmt_loop_6:42]
                      │                                                                                                                                      ├── args
+                     │                                                                                                                                      │    ├── variable: a:35
+                     │                                                                                                                                      │    ├── variable: b:36
                      │                                                                                                                                      │    ├── variable: sum:40
-                     │                                                                                                                                      │    ├── variable: i:36
-                     │                                                                                                                                      │    ├── variable: j:41
-                     │                                                                                                                                      │    ├── variable: a:38
-                     │                                                                                                                                      │    └── variable: b:39
+                     │                                                                                                                                      │    ├── variable: i:38
+                     │                                                                                                                                      │    └── variable: j:41
                      │                                                                                                                                      └── recursive-call
                      └── const: 1
 
@@ -1592,10 +1592,10 @@ project
                      │    └── projections
                      │         └── udf: stmt_loop_3 [as=stmt_loop_3:20]
                      │              ├── args
+                     │              │    ├── variable: n:1
                      │              │    ├── variable: sum:2
-                     │              │    ├── variable: i:3
-                     │              │    └── variable: n:1
-                     │              ├── params: sum:8 i:9 n:10
+                     │              │    └── variable: i:3
+                     │              ├── params: n:8 sum:9 i:10
                      │              └── body
                      │                   └── project
                      │                        ├── columns: stmt_if_5:19
@@ -1606,8 +1606,8 @@ project
                      │                                  ├── true
                      │                                  ├── when
                      │                                  │    ├── lt
-                     │                                  │    │    ├── variable: i:9
-                     │                                  │    │    └── variable: n:10
+                     │                                  │    │    ├── variable: i:10
+                     │                                  │    │    └── variable: n:8
                      │                                  │    └── subquery
                      │                                  │         └── project
                      │                                  │              ├── columns: stmt_if_4:17
@@ -1619,19 +1619,19 @@ project
                      │                                  │              │    │    │    └── tuple
                      │                                  │              │    │    └── projections
                      │                                  │              │    │         └── plus [as=sum:15]
-                     │                                  │              │    │              ├── variable: sum:8
-                     │                                  │              │    │              └── variable: i:9
+                     │                                  │              │    │              ├── variable: sum:9
+                     │                                  │              │    │              └── variable: i:10
                      │                                  │              │    └── projections
                      │                                  │              │         └── plus [as=i:16]
-                     │                                  │              │              ├── variable: i:9
+                     │                                  │              │              ├── variable: i:10
                      │                                  │              │              └── const: 1
                      │                                  │              └── projections
                      │                                  │                   └── udf: stmt_if_4 [as=stmt_if_4:17]
                      │                                  │                        ├── args
+                     │                                  │                        │    ├── variable: n:8
                      │                                  │                        │    ├── variable: sum:15
-                     │                                  │                        │    ├── variable: i:16
-                     │                                  │                        │    └── variable: n:10
-                     │                                  │                        ├── params: sum:11 i:12 n:13
+                     │                                  │                        │    └── variable: i:16
+                     │                                  │                        ├── params: n:11 sum:12 i:13
                      │                                  │                        └── body
                      │                                  │                             └── project
                      │                                  │                                  ├── columns: stmt_loop_3:14
@@ -1640,9 +1640,9 @@ project
                      │                                  │                                  └── projections
                      │                                  │                                       └── udf: stmt_loop_3 [as=stmt_loop_3:14]
                      │                                  │                                            ├── args
-                     │                                  │                                            │    ├── variable: sum:11
-                     │                                  │                                            │    ├── variable: i:12
-                     │                                  │                                            │    └── variable: n:13
+                     │                                  │                                            │    ├── variable: n:11
+                     │                                  │                                            │    ├── variable: sum:12
+                     │                                  │                                            │    └── variable: i:13
                      │                                  │                                            └── recursive-call
                      │                                  └── subquery
                      │                                       └── project
@@ -1652,17 +1652,17 @@ project
                      │                                            └── projections
                      │                                                 └── udf: loop_exit_1 [as=loop_exit_1:18]
                      │                                                      ├── args
-                     │                                                      │    ├── variable: sum:8
-                     │                                                      │    ├── variable: i:9
-                     │                                                      │    └── variable: n:10
-                     │                                                      ├── params: sum:4 i:5 n:6
+                     │                                                      │    ├── variable: n:8
+                     │                                                      │    ├── variable: sum:9
+                     │                                                      │    └── variable: i:10
+                     │                                                      ├── params: n:4 sum:5 i:6
                      │                                                      └── body
                      │                                                           └── project
                      │                                                                ├── columns: stmt_return_2:7
                      │                                                                ├── values
                      │                                                                │    └── tuple
                      │                                                                └── projections
-                     │                                                                     └── variable: sum:4 [as=stmt_return_2:7]
+                     │                                                                     └── variable: sum:5 [as=stmt_return_2:7]
                      └── const: 1
 
 exec-ddl
@@ -3379,16 +3379,16 @@ project
                      │              │              └── projections
                      │              │                   └── udf: stmt_if_1 [as=stmt_if_1:8]
                      │              │                        ├── args
-                     │              │                        │    ├── variable: i:7
-                     │              │                        │    └── variable: n:1
-                     │              │                        ├── params: i:3 n:4
+                     │              │                        │    ├── variable: n:1
+                     │              │                        │    └── variable: i:7
+                     │              │                        ├── params: n:3 i:4
                      │              │                        └── body
                      │              │                             └── project
                      │              │                                  ├── columns: stmt_return_2:5
                      │              │                                  ├── values
                      │              │                                  │    └── tuple
                      │              │                                  └── projections
-                     │              │                                       └── variable: i:3 [as=stmt_return_2:5]
+                     │              │                                       └── variable: i:4 [as=stmt_return_2:5]
                      │              ├── when
                      │              │    ├── eq
                      │              │    │    ├── variable: n:1
@@ -3412,16 +3412,16 @@ project
                      │                        └── projections
                      │                             └── udf: stmt_if_1 [as=stmt_if_1:11]
                      │                                  ├── args
-                     │                                  │    ├── variable: i:2
-                     │                                  │    └── variable: n:1
-                     │                                  ├── params: i:3 n:4
+                     │                                  │    ├── variable: n:1
+                     │                                  │    └── variable: i:2
+                     │                                  ├── params: n:3 i:4
                      │                                  └── body
                      │                                       └── project
                      │                                            ├── columns: stmt_return_2:5
                      │                                            ├── values
                      │                                            │    └── tuple
                      │                                            └── projections
-                     │                                                 └── variable: i:3 [as=stmt_return_2:5]
+                     │                                                 └── variable: i:4 [as=stmt_return_2:5]
                      └── const: 1
 
 # Testing EXCEPTION blocks.
@@ -3794,16 +3794,16 @@ project
                      │    └── projections
                      │         └── udf: exception_block_3 [as=exception_block_3:9]
                      │              ├── args
-                     │              │    ├── variable: i:2
-                     │              │    └── variable: n:1
-                     │              ├── params: i:6 n:7
+                     │              │    ├── variable: n:1
+                     │              │    └── variable: i:2
+                     │              ├── params: n:6 i:7
                      │              ├── body
                      │              │    └── project
                      │              │         ├── columns: stmt_return_4:8
                      │              │         ├── values
                      │              │         │    └── tuple
                      │              │         └── projections
-                     │              │              └── variable: i:6 [as=stmt_return_4:8]
+                     │              │              └── variable: i:7 [as=stmt_return_4:8]
                      │              └── exception-handler
                      │                   └── SQLSTATE '22012'
                      │                        └── project
@@ -3861,11 +3861,11 @@ project
                      │    └── projections
                      │         └── udf: exception_block_3 [as=exception_block_3:33]
                      │              ├── args
-                     │              │    ├── variable: x:4
                      │              │    ├── variable: i:1
                      │              │    ├── variable: j:2
-                     │              │    └── variable: k:3
-                     │              ├── params: x:10 i:11 j:12 k:13
+                     │              │    ├── variable: k:3
+                     │              │    └── variable: x:4
+                     │              ├── params: i:10 j:11 k:12 x:13
                      │              ├── body
                      │              │    └── project
                      │              │         ├── columns: assign_exception_block_4:32
@@ -3878,15 +3878,15 @@ project
                      │              │         │         └── projections
                      │              │         │              └── floor-div [as=x:14]
                      │              │         │                   ├── const: 1
-                     │              │         │                   └── variable: i:11
+                     │              │         │                   └── variable: i:10
                      │              │         └── projections
                      │              │              └── udf: assign_exception_block_4 [as=assign_exception_block_4:32]
                      │              │                   ├── args
-                     │              │                   │    ├── variable: x:14
-                     │              │                   │    ├── variable: i:11
-                     │              │                   │    ├── variable: j:12
-                     │              │                   │    └── variable: k:13
-                     │              │                   ├── params: x:15 i:16 j:17 k:18
+                     │              │                   │    ├── variable: i:10
+                     │              │                   │    ├── variable: j:11
+                     │              │                   │    ├── variable: k:12
+                     │              │                   │    └── variable: x:14
+                     │              │                   ├── params: i:15 j:16 k:17 x:18
                      │              │                   └── body
                      │              │                        └── project
                      │              │                             ├── columns: assign_exception_block_5:31
@@ -3899,15 +3899,15 @@ project
                      │              │                             │         └── projections
                      │              │                             │              └── floor-div [as=x:19]
                      │              │                             │                   ├── const: 2
-                     │              │                             │                   └── variable: j:17
+                     │              │                             │                   └── variable: j:16
                      │              │                             └── projections
                      │              │                                  └── udf: assign_exception_block_5 [as=assign_exception_block_5:31]
                      │              │                                       ├── args
-                     │              │                                       │    ├── variable: x:19
-                     │              │                                       │    ├── variable: i:16
-                     │              │                                       │    ├── variable: j:17
-                     │              │                                       │    └── variable: k:18
-                     │              │                                       ├── params: x:20 i:21 j:22 k:23
+                     │              │                                       │    ├── variable: i:15
+                     │              │                                       │    ├── variable: j:16
+                     │              │                                       │    ├── variable: k:17
+                     │              │                                       │    └── variable: x:19
+                     │              │                                       ├── params: i:20 j:21 k:22 x:23
                      │              │                                       └── body
                      │              │                                            └── project
                      │              │                                                 ├── columns: assign_exception_block_6:30
@@ -3920,22 +3920,22 @@ project
                      │              │                                                 │         └── projections
                      │              │                                                 │              └── floor-div [as=x:24]
                      │              │                                                 │                   ├── const: 3
-                     │              │                                                 │                   └── variable: k:23
+                     │              │                                                 │                   └── variable: k:22
                      │              │                                                 └── projections
                      │              │                                                      └── udf: assign_exception_block_6 [as=assign_exception_block_6:30]
                      │              │                                                           ├── args
-                     │              │                                                           │    ├── variable: x:24
-                     │              │                                                           │    ├── variable: i:21
-                     │              │                                                           │    ├── variable: j:22
-                     │              │                                                           │    └── variable: k:23
-                     │              │                                                           ├── params: x:25 i:26 j:27 k:28
+                     │              │                                                           │    ├── variable: i:20
+                     │              │                                                           │    ├── variable: j:21
+                     │              │                                                           │    ├── variable: k:22
+                     │              │                                                           │    └── variable: x:24
+                     │              │                                                           ├── params: i:25 j:26 k:27 x:28
                      │              │                                                           └── body
                      │              │                                                                └── project
                      │              │                                                                     ├── columns: stmt_return_7:29
                      │              │                                                                     ├── values
                      │              │                                                                     │    └── tuple
                      │              │                                                                     └── projections
-                     │              │                                                                          └── variable: x:25 [as=stmt_return_7:29]
+                     │              │                                                                          └── variable: x:28 [as=stmt_return_7:29]
                      │              └── exception-handler
                      │                   └── SQLSTATE '22012'
                      │                        └── project
@@ -3943,7 +3943,7 @@ project
                      │                             ├── values
                      │                             │    └── tuple
                      │                             └── projections
-                     │                                  └── variable: x:5 [as=stmt_return_2:9]
+                     │                                  └── variable: x:8 [as=stmt_return_2:9]
                      └── const: 1
 
 exec-ddl
@@ -3995,9 +3995,9 @@ project
                      │    └── projections
                      │         └── udf: exception_block_3 [as=exception_block_3:30]
                      │              ├── args
-                     │              │    ├── variable: x:2
-                     │              │    └── variable: i:1
-                     │              ├── params: x:6 i:7
+                     │              │    ├── variable: i:1
+                     │              │    └── variable: x:2
+                     │              ├── params: i:6 x:7
                      │              ├── body
                      │              │    └── project
                      │              │         ├── columns: stmt_if_12:29
@@ -4008,7 +4008,7 @@ project
                      │              │                   ├── true
                      │              │                   ├── when
                      │              │                   │    ├── eq
-                     │              │                   │    │    ├── variable: i:7
+                     │              │                   │    │    ├── variable: i:6
                      │              │                   │    │    └── const: 0
                      │              │                   │    └── subquery
                      │              │                   │         └── project
@@ -4024,9 +4024,9 @@ project
                      │              │                   │              └── projections
                      │              │                   │                   └── udf: assign_exception_block_6 [as=assign_exception_block_6:19]
                      │              │                   │                        ├── args
-                     │              │                   │                        │    ├── variable: x:11
-                     │              │                   │                        │    └── variable: i:7
-                     │              │                   │                        ├── params: x:12 i:13
+                     │              │                   │                        │    ├── variable: i:6
+                     │              │                   │                        │    └── variable: x:11
+                     │              │                   │                        ├── params: i:12 x:13
                      │              │                   │                        └── body
                      │              │                   │                             └── project
                      │              │                   │                                  ├── columns: "_stmt_raise_7":18
@@ -4035,9 +4035,9 @@ project
                      │              │                   │                                  └── projections
                      │              │                   │                                       └── udf: _stmt_raise_7 [as="_stmt_raise_7":18]
                      │              │                   │                                            ├── args
-                     │              │                   │                                            │    ├── variable: x:12
-                     │              │                   │                                            │    └── variable: i:13
-                     │              │                   │                                            ├── params: x:14 i:15
+                     │              │                   │                                            │    ├── variable: i:12
+                     │              │                   │                                            │    └── variable: x:13
+                     │              │                   │                                            ├── params: i:14 x:15
                      │              │                   │                                            └── body
                      │              │                   │                                                 ├── project
                      │              │                   │                                                 │    ├── columns: stmt_raise_8:16
@@ -4057,9 +4057,9 @@ project
                      │              │                   │                                                      └── projections
                      │              │                   │                                                           └── udf: stmt_if_4 [as=stmt_if_4:17]
                      │              │                   │                                                                ├── args
-                     │              │                   │                                                                │    ├── variable: x:14
-                     │              │                   │                                                                │    └── variable: i:15
-                     │              │                   │                                                                ├── params: x:8 i:9
+                     │              │                   │                                                                │    ├── variable: i:14
+                     │              │                   │                                                                │    └── variable: x:15
+                     │              │                   │                                                                ├── params: i:8 x:9
                      │              │                   │                                                                └── body
                      │              │                   │                                                                     └── project
                      │              │                   │                                                                          ├── columns: stmt_return_5:10!null
@@ -4081,9 +4081,9 @@ project
                      │              │                             └── projections
                      │              │                                  └── udf: assign_exception_block_9 [as=assign_exception_block_9:28]
                      │              │                                       ├── args
-                     │              │                                       │    ├── variable: x:20
-                     │              │                                       │    └── variable: i:7
-                     │              │                                       ├── params: x:21 i:22
+                     │              │                                       │    ├── variable: i:6
+                     │              │                                       │    └── variable: x:20
+                     │              │                                       ├── params: i:21 x:22
                      │              │                                       └── body
                      │              │                                            └── project
                      │              │                                                 ├── columns: "_stmt_raise_10":27
@@ -4092,9 +4092,9 @@ project
                      │              │                                                 └── projections
                      │              │                                                      └── udf: _stmt_raise_10 [as="_stmt_raise_10":27]
                      │              │                                                           ├── args
-                     │              │                                                           │    ├── variable: x:21
-                     │              │                                                           │    └── variable: i:22
-                     │              │                                                           ├── params: x:23 i:24
+                     │              │                                                           │    ├── variable: i:21
+                     │              │                                                           │    └── variable: x:22
+                     │              │                                                           ├── params: i:23 x:24
                      │              │                                                           └── body
                      │              │                                                                ├── project
                      │              │                                                                │    ├── columns: stmt_raise_11:25
@@ -4114,9 +4114,9 @@ project
                      │              │                                                                     └── projections
                      │              │                                                                          └── udf: stmt_if_4 [as=stmt_if_4:26]
                      │              │                                                                               ├── args
-                     │              │                                                                               │    ├── variable: x:23
-                     │              │                                                                               │    └── variable: i:24
-                     │              │                                                                               ├── params: x:8 i:9
+                     │              │                                                                               │    ├── variable: i:23
+                     │              │                                                                               │    └── variable: x:24
+                     │              │                                                                               ├── params: i:8 x:9
                      │              │                                                                               └── body
                      │              │                                                                                    └── project
                      │              │                                                                                         ├── columns: stmt_return_5:10!null
@@ -4131,7 +4131,7 @@ project
                      │                             ├── values
                      │                             │    └── tuple
                      │                             └── projections
-                     │                                  └── variable: x:3 [as=stmt_return_2:5]
+                     │                                  └── variable: x:4 [as=stmt_return_2:5]
                      └── const: 1
 
 exec-ddl
@@ -4186,11 +4186,11 @@ project
                      │    └── projections
                      │         └── udf: exception_block_3 [as=exception_block_3:44]
                      │              ├── args
-                     │              │    ├── variable: x:3
-                     │              │    ├── variable: i:4
                      │              │    ├── variable: n:1
-                     │              │    └── variable: a:2
-                     │              ├── params: x:10 i:11 n:12 a:13
+                     │              │    ├── variable: a:2
+                     │              │    ├── variable: x:3
+                     │              │    └── variable: i:4
+                     │              ├── params: n:10 a:11 x:12 i:13
                      │              ├── body
                      │              │    └── project
                      │              │         ├── columns: stmt_loop_6:43
@@ -4199,11 +4199,11 @@ project
                      │              │         └── projections
                      │              │              └── udf: stmt_loop_6 [as=stmt_loop_6:43]
                      │              │                   ├── args
-                     │              │                   │    ├── variable: x:10
-                     │              │                   │    ├── variable: i:11
-                     │              │                   │    ├── variable: n:12
-                     │              │                   │    └── variable: a:13
-                     │              │                   ├── params: x:19 i:20 n:21 a:22
+                     │              │                   │    ├── variable: n:10
+                     │              │                   │    ├── variable: a:11
+                     │              │                   │    ├── variable: x:12
+                     │              │                   │    └── variable: i:13
+                     │              │                   ├── params: n:19 a:20 x:21 i:22
                      │              │                   └── body
                      │              │                        └── project
                      │              │                             ├── columns: stmt_if_10:42
@@ -4214,8 +4214,8 @@ project
                      │              │                                       ├── true
                      │              │                                       ├── when
                      │              │                                       │    ├── ge
-                     │              │                                       │    │    ├── variable: i:20
-                     │              │                                       │    │    └── variable: n:21
+                     │              │                                       │    │    ├── variable: i:22
+                     │              │                                       │    │    └── variable: n:19
                      │              │                                       │    └── subquery
                      │              │                                       │         └── project
                      │              │                                       │              ├── columns: loop_exit_4:40
@@ -4224,11 +4224,11 @@ project
                      │              │                                       │              └── projections
                      │              │                                       │                   └── udf: loop_exit_4 [as=loop_exit_4:40]
                      │              │                                       │                        ├── args
-                     │              │                                       │                        │    ├── variable: x:19
-                     │              │                                       │                        │    ├── variable: i:20
-                     │              │                                       │                        │    ├── variable: n:21
-                     │              │                                       │                        │    └── variable: a:22
-                     │              │                                       │                        ├── params: x:14 i:15 n:16 a:17
+                     │              │                                       │                        │    ├── variable: n:19
+                     │              │                                       │                        │    ├── variable: a:20
+                     │              │                                       │                        │    ├── variable: x:21
+                     │              │                                       │                        │    └── variable: i:22
+                     │              │                                       │                        ├── params: n:14 a:15 x:16 i:17
                      │              │                                       │                        └── body
                      │              │                                       │                             └── project
                      │              │                                       │                                  ├── columns: stmt_return_5:18!null
@@ -4244,11 +4244,11 @@ project
                      │              │                                                 └── projections
                      │              │                                                      └── udf: stmt_if_7 [as=stmt_if_7:41]
                      │              │                                                           ├── args
-                     │              │                                                           │    ├── variable: x:19
-                     │              │                                                           │    ├── variable: i:20
-                     │              │                                                           │    ├── variable: n:21
-                     │              │                                                           │    └── variable: a:22
-                     │              │                                                           ├── params: x:23 i:24 n:25 a:26
+                     │              │                                                           │    ├── variable: n:19
+                     │              │                                                           │    ├── variable: a:20
+                     │              │                                                           │    ├── variable: x:21
+                     │              │                                                           │    └── variable: i:22
+                     │              │                                                           ├── params: n:23 a:24 x:25 i:26
                      │              │                                                           └── body
                      │              │                                                                └── project
                      │              │                                                                     ├── columns: assign_exception_block_8:39
@@ -4262,16 +4262,16 @@ project
                      │              │                                                                     │              └── floor-div [as=x:27]
                      │              │                                                                     │                   ├── const: 1
                      │              │                                                                     │                   └── minus
-                     │              │                                                                     │                        ├── variable: i:24
-                     │              │                                                                     │                        └── variable: a:26
+                     │              │                                                                     │                        ├── variable: i:26
+                     │              │                                                                     │                        └── variable: a:24
                      │              │                                                                     └── projections
                      │              │                                                                          └── udf: assign_exception_block_8 [as=assign_exception_block_8:39]
                      │              │                                                                               ├── args
+                     │              │                                                                               │    ├── variable: n:23
+                     │              │                                                                               │    ├── variable: a:24
                      │              │                                                                               │    ├── variable: x:27
-                     │              │                                                                               │    ├── variable: i:24
-                     │              │                                                                               │    ├── variable: n:25
-                     │              │                                                                               │    └── variable: a:26
-                     │              │                                                                               ├── params: x:28 i:29 n:30 a:31
+                     │              │                                                                               │    └── variable: i:26
+                     │              │                                                                               ├── params: n:28 a:29 x:30 i:31
                      │              │                                                                               └── body
                      │              │                                                                                    └── project
                      │              │                                                                                         ├── columns: assign_exception_block_9:38
@@ -4283,16 +4283,16 @@ project
                      │              │                                                                                         │         │    └── tuple
                      │              │                                                                                         │         └── projections
                      │              │                                                                                         │              └── plus [as=i:32]
-                     │              │                                                                                         │                   ├── variable: i:29
+                     │              │                                                                                         │                   ├── variable: i:31
                      │              │                                                                                         │                   └── const: 1
                      │              │                                                                                         └── projections
                      │              │                                                                                              └── udf: assign_exception_block_9 [as=assign_exception_block_9:38]
                      │              │                                                                                                   ├── args
-                     │              │                                                                                                   │    ├── variable: x:28
-                     │              │                                                                                                   │    ├── variable: i:32
-                     │              │                                                                                                   │    ├── variable: n:30
-                     │              │                                                                                                   │    └── variable: a:31
-                     │              │                                                                                                   ├── params: x:33 i:34 n:35 a:36
+                     │              │                                                                                                   │    ├── variable: n:28
+                     │              │                                                                                                   │    ├── variable: a:29
+                     │              │                                                                                                   │    ├── variable: x:30
+                     │              │                                                                                                   │    └── variable: i:32
+                     │              │                                                                                                   ├── params: n:33 a:34 x:35 i:36
                      │              │                                                                                                   └── body
                      │              │                                                                                                        └── project
                      │              │                                                                                                             ├── columns: stmt_loop_6:37
@@ -4301,10 +4301,10 @@ project
                      │              │                                                                                                             └── projections
                      │              │                                                                                                                  └── udf: stmt_loop_6 [as=stmt_loop_6:37]
                      │              │                                                                                                                       ├── args
-                     │              │                                                                                                                       │    ├── variable: x:33
-                     │              │                                                                                                                       │    ├── variable: i:34
-                     │              │                                                                                                                       │    ├── variable: n:35
-                     │              │                                                                                                                       │    └── variable: a:36
+                     │              │                                                                                                                       │    ├── variable: n:33
+                     │              │                                                                                                                       │    ├── variable: a:34
+                     │              │                                                                                                                       │    ├── variable: x:35
+                     │              │                                                                                                                       │    └── variable: i:36
                      │              │                                                                                                                       └── recursive-call
                      │              └── exception-handler
                      │                   └── SQLSTATE '22012'
@@ -4313,7 +4313,7 @@ project
                      │                             ├── values
                      │                             │    └── tuple
                      │                             └── projections
-                     │                                  └── variable: i:6 [as=stmt_return_2:9]
+                     │                                  └── variable: i:8 [as=stmt_return_2:9]
                      └── const: 1
 
 # Testing SQL statement execution.

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -26,7 +26,7 @@ type Statement interface {
 	GetLineNo() int
 	GetStmtID() uint
 	plpgsqlStmt()
-	WalkStmt(StatementVisitor) (newStmt Statement, changed bool)
+	WalkStmt(StatementVisitor) Statement
 }
 
 type TaggedStatement interface {
@@ -108,39 +108,39 @@ func (s *Block) PlpgSQLStatementTag() string {
 	return "stmt_block"
 }
 
-func (s *Block) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	for i, stmt := range s.Decls {
-		ns, ch := stmt.WalkStmt(visitor)
-		if ch {
-			changed = true
-			if newStmt == s {
-				newStmt = s.CopyNode()
+func (s *Block) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, recurse := visitor.Visit(s)
+	if recurse {
+		for i, decl := range s.Decls {
+			newDecl := decl.WalkStmt(visitor)
+			if newDecl != decl {
+				if newStmt == s {
+					newStmt = s.CopyNode()
+				}
+				newStmt.(*Block).Decls[i] = newDecl
 			}
-			newStmt.(*Block).Decls[i] = ns
+		}
+		for i, bodyStmt := range s.Body {
+			newBodyStmt := bodyStmt.WalkStmt(visitor)
+			if newBodyStmt != bodyStmt {
+				if newStmt == s {
+					newStmt = s.CopyNode()
+				}
+				newStmt.(*Block).Body[i] = newBodyStmt
+			}
+		}
+		for i := range s.Exceptions {
+			exception := &s.Exceptions[i]
+			newException := exception.WalkStmt(visitor)
+			if newException != exception {
+				if newStmt == s {
+					newStmt = s.CopyNode()
+				}
+				newStmt.(*Block).Exceptions[i] = *(newException.(*Exception))
+			}
 		}
 	}
-	for i, stmt := range s.Body {
-		ns, ch := stmt.WalkStmt(visitor)
-		if ch {
-			changed = true
-			if newStmt == s {
-				newStmt = s.CopyNode()
-			}
-			newStmt.(*Block).Body[i] = ns
-		}
-	}
-	for i, stmt := range s.Exceptions {
-		ns, ch := stmt.WalkStmt(visitor)
-		if ch {
-			changed = true
-			if newStmt == s {
-				newStmt = s.CopyNode()
-			}
-			newStmt.(*Block).Exceptions[i] = *(ns.(*Exception))
-		}
-	}
-	return newStmt, changed
+	return newStmt
 }
 
 // decl_stmt
@@ -184,9 +184,9 @@ func (s *Declaration) PlpgSQLStatementTag() string {
 	return "decl_stmt"
 }
 
-func (s *Declaration) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Declaration) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 type CursorDeclaration struct {
@@ -218,9 +218,9 @@ func (s *CursorDeclaration) PlpgSQLStatementTag() string {
 	return "decl_cursor_stmt"
 }
 
-func (s *CursorDeclaration) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *CursorDeclaration) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_assign
@@ -246,9 +246,9 @@ func (s *Assignment) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(";\n")
 }
 
-func (s *Assignment) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Assignment) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_if
@@ -298,43 +298,40 @@ func (s *If) PlpgSQLStatementTag() string {
 	return "stmt_if"
 }
 
-func (s *If) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
+func (s *If) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, recurse := visitor.Visit(s)
 
-	for i, thenStmt := range s.ThenBody {
-		ns, ch := thenStmt.WalkStmt(visitor)
-		if ch {
-			changed = true
-			if newStmt == s {
-				newStmt = s.CopyNode()
+	if recurse {
+		for i, thenStmt := range s.ThenBody {
+			newThenStmt := thenStmt.WalkStmt(visitor)
+			if newThenStmt != thenStmt {
+				if newStmt == s {
+					newStmt = s.CopyNode()
+				}
+				newStmt.(*If).ThenBody[i] = newThenStmt
 			}
-			newStmt.(*If).ThenBody[i] = ns
+		}
+		for i := range s.ElseIfList {
+			elseIf := &s.ElseIfList[i]
+			newElseIf := elseIf.WalkStmt(visitor)
+			if newElseIf != elseIf {
+				if newStmt == s {
+					newStmt = s.CopyNode()
+				}
+				newStmt.(*If).ElseIfList[i] = *newElseIf.(*ElseIf)
+			}
+		}
+		for i, elseStmt := range s.ElseBody {
+			newElseStmt := elseStmt.WalkStmt(visitor)
+			if newElseStmt != elseStmt {
+				if newStmt == s {
+					newStmt = s.CopyNode()
+				}
+				newStmt.(*If).ElseBody[i] = newElseStmt
+			}
 		}
 	}
-
-	for i, elseIf := range s.ElseIfList {
-		ns, ch := elseIf.WalkStmt(visitor)
-		if ch {
-			changed = true
-			if newStmt == s {
-				newStmt = s.CopyNode()
-			}
-			newStmt.(*If).ElseIfList[i] = *ns.(*ElseIf)
-		}
-	}
-
-	for i, elseStmt := range s.ElseBody {
-		ns, ch := elseStmt.WalkStmt(visitor)
-		if ch {
-			changed = true
-			if newStmt == s {
-				newStmt = s.CopyNode()
-			}
-			newStmt.(*If).ElseBody[i] = ns
-		}
-	}
-
-	return newStmt, changed
+	return newStmt
 }
 
 type ElseIf struct {
@@ -363,20 +360,21 @@ func (s *ElseIf) PlpgSQLStatementTag() string {
 	return "stmt_if_else_if"
 }
 
-func (s *ElseIf) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
+func (s *ElseIf) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, recurse := visitor.Visit(s)
 
-	for i, stmt := range s.Stmts {
-		ns, ch := stmt.WalkStmt(visitor)
-		if ch {
-			changed = true
-			if newStmt == s {
-				newStmt = s.CopyNode()
+	if recurse {
+		for i, bodyStmt := range s.Stmts {
+			newBodyStmt := bodyStmt.WalkStmt(visitor)
+			if newBodyStmt != bodyStmt {
+				if newStmt == s {
+					newStmt = s.CopyNode()
+				}
+				newStmt.(*ElseIf).Stmts[i] = newBodyStmt
 			}
-			newStmt.(*ElseIf).Stmts[i] = ns
 		}
 	}
-	return newStmt, changed
+	return newStmt
 }
 
 // stmt_case
@@ -427,33 +425,32 @@ func (s *Case) PlpgSQLStatementTag() string {
 	return "stmt_case"
 }
 
-func (s *Case) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
+func (s *Case) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, recurse := visitor.Visit(s)
 
-	for i, when := range s.CaseWhenList {
-		ns, ch := when.WalkStmt(visitor)
-		if ch {
-			changed = true
-			if newStmt == s {
-				newStmt = s.CopyNode()
-			}
-			newStmt.(*Case).CaseWhenList[i] = ns.(*CaseWhen)
-		}
-	}
-
-	if s.HaveElse {
-		for i, stmt := range s.ElseStmts {
-			ns, ch := stmt.WalkStmt(visitor)
-			if ch {
-				changed = true
+	if recurse {
+		for i, when := range s.CaseWhenList {
+			newWhen := when.WalkStmt(visitor)
+			if newWhen != when {
 				if newStmt == s {
 					newStmt = s.CopyNode()
 				}
-				newStmt.(*Case).ElseStmts[i] = ns
+				newStmt.(*Case).CaseWhenList[i] = newWhen.(*CaseWhen)
+			}
+		}
+		if s.HaveElse {
+			for i, elseStmt := range s.ElseStmts {
+				newElseStmt := elseStmt.WalkStmt(visitor)
+				if newElseStmt != elseStmt {
+					if newStmt == s {
+						newStmt = s.CopyNode()
+					}
+					newStmt.(*Case).ElseStmts[i] = newElseStmt
+				}
 			}
 		}
 	}
-	return newStmt, changed
+	return newStmt
 }
 
 type CaseWhen struct {
@@ -484,20 +481,21 @@ func (s *CaseWhen) PlpgSQLStatementTag() string {
 	return "stmt_when"
 }
 
-func (s *CaseWhen) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
+func (s *CaseWhen) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, recurse := visitor.Visit(s)
 
-	for i, stmt := range s.Stmts {
-		ns, ch := stmt.WalkStmt(visitor)
-		if ch {
-			changed = true
-			if newStmt == s {
-				newStmt = s.CopyNode()
+	if recurse {
+		for i, bodyStmt := range s.Stmts {
+			newBodyStmt := bodyStmt.WalkStmt(visitor)
+			if newBodyStmt != bodyStmt {
+				if newStmt == s {
+					newStmt = s.CopyNode()
+				}
+				newStmt.(*CaseWhen).Stmts[i] = newBodyStmt
 			}
-			newStmt.(*CaseWhen).Stmts[i] = ns
 		}
 	}
-	return newStmt, changed
+	return newStmt
 }
 
 // stmt_loop
@@ -535,19 +533,21 @@ func (s *Loop) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(";\n")
 }
 
-func (s *Loop) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	for i, stmt := range s.Body {
-		ns, ch := stmt.WalkStmt(visitor)
-		if ch {
-			changed = true
-			if newStmt == s {
-				newStmt = s.CopyNode()
+func (s *Loop) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, recurse := visitor.Visit(s)
+
+	if recurse {
+		for i, bodyStmt := range s.Body {
+			newBodyStmt := bodyStmt.WalkStmt(visitor)
+			if newBodyStmt != bodyStmt {
+				if newStmt == s {
+					newStmt = s.CopyNode()
+				}
+				newStmt.(*Loop).Body[i] = newBodyStmt
 			}
-			newStmt.(*Loop).Body[i] = ns
 		}
 	}
-	return newStmt, changed
+	return newStmt
 }
 
 // stmt_while
@@ -588,19 +588,21 @@ func (s *While) PlpgSQLStatementTag() string {
 	return "stmt_while"
 }
 
-func (s *While) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	for i, stmt := range s.Body {
-		ns, ch := stmt.WalkStmt(visitor)
-		if ch {
-			changed = true
-			if newStmt == s {
-				newStmt = s.CopyNode()
+func (s *While) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, recurse := visitor.Visit(s)
+
+	if recurse {
+		for i, bodyStmt := range s.Body {
+			newBodyStmt := bodyStmt.WalkStmt(visitor)
+			if newBodyStmt != bodyStmt {
+				if newStmt == s {
+					newStmt = s.CopyNode()
+				}
+				newStmt.(*While).Body[i] = newBodyStmt
 			}
-			newStmt.(*While).Body[i] = ns
 		}
 	}
-	return newStmt, changed
+	return newStmt
 }
 
 // stmt_for
@@ -622,7 +624,7 @@ func (s *ForInt) PlpgSQLStatementTag() string {
 	return "stmt_for_int_loop"
 }
 
-func (s *ForInt) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
+func (s *ForInt) WalkStmt(visitor StatementVisitor) Statement {
 	panic(unimplemented.New("plpgsql visitor", "Unimplemented PLpgSQL visitor pattern"))
 }
 
@@ -640,7 +642,7 @@ func (s *ForQuery) PlpgSQLStatementTag() string {
 	return "stmt_for_query_loop"
 }
 
-func (s *ForQuery) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
+func (s *ForQuery) WalkStmt(visitor StatementVisitor) Statement {
 	panic(unimplemented.New("plpgsql visitor", "Unimplemented PLpgSQL visitor pattern"))
 }
 
@@ -656,7 +658,7 @@ func (s *ForSelect) PlpgSQLStatementTag() string {
 	return "stmt_query_select_loop"
 }
 
-func (s *ForSelect) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
+func (s *ForSelect) WalkStmt(visitor StatementVisitor) Statement {
 	panic(unimplemented.New("plpgsql visitor", "Unimplemented PLpgSQL visitor pattern"))
 }
 
@@ -673,7 +675,7 @@ func (s *ForCursor) PlpgSQLStatementTag() string {
 	return "stmt_for_query_cursor_loop"
 }
 
-func (s *ForCursor) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
+func (s *ForCursor) WalkStmt(visitor StatementVisitor) Statement {
 	panic(unimplemented.New("plpgsql visitor", "Unimplemented PLpgSQL visitor pattern"))
 }
 
@@ -690,7 +692,7 @@ func (s *ForDynamic) PlpgSQLStatementTag() string {
 	return "stmt_for_dyn_loop"
 }
 
-func (s *ForDynamic) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
+func (s *ForDynamic) WalkStmt(visitor StatementVisitor) Statement {
 	panic(unimplemented.New("plpgsql visitor", "Unimplemented PLpgSQL visitor pattern"))
 }
 
@@ -711,7 +713,7 @@ func (s *ForEachArray) PlpgSQLStatementTag() string {
 	return "stmt_for_each_a"
 }
 
-func (s *ForEachArray) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
+func (s *ForEachArray) WalkStmt(visitor StatementVisitor) Statement {
 	panic(unimplemented.New("plpgsql visitor", "Unimplemented PLpgSQL visitor pattern"))
 }
 
@@ -745,9 +747,9 @@ func (s *Exit) PlpgSQLStatementTag() string {
 	return "stmt_exit"
 }
 
-func (s *Exit) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Exit) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_continue
@@ -779,9 +781,9 @@ func (s *Continue) PlpgSQLStatementTag() string {
 	return "stmt_continue"
 }
 
-func (s *Continue) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Continue) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_return
@@ -810,9 +812,9 @@ func (s *Return) PlpgSQLStatementTag() string {
 	return "stmt_return"
 }
 
-func (s *Return) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Return) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 type ReturnNext struct {
@@ -828,7 +830,7 @@ func (s *ReturnNext) PlpgSQLStatementTag() string {
 	return "stmt_return_next"
 }
 
-func (s *ReturnNext) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
+func (s *ReturnNext) WalkStmt(visitor StatementVisitor) Statement {
 	panic(unimplemented.New("plpgsql visitor", "Unimplemented PLpgSQL visitor pattern"))
 }
 
@@ -846,7 +848,7 @@ func (s *ReturnQuery) PlpgSQLStatementTag() string {
 	return "stmt_return_query"
 }
 
-func (s *ReturnQuery) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
+func (s *ReturnQuery) WalkStmt(visitor StatementVisitor) Statement {
 	panic(unimplemented.New("plpgsql visitor", "Unimplemented PLpgSQL visitor pattern"))
 }
 
@@ -915,9 +917,9 @@ func (s *Raise) PlpgSQLStatementTag() string {
 	return "stmt_raise"
 }
 
-func (s *Raise) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Raise) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_assert
@@ -941,9 +943,9 @@ func (s *Assert) PlpgSQLStatementTag() string {
 	return "stmt_assert"
 }
 
-func (s *Assert) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Assert) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_execsql
@@ -981,9 +983,9 @@ func (s *Execute) PlpgSQLStatementTag() string {
 	return "stmt_exec_sql"
 }
 
-func (s *Execute) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Execute) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_dynexecute
@@ -1022,9 +1024,9 @@ func (s *DynamicExecute) PlpgSQLStatementTag() string {
 	return "stmt_dyn_exec"
 }
 
-func (s *DynamicExecute) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *DynamicExecute) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_perform
@@ -1040,7 +1042,7 @@ func (s *Perform) PlpgSQLStatementTag() string {
 	return "stmt_perform"
 }
 
-func (s *Perform) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
+func (s *Perform) WalkStmt(visitor StatementVisitor) Statement {
 	panic(unimplemented.New("plpgsql visitor", "Unimplemented PLpgSQL visitor pattern"))
 }
 
@@ -1070,9 +1072,9 @@ func (s *Call) PlpgSQLStatementTag() string {
 	return "stmt_call"
 }
 
-func (s *Call) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Call) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_getdiag
@@ -1114,9 +1116,9 @@ func (s *GetDiagnostics) PlpgSQLStatementTag() string {
 	return "stmt_get_diag"
 }
 
-func (s *GetDiagnostics) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *GetDiagnostics) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_open
@@ -1152,9 +1154,9 @@ func (s *Open) PlpgSQLStatementTag() string {
 	return "stmt_open"
 }
 
-func (s *Open) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Open) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_fetch
@@ -1201,9 +1203,9 @@ func (s *Fetch) PlpgSQLStatementTag() string {
 	return "stmt_fetch"
 }
 
-func (s *Fetch) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Fetch) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_close
@@ -1222,9 +1224,9 @@ func (s *Close) PlpgSQLStatementTag() string {
 	return "stmt_close"
 }
 
-func (s *Close) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Close) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_commit
@@ -1240,9 +1242,9 @@ func (s *Commit) PlpgSQLStatementTag() string {
 	return "stmt_commit"
 }
 
-func (s *Commit) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Commit) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_rollback
@@ -1258,9 +1260,9 @@ func (s *Rollback) PlpgSQLStatementTag() string {
 	return "stmt_rollback"
 }
 
-func (s *Rollback) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Rollback) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_null
@@ -1276,9 +1278,9 @@ func (s *Null) PlpgSQLStatementTag() string {
 	return "stmt_null"
 }
 
-func (s *Null) WalkStmt(visitor StatementVisitor) (newStmt Statement, changed bool) {
-	newStmt, changed = visitor.Visit(s)
-	return newStmt, changed
+func (s *Null) WalkStmt(visitor StatementVisitor) Statement {
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // formatString is a helper function that prints "_" if FmtHideConstants is set,

--- a/pkg/sql/sem/plpgsqltree/utils/plpg_visitor.go
+++ b/pkg/sql/sem/plpgsqltree/utils/plpg_visitor.go
@@ -60,7 +60,7 @@ var _ plpgsqltree.StatementVisitor = &telemetryVisitor{}
 // Visit implements the StatementVisitor interface
 func (v *telemetryVisitor) Visit(
 	stmt plpgsqltree.Statement,
-) (newStmt plpgsqltree.Statement, changed bool) {
+) (newStmt plpgsqltree.Statement, recurse bool) {
 	taggedStmt, ok := stmt.(plpgsqltree.TaggedStatement)
 	if !ok {
 		v.Err = errors.AssertionFailedf("no tag found for stmt %q", stmt)
@@ -77,7 +77,7 @@ func (v *telemetryVisitor) Visit(
 	}
 	v.Err = nil
 
-	return stmt, false
+	return stmt, true
 }
 
 // MakePLpgSQLTelemetryVisitor makes a plpgsql telemetry visitor, for capturing
@@ -130,7 +130,7 @@ func simpleVisit(expr tree.Expr, fn tree.SimpleVisitFn) (tree.Expr, error) {
 
 func (v *SQLStmtVisitor) Visit(
 	stmt plpgsqltree.Statement,
-) (newStmt plpgsqltree.Statement, changed bool) {
+) (newStmt plpgsqltree.Statement, recurse bool) {
 	if v.Err != nil {
 		return stmt, false
 	}
@@ -143,8 +143,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Query != s
-		if changed {
+		if t.Query != s {
 			cpy := t.CopyNode()
 			cpy.Query = s
 			newStmt = cpy
@@ -154,8 +153,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.SqlStmt != s
-		if changed {
+		if t.SqlStmt != s {
 			cpy := t.CopyNode()
 			cpy.SqlStmt = s
 			newStmt = cpy
@@ -165,8 +163,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Query != s
-		if changed {
+		if t.Query != s {
 			cpy := t.CopyNode()
 			cpy.Query = s
 			newStmt = cpy
@@ -176,8 +173,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Expr != e
-		if changed {
+		if t.Expr != e {
 			cpy := t.CopyNode()
 			cpy.Expr = e
 			newStmt = cpy
@@ -188,8 +184,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Value != e
-		if changed {
+		if t.Value != e {
 			cpy := t.CopyNode()
 			cpy.Value = e
 			newStmt = cpy
@@ -199,8 +194,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Condition != e
-		if changed {
+		if t.Condition != e {
 			cpy := t.CopyNode()
 			cpy.Condition = e
 			newStmt = cpy
@@ -210,8 +204,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Condition != e
-		if changed {
+		if t.Condition != e {
 			cpy := t.CopyNode()
 			cpy.Condition = e
 			newStmt = cpy
@@ -221,8 +214,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Condition != e
-		if changed {
+		if t.Condition != e {
 			cpy := t.CopyNode()
 			cpy.Condition = e
 			newStmt = cpy
@@ -231,8 +223,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Condition != e
-		if changed {
+		if t.Condition != e {
 			cpy := t.CopyNode()
 			cpy.Condition = e
 			newStmt = cpy
@@ -242,8 +233,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Condition != e
-		if changed {
+		if t.Condition != e {
 			cpy := t.CopyNode()
 			cpy.Condition = e
 			newStmt = cpy
@@ -253,8 +243,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Condition != e
-		if changed {
+		if t.Condition != e {
 			cpy := t.CopyNode()
 			cpy.Condition = e
 			newStmt = cpy
@@ -264,8 +253,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Expr != e
-		if changed {
+		if t.Expr != e {
 			cpy := t.CopyNode()
 			cpy.Expr = e
 			newStmt = cpy
@@ -276,8 +264,7 @@ func (v *SQLStmtVisitor) Visit(
 			if v.Err != nil {
 				return stmt, false
 			}
-			changed = changed || (t.Params[i] != e)
-			if changed {
+			if t.Params[i] != e {
 				if newStmt != stmt {
 					cpy := t.CopyNode()
 					newStmt = cpy
@@ -290,8 +277,7 @@ func (v *SQLStmtVisitor) Visit(
 			if v.Err != nil {
 				return stmt, false
 			}
-			changed = changed || (t.Options[i].Expr != e)
-			if changed {
+			if t.Options[i].Expr != e {
 				if newStmt != stmt {
 					cpy := t.CopyNode()
 					newStmt = cpy
@@ -304,8 +290,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Condition != e
-		if changed {
+		if t.Condition != e {
 			cpy := t.CopyNode()
 			cpy.Condition = e
 			newStmt = cpy
@@ -317,8 +302,7 @@ func (v *SQLStmtVisitor) Visit(
 			if v.Err != nil {
 				return stmt, false
 			}
-			changed = changed || (t.Params[i] != e)
-			if changed {
+			if t.Params[i] != e {
 				if newStmt != stmt {
 					cpy := t.CopyNode()
 					newStmt = cpy
@@ -331,8 +315,7 @@ func (v *SQLStmtVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Expr != e
-		if changed {
+		if t.Expr != e {
 			cpy := t.CopyNode()
 			cpy.Expr = e
 			newStmt = cpy
@@ -346,7 +329,7 @@ func (v *SQLStmtVisitor) Visit(
 	if v.Err != nil {
 		return stmt, false
 	}
-	return newStmt, changed
+	return newStmt, true
 }
 
 // TypeRefVisitor calls the given replace function on each type reference
@@ -361,7 +344,7 @@ var _ plpgsqltree.StatementVisitor = &TypeRefVisitor{}
 
 func (v *TypeRefVisitor) Visit(
 	stmt plpgsqltree.Statement,
-) (newStmt plpgsqltree.Statement, changed bool) {
+) (newStmt plpgsqltree.Statement, recurse bool) {
 	if v.Err != nil {
 		return stmt, false
 	}
@@ -372,13 +355,12 @@ func (v *TypeRefVisitor) Visit(
 		if v.Err != nil {
 			return stmt, false
 		}
-		changed = t.Typ != newTyp
-		if changed {
+		if t.Typ != newTyp {
 			if newStmt == stmt {
 				newStmt = t.CopyNode()
 				newStmt.(*plpgsqltree.Declaration).Typ = newTyp
 			}
 		}
 	}
-	return newStmt, changed
+	return newStmt, true
 }

--- a/pkg/sql/sem/plpgsqltree/visitor.go
+++ b/pkg/sql/sem/plpgsqltree/visitor.go
@@ -13,12 +13,13 @@ package plpgsqltree
 // StatementVisitor defines methods that are called plpgsql statements during
 // a statement walk.
 type StatementVisitor interface {
-	// Visit is called during a statement walk.
-	Visit(stmt Statement) (newStmt Statement, changed bool)
+	// Visit is called during a statement walk. If recurse is false for a given
+	// node, the node's children (if any) will not be visited.
+	Visit(stmt Statement) (newStmt Statement, recurse bool)
 }
 
 // Walk traverses the plpgsql statement.
 func Walk(v StatementVisitor, stmt Statement) Statement {
-	newStmt, _ := stmt.WalkStmt(v)
+	newStmt := stmt.WalkStmt(v)
 	return newStmt
 }


### PR DESCRIPTION
#### plpgsql: change order of params and variables

Previously, the parameters of a continuation sub-routine would be chosen
by first appending the variables of the (single) block, then the parameters
of the PL/pgSQL routine. In preparation for supporting nested blocks, this
commit changes the order to first add the routine's parameters, and then the
variables from the block. This prepares to enforce an invariant that the
parameters/arguments of a parent sub-routine are always a prefix of those
of a child sub-routine. This will simplify exception handling later on.

#### plpgsql: allow early exit for visitor

This commit makes two changes to the plpgsql Visitor interface and
implementation - first, the `changed` return value has been replaced
with pointer comparisons. Second, a new return value, `recurse`,
indicates whether a node's children should be visited. This will
allow for Visitor implementations that have to return early.

#### plpgsql: refactor logic for building PL/pgSQL blocks

This commit pulls the logic for handling a PL/pgSQL block into a single
method. Information specific to a given block (including a pointer to the
parent block) is stored in a new struct, `blockScope`, which is allocated
when the block is built. Note that nested blocks are still not allowed in
this commit.

#### plpgsql: add support for nested blocks

This commit makes the final change to support nested blocks with some
limitations, and adds corresponding tests. Currently, variable shadowing
is not allowed, and a block cannot be nested in another block that has an
exception handler.

Fixes #114775

Release note (sql change): PL/pgSQL now supports nested blocks, with
the following limitations for now: variable shadowing is disallowed,
and exception handlers cannot be used in a routine with nested blocks.