### PR TITLE
release-23.2: plpgsql: allow assigning to routine parameters

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -2829,4 +2829,71 @@ statement ok
 SELECT f114678();
 CALL p114678();
 
+# Regression test for #117503 - PLpgSQL routine parameters can be assigned just
+# like declared variables.
+subtest param_assign
+
+# Assign statement case.
+statement ok
+DROP FUNCTION IF EXISTS f(INT);
+CREATE OR REPLACE FUNCTION f(x INT) RETURNS INT AS $$
+  DECLARE
+    y INT := x + 1;
+  BEGIN
+    x := x + y;
+    RETURN x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query III
+SElECT f(0), f(100), f(-100);
+----
+1  201  -199
+
+# SELECT INTO case.
+statement ok
+DROP FUNCTION IF EXISTS f(INT);
+CREATE OR REPLACE FUNCTION f(x INT) RETURNS INT AS $$
+  BEGIN
+    SELECT x INTO x FROM xy ORDER BY x DESC;
+    RETURN x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query III
+SElECT f(0), f(100), f(-100);
+----
+3  3  3
+
+# FETCH INTO case.
+statement ok
+DROP FUNCTION IF EXISTS f(INT);
+CREATE OR REPLACE FUNCTION f(x INT) RETURNS INT AS $$
+  DECLARE
+    curs CURSOR FOR SELECT 1000;
+  BEGIN
+    OPEN curs;
+    FETCH curs INTO x;
+    RETURN x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query III
+SElECT f(0), f(100), f(-100);
+----
+1000  1000  1000
+
+# Variable shadowing is disallowed, tracked in #117508.
+statement ok
+DROP FUNCTION IF EXISTS f(INT);
+
+statement error pgcode 0A000 pq: unimplemented: variable shadowing is not yet implemented
+CREATE OR REPLACE FUNCTION f(x INT) RETURNS INT AS $$
+  DECLARE
+    x INT := 1000;
+  BEGIN
+    RETURN x;
+  END
+$$ LANGUAGE PLpgSQL;
+
 subtest end


### PR DESCRIPTION
Backport 1/1 commits from #117511.

/cc @cockroachdb/release

---

#### plpgsql: allow assigning to routine parameters

This patch adds support for assigning to a PL/pgSQL routine parameter.
Previously, attempting to do so would result in a "variable not found"
non-internal error. As part of this change, variable shadowing is
explicitly disabled with an "unimplemented" error (tracked in #117508).
In addition, variable shadowing is now explicitly disabled, when it could
previously result in an internal error due to unexpected column type.

Fixes #117503
Fixes #114851

Release note (bug fix): It is now possible to assign to the parameter
of a PL/pgSQL routine. Previously, attempts to do this would result in
a "variable not found" error at routine creation time. In addition,
variable shadowing is now explicitly disabled, when previously it
would cause an internal error. These bugs existed in the 23.2.0
release and the 23.2 pre-release versions.

Release justification: fix for internal error in new 23.2 functionality