### PR TITLE
release-23.1: roachtest: pull tpc-e image from GAR

### DIFF
--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -68,7 +68,7 @@ func registerTPCE(r registry.Registry) {
 
 		m := c.NewMonitor(ctx, roachNodes)
 		m.Go(func(ctx context.Context) error {
-			const dockerRun = `sudo docker run cockroachdb/tpc-e:latest`
+			const dockerRun = `sudo docker run us-east1-docker.pkg.dev/crl-ci-images/cockroach/tpc-e:latest`
 
 			roachNodeIPs, err := c.InternalIP(ctx, t.L(), roachNodes)
 			if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #117691.

/cc @cockroachdb/release

---

Previously, we pulled the tpc-e image from Docker Hub. Now that we move most of our CI images to GAR, this image will be pulled from GAR as well

Epic: RE-539
Release note: None
Release justification: CI changes
