### PR TITLE
kvcoord: use rangefeed connection class

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -235,6 +235,7 @@ var retiredSettings = map[InternalKey]struct{}{
 	"kv.rangefeed.catchup_scan_concurrency":                {},
 	"kv.rangefeed.scheduler.enabled":                       {},
 	"physical_replication.producer.mux_rangefeeds.enabled": {},
+	"kv.rangefeed.use_dedicated_connection_class.enabled":  {},
 }
 
 // sqlDefaultSettings is the list of "grandfathered" existing sql.defaults


### PR DESCRIPTION
This change switches rangefeed to use `RangefeedClass` for RPC traffic by default. The corresponding cluster setting is removed since we don't expect needing to dynamically change this. We leave an escape option: the new env variable allows using `DefaultClass` instead.

This is analogous to the usage of `RaftClass` for raft traffic.

Part of #108992

Release note (performance improvement): this change separates the rangefeed traffic into its own RPC connection class. This improves isolation and reduces interference with the foreground SQL traffic, which reduces chances of head-of-line blocking caused by unrelated traffic. The new `COCKROACH_RANGEFEED_USE_DEFAULT_CONNECTION_CLASS` env variable can be set to use the `DefaultClass` instead (which was the previous default choice for rangefeeds).