### PR TITLE
schemaworkload: Add metrics that keep track of workload operations

### DIFF
--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "tracing.go",
         "type_resolver.go",
         "watch_dog.go",
+        "workload_result.go",
         ":gen-optype-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/workload/schemachange",

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -35,8 +35,10 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/spf13/pflag"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // This workload executes batches of schema changes asynchronously. Each
@@ -90,6 +92,7 @@ type schemaChange struct {
 	declarativeSchemaChangerPct     int
 	declarativeSchemaMaxStmtsPerTxn int
 	traceFilePath                   string
+	schemaWorkloadResultAnnotator   *schemaWorkloadResultAnnotator
 }
 
 var schemaChangeMeta = workload.Meta{
@@ -160,10 +163,12 @@ func (s *schemaChange) Ops(
 	// managing the life cycle of this workload so we keep tracing localized to
 	// this function.
 	tracerProvider, err := s.initTracerProvider()
+	// Initialize workload result annotator to compute metrics on the workload performance.
+	s.schemaWorkloadResultAnnotator = &schemaWorkloadResultAnnotator{}
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
-
+	tracerProvider.RegisterSpanProcessor(s.schemaWorkloadResultAnnotator)
 	tracer := tracerProvider.Tracer("schemachange")
 
 	// NB: The schemaChange.Ops span ends when this function returns, NOT when
@@ -221,9 +226,10 @@ func (s *schemaChange) Ops(
 			defer cancel()
 
 			pool.Close()
+
 			closeErr := s.closeJSONLogFile()
 			shutdownErr := tracerProvider.Shutdown(ctx)
-
+			s.schemaWorkloadResultAnnotator.logWorkloadStats(stdoutLog)
 			return errors.CombineErrors(closeErr, shutdownErr)
 		},
 	}
@@ -286,6 +292,7 @@ func (s *schemaChange) Ops(
 				artifactsLog: artifactsLog,
 			},
 			isHoldingEntryLocks: false,
+			tracer:              tracer,
 		}
 
 		s.workers = append(s.workers, w)
@@ -350,6 +357,7 @@ type schemaChangeWorker struct {
 	opGen               *operationGenerator
 	isHoldingEntryLocks bool
 	logger              *logger
+	tracer              trace.Tracer
 }
 
 var (
@@ -401,7 +409,10 @@ func (w *schemaChangeWorker) WrapWithErrorState(err error) error {
 }
 
 func (w *schemaChangeWorker) runInTxn(
-	ctx context.Context, tx pgx.Tx, useDeclarativeSchemaChanger bool,
+	ctx context.Context,
+	tx pgx.Tx,
+	useDeclarativeSchemaChanger bool,
+	workloadMetrics map[string]attribute.Value,
 ) error {
 	w.logger.startLog(w.id)
 	w.logger.writeLog("BEGIN")
@@ -419,6 +430,7 @@ func (w *schemaChangeWorker) runInTxn(
 		// will not fail. To prevent the covering up of unexpected behavior as outlined above, no further ops
 		// should be generated if there are any errors in the expected commit errors set.
 		if !w.opGen.expectedCommitErrors.empty() {
+			incWorkloadMetric(numSchemaOpsExpectedFailed, workloadMetrics)
 			break
 		}
 
@@ -463,8 +475,10 @@ func (w *schemaChangeWorker) runInTxn(
 				}
 				return err
 			}
+			incWorkloadMetric(numSchemaOpsSucceeded, workloadMetrics)
 			w.recordInHist(timeutil.Since(start), operationOk)
 		}
+		incWorkloadMetric(numSchemaOps, workloadMetrics)
 	}
 	return nil
 }
@@ -485,10 +499,18 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 			return err
 		}
 	}
+
 	tx, err := conn.Begin(ctx)
 	if err != nil {
 		return errors.Wrap(err, "cannot get a connection and begin a txn")
 	}
+
+	// Initialize workload metrics.
+	workloadMetrics := initWorkloadMetrics()
+	_, workerSpan := w.tracer.Start(ctx, schemaWorkerSpanName)
+	// The worker span is for a single schema change worker and captures workload
+	// metrics specific for the schema operations run by the worker.
+	defer func() { endSchemaWorkerSpan(workerSpan, workloadMetrics) }()
 
 	// Enable extra schema changes, if they are available this moment.
 	if !w.workload.declarativeStatementsEnabled.Load() {
@@ -499,7 +521,7 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 		if !cannotEnableSchemaChanges {
 			_, err = w.pool.Get().Exec(ctx, `SET CLUSTER SETTING sql.schema.force_declarative_statements="+CREATE SCHEMA, +CREATE SEQUENCE"`)
 			if err != nil {
-				return errors.Wrap(err, "cannot to enable extra schema changes")
+				return errors.Wrap(err, "cannot enable extra schema changes")
 			}
 			w.workload.declarativeStatementsEnabled.Store(true)
 		}
@@ -516,7 +538,7 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 	defer watchDog.Stop()
 	start := timeutil.Now()
 	w.opGen.resetTxnState()
-	err = w.runInTxn(ctx, tx, useDeclarativeSchemaChanger)
+	err = w.runInTxn(ctx, tx, useDeclarativeSchemaChanger, workloadMetrics)
 
 	if err != nil {
 		// Rollback in all cases to release the txn object and its conn pool. Wrap the original
@@ -531,7 +553,7 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 			}
 		}
 
-		w.logger.flushLogWithError(tx, err)
+		w.logger.flushLogWithError(err)
 		switch {
 		case errors.Is(err, errRunInTxnFatalSentinel):
 			w.preErrorHook()
@@ -559,7 +581,7 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 				errors.Wrap(err, "***UNEXPECTED COMMIT ERROR; Received a non pg error"),
 				errRunInTxnFatalSentinel,
 			)
-			w.logger.flushLogWithError(tx, err)
+			w.logger.flushLogWithError(err)
 			w.preErrorHook()
 			return err
 		}
@@ -568,7 +590,7 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 		// to rollback.
 		if pgcode.MakeCode(pgErr.Code) == pgcode.SerializationFailure {
 			w.recordInHist(timeutil.Since(start), txnCommitError)
-			w.logger.flushLog(tx, fmt.Sprintf("TXN RETRY ERROR; %v", pgErr))
+			w.logger.flushLog(fmt.Sprintf("TXN RETRY ERROR; %v", pgErr))
 			return nil
 		}
 
@@ -590,26 +612,27 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 					errors.Wrapf(err, "***UNEXPECTED COMMIT ERROR; Received an unexpected commit error")),
 				errRunInTxnFatalSentinel,
 			)
-			w.logger.flushLogWithError(tx, err)
+			w.logger.flushLogWithError(err)
 			w.preErrorHook()
 			return err
 		}
 
 		// Error was anticipated, so it is acceptable.
 		w.recordInHist(timeutil.Since(start), txnCommitError)
-		w.logger.flushLog(tx, "COMMIT; Successfully got expected commit error")
+		w.logger.flushLog("COMMIT; Successfully got expected commit error")
 		return nil
 	}
 	if !w.opGen.expectedCommitErrors.empty() {
 		err := w.WrapWithErrorState(errors.Newf("***FAIL; Failed to receive a commit error when at least one commit error was expected"))
-		w.logger.flushLogWithError(tx, err)
+		w.logger.flushLogWithError(err)
 		w.preErrorHook()
 		return errors.Mark(err, errRunInTxnFatalSentinel)
 	}
 
 	// If there were no errors while committing the txn.
-	w.logger.flushLog(tx, "")
+	w.logger.flushLog("")
 	w.recordInHist(timeutil.Since(start), txnOk)
+	workloadMetrics[txnCommitted] = attribute.BoolValue(true)
 	return nil
 }
 
@@ -627,7 +650,7 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 func (w *schemaChangeWorker) preErrorHook() {
 	w.workload.dumpLogsOnce.Do(func() {
 		for _, worker := range w.workload.workers {
-			worker.logger.flushLogAndLock(nil, "Flushed by pre-error hook", false)
+			worker.logger.flushLogAndLock("Flushed by pre-error hook", false)
 			worker.logger.artifactsLog = nil
 		}
 		_ = w.workload.closeJSONLogFile()
@@ -701,7 +724,7 @@ func (l *logger) addExpectedErrors(execErrors errorCodeSet, commitErrors errorCo
 // flushLogWithError outputs the currentLogEntry of the schemaChangeWorker, with
 // an error message (any available error state information is also added).
 // It is a noop if l.verbose < 0.
-func (l *logger) flushLogWithError(tx pgx.Tx, err error) {
+func (l *logger) flushLogWithError(err error) {
 	if l.verbose < 1 {
 		return
 	}
@@ -718,23 +741,23 @@ func (l *logger) flushLogWithError(tx pgx.Tx, err error) {
 		}
 	}()
 
-	l.flushLogAndLock(tx, err.Error(), true)
+	l.flushLogAndLock(err.Error(), true)
 	defer l.currentLogEntry.mu.Unlock()
 }
 
 // flushLog outputs the currentLogEntry of the schemaChangeWorker.
 // It is a noop if l.verbose < 0.
-func (l *logger) flushLog(tx pgx.Tx, message string) {
+func (l *logger) flushLog(message string) {
 	if l.verbose < 1 {
 		return
 	}
-	l.flushLogAndLock(tx, message, true)
+	l.flushLogAndLock(message, true)
 	defer l.currentLogEntry.mu.Unlock()
 }
 
 // flushLogAndLock prints the currentLogEntry of the schemaChangeWorker and does not release
 // the lock for w.currentLogEntry upon returning. The lock will not be acquired if l.verbose < 1.
-func (l *logger) flushLogAndLock(_ pgx.Tx, message string, stdout bool) {
+func (l *logger) flushLogAndLock(message string, stdout bool) {
 	if l.verbose < 1 {
 		return
 	}

--- a/pkg/workload/schemachange/workload_result.go
+++ b/pkg/workload/schemachange/workload_result.go
@@ -1,0 +1,137 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schemachange
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/trace"
+	trace2 "go.opentelemetry.io/otel/trace"
+)
+
+const (
+	numSchemaOps               = "numSchemaOps"
+	numSchemaOpsSucceeded      = "numSchemaOpsSucceeded"
+	numSchemaOpsExpectedFailed = "numSchemaOpsExpectedToFail"
+	txnCommitted               = "txnCommitted"
+	schemaWorkerSpanName       = "schemachange.worker"
+)
+
+// schemaWorkloadResultAnnotator is a SpanProcessor that adds workload attributes
+// to a span. The workload attributes are used to summarize various operations
+// executed by the schema workload and are output to the log file. These attributes
+// can be reviewed to get a summary of the type of operations executed by the random
+// schema workload.
+type schemaWorkloadResultAnnotator struct {
+	// numSchemaOps indicates the total number of schema operations (aka statements) run.
+	numSchemaOps atomic.Int64
+	// numSchemaOpsSucceeded indicates the number of schema operations that succeeded. A value of 0
+	// would indicate the workload was unable to generate any random operation that could succeed.
+	numSchemaOpsSucceeded atomic.Int64
+	// numSchemaOpsExpectedFailed indicates the number of schema operations that were expected to fail.
+	// Ideally, we should have a healthy balance between numSchemaOpsSucceeded and numSchemaOpsExpectedFailed
+	// in a run of the random schema workload.
+	numSchemaOpsExpectedFailed atomic.Int64
+	// numTxnsCommitted indicates the number of transactions that committed successfully in this workload run.
+	numTxnsCommitted atomic.Int64
+	// numTxnRollbacks indicates the number of transactions that were rolled back in this workload run.
+	numTxnRollbacks atomic.Int64
+	// numTxns indicates the total number of transactions that ran in this workload.
+	// This value should be greater than zero.
+	numTxns atomic.Int64
+
+	// To provide more stats about the workload, add fields below. Any new field should also be added
+	// to (schemaWorkloadResultAnnotator).OnEnd, (schemaWorkloadResultAnnotator).initWorkloadMetrics
+	// and (schemaWorkloadResultAnnotator).logWorkloadStats to ensure it is printed in the workload logs.
+}
+
+// OnStart implements the SpanProcessor interface.
+func (s *schemaWorkloadResultAnnotator) OnStart(_ context.Context, _ trace.ReadWriteSpan) {}
+
+// Shutdown implements the SpanProcessor interface.
+func (s *schemaWorkloadResultAnnotator) Shutdown(_ context.Context) error {
+	return nil
+}
+
+// ForceFlush implements the SpanProcessor interface.
+func (s *schemaWorkloadResultAnnotator) ForceFlush(_ context.Context) error {
+	return nil
+}
+
+// OnEnd implements the SpanProcessor interface. It aggregates and logs metrics
+// for the schema change workload. These metrics provide an overview of the work
+// done by the random schema change workload run. These metrics can be viewed
+// in the output log file to get an idea of the number and variety of operations
+// performed by the workload. These can give some insight into how valuable the particular
+// run of the schema change workload was. For example, if the workload did not execute a
+// large number of schema change operations, that could be an indication that the workload
+// is not producing meaningful runs even if the test is succeeding. These metrics can be
+// used as a sanity check to ensure the workload is generating and running meaningful tests.
+func (s *schemaWorkloadResultAnnotator) OnEnd(sp trace.ReadOnlySpan) {
+	if sp.Name() == schemaWorkerSpanName {
+		for _, attr := range sp.Attributes() {
+			switch attr.Key {
+			case numSchemaOps:
+				s.numSchemaOps.Add(attr.Value.AsInt64())
+			case numSchemaOpsSucceeded:
+				s.numSchemaOpsSucceeded.Add(attr.Value.AsInt64())
+			case numSchemaOpsExpectedFailed:
+				s.numSchemaOpsExpectedFailed.Add(attr.Value.AsInt64())
+			case txnCommitted:
+				if attr.Value.AsBool() {
+					s.numTxnsCommitted.Add(1)
+				} else {
+					s.numTxnRollbacks.Add(1)
+				}
+				s.numTxns.Add(1)
+			}
+		}
+	}
+}
+
+// logWorkloadStats aggregates and logs metrics across all schema change workers.
+// This should be called once at the end of a schemachange workload run.
+func (s *schemaWorkloadResultAnnotator) logWorkloadStats(log *atomicLog) {
+	log.printLn("Schema Workload Stats")
+	log.printLn(fmt.Sprintf("Total Schema Statements Executed = %d", s.numSchemaOps.Load()))
+	log.printLn(fmt.Sprintf("Total Schema Statements Succeeded = %d", s.numSchemaOpsSucceeded.Load()))
+	log.printLn(fmt.Sprintf("Total Schema Statement Expected Failures = %d", s.numSchemaOpsExpectedFailed.Load()))
+	log.printLn(fmt.Sprintf("Total Transactions Committed = %d", s.numTxnsCommitted.Load()))
+	log.printLn(fmt.Sprintf("Total Transactions Rolled Back = %d", s.numTxnRollbacks.Load()))
+	log.printLn(fmt.Sprintf("Total Transactions Executed = %d", s.numTxns.Load()))
+}
+
+// initWorkloadMetrics initializes metrics being captured for a schema change run.
+func initWorkloadMetrics() map[string]attribute.Value {
+	return map[string]attribute.Value{
+		numSchemaOps:               attribute.Int64Value(0),
+		numSchemaOpsSucceeded:      attribute.Int64Value(0),
+		numSchemaOpsExpectedFailed: attribute.Int64Value(0),
+		txnCommitted:               attribute.BoolValue(false),
+	}
+}
+
+// incWorkloadMetric is a helper function to increment the value of a metric by one.
+func incWorkloadMetric(metricName string, workloadMetrics map[string]attribute.Value) {
+	metricValue := workloadMetrics[metricName].AsInt64() + 1
+	workloadMetrics[metricName] = attribute.Int64Value(metricValue)
+}
+
+// endSchemaWorkerSpan is a helper function to attach workload metrics as attributes to a span.
+func endSchemaWorkerSpan(span trace2.Span, workloadMetrics map[string]attribute.Value) {
+	for name, value := range workloadMetrics {
+		span.SetAttributes(attribute.KeyValue{Key: attribute.Key(name), Value: value})
+	}
+	span.End()
+}


### PR DESCRIPTION
This PR adds metrics that indicate operations performed by the schema change workload. These metrics are output in logs at the end of a workload run. These metrics will function as a sanity check to ensure that the workload is doing something meaningful and will need to be checked manually. The current set of metrics are fairly rudimentary but will help provide some initial insight into the efficacy of this workload.

Fixes: https://github.com/cockroachdb/cockroach/issues/81928
Epic: none
Release note: None