### PR TITLE
stress: reduce timeouts for `deadlock` and `race` under RBE

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 export RUNS_PER_TEST=3
-export EXTRA_TEST_ARGS="--define gotags=bazel,gss,deadlock --test_timeout=1800,3600,5395,5395 --heavy"
+export EXTRA_TEST_ARGS="--define gotags=bazel,gss,deadlock --test_timeout=300,1000,1500,2000 --heavy"
 export EXTRA_ISSUE_PARAMS=deadlock
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)

--- a/build/teamcity/cockroach/nightlies/stress_engflow_race.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_race.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 export RUNS_PER_TEST=3
-export EXTRA_TEST_ARGS="--config=race --test_timeout=1800,3600,5395,5395"
+export EXTRA_TEST_ARGS="--config=race --test_timeout=1200,2500,3200,4600"
 export EXTRA_ISSUE_PARAMS=race
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)


### PR DESCRIPTION
`deadlock` timeouts appear to be much higher than they need to: `race` can also be reduced somewhat.

Epic: CRDB-8308
Release note: None