### PR TITLE
pcr: add ability to resume replicating after cutting over

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -168,7 +168,7 @@ func (c *TenantStreamingClusters) init(ctx context.Context) {
 // destination tenant starts up via a testServer.StartSharedProcessTenant().
 func (c *TenantStreamingClusters) StartDestTenant(
 	ctx context.Context, withTestingKnobs *base.TestingKnobs, server int,
-) func() error {
+) func() {
 	if withTestingKnobs != nil {
 		var err error
 		_, c.DestTenantConn, err = c.DestCluster.Server(server).TenantController().StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
@@ -193,8 +193,8 @@ func (c *TenantStreamingClusters) StartDestTenant(
 	require.NoError(c.T, c.DestCluster.Server(server).TenantController().WaitForTenantCapabilities(ctx, c.Args.DestTenantID, map[tenantcapabilities.ID]string{
 		tenantcapabilities.CanUseNodelocalStorage: "true",
 	}, ""))
-	return func() error {
-		return c.DestTenantConn.Close()
+	return func() {
+		require.NoError(c.T, c.DestTenantConn.Close())
 	}
 }
 

--- a/pkg/ccl/streamingccl/streamclient/client.go
+++ b/pkg/ccl/streamingccl/streamclient/client.go
@@ -90,7 +90,18 @@ type Client interface {
 	// Complete completes a replication stream consumption.
 	Complete(ctx context.Context, streamID streampb.StreamID, successfulIngestion bool) error
 
-	PriorReplicationDetails(ctx context.Context, tenant roachpb.TenantName) (string, hlc.Timestamp, error)
+	// PriorReplicationDetails returns a given tenant's "historyID" as well as the
+	// historyID, if any, from which that tenant was previously replicated and the
+	// timestamp as of which that replication ended.
+	//
+	// A HistoryID is a globally unique identifier a tenant span on some cluster,
+	// that can be uniquely used to identify it and its MVCC history. It is
+	// composed of a cluster ID on which a tenant's span resides and the tenant's
+	// ID on that cluster, which uniquely identifies that span -- and its mvcc
+	// history -- across all Cockroach clusters.
+	PriorReplicationDetails(
+		ctx context.Context, tenant roachpb.TenantName,
+	) (id string, replicatedFrom string, activated hlc.Timestamp, _ error)
 }
 
 // Topology is a configuration of stream partitions. These are particular to a

--- a/pkg/ccl/streamingccl/streamclient/client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/client_test.go
@@ -114,8 +114,8 @@ func (sc testStreamClient) Complete(_ context.Context, _ streampb.StreamID, _ bo
 // PriorReplicationDetails implements the streamclient.Client interface.
 func (sc testStreamClient) PriorReplicationDetails(
 	_ context.Context, _ roachpb.TenantName,
-) (string, hlc.Timestamp, error) {
-	return "", hlc.Timestamp{}, nil
+) (string, string, hlc.Timestamp, error) {
+	return "", "", hlc.Timestamp{}, nil
 }
 
 type testStreamSubscription struct {

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
@@ -10,6 +10,7 @@ package streamclient
 
 import (
 	"context"
+	gosql "database/sql"
 	"net"
 	"net/url"
 
@@ -258,26 +259,29 @@ func (p *partitionedStreamClient) Complete(
 // PriorReplicationDetails implements the streamclient.Client interface.
 func (p *partitionedStreamClient) PriorReplicationDetails(
 	ctx context.Context, tenant roachpb.TenantName,
-) (string, hlc.Timestamp, error) {
+) (string, string, hlc.Timestamp, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "streamclient.Client.PriorReplicationDetails")
 	defer sp.Finish()
 
-	var srcID string
-	var activated string
+	var id string
+	var fromID, activated gosql.NullString
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	row := p.mu.srcConn.QueryRow(ctx,
-		`SELECT source_id, activation_time FROM [SHOW VIRTUAL CLUSTER $1 WITH PRIOR REPLICATION DETAILS]`, tenant)
-	if err := row.Scan(&srcID, &activated); err != nil {
-		return "", hlc.Timestamp{}, errors.Wrapf(err, "error querying prior replication details for %s", tenant)
+		`SELECT crdb_internal.cluster_id()::string||':'||id::string, source_id, activation_time FROM [SHOW VIRTUAL CLUSTER $1 WITH PRIOR REPLICATION DETAILS]`, tenant)
+	if err := row.Scan(&id, &fromID, &activated); err != nil {
+		return "", "", hlc.Timestamp{}, errors.Wrapf(err, "error querying prior replication details for %s", tenant)
 	}
 
-	d, _, err := apd.NewFromString(activated)
-	if err != nil {
-		return "", hlc.Timestamp{}, err
+	if activated.Valid {
+		d, _, err := apd.NewFromString(activated.String)
+		if err != nil {
+			return "", "", hlc.Timestamp{}, err
+		}
+		ts, err := hlc.DecimalToHLC(d)
+		return id, fromID.String, ts, err
 	}
-	ts, err := hlc.DecimalToHLC(d)
-	return srcID, ts, err
+	return id, "", hlc.Timestamp{}, nil
 }
 
 type partitionedStreamSubscription struct {

--- a/pkg/ccl/streamingccl/streamclient/random_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/random_stream_client.go
@@ -551,8 +551,8 @@ func (m *RandomStreamClient) Complete(_ context.Context, _ streampb.StreamID, _ 
 // PriorReplicationDetails implements the streamclient.Client interface.
 func (p *RandomStreamClient) PriorReplicationDetails(
 	ctx context.Context, tenant roachpb.TenantName,
-) (string, hlc.Timestamp, error) {
-	return "", hlc.Timestamp{}, nil
+) (string, string, hlc.Timestamp, error) {
+	return "", "", hlc.Timestamp{}, nil
 
 }
 

--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
@@ -114,10 +114,7 @@ func TestAlterTenantPauseResume(t *testing.T) {
 	cutoverOutput := replicationtestutils.DecimalTimeToHLC(t, cutoverStr)
 	require.Equal(t, cutoverTime, cutoverOutput.GoTime())
 	jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
-	cleanupTenant := c.StartDestTenant(ctx, nil, 0)
-	defer func() {
-		require.NoError(t, cleanupTenant())
-	}()
+	defer c.StartDestTenant(ctx, nil, 0)()
 
 	t.Run("pause-nonexistant-tenant", func(t *testing.T) {
 		c.DestSysSQL.ExpectErr(t, "tenant \"nonexistent\" does not exist", `ALTER TENANT $1 PAUSE REPLICATION`, "nonexistent")

--- a/pkg/ccl/streamingccl/streamingest/datadriven_test.go
+++ b/pkg/ccl/streamingccl/streamingest/datadriven_test.go
@@ -157,7 +157,7 @@ func TestDataDriven(t *testing.T) {
 			case "start-replicated-tenant":
 				testingKnobs := replicationtestutils.DefaultAppTenantTestingKnobs()
 				cleanupTenant := ds.replicationClusters.StartDestTenant(ctx, &testingKnobs, 0)
-				ds.cleanupFns = append(ds.cleanupFns, cleanupTenant)
+				ds.cleanupFns = append(ds.cleanupFns, func() error { cleanupTenant(); return nil })
 			case "let":
 				if len(d.CmdArgs) == 0 {
 					t.Fatalf("Must specify at least one variable name.")

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -1307,10 +1307,7 @@ func TestStreamingMismatchedMRDatabase(t *testing.T) {
 	srcTime := c.SrcCluster.Server(0).Clock().Now()
 	c.Cutover(producerJobID, ingestionJobID, srcTime.GoTime(), false)
 
-	cleanupTenant := c.StartDestTenant(ctx, nil, 0)
-	defer func() {
-		require.NoError(t, cleanupTenant())
-	}()
+	defer c.StartDestTenant(ctx, nil, 0)()
 
 	// Check how MR primitives have replicated to non-mr stand by cluster
 	t.Run("mr db only with primary region", func(t *testing.T) {
@@ -1385,10 +1382,7 @@ func TestStreamingZoneConfigsMismatchedRegions(t *testing.T) {
 	srcTime := c.SrcCluster.Server(0).Clock().Now()
 	c.Cutover(producerJobID, ingestionJobID, srcTime.GoTime(), false)
 
-	cleanupTenant := c.StartDestTenant(ctx, nil, 0)
-	defer func() {
-		require.NoError(t, cleanupTenant())
-	}()
+	defer c.StartDestTenant(ctx, nil, 0)()
 
 	// Note that the unsatisfiable zone config does not appear in the create statement.
 	var res string

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -162,8 +162,8 @@ func (m *mockStreamClient) Complete(_ context.Context, _ streampb.StreamID, _ bo
 // PriorReplicationDetails implements the streamclient.Client interface.
 func (m *mockStreamClient) PriorReplicationDetails(
 	_ context.Context, _ roachpb.TenantName,
-) (string, hlc.Timestamp, error) {
-	return "", hlc.Timestamp{}, nil
+) (string, string, hlc.Timestamp, error) {
+	return "", "", hlc.Timestamp{}, nil
 }
 
 // errorStreamClient always returns an error when consuming a partition.


### PR DESCRIPTION
Previously once a virtual cluster completed replication, it could not go back to replicating; if you promoted a replicating virtual cluster to active, you would need to make a _new_ virtual cluster and backfill it entirely if you once again wanted to have a standby virtual cluster replicating from the source.

However a recently promoted former standby still has most of the data that a new cluster would need to backfill, so a much faster option than making a new one, if the activated cluster no longer needs to be activated, is to deactivate it, rewind it to the point at which it diverged, and then resume replcating from there, if still possible.

This change adds the ability to do just that, using the same syntax that can be used in the very similar case of reversing replication where a previously active virtual cluster is also rewound to then be used as replicating standby.

Release note: none.
Epic: none.