### PR TITLE
cli/demo: expand demo://tenant to postgres:// URL

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -1392,6 +1392,10 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 	// to handle it as a statement, so save the history.
 	c.addHistory(c.lastInputLine)
 
+	if c.sqlCtx.DemoCluster != nil {
+		c.lastInputLine = c.sqlCtx.DemoCluster.ExpandShortDemoURLs(c.lastInputLine)
+	}
+
 	// As a convenience to the user, we strip the final semicolon, if
 	// any, in all cases.
 	line := strings.TrimRight(c.lastInputLine, "; ")
@@ -1978,6 +1982,10 @@ func (c *cliState) doPrepareStatementLine(
 	// Complete input. Remember it in the history.
 	if !c.inCopy() {
 		c.addHistory(c.concatLines)
+	}
+
+	if c.sqlCtx.DemoCluster != nil {
+		c.concatLines = c.sqlCtx.DemoCluster.ExpandShortDemoURLs(c.concatLines)
 	}
 
 	if !c.iCtx.checkSyntax {

--- a/pkg/cli/democluster/api/api.go
+++ b/pkg/cli/democluster/api/api.go
@@ -26,6 +26,9 @@ type DemoCluster interface {
 	// Listing is printed to 'w'. Errors/warnings are printed to 'ew'.
 	ListDemoNodes(w, ew io.Writer, justOne, verbose bool)
 
+	// ExpandShortDemoURLs expands `demo://` in a string URLs to `postgres://...`.
+	ExpandShortDemoURLs(string) string
+
 	// AddNode creates a new node with the given locality string.
 	AddNode(ctx context.Context, localityString string) (newNodeID int32, err error)
 

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -2038,6 +2038,17 @@ func (c *transientCluster) ListDemoNodes(w, ew io.Writer, justOne, verbose bool)
 	}
 }
 
+func (c *transientCluster) ExpandShortDemoURLs(s string) string {
+	if !strings.Contains(s, "demo://") {
+		return s
+	}
+	u, err := c.getNetworkURLForServer(context.Background(), 0, false, forSystemTenant)
+	if err != nil {
+		return s
+	}
+	return regexp.MustCompile(`demo://([[:alnum:]]+)`).ReplaceAllString(s, strings.ReplaceAll(u.String(), "-ccluster%3Dsystem", "-ccluster%3D$1"))
+}
+
 func (c *transientCluster) printURLs(
 	w, ew io.Writer,
 	sqlURL *pgurl.URL,


### PR DESCRIPTION
The SQL connection URLs are large and somewhat unwieldy when used with \c to reconnect or in PCR control statements. One particular source of friction, beyond the sheer length of the string making statements harder to read or modify by hand, is that the connection string in it includes values that are specific to a given `demo` session, meaning a subsequent session cannot simply re-run the same commands from the recorded shell history as they contain the ephemeral ports and passwords.

This change adds a small special-case to the shell when it is running in demo mode, so that it will replace any occurrence of a string of the form 'demo://<cluster_name>' with the pgurl for the virtual cluster of that name on its first server.

For example, when used reconnecting the shell itself to a different pgurl:

```
demo@127.0.0.1:26257/system/defaultdb> \c demo://demoapp
using new connection URL: postgresql://demo:demo36905@127.0.0.1:26257/defaultdb?options=-ccluster%3Ddemoapp&sslmode=require&sslrootcert=%2FUsers%2Fuser%2F.cockroach-demo%2Fca.crt

demo@127.0.0.1:26257/demoapp/defaultdb> \c demo://system
using new connection URL: postgresql://demo:demo36905@127.0.0.1:26257/defaultdb?options=-ccluster%3Dsystem&sslmode=require&sslrootcert=%2FUsers%2Fuser%2F.cockroach-demo%2Fca.crt
```

For another example, when used in the content of a statement that will be sent to the database:
```
demo@127.0.0.1:26257/system/defaultdb> create virtual cluster t2 from replication of demoapp on 'demo://system';
CREATE VIRTUAL CLUSTER FROM REPLICATION 0

demo@127.0.0.1:26257/system/defaultdb> SELECT source_cluster_uri FROM [SHOW VIRTUAL CLUSTER t2 WITH REPLICATION STATUS];
                                                   source_cluster_uri
------------------------------------------------------------------------------------------------------------------------
  postgresql://demo:redacted@127.0.0.1:26257/defaultdb?options=-ccluster%3Dsystem&sslmode=require&sslrootcert=redacted
```

The substitutions are performed after recording the line in the shell history, so that the history is kept in terms of the short name that remains constant across demo sessions.

Release note: none.
Epic: none.