### PR TITLE
kvserver: fix `TestRaftForceCampaignPreVoteCheckQuorum`

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -6051,7 +6051,7 @@ func TestRaftForceCampaignPreVoteCheckQuorum(t *testing.T) {
 
 	repl1, err := tc.GetFirstStoreFromServer(t, 0).GetReplica(desc.RangeID)
 	require.NoError(t, err)
-	repl2, err := tc.GetFirstStoreFromServer(t, 2).GetReplica(desc.RangeID)
+	repl2, err := tc.GetFirstStoreFromServer(t, 1).GetReplica(desc.RangeID)
 	require.NoError(t, err)
 	repl3, err := tc.GetFirstStoreFromServer(t, 2).GetReplica(desc.RangeID)
 	require.NoError(t, err)


### PR DESCRIPTION
This was supposed to check that one of the replicas was the leader, but because of a typo it checked n3 twice instead of n2.

Touches #117615.
Epic: none
Release note: None