### PR TITLE
roachtest: use 'master' tag for tpc-e docker images

### DIFF
--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -80,7 +80,7 @@ func initTPCESpec(
 }
 
 func (ts *tpceSpec) newCmd(o tpceCmdOptions) *roachtestutil.Command {
-	cmd := roachtestutil.NewCommand(`sudo docker run us-east1-docker.pkg.dev/crl-ci-images/cockroach/tpc-e:latest`)
+	cmd := roachtestutil.NewCommand(`sudo docker run us-east1-docker.pkg.dev/crl-ci-images/cockroach/tpc-e:master`)
 	o.AddCommandOptions(cmd)
 	return cmd
 }


### PR DESCRIPTION
In [1], [2], we moved tpc-e docker images from the Docker Hub to a publicly accessible Google Container Registry (under https://us-east1-docker.pkg.dev/v2/crl-ci-images). Consequently, most recent changes to tpc-e are now tagged as 'master'. (This happens as part of the docker GH action upon merging a PR into master.)

[1] https://github.com/cockroachlabs/tpc-e/pull/71
[2] https://github.com/cockroachdb/cockroach/pull/117691

Epic: none

Release note: None