### PR TITLE
sql: fix float to integer casting

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -2405,7 +2405,6 @@ subtest plpgsql_types
 # If an assignment cast is available, the cast is performed automatically.
 #
 # float -> int
-# TODO(112515): the float value is incorrectly truncated instead of rounded.
 statement ok
 DROP FUNCTION F();
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
@@ -2417,7 +2416,7 @@ $$ LANGUAGE PLpgSQL;
 query I
 SELECT f();
 ----
-105
+106
 
 # decimal -> int
 statement ok

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -5396,7 +5396,7 @@ func (c *castFloatInt2Op) Next() coldata.Batch {
 							if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
-							r = int16(v)
+							r = int16(math.RoundToEven(v))
 
 							outputCol.Set(tupleIdx, r)
 						}
@@ -5425,7 +5425,7 @@ func (c *castFloatInt2Op) Next() coldata.Batch {
 							if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
-							r = int16(v)
+							r = int16(math.RoundToEven(v))
 
 							//gcassert:bce
 							outputCol.Set(tupleIdx, r)
@@ -5454,7 +5454,7 @@ func (c *castFloatInt2Op) Next() coldata.Batch {
 							if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
-							r = int16(v)
+							r = int16(math.RoundToEven(v))
 
 							outputCol.Set(tupleIdx, r)
 						}
@@ -5483,7 +5483,7 @@ func (c *castFloatInt2Op) Next() coldata.Batch {
 							if math.IsNaN(float64(v)) || v <= float64(math.MinInt16) || v >= float64(math.MaxInt16) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
-							r = int16(v)
+							r = int16(math.RoundToEven(v))
 
 							//gcassert:bce
 							outputCol.Set(tupleIdx, r)
@@ -5544,7 +5544,7 @@ func (c *castFloatInt4Op) Next() coldata.Batch {
 							if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
-							r = int32(v)
+							r = int32(math.RoundToEven(v))
 
 							outputCol.Set(tupleIdx, r)
 						}
@@ -5573,7 +5573,7 @@ func (c *castFloatInt4Op) Next() coldata.Batch {
 							if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
-							r = int32(v)
+							r = int32(math.RoundToEven(v))
 
 							//gcassert:bce
 							outputCol.Set(tupleIdx, r)
@@ -5602,7 +5602,7 @@ func (c *castFloatInt4Op) Next() coldata.Batch {
 							if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
-							r = int32(v)
+							r = int32(math.RoundToEven(v))
 
 							outputCol.Set(tupleIdx, r)
 						}
@@ -5631,7 +5631,7 @@ func (c *castFloatInt4Op) Next() coldata.Batch {
 							if math.IsNaN(float64(v)) || v <= float64(math.MinInt32) || v >= float64(math.MaxInt32) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
-							r = int32(v)
+							r = int32(math.RoundToEven(v))
 
 							//gcassert:bce
 							outputCol.Set(tupleIdx, r)
@@ -5692,7 +5692,7 @@ func (c *castFloatIntOp) Next() coldata.Batch {
 							if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
-							r = int64(v)
+							r = int64(math.RoundToEven(v))
 
 							outputCol.Set(tupleIdx, r)
 						}
@@ -5721,7 +5721,7 @@ func (c *castFloatIntOp) Next() coldata.Batch {
 							if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
-							r = int64(v)
+							r = int64(math.RoundToEven(v))
 
 							//gcassert:bce
 							outputCol.Set(tupleIdx, r)
@@ -5750,7 +5750,7 @@ func (c *castFloatIntOp) Next() coldata.Batch {
 							if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
-							r = int64(v)
+							r = int64(math.RoundToEven(v))
 
 							outputCol.Set(tupleIdx, r)
 						}
@@ -5779,7 +5779,7 @@ func (c *castFloatIntOp) Next() coldata.Batch {
 							if math.IsNaN(float64(v)) || v <= float64(math.MinInt64) || v >= float64(math.MaxInt64) {
 								colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 							}
-							r = int64(v)
+							r = int64(math.RoundToEven(v))
 
 							//gcassert:bce
 							outputCol.Set(tupleIdx, r)

--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
@@ -271,7 +271,7 @@ func floatToInt(intWidth, floatWidth int32) castFunc {
 			if math.IsNaN(float64(%[2]s)) || %[2]s <= float%[4]d(math.MinInt%[3]d) || %[2]s >= float%[4]d(math.MaxInt%[3]d) {
 				colexecerror.ExpectedError(tree.ErrIntOutOfRange)
 			}
-			%[1]s = int%[3]d(%[2]s)
+			%[1]s = int%[3]d(math.RoundToEven(%[2]s))
 		`
 		if intWidth == anyWidth {
 			intWidth = 64

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -989,12 +989,12 @@ UPDATE mnop SET o = n::decimal, p = (n * 10)::bigint
 query RRR
 SELECT round(variance(n), 2), round(variance(n), 2), round(variance(p)) FROM mnop
 ----
-0.08 0.08 8
+0.08 0.08 9
 
 query RRR
 SELECT round(var_pop(n), 2), round(var_pop(n), 2), round(var_pop(p)) FROM mnop
 ----
-0.08 0.08 8
+0.08 0.08 9
 
 query RRR
 SELECT round(stddev_samp(n), 2), round(stddev(n), 2), round(stddev_samp(p)) FROM mnop

--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -1533,3 +1533,18 @@ array_agg
 array_agg
 array_agg
 array_agg
+
+subtest regression_112515
+
+statement ok
+CREATE TABLE t112515 (f FLOAT);
+INSERT INTO t112515 VALUES (-1.5), (-0.5), (0.5), (1.5), (2.5);
+
+query I rowsort
+SELECT f::INT FROM t112515
+----
+-2
+0
+0
+2
+2

--- a/pkg/sql/logictest/testdata/logic_test/target_names
+++ b/pkg/sql/logictest/testdata/logic_test/target_names
@@ -73,4 +73,4 @@ SELECT (SELECT 123 AS a),
        (SELECT cos(0)::INT)
 ----
 a   column1 cos
-123 0       1
+123 1       1

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -220,7 +220,7 @@ func performCastWithoutPrecisionTruncation(
 			if math.IsNaN(f) || f <= float64(math.MinInt64) || f >= float64(math.MaxInt64) {
 				return nil, tree.ErrIntOutOfRange
 			}
-			res = tree.NewDInt(tree.DInt(f))
+			res = tree.NewDInt(tree.DInt(math.RoundToEven(f)))
 		case *tree.DDecimal:
 			i, err := roundDecimalToInt(&v.Decimal)
 			if err != nil {

--- a/pkg/sql/sem/eval/testdata/eval/cast
+++ b/pkg/sql/sem/eval/testdata/eval/cast
@@ -1460,3 +1460,25 @@ eval
 text(1.11::float8)
 ----
 '1.11'
+
+# Issue #112515: float casting returns the nearest integer,
+# rounding ties to even (Banker's rounding).
+eval
+int8(0.5::float8)
+----
+0
+
+eval
+int8(1.5::float8)
+----
+2
+
+eval
+int8(-0.5::float8)
+----
+0
+
+eval
+int8(-1.5::float8)
+----
+-2


### PR DESCRIPTION
Previously, casting a float value to an integer simply truncates the float. This commit fixes that by rounding the float value to the nearest integer, rounding ties to even, as in postgres.

Epic: None
Fixes: #112515

Release note (bug fix): A bug has been fixed where casts of floats to integers
truncated the value. These casts now round a float to the nearest integer,
rounding ties to even integers.