### PR TITLE
sql: fix benchmark regressions

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1230,6 +1230,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		}
 	})
 
+	b.StopTimer()
 }
 
 // This test makes sure leases get renewed automatically in the

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -3896,6 +3896,8 @@ func benchUserUpload(b *testing.B, uploadBaseURI string) {
 			`IMPORT INTO t CSV DATA ('%s%s')`,
 			uploadBaseURI, testFileBase,
 		))
+
+	b.StopTimer()
 }
 
 // goos: darwin


### PR DESCRIPTION
This commit fixes several benchmarks that incorrectly included cluster
shutdown as part of the benchmark timing. This caused major regressions.
See #117542 for more details.

Epic: None

Release note: None
