### PR TITLE
release-23.1: roachtest: use 'master' tag for tpc-e docker images

### DIFF
--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -68,7 +68,7 @@ func registerTPCE(r registry.Registry) {
 
 		m := c.NewMonitor(ctx, roachNodes)
 		m.Go(func(ctx context.Context) error {
-			const dockerRun = `sudo docker run us-east1-docker.pkg.dev/crl-ci-images/cockroach/tpc-e:latest`
+			const dockerRun = `sudo docker run us-east1-docker.pkg.dev/crl-ci-images/cockroach/tpc-e:master`
 
 			roachNodeIPs, err := c.InternalIP(ctx, t.L(), roachNodes)
 			if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #117795.

/cc @cockroachdb/release

---

In [1], [2], we moved tpc-e docker images from the Docker Hub to a publicly accessible Google Container Registry (under https://us-east1-docker.pkg.dev/v2/crl-ci-images). Consequently, most recent changes to tpc-e are now tagged as 'master'. (This happens as part of the docker GH action upon merging a PR into master.)

[1] https://github.com/cockroachlabs/tpc-e/pull/71
[2] https://github.com/cockroachdb/cockroach/pull/117691

Epic: none

Release note: None
Release justification: test-only change
