### PR TITLE
kv: fix assertion output in TestReplicationStatusReportIntegration

### DIFF
--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -375,7 +375,7 @@ func checkZoneReplication(db *gosql.DB, zoneID, total, under, over, unavailable 
 			return fmt.Errorf("expected total: %d, got: %d", total, gotTotal)
 		}
 		if under != gotUnder {
-			return fmt.Errorf("expected under: %d, got: %d", total, gotUnder)
+			return fmt.Errorf("expected under: %d, got: %d", under, gotUnder)
 		}
 		if over != gotOver {
 			return fmt.Errorf("expected over: %d, got: %d", over, gotOver)


### PR DESCRIPTION
Informs #117175.

This doesn't fix the failing test, but it resolves the nonsensical failure message and allows us to debug the test.

Release note: None