### PR TITLE
kv: [DNM] approximate MVCCStats during splits

### DIFF
--- a/pkg/kv/kvserver/batcheval/split_stats_helper.go
+++ b/pkg/kv/kvserver/batcheval/split_stats_helper.go
@@ -135,6 +135,23 @@ type splitStatsHelperInput struct {
 	ScanRightFirst bool
 }
 
+func makeApproxSplitStatsHelper(input splitStatsHelperInput) (splitStatsHelper, error) {
+	h := splitStatsHelper{in: input}
+
+	rightStats := h.in.AbsPreSplitBothStored
+	rightStats.Scale(0.5)
+	h.absPostSplitRight = &rightStats
+	h.absPostSplitRight.ContainsEstimates += 1
+
+	leftStats := h.in.AbsPreSplitBothStored
+	leftStats.Subtract(rightStats)
+	leftStats.Add(h.in.DeltaBatchEstimated)
+	h.absPostSplitLeft = &leftStats
+	h.absPostSplitLeft.ContainsEstimates += 1
+
+	return h, nil
+}
+
 // makeSplitStatsHelper initializes a splitStatsHelper. The values in the input
 // are assumed to not change outside of the helper and must no longer be used.
 // The provided PostSplitScanLeftFn and PostSplitScanRightFn recompute the left

--- a/pkg/storage/enginepb/mvcc.go
+++ b/pkg/storage/enginepb/mvcc.go
@@ -202,6 +202,28 @@ func (ms *MVCCStats) Subtract(oms MVCCStats) {
 	ms.AbortSpanBytes -= oms.AbortSpanBytes
 }
 
+func (ms *MVCCStats) Scale(factor float32) {
+	ms.LockAge = int64(float32(ms.LockAge) * factor)
+	ms.GCBytesAge = int64(float32(ms.GCBytesAge) * factor)
+	ms.LiveBytes = int64(float32(ms.LiveBytes) * factor)
+	ms.KeyBytes = int64(float32(ms.KeyBytes) * factor)
+	ms.ValBytes = int64(float32(ms.ValBytes) * factor)
+	ms.IntentBytes = int64(float32(ms.IntentBytes) * factor)
+	ms.LiveCount = int64(float32(ms.LiveCount) * factor)
+	ms.KeyCount = int64(float32(ms.KeyCount) * factor)
+	ms.ValCount = int64(float32(ms.ValCount) * factor)
+	ms.IntentCount = int64(float32(ms.IntentCount) * factor)
+	ms.LockBytes = int64(float32(ms.LockBytes) * factor)
+	ms.LockCount = int64(float32(ms.LockCount) * factor)
+	ms.RangeKeyCount = int64(float32(ms.RangeKeyCount) * factor)
+	ms.RangeKeyBytes = int64(float32(ms.RangeKeyBytes) * factor)
+	ms.RangeValCount = int64(float32(ms.RangeValCount) * factor)
+	ms.RangeValBytes = int64(float32(ms.RangeValBytes) * factor)
+	ms.SysBytes = int64(float32(ms.SysBytes) * factor)
+	ms.SysCount = int64(float32(ms.SysCount) * factor)
+	ms.AbortSpanBytes = int64(float32(ms.AbortSpanBytes) * factor)
+}
+
 // IsInline returns true if the value is inlined in the metadata.
 func (meta MVCCMetadata) IsInline() bool {
 	return meta.RawBytes != nil


### PR DESCRIPTION
Instead of computing accurate MVCCStats for the LHS and RHS of a split, approximate the stats as half belonging to the LHS and half to the RHS. Then, immedately kick off a stats recomputation for both sides.

Do not merge, this is an experiment.