### PR TITLE
roachtest/cdc: change CompatibleClouds to OnlyAzure

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -216,6 +216,9 @@ var OnlyAWS = Clouds(spec.AWS)
 // OnlyGCE contains only the GCE cloud.
 var OnlyGCE = Clouds(spec.GCE)
 
+// OnlyAzure contains only the Azure cloud.
+var OnlyAzure = Clouds(spec.Azure)
+
 // OnlyLocal contains only the GCE cloud.
 var OnlyLocal = Clouds(spec.Local)
 

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1629,8 +1629,8 @@ func registerCDC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "cdc/kafka-azure",
 		Owner:            `cdc`,
-		CompatibleClouds: registry.AllExceptAWS,
-		Cluster:          r.MakeClusterSpec(2, spec.GCEZones("us-east1-b")),
+		CompatibleClouds: registry.OnlyAzure,
+		Cluster:          r.MakeClusterSpec(2),
 		Leases:           registry.MetamorphicLeases,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
Previously, cdc/kafka-azure could be run on TeamCity agents that do not have
env var credentials configured properly. This patch fixes it by changing
CompatibleClouds to OnlyAzure so that it runs exclusively on `Roachtest Nightly - Azure`.

Fixes: https://github.com/cockroachdb/cockroach/issues/117803

Release note: none