### PR TITLE
stress-deadlock: bump `enormous` timeout

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 export RUNS_PER_TEST=3
-export EXTRA_TEST_ARGS="--define gotags=bazel,gss,deadlock --test_timeout=300,1000,1500,2000 --heavy"
+export EXTRA_TEST_ARGS="--define gotags=bazel,gss,deadlock --test_timeout=300,1000,1500,2400 --heavy"
 export EXTRA_ISSUE_PARAMS=deadlock
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)


### PR DESCRIPTION
Some of the timeouts here are bumping up against the maximum.

Epic: CRDB-8308
Release note: None