### PR TITLE
backup,kvserver: plumb backing file vs physical size through raft

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -660,10 +660,11 @@ func runBackupProcessor(
 								// to store the metadata we need, but there's no actual File
 								// on-disk anywhere yet.
 								metadata: backuppb.BackupManifest_File{
-									Span:        file.Span,
-									Path:        file.Path,
-									EntryCounts: entryCounts,
-									LocalityKV:  destLocalityKV,
+									Span:                    file.Span,
+									Path:                    file.Path,
+									EntryCounts:             entryCounts,
+									LocalityKV:              destLocalityKV,
+									ApproximatePhysicalSize: uint64(len(file.SST)),
 								},
 								dataSST:       file.SST,
 								revStart:      resp.StartTime,

--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -660,11 +660,10 @@ func runBackupProcessor(
 								// to store the metadata we need, but there's no actual File
 								// on-disk anywhere yet.
 								metadata: backuppb.BackupManifest_File{
-									Span:            file.Span,
-									Path:            file.Path,
-									EntryCounts:     entryCounts,
-									LocalityKV:      destLocalityKV,
-									BackingFileSize: uint64(len(file.SST)),
+									Span:        file.Span,
+									Path:        file.Path,
+									EntryCounts: entryCounts,
+									LocalityKV:  destLocalityKV,
 								},
 								dataSST:       file.SST,
 								revStart:      resp.StartTime,

--- a/pkg/ccl/backupccl/backuppb/backup.proto
+++ b/pkg/ccl/backupccl/backuppb/backup.proto
@@ -48,7 +48,13 @@ message BackupManifest {
     util.hlc.Timestamp start_time = 7 [(gogoproto.nullable) = false];
     util.hlc.Timestamp end_time = 8 [(gogoproto.nullable) = false];
     string locality_kv = 9 [(gogoproto.customname) = "LocalityKV"];
+    // BackingFileSize is the actual size of the backing file, if known. This
+    // can be zero if unknown, in which case opening the file will need to find
+    // it via an additional stat/size call.
     uint64 backing_file_size = 10;
+    // ApproximatePhysicalSize is the approximate size of the physical bytes in
+    // compressed SST form.
+    uint64 approximate_physical_size = 11;
   }
 
   message DescriptorRevision {

--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -234,6 +234,7 @@ func (s *fileSSTSink) write(ctx context.Context, resp exportedSpan) error {
 		s.flushedFiles[l].StartTime.EqOrdering(resp.metadata.StartTime) {
 		s.flushedFiles[l].Span.EndKey = span.EndKey
 		s.flushedFiles[l].EntryCounts.Add(resp.metadata.EntryCounts)
+		s.flushedFiles[l].ApproximatePhysicalSize += resp.metadata.ApproximatePhysicalSize
 		s.stats.spanGrows++
 	} else {
 		f := resp.metadata

--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -125,8 +125,13 @@ func (s *fileSSTSink) flushFile(ctx context.Context) error {
 		log.Warningf(ctx, "failed to close write in fileSSTSink: % #v", pretty.Formatter(err))
 		return errors.Wrap(err, "writing SST")
 	}
+	wroteSize := s.sst.Meta.Size
 	s.outName = ""
 	s.out = nil
+
+	for i := range s.flushedFiles {
+		s.flushedFiles[i].BackingFileSize = wroteSize
+	}
 
 	progDetails := backuppb.BackupManifest_Progress{
 		RevStartTime:   s.flushedRevStart,
@@ -229,7 +234,6 @@ func (s *fileSSTSink) write(ctx context.Context, resp exportedSpan) error {
 		s.flushedFiles[l].StartTime.EqOrdering(resp.metadata.StartTime) {
 		s.flushedFiles[l].Span.EndKey = span.EndKey
 		s.flushedFiles[l].EntryCounts.Add(resp.metadata.EntryCounts)
-		s.flushedFiles[l].BackingFileSize += resp.metadata.BackingFileSize
 		s.stats.spanGrows++
 	} else {
 		f := resp.metadata

--- a/pkg/ccl/backupccl/restore_online.go
+++ b/pkg/ccl/backupccl/restore_online.go
@@ -128,8 +128,8 @@ func sendAddRemoteSSTWorker(
 				// NB: Since the restored span is a subset of the BackupFileEntrySpan,
 				// these counts may be an overestimate of what actually gets restored.
 				counts := file.BackupFileEntryCounts
-				fileSize := file.BackingFileSize
-				// If we don't have backing file size info, just use the mvcc size; it
+				fileSize := file.ApproximatePhysicalSize
+				// If we don't have physical file size info, just use the mvcc size; it
 				// isn't physical size but is good enough for reflecting that there are
 				// some number of bytes in this sst span for the purposes tracking which
 				// spans have non-zero remote bytes.
@@ -142,9 +142,10 @@ func sendAddRemoteSSTWorker(
 				}
 
 				loc := kvpb.AddSSTableRequest_RemoteFile{
-					Locator:         file.Dir.URI,
-					Path:            file.Path,
-					BackingFileSize: fileSize,
+					Locator:                 file.Dir.URI,
+					Path:                    file.Path,
+					ApproximatePhysicalSize: fileSize,
+					BackingFileSize:         file.BackingFileSize,
 				}
 				// TODO(dt): see if KV has any better ideas for making these up.
 				fileStats := &enginepb.MVCCStats{

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -2118,6 +2118,7 @@ message AddSSTableRequest {
     string locator = 1;
     string path = 2;
     uint64 backing_file_size = 3;
+    uint64 approximate_physical_size = 4;
   }
   RemoteFile remote_file = 10 [(gogoproto.nullable) = false];
 

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -162,10 +162,11 @@ func EvalAddSSTable(
 		return result.Result{
 			Replicated: kvserverpb.ReplicatedEvalResult{
 				AddSSTable: &kvserverpb.ReplicatedEvalResult_AddSSTable{
-					RemoteFileLoc:   args.RemoteFile.Locator,
-					RemoteFilePath:  path,
-					BackingFileSize: args.RemoteFile.BackingFileSize,
-					Span:            roachpb.Span{Key: start.Key, EndKey: end.Key},
+					RemoteFileLoc:           args.RemoteFile.Locator,
+					RemoteFilePath:          path,
+					ApproximatePhysicalSize: args.RemoteFile.ApproximatePhysicalSize,
+					BackingFileSize:         args.RemoteFile.BackingFileSize,
+					Span:                    roachpb.Span{Key: start.Key, EndKey: end.Key},
 				},
 				// Since the remote SST could contain keys at any timestamp, consider it
 				// a history mutation.

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -198,6 +198,7 @@ message ReplicatedEvalResult {
     string remote_file_loc = 5;
     string remote_file_path = 6;
     uint64 backing_file_size = 7;
+    uint64 approximate_physical_size = 8;
   }
   AddSSTable add_sstable = 17 [(gogoproto.customname) = "AddSSTable"];
 

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -641,20 +641,22 @@ func addSSTablePreApply(
 ) bool {
 	if sst.RemoteFilePath != "" {
 		log.Infof(ctx,
-			"EXPERIMENTAL AddSSTABLE EXTERNAL %s (size %d, span %s) from %s",
+			"EXPERIMENTAL AddSSTABLE EXTERNAL %s (size %d, span %s) from %s (size %d)",
 			sst.RemoteFilePath,
-			sst.BackingFileSize,
+			sst.ApproximatePhysicalSize,
 			sst.Span,
 			sst.RemoteFileLoc,
+			sst.BackingFileSize,
 		)
 		start := storage.EngineKey{Key: sst.Span.Key}
 		end := storage.EngineKey{Key: sst.Span.EndKey}
 		externalFile := pebble.ExternalFile{
 			Locator:         remote.Locator(sst.RemoteFileLoc),
 			ObjName:         sst.RemoteFilePath,
-			Size:            sst.BackingFileSize,
+			Size:            sst.ApproximatePhysicalSize,
 			SmallestUserKey: start.Encode(),
 			LargestUserKey:  end.Encode(),
+			// TODO(dt): pass pebble the backing file size to avoid a stat call.
 
 			// TODO(msbutler): I guess we need to figure out if the backing external
 			// file has point or range keys in the target span.

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -322,6 +322,9 @@ message RestoreFileSpec {
   optional roachpb.Span backup_file_entry_span = 5 [(gogoproto.nullable) = false];
   optional roachpb.RowCount backup_file_entry_counts = 6 [(gogoproto.nullable) = false];
   optional uint64 backing_file_size = 7 [(gogoproto.nullable) = false];
+  optional uint64 approximate_physical_size = 8 [(gogoproto.nullable) = false];
+  
+  // NEXT ID: 9.
 }
 
 message TableRekey {


### PR DESCRIPTION
See commits.

Release note: none.
Epic: none.