### PR TITLE
release-23.1: backport #115599 #117505 #117745

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1971,6 +1971,17 @@ func (c *clusterImpl) StartE(
 	return nil
 }
 
+// StartServiceForVirtualClusterE can start either external or shared process
+// virtual clusters. This can be specified in startOpts.RoachprodOpts. Set the
+// `Target` to the required virtual cluster type. Refer to the virtual cluster
+// section in the struct for more information on what fields are available for
+// virtual clusters.
+//
+// With external process virtual clusters an external process will be started on
+// each node specified in the externalNodes parameter.
+//
+// With shared process virtual clusters the required queries will be run on a
+// storage node of the cluster specified in the opts parameter.
 func (c *clusterImpl) StartServiceForVirtualClusterE(
 	ctx context.Context,
 	l *logger.Logger,

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2455,6 +2455,12 @@ func (c *clusterImpl) ExternalAdminUIAddr(
 	return c.adminUIAddr(ctx, l, node, true)
 }
 
+func (c *clusterImpl) AdminUIPorts(
+	ctx context.Context, l *logger.Logger, nodes option.NodeListOption,
+) ([]int, error) {
+	return roachprod.AdminPorts(ctx, l, c.MakeNodes(nodes), c.IsSecure())
+}
+
 func (c *clusterImpl) adminUIAddr(
 	ctx context.Context, l *logger.Logger, node option.NodeListOption, external bool,
 ) ([]string, error) {

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -640,8 +640,11 @@ type clusterImpl struct {
 	expiration    time.Time
 	encAtRest     bool // use encryption at rest
 
-	// clusterSettings are additional cluster settings set on cluster startup.
+	// clusterSettings are additional cluster settings set on the storage cluster startup.
 	clusterSettings map[string]string
+	// virtualClusterSettings are additional cluster settings to set on the
+	// virtual cluster startup.
+	virtualClusterSettings map[string]string
 	// goCoverDir is the directory for Go coverage data (if coverage is enabled).
 	// BAZEL_COVER_DIR will be set to this value when starting a node.
 	goCoverDir string
@@ -1894,6 +1897,38 @@ func (c *clusterImpl) clearStatusForClusterOpt(worker bool) {
 	}
 }
 
+func (c *clusterImpl) configureClusterSettingOptions(
+	defaultClusterSettings install.ClusterSettingsOption, settings install.ClusterSettings,
+) []install.ClusterSettingOption {
+	setUnlessExists := func(name string, value interface{}) {
+		if !envExists(settings.Env, name) {
+			settings.Env = append(settings.Env, fmt.Sprintf("%s=%s", name, fmt.Sprint(value)))
+		}
+	}
+	// Set the same seed on every node, to be used by builds with
+	// runtime assertions enabled.
+	setUnlessExists("COCKROACH_RANDOM_SEED", c.cockroachRandomSeed())
+
+	// Panic on span use-after-Finish, so we catch such bugs.
+	setUnlessExists("COCKROACH_CRASH_ON_SPAN_USE_AFTER_FINISH", true)
+
+	if c.goCoverDir != "" {
+		settings.Env = append(settings.Env, fmt.Sprintf("BAZEL_COVER_DIR=%s", c.goCoverDir))
+	}
+
+	return []install.ClusterSettingOption{
+		install.TagOption(settings.Tag),
+		install.PGUrlCertsDirOption(settings.PGUrlCertsDir),
+		install.SecureOption(settings.Secure),
+		install.UseTreeDistOption(settings.UseTreeDist),
+		install.EnvOption(settings.Env),
+		install.NumRacksOption(settings.NumRacks),
+		install.BinaryOption(settings.Binary),
+		defaultClusterSettings,
+		install.ClusterSettingsOption(settings.ClusterSettings),
+	}
+}
+
 // StartE starts cockroach nodes on a subset of the cluster. The nodes parameter
 // can either be a specific node, empty (to indicate all nodes), or a pair of
 // nodes indicating a range.
@@ -1912,17 +1947,6 @@ func (c *clusterImpl) StartE(
 
 	startOpts.RoachprodOpts.EncryptedStores = c.encAtRest
 
-	setUnlessExists := func(name string, value interface{}) {
-		if !envExists(settings.Env, name) {
-			settings.Env = append(settings.Env, fmt.Sprintf("%s=%s", name, fmt.Sprint(value)))
-		}
-	}
-	// Panic on span use-after-Finish, so we catch such bugs.
-	setUnlessExists("COCKROACH_CRASH_ON_SPAN_USE_AFTER_FINISH", true)
-	// Set the same seed on every node, to be used by builds with
-	// runtime assertions enabled.
-	setUnlessExists("COCKROACH_RANDOM_SEED", c.cockroachRandomSeed())
-
 	// Needed for backward-compat on crdb_internal.ranges{_no_leases}.
 	// Remove in v23.2.
 	if !envExists(settings.Env, "COCKROACH_FORCE_DEPRECATED_SHOW_RANGE_BEHAVIOR") {
@@ -1931,21 +1955,7 @@ func (c *clusterImpl) StartE(
 		settings.Env = append(settings.Env, "COCKROACH_FORCE_DEPRECATED_SHOW_RANGE_BEHAVIOR=false")
 	}
 
-	if c.goCoverDir != "" {
-		settings.Env = append(settings.Env, fmt.Sprintf("BAZEL_COVER_DIR=%s", c.goCoverDir))
-	}
-
-	clusterSettingsOpts := []install.ClusterSettingOption{
-		install.TagOption(settings.Tag),
-		install.PGUrlCertsDirOption(settings.PGUrlCertsDir),
-		install.SecureOption(settings.Secure),
-		install.UseTreeDistOption(settings.UseTreeDist),
-		install.EnvOption(settings.Env),
-		install.NumRacksOption(settings.NumRacks),
-		install.BinaryOption(settings.Binary),
-		install.ClusterSettingsOption(c.clusterSettings),
-		install.ClusterSettingsOption(settings.ClusterSettings),
-	}
+	clusterSettingsOpts := c.configureClusterSettingOptions(c.clusterSettings, settings)
 
 	if err := roachprod.Start(ctx, l, c.MakeNodes(opts...), startOpts.RoachprodOpts, clusterSettingsOpts...); err != nil {
 		return err
@@ -1959,6 +1969,45 @@ func (c *clusterImpl) StartE(
 		}
 	}
 	return nil
+}
+
+func (c *clusterImpl) StartServiceForVirtualClusterE(
+	ctx context.Context,
+	l *logger.Logger,
+	externalNodes option.NodeListOption,
+	startOpts option.StartOpts,
+	settings install.ClusterSettings,
+	opts ...option.Option,
+) error {
+
+	c.setStatusForClusterOpt("starting virtual cluster", startOpts.RoachtestOpts.Worker, opts...)
+	defer c.clearStatusForClusterOpt(startOpts.RoachtestOpts.Worker)
+
+	clusterSettingsOpts := c.configureClusterSettingOptions(c.virtualClusterSettings, settings)
+
+	if err := roachprod.StartServiceForVirtualCluster(ctx, l, c.MakeNodes(externalNodes), c.MakeNodes(opts...), startOpts.RoachprodOpts, clusterSettingsOpts...); err != nil {
+		return err
+	}
+
+	if settings.Secure {
+		if err := c.RefetchCertsFromNode(ctx, 1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *clusterImpl) StartServiceForVirtualCluster(
+	ctx context.Context,
+	l *logger.Logger,
+	externalNodes option.NodeListOption,
+	startOpts option.StartOpts,
+	settings install.ClusterSettings,
+	opts ...option.Option,
+) {
+	if err := c.StartServiceForVirtualClusterE(ctx, l, externalNodes, startOpts, settings, opts...); err != nil {
+		c.t.Fatal(err)
+	}
 }
 
 func (c *clusterImpl) RefetchCertsFromNode(ctx context.Context, node int) error {

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -86,10 +86,11 @@ type Cluster interface {
 	Conn(ctx context.Context, l *logger.Logger, node int, opts ...func(*option.ConnOption)) *gosql.DB
 	ConnE(ctx context.Context, l *logger.Logger, node int, opts ...func(*option.ConnOption)) (*gosql.DB, error)
 
-	// URLs for the Admin UI.
+	// URLs and Ports for the Admin UI.
 
 	InternalAdminUIAddr(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)
 	ExternalAdminUIAddr(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)
+	AdminUIPorts(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]int, error)
 
 	// Running commands on nodes.
 

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -64,6 +64,11 @@ type Cluster interface {
 	StopCockroachGracefullyOnNode(ctx context.Context, l *logger.Logger, node int) error
 	NewMonitor(context.Context, ...option.Option) Monitor
 
+	// Starting virtual clusters.
+
+	StartServiceForVirtualClusterE(ctx context.Context, l *logger.Logger, externalNodes option.NodeListOption, startOpts option.StartOpts, settings install.ClusterSettings, opts ...option.Option) error
+	StartServiceForVirtualCluster(ctx context.Context, l *logger.Logger, externalNodes option.NodeListOption, startOpts option.StartOpts, settings install.ClusterSettings, opts ...option.Option)
+
 	// Hostnames and IP addresses of the nodes.
 
 	InternalAddr(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)

--- a/pkg/cmd/roachtest/option/connection_options.go
+++ b/pkg/cmd/roachtest/option/connection_options.go
@@ -35,6 +35,12 @@ func TenantName(tenantName string) func(*ConnOption) {
 	}
 }
 
+func SQLInstance(sqlInstance int) func(*ConnOption) {
+	return func(option *ConnOption) {
+		option.SQLInstance = sqlInstance
+	}
+}
+
 func ConnectionOption(key, value string) func(*ConnOption) {
 	return func(option *ConnOption) {
 		if len(option.Options) == 0 {

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -53,7 +53,7 @@ func DefaultStartVirtualClusterOpts(tenantName string, sqlInstance int) StartOpt
 	startOpts.RoachprodOpts.Target = install.StartServiceForVirtualCluster
 	startOpts.RoachprodOpts.VirtualClusterName = tenantName
 	startOpts.RoachprodOpts.SQLInstance = sqlInstance
-	// TODO(DarrylWong): remove once #117125 is addressed.
+	startOpts.RoachprodOpts.SQLPort = 0
 	startOpts.RoachprodOpts.AdminUIPort = 0
 	return startOpts
 }

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -46,6 +46,16 @@ func DefaultStartSingleNodeOpts() StartOpts {
 	return startOpts
 }
 
+// DefaultStartVirtualClusterOpts returns StartOpts for starting an external
+// process virtual cluster with the given tenant name and SQL instance.
+func DefaultStartVirtualClusterOpts(tenantName string, sqlInstance int) StartOpts {
+	startOpts := StartOpts{RoachprodOpts: roachprod.DefaultStartOpts()}
+	startOpts.RoachprodOpts.Target = install.StartServiceForVirtualCluster
+	startOpts.RoachprodOpts.VirtualClusterName = tenantName
+	startOpts.RoachprodOpts.SQLInstance = sqlInstance
+	return startOpts
+}
+
 // StopOpts is a type that combines the stop options needed by roachprod and roachtest.
 type StopOpts struct {
 	RoachprodOpts roachprod.StopOpts

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -53,6 +53,8 @@ func DefaultStartVirtualClusterOpts(tenantName string, sqlInstance int) StartOpt
 	startOpts.RoachprodOpts.Target = install.StartServiceForVirtualCluster
 	startOpts.RoachprodOpts.VirtualClusterName = tenantName
 	startOpts.RoachprodOpts.SQLInstance = sqlInstance
+	// TODO(DarrylWong): remove once #117125 is addressed.
+	startOpts.RoachprodOpts.AdminUIPort = 0
 	return startOpts
 }
 

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -783,6 +783,7 @@ func (r *testRunner) runWorker(
 
 				// Set initial cluster settings for this test.
 				c.clusterSettings = map[string]string{}
+				c.virtualClusterSettings = map[string]string{}
 
 				switch testSpec.Leases {
 				case registry.DefaultLeases:

--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -425,13 +425,18 @@ SELECT count(replicas)
 	t.L().Printf("killing all nodes\n")
 	c.Stop(ctx, t.L(), option.DefaultStopOpts())
 
+	adminPorts, err := c.AdminUIPorts(ctx, t.L(), c.Node(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// Restart node 1, but have it listen on a different port for internal
 	// connections. This will require node 1 to reach out to the other nodes in
 	// the cluster for gossip info.
-	err := c.RunE(ctx, c.Node(1),
+	err = c.RunE(ctx, c.Node(1),
 		` ./cockroach start --insecure --background --store={store-dir} `+
 			`--log-dir={log-dir} --cache=10% --max-sql-memory=10% `+
-			`--listen-addr=:$[{pgport:1}+1000] --http-port=$[{pgport:1}+1] `+
+			fmt.Sprintf(`--listen-addr=:$[{pgport:1}+1000] --http-port=%d `, adminPorts[0])+
 			`--join={pghost:1}:{pgport:1} `+
 			`--advertise-addr={pghost:1}:$[{pgport:1}+1000] `+
 			`> {log-dir}/cockroach.stdout 2> {log-dir}/cockroach.stderr`)

--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -13,7 +13,6 @@ package tests
 import (
 	"archive/zip"
 	"context"
-	gosql "database/sql"
 	"fmt"
 	"io"
 	"strconv"
@@ -59,66 +58,51 @@ func runMultiTenantDistSQL(
 	bundle bool,
 	timeoutMillis int,
 ) {
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(install.SecureOption(true)), c.Node(1))
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(install.SecureOption(true)), c.Node(2))
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(install.SecureOption(true)), c.Node(3))
+	// This test sets a smaller default range size than the default due to
+	// performance and resource limitations. We set the minimum range max bytes to
+	// 1 byte to bypass the guardrails.
+	settings := install.MakeClusterSettings(install.SecureOption(true))
+	settings.Env = append(settings.Env, "COCKROACH_MIN_RANGE_MAX_BYTES=1")
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.Node(1))
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.Node(2))
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.Node(3))
+	storageNodes := c.Range(1, 3)
 
-	const (
-		tenantID           = 11
-		tenantBaseHTTPPort = 8081
-		tenantBaseSQLPort  = 26259
-	)
-
-	tenantHTTPPort := func(offset int) int {
-		if c.IsLocal() || numInstances > c.Spec().NodeCount {
-			return tenantBaseHTTPPort + offset
-		}
-		return tenantBaseHTTPPort
-	}
-	tenantSQLPort := func(offset int) int {
-		if c.IsLocal() || numInstances > c.Spec().NodeCount {
-			return tenantBaseSQLPort + offset
-		}
-		return tenantBaseSQLPort
-	}
-
-	storConn := c.Conn(ctx, t.L(), 1)
-	_, err := storConn.Exec(`SELECT crdb_internal.create_tenant($1::INT)`, tenantID)
-	require.NoError(t, err)
-
-	instances := make([]*tenantNode, 0, numInstances)
-	instance1 := createTenantNode(ctx, t, c, c.Node(1), tenantID, 2 /* node */, tenantHTTPPort(0), tenantSQLPort(0),
-		createTenantCertNodes(c.All()))
-	instances = append(instances, instance1)
-	defer instance1.stop(ctx, t, c)
-	instance1.start(ctx, t, c, "./cockroach")
-
-	// Open things up so we can configure range sizes below.
-	_, err = storConn.Exec(`ALTER TENANT [$1] SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true`, tenantID)
-	require.NoError(t, err)
-
-	// Create numInstances sql pods and spread them evenly across the machines.
+	tenantName := "test-tenant"
 	var nodes intsets.Fast
-	nodes.Add(1)
-	for i := 1; i < numInstances; i++ {
-		node := ((i + 1) % c.Spec().NodeCount) + 1
-		inst, err := newTenantInstance(ctx, instance1, t, c, node, tenantHTTPPort(i), tenantSQLPort(i))
-		instances = append(instances, inst)
-		require.NoError(t, err)
-		defer inst.stop(ctx, t, c)
-		inst.start(ctx, t, c, "./cockroach")
+	for i := 0; i < numInstances; i++ {
+		node := (i % c.Spec().NodeCount) + 1
+		sqlInstance := i / c.Spec().NodeCount
+		instStartOps := option.DefaultStartOpts()
+		instStartOps.RoachprodOpts.Target = install.StartServiceForVirtualCluster
+		instStartOps.RoachprodOpts.VirtualClusterName = tenantName
+		instStartOps.RoachprodOpts.SQLInstance = sqlInstance
+		// We set the ports to 0 so that ports are assigned dynamically. This is a
+		// temporary workaround until we use dynamic port assignment as the default.
+		// See: https://github.com/cockroachdb/cockroach/issues/111052
+		// TODO(herko): remove this once dynamic port assignment is the default.
+		instStartOps.RoachprodOpts.SQLPort = 0
+		instStartOps.RoachprodOpts.AdminUIPort = 0
+
+		t.L().Printf("Starting instance %d on node %d", i, node)
+		c.StartServiceForVirtualCluster(ctx, t.L(), c.Node(node), instStartOps, settings, storageNodes)
 		nodes.Add(i + 1)
 	}
 
+	storConn := c.Conn(ctx, t.L(), 1)
+	// Open things up, so we can configure range sizes below.
+	_, err := storConn.Exec(`ALTER TENANT $1 SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true`, tenantName)
+	require.NoError(t, err)
+
 	m := c.NewMonitor(ctx, c.Nodes(1, 2, 3))
 
-	inst1Conn, err := gosql.Open("postgres", instance1.pgURL)
+	inst1Conn, err := c.ConnE(ctx, t.L(), 1, option.TenantName(tenantName))
 	require.NoError(t, err)
 	_, err = inst1Conn.Exec("CREATE TABLE t(n INT, i INT,s STRING, PRIMARY KEY(n,i))")
 	require.NoError(t, err)
 
 	// DistSQL needs at least a range per node to distribute query everywhere
-	// and test takes too long and too much resources with default range sizes
+	// and test takes too long and too many resources with default range sizes
 	// so make them much smaller.
 	_, err = inst1Conn.Exec(`ALTER TABLE t CONFIGURE ZONE USING range_min_bytes = 1000,range_max_bytes = 100000`)
 	require.NoError(t, err)
@@ -126,11 +110,12 @@ func runMultiTenantDistSQL(
 	insertCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	for i, inst := range instances {
-		url := inst.pgURL
+	for i := 0; i < numInstances; i++ {
 		li := i
 		m.Go(func(ctx context.Context) error {
-			dbi, err := gosql.Open("postgres", url)
+			node := (li % c.Spec().NodeCount) + 1
+			sqlInstance := li / c.Spec().NodeCount
+			dbi, err := c.ConnE(ctx, t.L(), node, option.TenantName(tenantName), option.SQLInstance(sqlInstance))
 			require.NoError(t, err)
 			iter := 0
 			for {
@@ -140,7 +125,7 @@ func runMultiTenantDistSQL(
 					t.L().Printf("worker %d done:%v", li, insertCtx.Err())
 					return nil
 				default:
-					// procede to report error
+					// proceed to report error
 				}
 				require.NoError(t, err, "instance idx = %d, iter = %d", li, iter)
 				iter++
@@ -180,7 +165,6 @@ func runMultiTenantDistSQL(
 		} else {
 			t.L().Printf("Only %d nodes present: %v", nodesInPlan.Len(), nodesInPlan)
 		}
-
 	}
 	m.Wait()
 
@@ -224,7 +208,8 @@ func runMultiTenantDistSQL(
 		if bundle {
 			// Open bundle and verify its contents
 			sqlConnCtx := clisqlclient.Context{}
-			conn := sqlConnCtx.MakeSQLConn(io.Discard, io.Discard, instance1.pgURL)
+			pgURL, err := c.ExternalPGUrl(ctx, t.L(), c.Node(1), tenantName, 0)
+			conn := sqlConnCtx.MakeSQLConn(io.Discard, io.Discard, pgURL[0])
 			bundles, err := clisqlclient.StmtDiagListBundles(ctx, conn)
 			require.NoError(t, err)
 

--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -209,6 +209,7 @@ func runMultiTenantDistSQL(
 			// Open bundle and verify its contents
 			sqlConnCtx := clisqlclient.Context{}
 			pgURL, err := c.ExternalPGUrl(ctx, t.L(), c.Node(1), tenantName, 0)
+			require.NoError(t, err)
 			conn := sqlConnCtx.MakeSQLConn(io.Discard, io.Discard, pgURL[0])
 			bundles, err := clisqlclient.StmtDiagListBundles(ctx, conn)
 			require.NoError(t, err)

--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -73,17 +73,7 @@ func runMultiTenantDistSQL(
 	for i := 0; i < numInstances; i++ {
 		node := (i % c.Spec().NodeCount) + 1
 		sqlInstance := i / c.Spec().NodeCount
-		instStartOps := option.DefaultStartOpts()
-		instStartOps.RoachprodOpts.Target = install.StartServiceForVirtualCluster
-		instStartOps.RoachprodOpts.VirtualClusterName = tenantName
-		instStartOps.RoachprodOpts.SQLInstance = sqlInstance
-		// We set the ports to 0 so that ports are assigned dynamically. This is a
-		// temporary workaround until we use dynamic port assignment as the default.
-		// See: https://github.com/cockroachdb/cockroach/issues/111052
-		// TODO(herko): remove this once dynamic port assignment is the default.
-		instStartOps.RoachprodOpts.SQLPort = 0
-		instStartOps.RoachprodOpts.AdminUIPort = 0
-
+		instStartOps := option.DefaultStartVirtualClusterOpts(tenantName, sqlInstance)
 		t.L().Printf("Starting instance %d on node %d", i, node)
 		c.StartServiceForVirtualCluster(ctx, t.L(), c.Node(node), instStartOps, settings, storageNodes)
 		nodes.Add(i + 1)

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -16,8 +16,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/url"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -68,10 +66,6 @@ type createTenantOpt func(*createTenantOptions)
 
 func createTenantOtherTenantIDs(ids []int) createTenantOpt {
 	return func(c *createTenantOptions) { c.otherTenantIDs = ids }
-}
-
-func createTenantCertNodes(nodes option.NodeListOption) createTenantOpt {
-	return func(c *createTenantOptions) { c.certNodes = nodes }
 }
 
 func createTenantNodeInternal(
@@ -283,43 +277,6 @@ func startTenantServer(
 		close(errCh)
 	}()
 	return errCh
-}
-
-func newTenantInstance(
-	ctx context.Context, tn *tenantNode, t test.Test, c cluster.Cluster, node, http, sql int,
-) (*tenantNode, error) {
-	instID := tenantIds[tn.tenantID] + 1
-	tenantIds[tn.tenantID] = instID
-	inst := tenantNode{
-		tenantID:   tn.tenantID,
-		instanceID: instID,
-		kvAddrs:    tn.kvAddrs,
-		node:       node,
-		httpPort:   http,
-		sqlPort:    sql,
-	}
-	tenantCertsDir, err := os.MkdirTemp("", "tenant-certs")
-	if err != nil {
-		return nil, err
-	}
-	key, crt := fmt.Sprintf("client-tenant.%d.key", tn.tenantID), fmt.Sprintf("client-tenant.%d.crt", tn.tenantID)
-	err = c.Get(ctx, t.L(), filepath.Join("certs", key), filepath.Join(tenantCertsDir, key), c.Node(tn.node))
-	if err != nil {
-		return nil, err
-	}
-	err = c.Get(ctx, t.L(), filepath.Join("certs", crt), filepath.Join(tenantCertsDir, crt), c.Node(tn.node))
-	if err != nil {
-		return nil, err
-	}
-	c.Put(ctx, filepath.Join(tenantCertsDir, key), filepath.Join("certs", key), c.Node(node))
-	c.Put(ctx, filepath.Join(tenantCertsDir, crt), filepath.Join("certs", crt), c.Node(node))
-	// sigh: locally theses are symlinked which breaks our crypto cert checks
-	if c.IsLocal() {
-		c.Run(ctx, c.Node(node), "rm", filepath.Join("certs", key))
-		c.Run(ctx, c.Node(node), "cp", filepath.Join(tenantCertsDir, key), filepath.Join("certs", key))
-	}
-	c.Run(ctx, c.Node(node), "chmod", "0600", filepath.Join("certs", key))
-	return &inst, nil
 }
 
 // createTenantAdminRole creates a role that can be used to log into a secure cluster's db console.

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -160,7 +160,9 @@ const (
 	// StartRoutingProxy starts the SQL proxy process to route
 	// connections to multiple virtual clusters.
 	StartRoutingProxy
+)
 
+const (
 	// startSQLTimeout identifies the COCKROACH_CONNECT_TIMEOUT to use (in seconds)
 	// for sql cmds within syncedCluster.Start().
 	startSQLTimeout = 1200

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -13,7 +13,7 @@ package install
 import (
 	"context"
 	_ "embed" // required for go:embed
-	"encoding/json"
+	"encoding/csv"
 	"fmt"
 	"net/url"
 	"os"
@@ -1255,7 +1255,7 @@ func (c *SyncedCluster) upsertVirtualClusterMetadata(
 ) (int, error) {
 	runSQL := func(stmt string) (string, error) {
 		results, err := startOpts.KVCluster.ExecSQL(ctx, l, startOpts.KVCluster.Nodes[:1], "", 0, []string{
-			"--format", "json", "-e", stmt,
+			"--format", "csv", "-e", stmt,
 		})
 		if err != nil {
 			return "", err
@@ -1268,10 +1268,6 @@ func (c *SyncedCluster) upsertVirtualClusterMetadata(
 	}
 
 	virtualClusterIDByName := func(name string) (int, error) {
-		type tenantRow struct {
-			ID string `json:"id"`
-		}
-
 		query := fmt.Sprintf(
 			"SELECT id FROM system.tenants WHERE name = '%s'", startOpts.VirtualClusterName,
 		)
@@ -1281,16 +1277,17 @@ func (c *SyncedCluster) upsertVirtualClusterMetadata(
 			return -1, err
 		}
 
-		var tenants []tenantRow
-		if err := json.Unmarshal([]byte(existsOut), &tenants); err != nil {
-			return -1, fmt.Errorf("failed to unmarshal system.tenants output: %w\n%s", err, existsOut)
+		rows, err := csv.NewReader(strings.NewReader(existsOut)).ReadAll()
+		if err != nil {
+			return -1, fmt.Errorf("failed to parse system.tenants output: %w\n%s", err, existsOut)
 		}
 
-		if len(tenants) == 0 {
+		records := rows[1:] // skip header
+		if len(records) == 0 {
 			return -1, nil
 		}
 
-		n, err := strconv.Atoi(tenants[0].ID)
+		n, err := strconv.Atoi(records[0][0])
 		if err != nil {
 			return -1, fmt.Errorf("failed to parse virtual cluster ID: %w", err)
 		}

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1049,6 +1049,28 @@ func AdminURL(
 	return urlGenerator(ctx, c, l, c.TargetNodes(), uConfig)
 }
 
+// AdminPorts finds the AdminUI ports for a cluster.
+func AdminPorts(
+	ctx context.Context, l *logger.Logger, clusterName string, secure bool,
+) ([]int, error) {
+	if err := LoadClusters(); err != nil {
+		return nil, err
+	}
+	c, err := newCluster(l, clusterName, install.SecureOption(secure))
+	if err != nil {
+		return nil, err
+	}
+	var ports []int
+	for _, node := range c.Nodes {
+		port, err := c.NodeUIPort(ctx, node)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Error discovering UI Port for node %d", node)
+		}
+		ports = append(ports, port)
+	}
+	return ports, nil
+}
+
 // PprofOpts specifies the options needed by Pprof().
 type PprofOpts struct {
 	Heap         bool


### PR DESCRIPTION
Backport:
  * 6/6 commits from "roachtest: update multitenant/distsql to use new roachprod service APIs" (#115599)
  * 2/2 commits from "roachtest: assign adminui ports dynamically for virtual clusters" (#117505)
  * 1/1 commits from "roachprod: use csv when upserting virtual cluster metadata" (#117745)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: test-only changes
