### PR TITLE
roachtest: use EXPLAIN (DISTSQL) instead of EXPLAIN in a few tests

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -470,9 +470,9 @@ func (h *queryComparisonHelper) runQuery(stmt string) ([][]string, error) {
 		return sqlutils.RowsToStrMatrix(rows)
 	}
 
-	// First use EXPLAIN to try to get the query plan. This is best-effort, and
-	// only for the purpose of debugging, so ignore any errors.
-	explainStmt := "EXPLAIN " + stmt
+	// First use EXPLAIN (DISTSQL) to try to get the query plan. This is
+	// best-effort, and only for the purpose of debugging, so ignore any errors.
+	explainStmt := "EXPLAIN (DISTSQL)" + stmt
 	explainRows, err := runQueryImpl(explainStmt)
 	if err == nil {
 		h.statementsAndExplains = append(


### PR DESCRIPTION
This EXPLAIN output is used for debugging purposes, so using more expressive variant could be helpful.

Informs: #117477.

Epic: None

Release note: None