### PR TITLE
sql: fix trigram inverted index on NAME type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/trigram_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_indexes
@@ -335,3 +335,26 @@ CREATE TABLE public.t_112713 (
 )
 
 subtest end
+
+# Regression test for hitting an internal error on string-like datums (e.g NAME).
+statement ok
+CREATE TABLE t117758 (
+  col1 VARCHAR NOT NULL,
+  col2 NAME NOT NULL,
+  INVERTED INDEX (col2 gin_trgm_ops)
+);
+SELECT
+    tab.col1_1
+FROM
+    t117758 AS tab2
+    JOIN (
+            SELECT
+                'foo'::NAME, 'bar'::NAME
+            FROM
+                t117758 AS tab3
+                JOIN t117758 AS tab4 ON
+                        (tab3.col2) = (tab4.col2)
+        )
+            AS tab (col1_1, col1_2) ON
+            (tab2.col1) = (tab.col1_1)
+            AND (tab2.col2) = (tab.col1_2);


### PR DESCRIPTION
Previously, we would hit an internal error when trying to use string-like datum of NAME type for the trigram inverted index. This data type is handled via the DOidWrapper around the DString, so we simply need to unwrap that.

I decided to not include a release note given that we've only seen this issue once in our own randomized testing.

Fixes: #117758.

Release note: None