### PR TITLE
roachtest: fix up recent change

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -472,7 +472,7 @@ func (h *queryComparisonHelper) runQuery(stmt string) ([][]string, error) {
 
 	// First use EXPLAIN (DISTSQL) to try to get the query plan. This is
 	// best-effort, and only for the purpose of debugging, so ignore any errors.
-	explainStmt := "EXPLAIN (DISTSQL)" + stmt
+	explainStmt := "EXPLAIN (DISTSQL) " + stmt
 	explainRows, err := runQueryImpl(explainStmt)
 	if err == nil {
 		h.statementsAndExplains = append(


### PR DESCRIPTION
I forgot to add a space after `EXPLAIN (DISTSQL)` in b9f144bd6d1de0063b18c3c0cab3f07f6fe14a62.

Epic: None

Release note: None