### PR TITLE
roachtest: harmonize GCE, AWS, Azure machine types

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -105,6 +105,7 @@ go_test(
         "//pkg/roachprod/errors",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
+        "//pkg/roachprod/vm/azure",
         "//pkg/roachprod/vm/gce",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -538,8 +538,8 @@ func makeClusterName(name string) string {
 	return makeGCEClusterName(name)
 }
 
-// MachineTypeToCPUs returns a CPU count for either a GCE or AWS
-// machine type.
+// MachineTypeToCPUs returns a CPU count for GCE, AWS, and Azure machine types.
+// -1 is returned for unknown machine types.
 func MachineTypeToCPUs(s string) int {
 	{
 		// GCE machine types.
@@ -588,28 +588,36 @@ func MachineTypeToCPUs(s string) int {
 
 	// Azure doesn't have a standard way to size machines.
 	// This method is implemented for the default machine type.
-	// Not all of Azure machine types contain the number of vCPUs int he size and
+	// Not all of Azure machine types contain the number of vCPUs in the size and
 	// the sizing naming scheme is dependent on the machine type family.
 	switch s {
-	case "Standard_D2_v3":
+	case "Standard_D2ds_v5", "Standard_D2pds_v5", "Standard_D2lds_v5",
+		"Standard_D2plds_v5", "Standard_E2ds_v5", "Standard_E2pds_v5":
 		return 2
-	case "Standard_D4_v3":
+	case "Standard_D4ds_v5", "Standard_D4pds_v5", "Standard_D4lds_v5",
+		"Standard_D4plds_v5", "Standard_E4ds_v5", "Standard_E4pds_v5":
 		return 4
-	case "Standard_D8_v3":
+	case "Standard_D8ds_v5", "Standard_D8pds_v5", "Standard_D8lds_v5",
+		"Standard_D8plds_v5", "Standard_E8ds_v5", "Standard_E8pds_v5":
 		return 8
-	case "Standard_D16_v3":
+	case "Standard_D16ds_v5", "Standard_D16pds_v5", "Standard_D16lds_v5",
+		"Standard_D16plds_v5", "Standard_E16ds_v5", "Standard_E16pds_v5":
 		return 16
-	case "Standard_D32_v3":
+	case "Standard_D32ds_v5", "Standard_D32pds_v5", "Standard_D32lds_v5",
+		"Standard_D32plds_v5", "Standard_E32ds_v5", "Standard_E32pds_v5":
 		return 32
-	case "Standard_D48_v3":
+	case "Standard_D48ds_v5", "Standard_D48pds_v5", "Standard_D48lds_v5",
+		"Standard_D48plds_v5", "Standard_E48ds_v5", "Standard_E48pds_v5":
 		return 48
-	case "Standard_D64_v3":
+	case "Standard_D64ds_v5", "Standard_D64pds_v5", "Standard_D64lds_v5",
+		"Standard_D64plds_v5", "Standard_E64ds_v5", "Standard_E64pds_v5":
 		return 64
+	case "Standard_D96ds_v5", "Standard_D96pds_v5", "Standard_D96lds_v5",
+		"Standard_D96plds_v5", "Standard_E96ds_v5", "Standard_E96pds_v5":
+		return 96
 	}
-
-	// TODO(pbardea): Non-default Azure machine types are not supported
-	// and will return unknown machine type error.
-	panic(fmt.Sprintf("unknown machine type: %s\n", s))
+	// Unknown or unsupported machine type.
+	return -1
 }
 
 type nodeSelector interface {

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -12,6 +12,8 @@ package main
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,7 +22,10 @@ import (
 	test2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/azure"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
+	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -141,10 +146,11 @@ func (t testWrapper) L() *logger.Logger {
 func (t testWrapper) Status(args ...interface{}) {}
 
 func TestClusterMachineType(t *testing.T) {
-	testCases := []struct {
+	type machineTypeTestCase struct {
 		machineType      string
 		expectedCPUCount int
-	}{
+	}
+	testCases := []machineTypeTestCase{
 		// AWS machine types
 		{"m6i.large", 2},
 		{"m6i.xlarge", 4},
@@ -188,6 +194,16 @@ func TestClusterMachineType(t *testing.T) {
 		{"t2a-standard-32", 32},
 		{"t2a-standard-48", 48},
 	}
+	// Azure machine types
+	for i := 2; i <= 96; i *= 2 {
+		testCases = append(testCases, machineTypeTestCase{fmt.Sprintf("Standard_D%dds_v5", i), i})
+		testCases = append(testCases, machineTypeTestCase{fmt.Sprintf("Standard_D%dpds_v5", i), i})
+		testCases = append(testCases, machineTypeTestCase{fmt.Sprintf("Standard_D%dlds_v5", i), i})
+		testCases = append(testCases, machineTypeTestCase{fmt.Sprintf("Standard_D%dplds_v5", i), i})
+		testCases = append(testCases, machineTypeTestCase{fmt.Sprintf("Standard_E%dds_v5", i), i})
+		testCases = append(testCases, machineTypeTestCase{fmt.Sprintf("Standard_E%dpds_v5", i), i})
+	}
+
 	for _, tc := range testCases {
 		t.Run(tc.machineType, func(t *testing.T) {
 			cpuCount := MachineTypeToCPUs(tc.machineType)
@@ -207,8 +223,7 @@ type machineTypeTestCase struct {
 	expectedArch        vm.CPUArch
 }
 
-// TODO(srosenberg): restore the change in https://github.com/cockroachdb/cockroach/pull/111140 after 23.2 branch cut.
-func TestAWSMachineTypeNew(t *testing.T) {
+func TestAWSMachineType(t *testing.T) {
 	testCases := []machineTypeTestCase{}
 
 	xlarge := func(cpus int) string {
@@ -258,7 +273,12 @@ func TestAWSMachineTypeNew(t *testing.T) {
 				fmt.Sprintf("%sd.%s", family, xlarge(1)), arch})
 			for i := 2; i <= 128; i += 2 {
 				if i > 16 && mem == spec.Auto {
-					family = "c6i"
+					if i > 80 {
+						// N.B. to keep parity with GCE, we use AMD Milan instead of Intel Ice Lake, keeping same 2GB RAM per CPU ratio.
+						family = "c6a"
+					} else {
+						family = "c6i"
+					}
 				}
 				testCases = append(testCases, machineTypeTestCase{i, mem, false, arch,
 					fmt.Sprintf("%s.%s", family, xlarge(i)), arch})
@@ -300,7 +320,12 @@ func TestAWSMachineTypeNew(t *testing.T) {
 
 			if fallback {
 				if mem == spec.Auto {
-					family = "c6i"
+					if i > 80 {
+						// N.B. to keep parity with GCE, we use AMD Milan instead of Intel Ice Lake, keeping same 2GB RAM per CPU ratio.
+						family = "c6a"
+					} else {
+						family = "c6i"
+					}
 				} else if mem == spec.Standard {
 					family = "m6i"
 				}
@@ -324,22 +349,22 @@ func TestAWSMachineTypeNew(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%d/%s/%t/%s", tc.cpus, tc.mem, tc.localSSD, tc.arch), func(t *testing.T) {
-			machineType, selectedArch, _ := spec.SelectAWSMachineTypeNew(tc.cpus, tc.mem, tc.localSSD, tc.arch)
+			machineType, selectedArch, err := spec.SelectAWSMachineType(tc.cpus, tc.mem, tc.localSSD, tc.arch)
 
 			require.Equal(t, tc.expectedMachineType, machineType)
 			require.Equal(t, tc.expectedArch, selectedArch)
+			require.NoError(t, err)
 		})
 	}
 	// spec.Low is not supported.
-	_, _, err := spec.SelectAWSMachineTypeNew(4, spec.Low, false, vm.ArchAMD64)
+	_, _, err := spec.SelectAWSMachineType(4, spec.Low, false, vm.ArchAMD64)
 	require.Error(t, err)
 
-	_, _, err2 := spec.SelectAWSMachineTypeNew(16, spec.Low, false, vm.ArchAMD64)
+	_, _, err2 := spec.SelectAWSMachineType(16, spec.Low, false, vm.ArchAMD64)
 	require.Error(t, err2)
 }
 
-// TODO(srosenberg): restore the change in https://github.com/cockroachdb/cockroach/pull/111140 after 23.2 branch cut.
-func TestGCEMachineTypeNew(t *testing.T) {
+func TestGCEMachineType(t *testing.T) {
 	testCases := []machineTypeTestCase{}
 
 	addAMD := func(mem spec.MemPerCPU) {
@@ -364,9 +389,15 @@ func TestGCEMachineTypeNew(t *testing.T) {
 				fmt.Sprintf("n2-%s-%d", series, 2), arch})
 			for i := 2; i <= 128; i += 2 {
 				if i > 16 && mem == spec.Auto {
-					// n2-custom with 2GB per CPU.
+					var expectedMachineType string
+					if i > 80 {
+						// N.B. n2 doesn't support custom instances with > 80 vCPUs. So, the best we can do is to go with n2d.
+						expectedMachineType = fmt.Sprintf("n2d-custom-%d-%d", i, i*2048)
+					} else {
+						expectedMachineType = fmt.Sprintf("n2-custom-%d-%d", i, i*2048)
+					}
 					testCases = append(testCases, machineTypeTestCase{i, mem, false, arch,
-						fmt.Sprintf("n2-custom-%d-%d", i, i*2048), arch})
+						expectedMachineType, arch})
 				} else {
 					testCases = append(testCases, machineTypeTestCase{i, mem, false, arch,
 						fmt.Sprintf("n2-%s-%d", series, i), arch})
@@ -404,7 +435,12 @@ func TestGCEMachineTypeNew(t *testing.T) {
 			if fallback {
 				expectedMachineType := fmt.Sprintf("n2-%s-%d", series, i)
 				if i > 16 && mem == spec.Auto {
-					expectedMachineType = fmt.Sprintf("n2-custom-%d-%d", i, i*2048)
+					if i > 80 {
+						// N.B. n2 doesn't support custom instances with > 80 vCPUs. So, the best we can do is to go with n2d.
+						expectedMachineType = fmt.Sprintf("n2d-custom-%d-%d", i, i*2048)
+					} else {
+						expectedMachineType = fmt.Sprintf("n2-custom-%d-%d", i, i*2048)
+					}
 				}
 				// Expect fallback to AMD64.
 				testCases = append(testCases, machineTypeTestCase{i, mem, false, vm.ArchARM64,
@@ -422,7 +458,7 @@ func TestGCEMachineTypeNew(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%d/%s/%s", tc.cpus, tc.mem, tc.arch), func(t *testing.T) {
-			machineType, selectedArch := spec.SelectGCEMachineTypeNew(tc.cpus, tc.mem, tc.arch)
+			machineType, selectedArch := spec.SelectGCEMachineType(tc.cpus, tc.mem, tc.arch)
 
 			require.Equal(t, tc.expectedMachineType, machineType)
 			require.Equal(t, tc.expectedArch, selectedArch)
@@ -431,16 +467,171 @@ func TestGCEMachineTypeNew(t *testing.T) {
 }
 
 func TestAzureMachineType(t *testing.T) {
-	m, err := spec.SelectAzureMachineType(8, spec.Auto, true)
-	require.NoError(t, err)
-	require.Equal(t, "Standard_D8_v3", m)
+	testCases := []machineTypeTestCase{}
 
-	m, err2 := spec.SelectAzureMachineType(96, spec.Auto, false)
-	require.NoError(t, err2)
-	require.Equal(t, "Standard_D96s_v5", m)
+	addAMD := func(mem spec.MemPerCPU) {
+		var series string
+		switch mem {
+		case spec.Auto:
+			series = "D?ds_v5"
+		case spec.Standard:
+			series = "D?ds_v5"
+		case spec.High:
+			series = "E?ds_v5"
+		}
 
-	_, err3 := spec.SelectAzureMachineType(4, spec.High, true)
-	require.Error(t, err3)
+		for _, arch := range []vm.CPUArch{vm.ArchAMD64, vm.ArchFIPS} {
+			testCases = append(testCases, machineTypeTestCase{1, mem, false, arch,
+				fmt.Sprintf("Standard_%s", strings.Replace(series, "?", strconv.Itoa(2), 1)), arch})
+			for _, i := range []int{2, 4, 8, 16, 32, 64, 96, 128} {
+				if i > 16 && mem == spec.Auto {
+					// Dlds_v5 with 2GB per CPU.
+					testCases = append(testCases, machineTypeTestCase{i, mem, false, arch,
+						fmt.Sprintf("Standard_D%dlds_v5", i), arch})
+				} else {
+					testCases = append(testCases, machineTypeTestCase{i, mem, false, arch,
+						fmt.Sprintf("Standard_%s", strings.Replace(series, "?", strconv.Itoa(i), 1)), arch})
+				}
+			}
+		}
+	}
+	addARM := func(mem spec.MemPerCPU) {
+		var series string
+		switch mem {
+		case spec.Auto:
+			series = "D?pds_v5"
+		case spec.Standard:
+			series = "D?pds_v5"
+		case spec.High:
+			series = "E?pds_v5"
+		}
+
+		testCases = append(testCases, machineTypeTestCase{1, mem, false, vm.ArchARM64,
+			fmt.Sprintf("Standard_%s", strings.Replace(series, "?", strconv.Itoa(2), 1)), vm.ArchARM64})
+
+		for i := 2; i <= 96; i *= 2 {
+			fallback := (series == "D?pds_v5" && i > 64) || (series == "D?plds_v5" && i > 64) || (series == "E?pds_v5" && i > 32)
+
+			if fallback {
+				var expectedMachineType string
+				if series == "D?pds_v5" {
+					expectedMachineType = fmt.Sprintf("Standard_D%dds_v5", i)
+				} else if series == "D?plds_v5" {
+					expectedMachineType = fmt.Sprintf("Standard_D%dlds_v5", i)
+				} else if series == "E?pds_v5" {
+					expectedMachineType = fmt.Sprintf("Standard_E%dds_v5", i)
+				}
+				// Expect fallback to AMD64.
+				testCases = append(testCases, machineTypeTestCase{i, mem, false, vm.ArchARM64,
+					expectedMachineType, vm.ArchAMD64})
+			} else {
+				if i > 16 && mem == spec.Auto {
+					// Dplds_v5 with 2GB per CPU.
+					testCases = append(testCases, machineTypeTestCase{i, mem, false, vm.ArchARM64,
+						fmt.Sprintf("Standard_D%dplds_v5", i), vm.ArchARM64})
+				} else {
+					testCases = append(testCases, machineTypeTestCase{i, mem, false, vm.ArchARM64,
+						fmt.Sprintf("Standard_%s", strings.Replace(series, "?", strconv.Itoa(i), 1)), vm.ArchARM64})
+				}
+			}
+		}
+	}
+	for _, mem := range []spec.MemPerCPU{spec.Auto, spec.Standard, spec.High} {
+		addAMD(mem)
+		addARM(mem)
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%d/%s/%s", tc.cpus, tc.mem, tc.arch), func(t *testing.T) {
+			machineType, selectedArch, err := spec.SelectAzureMachineType(tc.cpus, tc.mem, tc.arch)
+
+			require.Equal(t, tc.expectedMachineType, machineType)
+			require.Equal(t, tc.expectedArch, selectedArch)
+			require.NoError(t, err)
+
+			if tc.expectedArch != vm.ArchFIPS {
+				// Check that we can derive the right cpu architecture from the machine type.
+				require.Equal(t, tc.expectedArch, azure.CpuArchFromAzureMachineType(machineType))
+			}
+		})
+	}
+	// spec.Low is not supported.
+	_, _, err := spec.SelectAzureMachineType(4, spec.Low, vm.ArchAMD64)
+	require.Error(t, err)
+
+	_, _, err2 := spec.SelectAzureMachineType(16, spec.Low, vm.ArchAMD64)
+	require.Error(t, err2)
+}
+
+func TestMachineTypes(t *testing.T) {
+	datadriven.Walk(t, datapathutils.TestDataPath(t, "cluster_test"), func(t *testing.T, path string) {
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			if d.Cmd != "select-machine-type" {
+				t.Fatalf("unknown directive: %q", d.Cmd)
+			}
+			var mem spec.MemPerCPU
+			var cpuArch vm.CPUArch
+
+			for _, arg := range d.CmdArgs {
+				switch arg.Key {
+				case "mem-per-cpu":
+					mem = spec.ParseMemCPU(arg.Vals[0])
+					if mem.String() == "unknown" {
+						t.Fatalf("illegal value for 'mem-per-cpu': %s", arg.Vals[0])
+					}
+				case "cpu-arch":
+					cpuArch = vm.ParseArch(arg.Vals[0])
+					if cpuArch == vm.ArchUnknown {
+						t.Fatalf("illegal value for 'cpu-arch': %s", arg.Vals[0])
+					}
+				default:
+					t.Fatalf("unknown machine-type spec: %q", arg.Key)
+				}
+			}
+			if cpuArch == "" {
+				t.Fatalf("missing 'cpu-arch' spec")
+			}
+			var out strings.Builder
+			var err error
+			var gceMachineType, awsMachineType, azureMachineType []string
+
+			cpu := []int{1, 2, 4, 8, 16, 32, 64, 96, 128}
+			out.WriteString("cpus | 1,2,4,8,16 | 32,64 | 96,128\n")
+			out.WriteString("----\n")
+
+			for _, i := range cpu {
+				machineType, selectedArch := spec.SelectGCEMachineType(i, mem, cpuArch)
+				if selectedArch != cpuArch {
+					machineType += fmt.Sprintf(" (%s)", selectedArch)
+				}
+				gceMachineType = append(gceMachineType, machineType)
+
+				machineType, selectedArch, err = spec.SelectAWSMachineType(i, mem, false, cpuArch)
+				if err != nil {
+					machineType = "unsupported"
+				} else if selectedArch != cpuArch {
+					machineType += fmt.Sprintf(" (%s)", selectedArch)
+				}
+				awsMachineType = append(awsMachineType, machineType)
+
+				machineType, selectedArch, err = spec.SelectAzureMachineType(i, mem, cpuArch)
+				if err != nil {
+					machineType = "unsupported"
+				} else if selectedArch != cpuArch {
+					machineType += fmt.Sprintf(" (%s)", selectedArch)
+				}
+				azureMachineType = append(azureMachineType, machineType)
+			}
+			out.WriteString("GCE | ")
+			out.WriteString(fmt.Sprintf("%s | %s | %s\n", strings.Join(gceMachineType[:5], ", "), strings.Join(gceMachineType[5:7], ", "), strings.Join(gceMachineType[7:], ", ")))
+			out.WriteString("AWS | ")
+			out.WriteString(fmt.Sprintf("%s | %s | %s\n", strings.Join(awsMachineType[:5], ", "), strings.Join(awsMachineType[5:7], ", "), strings.Join(awsMachineType[7:], ", ")))
+			out.WriteString("Azure | ")
+			out.WriteString(fmt.Sprintf("%s | %s | %s\n", strings.Join(azureMachineType[:5], ", "), strings.Join(azureMachineType[5:7], ","), strings.Join(azureMachineType[7:], ", ")))
+
+			return out.String()
+		})
+	})
 }
 
 func TestCmdLogFileName(t *testing.T) {

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -59,6 +59,22 @@ func (m MemPerCPU) String() string {
 	return "unknown"
 }
 
+// ParseMemCPU parses a string into a MemPerCPU value. Returns -1 if no match is found.
+func ParseMemCPU(s string) MemPerCPU {
+	s = strings.ToLower(s)
+	switch s {
+	case "auto":
+		return Auto
+	case "standard":
+		return Standard
+	case "high":
+		return High
+	case "low":
+		return Low
+	}
+	return -1
+}
+
 // LocalSSDSetting controls whether test cluster nodes use an instance-local SSD
 // as storage.
 type LocalSSDSetting int
@@ -229,11 +245,14 @@ func getGCEOpts(
 	return opts
 }
 
-func getAzureOpts(machineType string, zones []string) vm.ProviderOpts {
+func getAzureOpts(machineType string, zones []string, volumeSize int) vm.ProviderOpts {
 	opts := azure.DefaultProviderOpts()
 	opts.MachineType = machineType
 	if len(zones) != 0 {
 		opts.Locations = zones
+	}
+	if volumeSize != 0 {
+		opts.NetworkDiskSize = int32(volumeSize)
 	}
 	return opts
 }
@@ -308,11 +327,6 @@ func (s *ClusterSpec) RoachprodOpts(
 		return vm.CreateOpts{}, nil, errors.Errorf("unsupported cloud %v", cloud)
 	}
 
-	if cloud != GCE && cloud != AWS {
-		if s.VolumeSize != 0 {
-			return vm.CreateOpts{}, nil, errors.Errorf("specifying volume size is not yet supported on %s", cloud)
-		}
-	}
 	if cloud != GCE {
 		if s.SSDs != 0 {
 			return vm.CreateOpts{}, nil, errors.Errorf("specifying SSD count is not yet supported on %s", cloud)
@@ -350,7 +364,7 @@ func (s *ClusterSpec) RoachprodOpts(
 			case GCE:
 				machineType, selectedArch = SelectGCEMachineType(s.CPUs, s.Mem, arch)
 			case Azure:
-				machineType, err = SelectAzureMachineType(s.CPUs, s.Mem, preferLocalSSD)
+				machineType, selectedArch, err = SelectAzureMachineType(s.CPUs, s.Mem, arch)
 			}
 
 			if err != nil {
@@ -431,7 +445,7 @@ func (s *ClusterSpec) RoachprodOpts(
 			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType, s.UseSpotVMs,
 		)
 	case Azure:
-		providerOpts = getAzureOpts(machineType, zones)
+		providerOpts = getAzureOpts(machineType, zones, s.VolumeSize)
 	}
 
 	return createVMOpts, providerOpts, nil

--- a/pkg/cmd/roachtest/testdata/cluster_test/machine_types
+++ b/pkg/cmd/roachtest/testdata/cluster_test/machine_types
@@ -1,0 +1,66 @@
+# Test various machine types selected by roachtests, in accordance with MemPerCPU and CPUArch specification,
+# across all three cloud providers, namely GCE, AWS, and Azure. 
+
+select-machine-type mem-per-cpu=Auto cpu-arch=ARM64
+----
+cpus | 1,2,4,8,16 | 32,64 | 96,128
+----
+GCE | t2a-standard-1, t2a-standard-2, t2a-standard-4, t2a-standard-8, t2a-standard-16 | n2-custom-32-65536 (amd64), n2-custom-64-131072 (amd64) | n2d-custom-96-196608 (amd64), n2d-custom-128-262144 (amd64)
+AWS | m7g.large, m7g.large, m7g.xlarge, m7g.2xlarge, m7g.4xlarge | c7g.8xlarge, c7g.16xlarge | c6a.24xlarge (amd64), c6a.24xlarge (amd64)
+Azure | Standard_D2pds_v5, Standard_D2pds_v5, Standard_D4pds_v5, Standard_D8pds_v5, Standard_D16pds_v5 | Standard_D32plds_v5,Standard_D64plds_v5 | Standard_D96lds_v5 (amd64), Standard_D128lds_v5 (amd64)
+
+select-machine-type mem-per-cpu=Auto cpu-arch=AMD64
+----
+cpus | 1,2,4,8,16 | 32,64 | 96,128
+----
+GCE | n2-standard-2, n2-standard-2, n2-standard-4, n2-standard-8, n2-standard-16 | n2-custom-32-65536, n2-custom-64-131072 | n2d-custom-96-196608, n2d-custom-128-262144
+AWS | m6i.large, m6i.large, m6i.xlarge, m6i.2xlarge, m6i.4xlarge | c6i.8xlarge, c6i.16xlarge | c6a.24xlarge, c6a.24xlarge
+Azure | Standard_D2ds_v5, Standard_D2ds_v5, Standard_D4ds_v5, Standard_D8ds_v5, Standard_D16ds_v5 | Standard_D32lds_v5,Standard_D64lds_v5 | Standard_D96lds_v5, Standard_D128lds_v5
+
+select-machine-type mem-per-cpu=Standard cpu-arch=ARM64
+----
+cpus | 1,2,4,8,16 | 32,64 | 96,128
+----
+GCE | t2a-standard-1, t2a-standard-2, t2a-standard-4, t2a-standard-8, t2a-standard-16 | t2a-standard-32, n2-standard-64 (amd64) | n2-standard-96 (amd64), n2-standard-128 (amd64)
+AWS | m7g.large, m7g.large, m7g.xlarge, m7g.2xlarge, m7g.4xlarge | m7g.8xlarge, m7g.16xlarge | m6i.24xlarge (amd64), m6i.24xlarge (amd64)
+Azure | Standard_D2pds_v5, Standard_D2pds_v5, Standard_D4pds_v5, Standard_D8pds_v5, Standard_D16pds_v5 | Standard_D32pds_v5,Standard_D64pds_v5 | Standard_D96ds_v5 (amd64), Standard_D128ds_v5 (amd64)
+
+select-machine-type mem-per-cpu=Standard cpu-arch=AMD64
+----
+cpus | 1,2,4,8,16 | 32,64 | 96,128
+----
+GCE | n2-standard-2, n2-standard-2, n2-standard-4, n2-standard-8, n2-standard-16 | n2-standard-32, n2-standard-64 | n2-standard-96, n2-standard-128
+AWS | m6i.large, m6i.large, m6i.xlarge, m6i.2xlarge, m6i.4xlarge | m6i.8xlarge, m6i.16xlarge | m6i.24xlarge, m6i.24xlarge
+Azure | Standard_D2ds_v5, Standard_D2ds_v5, Standard_D4ds_v5, Standard_D8ds_v5, Standard_D16ds_v5 | Standard_D32ds_v5,Standard_D64ds_v5 | Standard_D96ds_v5, Standard_D128ds_v5
+
+select-machine-type mem-per-cpu=High cpu-arch=ARM64
+----
+cpus | 1,2,4,8,16 | 32,64 | 96,128
+----
+GCE | n2-highmem-2 (amd64), n2-highmem-2 (amd64), n2-highmem-4 (amd64), n2-highmem-8 (amd64), n2-highmem-16 (amd64) | n2-highmem-32 (amd64), n2-highmem-64 (amd64) | n2-highmem-96 (amd64), n2-highmem-128 (amd64)
+AWS | r6i.large (amd64), r6i.large (amd64), r6i.xlarge (amd64), r6i.2xlarge (amd64), r6i.4xlarge (amd64) | r6i.8xlarge (amd64), r6i.16xlarge (amd64) | r6i.24xlarge (amd64), r6i.24xlarge (amd64)
+Azure | Standard_E2pds_v5, Standard_E2pds_v5, Standard_E4pds_v5, Standard_E8pds_v5, Standard_E16pds_v5 | Standard_E32pds_v5,Standard_E64ds_v5 (amd64) | Standard_E96ds_v5 (amd64), Standard_E128ds_v5 (amd64)
+
+select-machine-type mem-per-cpu=High cpu-arch=AMD64
+----
+cpus | 1,2,4,8,16 | 32,64 | 96,128
+----
+GCE | n2-highmem-2, n2-highmem-2, n2-highmem-4, n2-highmem-8, n2-highmem-16 | n2-highmem-32, n2-highmem-64 | n2-highmem-96, n2-highmem-128
+AWS | r6i.large, r6i.large, r6i.xlarge, r6i.2xlarge, r6i.4xlarge | r6i.8xlarge, r6i.16xlarge | r6i.24xlarge, r6i.24xlarge
+Azure | Standard_E2ds_v5, Standard_E2ds_v5, Standard_E4ds_v5, Standard_E8ds_v5, Standard_E16ds_v5 | Standard_E32ds_v5,Standard_E64ds_v5 | Standard_E96ds_v5, Standard_E128ds_v5
+
+select-machine-type mem-per-cpu=Low cpu-arch=ARM64
+----
+cpus | 1,2,4,8,16 | 32,64 | 96,128
+----
+GCE | n2-highcpu-2 (amd64), n2-highcpu-2 (amd64), n2-highcpu-4 (amd64), n2-highcpu-8 (amd64), n2-highcpu-16 (amd64) | n2-highcpu-32 (amd64), n2-highcpu-64 (amd64) | n2-highcpu-96 (amd64), n2-highcpu-128 (amd64)
+AWS | unsupported, unsupported, unsupported, unsupported, unsupported | unsupported, unsupported | unsupported, unsupported
+Azure | unsupported, unsupported, unsupported, unsupported, unsupported | unsupported,unsupported | unsupported, unsupported
+
+select-machine-type mem-per-cpu=Low cpu-arch=AMD64
+----
+cpus | 1,2,4,8,16 | 32,64 | 96,128
+----
+GCE | n2-highcpu-2, n2-highcpu-2, n2-highcpu-4, n2-highcpu-8, n2-highcpu-16 | n2-highcpu-32, n2-highcpu-64 | n2-highcpu-96, n2-highcpu-128
+AWS | unsupported, unsupported, unsupported, unsupported, unsupported | unsupported, unsupported | unsupported, unsupported
+Azure | unsupported, unsupported, unsupported, unsupported, unsupported | unsupported,unsupported | unsupported, unsupported

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -33,7 +33,6 @@ func registerDatabaseDrop(r registry.Registry) {
 		10, /* nodeCount */
 		spec.CPU(8),
 		spec.VolumeSize(500),
-		spec.GCEMinCPUPlatform("Intel Ice Lake"),
 		spec.GCEVolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 		spec.GCEZones("us-east1-b"),

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -34,7 +34,6 @@ func registerIndexBackfill(r registry.Registry) {
 		10, /* nodeCount */
 		spec.CPU(8),
 		spec.VolumeSize(500),
-		spec.GCEMinCPUPlatform("Intel Ice Lake"),
 		spec.GCEVolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 		spec.GCEZones("us-east1-b"),

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1137,7 +1137,8 @@ func (p *Provider) runInstance(
 		return *fl
 	}
 	imageID := withFlagOverride(az.region.AMI_X86_64, &providerOpts.ImageAMI)
-	useArmAMI := strings.Index(machineType, "6g.") == 1 || strings.Index(machineType, "7g.") == 1
+	useArmAMI := strings.Index(machineType, "6g.") == 1 || strings.Index(machineType, "6gd.") == 1 ||
+		strings.Index(machineType, "7g.") == 1 || strings.Index(machineType, "7gd.") == 1
 	if useArmAMI && (opts.Arch != "" && opts.Arch != string(vm.ArchARM64)) {
 		return errors.Errorf("machine type %s is arm64, but requested arch is %s", machineType, opts.Arch)
 	}

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -513,6 +514,7 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 			RemoteUser:  remoteUser,
 			VPC:         "global",
 			MachineType: string(found.HardwareProfile.VMSize),
+			CPUArch:     CpuArchFromAzureMachineType(string(found.HardwareProfile.VMSize)),
 			// We add a fake availability-zone suffix since other roachprod
 			// code assumes particular formats. For example, "eastus2z".
 			Zone: *found.Location + "z",
@@ -644,7 +646,7 @@ func (p *Provider) createVM(
 	name, sshKey string,
 	opts vm.CreateOpts,
 	providerOpts ProviderOpts,
-) (vm compute.VirtualMachine, err error) {
+) (machine compute.VirtualMachine, err error) {
 	startupArgs := azureStartupArgs{RemoteUser: remoteUser}
 	if !opts.SSDOpts.UseLocalSSD {
 		// We define lun42 explicitly in the data disk request below.
@@ -654,7 +656,7 @@ func (p *Provider) createVM(
 
 	startupScript, err := evalStartupTemplate(startupArgs)
 	if err != nil {
-		return vm, err
+		return machine, err
 	}
 	sub, err := p.getSubscription(ctx)
 	if err != nil {
@@ -690,9 +692,16 @@ func (p *Provider) createVM(
 		l.Printf("WARNING: increasing the OS volume size to minimally allowed 32GB")
 		osVolumeSize = 32
 	}
+	imageSKUForArch := func(arch string) string {
+		if arch == string(vm.ArchARM64) {
+			return "22_04-lts-arm64"
+		}
+		return "22_04-lts-gen2"
+	}
+
 	// Derived from
 	// https://github.com/Azure-Samples/azure-sdk-for-go-samples/blob/79e3f3af791c3873d810efe094f9d61e93a6ccaa/compute/vm.go#L41
-	vm = compute.VirtualMachine{
+	machine = compute.VirtualMachine{
 		Location: group.Location,
 		Zones:    to.StringSlicePtr([]string{providerOpts.Zone}),
 		Tags:     tags,
@@ -703,15 +712,15 @@ func (p *Provider) createVM(
 			StorageProfile: &compute.StorageProfile{
 				// From https://discourse.ubuntu.com/t/find-ubuntu-images-on-microsoft-azure/18918
 				// You can find available versions by running the following command:
-				// az vm image list --all --publisher Canonical
+				// az machine image list --all --publisher Canonical
 				// To get the latest 22.04 version:
-				// az vm image list --all --publisher Canonical | \
+				// az machine image list --all --publisher Canonical | \
 				// jq '[.[] | select(.sku=="22_04-lts")] | max_by(.version)'
 				ImageReference: &compute.ImageReference{
 					Publisher: to.StringPtr("Canonical"),
 					Offer:     to.StringPtr("0001-com-ubuntu-server-jammy"),
-					Sku:       to.StringPtr("22_04-lts"),
-					Version:   to.StringPtr("22.04.202309190"),
+					Sku:       to.StringPtr(imageSKUForArch(opts.Arch)),
+					Version:   to.StringPtr("22.04.202312060"),
 				},
 				OsDisk: &compute.OSDisk{
 					CreateOption: compute.DiskCreateOptionTypesFromImage,
@@ -788,7 +797,7 @@ func (p *Provider) createVM(
 			}
 
 			// UltraSSDs must be enabled separately.
-			vm.AdditionalCapabilities = &compute.AdditionalCapabilities{
+			machine.AdditionalCapabilities = &compute.AdditionalCapabilities{
 				UltraSSDEnabled: to.BoolPtr(true),
 			}
 		case "premium-disk":
@@ -802,9 +811,9 @@ func (p *Provider) createVM(
 			return compute.VirtualMachine{}, err
 		}
 
-		vm.StorageProfile.DataDisks = &dataDisks
+		machine.StorageProfile.DataDisks = &dataDisks
 	}
-	future, err := client.CreateOrUpdate(ctx, *group.Name, name, vm)
+	future, err := client.CreateOrUpdate(ctx, *group.Name, name, machine)
 	if err != nil {
 		return
 	}
@@ -1498,4 +1507,23 @@ func (p *Provider) getResourcesAndSecurityGroupByName(
 		sGroup = p.mu.securityGroups[sName]
 	}
 	return rGroup, sGroup
+}
+
+var azureMachineTypes = regexp.MustCompile(`^(Standard_[DE])(\d+)((?:p|l|pl)?ds)_v5$`)
+
+// CpuArchFromAzureMachineType attempts to determine the CPU architecture from the corresponding Azure
+// machine type. In case the machine type is not recognized, it defaults to AMD64.
+// TODO(srosenberg): remove when the Azure SDK finally exposes the CPU architecture for a given VM.
+func CpuArchFromAzureMachineType(machineType string) vm.CPUArch {
+	matches := azureMachineTypes.FindStringSubmatch(machineType)
+
+	if len(matches) >= 3 {
+		series := matches[1] + matches[3]
+		if series == "Standard_Dps" || series == "Standard_Dpds" ||
+			series == "Standard_Dplds" || series == "Standard_Dpls" ||
+			series == "Standard_Eps" || series == "Standard_Epds" {
+			return vm.ArchARM64
+		}
+	}
+	return vm.ArchAMD64
 }

--- a/pkg/roachprod/vm/azure/flags.go
+++ b/pkg/roachprod/vm/azure/flags.go
@@ -35,8 +35,8 @@ type ProviderOpts struct {
 // this comment, `westus` did not.
 var defaultLocations = []string{
 	"eastus",
+	"canadacentral",
 	"westus2",
-	"westeurope",
 }
 
 var defaultZone = "1"

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -270,10 +270,8 @@ func DefaultProviderOpts() *ProviderOpts {
 	return &ProviderOpts{
 		// N.B. we set minCPUPlatform to "Intel Ice Lake" by default because it's readily available in the majority of GCE
 		// regions. Furthermore, it gets us closer to AWS instances like m6i which exclusively run Ice Lake.
-		MachineType: "n2-standard-4",
-		// TODO(srosenberg): restore the change in https://github.com/cockroachdb/cockroach/pull/111140 after 23.2 branch cut.
-		//MinCPUPlatform:       "Intel Ice Lake",
-		MinCPUPlatform:       "",
+		MachineType:          "n2-standard-4",
+		MinCPUPlatform:       "Intel Ice Lake",
 		Zones:                nil,
 		Image:                DefaultImage,
 		SSDCount:             1,
@@ -1227,6 +1225,10 @@ func (p *Provider) computeInstanceArgs(
 
 	args = append(args, "--machine-type", providerOpts.MachineType)
 	if providerOpts.MinCPUPlatform != "" {
+		if strings.HasPrefix(providerOpts.MachineType, "n2d-") && strings.HasPrefix(providerOpts.MinCPUPlatform, "Intel") {
+			l.Printf("WARNING: MinCPUPlatform=%q is not supported for MachineType=%q, falling back to AMD Milan", providerOpts.MinCPUPlatform, providerOpts.MachineType)
+			providerOpts.MinCPUPlatform = "AMD Milan"
+		}
 		args = append(args, "--min-cpu-platform", providerOpts.MinCPUPlatform)
 	}
 
@@ -1449,11 +1451,11 @@ func (p *Provider) Create(
 }
 
 // Given a machine type, return the allowed number (> 0) of local SSDs, sorted in ascending order.
-// N.B. Only n1, n2 and c2 instances are supported since we don't typically use other instance types.
+// N.B. Only n1, n2, n2d and c2 instances are supported since we don't typically use other instance types.
 // Consult https://cloud.google.com/compute/docs/disks/#local_ssd_machine_type_restrictions for other types of instances.
 func AllowedLocalSSDCount(machineType string) ([]int, error) {
 	// E.g., n2-standard-4, n2-custom-8-16384.
-	machineTypes := regexp.MustCompile(`^([cn])(\d+)-[a-z]+-(\d+)(?:-\d+)?$`)
+	machineTypes := regexp.MustCompile(`^([cn])(\d+)(?:d)?-[a-z]+-(\d+)(?:-\d+)?$`)
 	matches := machineTypes.FindStringSubmatch(machineType)
 
 	if len(matches) >= 3 {


### PR DESCRIPTION
Previously, same (performance) roachtest executed in GCE and AWS
may have used a different memory (per CPU) multiplier and/or
cpu family, e.g., cascade lake vs ice lake. In the best case,
this resulted in different performance baselines on an otherwise
equivalent machine type. In the worst case, this resulted in OOMs
due to VMs in AWS having 2x less memory per CPU.

This change harmozines GCE and AWS machine types by making them
as isomorphic as possible, wrt memory, cpu family and price.
The following heuristics are used depending on specified MemPerCPU:
Standard yields 4GB/cpu, High yields 8GB/cpu,
Auto yields 4GB/cpu up to and including 16 vCPUs, then 2GB/cpu.
Low is supported only in GCE.
Consequently, n2-standard maps to m6i, n2-highmem maps to r6i,
n2-custom maps to c6i, modulo local SSDs in which case m6id is
used, etc. Note, we also force --gce-min-cpu-platform to Ice Lake;
isomorphic AWS machine types are exclusively on Ice Lake.

Roachprod is extended to show cpu family and architecture on List.
Cost estimation now correctly deals with custom machine types.

Note, this PR essentially resurrects [1], after it was reverted
in [2]. Since [1], `SelectAzureMachineType` has been added.
MemPerCPU is preserved across all three cloud providers.
However, when mem is Auto (default) and cpus > 80, we switch
to AMD Milan, both in GCE and AWS, but not Azure. (The latter
doesn't support 2GB per AMD CPU.)

For complete lists of machine types see `ExampleXXXMachineType`.

[1] https://github.com/cockroachdb/cockroach/pull/111140
[2] https://github.com/cockroachdb/cockroach/pull/111633

Epic: none
Fixes: #106570

Release note: None