### PR TITLE
roachtest: fix cdc/mixed-versions to work with deleted cluster settings

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -492,7 +492,6 @@ func (f *enumFeatureFlag) enabled(r enthropy, choose func(enthropy) string) (str
 // cdcFeatureFlags describes various cdc feature flags.
 // zero value cdcFeatureFlags uses metamorphic settings for features.
 type cdcFeatureFlags struct {
-	RangeFeedScheduler   featureFlag
 	SchemaLockTables     featureFlag
 	DistributionStrategy enumFeatureFlag
 }

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -25,10 +25,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -371,14 +371,6 @@ func (cmvt *cdcMixedVersionTester) createChangeFeed(
 	}
 
 	var ff cdcFeatureFlags
-	schedulerSupported, err := cmvt.rangefeedSchedulerSupported(r, h)
-	if err != nil {
-		return err
-	}
-	if !schedulerSupported {
-		ff.RangeFeedScheduler.v = &featureUnset
-	}
-
 	distributionStrategySupported, err := cmvt.distributionStrategySupported(r, h)
 	if err != nil {
 		return err
@@ -425,55 +417,80 @@ func (cmvt *cdcMixedVersionTester) initWorkload(
 }
 
 func (cmvt *cdcMixedVersionTester) muxRangeFeedSupported(
-	r *rand.Rand, h *mixedversion.Helper,
+	h *mixedversion.Helper,
 ) (bool, option.NodeListOption, error) {
-	// The mux setting was added in 22.2 and deleted in 24.1, so we need to first
-	// determine if the cluster version is in the range [22.2, 24.1).
-	cv, err := h.ClusterVersion(r)
-	if err != nil {
-		return false, nil, err
-	}
-	if !cv.AtLeast(roachpb.MustParseVersion(v222CV)) ||
-		cv.AtLeast(roachpb.MustParseVersion(v241CV)) {
-		return false, nil, nil
-	}
-
-	// Since the setting was deleted in 24.1, there may be nodes running binaries
-	// that no longer know about the setting.
-
-	// If we are upgrading to a version < 24.1, the setting is known to all nodes.
-	if h.Context.ToVersion.Major() < 24 {
-		return true, h.Context.CockroachNodes, nil
-	}
-
-	// If we are upgrading to 24.1, the setting is only known to pre-24.1 nodes.
-	if h.Context.ToVersion.Major() == 24 && h.Context.ToVersion.Minor() == 1 && h.Context.MixedBinary() {
-		return true, h.Context.NodesInPreviousVersion(), nil
-	}
-
-	// Otherwise, the setting is unknown to all nodes.
-	return false, nil, nil
+	// changefeed.mux_rangefeed.enabled was added in 22.2 and deleted in 24.1.
+	return canMixedVersionUseDeletedClusterSetting(h,
+		clusterupgrade.MustParseVersion("v22.2.0"),
+		clusterupgrade.MustParseVersion("v24.1.0-alpha.00000000"),
+	)
 }
 
-const v232CV = "23.2"
 const v241CV = "24.1"
 
 func (cmvt *cdcMixedVersionTester) rangefeedSchedulerSupported(
-	r *rand.Rand, h *mixedversion.Helper,
-) (bool, error) {
-	cv, err := h.ClusterVersion(r)
-	if err != nil {
-		return false, err
-	}
+	h *mixedversion.Helper,
+) (bool, option.NodeListOption, error) {
 	// kv.rangefeed.scheduler.enabled only exists in 23.2. In 24.1, it is enabled
 	// unconditionally.
-	return cv.Major == 23 && cv.Minor == 2 && cv.Internal == 0, nil
+	return canMixedVersionUseDeletedClusterSetting(h,
+		clusterupgrade.MustParseVersion("v23.2.0"),
+		clusterupgrade.MustParseVersion("v24.1.0-alpha.00000000"),
+	)
 }
 
 func (cmvt *cdcMixedVersionTester) distributionStrategySupported(
 	r *rand.Rand, h *mixedversion.Helper,
 ) (bool, error) {
-	return h.ClusterVersionAtLeast(r, v232CV)
+	return h.ClusterVersionAtLeast(r, v241CV)
+}
+
+// canMixedVersionUseDeletedClusterSetting returns whether a mixed-version
+// cluster can use a deleted cluster setting. If it returns true, it will
+// also return the subset of nodes that understand the setting.
+func canMixedVersionUseDeletedClusterSetting(
+	h *mixedversion.Helper,
+	addedVersion *clusterupgrade.Version,
+	deletedVersion *clusterupgrade.Version,
+) (bool, option.NodeListOption, error) {
+	fromVersion := h.Context.FromVersion
+	toVersion := h.Context.ToVersion
+
+	// Cluster setting was deleted at or before the from version so no nodes
+	// know about the setting.
+	if fromVersion.AtLeast(deletedVersion) {
+		return false, nil, nil
+	}
+
+	// Cluster setting was deleted later than the from version but at or before
+	// the to version, so if the from version is at least the added version,
+	// all the nodes on that version will know about the setting.
+	if toVersion.AtLeast(deletedVersion) {
+		if fromVersion.AtLeast(addedVersion) {
+			fromVersionNodes := h.Context.NodesInPreviousVersion()
+			if len(fromVersionNodes) > 0 {
+				return true, fromVersionNodes, nil
+			}
+		}
+		return false, nil, nil
+	}
+
+	// Cluster setting was deleted later than to version, so any nodes that are
+	// at least the added version will know about the setting.
+
+	if fromVersion.AtLeast(addedVersion) {
+		return true, h.Context.CockroachNodes, nil
+	}
+
+	if toVersion.AtLeast(addedVersion) {
+		toVersionNodes := h.Context.NodesInNextVersion()
+		if len(toVersionNodes) > 0 {
+			return true, toVersionNodes, nil
+		}
+		return false, nil, nil
+	}
+
+	return false, nil, nil
 }
 
 func runCDCMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -499,7 +516,7 @@ func runCDCMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	// MuxRangefeed in various forms is available starting from v22.2.
 	setMuxRangeFeedEnabled := func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
-		supported, gatewayNodes, err := tester.muxRangeFeedSupported(r, h)
+		supported, gatewayNodes, err := tester.muxRangeFeedSupported(h)
 		if err != nil {
 			return err
 		}
@@ -513,14 +530,14 @@ func runCDCMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	// Rangefeed scheduler available in 23.2
 	setRangeFeedSchedulerEnabled := func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
-		supported, err := tester.rangefeedSchedulerSupported(r, h)
+		supported, gatewayNodes, err := tester.rangefeedSchedulerSupported(h)
 		if err != nil {
 			return err
 		}
 		if supported {
 			coin := r.Int()%2 == 0
 			l.PrintfCtx(ctx, "Setting kv.rangefeed.scheduler.enabled=%t", coin)
-			return h.Exec(r, "SET CLUSTER SETTING kv.rangefeed.scheduler.enabled=$1", coin)
+			return h.ExecWithGateway(r, gatewayNodes, "SET CLUSTER SETTING kv.rangefeed.scheduler.enabled=$1", coin)
 		}
 		return nil
 	}


### PR DESCRIPTION
This patch updates the `cdc/mixed-versions` test to work properly with
the `changefeed.mux_rangefeed.enabled` and `kv.rangefeed.scheduler.enabled`
cluster settings that have been deleted in 24.1. The gating for the
`changefeed.default_range_distribution_strategy` cluster setting is
also fixed to reflect that it is new in 24.1, not 23.2.

Fixes #117804

Release note: None