### PR TITLE
reduce: add option to specify output to a file

### DIFF
--- a/pkg/cmd/reduce/main.go
+++ b/pkg/cmd/reduce/main.go
@@ -51,6 +51,7 @@ var (
 	flags             = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	binary            = flags.String("binary", "./cockroach", "path to cockroach binary")
 	file              = flags.String("file", "", "the path to a file containing SQL queries to reduce; required")
+	outFlag           = flags.String("out", "", "if set, the path to a new file where reduced result will be written to")
 	verbose           = flags.Bool("v", false, "print progress to standard output and the original test case output if it is not interesting")
 	contains          = flags.String("contains", "", "error regex to search for")
 	unknown           = flags.Bool("unknown", false, "print unknown types during walk")
@@ -125,7 +126,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(out)
+	if *outFlag != "" {
+		file, err := os.Create(*outFlag)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer file.Close()
+		fmt.Fprint(file, out)
+	} else {
+		fmt.Println(out)
+	}
 }
 
 func reduceSQL(


### PR DESCRIPTION
This commit adds another flag to specify that the reduced output should be written to a file instead of the stdout. This can be particularly handy when dealing with complicated table / column names that span multiple lines.

Epic: None

Release note: None