### PR TITLE
kv: correctly handle replicated locks when using the SKIP LOCKED policy

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//pkg/kv/kvnemesis/kvnemesisutil",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
-        "//pkg/kv/kvserver/batcheval",
         "//pkg/kv/kvserver/concurrency",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -118,10 +117,6 @@ func exceptSharedLockPromotionError(err error) bool { // true if lock promotion 
 
 func exceptSkipLockedReplayError(err error) bool { // true if skip locked replay error
 	return errors.Is(err, &concurrency.SkipLockedReplayError{})
-}
-
-func exceptSkipLockedUnsupportedError(err error) bool { // true if unsupported use of skip locked error
-	return errors.Is(err, &batcheval.SkipLockedUnsupportedError{})
 }
 
 func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -798,7 +798,6 @@ func (v *validator) processOp(op Operation) {
 		v.failIfError(
 			op, t.Result,
 			exceptRollback, exceptAmbiguous, exceptSharedLockPromotionError, exceptSkipLockedReplayError,
-			exceptSkipLockedUnsupportedError,
 		)
 
 		ops := t.Ops
@@ -1381,7 +1380,6 @@ func (v *validator) checkError(
 		exceptDelRangeUsingTombstoneStraddlesRangeBoundary,
 		exceptSharedLockPromotionError,
 		exceptSkipLockedReplayError,
-		exceptSkipLockedUnsupportedError,
 	}
 	sl = append(sl, extraExceptions...)
 	return v.failIfError(op, r, sl...)

--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -38,6 +38,7 @@ func Get(
 		lockTableForSkipLocked = newRequestBoundLockTableView(
 			readWriter, cArgs.Concurrency, h.Txn, args.KeyLockingStrength,
 		)
+		defer lockTableForSkipLocked.Close()
 	}
 
 	getRes, err := storage.MVCCGet(ctx, readWriter, args.Key, h.Timestamp, storage.MVCCGetOptions{

--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -35,7 +35,9 @@ func Get(
 
 	var lockTableForSkipLocked storage.LockTableView
 	if h.WaitPolicy == lock.WaitPolicy_SkipLocked {
-		lockTableForSkipLocked = newRequestBoundLockTableView(cArgs.Concurrency, args.KeyLockingStrength)
+		lockTableForSkipLocked = newRequestBoundLockTableView(
+			readWriter, cArgs.Concurrency, h.Txn, args.KeyLockingStrength,
+		)
 	}
 
 	getRes, err := storage.MVCCGet(ctx, readWriter, args.Key, h.Timestamp, storage.MVCCGetOptions{
@@ -93,7 +95,7 @@ func Get(
 		acq, err := acquireLockOnKey(ctx, readWriter, h.Txn, args.KeyLockingStrength,
 			args.KeyLockingDurability, args.Key, cArgs.Stats, cArgs.EvalCtx.ClusterSettings())
 		if err != nil {
-			return result.Result{}, maybeInterceptDisallowedSkipLockedUsage(h, err)
+			return result.Result{}, err
 		}
 		res.Local.AcquiredLocks = []roachpb.LockAcquisition{acq}
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -40,6 +40,7 @@ func ReverseScan(
 		lockTableForSkipLocked = newRequestBoundLockTableView(
 			readWriter, cArgs.Concurrency, h.Txn, args.KeyLockingStrength,
 		)
+		defer lockTableForSkipLocked.Close()
 	}
 
 	var res result.Result

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -37,7 +37,9 @@ func ReverseScan(
 
 	var lockTableForSkipLocked storage.LockTableView
 	if h.WaitPolicy == lock.WaitPolicy_SkipLocked {
-		lockTableForSkipLocked = newRequestBoundLockTableView(cArgs.Concurrency, args.KeyLockingStrength)
+		lockTableForSkipLocked = newRequestBoundLockTableView(
+			readWriter, cArgs.Concurrency, h.Txn, args.KeyLockingStrength,
+		)
 	}
 
 	var res result.Result
@@ -121,7 +123,7 @@ func ReverseScan(
 			ctx, readWriter, h.Txn, args.KeyLockingStrength, args.KeyLockingDurability,
 			args.ScanFormat, &scanRes, cArgs.Stats, cArgs.EvalCtx.ClusterSettings())
 		if err != nil {
-			return result.Result{}, maybeInterceptDisallowedSkipLockedUsage(h, err)
+			return result.Result{}, err
 		}
 		res.Local.AcquiredLocks = acquiredLocks
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -41,6 +41,7 @@ func Scan(
 		lockTableForSkipLocked = newRequestBoundLockTableView(
 			readWriter, cArgs.Concurrency, h.Txn, args.KeyLockingStrength,
 		)
+		defer lockTableForSkipLocked.Close()
 	}
 
 	var res result.Result

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -14,13 +14,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
-	"github.com/cockroachdb/errors"
 )
 
 func init() {
@@ -40,7 +38,9 @@ func Scan(
 
 	var lockTableForSkipLocked storage.LockTableView
 	if h.WaitPolicy == lock.WaitPolicy_SkipLocked {
-		lockTableForSkipLocked = newRequestBoundLockTableView(cArgs.Concurrency, args.KeyLockingStrength)
+		lockTableForSkipLocked = newRequestBoundLockTableView(
+			readWriter, cArgs.Concurrency, h.Txn, args.KeyLockingStrength,
+		)
 	}
 
 	var res result.Result
@@ -124,7 +124,7 @@ func Scan(
 			ctx, readWriter, h.Txn, args.KeyLockingStrength, args.KeyLockingDurability,
 			args.ScanFormat, &scanRes, cArgs.Stats, cArgs.EvalCtx.ClusterSettings())
 		if err != nil {
-			return result.Result{}, maybeInterceptDisallowedSkipLockedUsage(h, err)
+			return result.Result{}, err
 		}
 		res.Local.AcquiredLocks = acquiredLocks
 	}
@@ -139,38 +139,4 @@ func ScanReadCategory(ah kvpb.AdmissionHeader) storage.ReadCategory {
 		readCategory = storage.ScanBackgroundBatchEvalReadCategory
 	}
 	return readCategory
-}
-
-// maybeInterceptDisallowedSkipLockedUsage checks if read evaluation for a skip
-// locked request encountered a replicated lock by checking the supplier error
-// type. It transforms the error into an unimplemented error if that's the case;
-// otherwise, the error is passed through.
-//
-// TODO(arul): this won't be needed once
-// https://github.com/cockroachdb/cockroach/issues/115057 is addressed.
-func maybeInterceptDisallowedSkipLockedUsage(h kvpb.Header, err error) error {
-	if h.WaitPolicy == lock.WaitPolicy_SkipLocked && errors.HasType(err, (*kvpb.LockConflictError)(nil)) {
-		return MarkSkipLockedUnsupportedError(errors.UnimplementedError(
-			errors.IssueLink{IssueURL: build.MakeIssueURL(115057)},
-			"usage of replicated locks in conjunction with skip locked wait policy is currently unsupported",
-		))
-	}
-	return err
-}
-
-// SkipLockedUnsupportedError is used to mark errors resulting from unsupported
-// (currently unimplemented) uses of the skip locked wait policy.
-type SkipLockedUnsupportedError struct{}
-
-func (e *SkipLockedUnsupportedError) Error() string {
-	return "unsupported skip locked use error"
-}
-
-// MarkSkipLockedUnsupportedError wraps the given error, if not nil, as a skip
-// locked unsupported error.
-func MarkSkipLockedUnsupportedError(cause error) error {
-	if cause == nil {
-		return nil
-	}
-	return errors.Mark(cause, &SkipLockedUnsupportedError{})
 }

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -801,7 +801,7 @@ type lockTableGuard interface {
 	// for conflicts. This helps prevent a stream of locking SKIP LOCKED requests
 	// from starving out regular locking requests. In such cases, true is
 	// returned, but so is nil.
-	IsKeyLockedByConflictingTxn(roachpb.Key, lock.Strength) (bool, *enginepb.TxnMeta, error)
+	IsKeyLockedByConflictingTxn(context.Context, roachpb.Key, lock.Strength) (bool, *enginepb.TxnMeta, error)
 }
 
 // lockTableWaiter is concerned with waiting in lock wait-queues for locks held

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -804,9 +804,9 @@ func (g *Guard) CheckOptimisticNoLatchConflicts() (ok bool) {
 // from starving out regular locking requests. In such cases, true is
 // returned, but so is nil.
 func (g *Guard) IsKeyLockedByConflictingTxn(
-	key roachpb.Key, strength lock.Strength,
+	ctx context.Context, key roachpb.Key, strength lock.Strength,
 ) (bool, *enginepb.TxnMeta, error) {
-	return g.ltg.IsKeyLockedByConflictingTxn(key, strength)
+	return g.ltg.IsKeyLockedByConflictingTxn(ctx, key, strength)
 }
 
 func (g *Guard) moveLatchGuard() latchGuard {

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -391,7 +391,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				d.ScanArgs(t, "key", &key)
 				// TODO(nvanbenschoten): replace with scanLockStrength.
 				strength := concurrency.ScanLockStrength(t, d)
-				ok, txn, err := g.IsKeyLockedByConflictingTxn(roachpb.Key(key), strength)
+				ok, txn, err := g.IsKeyLockedByConflictingTxn(context.Background(), roachpb.Key(key), strength)
 				if err != nil {
 					return err.Error()
 				}

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -11,6 +11,7 @@
 package concurrency
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"sync"
@@ -687,7 +688,7 @@ func (g *lockTableGuardImpl) CheckOptimisticNoConflicts(
 }
 
 func (g *lockTableGuardImpl) IsKeyLockedByConflictingTxn(
-	key roachpb.Key, str lock.Strength,
+	_ context.Context, key roachpb.Key, str lock.Strength,
 ) (bool, *enginepb.TxnMeta, error) {
 	iter := g.tableSnapshot.MakeIter()
 	iter.SeekGE(&keyLocks{key: key})

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -516,7 +516,7 @@ func TestLockTableBasic(t *testing.T) {
 				var key string
 				d.ScanArgs(t, "k", &key)
 				strength := ScanLockStrength(t, d)
-				ok, txn, err := g.IsKeyLockedByConflictingTxn(roachpb.Key(key), strength)
+				ok, txn, err := g.IsKeyLockedByConflictingTxn(context.Background(), roachpb.Key(key), strength)
 				if err != nil {
 					return err.Error()
 				}

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -88,7 +88,7 @@ func (g *mockLockTableGuard) CheckOptimisticNoConflicts(*lockspanset.LockSpanSet
 	return true
 }
 func (g *mockLockTableGuard) IsKeyLockedByConflictingTxn(
-	roachpb.Key, lock.Strength,
+	context.Context, roachpb.Key, lock.Strength,
 ) (bool, *enginepb.TxnMeta, error) {
 	panic("unimplemented")
 }

--- a/pkg/sql/logictest/testdata/logic_test/read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/read_committed
@@ -455,3 +455,61 @@ subtest end
 
 statement ok
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE
+
+# Ensure FOR SHARE SKIP LOCKED works correctly with read committed.
+
+statement ok
+CREATE USER testuser2 WITH VIEWACTIVITY;
+DROP TABLE IF EXISTS t;
+CREATE TABLE t(a INT PRIMARY KEY);
+INSERT INTO t VALUES(1), (2);
+GRANT ALL ON t TO testuser;
+GRANT ALL ON t TO testuser2;
+
+user testuser
+
+query I
+BEGIN ISOLATION LEVEL READ COMMITTED;
+SELECT * FROM t WHERE a = 1 FOR SHARE;
+----
+1
+
+user root
+
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+----
+database_name  schema_name  table_name  lock_key_pretty  lock_strength  durability  isolation_level  granted  contended
+
+# Locks:
+# 1: Shared
+# 2: None
+
+query I
+BEGIN ISOLATION LEVEL READ COMMITTED;
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+2
+
+user testuser2
+
+# Locks:
+# 1: Shared
+# 2: Exclusive
+
+query I
+BEGIN ISOLATION LEVEL READ COMMITTED;
+SELECT * FROM t FOR SHARE SKIP LOCKED;
+COMMIT;
+----
+1
+
+user root
+
+statement ok
+COMMIT
+
+user testuser
+
+statement ok
+COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/select_for_share
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_share
@@ -164,6 +164,64 @@ user testuser2
 statement ok
 COMMIT
 
+# Ensure FOR SHARE SKIP LOCKED works correctly with replicated locks.
+
+statement ok
+DROP TABLE IF EXISTS t;
+CREATE TABLE t(a INT PRIMARY KEY);
+INSERT INTO t VALUES(1), (2);
+GRANT ALL ON t TO testuser;
+
+user testuser
+
+statement ok
+SET enable_durable_locking_for_serializable = true;
+
+query I
+BEGIN;
+SELECT * FROM t WHERE a = 1 FOR SHARE;
+----
+1
+
+user root
+
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+----
+database_name  schema_name  table_name  lock_key_pretty  lock_strength  durability  isolation_level  granted  contended
+
+# Locks:
+# 1: Shared
+# 2: None
+
+query I
+BEGIN;
+SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+2
+
+user testuser2
+
+# Locks:
+# 1: Shared
+# 2: Exclusive
+
+query I
+BEGIN;
+SELECT * FROM t FOR SHARE SKIP LOCKED;
+COMMIT;
+----
+1
+
+user root
+
+statement ok
+COMMIT
+
+user testuser
+
+statement ok
+COMMIT
 
 # TODO(arul): Add a test to show that the session setting doesn't apply to read
 # committed transactions. We currently can't issue SELECT FOR SHARE statements

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -629,13 +629,12 @@ SELECT * FROM t94290 WHERE b = 2 FOR UPDATE;
 statement ok
 RESET statement_timeout;
 
-# Ensure when SKIP LOCKED is used in conjunction with replicated locks we return
-# appropriate errors.
+# Ensure FOR UPDATE SKIP LOCKED works correctly with replicated locks.
 
 statement ok
 DROP TABLE IF EXISTS t;
 CREATE TABLE t(a INT PRIMARY KEY);
-INSERT INTO t VALUES(1);
+INSERT INTO t VALUES(1), (2);
 GRANT ALL ON t TO testuser;
 GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser;
 
@@ -644,10 +643,8 @@ user testuser
 statement ok
 SET enable_durable_locking_for_serializable = true;
 
-statement ok
-BEGIN
-
 query I
+BEGIN;
 SELECT * FROM t WHERE a = 1 FOR UPDATE;
 ----
 1
@@ -661,8 +658,10 @@ SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, d
 database_name  schema_name  table_name  lock_key_pretty  lock_strength  durability  isolation_level  granted  contended
 
 skipif config local-mixed-23.1
-statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
+query I
 SELECT * FROM t FOR UPDATE SKIP LOCKED
+----
+2
 
 # Ensure the replicated lock isn't pulled into the in-memory lock table, even
 # after the skip locked statement has run.

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
@@ -66,19 +66,20 @@ COMMIT;
 
 # SKIP LOCKED reads do not block.
 
-statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
+query III rowsort
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM abc FOR UPDATE SKIP LOCKED;
+COMMIT;
+----
+3 30 300
 
-statement ok
-ROLLBACK;
-
-statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
+query III rowsort
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM bcd FOR UPDATE SKIP LOCKED;
+COMMIT;
+----
+20 200 2000
 
-statement ok
-ROLLBACK
 
 # Shared reads block on exclusive locks but not on shared locks.
 
@@ -238,19 +239,19 @@ SELECT * FROM bcd WHERE b = 7 FOR UPDATE
 
 user root
 
-statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
+query III rowsort
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM abc WHERE a > 4 FOR UPDATE SKIP LOCKED;
+COMMIT;
+----
+6 1 7
 
-statement ok
-ROLLBACK
-
-statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
+query III rowsort
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM bcd WHERE b < 8 FOR UPDATE SKIP LOCKED;
-
-statement ok
-ROLLBACK
+COMMIT;
+----
+6 1 5
 
 query III async,rowsort q10
 BEGIN ISOLATION LEVEL READ COMMITTED;
@@ -327,19 +328,19 @@ SELECT * FROM bcd WHERE b = 7 FOR UPDATE
 
 user root
 
-statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
+query III rowsort
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM abc WHERE a > 4 FOR UPDATE SKIP LOCKED;
+COMMIT;
+----
+6 1 7
 
-statement ok
-ROLLBACK
-
-statement error usage of replicated locks in conjunction with skip locked wait policy is currently unsupported
+query III rowsort
 BEGIN ISOLATION LEVEL READ COMMITTED;
 SELECT * FROM bcd WHERE b < 8 FOR UPDATE SKIP LOCKED;
-
-statement ok
-ROLLBACK;
+COMMIT;
+----
+6 1 5
 
 query III async,rowsort q12
 BEGIN ISOLATION LEVEL READ COMMITTED;

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1182,7 +1182,7 @@ type LockTableView interface {
 	//
 	// This method is used by requests in conjunction with the SkipLocked wait
 	// policy to determine which keys they should skip over during evaluation.
-	IsKeyLockedByConflictingTxn(roachpb.Key) (bool, *enginepb.TxnMeta, error)
+	IsKeyLockedByConflictingTxn(context.Context, roachpb.Key) (bool, *enginepb.TxnMeta, error)
 }
 
 // MVCCGetOptions bundles options for the MVCCGet family of functions.

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1183,6 +1183,9 @@ type LockTableView interface {
 	// This method is used by requests in conjunction with the SkipLocked wait
 	// policy to determine which keys they should skip over during evaluation.
 	IsKeyLockedByConflictingTxn(context.Context, roachpb.Key) (bool, *enginepb.TxnMeta, error)
+	// Close cleans up the LockTableView; it should not be used after being
+	// closed.
+	Close()
 }
 
 // MVCCGetOptions bundles options for the MVCCGet family of functions.

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -2807,7 +2807,7 @@ type mockLockTableView struct {
 }
 
 func (lt *mockLockTableView) IsKeyLockedByConflictingTxn(
-	k roachpb.Key,
+	_ context.Context, k roachpb.Key,
 ) (bool, *enginepb.TxnMeta, error) {
 	info, ok := lt.unreplLocks[string(k)]
 	if !ok {

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -2848,6 +2848,8 @@ func (lt *mockLockTableView) IsKeyLockedByConflictingTxn(
 	}
 }
 
+func (lt *mockLockTableView) Close() {}
+
 func (e *evalCtx) visitWrappedIters(fn func(it storage.SimpleMVCCIterator) (done bool)) {
 	iter := e.iter
 	if iter == nil {

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -1804,7 +1804,7 @@ func (p *pebbleMVCCScanner) isKeyLockedByConflictingTxn(
 		p.err = err
 		return false, false
 	}
-	ok, txn, err := p.lockTable.IsKeyLockedByConflictingTxn(key)
+	ok, txn, err := p.lockTable.IsKeyLockedByConflictingTxn(ctx, key)
 	if err != nil {
 		p.err = err
 		return false, false

--- a/pkg/storage/testdata/mvcc_histories/replicated_locks
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks
@@ -275,6 +275,32 @@ lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri
 lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 error: (*kvpb.LockConflictError:) conflicting locks on "k1"
 
+# Non-transactional requests are able to check for conflicts (but they can't
+# acquire locks).
+run ok
+check_for_acquire_lock notxn k=k1 str=shared
+----
+
+run error
+check_for_acquire_lock notxn k=k2 str=shared
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k2"
+
+run error
+check_for_acquire_lock notxn k=k2 str=exclusive
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k2", "k2"
+
+run error
+check_for_acquire_lock notxn k=k3 str=exclusive
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k3"
+
+run error
+check_for_acquire_lock notxn k=k3 str=shared
+----
+error: (*kvpb.LockConflictError:) conflicting locks on "k3"
+
 # Intents are treated similarly to Exclusive locks.
 
 run stats ok

--- a/pkg/storage/testdata/mvcc_histories/replicated_locks_errors
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks_errors
@@ -1,15 +1,10 @@
 # Test invalid lock acquisition inputs.
 
 run error
-check_for_acquire_lock notxn k=k1 str=shared
-----
-error: (*withstack.withStack:) txn must be non-nil to acquire lock
-
-run error
 acquire_lock notxn k=k1 str=shared
 ----
 >> at end:
-error: (*withstack.withStack:) txn must be non-nil to acquire lock
+error: (*withstack.withStack:) txn must be non-nil to acquire a replicated lock
 
 run ok
 txn_begin t=A ts=10,0


### PR DESCRIPTION
Previously, we weren't correctly handling replicated locks when using the SKIP LOCKED wait policy. Instead of skipping the replicated lock, we'd instead throw an unsupported error. This patch lifts this limitation. After doing so, we're able to support SKIP LOCKED in conjunction with both replicated locks and read committed transactions, as demostrated by the change to logic tests.

Closes #115057

Release note: None