### PR TITLE
util/admission: remove unused elasticCPUGranter.tbReset field

### DIFF
--- a/pkg/util/admission/elastic_cpu_granter.go
+++ b/pkg/util/admission/elastic_cpu_granter.go
@@ -110,7 +110,6 @@ type elasticCPUGranter struct {
 		syncutil.Mutex
 		tb               *tokenbucket.TokenBucket
 		tbLastReset      time.Time
-		tbReset          *util.EveryN
 		utilizationLimit float64
 	}
 	requester requester


### PR DESCRIPTION
Noticed in passing while inspecting usages of `util.EveryN`.

Epic: none
Release note: none
