### PR TITLE
release-23.2: copy: improve behavior of non-atomic COPY

### DIFF
--- a/pkg/sql/copy/copy_in_test.go
+++ b/pkg/sql/copy/copy_in_test.go
@@ -428,22 +428,26 @@ func TestCopyFromRetries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	const numRows = sql.CopyBatchRowSizeDefault * 5
+	// sql.CopyBatchRowSize can change depending on the metamorphic
+	// randomization, so we derive all rows counts from it.
+	var numRows = sql.CopyBatchRowSize * 5
 
 	testCases := []struct {
-		desc           string
-		hook           func(attemptNum int) error
-		atomicEnabled  bool
-		retriesEnabled bool
-		inTxn          bool
-		expectedRows   int
-		expectedErr    bool
+		desc               string
+		hookBefore         func(attemptNum int) error
+		hookAfter          func(attemptNum int) error
+		atomicEnabled      bool
+		retriesEnabled     bool
+		autoCommitDisabled bool
+		inTxn              bool
+		expectedRows       int
+		expectedErr        bool
 	}{
 		{
 			desc:           "failure in atomic transaction does not retry",
 			atomicEnabled:  true,
 			retriesEnabled: true,
-			hook: func(attemptNum int) error {
+			hookBefore: func(attemptNum int) error {
 				if attemptNum == 1 {
 					return &kvpb.TransactionRetryWithProtoRefreshError{}
 				}
@@ -455,7 +459,7 @@ func TestCopyFromRetries(t *testing.T) {
 			desc:           "does not attempt to retry if disabled",
 			atomicEnabled:  false,
 			retriesEnabled: false,
-			hook: func(attemptNum int) error {
+			hookBefore: func(attemptNum int) error {
 				if attemptNum == 1 {
 					return &kvpb.TransactionRetryWithProtoRefreshError{}
 				}
@@ -468,7 +472,7 @@ func TestCopyFromRetries(t *testing.T) {
 			atomicEnabled:  true,
 			retriesEnabled: true,
 			inTxn:          true,
-			hook: func(attemptNum int) error {
+			hookBefore: func(attemptNum int) error {
 				if attemptNum == 1 {
 					return &kvpb.TransactionRetryWithProtoRefreshError{}
 				}
@@ -477,10 +481,44 @@ func TestCopyFromRetries(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			desc:           "retries successfully on every batch",
+			desc:           "retries successfully on every batch (errors before)",
 			atomicEnabled:  false,
 			retriesEnabled: true,
-			hook: func(attemptNum int) error {
+			hookBefore: func(attemptNum int) error {
+				if attemptNum%2 == 1 {
+					return &kvpb.TransactionRetryWithProtoRefreshError{}
+				}
+				return nil
+			},
+			expectedRows: numRows,
+		},
+		{
+			// In this scenario, only the first COPY batch is auto-committed,
+			// after which we inject a retryable error. The txn cannot be rolled
+			// back, so the COPY then returns that error to the client, yet the
+			// first batch of rows is already in the table.
+			desc:           "cannot roll back committed txn (errors after)",
+			atomicEnabled:  false,
+			retriesEnabled: true,
+			hookAfter: func(attemptNum int) error {
+				if attemptNum%2 == 1 {
+					return &kvpb.TransactionRetryWithProtoRefreshError{}
+				}
+				return nil
+			},
+			expectedRows: sql.CopyBatchRowSize,
+			expectedErr:  true,
+		},
+		{
+			// When auto commit is disabled, each COPY batch ends being
+			// processed twice - after the first attempt on each batch we inject
+			// a retryable error, which is then successfully retried on the
+			// second attempt.
+			desc:               "retries successfully on every batch (errors after, no auto commit)",
+			autoCommitDisabled: true,
+			atomicEnabled:      false,
+			retriesEnabled:     true,
+			hookAfter: func(attemptNum int) error {
 				if attemptNum%2 == 1 {
 					return &kvpb.TransactionRetryWithProtoRefreshError{}
 				}
@@ -492,7 +530,7 @@ func TestCopyFromRetries(t *testing.T) {
 			desc:           "eventually dies on too many restarts",
 			atomicEnabled:  false,
 			retriesEnabled: true,
-			hook: func(attemptNum int) error {
+			hookBefore: func(attemptNum int) error {
 				return &kvpb.TransactionRetryWithProtoRefreshError{}
 			},
 			expectedErr: true,
@@ -501,13 +539,17 @@ func TestCopyFromRetries(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			knobs := &sql.ExecutorTestingKnobs{
+				DisableAutoCommitDuringExec: tc.autoCommitDisabled,
+			}
 			var params base.TestServerArgs
-			var attemptNumber int
-			params.Knobs.SQLExecutor = &sql.ExecutorTestingKnobs{
-				BeforeCopyFromInsert: func(txn *kv.Txn) error {
+			params.Knobs.SQLExecutor = knobs
+			if tc.hookBefore != nil {
+				var attemptNumber int
+				knobs.CopyFromInsertBeforeBatch = func(txn *kv.Txn) error {
 					if !tc.inTxn {
-						// When we're not in an explicit txn, we expect that all
-						// txns used by the COPY use the background QoS.
+						// When we're not in an explicit txn, we expect that
+						// all txns used by the COPY use the background QoS.
 						if txn.AdmissionHeader().Priority != int32(admissionpb.UserLowPri) {
 							t.Errorf(
 								"unexpected QoS level %d (expected %d)",
@@ -516,8 +558,15 @@ func TestCopyFromRetries(t *testing.T) {
 						}
 					}
 					attemptNumber++
-					return tc.hook(attemptNumber)
-				},
+					return tc.hookBefore(attemptNumber)
+				}
+			}
+			if tc.hookAfter != nil {
+				var attemptNumber int
+				knobs.CopyFromInsertAfterBatch = func() error {
+					attemptNumber++
+					return tc.hookAfter(attemptNumber)
+				}
 			}
 			srv, db, _ := serverutils.StartServer(t, params)
 			defer srv.Stopper().Stop(context.Background())

--- a/pkg/sql/copy/copy_in_test.go
+++ b/pkg/sql/copy/copy_in_test.go
@@ -428,6 +428,14 @@ func TestCopyFromRetries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// Ensure that the COPY batch size isn't too large (this test becomes too
+	// slow when metamorphic sql.CopyBatchRowSize is set to a relatively large
+	// number).
+	const maxCopyBatchRowSize = 1000
+	if sql.CopyBatchRowSize > maxCopyBatchRowSize {
+		sql.SetCopyFromBatchSize(maxCopyBatchRowSize)
+	}
+
 	// sql.CopyBatchRowSize can change depending on the metamorphic
 	// randomization, so we derive all rows counts from it.
 	var numRows = sql.CopyBatchRowSize * 5

--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -610,7 +610,7 @@ func TestLargeDynamicRows(t *testing.T) {
 	}
 	_, err = conn.GetDriverConn().CopyFrom(ctx, strings.NewReader(sb.String()), "COPY t FROM STDIN")
 	require.NoError(t, err)
-	require.Greater(t, batchNumber, 4)
+	require.GreaterOrEqual(t, 4, batchNumber)
 	batchNumber = 0
 
 	// Reset and make sure we use 1 batch.

--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -570,7 +570,7 @@ func TestLargeDynamicRows(t *testing.T) {
 	var params base.TestServerArgs
 	var batchNumber int
 	params.Knobs.SQLExecutor = &sql.ExecutorTestingKnobs{
-		BeforeCopyFromInsert: func(*kv.Txn) error {
+		CopyFromInsertBeforeBatch: func(*kv.Txn) error {
 			batchNumber++
 			return nil
 		},

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -216,6 +216,5 @@ func (f *fileUploadMachine) writeFile(ctx context.Context, finalBatch bool) erro
 	if err != nil {
 		return err
 	}
-	f.c.insertedRows += f.c.rows.Len()
-	return f.c.rows.UnsafeReset(ctx)
+	return f.c.doneWithRows(ctx)
 }

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -1008,32 +1008,41 @@ func (p *planner) preparePlannerForCopy(
 	}
 	p.autoCommit = autoCommit && !p.execCfg.TestingKnobs.DisableAutoCommitDuringExec
 
-	return func(ctx context.Context, prevErr error) (err error) {
-		// Ensure that we commit the transaction if atomic copy is off. If it's on,
-		// the conn executor will commit the transaction.
+	return func(ctx context.Context, prevErr error) error {
+		// Ensure that we commit the transaction if atomic copy is off. If it's
+		// on, the conn executor will commit the transaction.
 		if implicitTxn && !p.SessionData().CopyFromAtomicEnabled {
 			if prevErr == nil {
-				// Ensure that the txn is committed if the copyMachine is in charge of
-				// committing its transactions and the execution didn't already commit it
-				// (through the planner.autoCommit optimization).
+				// Ensure that the txn is committed if the copyMachine is in
+				// charge of committing its transactions and the execution
+				// didn't already commit it (through the planner.autoCommit
+				// optimization).
 				if !txnOpt.txn.IsCommitted() {
-					err = txnOpt.txn.Commit(ctx)
-					if err != nil {
+					if err := txnOpt.txn.Commit(ctx); err != nil {
 						if rollbackErr := txnOpt.txn.Rollback(ctx); rollbackErr != nil {
-							log.Eventf(ctx, "rollback failed: %s", rollbackErr)
+							// Since we failed to roll back the txn, we don't
+							// know whether retrying this batch wouldn't corrupt
+							// the data, so we return this non-retriable error.
+							return errors.Wrap(rollbackErr, "non-atomic COPY couldn't roll back its txn")
 						}
-						return err
+						// The rollback succeeded, so we can simply attempt to
+						// retry this batch, after having prepared a fresh txn
+						// below.
+						prevErr = err
 					}
 				}
 			} else if rollbackErr := txnOpt.txn.Rollback(ctx); rollbackErr != nil {
-				log.Eventf(ctx, "rollback failed: %s", rollbackErr)
+				// Since we failed to roll back the txn, we don't know whether
+				// retrying this batch wouldn't corrupt the data, so we return
+				// this non-retriable error.
+				return errors.Wrap(rollbackErr, "non-atomic COPY couldn't roll back its txn")
 			}
 
 			// Start the implicit txn for the next batch.
 			nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID()
 			txnOpt.txn = kv.NewTxnWithSteppingEnabled(ctx, p.execCfg.DB, nodeID, p.SessionData().CopyTxnQualityOfService)
 			if !p.SessionData().CopyWritePipeliningEnabled {
-				if err = txnOpt.txn.DisablePipelining(); err != nil {
+				if err := txnOpt.txn.DisablePipelining(); err != nil {
 					return err
 				}
 			}
@@ -1042,6 +1051,31 @@ func (p *planner) preparePlannerForCopy(
 		}
 		return prevErr
 	}
+}
+
+// doneWithRows resets the buffered data (either the columnar batch or the row
+// container) for reuse. It also updates insertedRows accordingly.
+func (c *copyMachine) doneWithRows(ctx context.Context) error {
+	c.insertedRows += c.currentBatchSize()
+	if c.vectorized {
+		var realloc bool
+		if err := colexecerror.CatchVectorizedRuntimeError(func() {
+			c.batch, realloc = c.accHelper.ResetMaybeReallocate(c.typs, c.batch, 0 /* tuplesToBeSet*/)
+		}); err != nil {
+			return err
+		}
+		if realloc {
+			for i := range c.typs {
+				c.valueHandlers[i] = coldataext.MakeVecHandler(c.batch.ColVec(i))
+			}
+		} else {
+			for _, vh := range c.valueHandlers {
+				vh.Reset()
+			}
+		}
+		return nil
+	}
+	return c.rows.UnsafeReset(ctx)
 }
 
 // insertRows inserts rows, retrying if necessary.
@@ -1053,14 +1087,15 @@ func (c *copyMachine) insertRows(ctx context.Context, finalBatch bool) error {
 	r := retry.StartWithCtx(ctx, rOpts)
 	for r.Next() {
 		if err = c.insertRowsInternal(ctx, finalBatch); err == nil {
-			return nil
+			// We're done with this batch of rows, so reset the buffered data
+			// for the next batch.
+			return c.doneWithRows(ctx)
 		} else {
-			// It is currently only safe to retry if we are not in atomic copy mode &
-			// we are in an implicit transaction.
+			// It is currently only safe to retry if we are not in atomic copy
+			// mode & we are in an implicit transaction.
 			// NOTE: we cannot re-use the connExecutor retry scheme here as COPY
-			// consumes directly from the read buffer, and the data would no longer
-			// be available during the retry.
-			// NOTE: in theory we can also retry if c.insertRows == 0.
+			// consumes directly from the read buffer, and the data would no
+			// longer be available during the retry.
 			if c.implicitTxn && !c.p.SessionData().CopyFromAtomicEnabled && c.p.SessionData().CopyFromRetriesEnabled && errIsRetriable(err) {
 				log.SqlExec.Infof(ctx, "%s failed on attempt %d and is retrying, error %+v", c.copyFromAST.String(), r.CurrentAttempt(), err)
 				if c.p.ExecCfg().TestingKnobs.CopyFromInsertRetry != nil {
@@ -1086,10 +1121,19 @@ func (c *copyMachine) insertRowsInternal(ctx context.Context, finalBatch bool) (
 	defer func() {
 		retErr = cleanup(ctx, retErr)
 	}()
-	if c.p.ExecCfg().TestingKnobs.BeforeCopyFromInsert != nil {
-		if err := c.p.ExecCfg().TestingKnobs.BeforeCopyFromInsert(c.txnOpt.txn); err != nil {
+	if c.p.ExecCfg().TestingKnobs.CopyFromInsertBeforeBatch != nil {
+		if err := c.p.ExecCfg().TestingKnobs.CopyFromInsertBeforeBatch(c.txnOpt.txn); err != nil {
 			return err
 		}
+	}
+	if c.p.ExecCfg().TestingKnobs.CopyFromInsertAfterBatch != nil {
+		defer func() {
+			if retErr == nil {
+				if err := c.p.ExecCfg().TestingKnobs.CopyFromInsertAfterBatch(); err != nil {
+					retErr = err
+				}
+			}
+		}()
 	}
 	// TODO(cucaroach): Investigate caching memo/plan/etc so that we don't
 	// rebuild everything for every batch.
@@ -1146,29 +1190,6 @@ func (c *copyMachine) insertRowsInternal(ctx context.Context, finalBatch bool) (
 	if rows := res.RowsAffected(); rows != numRows {
 		return errors.AssertionFailedf("COPY didn't insert all buffered rows and yet no error was reported. "+
 			"Inserted %d out of %d rows.", rows, numRows)
-	}
-	c.insertedRows += numRows
-	// We're done reset for next batch.
-	if c.vectorized {
-		var realloc bool
-		if err := colexecerror.CatchVectorizedRuntimeError(func() {
-			c.batch, realloc = c.accHelper.ResetMaybeReallocate(c.typs, c.batch, 0 /* tuplesToBeSet*/)
-		}); err != nil {
-			return err
-		}
-		if realloc {
-			for i := range c.typs {
-				c.valueHandlers[i] = coldataext.MakeVecHandler(c.batch.ColVec(i))
-			}
-		} else {
-			for _, vh := range c.valueHandlers {
-				vh.Reset()
-			}
-		}
-	} else {
-		if err := c.rows.UnsafeReset(ctx); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -1078,6 +1078,10 @@ func (c *copyMachine) insertRows(ctx context.Context, finalBatch bool) error {
 
 // insertRowsInternal transforms the buffered rows into an insertNode and executes it.
 func (c *copyMachine) insertRowsInternal(ctx context.Context, finalBatch bool) (retErr error) {
+	numRows := c.currentBatchSize()
+	if numRows == 0 {
+		return nil
+	}
 	cleanup := c.p.preparePlannerForCopy(ctx, &c.txnOpt, finalBatch, c.implicitTxn)
 	defer func() {
 		retErr = cleanup(ctx, retErr)
@@ -1086,10 +1090,6 @@ func (c *copyMachine) insertRowsInternal(ctx context.Context, finalBatch bool) (
 		if err := c.p.ExecCfg().TestingKnobs.BeforeCopyFromInsert(c.txnOpt.txn); err != nil {
 			return err
 		}
-	}
-	numRows := c.currentBatchSize()
-	if numRows == 0 {
-		return nil
 	}
 	// TODO(cucaroach): Investigate caching memo/plan/etc so that we don't
 	// rebuild everything for every batch.

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -1083,7 +1083,13 @@ func (c *copyMachine) insertRows(ctx context.Context, finalBatch bool) error {
 	var err error
 
 	rOpts := base.DefaultRetryOptions()
-	rOpts.MaxRetries = 5
+	rOpts.MaxRetries = int(c.p.SessionData().CopyNumRetriesPerBatch)
+	if rOpts.MaxRetries < 1 {
+		// MaxRetries == 0 means infinite number of attempts, and although
+		// CopyNumRetriesPerBatch should always be a positive number, let's be
+		// careful here.
+		rOpts.MaxRetries = 1
+	}
 	r := retry.StartWithCtx(ctx, rOpts)
 	for r.Next() {
 		if err = c.insertRowsInternal(ctx, finalBatch); err == nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3413,6 +3413,10 @@ func (m *sessionDataMutator) SetCopyWritePipeliningEnabled(val bool) {
 	m.data.CopyWritePipeliningEnabled = val
 }
 
+func (m *sessionDataMutator) SetCopyNumRetriesPerBatch(val int32) {
+	m.data.CopyNumRetriesPerBatch = val
+}
+
 func (m *sessionDataMutator) SetOptSplitScanLimit(val int32) {
 	m.data.OptSplitScanLimit = val
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1650,10 +1650,16 @@ type ExecutorTestingKnobs struct {
 	// descriptor IDs at the cost of decreased parallelism.
 	UseTransactionalDescIDGenerator bool
 
-	// BeforeCopyFromInsert, if set, will be called during a COPY FROM insert statement.
-	BeforeCopyFromInsert func(txn *kv.Txn) error
+	// CopyFromInsertBeforeBatch, if set, will be called during a COPY FROM
+	// insert statement before each COPY batch.
+	CopyFromInsertBeforeBatch func(txn *kv.Txn) error
 
-	// CopyFromInsertRetry, if set, will be called when a COPY FROM insert statement is retried.
+	// CopyFromInsertAfterBatch, if set, will be called during a COPY FROM
+	// insert statement after each COPY batch.
+	CopyFromInsertAfterBatch func() error
+
+	// CopyFromInsertRetry, if set, will be called when a COPY FROM insert
+	// statement is retried.
 	CopyFromInsertRetry func() error
 
 	// ForceSQLLivenessSession will force the use of a sqlliveness session for

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5484,6 +5484,7 @@ client_encoding                                            UTF8
 client_min_messages                                        notice
 copy_from_atomic_enabled                                   on
 copy_from_retries_enabled                                  on
+copy_num_retries_per_batch                                 5
 copy_transaction_quality_of_service                        background
 copy_write_pipelining_enabled                              off
 cost_scans_with_default_col_size                           off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2801,6 +2801,7 @@ client_encoding                                            UTF8                N
 client_min_messages                                        notice              NULL      NULL        NULL        string
 copy_from_atomic_enabled                                   on                  NULL      NULL        NULL        string
 copy_from_retries_enabled                                  on                  NULL      NULL        NULL        string
+copy_num_retries_per_batch                                 5                   NULL      NULL        NULL        string
 copy_transaction_quality_of_service                        background          NULL      NULL        NULL        string
 copy_write_pipelining_enabled                              off                 NULL      NULL        NULL        string
 cost_scans_with_default_col_size                           off                 NULL      NULL        NULL        string
@@ -2973,6 +2974,7 @@ client_encoding                                            UTF8                N
 client_min_messages                                        notice              NULL  user     NULL      notice              notice
 copy_from_atomic_enabled                                   on                  NULL  user     NULL      on                  on
 copy_from_retries_enabled                                  on                  NULL  user     NULL      on                  on
+copy_num_retries_per_batch                                 5                   NULL  user     NULL      5                   5
 copy_transaction_quality_of_service                        background          NULL  user     NULL      background          background
 copy_write_pipelining_enabled                              off                 NULL  user     NULL      off                 off
 cost_scans_with_default_col_size                           off                 NULL  user     NULL      off                 off
@@ -3139,6 +3141,7 @@ client_min_messages                                        NULL    NULL     NULL
 copy_fast_path_enabled                                     NULL    NULL     NULL     NULL        NULL
 copy_from_atomic_enabled                                   NULL    NULL     NULL     NULL        NULL
 copy_from_retries_enabled                                  NULL    NULL     NULL     NULL        NULL
+copy_num_retries_per_batch                                 NULL    NULL     NULL     NULL        NULL
 copy_transaction_quality_of_service                        NULL    NULL     NULL     NULL        NULL
 copy_write_pipelining_enabled                              NULL    NULL     NULL     NULL        NULL
 cost_scans_with_default_col_size                           NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -39,6 +39,7 @@ client_encoding                                            UTF8
 client_min_messages                                        notice
 copy_from_atomic_enabled                                   on
 copy_from_retries_enabled                                  on
+copy_num_retries_per_batch                                 5
 copy_transaction_quality_of_service                        background
 copy_write_pipelining_enabled                              off
 cost_scans_with_default_col_size                           off

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -472,6 +472,9 @@ message LocalOnlySessionData {
   // CopyWritePipeliningEnabled indicates whether the write pipelining is
   // enabled for implicit txns used by COPY.
   bool copy_write_pipelining_enabled = 118;
+  // CopyNumRetriesPerBatch determines the number of times a single batch of
+  // rows can be retried for non-atomic COPY.
+  int32 copy_num_retries_per_batch = 120;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2275,6 +2275,33 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`copy_num_retries_per_batch`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`copy_num_retries_per_batch`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return err
+			}
+			if b <= 0 {
+				return pgerror.Newf(pgcode.InvalidParameterValue,
+					"copy_num_retries_per_batch must be a positive value: %d", b)
+			}
+			if b > math.MaxInt32 {
+				return pgerror.Newf(pgcode.InvalidParameterValue,
+					"cannot set copy_num_retries_per_batch to a value greater than %d: %d", math.MaxInt32, b)
+			}
+			m.SetCopyNumRetriesPerBatch(int32(b))
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return strconv.FormatInt(int64(evalCtx.SessionData().CopyNumRetriesPerBatch), 10), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return "5"
+		},
+	},
+
+	// CockroachDB extension.
 	`opt_split_scan_limit`: {
 		GetStringVal: makeIntGetStringValFn(`opt_split_scan_limit`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {


### PR DESCRIPTION
Backport 3/3 commits from #116512.

/cc @cockroachdb/release

---

This commit audits the behavior of non-atomic COPY. As a reminder, in such a setup we create a separate txn for each batch of rows, and the responsibility of committing these txns lies with the COPY state machine. To further complicate the story, we have a retry loop around each batch of rows, where we give each batch up to 5 times to be processed in case it is hitting retryable errors.

One problem that this commit addresses is how we reset the buffered data. Previously, we would do the reset right after executing the INSERT pipeline. In some cases, that pipeline results in the txn being auto committed, so we're good then; however, if the INSERTs cannot auto commit, then it is possible that we will fail to commit the txn in the COPY state machine, but by that point we will have reset the buffered data, effectively silently losing it. On the second retry attempt for this batch we'd have zero rows to insert, so in absence of other problems, we could end up proceeding with the COPY without inserting some of the data. This commit addresses this scenario by resetting the buffered state only after we know that the INSERTs have been committed.

However, I believe previously it wouldn't be possible to hit this silent data loss scenario because of a second issue this commit addresses. In particular, when the COPY state machine fails to commit its txn, it attempts to roll it back, and previously, regardless of whether the rollback succeeded or not, we would always short-circuit execution of the `cleanup` function returned by `preparePlannerForCopy` so that we'd end up keeping the same txn, that is in finalized state and couldn't be used anymore. Thus, on the next retry attempt we'd always get a non-retrible error failing the COPY overall. This commit addresses this issue by not short-circuiting the execution of that deferred method which creates a fresh txn for the next retry attempt.

It also now makes it so that if a txn rollback fails, then that non-retriable error is returned to the client, failing the COPY. This seems like a sane thing to me because at that point we're kind of in an undefined state. However, I could also see a benefit of proceeding still since we're in non-atomic COPY scenario and perhaps the user wants COPY to succeed even if it results in somewhat corrupted inserted data.

Kudos to Nathan for identifying these two problems.

As an additional minor change it fixes the number of inserted rows that could previously be inflated in case non-atomic COPY had internal retries (although, again, due to the second issue described above, this was hidden).

Epic: None

Release note (bug fix): CockroachDB can now retry more retryable errors transparently when performing non-atomic COPY command.

Release justification: bug fix.