### PR TITLE
testcluster: re-enable tenant in multi-node clusters under race

### DIFF
--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -85,7 +85,7 @@ var PreventStartTenantError = errors.New("attempting to manually start a virtual
 // directly so that it only gets linked into test code (and to avoid a linter
 // error that 'skip' must only be used in test code).
 func ShouldStartDefaultTestTenant(
-	t TestLogger, baseArg base.DefaultTestTenantOptions, multiNodeCluster bool,
+	t TestLogger, baseArg base.DefaultTestTenantOptions,
 ) (retval base.DefaultTestTenantOptions) {
 	// Explicit case for disabling the default test tenant.
 	if baseArg.TestTenantAlwaysDisabled() {
@@ -147,17 +147,6 @@ func ShouldStartDefaultTestTenant(
 			t.Log(defaultTestTenantMessage(shared) + "\n(override via TestingSetDefaultTenantSelectionOverride)")
 		}
 		return override
-	}
-
-	if multiNodeCluster && util.RaceEnabled {
-		// Race builds now run in the EngFlow environment which seems to be
-		// often overloaded if we have multi-node clusters and start a default
-		// test tenant, so we disable the tenant randomization in such a
-		// scenario.
-		if t != nil {
-			t.Log("cluster virtualization disabled under race")
-		}
-		return base.InternalNonDefaultDecision(baseArg, false /* enable */, false /* shared */)
 	}
 
 	// Note: we ask the metamorphic framework for a "disable" value, instead
@@ -269,9 +258,7 @@ func StartServerOnlyE(t TestLogger, params base.TestServerArgs) (TestServerInter
 	allowAdditionalTenants := params.DefaultTestTenant.AllowAdditionalTenants()
 	// Update the flags with the actual decision as to whether we should
 	// start the service for a default test tenant.
-	params.DefaultTestTenant = ShouldStartDefaultTestTenant(
-		t, params.DefaultTestTenant, false, /* multiNodeCluster */
-	)
+	params.DefaultTestTenant = ShouldStartDefaultTestTenant(t, params.DefaultTestTenant)
 
 	s, err := NewServer(params)
 	if err != nil {

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -294,9 +294,7 @@ func NewTestCluster(
 				args.DefaultTestTenant, defaultTestTenantOptions)
 		}
 	}
-	tc.defaultTestTenantOptions = serverutils.ShouldStartDefaultTestTenant(
-		t, defaultTestTenantOptions, nodes > 1, /* multiNodeCluster */
-	)
+	tc.defaultTestTenantOptions = serverutils.ShouldStartDefaultTestTenant(t, defaultTestTenantOptions)
 
 	var firstListener net.Listener
 	for i := 0; i < nodes; i++ {


### PR DESCRIPTION
This commit is a partial revert of adfc98a5e8f987001eb2858268fc74642d8cb8a7. In that commit we disabled tenant randomization in multi-node-clusters under race because EngFlow executors were too overloaded in such a setup. We now use beefier executors, so let's see how they fare.

Epic: None

Release note: None