### PR TITLE
importer: unskip TestImportWorkerFailure in some configs

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -5321,9 +5321,8 @@ func TestImportWorkerFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStressWithIssue(t, 108547, "flaky test")
-	skip.UnderDeadlockWithIssue(t, 108547, "flaky test")
-	skip.UnderRaceWithIssue(t, 108547, "flaky test")
+	skip.UnderDeadlock(t, "test is flaky under deadlock")
+	skip.UnderStressRace(t, "test is flaky under stressrace")
 
 	allowResponse := make(chan struct{})
 	params := base.TestClusterArgs{}


### PR DESCRIPTION
This commit unskips `TestImportWorkerFailure` under stress and race, but not under deadlock nor stressrace configs. Previously this test was somewhat flaky, but as of 14ef3c034f1ebd9b8a36adfc5b2b6fc144a0d369 we relaxed the passing criteria, so it shouldn't be flaky anymore.

The following runs succeeded on the gceworker:
```
./dev test pkg/sql/importer -f=TestImportWorkerFailure --stress -v --cpus=48
./dev test pkg/sql/importer -f=TestImportWorkerFailure --stress -v --race --cpus=4
```
This run didn't succeed:
```
./dev test pkg/sql/importer -f=TestImportWorkerFailure --deadlock --count=100 -v
```
but it doesn't seem that important to run this test under deadlock.

Fixes: #107456.

Release note: None