### PR TITLE
sql,plpgsql: add setting to give cursors default WITH HOLD behavior

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cursor
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cursor
@@ -1923,3 +1923,133 @@ CREATE OR REPLACE FUNCTION f(curs STRING) RETURNS INT AS $$
     RETURN 0;
   END
 $$ LANGUAGE PLpgSQL;
+
+subtest hold_setting
+
+# Test the open_plpgsql_cursor_with_hold setting, which causes PL/pgSQL cursors
+# to remain open after their transaction closes.
+statement ok
+CREATE PROCEDURE make_curs(curs REFCURSOR) AS $$
+  BEGIN
+    OPEN curs FOR SELECT 1, 2;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# The cursors should be closed when the implicit transaction closes.
+statement ok
+CALL make_curs('foo');
+CALL make_curs('bar');
+
+query T
+SELECT name FROM pg_cursors;
+----
+
+# The cursors should be visible within the explicit transcation.
+statement ok
+BEGIN;
+CALL make_curs('foo');
+CALL make_curs('bar');
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+foo
+bar
+
+# The cursors should be closed when the explicit transaction commits.
+statement ok
+COMMIT;
+
+query T
+SELECT name FROM pg_cursors;
+----
+
+# The cursors should still be visible even through they were opened within
+# implicit transactions.
+statement ok
+SET close_cursors_at_commit = false;
+CALL make_curs('foo');
+CALL make_curs('bar');
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+foo
+bar
+
+query II
+FETCH FROM foo;
+----
+1  2
+
+# A CLOSE statement should still close the open cursors.
+statement ok
+CLOSE ALL;
+
+query T
+SELECT name FROM pg_cursors;
+----
+
+# Cursors should remain open after the explicit transaction commits.
+statement ok
+BEGIN;
+CALL make_curs('foo');
+CALL make_curs('bar');
+COMMIT;
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+foo
+bar
+
+query II
+FETCH FROM bar;
+----
+1  2
+
+statement ok
+CLOSE ALL;
+
+# Cursors should be rolled back if opened in a transaction that is rolled back.
+statement ok
+BEGIN;
+CALL make_curs('foo');
+CALL make_curs('bar');
+ROLLBACK;
+
+query T
+SELECT name FROM pg_cursors;
+----
+
+# A preexisting cursor should not be rolled back when a transaction aborts.
+statement ok
+CALL make_curs('foo');
+
+statement ok
+BEGIN;
+CALL make_curs('bar');
+ROLLBACK;
+
+query T
+SELECT name FROM pg_cursors;
+----
+foo
+
+query II
+FETCH FROM foo;
+----
+1  2
+
+# The preexisting cursor should still be closed by CLOSE ALL.
+statement ok
+CLOSE ALL;
+
+query T
+SELECT name FROM pg_cursors;
+----
+
+statement ok
+RESET close_cursors_at_commit;
+
+subtest end

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -77,6 +77,34 @@ func (c *rowContainerHelper) InitWithDedup(
 	c.scratch = make(rowenc.EncDatumRow, len(typs))
 }
 
+// InitWithParentMon is a variant of Init that allows the parent memory monitor
+// to be specified. This is useful when the container should not be owned by the
+// current transaction (e.g. a SQL cursor that lives on the session).
+func (c *rowContainerHelper) InitWithParentMon(
+	ctx context.Context,
+	typs []*types.T,
+	parent *mon.BytesMonitor,
+	evalContext *extendedEvalContext,
+	opName redact.RedactableString,
+) {
+	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
+	// TODO(yuzefovich): currently the memory usage of c.memMonitor doesn't
+	// count against sql.mem.distsql.current metric. Fix it.
+	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
+		ctx, parent, distSQLCfg, evalContext.SessionData(),
+		redact.Sprintf("%s-limited", opName),
+	)
+	c.diskMonitor = execinfra.NewMonitor(
+		ctx, distSQLCfg.ParentDiskMonitor, redact.Sprintf("%s-disk", opName),
+	)
+	c.rows = &rowcontainer.DiskBackedRowContainer{}
+	c.rows.Init(
+		colinfo.NoOrdering, typs, &evalContext.Context,
+		distSQLCfg.TempStorage, c.memMonitor, c.diskMonitor,
+	)
+	c.scratch = make(rowenc.EncDatumRow, len(typs))
+}
+
 func (c *rowContainerHelper) initMonitors(
 	ctx context.Context, evalContext *extendedEvalContext, opName redact.RedactableString,
 ) {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1219,7 +1219,7 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 	ex.extraTxnState.prepStmtsNamespaceAtTxnRewindPos.closeAllPortals(
 		ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc,
 	)
-	if err := ex.extraTxnState.sqlCursors.closeAll(false /* errorOnWithHold */); err != nil {
+	if err := ex.extraTxnState.sqlCursors.closeAll(cursorCloseForExplicitClose); err != nil {
 		log.Warningf(ctx, "error closing cursors: %v", err)
 	}
 
@@ -1464,10 +1464,12 @@ type connExecutor struct {
 		// connExecutor's closure.
 		prepStmtsNamespaceMemAcc mon.BoundAccount
 
-		// sqlCursors contains the list of SQL CURSORs the session currently has
+		// sqlCursors contains the list of SQL cursors the session currently has
 		// access to.
-		// Cursors are bound to an explicit transaction and they're all destroyed
-		// once the transaction finishes.
+		//
+		// Cursors declared WITH HOLD belong to the session, and can outlive their
+		// parent transaction. Otherwise, cursors are bound to their transaction,
+		// and are destroyed when the transaction finishes.
 		sqlCursors cursorMap
 
 		// shouldExecuteOnTxnFinish indicates that ex.onTxnFinish will be called
@@ -2000,8 +2002,12 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent, pay
 		ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc,
 	)
 
-	// Close all cursors.
-	if err := ex.extraTxnState.sqlCursors.closeAll(false /* errorOnWithHold */); err != nil {
+	// Close all (non HOLD) cursors.
+	closeReason := cursorCloseForTxnCommit
+	if ev.eventType != txnCommit {
+		closeReason = cursorCloseForTxnRollback
+	}
+	if err := ex.extraTxnState.sqlCursors.closeAll(closeReason); err != nil {
 		log.Warningf(ctx, "error closing cursors: %v", err)
 	}
 
@@ -2465,7 +2471,7 @@ func (ex *connExecutor) execCmd() (retErr error) {
 			// txnState.finishSQLTxn() is being called, as the underlying resources of
 			// pausable portals hasn't been cleared yet.
 			ex.extraTxnState.prepStmtsNamespace.closeAllPausablePortals(ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc)
-			if err := ex.extraTxnState.sqlCursors.closeAll(false /* errorOnWithHold */); err != nil {
+			if err := ex.extraTxnState.sqlCursors.closeAll(cursorCloseForTxnRollback); err != nil {
 				log.Warningf(ctx, "error closing cursors: %v", err)
 			}
 		}
@@ -3709,7 +3715,7 @@ func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
 func (ex *connExecutor) resetPlanner(
 	ctx context.Context, p *planner, txn *kv.Txn, stmtTS time.Time,
 ) {
-	p.resetPlanner(ctx, txn, stmtTS, ex.sessionData(), ex.state.mon)
+	p.resetPlanner(ctx, txn, stmtTS, ex.sessionData(), ex.state.mon, ex.sessionMon)
 	autoRetryReason := ex.state.mu.autoRetryReason
 	// If we are retrying due to an unsatisfiable timestamp bound which is
 	// retriable, it means we were unable to serve the previous minimum timestamp

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1472,7 +1472,7 @@ func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) (retEr
 		ex.recordDDLTxnTelemetry(failed)
 	}()
 
-	if err := ex.extraTxnState.sqlCursors.closeAll(true /* errorOnWithHold */); err != nil {
+	if err := ex.extraTxnState.sqlCursors.closeAll(cursorCloseForTxnCommit); err != nil {
 		return err
 	}
 
@@ -1599,7 +1599,7 @@ func (ex *connExecutor) createJobs(ctx context.Context) error {
 func (ex *connExecutor) rollbackSQLTransaction(
 	ctx context.Context, stmt tree.Statement,
 ) (fsm.Event, fsm.EventPayload) {
-	if err := ex.extraTxnState.sqlCursors.closeAll(false /* errorOnWithHold */); err != nil {
+	if err := ex.extraTxnState.sqlCursors.closeAll(cursorCloseForTxnRollback); err != nil {
 		return ex.makeErrEvent(err, stmt)
 	}
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3711,6 +3711,10 @@ func (m *sessionDataMutator) SetDistSQLPlanGatewayBias(val int64) {
 	m.data.DistsqlPlanGatewayBias = val
 }
 
+func (m *sessionDataMutator) SetCloseCursorsAtCommit(val bool) {
+	m.data.CloseCursorsAtCommit = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5487,6 +5487,7 @@ bytea_output                                               hex
 check_function_bodies                                      on
 client_encoding                                            UTF8
 client_min_messages                                        notice
+close_cursors_at_commit                                    on
 copy_from_atomic_enabled                                   on
 copy_from_retries_enabled                                  on
 copy_num_retries_per_batch                                 5

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2800,6 +2800,7 @@ bytea_output                                               hex                 N
 check_function_bodies                                      on                  NULL      NULL        NULL        string
 client_encoding                                            UTF8                NULL      NULL        NULL        string
 client_min_messages                                        notice              NULL      NULL        NULL        string
+close_cursors_at_commit                                    on                  NULL      NULL        NULL        string
 copy_from_atomic_enabled                                   on                  NULL      NULL        NULL        string
 copy_from_retries_enabled                                  on                  NULL      NULL        NULL        string
 copy_num_retries_per_batch                                 5                   NULL      NULL        NULL        string
@@ -2975,6 +2976,7 @@ bytea_output                                               hex                 N
 check_function_bodies                                      on                  NULL  user     NULL      on                  on
 client_encoding                                            UTF8                NULL  user     NULL      UTF8                UTF8
 client_min_messages                                        notice              NULL  user     NULL      notice              notice
+close_cursors_at_commit                                    on                  NULL  user     NULL      on                  on
 copy_from_atomic_enabled                                   on                  NULL  user     NULL      on                  on
 copy_from_retries_enabled                                  on                  NULL  user     NULL      on                  on
 copy_num_retries_per_batch                                 5                   NULL  user     NULL      5                   5
@@ -3143,6 +3145,7 @@ bytea_output                                               NULL    NULL     NULL
 check_function_bodies                                      NULL    NULL     NULL     NULL        NULL
 client_encoding                                            NULL    NULL     NULL     NULL        NULL
 client_min_messages                                        NULL    NULL     NULL     NULL        NULL
+close_cursors_at_commit                                    NULL    NULL     NULL     NULL        NULL
 copy_fast_path_enabled                                     NULL    NULL     NULL     NULL        NULL
 copy_from_atomic_enabled                                   NULL    NULL     NULL     NULL        NULL
 copy_from_retries_enabled                                  NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -38,6 +38,7 @@ bytea_output                                               hex
 check_function_bodies                                      on
 client_encoding                                            UTF8
 client_min_messages                                        notice
+close_cursors_at_commit                                    on
 copy_from_atomic_enabled                                   on
 copy_from_retries_enabled                                  on
 copy_num_retries_per_batch                                 5

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -4193,12 +4193,12 @@ https://www.postgresql.org/docs/14/view-pg-cursors.html`,
 				return err
 			}
 			if err := addRow(
-				tree.NewDString(string(name)), /* name */
-				tree.NewDString(c.statement),  /* statement */
-				tree.DBoolFalse,               /* is_holdable */
-				tree.DBoolFalse,               /* is_binary */
-				tree.DBoolFalse,               /* is_scrollable */
-				tz,                            /* creation_date */
+				tree.NewDString(string(name)),          /* name */
+				tree.NewDString(c.statement),           /* statement */
+				tree.MakeDBool(tree.DBool(c.withHold)), /* is_holdable */
+				tree.DBoolFalse,                        /* is_binary */
+				tree.DBoolFalse,                        /* is_scrollable */
+				tz,                                     /* creation_date */
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -485,6 +485,9 @@ message LocalOnlySessionData {
   // in the transaction block will instead be executed in their own
   // implicit transaction.
   bool autocommit_before_ddl = 121 [(gogoproto.customname) = "AutoCommitBeforeDDL"];
+  // CloseCursorsAtCommit determines whether cursors remain open after their
+  // parent transaction closes.
+  bool close_cursors_at_commit = 122;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -285,7 +285,7 @@ func (p *planner) CloseCursor(ctx context.Context, n *tree.CloseCursor) (planNod
 		name: n.String(),
 		constructor: func(ctx context.Context, p *planner) (planNode, error) {
 			if n.All {
-				return newZeroNode(nil /* columns */), p.sqlCursors.closeAll(false /* errorOnWithHold */)
+				return newZeroNode(nil /* columns */), p.sqlCursors.closeAll(cursorCloseForExplicitClose)
 			}
 			return newZeroNode(nil /* columns */), p.sqlCursors.closeCursor(n.Name)
 		},
@@ -344,8 +344,14 @@ type sqlCursor struct {
 	withHold   bool
 	// eagerExecution indicates that the cursor's query was executed eagerly and
 	// stored in a row container. If true, there is no need to set the transaction
-	// sequence number, since the query is no longer active.
+	// sequence number, since the query is no longer active. In addition, the
+	// cursor need not be closed when its parent transaction closes.
 	eagerExecution bool
+	// committed is set when the transaction that created the cursor has
+	// successfully committed. It is only used for cursors declared using
+	// WITH HOLD. It is used to ensure that aborting a transaction only closes
+	// cursors that were opened by that transaction.
+	committed bool
 }
 
 // Next implements the Rows interface.
@@ -359,10 +365,17 @@ func (s *sqlCursor) Next(ctx context.Context) (bool, error) {
 
 // sqlCursors contains a set of active cursors for a session.
 type sqlCursors interface {
-	// closeAll closes all cursors in the set. If any of the cursors were
-	// created WITH HOLD, and the errorOnWithHold flag is true, an error is
-	// returned.
-	closeAll(errorOnWithHold bool) error
+	// closeAll closes cursors in the set according to the following rules:
+	//   * If the reason for closing is txn commit, non-HOLD cursors are closed.
+	//   * If the reason for closing is txn rollback, all cursors created by the
+	//     current transaction are closed.
+	//   * If the reason for closing is an explicit CLOSE ALL or the session
+	//     closing, all cursors are closed unconditionally.
+	//
+	// NOTE: a SQL cursor declared WITH HOLD will currently result in an
+	// "unimplemented" error if the reason for closing is txn commit, since
+	// WITH HOLD is not yet implemented for SQL cursors.
+	closeAll(reason cursorCloseReason) error
 	// closeCursor closes the named cursor, returning an error if that cursor
 	// didn't exist in the set.
 	closeCursor(tree.Name) error
@@ -385,7 +398,7 @@ type emptySqlCursors struct{}
 
 var _ sqlCursors = emptySqlCursors{}
 
-func (e emptySqlCursors) closeAll(bool) error {
+func (e emptySqlCursors) closeAll(cursorCloseReason) error {
 	return errors.AssertionFailedf("closeAll not supported in emptySqlCursors")
 }
 
@@ -417,16 +430,44 @@ type cursorMap struct {
 	nameCounter int
 }
 
-func (c *cursorMap) closeAll(errorOnWithHold bool) error {
-	for n, c := range c.cursors {
-		if c.withHold && errorOnWithHold {
-			return unimplemented.NewWithIssuef(77101, "cursor %s WITH HOLD must be closed before committing", n)
+type cursorCloseReason uint8
+
+const (
+	cursorCloseForTxnCommit cursorCloseReason = iota
+	cursorCloseForTxnRollback
+	cursorCloseForExplicitClose
+)
+
+func (c *cursorMap) closeAll(reason cursorCloseReason) error {
+	for n, curs := range c.cursors {
+		switch reason {
+		case cursorCloseForTxnCommit:
+			if curs.withHold {
+				if curs.eagerExecution {
+					// Cursors declared using WITH HOLD are not closed at transaction
+					// commit, and become the responsibility of the session.
+					curs.committed = true
+					continue
+				}
+				return unimplemented.NewWithIssuef(77101, "cursor %s WITH HOLD must be closed before committing", n)
+			}
+		case cursorCloseForTxnRollback:
+			if curs.committed {
+				// Transaction rollback should only remove cursors that were created in
+				// the current transaction.
+				continue
+			}
 		}
-		if err := c.Close(); err != nil {
+		if err := curs.Close(); err != nil {
 			return err
 		}
+		delete(c.cursors, n)
 	}
-	c.cursors = nil
+	if reason == cursorCloseForExplicitClose {
+		// All cursors are closed for explicit close, so we can lose the reference
+		// to the map.
+		c.cursors = nil
+	}
 	return nil
 }
 
@@ -476,8 +517,8 @@ type connExCursorAccessor struct {
 	ex *connExecutor
 }
 
-func (c connExCursorAccessor) closeAll(errorOnWithHold bool) error {
-	return c.ex.extraTxnState.sqlCursors.closeAll(errorOnWithHold)
+func (c connExCursorAccessor) closeAll(reason cursorCloseReason) error {
+	return c.ex.extraTxnState.sqlCursors.closeAll(reason)
 }
 
 func (c connExCursorAccessor) closeCursor(s tree.Name) error {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3214,6 +3214,23 @@ var varGen = map[string]sessionVar{
 			return strconv.FormatInt(2, 10)
 		},
 	},
+
+	// CockroachDB extension.
+	`close_cursors_at_commit`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`close_cursors_at_commit`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar(`close_cursors_at_commit`, s)
+			if err != nil {
+				return err
+			}
+			m.SetCloseCursorsAtCommit(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().CloseCursorsAtCommit), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
This patch introduces a new setting, `close_cursors_at_commit`, which causes cursors opened using a PL/pgSQL OPEN statement to remain open once the calling transaction commits. This is similar to oracle behavior, and will be useful for enabling migrations.

As part of this change, the `sqlCursors.closeAll` method has been expanded to take in the reason for closing as a parameter. It now uses the following rules:
* If the reason for closing is txn commit, non-HOLD cursors are closed.
* If the reason for closing is txn rollback, all cursors created by the current transaction are closed.
* If the reason for closing is an explicit CLOSE ALL or the session closing, all cursors are closed unconditionally.

Note that the behavior has not changed for SQL cursors - if a SQL cursor is declared using `WITH HOLD` and is open at txn commit, an error will result.

Informs #77101

Release note (sql change): Introduced a new setting, `close_cursors_at_commit`, which causes a cursor to remain open even after its calling transaction commits. Note that transaction rollback still closes any cursor created in that transaction.