### PR TITLE
sql: fix delimiter of _geometry and _geography types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2027,9 +2027,9 @@ oid     typname                typcategory  typispreferred  typisdefined  typdel
 4096    regrole                N            false           true          ,         0         0        4097
 4097    _regrole               A            false           true          ,         0         4096     0
 90000   geometry               U            false           true          :         0         0        90001
-90001   _geometry              A            false           true          ,         0         90000    0
+90001   _geometry              A            false           true          :         0         90000    0
 90002   geography              U            false           true          :         0         0        90003
-90003   _geography             A            false           true          ,         0         90002    0
+90003   _geography             A            false           true          :         0         90002    0
 90004   box2d                  U            false           true          ,         0         0        90005
 90005   _box2d                 A            false           true          ,         0         90004    0
 100110  t1                     C            false           true          ,         110       0        0

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -3006,6 +3006,11 @@ func (t *T) Delimiter() string {
 	switch t.Family() {
 	case Geometry.Family(), Geography.Family():
 		return ":"
+	case ArrayFamily:
+		if t.Oid() == oidext.T__geometry || t.Oid() == oidext.T__geography {
+			return ":"
+		}
+		return ","
 	default:
 		return ","
 	}


### PR DESCRIPTION
This PR fixes the delimiter for the `_geometry` and `_geography` array types, which are `:` in postgres like the other geometry and geography types.

Epic: none

Release note: None