### PR TITLE
storage: add storage.mvcc.target_intent_bytes_per_error (wip)

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -231,6 +231,7 @@ func EvalAddSSTable(
 
 	var statsDelta enginepb.MVCCStats
 	maxLockConflicts := storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
+	maxLockConflictBytes := storage.MaxBytesPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
 	checkConflicts := args.DisallowConflicts || args.DisallowShadowing ||
 		!args.DisallowShadowingBelow.IsEmpty()
 	if checkConflicts {
@@ -266,7 +267,7 @@ func EvalAddSSTable(
 
 		log.VEventf(ctx, 2, "checking conflicts for SSTable [%s,%s)", start.Key, end.Key)
 		statsDelta, err = storage.CheckSSTConflicts(ctx, sst, readWriter, start, end, leftPeekBound, rightPeekBound,
-			args.DisallowShadowing, args.DisallowShadowingBelow, sstTimestamp, maxLockConflicts, usePrefixSeek)
+			args.DisallowShadowing, args.DisallowShadowingBelow, sstTimestamp, maxLockConflicts, maxLockConflictBytes, usePrefixSeek)
 		statsDelta.Add(sstReqStatsDelta)
 		if err != nil {
 			return result.Result{}, errors.Wrap(err, "checking for key collisions")

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -1154,7 +1154,7 @@ func TestEvalAddSSTable(t *testing.T) {
 								kv.RangeKey.Timestamp.WallTime *= 1e9
 								v.MVCCValueHeader.LocalTimestamp.WallTime *= 1e9
 								require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
-									ctx, b, nil, kv.RangeKey.StartKey, kv.RangeKey.EndKey, kv.RangeKey.Timestamp, v.MVCCValueHeader.LocalTimestamp, nil, nil, false, 0, nil))
+									ctx, b, nil, kv.RangeKey.StartKey, kv.RangeKey.EndKey, kv.RangeKey.Timestamp, v.MVCCValueHeader.LocalTimestamp, nil, nil, false, 0, 0,nil))
 							default:
 								t.Fatalf("unknown KV type %T", kv)
 							}

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -117,7 +117,8 @@ func ClearRange(
 	// consider the txn incomplete, uncommitting it and its writes (even those
 	// outside of the cleared range).
 	maxLockConflicts := storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
-	locks, err := storage.ScanLocks(ctx, readWriter, from, to, maxLockConflicts, 0,
+	maxLockConflictBytes := storage.MaxBytesPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
+	locks, err := storage.ScanLocks(ctx, readWriter, from, to, maxLockConflicts, maxLockConflictBytes,
 		storage.BatchEvalReadCategory)
 	if err != nil {
 		return result.Result{}, err

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -146,7 +146,7 @@ func TestCmdClearRange(t *testing.T) {
 				for _, rk := range rangeTombstones {
 					localTS := hlc.ClockTimestamp{WallTime: rk.Timestamp.WallTime - 1e9} // give range key a value if > 0
 					require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
-						ctx, eng, nil, rk.StartKey, rk.EndKey, rk.Timestamp, localTS, nil, nil, false, 0, nil))
+						ctx, eng, nil, rk.StartKey, rk.EndKey, rk.Timestamp, localTS, nil, nil, false, 0, 0, nil))
 				}
 
 				// Write some random point keys within the cleared span, above the range tombstones.

--- a/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
@@ -66,6 +66,7 @@ func ConditionalPut(
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
+		MaxLockConflictBytes:           storage.MaxBytesPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		Category:                       storage.BatchEvalReadCategory,
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_delete.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete.go
@@ -39,6 +39,7 @@ func Delete(
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
+		MaxLockConflictBytes:           storage.MaxBytesPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		Category:                       storage.BatchEvalReadCategory,
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -163,6 +163,8 @@ func evalExport(
 		maxLockConflicts = uint64(m)
 	}
 
+	maxLockConflictBytes := uint64(storage.MaxBytesPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV))
+
 	// Only use resume timestamp if splitting mid key is enabled.
 	resumeKeyTS := hlc.Timestamp{}
 	if args.SplitMidKey {
@@ -181,16 +183,17 @@ func evalExport(
 	for start := args.Key; start != nil; {
 		var destFile bytes.Buffer
 		opts := storage.MVCCExportOptions{
-			StartKey:           storage.MVCCKey{Key: start, Timestamp: resumeKeyTS},
-			EndKey:             args.EndKey,
-			StartTS:            args.StartTime,
-			EndTS:              h.Timestamp,
-			ExportAllRevisions: exportAllRevisions,
-			TargetSize:         targetSize,
-			MaxSize:            maxSize,
-			MaxLockConflicts:   maxLockConflicts,
-			StopMidKey:         args.SplitMidKey,
-			ScanStats:          cArgs.ScanStats,
+			StartKey:             storage.MVCCKey{Key: start, Timestamp: resumeKeyTS},
+			EndKey:               args.EndKey,
+			StartTS:              args.StartTime,
+			EndTS:                h.Timestamp,
+			ExportAllRevisions:   exportAllRevisions,
+			TargetSize:           targetSize,
+			MaxSize:              maxSize,
+			MaxLockConflicts:     maxLockConflicts,
+			MaxLockConflictBytes: maxLockConflictBytes,
+			StopMidKey:           args.SplitMidKey,
+			ScanStats:            cArgs.ScanStats,
 		}
 		var summary kvpb.BulkOpSummary
 		var resumeInfo storage.ExportRequestResumeInfo

--- a/pkg/kv/kvserver/batcheval/cmd_increment.go
+++ b/pkg/kv/kvserver/batcheval/cmd_increment.go
@@ -40,6 +40,7 @@ func Increment(
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
+		MaxLockConflictBytes:           storage.MaxBytesPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		Category:                       storage.BatchEvalReadCategory,
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_init_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_init_put.go
@@ -41,6 +41,7 @@ func InitPut(
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
+		MaxLockConflictBytes:           storage.MaxBytesPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		Category:                       storage.BatchEvalReadCategory,
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_put.go
@@ -62,6 +62,7 @@ func Put(
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
 		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		MaxLockConflicts:               storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
+		MaxLockConflictBytes:           storage.MaxBytesPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		Category:                       storage.BatchEvalReadCategory,
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp_test.go
@@ -58,7 +58,7 @@ func TestQueryResolvedTimestamp(t *testing.T) {
 	}
 	writeLock := func(k string, str lock.Strength) {
 		txn := roachpb.MakeTransaction("test", roachpb.Key(k), 0, 0, makeTS(1), 0, 1, 0, false /* omitInRangefeeds */)
-		err := storage.MVCCAcquireLock(ctx, db, &txn, str, roachpb.Key(k), nil, 0)
+		err := storage.MVCCAcquireLock(ctx, db, &txn, str, roachpb.Key(k), nil, 0, 0)
 		require.NoError(t, err)
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -52,6 +52,7 @@ func ReverseScan(
 		Uncertainty:           cArgs.Uncertainty,
 		MaxKeys:               h.MaxSpanRequestKeys,
 		MaxLockConflicts:      storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
+		MaxLockConflictBytes:  storage.MaxBytesPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetBytes:           h.TargetBytes,
 		AllowEmpty:            h.AllowEmpty,
 		WholeRowsOfSize:       h.WholeRowsOfSize,

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -55,6 +55,7 @@ func Scan(
 		Uncertainty:           cArgs.Uncertainty,
 		MaxKeys:               h.MaxSpanRequestKeys,
 		MaxLockConflicts:      storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
+		MaxLockConflictBytes:  storage.MaxBytesPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetBytes:           h.TargetBytes,
 		AllowEmpty:            h.AllowEmpty,
 		WholeRowsOfSize:       h.WholeRowsOfSize,

--- a/pkg/kv/kvserver/batcheval/intent.go
+++ b/pkg/kv/kvserver/batcheval/intent.go
@@ -177,6 +177,7 @@ func acquireLockOnKey(
 	settings *cluster.Settings,
 ) (roachpb.LockAcquisition, error) {
 	maxLockConflicts := storage.MaxConflictsPerLockConflictError.Get(&settings.SV)
+	maxLockConflictBytes := storage.MaxBytesPerLockConflictError.Get(&settings.SV)
 	switch dur {
 	case lock.Unreplicated:
 		// Evaluation up until this point has only scanned for (and not found any)
@@ -184,7 +185,7 @@ func acquireLockOnKey(
 		// unreplicated locks and contended replicated locks. We haven't considered
 		// conflicts with un-contended replicated locks -- we need to do so before
 		// we can acquire our own unreplicated lock; do so now.
-		err := storage.MVCCCheckForAcquireLock(ctx, readWriter, txn, str, key, maxLockConflicts)
+		err := storage.MVCCCheckForAcquireLock(ctx, readWriter, txn, str, key, maxLockConflicts, maxLockConflictBytes)
 		if err != nil {
 			return roachpb.LockAcquisition{}, err
 		}
@@ -195,7 +196,7 @@ func acquireLockOnKey(
 		// conflicts with un-contended replicated locks -- we need to do so before
 		// we can acquire our own replicated lock; do that now, and also acquire
 		// the replicated lock if no conflicts are found.
-		if err := storage.MVCCAcquireLock(ctx, readWriter, txn, str, key, ms, maxLockConflicts); err != nil {
+		if err := storage.MVCCAcquireLock(ctx, readWriter, txn, str, key, ms, maxLockConflicts, maxLockConflictBytes); err != nil {
 			return roachpb.LockAcquisition{}, err
 		}
 	default:

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -153,9 +153,9 @@ func TestLockAgeThresholdSetting(t *testing.T) {
 		require.NoError(t, err)
 		// Acquire some shared and exclusive locks as well.
 		for _, txn := range []*roachpb.Transaction{&txn1, &txn2} {
-			require.NoError(t, storage.MVCCAcquireLock(ctx, eng, txn, lock.Shared, makeKey(local, lock.Shared), nil, 0))
+			require.NoError(t, storage.MVCCAcquireLock(ctx, eng, txn, lock.Shared, makeKey(local, lock.Shared), nil, 0, 0))
 		}
-		require.NoError(t, storage.MVCCAcquireLock(ctx, eng, &txn1, lock.Exclusive, makeKey(local, lock.Exclusive), nil, 0))
+		require.NoError(t, storage.MVCCAcquireLock(ctx, eng, &txn1, lock.Exclusive, makeKey(local, lock.Exclusive), nil, 0, 0))
 	}
 	require.NoError(t, eng.Flush())
 
@@ -222,9 +222,9 @@ func TestIntentCleanupBatching(t *testing.T) {
 			idx := i*len(objectKeys) + j
 			switch idx % 3 {
 			case 0:
-				require.NoError(t, storage.MVCCAcquireLock(ctx, eng, &txn, lock.Shared, key, nil, 0))
+				require.NoError(t, storage.MVCCAcquireLock(ctx, eng, &txn, lock.Shared, key, nil, 0, 0))
 			case 1:
-				require.NoError(t, storage.MVCCAcquireLock(ctx, eng, &txn, lock.Exclusive, key, nil, 0))
+				require.NoError(t, storage.MVCCAcquireLock(ctx, eng, &txn, lock.Exclusive, key, nil, 0, 0))
 			case 2:
 				_, err := storage.MVCCPut(ctx, eng, key, intentHlc, value, storage.MVCCWriteOptions{Txn: &txn})
 				require.NoError(t, err)

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -316,7 +316,7 @@ func TestInitResolvedTSScan(t *testing.T) {
 			roachpb.MakeLock(&txn1.TxnMeta, roachpb.Key("p"), lock.Exclusive),
 		}
 		for _, l := range testLocks {
-			err := storage.MVCCAcquireLock(ctx, engine, &txn1, l.Strength, l.Key, nil, 0)
+			err := storage.MVCCAcquireLock(ctx, engine, &txn1, l.Strength, l.Key, nil, 0, 0)
 			require.NoError(t, err)
 		}
 		return engine

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -333,7 +333,7 @@ func TestReplicaChecksumSHA512(t *testing.T) {
 	for i, l := range locks {
 		txnID := uuid.FromUint128(uint128.FromInts(0, uint64(l.txnID)))
 		txn := &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{ID: txnID}}
-		require.NoError(t, storage.MVCCAcquireLock(ctx, eng, txn, l.str, roachpb.Key(l.key), nil, 0))
+		require.NoError(t, storage.MVCCAcquireLock(ctx, eng, txn, l.str, roachpb.Key(l.key), nil, 0, 0))
 
 		rd, err = CalcReplicaDigest(ctx, desc, eng, kvpb.ChecksumMode_CHECK_FULL, unlim, nil /* settings */)
 		require.NoError(t, err)

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -314,6 +314,7 @@ func (r *Replica) canDropLatchesBeforeEval(
 	)
 
 	maxLockConflicts := storage.MaxConflictsPerLockConflictError.Get(&r.store.cfg.Settings.SV)
+	maxLockConflictBytes := storage.MaxBytesPerLockConflictError.Get(&r.store.cfg.Settings.SV)
 	var intents []roachpb.Intent
 	// Check if any of the requests within the batch need to resolve any intents
 	// or if any of them need to use an intent interleaving iterator.
@@ -325,7 +326,7 @@ func (r *Replica) canDropLatchesBeforeEval(
 			txnID = ba.Txn.ID
 		}
 		needsIntentInterleavingForThisRequest, err := storage.ScanConflictingIntentsForDroppingLatchesEarly(
-			ctx, rw, txnID, ba.Header.Timestamp, start, end, &intents, maxLockConflicts,
+			ctx, rw, txnID, ba.Header.Timestamp, start, end, &intents, maxLockConflicts, maxLockConflictBytes,
 		)
 		if err != nil {
 			return false /* ok */, true /* stillNeedsIntentInterleaving */, kvpb.NewError(

--- a/pkg/storage/bench_data_test.go
+++ b/pkg/storage/bench_data_test.go
@@ -273,7 +273,7 @@ func (d mvccBenchData) Build(ctx context.Context, b *testing.B, eng Engine) erro
 			startKey := roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(start)))
 			endKey := roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(end)))
 			require.NoError(b, MVCCDeleteRangeUsingTombstone(
-				ctx, batch, nil, startKey, endKey, ts, hlc.ClockTimestamp{}, nil, nil, false, 0, nil))
+				ctx, batch, nil, startKey, endKey, ts, hlc.ClockTimestamp{}, nil, nil, false, 0, 0, nil))
 		}
 		require.NoError(b, batch.Commit(false /* sync */))
 	}

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1251,6 +1251,7 @@ func runMVCCDeleteRangeUsingTombstone(
 				rightPeekBound,
 				false, // idempotent
 				0,
+				0,
 				msCovered,
 			); err != nil {
 				b.Fatal(err)
@@ -1298,6 +1299,7 @@ func runMVCCDeleteRangeWithPredicate(
 				0,
 				math.MaxInt64,
 				rangeTombstoneThreshold,
+				0,
 				0,
 			)
 			b.StopTimer()
@@ -1480,7 +1482,7 @@ func runMVCCGarbageCollect(
 					}
 				}
 				if err := MVCCDeleteRangeUsingTombstone(ctx, batch, nil, startKey, endKey,
-					rts, hlc.ClockTimestamp{}, nil, nil, false, 0, nil); err != nil {
+					rts, hlc.ClockTimestamp{}, nil, nil, false, 0, 0, nil); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -1639,9 +1641,9 @@ func runMVCCAcquireLockCommon(
 				txn = &txn2
 			}
 			// Acquire a shared and an exclusive lock on the key.
-			err := MVCCAcquireLock(ctx, eng, txn, lock.Shared, key, nil, 0)
+			err := MVCCAcquireLock(ctx, eng, txn, lock.Shared, key, nil, 0, 0)
 			require.NoError(b, err)
-			err = MVCCAcquireLock(ctx, eng, txn, lock.Exclusive, key, nil, 0)
+			err = MVCCAcquireLock(ctx, eng, txn, lock.Exclusive, key, nil, 0, 0)
 			require.NoError(b, err)
 		}
 	}
@@ -1661,9 +1663,9 @@ func runMVCCAcquireLockCommon(
 		txn := &txn1
 		var err error
 		if checkFor {
-			err = MVCCCheckForAcquireLock(ctx, rw, txn, strength, key, 0)
+			err = MVCCCheckForAcquireLock(ctx, rw, txn, strength, key, 0, 0)
 		} else {
-			err = MVCCAcquireLock(ctx, rw, txn, strength, key, ms, 0)
+			err = MVCCAcquireLock(ctx, rw, txn, strength, key, ms, 0, 0)
 		}
 		if heldOtherTxn {
 			require.Error(b, err)
@@ -1727,7 +1729,7 @@ func runMVCCExportToSST(b *testing.B, opts mvccExportToSSTOpts) {
 			startKey := mkKey(start)
 			endKey := mkKey(end)
 			require.NoError(b, MVCCDeleteRangeUsingTombstone(
-				ctx, batch, nil, startKey, endKey, ts, hlc.ClockTimestamp{}, nil, nil, false, 0, nil))
+				ctx, batch, nil, startKey, endKey, ts, hlc.ClockTimestamp{}, nil, nil, false, 0, 0, nil))
 		}
 		require.NoError(b, batch.Commit(false /* sync */))
 	}()
@@ -1908,7 +1910,7 @@ func runCheckSSTConflicts(
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := CheckSSTConflicts(context.Background(), sstFile.Data(), eng, sstStart, sstEnd, sstStart.Key, sstEnd.Key.Next(), false, hlc.Timestamp{}, hlc.Timestamp{}, math.MaxInt64, usePrefixSeek)
+		_, err := CheckSSTConflicts(context.Background(), sstFile.Data(), eng, sstStart, sstEnd, sstStart.Key, sstEnd.Key.Next(), false, hlc.Timestamp{}, hlc.Timestamp{}, math.MaxInt64, 0, usePrefixSeek)
 		require.NoError(b, err)
 	}
 }

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1530,9 +1530,9 @@ func TestGetIntent(t *testing.T) {
 	// Key "b" has an intent, an exclusive lock, and a shared lock from txn1.
 	// NOTE: acquire in increasing strength order so that acquisition is never
 	// skipped.
-	err = MVCCAcquireLock(ctx, eng, txn1, lock.Shared, keyB, nil, 0)
+	err = MVCCAcquireLock(ctx, eng, txn1, lock.Shared, keyB, nil, 0, 0)
 	require.NoError(t, err)
-	err = MVCCAcquireLock(ctx, eng, txn1, lock.Exclusive, keyB, nil, 0)
+	err = MVCCAcquireLock(ctx, eng, txn1, lock.Exclusive, keyB, nil, 0, 0)
 	require.NoError(t, err)
 	_, err = MVCCPut(ctx, eng, keyB, txn1.ReadTimestamp, val, MVCCWriteOptions{Txn: txn1})
 	require.NoError(t, err)
@@ -1542,15 +1542,15 @@ func TestGetIntent(t *testing.T) {
 	require.NoError(t, err)
 
 	// Key "d" has an exclusive lock and a shared lock from txn2.
-	err = MVCCAcquireLock(ctx, eng, txn2, lock.Shared, keyD, nil, 0)
+	err = MVCCAcquireLock(ctx, eng, txn2, lock.Shared, keyD, nil, 0, 0)
 	require.NoError(t, err)
-	err = MVCCAcquireLock(ctx, eng, txn2, lock.Exclusive, keyD, nil, 0)
+	err = MVCCAcquireLock(ctx, eng, txn2, lock.Exclusive, keyD, nil, 0, 0)
 	require.NoError(t, err)
 
 	// Key "e" has a shared lock from each txn.
-	err = MVCCAcquireLock(ctx, eng, txn1, lock.Shared, keyE, nil, 0)
+	err = MVCCAcquireLock(ctx, eng, txn1, lock.Shared, keyE, nil, 0, 0)
 	require.NoError(t, err)
-	err = MVCCAcquireLock(ctx, eng, txn2, lock.Shared, keyE, nil, 0)
+	err = MVCCAcquireLock(ctx, eng, txn2, lock.Shared, keyE, nil, 0, 0)
 	require.NoError(t, err)
 
 	// Key "f" has no intent/locks.
@@ -1638,7 +1638,7 @@ func TestScanLocks(t *testing.T) {
 		if str == lock.Intent {
 			_, err = MVCCPut(ctx, eng, roachpb.Key(k), txn1.ReadTimestamp, roachpb.Value{RawBytes: roachpb.Key(k)}, MVCCWriteOptions{Txn: txn1})
 		} else {
-			err = MVCCAcquireLock(ctx, eng, txn1, str, roachpb.Key(k), nil, 0)
+			err = MVCCAcquireLock(ctx, eng, txn1, str, roachpb.Key(k), nil, 0, 0)
 		}
 		require.NoError(t, err)
 	}
@@ -2226,11 +2226,11 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 			setup: func(t *testing.T, rw ReadWriter, _ *roachpb.Transaction) {
 				txnA := newTxn(belowTxnTS)
 				txnB := newTxn(belowTxnTS)
-				err := MVCCAcquireLock(ctx, rw, txnA, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/)
+				err := MVCCAcquireLock(ctx, rw, txnA, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/, 0 /*maxConflictBytes*/)
 				require.NoError(t, err)
-				err = MVCCAcquireLock(ctx, rw, txnB, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/)
+				err = MVCCAcquireLock(ctx, rw, txnB, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/, 0 /*maxConflictBytes*/)
 				require.NoError(t, err)
-				err = MVCCAcquireLock(ctx, rw, txnA, lock.Exclusive, keyB, nil /*ms*/, 0 /*maxConflicts*/)
+				err = MVCCAcquireLock(ctx, rw, txnA, lock.Exclusive, keyB, nil /*ms*/, 0 /*maxConflicts*/, 0 /*maxConflictBytes*/)
 				require.NoError(t, err)
 			},
 			start:                 keyA,
@@ -2244,9 +2244,9 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 			name: "shared and exclusive locks should be ignored no end key",
 			setup: func(t *testing.T, rw ReadWriter, _ *roachpb.Transaction) {
 				txnA := newTxn(belowTxnTS)
-				err := MVCCAcquireLock(ctx, rw, txnA, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/)
+				err := MVCCAcquireLock(ctx, rw, txnA, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/, 0 /*maxConflictBytes*/)
 				require.NoError(t, err)
-				err = MVCCAcquireLock(ctx, rw, txnA, lock.Exclusive, keyA, nil /*ms*/, 0 /*maxConflicts*/)
+				err = MVCCAcquireLock(ctx, rw, txnA, lock.Exclusive, keyA, nil /*ms*/, 0 /*maxConflicts*/, 0 /*maxConflictBytes*/)
 				require.NoError(t, err)
 			},
 			start:                 keyA,
@@ -2259,11 +2259,11 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 			setup: func(t *testing.T, rw ReadWriter, _ *roachpb.Transaction) {
 				txnA := newTxn(belowTxnTS)
 				txnB := newTxn(belowTxnTS)
-				err := MVCCAcquireLock(ctx, rw, txnA, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/)
+				err := MVCCAcquireLock(ctx, rw, txnA, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/, 0 /*maxConflictBytes*/)
 				require.NoError(t, err)
-				err = MVCCAcquireLock(ctx, rw, txnB, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/)
+				err = MVCCAcquireLock(ctx, rw, txnB, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/, 0 /*maxConflictBytes*/)
 				require.NoError(t, err)
-				err = MVCCAcquireLock(ctx, rw, txnA, lock.Exclusive, keyB, nil /*ms*/, 0 /*maxConflicts*/)
+				err = MVCCAcquireLock(ctx, rw, txnA, lock.Exclusive, keyB, nil /*ms*/, 0 /*maxConflicts*/, 0 /*maxConflictBytes*/)
 				require.NoError(t, err)
 				require.NoError(t, err)
 				_, err = MVCCPut(ctx, rw, keyC, txnA.WriteTimestamp, val, MVCCWriteOptions{Txn: txnA})
@@ -2279,11 +2279,11 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 			setup: func(t *testing.T, rw ReadWriter, txn *roachpb.Transaction) {
 				txnA := newTxn(belowTxnTS)
 				txnB := newTxn(belowTxnTS)
-				err := MVCCAcquireLock(ctx, rw, txnA, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/)
+				err := MVCCAcquireLock(ctx, rw, txnA, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/, 0 /*maxConflictBytes*/)
 				require.NoError(t, err)
-				err = MVCCAcquireLock(ctx, rw, txnB, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/)
+				err = MVCCAcquireLock(ctx, rw, txnB, lock.Shared, keyA, nil /*ms*/, 0 /*maxConflicts*/, 0 /*maxConflictBytes*/)
 				require.NoError(t, err)
-				err = MVCCAcquireLock(ctx, rw, txnA, lock.Exclusive, keyB, nil /*ms*/, 0 /*maxConflicts*/)
+				err = MVCCAcquireLock(ctx, rw, txnA, lock.Exclusive, keyB, nil /*ms*/, 0 /*maxConflicts*/, 0 /*maxConflictBytes*/)
 				require.NoError(t, err)
 				_, err = MVCCPut(ctx, rw, keyC, txn.WriteTimestamp, val, MVCCWriteOptions{Txn: txn})
 				require.NoError(t, err)
@@ -2314,6 +2314,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 				tc.end,
 				&intents,
 				0, /* maxLockConflicts */
+				0, /* maxLockConflictBytes */
 			)
 			if tc.expErr != "" {
 				require.Error(t, err)
@@ -2536,6 +2537,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarlyReadYourOwnWrites(t *testi
 				nil,
 				&intents,
 				0, /* maxLockConflicts */
+				0, /* maxLockConflictBytes */
 			)
 			require.NoError(t, err)
 			if alwaysFallbackToIntentInterleavingIteratorForReadYourOwnWrites {

--- a/pkg/storage/lock_table_key_scanner.go
+++ b/pkg/storage/lock_table_key_scanner.go
@@ -13,6 +13,7 @@ package storage
 import (
 	"context"
 	"sync"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -88,11 +89,16 @@ type lockTableKeyScanner struct {
 	// Stop adding conflicting locks and abort scan once the maxConflicts limit
 	// is reached. Ignored if zero.
 	maxConflicts int64
+	// Stop adding conflicting locks and abort scan once the maxConflictBytes limit
+	// is reached via collected intent size. Ignored if zero.
+	maxConflictBytes int64
 
 	// Stores any error returned. If non-nil, iteration short circuits.
 	err error
 	// Stores any locks that conflict with the transaction and locking strength.
 	conflicts []roachpb.Lock
+	// Stores the total byte size of conflicts.
+	conflictBytes int64
 	// Stores any locks that the transaction has already acquired.
 	ownLocks [len(replicatedLockStrengths)]*enginepb.MVCCMetadata
 
@@ -126,6 +132,7 @@ func newLockTableKeyScanner(
 	txn *roachpb.Transaction,
 	str lock.Strength,
 	maxConflicts int64,
+	maxConflictBytes int64,
 	readCategory ReadCategory,
 ) (*lockTableKeyScanner, error) {
 	var txnID uuid.UUID
@@ -149,6 +156,7 @@ func newLockTableKeyScanner(
 	s.iter = iter
 	s.txnID = txnID
 	s.maxConflicts = maxConflicts
+	s.maxConflictBytes = maxConflictBytes
 	return s, nil
 }
 
@@ -172,6 +180,7 @@ func (s *lockTableKeyScanner) scan(key roachpb.Key) error {
 func (s *lockTableKeyScanner) resetScanState() {
 	s.err = nil
 	s.conflicts = nil
+	s.conflictBytes = 0
 	for i := range s.ownLocks {
 		s.ownLocks[i] = nil
 	}
@@ -300,6 +309,11 @@ func (s *lockTableKeyScanner) consumeConflictingLock(
 	ltKey LockTableKey, ltValue *enginepb.MVCCMetadata,
 ) bool {
 	conflict := roachpb.MakeLock(ltValue.Txn, ltKey.Key.Clone(), ltKey.Strength)
+	conflictSize := int64(unsafe.Sizeof(conflict))
+	if s.maxConflictBytes != 0 && s.conflictBytes+conflictSize > s.maxConflictBytes {
+		return false
+	}
+	s.conflictBytes += conflictSize
 	s.conflicts = append(s.conflicts, conflict)
 	if s.maxConflicts != 0 && s.maxConflicts == int64(len(s.conflicts)) {
 		return false

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -282,19 +282,20 @@ func (m mvccInitPutOp) run(ctx context.Context) string {
 }
 
 type mvccCheckForAcquireLockOp struct {
-	m                *metaTestRunner
-	writer           readWriterID
-	key              roachpb.Key
-	txn              txnID
-	strength         lock.Strength
-	maxLockConflicts int
+	m                    *metaTestRunner
+	writer               readWriterID
+	key                  roachpb.Key
+	txn                  txnID
+	strength             lock.Strength
+	maxLockConflicts     int
+	maxLockConflictBytes int64
 }
 
 func (m mvccCheckForAcquireLockOp) run(ctx context.Context) string {
 	txn := m.m.getTxn(m.txn)
 	writer := m.m.getReadWriter(m.writer)
 
-	err := storage.MVCCCheckForAcquireLock(ctx, writer, txn, m.strength, m.key, int64(m.maxLockConflicts))
+	err := storage.MVCCCheckForAcquireLock(ctx, writer, txn, m.strength, m.key, int64(m.maxLockConflicts), m.maxLockConflictBytes)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err)
 	}
@@ -303,19 +304,20 @@ func (m mvccCheckForAcquireLockOp) run(ctx context.Context) string {
 }
 
 type mvccAcquireLockOp struct {
-	m                *metaTestRunner
-	writer           readWriterID
-	key              roachpb.Key
-	txn              txnID
-	strength         lock.Strength
-	maxLockConflicts int
+	m                    *metaTestRunner
+	writer               readWriterID
+	key                  roachpb.Key
+	txn                  txnID
+	strength             lock.Strength
+	maxLockConflicts     int
+	maxLockConflictBytes int64
 }
 
 func (m mvccAcquireLockOp) run(ctx context.Context) string {
 	txn := m.m.getTxn(m.txn)
 	writer := m.m.getReadWriter(m.writer)
 
-	err := storage.MVCCAcquireLock(ctx, writer, txn, m.strength, m.key, nil, int64(m.maxLockConflicts))
+	err := storage.MVCCAcquireLock(ctx, writer, txn, m.strength, m.key, nil, int64(m.maxLockConflicts), m.maxLockConflictBytes)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err)
 	}
@@ -380,7 +382,7 @@ func (m mvccDeleteRangeUsingRangeTombstoneOp) run(ctx context.Context) string {
 	}
 
 	err := storage.MVCCDeleteRangeUsingTombstone(ctx, writer, nil, m.key, m.endKey, m.ts,
-		hlc.ClockTimestamp{}, m.key, m.endKey, false /* idempotent */, math.MaxInt64, /* maxLockConflicts */
+		hlc.ClockTimestamp{}, m.key, m.endKey, false /* idempotent */, math.MaxInt64, 0, /* maxLockConflicts */
 		nil /* msCovered */)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err)

--- a/pkg/storage/mvcc_history_metamorphic_iterator_test.go
+++ b/pkg/storage/mvcc_history_metamorphic_iterator_test.go
@@ -423,6 +423,6 @@ func (m *metamorphicMVCCIncrementalIterator) NextKeyIgnoringTime() {
 	m.moveAround()
 }
 
-func (m *metamorphicMVCCIncrementalIterator) TryGetIntentError() error {
-	return m.it.(*storage.MVCCIncrementalIterator).TryGetIntentError()
+func (m *metamorphicMVCCIncrementalIterator) TryGetIntentError(maxTotalIntentSize uint64) error {
+	return m.it.(*storage.MVCCIncrementalIterator).TryGetIntentError(maxTotalIntentSize)
 }

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -13,6 +13,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -783,11 +784,27 @@ func (i *MVCCIncrementalIterator) NumCollectedIntents() int {
 // TryGetIntentError returns kvpb.LockConflictError if intents were encountered
 // during iteration and intent aggregation is enabled. Otherwise function
 // returns nil. kvpb.LockConflictError will contain all encountered intents.
-// TODO(nvanbenschoten): rename to TryGetLockConflictError.
-func (i *MVCCIncrementalIterator) TryGetIntentError() error {
+// TODO(nvanbenschoten): rename to TryGetIntentError.
+func (i *MVCCIncrementalIterator) TryGetIntentError(intentSizeLimit uint64) error {
 	if len(i.intents) == 0 {
 		return nil
 	}
+
+	if intentSizeLimit > 0 {
+		totalSize := uint64(0)
+		idx := 0
+		for idx = range i.intents {
+			intentSize := uint64(unsafe.Sizeof(i.intents[idx]))
+			if totalSize + intentSize > intentSizeLimit {
+				break
+			}
+			totalSize += intentSize
+		}
+		return &kvpb.LockConflictError{
+			Locks: roachpb.AsLocks(i.intents[:idx]),
+		}
+	}
+
 	return &kvpb.LockConflictError{
 		Locks: roachpb.AsLocks(i.intents),
 	}

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -168,7 +168,7 @@ func assertExpectErrs(
 	if iter.NumCollectedIntents() != len(expectedIntents) {
 		t.Fatalf("Expected %d intents but found %d", len(expectedIntents), iter.NumCollectedIntents())
 	}
-	err = iter.TryGetIntentError()
+	err = iter.TryGetIntentError(0)
 	if lcErr := (*kvpb.LockConflictError)(nil); errors.As(err, &lcErr) {
 		for i := range expectedIntents {
 			if !expectedIntents[i].Key.Equal(lcErr.Locks[i].Key) {

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -2019,20 +2019,22 @@ func TestMVCCStatsRandomized(t *testing.T) {
 			desc = fmt.Sprintf("mvccDeleteRangeUsingTombstone=%s",
 				roachpb.Span{Key: mvccRangeDelKey, EndKey: mvccRangeDelEndKey})
 			const idempotent = false
-			const maxLockConflicts = 0 // unlimited
+			const maxLockConflicts = 0     // unlimited
+			const maxLockConflictBytes = 0 // unlimited
 			msCovered := (*enginepb.MVCCStats)(nil)
 			err = MVCCDeleteRangeUsingTombstone(
 				ctx, s.batch, s.MSDelta, mvccRangeDelKey, mvccRangeDelEndKey, ts, hlc.ClockTimestamp{}, nil, /* leftPeekBound */
-				nil /* rightPeekBound */, idempotent, maxLockConflicts, msCovered,
+				nil /* rightPeekBound */, idempotent, maxLockConflicts, maxLockConflictBytes, msCovered,
 			)
 		} else {
 			rangeTombstoneThreshold := s.rng.Int63n(5)
 			desc = fmt.Sprintf("mvccPredicateDeleteRange=%s, predicates=%s, rangeTombstoneThreshold=%d",
 				roachpb.Span{Key: mvccRangeDelKey, EndKey: mvccRangeDelEndKey}, predicates, rangeTombstoneThreshold)
-			const maxLockConflicts = 0 // unlimited
+			const maxLockConflicts = 0     // unlimited
+			const maxLockConflictBytes = 0 // returned conflicting intents are unlimited in terms of total bytes
 			_, err = MVCCPredicateDeleteRange(ctx, s.batch, s.MSDelta, mvccRangeDelKey, mvccRangeDelEndKey,
 				ts, hlc.ClockTimestamp{}, nil /* leftPeekBound */, nil, /* rightPeekBound */
-				predicates, 0, 0, rangeTombstoneThreshold, maxLockConflicts)
+				predicates, 0, 0, rangeTombstoneThreshold, maxLockConflicts, maxLockConflictBytes)
 		}
 		if err != nil {
 			return false, desc + ": " + err.Error()
@@ -2078,7 +2080,7 @@ func TestMVCCStatsRandomized(t *testing.T) {
 		if s.rng.Intn(2) != 0 {
 			str = lock.Exclusive
 		}
-		if err := MVCCAcquireLock(ctx, s.batch, s.Txn, str, s.key, s.MSDelta, 0); err != nil {
+		if err := MVCCAcquireLock(ctx, s.batch, s.Txn, str, s.key, s.MSDelta, 0, 0); err != nil {
 			return false, err.Error()
 		}
 		return true, ""

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -4885,15 +4885,15 @@ func TestMVCCGarbageCollect(t *testing.T) {
 		}
 	}
 	if err := MVCCDeleteRangeUsingTombstone(ctx, engine, ms, roachpb.Key("r"),
-		roachpb.Key("r-del").Next(), ts3, hlc.ClockTimestamp{}, nil, nil, false, 0, nil); err != nil {
+		roachpb.Key("r-del").Next(), ts3, hlc.ClockTimestamp{}, nil, nil, false, 0, 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := MVCCDeleteRangeUsingTombstone(ctx, engine, ms, roachpb.Key("t"),
-		roachpb.Key("u").Next(), ts2, hlc.ClockTimestamp{}, nil, nil, false, 0, nil); err != nil {
+		roachpb.Key("u").Next(), ts2, hlc.ClockTimestamp{}, nil, nil, false, 0, 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := MVCCDeleteRangeUsingTombstone(ctx, engine, ms, roachpb.Key("t"),
-		roachpb.Key("u").Next(), ts3, hlc.ClockTimestamp{}, nil, nil, false, 0, nil); err != nil {
+		roachpb.Key("u").Next(), ts3, hlc.ClockTimestamp{}, nil, nil, false, 0, 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	if log.V(1) {
@@ -5306,7 +5306,7 @@ func (d rangeTestData) populateEngine(
 			ts = v.point.Key.Timestamp
 		} else {
 			require.NoError(t, MVCCDeleteRangeUsingTombstone(ctx, engine, ms, v.rangeTombstone.StartKey,
-				v.rangeTombstone.EndKey, v.rangeTombstone.Timestamp, hlc.ClockTimestamp{}, nil, nil, false, 0, nil),
+				v.rangeTombstone.EndKey, v.rangeTombstone.Timestamp, hlc.ClockTimestamp{}, nil, nil, false, 0, 0, nil),
 				"failed to insert range tombstone into engine (%s)", v.rangeTombstone.String())
 			ts = v.rangeTombstone.Timestamp
 		}

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -119,7 +119,7 @@ func CheckSSTConflicts(
 	disallowShadowing bool,
 	disallowShadowingBelow hlc.Timestamp,
 	sstTimestamp hlc.Timestamp,
-	maxLockConflicts int64,
+	maxLockConflicts, maxLockConflictBytes int64,
 	usePrefixSeek bool,
 ) (enginepb.MVCCStats, error) {
 
@@ -170,7 +170,7 @@ func CheckSSTConflicts(
 
 	// Check for any overlapping locks, and return them to be resolved.
 	if locks, err := ScanLocks(
-		ctx, reader, start.Key, end.Key, maxLockConflicts, 0, BatchEvalReadCategory); err != nil {
+		ctx, reader, start.Key, end.Key, maxLockConflicts, maxLockConflictBytes, BatchEvalReadCategory); err != nil {
 		return enginepb.MVCCStats{}, err
 	} else if len(locks) > 0 {
 		return enginepb.MVCCStats{}, &kvpb.LockConflictError{Locks: locks}


### PR DESCRIPTION
This commit adds new storage setting storage.mvcc.target_intent_bytes_per_error which limits the total size of intents returned in lock conflict error. This new constraint limit memory consumption of large intents. The default value for target_intent_bytes_per_error is 8mb.

Fixes: https://github.com/cockroachdb/cockroach/issues/77270

Release note: None