### PR TITLE
kvserver: add span for execution of some batches

### DIFF
--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -350,6 +350,12 @@ func (ba *BatchRequest) IsSingleExportRequest() bool {
 	return ba.isSingleRequestWithMethod(Export)
 }
 
+// IsSingleAddSSTableRequest returns true iff the batch contains a single
+// request, and that request is an ExportRequest.
+func (ba *BatchRequest) IsSingleAddSSTableRequest() bool {
+	return ba.isSingleRequestWithMethod(AddSSTable)
+}
+
 // RequiresConsensus returns true iff the batch contains a request that should
 // always force replication and proposal through raft, even if evaluation is
 // a no-op. The Barrier request requires consensus even though its evaluation

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -140,7 +140,7 @@ func EvalAddSSTable(
 
 	var span *tracing.Span
 	var err error
-	ctx, span = tracing.ChildSpan(ctx, "AddSSTable")
+	ctx, span = tracing.ChildSpan(ctx, "EvalAddSSTable")
 	defer span.Finish()
 	log.Eventf(ctx, "evaluating AddSSTable [%s,%s)", start.Key, end.Key)
 


### PR DESCRIPTION
The spans in Eval only capture the evaluation time, but this misses
the proposal time and then the time spent waiting for application of
 the proposal by the raft group.

Release note: none.
Epic: none.