### PR TITLE
roachtest: remove unnecessary cluster setting change

### DIFF
--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -149,9 +149,6 @@ func registerOnlineRestore(r registry.Registry) {
 							if _, err := db.Exec("SET CLUSTER SETTING kv.queue.process.guaranteed_time_budget='1h'"); err != nil {
 								return err
 							}
-							if _, err := db.Exec("SET CLUSTER SETTING kv.snapshot_receiver.excise.enabled=true"); err != nil {
-								return err
-							}
 							// TODO(dt): AC appears periodically reduce the workload to 0 QPS
 							// during the download phase (sudden jumps from 0 to 2k qps to 0).
 							// Disable for now until we figure out how to smooth this out.


### PR DESCRIPTION
As of #117116 this is now the default and the plan is to keep it the default in 24.1.

Epic: none

Release note: None