### PR TITLE
util/log/eventpb: direct cluster settings events to the OPS channel

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -342,7 +342,7 @@ They are relative to a particular SQL tenant.
 In a multi-tenant setup, copies of these miscellaneous events are
 preserved in each tenant's own system.eventlog table.
 
-Events in this category are logged to the `DEV` channel.
+Events in this category are logged to the `OPS` channel.
 
 
 ### `set_cluster_setting`

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -44,10 +44,10 @@ func (m *Import) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 func (m *Restore) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.
-func (m *SetClusterSetting) LoggingChannel() logpb.Channel { return logpb.Channel_DEV }
+func (m *SetClusterSetting) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.
-func (m *SetTenantClusterSetting) LoggingChannel() logpb.Channel { return logpb.Channel_DEV }
+func (m *SetTenantClusterSetting) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.
 func (m *AdminQuery) LoggingChannel() logpb.Channel { return logpb.Channel_SENSITIVE_ACCESS }

--- a/pkg/util/log/eventpb/misc_sql_events.proto
+++ b/pkg/util/log/eventpb/misc_sql_events.proto
@@ -17,7 +17,7 @@ import "util/log/eventpb/events.proto";
 import "util/log/logpb/event.proto";
 
 // Category: Miscellaneous SQL events
-// Channel: DEV
+// Channel: OPS
 //
 // Events in this category report miscellaneous SQL events.
 //


### PR DESCRIPTION
The OPS channel is documented as reporting "point" operational events such as
those initiated by human interactions, including cluster settings. Emitting
cluster setting events to the DEV channel was likely a mistake, not
intentional.

Epic: none
Release note (ops change): Events for cluster setting changes are now emitted
to the OPS channel rather than the DEV channel.
