### PR TITLE
gossip: remove gossip eventlog

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -269,7 +269,6 @@ func New(
 	registry *metric.Registry,
 	locality roachpb.Locality,
 ) *Gossip {
-	ambient.SetEventLog("gossip", "gossip")
 	g := &Gossip{
 		server:            newServer(ambient, clusterID, nodeID, stopper, registry),
 		Connected:         make(chan struct{}),
@@ -285,8 +284,6 @@ func New(
 		bootstrapAddrs:    map[util.UnresolvedAddr]roachpb.NodeID{},
 		locality:          locality,
 	}
-
-	stopper.AddCloser(stop.CloserFn(g.server.AmbientContext.FinishEventLog))
 
 	registry.AddMetric(g.outgoing.gauge)
 

--- a/pkg/kv/kvclient/kvcoord/range_iter.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter.go
@@ -179,7 +179,7 @@ func (ri *RangeIterator) Next(ctx context.Context) {
 
 // Seek positions the iterator at the specified key.
 func (ri *RangeIterator) Seek(ctx context.Context, key roachpb.RKey, scanDir ScanDirection) {
-	logEvents := log.HasSpanOrEvent(ctx)
+	logEvents := log.HasSpan(ctx)
 	if logEvents {
 		rev := ""
 		if scanDir == Descending {

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -62,7 +62,7 @@ func (r *Replica) maybeAcquireProposalQuota(
 
 	// Trace if we're running low on available proposal quota; it might explain
 	// why we're taking so long.
-	if log.HasSpanOrEvent(ctx) {
+	if log.HasSpan(ctx) {
 		if q := quotaPool.ApproximateQuota(); q < quotaPool.Capacity()/10 {
 			log.Eventf(ctx, "quota running low, currently available ~%d", q)
 		}

--- a/pkg/server/debug/debug_test.go
+++ b/pkg/server/debug/debug_test.go
@@ -108,8 +108,8 @@ func TestAdminDebugPprof(t *testing.T) {
 	}
 }
 
-// TestAdminDebugTrace verifies that the net/trace endpoints are available
-// via /debug/{requests,events}.
+// TestAdminDebugTrace verifies that the net/trace endpoints are available via
+// /debug/requests.
 func TestAdminDebugTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -126,7 +126,6 @@ func TestAdminDebugTrace(t *testing.T) {
 		segment, search string
 	}{
 		{"requests", "<title>/debug/requests</title>"},
-		{"events", "<title>events</title>"},
 	}
 
 	for _, c := range tc {

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -105,7 +105,6 @@ func setupProcessWideRoutes(
 	// Cribbed straight from trace's `init()` method. See:
 	// https://github.com/golang/net/blob/master/trace/trace.go
 	mux.HandleFunc("/debug/requests", authzFunc(trace.Traces))
-	mux.HandleFunc("/debug/events", authzFunc(trace.Events))
 
 	// This registers a superset of the variables exposed through the
 	// /debug/vars endpoint onto the /debug/metrics endpoint. It includes all

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1353,7 +1353,7 @@ func (n *Node) batchInternal(
 		}
 		reqSp.finish(br, redact)
 	}()
-	if log.HasSpanOrEvent(ctx) {
+	if log.HasSpan(ctx) {
 		log.Eventf(ctx, "node received request: %s", args.Summary())
 		defer log.Event(ctx, "node sending response")
 	}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -107,7 +107,7 @@ func (ex *connExecutor) execStmt(
 ) (fsm.Event, fsm.EventPayload, error) {
 	ast := parserStmt.AST
 	if log.V(2) || logStatementsExecuteEnabled.Get(&ex.server.cfg.Settings.SV) ||
-		log.HasSpanOrEvent(ctx) {
+		log.HasSpan(ctx) {
 		log.VEventf(ctx, 2, "executing: %s in state: %s", ast, ex.machine.CurState())
 	}
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -827,7 +827,7 @@ func (l pebbleLogger) Eventf(ctx context.Context, format string, args ...interfa
 }
 
 func (l pebbleLogger) IsTracingEnabled(ctx context.Context) bool {
-	return log.HasSpanOrEvent(ctx)
+	return log.HasSpan(ctx)
 }
 
 func (l pebbleLogger) Errorf(format string, args ...interface{}) {

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -82,7 +82,6 @@ go_library(
         "@com_github_cockroachdb_redact//interfaces",
         "@com_github_cockroachdb_ttycolor//:ttycolor",
         "@com_github_petermattis_goid//:goid",
-        "@org_golang_x_net//trace",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [
             "@org_golang_x_sys//unix",
@@ -196,7 +195,6 @@ go_test(
         "@com_github_pmezard_go_difflib//difflib",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_net//trace",
         "@org_golang_x_sys//unix",
     ],
 )

--- a/pkg/util/log/channels.go
+++ b/pkg/util/log/channels.go
@@ -101,10 +101,10 @@ func logfDepthInternal(
 	entry := makeUnstructuredEntry(
 		ctx, sev, ch,
 		depth+1, true /* redactable */, format, args...)
-	if sp, el, ok := getSpanOrEventLog(ctx); ok {
+	if sp := getSpan(ctx); sp != nil {
 		// Prevent `entry` from moving to the heap if this branch isn't taken.
 		heapEntry := entry
-		eventInternal(sp, el, sev >= severity.ERROR, &heapEntry)
+		eventInternal(sp, sev >= severity.ERROR, &heapEntry)
 	}
 	logger.outputLogEntry(entry)
 }

--- a/pkg/util/log/event_log.go
+++ b/pkg/util/log/event_log.go
@@ -38,10 +38,10 @@ func StructuredEvent(ctx context.Context, event logpb.EventPayload) {
 		0, /* depth */
 		event)
 
-	if sp, el, ok := getSpanOrEventLog(ctx); ok {
+	if sp := getSpan(ctx); sp != nil {
 		// Prevent `entry` from moving to the heap when this branch is not taken.
 		heapEntry := entry
-		eventInternal(sp, el, entry.sev >= severity.ERROR, &heapEntry)
+		eventInternal(sp, entry.sev >= severity.ERROR, &heapEntry)
 	}
 
 	logger := logging.getLogger(entry.ch)

--- a/pkg/util/log/gen/main.go
+++ b/pkg/util/log/gen/main.go
@@ -266,13 +266,13 @@ type ChannelLogger interface {
   Shoutf(ctx context.Context, sev Severity, format string, args ...interface{})
 
   // VEvent either logs a message to the channel (which also outputs to the
-  // active trace or event log) or to the trace/event log alone, depending on
-  // whether the specified verbosity level is active.
+  // active trace) or to the trace alone, depending on whether the specified
+  // verbosity level is active.
   VEvent(ctx context.Context, level Level, msg string)
 
   // VEventf either logs a message to the channel (which also outputs to the
-  // active trace or event log) or to the trace/event log alone, depending on
-  // whether the specified verbosity level is active.
+  // active trace) or to the trace alone, depending on whether the specified
+  // verbosity level is active.
   VEventf(ctx context.Context, level Level, format string, args ...interface{})
 
   // VEventfDepth performs the same as VEventf but checks the verbosity level
@@ -418,16 +418,16 @@ func (logger{{.Name}}) Shoutf(ctx context.Context, sev Severity, format string, 
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 {{.Comment -}}
 func (logger{{.Name}}) VEvent(ctx context.Context, level Level, msg string) {
 	vEventf(ctx, false /* isErr */, 1, level, channel.{{.NAME}}, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 {{.Comment -}}
 func (logger{{.Name}}) VEventf(ctx context.Context, level Level, format string, args ...interface{}) {
 	vEventf(ctx, false /* isErr */, 1, level, channel.{{.NAME}}, format, args...)

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -47,12 +47,11 @@ func V(level Level) bool {
 // verbosity is above level.
 //
 // NOTE: This doesn't take into consideration whether tracing is generally
-// enabled or whether a trace.EventLog or a trace.Trace (i.e. sp.netTr) is
-// attached to ctx. In particular, if OpenTelemetry collection is enabled,
-// that, by itself, does NOT cause the expensive messages to
-// be enabled. "SET tracing" and friends, on the other hand, does cause
-// these messages to be enabled, as it shows that a user has expressed
-// particular interest in a trace.
+// enabled or whether a trace.Trace (i.e. sp.netTr) is attached to ctx. In
+// particular, if OpenTelemetry collection is enabled, that, by itself, does
+// NOT cause the expensive messages to be enabled. "SET tracing" and friends,
+// on the other hand, does cause these messages to be enabled, as it shows
+// that a user has expressed particular interest in a trace.
 //
 // Usage:
 //

--- a/pkg/util/log/log_channels_generated.go
+++ b/pkg/util/log/log_channels_generated.go
@@ -121,13 +121,13 @@ type ChannelLogger interface {
 	Shoutf(ctx context.Context, sev Severity, format string, args ...interface{})
 
 	// VEvent either logs a message to the channel (which also outputs to the
-	// active trace or event log) or to the trace/event log alone, depending on
-	// whether the specified verbosity level is active.
+	// active trace) or to the trace alone, depending on whether the specified
+	// verbosity level is active.
 	VEvent(ctx context.Context, level Level, msg string)
 
 	// VEventf either logs a message to the channel (which also outputs to the
-	// active trace or event log) or to the trace/event log alone, depending on
-	// whether the specified verbosity level is active.
+	// active trace) or to the trace alone, depending on whether the specified
+	// verbosity level is active.
 	VEventf(ctx context.Context, level Level, format string, args ...interface{})
 
 	// VEventfDepth performs the same as VEventf but checks the verbosity level
@@ -958,8 +958,8 @@ func (loggerDev) Shoutf(ctx context.Context, sev Severity, format string, args .
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `DEV` channel is used during development to collect log
 // details useful for troubleshooting that fall outside the
 // scope of other channels. It is also the default logging
@@ -976,8 +976,8 @@ func (loggerDev) VEvent(ctx context.Context, level Level, msg string) {
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `DEV` channel is used during development to collect log
 // details useful for troubleshooting that fall outside the
 // scope of other channels. It is also the default logging
@@ -1490,8 +1490,8 @@ func (loggerOps) Shoutf(ctx context.Context, sev Severity, format string, args .
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
@@ -1508,8 +1508,8 @@ func (loggerOps) VEvent(ctx context.Context, level Level, msg string) {
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `OPS` channel is used to report "point" operational events,
 // initiated by user operators or automation:
 //
@@ -1928,8 +1928,8 @@ func (loggerHealth) Shoutf(ctx context.Context, sev Severity, format string, arg
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
@@ -1943,8 +1943,8 @@ func (loggerHealth) VEvent(ctx context.Context, level Level, msg string) {
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `HEALTH` channel is used to report "background" operational
 // events, initiated by CockroachDB or reporting on automatic processes:
 //
@@ -2243,8 +2243,8 @@ func (loggerStorage) Shoutf(ctx context.Context, sev Severity, format string, ar
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 func (loggerStorage) VEvent(ctx context.Context, level Level, msg string) {
@@ -2252,8 +2252,8 @@ func (loggerStorage) VEvent(ctx context.Context, level Level, msg string) {
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 func (loggerStorage) VEventf(ctx context.Context, level Level, format string, args ...interface{}) {
@@ -2692,8 +2692,8 @@ func (loggerSessions) Shoutf(ctx context.Context, sev Severity, format string, a
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
 // `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
@@ -2709,8 +2709,8 @@ func (loggerSessions) VEvent(ctx context.Context, level Level, msg string) {
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `SESSIONS` channel is used to report client network activity when enabled via
 // the `server.auth_log.sql_connections.enabled` and/or
 // `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
@@ -3222,8 +3222,8 @@ func (loggerSqlSchema) Shoutf(ctx context.Context, sev Severity, format string, 
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
 // (which are reported separately on the `PRIVILEGES` channel) and
@@ -3242,8 +3242,8 @@ func (loggerSqlSchema) VEvent(ctx context.Context, level Level, msg string) {
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `SQL_SCHEMA` channel is used to report changes to the
 // SQL logical schema, excluding privilege and ownership changes
 // (which are reported separately on the `PRIVILEGES` channel) and
@@ -3704,8 +3704,8 @@ func (loggerUserAdmin) Shoutf(ctx context.Context, sev Severity, format string, 
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
@@ -3721,8 +3721,8 @@ func (loggerUserAdmin) VEvent(ctx context.Context, level Level, msg string) {
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `USER_ADMIN` channel is used to report changes
 // in users and roles, including:
 //
@@ -4139,8 +4139,8 @@ func (loggerPrivileges) Shoutf(ctx context.Context, sev Severity, format string,
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
@@ -4154,8 +4154,8 @@ func (loggerPrivileges) VEvent(ctx context.Context, level Level, msg string) {
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `PRIVILEGES` channel is used to report data
 // authorization changes, including:
 //
@@ -4644,8 +4644,8 @@ func (loggerSensitiveAccess) Shoutf(ctx context.Context, sev Severity, format st
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `SENSITIVE_ACCESS` channel is used to report SQL
 // data access to sensitive data:
 //
@@ -4663,8 +4663,8 @@ func (loggerSensitiveAccess) VEvent(ctx context.Context, level Level, msg string
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `SENSITIVE_ACCESS` channel is used to report SQL
 // data access to sensitive data:
 //
@@ -5047,8 +5047,8 @@ func (loggerSqlExec) Shoutf(ctx context.Context, sev Severity, format string, ar
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
@@ -5060,8 +5060,8 @@ func (loggerSqlExec) VEvent(ctx context.Context, level Level, msg string) {
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `SQL_EXEC` channel is used to report SQL execution on
 // behalf of client connections:
 //
@@ -5489,8 +5489,8 @@ func (loggerSqlPerf) Shoutf(ctx context.Context, sev Severity, format string, ar
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `SQL_PERF` channel is used to report SQL executions
 // that are marked as "out of the ordinary"
 // to facilitate performance investigations.
@@ -5505,8 +5505,8 @@ func (loggerSqlPerf) VEvent(ctx context.Context, level Level, msg string) {
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `SQL_PERF` channel is used to report SQL executions
 // that are marked as "out of the ordinary"
 // to facilitate performance investigations.
@@ -5845,8 +5845,8 @@ func (loggerSqlInternalPerf) Shoutf(ctx context.Context, sev Severity, format st
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
 // channel so as to not pollute the `SQL_PERF` logging output with
@@ -5856,8 +5856,8 @@ func (loggerSqlInternalPerf) VEvent(ctx context.Context, level Level, msg string
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `SQL_INTERNAL_PERF` channel is like the `SQL_PERF` channel, but is aimed at
 // helping developers of CockroachDB itself. It exists as a separate
 // channel so as to not pollute the `SQL_PERF` logging output with
@@ -6167,8 +6167,8 @@ func (loggerTelemetry) Shoutf(ctx context.Context, sev Severity, format string, 
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `TELEMETRY` channel reports telemetry events. Telemetry events describe
 // feature usage within CockroachDB and anonymizes any application-
 // specific data.
@@ -6177,8 +6177,8 @@ func (loggerTelemetry) VEvent(ctx context.Context, level Level, msg string) {
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `TELEMETRY` channel reports telemetry events. Telemetry events describe
 // feature usage within CockroachDB and anonymizes any application-
 // specific data.
@@ -6486,8 +6486,8 @@ func (loggerKvDistribution) Shoutf(ctx context.Context, sev Severity, format str
 }
 
 // VEvent either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `KV_DISTRIBUTION` channel is used to report data distribution events, such as moving
 // replicas between stores in the cluster, or adding (removing) replicas to
 // ranges.
@@ -6496,8 +6496,8 @@ func (loggerKvDistribution) VEvent(ctx context.Context, level Level, msg string)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 // The `KV_DISTRIBUTION` channel is used to report data distribution events, such as moving
 // replicas between stores in the cluster, or adding (removing) replicas to
 // ranges.

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -16,123 +16,36 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/log/channel"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/logtags"
-	"golang.org/x/net/trace"
 )
 
-// ctxEventLogKey is an empty type for the handle associated with the
-// ctxEventLog value (see context.Value).
-type ctxEventLogKey struct{}
-
-// ctxEventLog is used for contexts to keep track of an EventLog.
-type ctxEventLog struct {
-	syncutil.Mutex
-	eventLog trace.EventLog
-}
-
-func (el *ctxEventLog) finish() {
-	el.Lock()
-	defer el.Unlock()
-	if el.eventLog != nil {
-		el.eventLog.Finish()
-		el.eventLog = nil
-	}
-}
-
-func embedCtxEventLog(ctx context.Context, el *ctxEventLog) context.Context {
-	return context.WithValue(ctx, ctxEventLogKey{}, el)
-}
-
-// withEventLogInternal embeds a trace.EventLog in the context, causing future
-// logging and event calls to go to the EventLog. The current context must not
-// have an existing open span.
-func withEventLogInternal(ctx context.Context, eventLog trace.EventLog) context.Context {
-	if tracing.SpanFromContext(ctx) != nil {
-		panic("event log under span")
-	}
-	return embedCtxEventLog(ctx, &ctxEventLog{eventLog: eventLog})
-}
-
-// WithEventLog creates and embeds a trace.EventLog in the context, causing
-// future logging and event calls to go to the EventLog. The current context
-// must not have an existing open span.
-func WithEventLog(ctx context.Context, family, title string) context.Context {
-	return withEventLogInternal(ctx, trace.NewEventLog(family, title))
-}
-
-var _ = WithEventLog
-
-// WithNoEventLog creates a context which no longer has an embedded event log.
-func WithNoEventLog(ctx context.Context) context.Context {
-	return withEventLogInternal(ctx, nil)
-}
-
-func eventLogFromCtx(ctx context.Context) *ctxEventLog {
-	if val := ctx.Value(ctxEventLogKey{}); val != nil {
-		return val.(*ctxEventLog)
+// getSpan returns the current Span or nil if the Span doesn't exist or is a
+// "black hole".
+func getSpan(ctx context.Context) *tracing.Span {
+	if sp := tracing.SpanFromContext(ctx); sp != nil {
+		if !sp.IsVerbose() && !sp.Tracer().HasExternalSink() {
+			return nil
+		}
+		return sp
 	}
 	return nil
 }
 
-// FinishEventLog closes the event log in the context (see WithEventLog).
-// Concurrent and subsequent calls to record events are allowed.
-func FinishEventLog(ctx context.Context) {
-	if el := eventLogFromCtx(ctx); el != nil {
-		el.finish()
-	}
-}
-
-// getSpanOrEventLog returns the current Span. If there is no Span, it returns
-// the current ctxEventLog. If neither (or the Span is "black hole"), returns
-// false.
-func getSpanOrEventLog(ctx context.Context) (*tracing.Span, *ctxEventLog, bool) {
-	if sp := tracing.SpanFromContext(ctx); sp != nil {
-		if !sp.IsVerbose() && !sp.Tracer().HasExternalSink() {
-			return nil, nil, false
-		}
-		return sp, nil, true
-	}
-	if el := eventLogFromCtx(ctx); el != nil {
-		return nil, el, true
-	}
-	return nil, nil, false
-}
-
-// eventInternal is the common code for logging an event to trace and/or
-// event logs. Entries passed to this method may or may not be
-// redactable (via the `logEntry.redactable` flag). However, if
-// sp.Redactable() is true then they will be printed as redactable by
-// `Recordf`. I the entry is not redactable, the entirety of the message
-// will be marked redactable, otherwise fine-grainer redaction will
-// remain in the result.
-func eventInternal(sp *tracing.Span, el *ctxEventLog, isErr bool, entry *logEntry) {
-	if sp != nil {
-		sp.Recordf("%s", entry)
-		// TODO(obs-inf): figure out a way to signal that this is an error. We could
-		// use a different "error" key (provided it shows up in LightStep). Things
-		// like NetTraceIntegrator would need to be modified to understand the
-		// difference. We could also set a special Tag on the span. See
-		// #8827 for more discussion.
-		_ = isErr
-		return
-	}
-
-	// No span, record to event log instead.
-	//
-	// TODO(obs-inf): making this either/or doesn't seem useful, but it
-	// is the status quo, and the callers only pass one of the two even
-	// if they have both.
-	el.Lock()
-	defer el.Unlock()
-	if el.eventLog != nil {
-		if isErr {
-			el.eventLog.Errorf("%s", entry)
-		} else {
-			el.eventLog.Printf("%s", entry)
-		}
-	}
+// eventInternal is the common code for logging an event to a trace. Entries
+// passed to this method may or may not be redactable (via the
+// `logEntry.redactable` flag). However, if sp.Redactable() is true then they
+// will be printed as redactable by `Recordf`. I the entry is not redactable,
+// the entirety of the message will be marked redactable, otherwise
+// fine-grainer redaction will remain in the result.
+func eventInternal(sp *tracing.Span, isErr bool, entry *logEntry) {
+	sp.Recordf("%s", entry)
+	// TODO(obs-inf): figure out a way to signal that this is an error. We could
+	// use a different "error" key (provided it shows up in LightStep). Things
+	// like NetTraceIntegrator would need to be modified to understand the
+	// difference. We could also set a special Tag on the span. See
+	// #8827 for more discussion.
+	_ = isErr
 }
 
 // formatTags appends the tags to a strings.Builder. If there are no tags,
@@ -153,11 +66,10 @@ func formatTags(ctx context.Context, brackets bool, buf *strings.Builder) bool {
 }
 
 // Event looks for a tracing span in the context and logs the given message to
-// it. If no span is found, it looks for an EventLog in the context and logs the
-// message to it. If neither is found, does nothing.
+// it.
 func Event(ctx context.Context, msg string) {
-	sp, el, ok := getSpanOrEventLog(ctx)
-	if !ok {
+	sp := getSpan(ctx)
+	if sp == nil {
 		// Nothing to log. Skip the work.
 		return
 	}
@@ -169,15 +81,14 @@ func Event(ctx context.Context, msg string) {
 		1,             /* depth */
 		sp.Redactable(),
 		msg)
-	eventInternal(sp, el, false /* isErr */, &entry)
+	eventInternal(sp, false /* isErr */, &entry)
 }
 
-// Eventf looks for a tracing span in the context and formats and logs
-// the given message to it. If no span is found, it looks for an EventLog in
-// the context and logs the message to it. If neither is found, does nothing.
+// Eventf looks for a tracing span in the context and formats and logs the
+// given message to it.
 func Eventf(ctx context.Context, format string, args ...interface{}) {
-	sp, el, ok := getSpanOrEventLog(ctx)
-	if !ok {
+	sp := getSpan(ctx)
+	if sp == nil {
 		// Nothing to log. Skip the work.
 		return
 	}
@@ -189,7 +100,7 @@ func Eventf(ctx context.Context, format string, args ...interface{}) {
 		1,             /* depth */
 		sp.Redactable(),
 		format, args...)
-	eventInternal(sp, el, false /* isErr */, &entry)
+	eventInternal(sp, false /* isErr */, &entry)
 }
 
 func vEventf(
@@ -209,8 +120,8 @@ func vEventf(
 		}
 		logfDepth(ctx, 1+depth, sev, ch, format, args...)
 	} else {
-		sp, el, ok := getSpanOrEventLog(ctx)
-		if !ok {
+		sp := getSpan(ctx)
+		if sp == nil {
 			// Nothing to log. Skip the work.
 			return
 		}
@@ -220,20 +131,20 @@ func vEventf(
 			depth+1,
 			sp.Redactable(),
 			format, args...)
-		eventInternal(sp, el, isErr, &entry)
+		eventInternal(sp, isErr, &entry)
 	}
 }
 
 // VEvent either logs a message to the DEV channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 func VEvent(ctx context.Context, level Level, msg string) {
 	vEventf(ctx, false /* isErr */, 1, level, channel.DEV, msg)
 }
 
 // VEventf either logs a message to the DEV channel (which also outputs to the
-// active trace or event log) or to the trace/event log alone, depending on
-// whether the specified verbosity level is active.
+// active trace) or to the trace alone, depending on whether the specified
+// verbosity level is active.
 func VEventf(ctx context.Context, level Level, format string, args ...interface{}) {
 	vEventf(ctx, false /* isErr */, 1, level, channel.DEV, format, args...)
 }
@@ -244,16 +155,16 @@ func VEventfDepth(ctx context.Context, depth int, level Level, format string, ar
 	vEventf(ctx, false /* isErr */, 1+depth, level, channel.DEV, format, args...)
 }
 
-// VErrEvent either logs an error message to the DEV channel (which also outputs
-// to the active trace or event log) or to the trace/event log alone, depending
-// on whether the specified verbosity level is active.
+// VErrEvent either logs an error message to the DEV channel (which also
+// outputs to the active trace) or to the trace alone, depending on whether
+// the specified verbosity level is active.
 func VErrEvent(ctx context.Context, level Level, msg string) {
 	vEventf(ctx, true /* isErr */, 1, level, channel.DEV, msg)
 }
 
-// VErrEventf either logs an error message to the DEV Channel (which also outputs
-// to the active trace or event log) or to the trace/event log alone, depending
-// on whether the specified verbosity level is active.
+// VErrEventf either logs an error message to the DEV Channel (which also
+// outputs to the active trace) or to the trace alone, depending on whether
+// the specified verbosity level is active.
 func VErrEventf(ctx context.Context, level Level, format string, args ...interface{}) {
 	vEventf(ctx, true /* isErr */, 1, level, channel.DEV, format, args...)
 }
@@ -268,9 +179,7 @@ func VErrEventfDepth(
 
 var _ = VErrEventfDepth // silence unused warning
 
-// HasSpanOrEvent returns true if the context has a span or event that should
-// be logged to.
-func HasSpanOrEvent(ctx context.Context) bool {
-	_, _, ok := getSpanOrEventLog(ctx)
-	return ok
+// HasSpan returns true if the context has a span that should be logged to.
+func HasSpan(ctx context.Context) bool {
+	return getSpan(ctx) != nil
 }

--- a/pkg/util/log/trace_client_test.go
+++ b/pkg/util/log/trace_client_test.go
@@ -66,7 +66,7 @@ func TestTrace(t *testing.T) {
 				// that a span so configured will actually log them to the external
 				// trace.
 				require.True(t, tr.HasExternalSink())
-				require.True(t, log.HasSpanOrEvent(ctx))
+				require.True(t, log.HasSpan(ctx))
 				require.True(t, log.ExpensiveLogEnabled(ctx, 0 /* level */))
 			},
 		},

--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -12,124 +12,27 @@ package log
 
 import (
 	"context"
-	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
-	"golang.org/x/net/trace"
 )
 
-type events []string
-
-func compareTraces(expected, actual events) bool {
-	if len(expected) != len(actual) {
-		return false
-	}
-	for i, ev := range expected {
-		if ev == actual[i] {
-			continue
-		}
-		// Try to strip file:line from a span event, e.g. from:
-		//   span:path/file:line msg
-		// to:
-		//   span:msg
-		groups := regexp.MustCompile(`^(.*):.*:[0-9]* (.*)$`).FindStringSubmatch(actual[i])
-		if len(groups) == 3 && fmt.Sprintf("%s:%s", groups[1], groups[2]) == ev {
-			continue
-		}
-		// Try to strip file:line from a non-span event, e.g. from:
-		//   path/file:line msg
-		// to:
-		//   msg
-		groups = regexp.MustCompile(`^.*:[0-9]* (.*)$`).FindStringSubmatch(actual[i])
-		if len(groups) == 2 && groups[1] == ev {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
-// testingEventLog is a simple implementation of trace.EventLog.
-type testingEventLog struct {
-	ev events
-}
-
-var _ trace.EventLog = &testingEventLog{}
-
-func (el *testingEventLog) Printf(format string, a ...interface{}) {
-	el.ev = append(el.ev, fmt.Sprintf(format, a...))
-}
-
-func (el *testingEventLog) Errorf(format string, a ...interface{}) {
-	el.ev = append(el.ev, fmt.Sprintf(format+"(err)", a...))
-}
-
-func (el *testingEventLog) Finish() {
-	el.ev = append(el.ev, "finish")
-}
-
-func TestEventLog(t *testing.T) {
+func TestTrace(t *testing.T) {
 	ctx := context.Background()
 
 	// Events to context without a trace should be no-ops.
 	Event(ctx, "should-not-show-up")
-
-	el := &testingEventLog{}
-	ctxWithEventLog := withEventLogInternal(ctx, el)
-
-	Eventf(ctxWithEventLog, "test%d", 1)
-	VEventf(ctxWithEventLog, NoLogV(), "test%d", 2)
-	VErrEvent(ctxWithEventLog, NoLogV(), "testerr")
-	Info(ctxWithEventLog, "log")
-	Errorf(ctxWithEventLog, "errlog%d", 1)
-
-	// Events to child contexts without the event log should be no-ops.
-	Event(WithNoEventLog(ctxWithEventLog), "should-not-show-up")
-
-	// Events to parent context should still be no-ops.
-	Event(ctx, "should-not-show-up")
-
-	FinishEventLog(ctxWithEventLog)
-
-	// Events after Finish should be ignored.
-	Errorf(ctxWithEventLog, "should-not-show-up")
-
-	expected := events{"test1", "test2", "testerr(err)", "log", "errlog1(err)", "finish"}
-	if !compareTraces(expected, el.ev) {
-		t.Errorf("expected events '%s', got '%v'", expected, el.ev)
-	}
-}
-
-func TestEventLogAndTrace(t *testing.T) {
-	ctx := context.Background()
-
-	// Events to context without a trace should be no-ops.
-	Event(ctx, "should-not-show-up")
-
-	el := &testingEventLog{}
-	ctxWithEventLog := withEventLogInternal(ctx, el)
-
-	Event(ctxWithEventLog, "test1")
-	VEventf(ctxWithEventLog, NoLogV(), "test2")
-	VErrEvent(ctxWithEventLog, NoLogV(), "testerr")
 
 	tracer := tracing.NewTracer()
 	sp := tracer.StartSpan("s", tracing.WithRecording(tracingpb.RecordingVerbose))
-	ctxWithBoth := tracing.ContextWithSpan(ctxWithEventLog, sp)
+	ctxWithTrace := tracing.ContextWithSpan(ctx, sp)
 	// Events should only go to the trace.
-	Event(ctxWithBoth, "test3")
-	VEventf(ctxWithBoth, NoLogV(), "test4")
-	VErrEventf(ctxWithBoth, NoLogV(), "%s", "test5err")
-
-	// Events to parent context should still go to the event log.
-	Event(ctxWithEventLog, "test6")
+	Event(ctxWithTrace, "test3")
+	VEventf(ctxWithTrace, NoLogV(), "test4")
+	VErrEventf(ctxWithTrace, NoLogV(), "%s", "test5err")
 
 	rec := sp.FinishAndGetRecording(tracingpb.RecordingVerbose)
-	el.Finish()
-
 	if err := tracing.CheckRecordedSpans(rec, `
 		span: s
 			tags: _verbose=1
@@ -138,15 +41,5 @@ func TestEventLogAndTrace(t *testing.T) {
 			event: test5err
 	`); err != nil {
 		t.Fatal(err)
-	}
-
-	elExpected := regexp.MustCompile(`^\[` +
-		`util/log/trace_test\.go:\d+ test1 ` +
-		`util/log/trace_test\.go:\d+ test2 ` +
-		`util/log/trace_test\.go:\d+ testerr\(err\) ` +
-		`util/log/trace_test\.go:\d+ test6 ` +
-		`finish\]$`)
-	if evStr := fmt.Sprint(el.ev); !elExpected.MatchString(evStr) {
-		t.Errorf("expected events '%s', got '%s'", elExpected, evStr)
 	}
 }


### PR DESCRIPTION
Remove the gossip eventlog which was the last remaining use of `AmbientContext.{Set,Finish}EventLog` allowing those methods to be removed as well. Remove `log.With{,No}EventLog` which were not being used and remove the associated eventlog machinery from `util/log`.

Epic: none
Release note (general change): Remove the /debug/events endpoint which is no longer populated.