### PR TITLE
roachprod: only wait on default target cluster if setting backup schedule

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -416,15 +416,13 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 		if startOpts.KVCluster != nil {
 			storageCluster = startOpts.KVCluster
 		}
-		if startOpts.Target == StartDefault {
+		if startOpts.Target == StartDefault && startOpts.ScheduleBackups && shouldInit && config.CockroachDevLicense != "" {
 			if err := storageCluster.waitForDefaultTargetCluster(ctx, l, startOpts); err != nil {
 				return errors.Wrap(err, "failed to wait for default target cluster")
 			}
 			// Only after a successful cluster initialization should we attempt to schedule backups.
-			if startOpts.ScheduleBackups && shouldInit && config.CockroachDevLicense != "" {
-				if err := c.createFixedBackupSchedule(ctx, l, startOpts.ScheduleBackupArgs); err != nil {
-					return err
-				}
+			if err := c.createFixedBackupSchedule(ctx, l, startOpts.ScheduleBackupArgs); err != nil {
+				return err
 			}
 		}
 		c.createAdminUserForSecureCluster(ctx, l, startOpts)


### PR DESCRIPTION
roachprod only uses the default target cluster setting when setting a backup schedule. As a result, if we're not setting a backup schedule in a given start call, we shouldn't wait until the default target cluster setting is set.

Release note: None

Informs: #117926