### PR TITLE
kvstreamer: deep-copy KV requests when they are evaluated twice

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -1447,6 +1447,11 @@ func (w *workerCoordinator) performRequestAsync(
 						// TODO(yuzefovich): consider updating the
 						// avgResponseSize and/or storing the information about
 						// the returned bytes size in req.
+
+						// The KV layer doesn't allow evaluation of the same
+						// Gets and Scans multiple times, so we need to make
+						// fresh copies of them.
+						req.deepCopyRequests(w.s)
 						w.s.requestsToServe.add(req)
 						return
 					}


### PR DESCRIPTION
In a single code path, previously it was possible for the same KV requests (Gets and Scans) to be evaluated multiple times. This is not allowed by the KV level, so this commit fixes the issue by making deep copy of all KV requests whenever the `singleRangeBatch` needs to be re-evaluated.

Fixes: #117233.

Release note: None