### PR TITLE
changefeedccl: migrate deprecated pts records to new scheme

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -243,6 +243,7 @@ go_test(
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/protectedts",
+        "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/roachpb",
         "//pkg/scheduledjobs",
         "//pkg/scheduledjobs/schedulebase",

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -81,6 +81,10 @@ type TestingKnobs struct {
 	// SpanPartitionsCallback is called with the span partition
 	// when the changefeed is planned.
 	SpanPartitionsCallback func([]sql.SpanPartition)
+
+	// PreserveDeprecatedPts is used to prevent a changefeed from upgrading
+	// its PTS record from the deprecated style to the new style.
+	PreserveDeprecatedPts func() bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
This change adds logic in changefeeds to "migrate" pts records which use the old style (ie. protect spans instead of targets / desc ids). With this change, when a changefeed manages its pts record (once every 10 minutes by default), it will check to see if the record is deprecated. If so, it will create a new record with the non-deprecated style and remove the old one.

This change helps accomplish #82888 by effectively removing changefeed jobs relying on the old PTS subsystem, allowing the old subsystem to be removed.

Informs: https://github.com/cockroachdb/cockroach/issues/82888
Release note: None
Epic: CRDB-34798