### PR TITLE
explain: improve output for multiple cascades from the same table

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -1189,3 +1189,199 @@ SELECT
 ;
 ----
 0 0
+
+statement ok
+CREATE TABLE t3 (
+    id3 INT PRIMARY KEY
+);
+CREATE TABLE t4 (
+    id4 INT PRIMARY KEY,
+    t4_id3_1 INT NOT NULL,
+    t4_id3_2 INT NOT NULL,
+    CONSTRAINT fk1 FOREIGN KEY (t4_id3_1) REFERENCES t3(id3) ON DELETE CASCADE,
+    CONSTRAINT fk2 FOREIGN KEY (t4_id3_2) REFERENCES t3(id3) ON DELETE CASCADE
+);
+CREATE TABLE t5 (
+    id5 INT PRIMARY KEY,
+    t5_id4 INT DEFAULT NULL,
+    t5_id3_1 INT NOT NULL,
+    t5_id3_2 INT NOT NULL,
+    CONSTRAINT fk1 FOREIGN KEY (t5_id3_1) REFERENCES t3(id3) ON DELETE CASCADE,
+    CONSTRAINT fk2 FOREIGN KEY (t5_id3_2) REFERENCES t3(id3) ON DELETE CASCADE,
+    CONSTRAINT fk3 FOREIGN KEY (t5_id4) REFERENCES t4(id4) ON DELETE SET NULL
+);
+
+# Ensure that the plan is provided for each FK cascade, even if they originate
+# from the same table or share names with constraints on other tables.
+query T
+EXPLAIN DELETE FROM t3 WHERE id3 = 1
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • delete
+│   │ from: t3
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • scan
+│             missing stats
+│             table: t3@t3_pkey
+│             spans: [/1 - /1]
+│
+├── • fk-cascade
+│   │ fk: fk1
+│   │
+│   └── • root
+│       │
+│       ├── • delete
+│       │   │ from: t4
+│       │   │
+│       │   └── • buffer
+│       │       │ label: buffer 1
+│       │       │
+│       │       └── • hash join
+│       │           │ equality: (t4_id3_1) = (id3)
+│       │           │ right cols are key
+│       │           │
+│       │           ├── • scan
+│       │           │     missing stats
+│       │           │     table: t4@t4_pkey
+│       │           │     spans: FULL SCAN
+│       │           │
+│       │           └── • distinct
+│       │               │ estimated row count: 10
+│       │               │ distinct on: id3
+│       │               │
+│       │               └── • scan buffer
+│       │                     estimated row count: 100
+│       │                     label: buffer 1000000
+│       │
+│       └── • fk-cascade
+│           │ fk: fk3
+│           │
+│           └── • update
+│               │ table: t5
+│               │ set: t5_id4
+│               │
+│               └── • render
+│                   │
+│                   └── • hash join
+│                       │ equality: (t5_id4) = (id4)
+│                       │ right cols are key
+│                       │
+│                       ├── • scan
+│                       │     missing stats
+│                       │     table: t5@t5_pkey
+│                       │     spans: FULL SCAN
+│                       │
+│                       └── • distinct
+│                           │ estimated row count: 10
+│                           │ distinct on: id4
+│                           │
+│                           └── • scan buffer
+│                                 estimated row count: 100
+│                                 label: buffer 1000000
+│
+├── • fk-cascade
+│   │ fk: fk2
+│   │
+│   └── • root
+│       │
+│       ├── • delete
+│       │   │ from: t4
+│       │   │
+│       │   └── • buffer
+│       │       │ label: buffer 1
+│       │       │
+│       │       └── • hash join
+│       │           │ equality: (t4_id3_2) = (id3)
+│       │           │ right cols are key
+│       │           │
+│       │           ├── • scan
+│       │           │     missing stats
+│       │           │     table: t4@t4_pkey
+│       │           │     spans: FULL SCAN
+│       │           │
+│       │           └── • distinct
+│       │               │ estimated row count: 10
+│       │               │ distinct on: id3
+│       │               │
+│       │               └── • scan buffer
+│       │                     estimated row count: 100
+│       │                     label: buffer 1000000
+│       │
+│       └── • fk-cascade
+│           │ fk: fk3
+│           │
+│           └── • update
+│               │ table: t5
+│               │ set: t5_id4
+│               │
+│               └── • render
+│                   │
+│                   └── • hash join
+│                       │ equality: (t5_id4) = (id4)
+│                       │ right cols are key
+│                       │
+│                       ├── • scan
+│                       │     missing stats
+│                       │     table: t5@t5_pkey
+│                       │     spans: FULL SCAN
+│                       │
+│                       └── • distinct
+│                           │ estimated row count: 10
+│                           │ distinct on: id4
+│                           │
+│                           └── • scan buffer
+│                                 estimated row count: 100
+│                                 label: buffer 1000000
+│
+├── • fk-cascade
+│   │ fk: fk1
+│   │
+│   └── • delete
+│       │ from: t5
+│       │
+│       └── • hash join
+│           │ equality: (t5_id3_1) = (id3)
+│           │ right cols are key
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: t5@t5_pkey
+│           │     spans: FULL SCAN
+│           │
+│           └── • distinct
+│               │ estimated row count: 10
+│               │ distinct on: id3
+│               │
+│               └── • scan buffer
+│                     estimated row count: 100
+│                     label: buffer 1000000
+│
+└── • fk-cascade
+    │ fk: fk2
+    │
+    └── • delete
+        │ from: t5
+        │
+        └── • hash join
+            │ equality: (t5_id3_2) = (id3)
+            │ right cols are key
+            │
+            ├── • scan
+            │     missing stats
+            │     table: t5@t5_pkey
+            │     spans: FULL SCAN
+            │
+            └── • distinct
+                │ estimated row count: 10
+                │ distinct on: id3
+                │
+                └── • scan buffer
+                      estimated row count: 100
+                      label: buffer 1000000

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	humanize "github.com/dustin/go-humanize"
@@ -35,21 +34,18 @@ import (
 // Emit produces the EXPLAIN output against the given OutputBuilder. The
 // OutputBuilder flags are taken into account.
 func Emit(ctx context.Context, plan *Plan, ob *OutputBuilder, spanFormatFn SpanFormatFn) error {
-	var visitedTablesByCascades *intsets.Fast
-	if len(plan.Cascades) > 0 {
-		visitedTablesByCascades = &intsets.Fast{}
-	}
-	return emitInternal(ctx, plan, ob, spanFormatFn, visitedTablesByCascades)
+	return emitInternal(ctx, plan, ob, spanFormatFn, nil /* visitedFKsByCascades */)
 }
 
-// - visitedTablesByCascades is updated on recursive calls for each cascade
-// plan. Can be nil if the plan doesn't have any cascades.
+// - visitedFKsByCascades is updated on recursive calls for each cascade plan.
+// Can be nil if the plan doesn't have any cascades. In this map the key is the
+// "id" of the FK constraint that we construct as OriginTableID || Name.
 func emitInternal(
 	ctx context.Context,
 	plan *Plan,
 	ob *OutputBuilder,
 	spanFormatFn SpanFormatFn,
-	visitedTablesByCascades *intsets.Fast,
+	visitedFKsByCascades map[string]struct{},
 ) error {
 	e := makeEmitter(ob, spanFormatFn)
 	var walk func(n *Node) error
@@ -132,17 +128,25 @@ func emitInternal(
 		const createPlanIfMissing = true
 		if cascadePlan, err := cascade.GetExplainPlan(ctx, createPlanIfMissing); err != nil {
 			return err
-		} else if fk := cascade.FKConstraint; visitedTablesByCascades.Contains(int(fk.OriginTableID())) {
-			// If the origin table for this FK has already been visited, we
-			// don't recurse into it again to prevent infinite recursion.
-			if buffer := cascade.Buffer; buffer != nil {
-				ob.Attr("input", buffer.(*Node).args.(*bufferArgs).Label)
-			}
 		} else {
-			visitedTablesByCascades.Add(int(fk.OriginTableID()))
-			defer visitedTablesByCascades.Remove(int(fk.OriginTableID()))
-			if err = emitInternal(ctx, cascadePlan.(*Plan), ob, spanFormatFn, visitedTablesByCascades); err != nil {
-				return err
+			if visitedFKsByCascades == nil {
+				visitedFKsByCascades = make(map[string]struct{})
+			}
+			fk := cascade.FKConstraint
+			// Come up with a custom "id" for this FK.
+			fkID := fmt.Sprintf("%d%s", fk.OriginTableID(), fk.Name())
+			if _, visited := visitedFKsByCascades[fkID]; visited {
+				// If we have already visited this particular FK cascade, we
+				// don't recurse into it again to prevent infinite recursion.
+				if buffer := cascade.Buffer; buffer != nil {
+					ob.Attr("input", buffer.(*Node).args.(*bufferArgs).Label)
+				}
+			} else {
+				visitedFKsByCascades[fkID] = struct{}{}
+				defer delete(visitedFKsByCascades, fkID)
+				if err = emitInternal(ctx, cascadePlan.(*Plan), ob, spanFormatFn, visitedFKsByCascades); err != nil {
+					return err
+				}
 			}
 		}
 		ob.LeaveNode()


### PR DESCRIPTION
In a recently merged change to show the EXPLAIN plan for cascades, we had to come up with a scheme for stopping recursing into the cascades in order to prevent infinite recursion on schemas with cascade cycles. We made it so that we don't explore the FK originating from a table that we've "visited" already. However, this strategy is suboptimal because we end up not expanding the plans for cascades on tables that have multiple FKs with ON CASCADE actions. This commit fixes that omission by coming up with a better strategy for "base of recursion" - namely, we don't explore the same FK "edge" twice. This is achieved by giving each FK constraint an "id" that is "OriginTableID || FKName". This should uniquely identify any FK constraint, so in case of cascade loops, we'd stop the very first time we see the same FK for the second time, preventing infinite recursion (we'd still explore the whole loop fully though - which is what we want).

Epic: None

Release note: None