### PR TITLE
cluster-ui: enable Explain Plan for tenant clusters

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
@@ -26,7 +26,7 @@ import {
   InsightExecEnum,
   InsightNameEnum,
   TxnContentionInsightDetails,
-} from "src/insights";
+} from "src/insights/types";
 import moment from "moment-timezone";
 import { FixFingerprintHexValue, getLogger } from "../util";
 import { TxnInsightDetailsRequest } from "./txnInsightDetailsApi";

--- a/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
@@ -20,15 +20,15 @@ import {
 } from "./sqlApi";
 import {
   ContentionDetails,
-  getInsightsFromProblemsAndCauses,
   InsightExecEnum,
   StatementStatus,
   StmtInsightEvent,
-} from "src/insights";
+} from "src/insights/types";
 import moment from "moment-timezone";
 import { INTERNAL_APP_NAME_PREFIX } from "src/util/constants";
 import { FixFingerprintHexValue } from "../util";
 import { getContentionDetailsApi } from "./contentionApi";
+import { getInsightsFromProblemsAndCauses } from "../insights/utils";
 
 export type StmtInsightsReq = {
   start?: moment.Moment;

--- a/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.spec.ts
@@ -24,24 +24,7 @@ import {
   getTxnInsightsContentionDetailsApi,
 } from "./contentionApi";
 import moment from "moment-timezone";
-
-function mockSqlResponse<T>(rows: T[]): SqlExecutionResponse<T> {
-  return {
-    execution: {
-      retries: 0,
-      txn_results: [
-        {
-          tag: "",
-          start: "",
-          end: "",
-          rows_affected: 0,
-          statement: 1,
-          rows: [...rows],
-        },
-      ],
-    },
-  };
-}
+import { MockSqlResponse } from "../util/testing";
 
 type TxnContentionDetailsTests = {
   name: string;
@@ -78,16 +61,16 @@ describe("test txn insights api functions", () => {
   test.each([
     {
       name: "all api responses empty",
-      contentionResp: mockSqlResponse([]),
-      txnFingerprintsResp: mockSqlResponse([]),
-      stmtsFingerprintsResp: mockSqlResponse([]),
+      contentionResp: MockSqlResponse([]),
+      txnFingerprintsResp: MockSqlResponse([]),
+      stmtsFingerprintsResp: MockSqlResponse([]),
       expected: null,
     },
     {
       name: "no fingerprints available",
-      contentionResp: mockSqlResponse([contentionDetailsMock]),
-      txnFingerprintsResp: mockSqlResponse([]),
-      stmtsFingerprintsResp: mockSqlResponse([]),
+      contentionResp: MockSqlResponse([contentionDetailsMock]),
+      txnFingerprintsResp: MockSqlResponse([]),
+      stmtsFingerprintsResp: MockSqlResponse([]),
       expected: {
         transactionExecutionID: contentionDetailsMock.waiting_txn_id,
         application: undefined,
@@ -121,8 +104,8 @@ describe("test txn insights api functions", () => {
     },
     {
       name: "no stmt fingerprints available",
-      contentionResp: mockSqlResponse([contentionDetailsMock]),
-      txnFingerprintsResp: mockSqlResponse<TxnStmtFingerprintsResponseColumns>([
+      contentionResp: MockSqlResponse([contentionDetailsMock]),
+      txnFingerprintsResp: MockSqlResponse<TxnStmtFingerprintsResponseColumns>([
         {
           transaction_fingerprint_id:
             contentionDetailsMock.blocking_txn_fingerprint_id,
@@ -130,7 +113,7 @@ describe("test txn insights api functions", () => {
           app_name: undefined,
         },
       ]),
-      stmtsFingerprintsResp: mockSqlResponse([]),
+      stmtsFingerprintsResp: MockSqlResponse([]),
       expected: {
         transactionExecutionID: contentionDetailsMock.waiting_txn_id,
         application: undefined,
@@ -168,8 +151,8 @@ describe("test txn insights api functions", () => {
     },
     {
       name: "all info available",
-      contentionResp: mockSqlResponse([contentionDetailsMock]),
-      txnFingerprintsResp: mockSqlResponse<TxnStmtFingerprintsResponseColumns>([
+      contentionResp: MockSqlResponse([contentionDetailsMock]),
+      txnFingerprintsResp: MockSqlResponse<TxnStmtFingerprintsResponseColumns>([
         {
           transaction_fingerprint_id:
             contentionDetailsMock.blocking_txn_fingerprint_id,
@@ -177,7 +160,7 @@ describe("test txn insights api functions", () => {
           app_name: undefined,
         },
       ]),
-      stmtsFingerprintsResp: mockSqlResponse<FingerprintStmtsResponseColumns>([
+      stmtsFingerprintsResp: MockSqlResponse<FingerprintStmtsResponseColumns>([
         {
           statement_fingerprint_id: "a",
           query: "select 1",

--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
@@ -16,7 +16,10 @@ import "antd/lib/icon/style";
 import { Modal } from "../modal";
 import { Text, TextTypes } from "../text";
 import { Button } from "../button";
-import { executeIndexRecAction, IndexActionResponse } from "../api";
+import {
+  executeIndexRecAction,
+  IndexActionResponse,
+} from "../api/indexActionsApi";
 import {
   alterIndex,
   createIndex,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetails.fixture.ts
@@ -1,0 +1,101 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import moment from "moment-timezone";
+import { createMemoryHistory } from "history";
+import { noop } from "lodash";
+import { StatementInsightDetailsProps } from "./statementInsightDetails";
+import {
+  InsightEventBase,
+  InsightExecEnum,
+  InsightNameEnum,
+  StatementStatus,
+  StmtInsightEvent,
+} from "../types";
+
+const insightEventBaseFixture: InsightEventBase = {
+  application: "app",
+  cpuSQLNanos: 25000000000,
+  elapsedTimeMillis: 127.0,
+  endTime: moment.utc("2021-12-10T05:06:07"),
+  implicitTxn: true,
+  insights: [
+    {
+      name: InsightNameEnum.slowExecution,
+      label: "label",
+      description: "slow query",
+      tooltipDescription: "a really slow query",
+    },
+    {
+      name: InsightNameEnum.suboptimalPlan,
+      label: "label2",
+      description: "bad plan",
+      tooltipDescription: "a really bad plan",
+    },
+  ],
+  priority: "high",
+  query: "SELECT count(*) FROM foo",
+  retries: 0,
+  rowsRead: 64500,
+  rowsWritten: 0,
+  sessionID: "123456789",
+  startTime: moment.utc("2021-12-08T15:19:42"),
+  transactionExecutionID: "87123cf6-13ea-40a8-9257-48b00b2af4cc",
+  transactionFingerprintID: "8a239b0afd5ebd3a",
+  username: "bob",
+  errorCode: "",
+  errorMsg: "",
+};
+
+const insightEventFixture: StmtInsightEvent = Object.assign(
+  insightEventBaseFixture,
+  {
+    statementExecutionID: "17a8d80bd38900b80000000000000005",
+    statementFingerprintID: "254026467b5f0ae5",
+    isFullScan: true,
+    indexRecommendations: [],
+    planGist: "AgGA////nxkAAAYAAAADBQIGAg==",
+    databaseName: "defaultdb",
+    execType: InsightExecEnum.STATEMENT,
+    status: StatementStatus.COMPLETED,
+  },
+);
+
+export const getStatementInsightPropsFixture =
+  (): StatementInsightDetailsProps => {
+    const history = createMemoryHistory({ initialEntries: ["/insights"] });
+    return {
+      history,
+      location: {
+        pathname: "/insights",
+        search: "",
+        hash: "",
+        state: null,
+      },
+      match: {
+        path: "/insights",
+        url: "/insights",
+        isExact: true,
+        params: {},
+      },
+      timeScale: {
+        windowSize: moment.duration(5, "day"),
+        sampleSize: moment.duration(5, "minutes"),
+        fixedWindowEnd: moment.utc("2021-12-12"),
+        key: "Custom",
+      },
+      insightEventDetails: insightEventFixture,
+      insightError: null,
+      hasAdminRole: true,
+      useObsService: false,
+      setTimeScale: noop,
+      refreshUserSQLRoles: noop,
+    };
+  };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetails.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetails.spec.tsx
@@ -1,0 +1,101 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createSandbox } from "sinon";
+import { MemoryRouter as Router } from "react-router-dom";
+import {
+  StatementInsightDetails,
+  StatementInsightDetailsProps,
+} from "./statementInsightDetails";
+import { getStatementInsightPropsFixture } from "./insightDetails.fixture";
+import * as sqlApi from "../../api/sqlApi";
+import * as stmtInsightsApi from "../../api/stmtInsightsApi";
+import { SqlApiResponse } from "../../api/sqlApi";
+import { StmtInsightEvent } from "../types";
+import { CollapseWhitespace, MockSqlResponse } from "../../util/testing";
+
+const sandbox = createSandbox();
+
+describe("StatementInsightDetails page", () => {
+  let props: StatementInsightDetailsProps;
+
+  beforeEach(() => {
+    sandbox.reset();
+    props = getStatementInsightPropsFixture();
+
+    // The StmtInsights API will be triggered on render to refresh data.
+    const resp: SqlApiResponse<StmtInsightEvent[]> = {
+      maxSizeReached: false,
+      results: [props.insightEventDetails],
+    };
+    jest
+      .spyOn(stmtInsightsApi, "getStmtInsightsApi")
+      .mockReturnValueOnce(Promise.resolve(resp));
+  });
+
+  it("shows loading indicator when data is not ready yet", async () => {
+    // Clear insights to trigger a loading state.
+    props.insightEventDetails = null;
+
+    render(
+      <Router>
+        <StatementInsightDetails {...props} />
+      </Router>,
+    );
+
+    screen.getByLabelText("Loading...");
+
+    // Wait for the StmtInsights API call to refresh the data.
+    await screen.findByText("Explain Plan");
+  });
+
+  it("shows two workload insights for a query", () => {
+    render(
+      <Router>
+        <StatementInsightDetails {...props} />
+      </Router>,
+    );
+
+    // Query should be shown in UI.
+    screen.getAllByText(
+      (_, e) =>
+        CollapseWhitespace(e.textContent) === "SELECT count(*) FROM foo",
+    );
+
+    // Two insights should be shown.
+    screen.getByText("Slow Execution");
+    screen.getByText("Suboptimal Plan");
+  });
+
+  it("switches to the Explain Plan tab and shows the plan", async () => {
+    render(
+      <Router>
+        <StatementInsightDetails {...props} />
+      </Router>,
+    );
+
+    // Click on the Explain tab. Mock a response to executeInternalSql, which
+    // should be called in order to decode the plan gist.
+    const resp = MockSqlResponse([{ plan_row: "SHOW DATABASE" }]);
+    const explainPlanSpy = jest
+      .spyOn(sqlApi, "executeInternalSql")
+      .mockReturnValueOnce(Promise.resolve(resp));
+
+    fireEvent.click(screen.getByText("Explain Plan"));
+    expect(explainPlanSpy).toHaveBeenCalled();
+
+    await screen.findByText("Plan Gist: AgGA////nxkAAAYAAAADBQIGAg==", {
+      exact: false,
+    });
+    screen.getByText("SHOW");
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -40,7 +40,6 @@ enum TabKeysEnum {
 export interface StatementInsightDetailsStateProps {
   insightEventDetails: StmtInsightEvent;
   insightError: Error | null;
-  isTenant?: boolean;
   timeScale?: TimeScale;
   hasAdminRole: boolean;
   useObsService: boolean;
@@ -74,7 +73,6 @@ export const StatementInsightDetails: React.FC<
   insightEventDetails,
   insightError,
   match,
-  isTenant,
   timeScale,
   hasAdminRole,
   refreshUserSQLRoles,
@@ -99,7 +97,6 @@ export const StatementInsightDetails: React.FC<
 
   const onTabClick = (key: TabKeysEnum) => {
     if (
-      !isTenant &&
       key === TabKeysEnum.EXPLAIN &&
       details?.planGist &&
       !explainPlanState.loaded
@@ -193,34 +190,30 @@ export const StatementInsightDetails: React.FC<
                 hasAdminRole={hasAdminRole}
               />
             </Tabs.TabPane>
-            {!isTenant && (
-              <Tabs.TabPane tab="Explain Plan" key={TabKeysEnum.EXPLAIN}>
-                <section className={cx("section")}>
-                  <Row gutter={24}>
-                    <Col span={24}>
-                      <Loading
-                        loading={
-                          !explainPlanState.loaded &&
-                          details?.planGist?.length > 0
-                        }
-                        page={"stmt_insight_details"}
-                        error={explainPlanState.error}
-                        renderError={() =>
-                          InsightsError(explainPlanState.error?.message)
-                        }
-                      >
-                        <SqlBox
-                          value={
-                            explainPlanState.explainPlan || "Not available."
-                          }
-                          size={SqlBoxSize.custom}
-                        />
-                      </Loading>
-                    </Col>
-                  </Row>
-                </section>
-              </Tabs.TabPane>
-            )}
+            <Tabs.TabPane tab="Explain Plan" key={TabKeysEnum.EXPLAIN}>
+              <section className={cx("section")}>
+                <Row gutter={24}>
+                  <Col span={24}>
+                    <Loading
+                      loading={
+                        !explainPlanState.loaded &&
+                        details?.planGist?.length > 0
+                      }
+                      page={"stmt_insight_details"}
+                      error={explainPlanState.error}
+                      renderError={() =>
+                        InsightsError(explainPlanState.error?.message)
+                      }
+                    >
+                      <SqlBox
+                        value={explainPlanState.explainPlan || "Not available."}
+                        size={SqlBoxSize.custom}
+                      />
+                    </Loading>
+                  </Col>
+                </Row>
+              </section>
+            </Tabs.TabPane>
           </Tabs>
         </Loading>
       </div>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -23,7 +23,7 @@ import { StmtInsightEvent } from "../types";
 import { getExplainPlanFromGist } from "src/api/decodePlanGistApi";
 import { StatementInsightDetailsOverviewTab } from "./statementInsightDetailsOverviewTab";
 import { TimeScale, toDateRange } from "../../timeScaleDropdown";
-import { getStmtInsightsApi } from "src/api";
+import { getStmtInsightsApi } from "src/api/stmtInsightsApi";
 import { InsightsError } from "../insightsErrorComponent";
 
 // Styles

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
@@ -20,11 +20,7 @@ import {
   selectStmtInsightDetails,
   selectStmtInsightsError,
 } from "src/store/insights/statementInsights";
-import {
-  selectHasAdminRole,
-  selectIsTenant,
-  selectUseObsService,
-} from "src/store/uiConfig";
+import { selectHasAdminRole, selectUseObsService } from "src/store/uiConfig";
 import { TimeScale } from "../../timeScaleDropdown";
 import { actions as sqlStatsActions } from "../../store/sqlStats";
 import { selectTimeScale } from "../../store/utils/selectors";
@@ -39,7 +35,6 @@ const mapStateToProps = (
   return {
     insightEventDetails: insightStatements,
     insightError: insightError,
-    isTenant: selectIsTenant(state),
     timeScale: selectTimeScale(state),
     hasAdminRole: selectHasAdminRole(state),
     useObsService: selectUseObsService(state),

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -76,7 +76,6 @@ export type StatementInsightsViewStateProps = {
   statementsError: Error | null;
   dropDownSelect?: React.ReactElement;
   isLoading?: boolean;
-  isTenant?: boolean;
   maxSizeApiReached?: boolean;
   timeScale?: TimeScale;
 };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -10,7 +10,7 @@
 
 import React, { ReactElement } from "react";
 import { Tooltip } from "@cockroachlabs/ui-components";
-import { InsightExecEnum } from "src/insights";
+import { InsightExecEnum } from "src/insights/types";
 import { contentModifiers } from "../../../statsTableUtil/statsTableUtil";
 import { Anchor } from "../../../anchor";
 import { contentionTime, readFromDisk, writtenToDisk } from "../../../util";

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
@@ -50,7 +50,7 @@ import { TimeScale } from "../../timeScaleDropdown";
 import { StmtInsightsReq, TxnInsightsRequest } from "src/api";
 import { selectTimeScale } from "../../store/utils/selectors";
 import { actions as analyticsActions } from "../../store/analytics";
-import { selectIsTenant, selectUseObsService } from "../../store/uiConfig";
+import { selectUseObsService } from "../../store/uiConfig";
 
 const transactionMapStateToProps = (
   state: AppState,
@@ -83,7 +83,6 @@ const statementMapStateToProps = (
   timeScale: selectTimeScale(state),
   isLoading: selectStmtInsightsLoading(state),
   maxSizeApiReached: selectStmtInsightsMaxApiReached(state),
-  isTenant: selectIsTenant(state),
   useObsService: selectUseObsService(state),
 });
 

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -32,8 +32,8 @@ import {
   InsightExecEnum,
   InsightRecommendation,
   InsightType,
-  insightType,
-} from "../insights";
+} from "../insights/types";
+import { insightType } from "../insights/utils";
 
 const cx = classNames.bind(styles);
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.fixture.ts
@@ -1,0 +1,47 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import moment from "moment-timezone";
+import { ActiveStatementDetailsProps } from "./activeStatementDetails";
+import { noop } from "lodash";
+import { ExecutionStatus } from "../activeExecutions";
+
+export const getActiveStatementDetailsPropsFixture =
+  (): ActiveStatementDetailsProps => {
+    return {
+      statement: {
+        statementID: "17ab864032f8e1c20000000000000001",
+        stmtNoConstants: "SELECT count(*) FROM foo",
+        transactionID: "fac8885a-f40a-4666-b746-a45061faad74",
+        sessionID: "123456789",
+        status: ExecutionStatus.Executing,
+        start: moment.utc("2021-12-12"),
+        elapsedTime: moment.duration("3s"),
+        application: "my-app",
+        database: "defaultdb",
+        query: "SELECT count(*) FROM foo",
+        timeSpentWaiting: moment.duration("1s"),
+        user: "andy",
+        clientAddress: "127.0.0.1",
+        isFullScan: true,
+        planGist: "AgICABoCBQQf0AEB",
+      },
+      match: {
+        path: "/execution/statement/:statement",
+        url: "/execution/statement/17ab864032f8e1c20000000000000001",
+        isExact: true,
+        params: {
+          statement: "17ab864032f8e1c20000000000000001",
+        },
+      },
+      hasAdminRole: true,
+      refreshLiveWorkload: noop,
+    };
+  };

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.spec.tsx
@@ -1,0 +1,93 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createSandbox } from "sinon";
+import { MemoryRouter as Router } from "react-router-dom";
+import {
+  ActiveStatementDetails,
+  ActiveStatementDetailsProps,
+} from "./activeStatementDetails";
+import { getActiveStatementDetailsPropsFixture } from "./activeStatementDetails.fixture";
+import * as sqlApi from "../api/sqlApi";
+import { MockSqlResponse } from "../util/testing";
+
+const sandbox = createSandbox();
+
+describe("ActiveStatementDetails page", () => {
+  let props: ActiveStatementDetailsProps;
+
+  beforeEach(() => {
+    sandbox.reset();
+    props = getActiveStatementDetailsPropsFixture();
+  });
+
+  it("shows information about the active statement", () => {
+    render(
+      <Router>
+        <ActiveStatementDetails {...props} />
+      </Router>,
+    );
+
+    screen.getAllByText(
+      (_, e) => e.textContent === "SELECT count(*) FROM foo",
+      { exact: false },
+    );
+    screen.getByText("Dec 12, 2021 at 0:00 UTC", { exact: false });
+    screen.getByText("Executing", { exact: false });
+    screen.getByText("my-app", { exact: false });
+    screen.getByText("andy", { exact: false });
+    screen.getByText("127.0.0.1", { exact: false });
+    screen.getByText("123456789", { exact: false });
+    screen.getByText("fac8885a-f40a-4666-b746-a45061faad74", { exact: false });
+  });
+
+  it("switches to the Explain Plan tab and shows the plan", async () => {
+    render(
+      <Router>
+        <ActiveStatementDetails {...props} />
+      </Router>,
+    );
+
+    // Click on the Explain tab. Mock executeInternalSql, which should be called
+    // in order to decode the plan gist and .
+    const planResponse = MockSqlResponse([
+      {
+        plan_row:
+          "• group (scalar)\n" +
+          "│\n" +
+          "└── • scan\n" +
+          "      table: foo@foo_pkey\n" +
+          "      spans: FULL SCAN",
+      },
+    ]);
+    const indexResponse = MockSqlResponse([
+      {
+        index_recommendations: [
+          "creation : CREATE INDEX ON defaultdb.public.foo (y);",
+        ],
+      },
+    ]);
+    const explainPlanSpy = jest
+      .spyOn(sqlApi, "executeInternalSql")
+      .mockReturnValueOnce(Promise.resolve(planResponse))
+      .mockReturnValueOnce(Promise.resolve(indexResponse));
+
+    fireEvent.click(screen.getByText("Explain Plan"));
+    expect(explainPlanSpy).toHaveBeenCalled();
+
+    await screen.findByText("Plan Gist: AgICABoCBQQf0AEB", { exact: false });
+    await screen.findByText("foo@foo_pkey", { exact: false });
+    await screen.findByText("CREATE INDEX ON defaultdb.public.foo (y);", {
+      exact: false,
+    });
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.tsx
@@ -38,7 +38,6 @@ import { SortSetting } from "../sortedtable";
 const cx = classNames.bind(styles);
 
 export type ActiveStatementDetailsStateProps = {
-  isTenant?: boolean;
   contentionDetails?: ExecutionContentionDetails;
   statement: ActiveStatement;
   match: match;
@@ -64,7 +63,6 @@ export type ActiveStatementDetailsProps = ActiveStatementDetailsStateProps &
   ActiveStatementDetailsDispatchProps;
 
 export const ActiveStatementDetails: React.FC<ActiveStatementDetailsProps> = ({
-  isTenant,
   contentionDetails,
   statement,
   match,
@@ -93,7 +91,6 @@ export const ActiveStatementDetails: React.FC<ActiveStatementDetailsProps> = ({
 
   const onTabClick = (key: TabKeysEnum) => {
     if (
-      !isTenant &&
       key === TabKeysEnum.EXPLAIN &&
       statement?.planGist &&
       !explainPlanState.loaded
@@ -161,42 +158,40 @@ export const ActiveStatementDetails: React.FC<ActiveStatementDetailsProps> = ({
             contentionDetails={contentionDetails}
           />
         </Tabs.TabPane>
-        {!isTenant && (
-          <Tabs.TabPane tab="Explain Plan" key={TabKeysEnum.EXPLAIN}>
-            <Row gutter={24} className={cx("margin-right")}>
-              <Col className="gutter-row" span={24}>
-                <Loading
-                  loading={
-                    !explainPlanState.loaded && statement?.planGist?.length > 0
-                  }
-                  page={"stmt_insight_details"}
-                  error={explainPlanState.error}
-                  renderError={() =>
-                    LoadingError({
-                      statsType: "explain plan",
-                      error: explainPlanState.error,
-                    })
-                  }
-                >
-                  <SqlBox
-                    value={explainPlanState.explainPlan || "Not available."}
-                    size={SqlBoxSize.custom}
+        <Tabs.TabPane tab="Explain Plan" key={TabKeysEnum.EXPLAIN}>
+          <Row gutter={24} className={cx("margin-right")}>
+            <Col className="gutter-row" span={24}>
+              <Loading
+                loading={
+                  !explainPlanState.loaded && statement?.planGist?.length > 0
+                }
+                page={"stmt_insight_details"}
+                error={explainPlanState.error}
+                renderError={() =>
+                  LoadingError({
+                    statsType: "explain plan",
+                    error: explainPlanState.error,
+                  })
+                }
+              >
+                <SqlBox
+                  value={explainPlanState.explainPlan || "Not available."}
+                  size={SqlBoxSize.custom}
+                />
+                {hasInsights && (
+                  <Insights
+                    idxRecommendations={indexRecommendations}
+                    query={statement.stmtNoConstants}
+                    database={statement.database}
+                    sortSetting={insightsSortSetting}
+                    onChangeSortSetting={setInsightsSortSetting}
+                    hasAdminRole={hasAdminRole}
                   />
-                  {hasInsights && (
-                    <Insights
-                      idxRecommendations={indexRecommendations}
-                      query={statement.stmtNoConstants}
-                      database={statement.database}
-                      sortSetting={insightsSortSetting}
-                      onChangeSortSetting={setInsightsSortSetting}
-                      hasAdminRole={hasAdminRole}
-                    />
-                  )}
-                </Loading>
-              </Col>
-            </Row>
-          </Tabs.TabPane>
-        )}
+                )}
+              </Loading>
+            </Col>
+          </Row>
+        </Tabs.TabPane>
       </Tabs>
     </div>
   );

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsConnected.tsx
@@ -22,7 +22,7 @@ import {
   selecteActiveStatement,
   selectContentionDetailsForStatement,
 } from "src/selectors/activeExecutions.selectors";
-import { selectHasAdminRole, selectIsTenant } from "src/store/uiConfig";
+import { selectHasAdminRole } from "src/store/uiConfig";
 
 // For tenant cases, we don't show information about node, regions and
 // diagnostics.
@@ -34,7 +34,6 @@ const mapStateToProps = (
     contentionDetails: selectContentionDetailsForStatement(state, props),
     statement: selecteActiveStatement(state, props),
     match: props.match,
-    isTenant: selectIsTenant(state),
     hasAdminRole: selectHasAdminRole(state),
   };
 };

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -344,7 +344,7 @@ export function makeStatementsColumns(
     },
   ];
 
-  if (activateDiagnosticsRef && !isTenant && !hasViewActivityRedactedRole) {
+  if (activateDiagnosticsRef && !hasViewActivityRedactedRole) {
     const diagnosticsColumn: ColumnDescriptor<AggregateStatistics> = {
       name: "diagnostics",
       title: statisticsTableTitles.diagnostics(statType),

--- a/pkg/ui/workspaces/cluster-ui/src/util/testing.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/testing.ts
@@ -1,0 +1,46 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { SqlExecutionResponse } from "../api";
+
+/**
+ * CollapseWhitespace collapses all adjacent whitespace to a single space
+ * character and trims leading and trailing whitespace. It is useful when
+ * normalizing text broken up by HTML elements for test assertions.
+ *
+ * @param s input string to collapse
+ */
+export function CollapseWhitespace(s: string): string {
+  return s.replace(/\s\s+/g, " ").trim();
+}
+
+/**
+ * MockSqlResponse formulates a mock response from a call to the
+ * executeInternalSql function.
+ *
+ * @param rows rows returned by the query
+ */
+export function MockSqlResponse<T>(rows: T[]): SqlExecutionResponse<T> {
+  return {
+    execution: {
+      retries: 0,
+      txn_results: [
+        {
+          tag: "",
+          start: "",
+          end: "",
+          rows_affected: 0,
+          statement: 1,
+          rows: [...rows],
+        },
+      ],
+    },
+  };
+}


### PR DESCRIPTION
Previously, Explain Plan tabs were not available for tenant clusters.
This commit enables them, as there is no technical reason to disable
them at this point. The commit also adds some simple tests for
components that are being modified, as there were no tests before,
making it harder to verify the fixes. It also converts an existing
spec to use the React Testing Library rather than Enzyme, as the RTL
is the preferred testing library going forward.

Part of: https://github.com/cockroachdb/cockroach/issues/83422

Release note: The Explain Plan tab is now shown for statements and
insight pages, for tenant clusters.
