### PR TITLE
roachprod: Use DefaultRunOptions in WithNodes

### DIFF
--- a/pkg/cmd/roachprod-microbench/cluster/execute.go
+++ b/pkg/cmd/roachprod-microbench/cluster/execute.go
@@ -63,7 +63,7 @@ func remoteWorker(
 			start := timeutil.Now()
 			runResult, err := roachprod.RunWithDetails(
 				context.Background(), log, clusterNode, "" /* SSHOptions */, "", /* processTag */
-				false /* secure */, command.Args, install.RunOptions{},
+				false /* secure */, command.Args, install.DefaultRunOptions(),
 			)
 			duration := timeutil.Since(start)
 			var stdout, stderr string

--- a/pkg/cmd/roachprod-microbench/util.go
+++ b/pkg/cmd/roachprod-microbench/util.go
@@ -86,7 +86,7 @@ func initRoachprod(l *logger.Logger) error {
 func roachprodRun(clusterName string, l *logger.Logger, cmdArray []string) error {
 	return roachprod.Run(
 		context.Background(), l, clusterName, "", "", false,
-		os.Stdout, os.Stderr, cmdArray, install.RunOptions{},
+		os.Stdout, os.Stderr, cmdArray, install.DefaultRunOptions(),
 	)
 }
 

--- a/pkg/cmd/roachprod-stress/main.go
+++ b/pkg/cmd/roachprod-stress/main.go
@@ -141,7 +141,7 @@ func roundToSeconds(d time.Duration) time.Duration {
 func roachprodRun(clusterName string, cmdArray []string) error {
 	return roachprod.Run(
 		context.Background(), l, clusterName, "", "", false,
-		os.Stdout, os.Stderr, cmdArray, install.RunOptions{},
+		os.Stdout, os.Stderr, cmdArray, install.DefaultRunOptions(),
 	)
 }
 

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2766,7 +2766,7 @@ type ParallelResult struct {
 // By default, this will fail fast, unless explicitly specified otherwise in the
 // RunOptions, if a command error occurs on any node, and return a slice
 // containing all results up to that point, along with a boolean indicating that
-// at least one error occurred. If `WithFailSlow(true)` is passed in, then the
+// at least one error occurred. If `WithFailSlow()` is passed in, then the
 // function will wait for all invocations to complete before returning.
 //
 // ParallelE only returns an error for roachprod itself, not any command errors run
@@ -2789,13 +2789,7 @@ func (c *SyncedCluster) ParallelE(
 	options RunOptions,
 	fn func(ctx context.Context, n Node) (*RunResultDetails, error),
 ) ([]*RunResultDetails, bool, error) {
-	// Defaults for RunOptions if not specified.
-	if options.RetryOptions == nil {
-		options.RetryOptions = DefaultRetryOpt
-	}
-	if options.ShouldRetryFn == nil {
-		options.ShouldRetryFn = DefaultShouldRetryFn
-	}
+	// Function specific default for FailOption if not specified.
 	if options.FailOption == FailDefault {
 		options.FailOption = FailFast
 	}

--- a/pkg/roachprod/install/run_options.go
+++ b/pkg/roachprod/install/run_options.go
@@ -37,7 +37,10 @@ type RunOptions struct {
 type FailOption int8
 
 const (
-	// FailDefault will use the default behaviour of the function you are using.
+	// FailDefault will use the default behaviour of the function it's being used
+	// with. For instance, note that `RunWithDetails` will use FailSlow, while
+	// `Run` and `Parallel` will use FailFast when FailDefault is specified in the
+	// RunOptions.
 	FailDefault FailOption = iota
 	// FailFast will exit immediately on the first error, in which case the slice
 	// of ParallelResults will only contain the one error result.
@@ -52,10 +55,18 @@ const (
 // result was.
 var AlwaysTrue = func(res *RunResultDetails) bool { return true }
 
-func WithNodes(nodes Nodes) RunOptions {
+func DefaultRunOptions() RunOptions {
 	return RunOptions{
-		Nodes: nodes,
+		RetryOptions:  DefaultRetryOpt,
+		ShouldRetryFn: DefaultShouldRetryFn,
+		FailOption:    FailDefault,
 	}
+}
+
+func WithNodes(nodes Nodes) RunOptions {
+	r := DefaultRunOptions()
+	r.Nodes = nodes
+	return r
 }
 
 func (r RunOptions) WithRetryOpts(retryOpts retry.Options) RunOptions {


### PR DESCRIPTION
`WithRetryDisabled` previously worked by setting the RetryOptions on RunOptions to nil. This was however a part of how the functional options worked before a refactor (see 112411) and no longer works as expected with the default values of the RunOptions struct.

In order to make this a useful option we introduce a DefaultRunOptions function that is used in conjunction with the `WithNodes` function. `ParallelE` now accepts options.RetryOptions as a `nil` value for disabling retries, and will no longer replace it with the default retry options.

See: #112411
Fixes: #117635

Epic: None
Release Note: None