### PR TITLE
release-23.1: roachprod: elide expiration notification for GCed dangling resources (in Azure)

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1405,7 +1405,7 @@ func Create(
 		}
 	}
 
-	l.Printf("Creating cluster %s with %d nodes", clusterName, numNodes)
+	l.Printf("Creating cluster %s with %d nodes...", clusterName, numNodes)
 	if createErr := cloud.CreateCluster(l, numNodes, createVMOpts, providerOptsContainer); createErr != nil {
 		return createErr
 	}
@@ -1414,6 +1414,7 @@ func Create(
 		// No need for ssh for local clusters.
 		return LoadClusters()
 	}
+	l.Printf("Created cluster %s; setting up SSH...", clusterName)
 	return SetupSSH(ctx, l, clusterName)
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #117848.

/cc @cockroachdb/release

---

In Azure, VM destroy is non-transactional; dangling resources, e.g., a resource group, may outlive a VM. Previously, `roachprod gc` would correctly destroy dangling resources, but its slack notification may have contained an expiration time in the future.

This change elides expiration time since it's ambiguous for an arbitrary dangling resource. Instead, such notifications are now under the rubric of `Destroyed Empty Clusters/Dangling Resources` which is disjoint from `Destroyed Clusters`.

Epic: none
Fixes: #110183

Release note: None
Release justification: Test-only change.
