### PR TITLE
Revert "logictest: unskip stressrace config for logic tests"

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -4060,6 +4060,8 @@ func RunLogicTest(
 	// Note: there is special code in teamcity-trigger/main.go to run this package
 	// with less concurrency in the nightly stress runs. If you see problems
 	// please make adjustments there.
+	// As of 6/4/2019, the logic tests never complete under race.
+	skip.UnderRace(t, "logic tests and race detector don't mix: #37993")
 
 	// This test relies on repeated sequential storage.EventuallyFileOnlySnapshot
 	// acquisitions. Reduce the max wait time for each acquisition to speed up


### PR DESCRIPTION
This reverts commit 2152bb164bc46eaf510f1638f6b4eb015b6f8d8b.

See https://github.com/cockroachdb/cockroach/pull/112495#issuecomment-1900880249 for context.

Epic: None

Release note: None