### PR TITLE
roachtest: admission/follower-overload test improvements

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_follower_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_follower_overload.go
@@ -32,7 +32,7 @@ func registerFollowerOverload(r registry.Registry) {
 			Name:             "admission/follower-overload/" + subtest,
 			Owner:            registry.OwnerAdmissionControl,
 			Timeout:          3 * time.Hour,
-			CompatibleClouds: registry.AllExceptAWS,
+			CompatibleClouds: registry.AllClouds,
 			Suites:           registry.ManualOnly,
 			// TODO(aaditya): Revisit this as part of #111614.
 			//Suites:           registry.Suites(registry.Weekly),
@@ -170,7 +170,7 @@ func runAdmissionControlFollowerOverload(
 	for _, row := range runner.QueryStr(
 		t, `SELECT target FROM [ SHOW ZONE CONFIGURATIONS ]`,
 	) {
-		q := `ALTER ` + row[0] + ` CONFIGURE ZONE USING lease_preferences = '[[-node3]]'`
+		q := `ALTER ` + row[0] + ` CONFIGURE ZONE USING lease_preferences = '[[-node3]]', constraints = COPY FROM PARENT`
 		t.L().Printf("%s", q)
 		_, err := db.Exec(q)
 		require.NoError(t, err)
@@ -185,8 +185,8 @@ func runAdmissionControlFollowerOverload(
 		var attempts int
 		for ctx.Err() == nil {
 			attempts++
-			m1 := runner.QueryStr(t, `SELECT range_id FROM crdb_internal.ranges WHERE lease_holder=3 AND database_name != 'kvn3'`)
-			m2 := runner.QueryStr(t, `SELECT range_id FROM crdb_internal.ranges WHERE lease_holder!=3 AND database_name = 'kvn3'`)
+			m1 := runner.QueryStr(t, `SELECT DISTINCT range_id FROM [SHOW CLUSTER RANGES WITH TABLES, DETAILS] WHERE lease_holder=3 AND database_name != 'kvn3'`)
+			m2 := runner.QueryStr(t, `SELECT DISTINCT range_id FROM [SHOW CLUSTER RANGES WITH TABLES, DETAILS] WHERE lease_holder!=3 AND database_name = 'kvn3'`)
 			if len(m1)+len(m2) == 0 {
 				t.L().Printf("done waiting for lease movement")
 				break


### PR DESCRIPTION
[roachtest: fix zone config syntax in ac follower overload test](https://github.com/cockroachdb/cockroach/pull/117988/commits/c80491e9e86bd37c7ce52a5f991f204d94e2020a) 

Informs https://github.com/cockroachdb/cockroach/issues/82508.

Release note: None

---

[roachtest: add bandwidth overload test in admission/follower-overload](https://github.com/cockroachdb/cockroach/pull/117988/commits/d0dc296e1d23345d3b387e735652fd2317066102) 

This aims to simulate read bandwidth induced overload by running a large
kv0 workload on a 3 node cluster, while all the leases are owned by n1 and
n2.

Informs https://github.com/cockroachdb/cockroach/issues/82508.

Release note: None