### PR TITLE
generate-logictest: skip certain CCL configurations under `race`

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -85,6 +85,7 @@ func runLogicTest(t *testing.T, file string) {
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
 func runCCLLogicTest(t *testing.T, file string) {
+	skip.UnderRace(t, "times out and/or hangs")
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }

--- a/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/generated_test.go
@@ -60,6 +60,7 @@ func TestMain(m *testing.M) {
 }
 
 func runCCLLogicTest(t *testing.T, file string) {
+	skip.UnderRace(t, "times out and/or hangs")
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }

--- a/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/generated_test.go
@@ -60,6 +60,7 @@ func TestMain(m *testing.M) {
 }
 
 func runCCLLogicTest(t *testing.T, file string) {
+	skip.UnderRace(t, "times out and/or hangs")
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/generated_test.go
@@ -60,6 +60,7 @@ func TestMain(m *testing.M) {
 }
 
 func runCCLLogicTest(t *testing.T, file string) {
+	skip.UnderRace(t, "times out and/or hangs")
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/generated_test.go
@@ -60,6 +60,7 @@ func TestMain(m *testing.M) {
 }
 
 func runCCLLogicTest(t *testing.T, file string) {
+	skip.UnderRace(t, "times out and/or hangs")
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/generated_test.go
@@ -60,6 +60,7 @@ func TestMain(m *testing.M) {
 }
 
 func runCCLLogicTest(t *testing.T, file string) {
+	skip.UnderRace(t, "times out and/or hangs")
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
@@ -60,6 +60,7 @@ func TestMain(m *testing.M) {
 }
 
 func runCCLLogicTest(t *testing.T, file string) {
+	skip.UnderRace(t, "times out and/or hangs")
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }

--- a/pkg/cmd/generate-logictest/main.go
+++ b/pkg/cmd/generate-logictest/main.go
@@ -32,6 +32,7 @@ type testFileTemplateConfig struct {
 	CockroachGoTestserverTest     bool
 	Ccl                           bool
 	ForceProductionValues         bool
+	SkipCclUnderRace              bool
 	Package, TestRuleName, RelDir string
 	ConfigIdx                     int
 	TestCount                     int
@@ -178,6 +179,9 @@ func (t *testdir) dump() error {
 		// allocate the tests which use 3-node clusters 2 vCPUs, and
 		// the ones which use more a bit more.
 		tplCfg.NumCPU = (cfg.NumNodes / 2) + 1
+		if cfg.Name == "3node-tenant" || strings.HasPrefix(cfg.Name, "multiregion-") {
+			tplCfg.SkipCclUnderRace = true
+		}
 		subdir := filepath.Join(t.dir, cfg.Name)
 		f, buildF, cleanup, err := openTestSubdir(subdir)
 		if err != nil {

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -60,7 +60,8 @@ func runLogicTest(t *testing.T, file string) {
 {{- define "runCCLLogicTest" }}
 {{- if .CclLogicTest -}}
 func runCCLLogicTest(t *testing.T, file string) {
-	skip.UnderDeadlock(t, "times out and/or hangs")
+	{{if .SkipCclUnderRace}}skip.UnderRace(t, "times out and/or hangs")
+	{{end}}skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }
 {{ end }}


### PR DESCRIPTION
For whatever reason these particular configurations are particularly prone to timing out under `race`. Presumably they are more sensitive to the extra load. The other configurations seem not to have this issue.

Epic: none
Release note: None