### PR TITLE
mixedversion: introduce mutator interface and internal API

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
@@ -11,7 +11,6 @@
 package mixedversion
 
 import (
-	"math/rand"
 	"sync/atomic"
 	"testing"
 
@@ -20,7 +19,7 @@ import (
 )
 
 func TestClusterVersionAtLeast(t *testing.T) {
-	rng := rand.New(rand.NewSource(seed))
+	rng := newRand()
 
 	testCases := []struct {
 		name           string

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -98,6 +98,7 @@ const (
 	backgroundLabel   = "start background hooks"
 	mixedVersionLabel = "run mixed-version hooks"
 	afterTestLabel    = "run after test hooks"
+	genericLabel      = "run following steps" // used by mutators to group steps
 
 	// runWhileMigratingProbability is the probability that a
 	// mixed-version hook will run after all nodes in the cluster have
@@ -927,6 +928,7 @@ type delayedStep struct {
 // before each step starts, see notes on `delayedStep`.
 type concurrentRunStep struct {
 	label        string
+	rng          *rand.Rand
 	delayedSteps []testStep
 }
 
@@ -936,7 +938,7 @@ func newConcurrentRunStep(label string, steps []testStep, rng *rand.Rand) concur
 		delayedSteps = append(delayedSteps, delayedStep{delay: randomDelay(rng), step: step})
 	}
 
-	return concurrentRunStep{label: label, delayedSteps: delayedSteps}
+	return concurrentRunStep{label: label, delayedSteps: delayedSteps, rng: rng}
 }
 
 func (s concurrentRunStep) Description() string {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -41,6 +41,9 @@ type (
 		// the run encoded by this plan. These upgrades happen *after*
 		// every update in `setup` is finished.
 		upgrades []*upgradePlan
+		// enabledMutators is a list of `mutator` implementations that
+		// were applied when generating this test plan.
+		enabledMutators []mutator
 	}
 
 	// testSetup includes the sequence of steps that run to setup the
@@ -118,6 +121,19 @@ type (
 	// implementations to select the steps in the test plan that they
 	// wish to mutate.
 	stepSelector []*singleStep
+
+	// singleStepInfo is the information we keep about single steps in
+	// `stepIndex`. `isConcurrent` indicates whether the step is part of
+	// a `concurrentRunStep`.
+	singleStepInfo struct {
+		step         *singleStep
+		isConcurrent bool
+	}
+
+	// stepIndex contains a sequence of `singleStep`s present in a plan,
+	// along with some step metadata, providing functionality to
+	// determine the test context when inserting new steps in a plan.
+	stepIndex []singleStepInfo
 )
 
 const (
@@ -149,6 +165,11 @@ const (
 	mutationInsertConcurrent
 	mutationRemove
 )
+
+// planMutators includes a list of all known `mutator`
+// implementations. A subset of these mutations might be enabled in
+// any mixedversion test plan.
+var planMutators = []mutator{}
 
 // Plan returns the TestPlan used to upgrade the cluster from the
 // first to the final version in the `versions` field. The test plan
@@ -212,6 +233,16 @@ func (p *testPlanner) Plan() *TestPlan {
 		setup:     setup,
 		initSteps: p.testStartSteps(),
 		upgrades:  testUpgrades,
+	}
+
+	// Probabilistically enable some of of the mutators on the base test
+	// plan generated above.
+	for _, mut := range planMutators {
+		if p.prng.Float64() < mut.Probability() {
+			mutations := mut.Generate(p.prng, testPlan)
+			testPlan.applyMutations(p.prng, mutations)
+			testPlan.enabledMutators = append(testPlan.enabledMutators, mut)
+		}
 	}
 
 	testPlan.assignIDs()
@@ -437,48 +468,166 @@ func (up *upgradePlan) Add(steps []testStep) {
 	up.sequentialStep.steps = append(up.sequentialStep.steps, steps...)
 }
 
-// forEachSingleStep iterates over every step in the test plan and
-// calls the given function `f` for every `singleStep` in the plan
-// (i.e., each step that actually performs an action in the test).
-func (plan *TestPlan) forEachSingleStep(f func(*singleStep)) {
-	var iterateOverSteps func([]testStep)
-	iterateOverSteps = func(steps []testStep) {
-		for _, step := range steps {
-			switch s := step.(type) {
-			case sequentialRunStep:
-				iterateOverSteps(s.steps)
-			case concurrentRunStep:
-				iterateOverSteps(s.delayedSteps)
-			case delayedStep:
-				iterateOverSteps([]testStep{s.step})
-			default:
-				ss := s.(*singleStep)
-				f(ss)
+// mapSingleSteps iterates over every step in the test plan and calls
+// the given function `f` for every `singleStep` (i.e., every step
+// that actually performs an action). The function should return a
+// list of testSteps that replace the given step in the plan.
+func (plan *TestPlan) mapSingleSteps(f func(*singleStep, bool) []testStep) {
+	var mapStep func(testStep, bool) []testStep
+	mapStep = func(step testStep, isConcurrent bool) []testStep {
+		switch s := step.(type) {
+		case sequentialRunStep:
+			var newSteps []testStep
+			for _, seqStep := range s.steps {
+				newSteps = append(newSteps, mapStep(seqStep, false)...)
 			}
+			s.steps = newSteps
+			return []testStep{s}
+		case concurrentRunStep:
+			var newSteps []testStep
+			for _, concurrentStep := range s.delayedSteps {
+				ds := concurrentStep.(delayedStep)
+				for _, ss := range mapStep(ds.step, true) {
+					// If the function returned the original step, don't
+					// generate a new delay for it.
+					if ss == ds.step {
+						newSteps = append(newSteps, delayedStep{delay: ds.delay, step: ss})
+					} else {
+						newSteps = append(newSteps, delayedStep{delay: randomDelay(s.rng), step: ss})
+					}
+				}
+			}
+
+			// If, after mapping, our concurrentRunStep only has one step,
+			// flatten it to that step alone. While it's harmless, from a
+			// test execution standpoint, to leave this as-is, it's silly to
+			// have a "concurrent run" of a single step, so this
+			// simplification makes the test plan more understandable.
+			if s.label == genericLabel && len(newSteps) == 1 {
+				return []testStep{newSteps[0].(delayedStep).step}
+			}
+
+			s.delayedSteps = newSteps
+			return []testStep{s}
+		default:
+			ss := s.(*singleStep)
+			return f(ss, isConcurrent)
 		}
 	}
 
-	iterateOverSteps(plan.setup.clusterSetup)
-	for _, upgrade := range plan.setup.upgrades {
-		iterateOverSteps(upgrade.sequentialStep.steps)
+	mapSteps := func(steps []testStep) []testStep {
+		var newSteps []testStep
+		for _, s := range steps {
+			newSteps = append(newSteps, mapStep(s, false)...)
+		}
+
+		return newSteps
 	}
 
-	iterateOverSteps(plan.initSteps)
-	for _, upgrade := range plan.upgrades {
-		iterateOverSteps(upgrade.sequentialStep.steps)
+	mapUpgrades := func(upgrades []*upgradePlan) []*upgradePlan {
+		var newUpgrades []*upgradePlan
+		for _, upgrade := range upgrades {
+			newUpgrades = append(newUpgrades, &upgradePlan{
+				from: upgrade.from,
+				to:   upgrade.to,
+				sequentialStep: sequentialRunStep{
+					label: upgrade.sequentialStep.label,
+					steps: mapSteps(upgrade.sequentialStep.steps),
+				},
+			})
+		}
+
+		return newUpgrades
 	}
+
+	plan.setup.clusterSetup = mapSteps(plan.setup.clusterSetup)
+	plan.setup.upgrades = mapUpgrades(plan.setup.upgrades)
+	plan.initSteps = mapSteps(plan.initSteps)
+	plan.upgrades = mapUpgrades(plan.upgrades)
+}
+
+func newStepIndex(plan *TestPlan) stepIndex {
+	var index stepIndex
+
+	plan.mapSingleSteps(func(ss *singleStep, isConcurrent bool) []testStep {
+		index = append(index, singleStepInfo{
+			step:         ss,
+			isConcurrent: isConcurrent,
+		})
+		return []testStep{ss}
+	})
+
+	return index
+}
+
+// ContextForInsertion returns a `Context` to be used when applying
+// the given `mutationOp` relative to the step passed as argument
+// (which is expected to exist in the underlying step sequence).
+//
+// The logic in this function relies on the assumption (withheld by
+// `mutator` implementations) that steps inserted by mutations do not
+// change the `Context` they run in (in other words, they don't
+// restart nodes with different binaries). In that case, when
+// inserting a step before a given step `s`, the inserted step should
+// have the same context as `s`; when inserting a step after `s`, then
+// it should have the same context as the `singleStep` that runs after
+// `s`.
+func (si stepIndex) ContextForInsertion(step *singleStep, op mutationOp) Context {
+	for j, info := range si {
+		if info.step == step {
+			// If this is the first or last singleStep in the plan, the
+			// context is inherited from `info.step`. We also inherit the
+			// same context if we are inserting the new step relative to a
+			// step that is part of a concurrent group.
+			if j == 0 || j == len(si)-1 || op == mutationInsertConcurrent {
+				return info.step.context.clone()
+			}
+
+			var idx int
+			switch op {
+			case mutationInsertBefore:
+				idx = j
+			case mutationInsertAfter:
+				idx = j + 1
+			default:
+				panic(fmt.Errorf("internal error: ContextForInsertion: unexpected operation %d", op))
+			}
+
+			return si[idx].step.context.clone()
+		}
+	}
+
+	panic(fmt.Errorf("internal error: could not find step %#v", *step))
+}
+
+// IsConcurrent returns whether the step passed is part of a
+// `concurrentRunStep`.
+func (si stepIndex) IsConcurrent(step *singleStep) bool {
+	for _, info := range si {
+		if info.step == step {
+			return info.isConcurrent
+		}
+	}
+
+	panic(fmt.Errorf("internal error: could not find step %#v", *step))
+}
+
+// singleSteps returns a list of all `singleStep`s in the test plan.
+func (plan *TestPlan) singleSteps() []*singleStep {
+	var result []*singleStep
+	plan.mapSingleSteps(func(ss *singleStep, _ bool) []testStep {
+		result = append(result, ss)
+		return []testStep{ss}
+	})
+
+	return result
 }
 
 // newStepSelector creates a `stepSelector` instance that can be used
 // by mutators to find a specific step or set of steps. The returned
 // selector will match every singleStep in the test plan.
 func (plan *TestPlan) newStepSelector() stepSelector {
-	var result stepSelector
-	plan.forEachSingleStep(func(ss *singleStep) {
-		result = append(result, ss)
-	})
-
-	return result
+	return plan.singleSteps()
 }
 
 // Filter returns a new selector that only applies to steps that match
@@ -580,6 +729,84 @@ func (ss stepSelector) Remove() []mutation {
 	return mutations
 }
 
+// applyMutations applies each mutation passed to the test plan,
+// making in place updates.
+func (plan *TestPlan) applyMutations(rng *rand.Rand, mutations []mutation) {
+	for _, mut := range mutationApplicationOrder(mutations) {
+		plan.mapSingleSteps(func(ss *singleStep, isConcurrent bool) []testStep {
+			index := newStepIndex(plan)
+
+			// If the mutation is not relative to this step, move on.
+			if ss != mut.reference {
+				return []testStep{ss}
+			}
+
+			// If we are inserting a new step via this mutation, create the
+			// `singleStep` here so that it is used accordingly in the
+			// `switch` below.
+			var newSingleStep *singleStep
+			if mut.op == mutationInsertBefore ||
+				mut.op == mutationInsertAfter ||
+				mut.op == mutationInsertConcurrent {
+				newSingleStep = &singleStep{
+					context: index.ContextForInsertion(ss, mut.op),
+					impl:    mut.impl,
+				}
+			}
+
+			switch mut.op {
+			case mutationInsertBefore:
+				return []testStep{newSingleStep, ss}
+			case mutationInsertAfter:
+				return []testStep{ss, newSingleStep}
+			case mutationInsertConcurrent:
+				steps := []testStep{ss, newSingleStep}
+
+				// If the reference step is already part of a
+				// `concurrentRunStep`, return the existing and new steps in
+				// sequence; they will already be running concurrently in this
+				// case, and nothing else is needed.
+				if index.IsConcurrent(ss) {
+					return steps
+				}
+
+				// Otherwise, create a new `concurrentRunStep` for the two
+				// steps.
+				return []testStep{
+					newConcurrentRunStep(genericLabel, steps, rng),
+				}
+			case mutationRemove:
+				return nil
+			default:
+				panic(fmt.Errorf("internal error: unknown mutation type (%d)", mut.op))
+			}
+		})
+	}
+}
+
+// mutationApplicationOrder rearranges the collection of mutations
+// passed so that all insertions happen before any removal. This is to
+// avoid the situation where an insertion references a step that is
+// removed by a previous mutation. This is a safe operation because
+// mutators generate mutations based on a fixed view of the test plan;
+// in other words, a mutation is never relative to a step created by
+// a previous mutation.
+func mutationApplicationOrder(mutations []mutation) []mutation {
+	var insertions []mutation
+	var removals []mutation
+
+	for _, mut := range mutations {
+		switch mut.op {
+		case mutationRemove:
+			removals = append(removals, mut)
+		default:
+			insertions = append(insertions, mut)
+		}
+	}
+
+	return append(insertions, removals...)
+}
+
 // assignIDs iterates over each `singleStep` in the test plan, and
 // assigns them a unique numeric ID. These IDs are not necessary for
 // correctness, but are nice to have when debugging failures and
@@ -591,12 +818,13 @@ func (plan *TestPlan) assignIDs() {
 		return currentID
 	}
 
-	plan.forEachSingleStep(func(ss *singleStep) {
+	plan.mapSingleSteps(func(ss *singleStep, _ bool) []testStep {
 		stepID := nextID()
 		if _, ok := ss.impl.(startStep); ok && plan.startClusterID == 0 {
 			plan.startClusterID = stepID
 		}
 		ss.ID = stepID
+		return []testStep{ss}
 	})
 }
 
@@ -666,9 +894,19 @@ func (plan *TestPlan) prettyPrintInternal(debug bool) string {
 		formattedVersions = append(formattedVersions, fmt.Sprintf("%q", v.String()))
 	}
 
+	var mutatorsDesc string
+	if len(plan.enabledMutators) > 0 {
+		mutatorNames := make([]string, 0, len(plan.enabledMutators))
+		for _, mut := range plan.enabledMutators {
+			mutatorNames = append(mutatorNames, mut.Name())
+		}
+
+		mutatorsDesc = fmt.Sprintf(" with mutators {%s}", strings.Join(mutatorNames, ", "))
+	}
+
 	return fmt.Sprintf(
-		"mixed-version test plan for upgrading from %s:\n%s",
-		strings.Join(formattedVersions, " to "), out.String(),
+		"mixed-version test plan for upgrading from %s%s:\n%s",
+		strings.Join(formattedVersions, " to "), mutatorsDesc, out.String(),
 	)
 }
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -76,6 +76,48 @@ type (
 		to             *clusterupgrade.Version
 		sequentialStep sequentialRunStep
 	}
+
+	// mutator describes the interface to be implemented by different
+	// `mutators`.
+	//
+	// Mutators exist as a way to introduce optional behaviour to
+	// upgrade tests in order to increase coverage of certain areas of
+	// the database and of the upgrade machinery itself.
+	mutator interface {
+		// Name returns the unique name of this mutator. This allows the
+		// test runner to log which mutators are active and test authors
+		// to opt-out of mutators that are incompatible with a test, if
+		// necessary.
+		Name() string
+		// Probability returns the probability that this mutator will run
+		// in any given test run. Every mutator should run under some
+		// probability. Making this an explicit part of the interface
+		// makes that more prominent.
+		Probability() float64
+		// Generate takes a test plan and a RNG and returns the list of
+		// mutations that should be applied to the plan.
+		Generate(*rand.Rand, *TestPlan) []mutation
+	}
+
+	// mutationOp encodes the type of mutation and controls how the
+	// mutation is applied to the test plan.
+	mutationOp int
+
+	// mutation describes a change to an upgrade test plan. The change
+	// is relative to a `reference` step (i.e., a step that exists in
+	// the original plan). `op` encodes the operation to be
+	// performed. If a new step is being added to the plan, `impl`
+	// includes its implementation.
+	mutation struct {
+		reference *singleStep
+		impl      singleStepProtocol
+		op        mutationOp
+	}
+
+	// stepSelector provides a high level API for mutator
+	// implementations to select the steps in the test plan that they
+	// wish to mutate.
+	stepSelector []*singleStep
 )
 
 const (
@@ -92,7 +134,7 @@ const (
 	// `BackgroundStage` is special in the sense that it may continue to
 	// run across stage changes, so doing direct stage comparisons as
 	// mentioned above doesn't make sense for background functions.
-	ClusterSetupStage = UpgradeStage(iota)
+	ClusterSetupStage UpgradeStage = iota
 	OnStartupStage
 	BackgroundStage
 	InitUpgradeStage
@@ -101,6 +143,11 @@ const (
 	LastUpgradeStage
 	RunningUpgradeMigrationsStage
 	AfterUpgradeFinalizedStage
+
+	mutationInsertBefore mutationOp = iota
+	mutationInsertAfter
+	mutationInsertConcurrent
+	mutationRemove
 )
 
 // Plan returns the TestPlan used to upgrade the cluster from the
@@ -390,6 +437,149 @@ func (up *upgradePlan) Add(steps []testStep) {
 	up.sequentialStep.steps = append(up.sequentialStep.steps, steps...)
 }
 
+// forEachSingleStep iterates over every step in the test plan and
+// calls the given function `f` for every `singleStep` in the plan
+// (i.e., each step that actually performs an action in the test).
+func (plan *TestPlan) forEachSingleStep(f func(*singleStep)) {
+	var iterateOverSteps func([]testStep)
+	iterateOverSteps = func(steps []testStep) {
+		for _, step := range steps {
+			switch s := step.(type) {
+			case sequentialRunStep:
+				iterateOverSteps(s.steps)
+			case concurrentRunStep:
+				iterateOverSteps(s.delayedSteps)
+			case delayedStep:
+				iterateOverSteps([]testStep{s.step})
+			default:
+				ss := s.(*singleStep)
+				f(ss)
+			}
+		}
+	}
+
+	iterateOverSteps(plan.setup.clusterSetup)
+	for _, upgrade := range plan.setup.upgrades {
+		iterateOverSteps(upgrade.sequentialStep.steps)
+	}
+
+	iterateOverSteps(plan.initSteps)
+	for _, upgrade := range plan.upgrades {
+		iterateOverSteps(upgrade.sequentialStep.steps)
+	}
+}
+
+// newStepSelector creates a `stepSelector` instance that can be used
+// by mutators to find a specific step or set of steps. The returned
+// selector will match every singleStep in the test plan.
+func (plan *TestPlan) newStepSelector() stepSelector {
+	var result stepSelector
+	plan.forEachSingleStep(func(ss *singleStep) {
+		result = append(result, ss)
+	})
+
+	return result
+}
+
+// Filter returns a new selector that only applies to steps that match
+// the predicate given.
+func (ss stepSelector) Filter(predicate func(*singleStep) bool) stepSelector {
+	var result stepSelector
+	for _, s := range ss {
+		if predicate(s) {
+			result = append(result, s)
+		}
+	}
+
+	return result
+}
+
+// RandomStep returns a new selector that selects a single step,
+// randomly chosen from the list of selected steps in the original
+// selector.
+func (ss stepSelector) RandomStep(rng *rand.Rand) stepSelector {
+	if len(ss) > 0 {
+		chosenStep := ss[rng.Intn(len(ss))]
+		return stepSelector{chosenStep}
+	}
+
+	return ss
+}
+
+func (ss stepSelector) insert(impl singleStepProtocol, opGen func() mutationOp) []mutation {
+	var mutations []mutation
+	for _, s := range ss {
+		mutations = append(mutations, mutation{
+			reference: s,
+			impl:      impl,
+			op:        opGen(),
+		})
+	}
+
+	return mutations
+}
+
+// Insert creates mutations to insert a step with the given
+// implementation randomly around each selected step (before, after,
+// or concurrently).
+func (ss stepSelector) Insert(rng *rand.Rand, impl singleStepProtocol) []mutation {
+	possibleInserts := []mutationOp{
+		mutationInsertBefore,
+		mutationInsertAfter,
+		mutationInsertConcurrent,
+	}
+
+	return ss.insert(impl, func() mutationOp {
+		return possibleInserts[rng.Intn(len(possibleInserts))]
+	})
+}
+
+// InsertSequential creates mutations to insert a step with the given
+// implementation sequentially relative to each selected step. The new
+// step might be inserted before or after selected steps.
+func (ss stepSelector) InsertSequential(rng *rand.Rand, impl singleStepProtocol) []mutation {
+	possibleInserts := []mutationOp{
+		mutationInsertBefore,
+		mutationInsertAfter,
+	}
+
+	return ss.insert(impl, func() mutationOp {
+		return possibleInserts[rng.Intn(len(possibleInserts))]
+	})
+}
+
+func (ss stepSelector) InsertBefore(impl singleStepProtocol) []mutation {
+	return ss.insert(impl, func() mutationOp {
+		return mutationInsertBefore
+	})
+}
+
+func (ss stepSelector) InsertAfter(impl singleStepProtocol) []mutation {
+	return ss.insert(impl, func() mutationOp {
+		return mutationInsertAfter
+	})
+}
+
+func (ss stepSelector) InsertConcurrent(impl singleStepProtocol) []mutation {
+	return ss.insert(impl, func() mutationOp {
+		return mutationInsertConcurrent
+	})
+}
+
+// Remove creates mutations to remove the steps currently selected by
+// the selector.
+func (ss stepSelector) Remove() []mutation {
+	var mutations []mutation
+	for _, s := range ss {
+		mutations = append(mutations, mutation{
+			reference: s,
+			op:        mutationRemove,
+		})
+	}
+
+	return mutations
+}
+
 // assignIDs iterates over each `singleStep` in the test plan, and
 // assigns them a unique numeric ID. These IDs are not necessary for
 // correctness, but are nice to have when debugging failures and
@@ -401,37 +591,13 @@ func (plan *TestPlan) assignIDs() {
 		return currentID
 	}
 
-	var assignIDsToSteps func([]testStep)
-	assignIDsToSteps = func(steps []testStep) {
-		for _, step := range steps {
-			switch s := step.(type) {
-			case sequentialRunStep:
-				assignIDsToSteps(s.steps)
-			case concurrentRunStep:
-				assignIDsToSteps(s.delayedSteps)
-			case delayedStep:
-				assignIDsToSteps([]testStep{s.step})
-			default:
-				ss := s.(*singleStep)
-				stepID := nextID()
-				if _, ok := ss.impl.(startStep); ok && plan.startClusterID == 0 {
-					plan.startClusterID = stepID
-				}
-
-				ss.ID = stepID
-			}
+	plan.forEachSingleStep(func(ss *singleStep) {
+		stepID := nextID()
+		if _, ok := ss.impl.(startStep); ok && plan.startClusterID == 0 {
+			plan.startClusterID = stepID
 		}
-	}
-
-	assignIDsToSteps(plan.setup.clusterSetup)
-	for _, upgrade := range plan.setup.upgrades {
-		assignIDsToSteps(upgrade.sequentialStep.steps)
-	}
-
-	assignIDsToSteps(plan.initSteps)
-	for _, upgrade := range plan.upgrades {
-		assignIDsToSteps(upgrade.sequentialStep.steps)
-	}
+		ss.ID = stepID
+	})
 }
 
 // allUpgrades returns a list of all upgrades encoded in this test

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -608,6 +608,20 @@ func Test_stepSelectorMutations(t *testing.T) {
 	}
 }
 
+func Test_mutationApplicationOrder(t *testing.T) {
+	mutations := []mutation{
+		{op: mutationInsertBefore},
+		{op: mutationRemove},
+		{op: mutationInsertAfter},
+	}
+
+	require.Equal(t, []mutation{
+		{op: mutationInsertBefore},
+		{op: mutationInsertAfter},
+		{op: mutationRemove},
+	}, mutationApplicationOrder(mutations))
+}
+
 // requireConcurrentHooks asserts that there is a concurrent step with
 // user-provided hooks of the given names.
 func requireConcurrentHooks(t *testing.T, steps []testStep, names ...string) error {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -272,13 +272,17 @@ func setBuildVersion() func() {
 	return func() { clusterupgrade.TestBuildVersion = previousV }
 }
 
+func newRand() *rand.Rand {
+	return rand.New(rand.NewSource(seed))
+}
+
 func newTest(options ...CustomOption) *Test {
 	testOptions := defaultTestOptions
 	for _, fn := range options {
 		fn(&testOptions)
 	}
 
-	prng := rand.New(rand.NewSource(seed))
+	prng := newRand()
 	return &Test{
 		ctx:             ctx,
 		logger:          nilLogger,
@@ -290,6 +294,16 @@ func newTest(options ...CustomOption) *Test {
 		hooks:           &testHooks{prng: prng, crdbNodes: nodes},
 		predecessorFunc: testPredecessorFunc,
 	}
+}
+
+func newBasicUpgradeTest(options ...CustomOption) *Test {
+	mvt := newTest(options...)
+	mvt.InMixedVersion("on startup 1", dummyHook)
+	mvt.InMixedVersion("mixed-version 1", dummyHook)
+	mvt.InMixedVersion("mixed-version 2", dummyHook)
+	mvt.AfterUpgradeFinalized("after finalization", dummyHook)
+
+	return mvt
 }
 
 func archP(a vm.CPUArch) *vm.CPUArch {
@@ -354,6 +368,244 @@ func createDataDrivenMixedVersionTest(t *testing.T, args []datadriven.CmdArg) *T
 	}
 
 	return mvt
+}
+
+func Test_stepSelectorFilter(t *testing.T) {
+	testCases := []struct {
+		name      string
+		predicate func(*singleStep) bool
+		// expectedAllSteps returns whether the step selector should match
+		// all original steps even after applying the `predicate`.
+		expectedAllSteps bool
+		// assertStepsFunc is called to assert on the current state of the
+		// selector, if `expectedAllSteps` is false.
+		assertStepsFunc func(*testing.T, stepSelector)
+		// expectedRandomStepType is the type of the step to be returned
+		// by RandomStep() after applying the predicate. Leave unset if
+		// the selector should be empty.
+		expectedRandomStepType interface{}
+	}{
+		{
+			name:                   "no filter",
+			predicate:              func(*singleStep) bool { return true },
+			expectedAllSteps:       true,
+			expectedRandomStepType: runHookStep{},
+		},
+		{
+			name: "filter eliminates all steps",
+			predicate: func(s *singleStep) bool {
+				return s.context.Stage == BackgroundStage // no background steps in the plan used in the test
+			},
+			assertStepsFunc: func(t *testing.T, sel stepSelector) {
+				require.Empty(t, sel)
+			},
+			expectedRandomStepType: nil, // no steps selected
+		},
+		{
+			name: "filtering by a specific stage",
+			predicate: func(s *singleStep) bool {
+				return s.context.Stage == AfterUpgradeFinalizedStage
+			},
+			assertStepsFunc: func(t *testing.T, sel stepSelector) {
+				require.Len(t, sel, 3) // number of upgrades we are performing
+				for _, s := range sel {
+					require.IsType(t, runHookStep{}, s.impl)
+					rhs := s.impl.(runHookStep)
+					require.Equal(t, "after finalization", rhs.hook.name)
+				}
+			},
+			expectedRandomStepType: runHookStep{},
+		},
+		{
+			name: "filtering by a specific stage and upgrade cycle",
+			predicate: func(s *singleStep) bool {
+				return s.context.ToVersion.IsCurrent() && s.context.Stage == AfterUpgradeFinalizedStage
+			},
+			assertStepsFunc: func(t *testing.T, sel stepSelector) {
+				require.Len(t, sel, 1)
+				require.IsType(t, runHookStep{}, sel[0].impl)
+				rhs := sel[0].impl.(runHookStep)
+				require.Equal(t, "after finalization", rhs.hook.name)
+			},
+			expectedRandomStepType: runHookStep{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mvt := newBasicUpgradeTest(NumUpgrades(3))
+			mvt.predecessorFunc = func(rng *rand.Rand, v *clusterupgrade.Version, n int) ([]*clusterupgrade.Version, error) {
+				return parseVersions([]string{"v22.2.2", "v23.1.9", "v23.2.0"}), nil
+			}
+
+			plan, err := mvt.plan()
+			require.NoError(t, err)
+
+			sel := plan.newStepSelector()
+			allSteps := sel
+
+			newSelector := sel.Filter(tc.predicate)
+			if tc.expectedAllSteps {
+				require.Equal(t, allSteps, newSelector)
+			} else {
+				tc.assertStepsFunc(t, newSelector)
+			}
+
+			randomSelector := newSelector.RandomStep(newRand())
+			if tc.expectedRandomStepType == nil {
+				require.Empty(t, randomSelector)
+			} else {
+				require.Len(t, randomSelector, 1)
+				require.IsType(t, tc.expectedRandomStepType, randomSelector[0].impl)
+			}
+		})
+	}
+}
+
+func Test_stepSelectorMutations(t *testing.T) {
+	validateMutations := func(
+		t *testing.T,
+		mutations []mutation,
+		expectedMutations int,
+		expectedName string,
+		expectedImpl singleStepProtocol,
+		expectedOps []mutationOp,
+	) {
+		require.Len(t, mutations, expectedMutations)
+
+		var ops []mutationOp
+		for _, mut := range mutations {
+			require.IsType(t, runHookStep{}, mut.reference.impl)
+			rhs := mut.reference.impl.(runHookStep)
+			require.Equal(t, expectedName, rhs.hook.name)
+
+			require.Equal(t, expectedImpl, mut.impl)
+			ops = append(ops, mut.op)
+		}
+
+		require.Equal(t, expectedOps, ops)
+	}
+
+	testCases := []struct {
+		name string
+		// numUpgrades limits the number of upgrades performed by the test
+		// planner.
+		numUpgrades int
+		// predicate is applied to the step selector for the basic test
+		// plan generated in each test case.
+		predicate func(*singleStep) bool
+		// op is the operation to be performed on the selector after
+		// applying the `predicate`.
+		op string
+		// assertMutationsFunc is called to validate that the mutations
+		// generated by this test case match the expectations.
+		assertMutationsFunc func(*testing.T, *singleStep, []mutation)
+	}{
+		{
+			name:        "insert step when filter has no matches",
+			numUpgrades: 1,
+			predicate: func(s *singleStep) bool {
+				return s.context.Stage == BackgroundStage // no background steps
+			},
+			op: "insert",
+			assertMutationsFunc: func(t *testing.T, step *singleStep, mutations []mutation) {
+				validateMutations(t, mutations, 0, "", nil, nil)
+			},
+		},
+		{
+			name:        "insert step in single upgrade, single step filtered",
+			numUpgrades: 1,
+			predicate: func(s *singleStep) bool {
+				return s.context.Stage == AfterUpgradeFinalizedStage
+			},
+			op: "insert",
+			assertMutationsFunc: func(t *testing.T, step *singleStep, mutations []mutation) {
+				validateMutations(
+					t, mutations, 1, "after finalization", step.impl,
+					[]mutationOp{mutationInsertConcurrent},
+				)
+			},
+		},
+		{
+			name:        "insert step in multiple upgrade plan",
+			numUpgrades: 3,
+			predicate: func(s *singleStep) bool {
+				return s.context.Stage == AfterUpgradeFinalizedStage
+			},
+			op: "insert",
+			assertMutationsFunc: func(t *testing.T, step *singleStep, mutations []mutation) {
+				validateMutations(
+					t, mutations, 3, "after finalization", step.impl,
+					[]mutationOp{mutationInsertConcurrent, mutationInsertAfter, mutationInsertAfter},
+				)
+			},
+		},
+		{
+			name:        "remove step when filter has no matches",
+			numUpgrades: 1,
+			predicate: func(s *singleStep) bool {
+				return s.context.Stage == BackgroundStage // no background steps
+			},
+			op: "remove",
+			assertMutationsFunc: func(t *testing.T, _ *singleStep, mutations []mutation) {
+				validateMutations(t, mutations, 0, "", nil, nil)
+			},
+		},
+		{
+			name:        "remove step in single upgrade, single step filtered",
+			numUpgrades: 1,
+			predicate: func(s *singleStep) bool {
+				return s.context.Stage == AfterUpgradeFinalizedStage
+			},
+			op: "remove",
+			assertMutationsFunc: func(t *testing.T, _ *singleStep, mutations []mutation) {
+				validateMutations(
+					t, mutations, 1, "after finalization", nil,
+					[]mutationOp{mutationRemove},
+				)
+			},
+		},
+		{
+			name:        "remove step in multiple upgrade plan",
+			numUpgrades: 3,
+			predicate: func(s *singleStep) bool {
+				return s.context.Stage == AfterUpgradeFinalizedStage
+			},
+			op: "remove",
+			assertMutationsFunc: func(t *testing.T, _ *singleStep, mutations []mutation) {
+				validateMutations(
+					t, mutations, 3, "after finalization", nil,
+					[]mutationOp{mutationRemove, mutationRemove, mutationRemove},
+				)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mvt := newBasicUpgradeTest(NumUpgrades(tc.numUpgrades))
+			mvt.predecessorFunc = func(rng *rand.Rand, v *clusterupgrade.Version, n int) ([]*clusterupgrade.Version, error) {
+				return parseVersions([]string{"v22.2.2", "v23.1.9", "v23.2.0"})[:tc.numUpgrades], nil
+			}
+
+			plan, err := mvt.plan()
+			require.NoError(t, err)
+
+			sel := plan.newStepSelector().Filter(tc.predicate)
+			ss := newTestStep(func() error { return nil })
+
+			var mutations []mutation
+			if tc.op == "insert" {
+				mutations = sel.Insert(newRand(), ss.impl)
+			} else if tc.op == "remove" {
+				mutations = sel.Remove()
+			} else {
+				require.FailNowf(t, "unknown op: %s", tc.op)
+			}
+
+			tc.assertMutationsFunc(t, ss, mutations)
+		})
+	}
 }
 
 // requireConcurrentHooks asserts that there is a concurrent step with

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
@@ -70,10 +70,10 @@ type testSingleStep struct {
 	runFunc func() error
 }
 
-func (testSingleStep) Description() string    { return "testSingleStep" }
-func (testSingleStep) Background() shouldStop { return nil }
+func (*testSingleStep) Description() string    { return "testSingleStep" }
+func (*testSingleStep) Background() shouldStop { return nil }
 
-func (tss testSingleStep) Run(
+func (tss *testSingleStep) Run(
 	_ context.Context, _ *logger.Logger, _ cluster.Cluster, _ *Helper,
 ) error {
 	return tss.runFunc()
@@ -81,5 +81,5 @@ func (tss testSingleStep) Run(
 
 func newTestStep(f func() error) *singleStep {
 	initialVersion := parseVersions([]string{predecessorVersion})[0]
-	return newSingleStep(newInitialContext(initialVersion, nodes), testSingleStep{runFunc: f})
+	return newSingleStep(newInitialContext(initialVersion, nodes), &testSingleStep{runFunc: f})
 }


### PR DESCRIPTION
This commit introduces the internal API to be used by future
implementations of the `mutator` interface. Mutators are components
that change the upgrade test plan generated by the planner in order to
introduce *optional* behaviours in a test. This could mean moving a
certain step around in the plan (if it is safe to do) or, most
commonly, inserting new steps that perform an action that should not
affect the outcome of the test.

The main new data structure added in this commit is the `stepSelector`
struct, providing an internal API that mutators will be able to use in
order to find parts of the test plan they are interested in and being
able to apply mutations to it. In a future commit, these mutations
will be applied to the original test plan.

Epic: none

Release note: None

**mixedversion: apply mutations generated by `mutator` implementations**
This commit introduces a list of `planMutators` (currently empty) and
adds the logic in the test planner to iterate over these mutators,
probabilistically enable *some* of them, and then apply the mutations
they generate on the original test plan.

Epic: none

Release note: None