### PR TITLE
sql: add AOST clause to CALL statement

### DIFF
--- a/docs/generated/sql/bnf/call_stmt.bnf
+++ b/docs/generated/sql/bnf/call_stmt.bnf
@@ -1,2 +1,2 @@
 call_stmt ::=
-	'CALL' proc_name '(' param_values ')'
+	'CALL' proc_name '(' param_values ')' opt_as_of_clause

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -65,7 +65,7 @@ analyze_stmt ::=
 	| 'ANALYSE' analyze_target
 
 call_stmt ::=
-	'CALL' func_application
+	'CALL' func_application opt_as_of_clause
 
 copy_stmt ::=
 	'COPY' table_name opt_column_list 'FROM' 'STDIN' opt_with_copy_options opt_where_clause
@@ -328,6 +328,10 @@ func_application ::=
 	| func_application_name '(' 'DISTINCT' expr_list ')'
 	| func_application_name '(' '*' ')'
 
+opt_as_of_clause ::=
+	as_of_clause
+	| 
+
 table_name ::=
 	db_object_name
 
@@ -546,10 +550,6 @@ sconst_or_placeholder ::=
 string_or_placeholder_opt_list ::=
 	string_or_placeholder
 	| '(' string_or_placeholder_list ')'
-
-opt_as_of_clause ::=
-	as_of_clause
-	| 
 
 opt_with_backup_options ::=
 	'WITH' backup_options_list
@@ -1004,6 +1004,9 @@ expr_list ::=
 opt_sort_clause_no_index ::=
 	sort_clause_no_index
 	| 
+
+as_of_clause ::=
+	'AS' 'OF' 'SYSTEM' 'TIME' a_expr
 
 db_object_name ::=
 	simple_db_object_name
@@ -1731,9 +1734,6 @@ set_or_reset_clause ::=
 	'SET' set_rest
 	| 'RESET_ALL' 'ALL'
 	| 'RESET' session_var
-
-as_of_clause ::=
-	'AS' 'OF' 'SYSTEM' 'TIME' a_expr
 
 backup_options_list ::=
 	( backup_options ) ( ( ',' backup_options ) )*

--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -19,6 +19,20 @@ statement ok
 INSERT INTO t VALUES (2);
 INSERT INTO t2 VALUES (2);
 
+statement ok
+CREATE PROCEDURE p_read() LANGUAGE PLPGSQL AS $$
+  DECLARE foo INT;
+  BEGIN SELECT i INTO foo FROM t ORDER BY i DESC; RAISE NOTICE '%', foo; END
+$$;
+
+statement ok
+CREATE PROCEDURE p_write(v INT) LANGUAGE PLPGSQL AS $$
+  BEGIN INSERT INTO t VALUES (v); END
+$$;
+
+statement ok
+SELECT pg_sleep(0.1);
+
 statement error pgcode 3D000 pq: database "test" does not exist
 SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp()
 
@@ -39,6 +53,14 @@ ROLLBACK
 
 statement error pgcode 0A000 inconsistent AS OF SYSTEM TIME timestamp
 SELECT * from t AS OF SYSTEM TIME '-1μs'; SELECT * from t AS OF SYSTEM TIME '-2μs'
+
+statement error pgcode 42883 pq: procedure p_read does not exist
+CALL p_read() AS OF SYSTEM TIME follower_read_timestamp();
+
+statement error pgcode 42883 pq: procedure p_write does not exist
+CALL p_write(100) AS OF SYSTEM TIME follower_read_timestamp();
+
+subtest default_follower_reads
 
 statement ok
 SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO TRUE
@@ -66,6 +88,12 @@ BEGIN; CREATE DATABASE IF NOT EXISTS d2
 statement ok
 ROLLBACK
 
+statement error pgcode 42883 pq: procedure p_read does not exist
+CALL p_read();
+
+statement error pgcode 42883 pq: procedure p_write does not exist
+CALL p_write(100);
+
 statement ok
 SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO FALSE
 
@@ -83,6 +111,8 @@ BEGIN READ WRITE; COMMIT
 
 statement ok
 BEGIN; CREATE DATABASE IF NOT EXISTS d2; COMMIT
+
+subtest default_txn_as_of
 
 statement ok
 SET SESSION CHARACTERISTICS AS TRANSACTION AS OF SYSTEM TIME follower_read_timestamp()
@@ -113,6 +143,8 @@ ROLLBACK
 statement ok
 SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO FALSE
 
+subtest as_of_funcs
+
 query B
 SELECT with_min_timestamp(statement_timestamp()) = statement_timestamp()
 ----
@@ -137,6 +169,7 @@ SELECT with_max_staleness(-'1s')
 #
 # Tests for optimizer bounded staleness checks.
 #
+subtest optimizer_checks
 
 statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
 SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms')
@@ -279,6 +312,7 @@ SELECT (
 #
 # Tests for nearest_only argument.
 #
+subtest nearest_only
 
 statement error with_max_staleness: expected bool argument for nearest_only
 SELECT * FROM t AS OF SYSTEM TIME with_max_staleness('1ms', 5)
@@ -301,6 +335,7 @@ SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '1m
 #
 # Tests for running bounded staleness queries in an explicit transaction.
 #
+subtest explicit_txn_bounded_staleness
 
 statement error AS OF SYSTEM TIME: only constant expressions or follower_read_timestamp are allowed
 BEGIN AS OF SYSTEM TIME with_max_staleness('1ms')
@@ -314,6 +349,7 @@ ROLLBACK
 #
 # Tests for bounded staleness with prepared statements.
 #
+subtest prepared_bounded_staleness
 
 statement ok
 PREPARE with_min_timestamp_prep AS SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(statement_timestamp() - '10s'::interval) WHERE i = 2
@@ -347,3 +383,125 @@ PREPARE placeholder_bounded_staleness_stmt AS SELECT * FROM t AS OF SYSTEM TIME 
 
 statement error expected float argument for to_timestamp
 PREPARE placeholder_with_min_timestamp_to_timestamp_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp(to_timestamp($1))
+
+subtest implicit_read_write_proc
+
+statement ok
+SELECT pg_sleep(1);
+
+statement ok
+CALL p_write(1001);
+
+statement ok
+SELECT pg_sleep(1);
+
+query T noticetrace
+CALL p_read();
+----
+NOTICE: 1001
+
+query T noticetrace
+CALL p_read() AS OF SYSTEM TIME '-10ms';
+----
+NOTICE: 1001
+
+query T noticetrace
+CALL p_read() AS OF SYSTEM TIME '-1.5s';
+----
+NOTICE: 2
+
+statement error pgcode 42883 pq: procedure p_read does not exist
+CALL p_read() AS OF SYSTEM TIME '-5s';
+
+statement error pq: cannot execute INSERT in a read-only transaction
+CALL p_write(1002) AS OF SYSTEM TIME '-10ms';
+
+# The supplied timestamp must match the transaction's timestamp if in a
+# multi-statement implicit transaction. The transaction's timestamp is
+# determined by the first statement that executes.
+statement error pgcode 0A000 inconsistent AS OF SYSTEM TIME timestamp
+CALL p_read();
+CALL p_read() AS OF SYSTEM TIME '-10ms';
+
+statement error pgcode 0A000 inconsistent AS OF SYSTEM TIME timestamp
+CALL p_read() AS OF SYSTEM TIME '-10ms';
+CALL p_read() AS OF SYSTEM TIME '-1.5ms';
+
+statement ok
+CALL p_read() AS OF SYSTEM TIME '-10ms';
+CALL p_read() AS OF SYSTEM TIME '-10ms';
+
+statement ok
+CALL p_read() AS OF SYSTEM TIME '-10ms';
+CALL p_read();
+
+subtest explicit_read_write_proc
+
+statement ok
+BEGIN TRANSACTION AS OF SYSTEM TIME '-10ms';
+
+query T noticetrace
+CALL p_read();
+----
+NOTICE: 1001
+
+statement error pq: cannot execute INSERT in a read-only transaction
+CALL p_write(1002);
+
+statement ok
+ABORT;
+
+statement ok
+BEGIN TRANSACTION AS OF SYSTEM TIME '-1.5s';
+
+query T noticetrace
+CALL p_read();
+----
+NOTICE: 2
+
+statement error pq: cannot execute INSERT in a read-only transaction
+CALL p_write(1002);
+
+statement ok
+ABORT;
+
+statement ok
+BEGIN TRANSACTION AS OF SYSTEM TIME '-5s';
+
+statement error pgcode 42883 pq: procedure p_read does not exist
+CALL p_read();
+
+statement ok
+ABORT;
+
+# The supplied timestamp must match the transaction's timestamp in an
+# explicit transaction.
+statement ok
+BEGIN;
+
+statement ok
+CALL p_read();
+
+statement error pgcode 0A000 inconsistent AS OF SYSTEM TIME timestamp
+CALL p_read() AS OF SYSTEM TIME '-10ms';
+
+statement ok
+ABORT;
+
+statement ok
+BEGIN TRANSACTION AS OF SYSTEM TIME '-10ms';
+
+# If no AOST is specified, the transaction's timestamp is used.
+statement ok
+CALL p_read();
+
+# If an AOST is specified, it must match the transaction.
+# NOTE: this case fails because the AOST timestamp is calculated using the
+# statement timestamp.
+statement error pgcode 0A000 inconsistent AS OF SYSTEM TIME timestamp
+CALL p_read() AS OF SYSTEM TIME '-10ms';
+
+statement ok
+ABORT;
+
+subtest end

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1242,6 +1242,13 @@ func (ex *connExecutor) handleAOST(ctx context.Context, stmt tree.Statement) err
 		return nil
 	}
 
+	// AOST means the transaction must be read-only.
+	p.extendedEvalCtx.TxnReadOnly = true
+	err = ex.state.setReadOnlyMode(tree.ReadOnly)
+	if err != nil {
+		return err
+	}
+
 	// Implicit transactions can have multiple statements, so we need to check
 	// if one has already been executed.
 	if ex.implicitTxn() && !ex.extraTxnState.firstStmtExecuted {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2081,6 +2081,11 @@ func (p *planner) isAsOf(ctx context.Context, stmt tree.Statement) (*eval.AsOfSy
 		asOf = s.Options.AsOf
 	case *tree.Explain:
 		return p.isAsOf(ctx, s.Statement)
+	case *tree.Call:
+		if s.AsOf.Expr == nil {
+			return nil, nil
+		}
+		asOf = s.AsOf
 	default:
 		return nil, nil
 	}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4067,11 +4067,11 @@ opt_with_options:
 // %Text: CALL <name> ( [ <expr> [, ...] ] )
 // %SeeAlso: CREATE PROCEDURE
 call_stmt:
-  CALL func_application
+  CALL func_application opt_as_of_clause
   {
     p := $2.expr().(*tree.FuncExpr)
     p.InCall = true
-    $$.val = &tree.Call{Proc: p}
+    $$.val = &tree.Call{Proc: p, AsOf: $3.asOfClause()}
   }
 
 // The COPY grammar in postgres has 3 different versions, all of which are supported by postgres:

--- a/pkg/sql/parser/testdata/call
+++ b/pkg/sql/parser/testdata/call
@@ -14,6 +14,14 @@ CALL p((1), ('foo'), (1.234), (true), (NULL)) -- fully parenthesized
 CALL p(_, '_', _, _, _) -- literals removed
 CALL _(1, 'foo', 1.234, true, NULL) -- identifiers removed
 
+parse
+CALL p(1, 'foo') AS OF SYSTEM TIME follower_read_timestamp();
+----
+CALL p(1, 'foo') AS OF SYSTEM TIME follower_read_timestamp() -- normalized!
+CALL p((1), ('foo')) AS OF SYSTEM TIME (follower_read_timestamp()) -- fully parenthesized
+CALL p(_, '_') AS OF SYSTEM TIME follower_read_timestamp() -- literals removed
+CALL _(1, 'foo') AS OF SYSTEM TIME _() -- identifiers removed
+
 error
 CALL p
 ----

--- a/pkg/sql/sem/tree/call.go
+++ b/pkg/sql/sem/tree/call.go
@@ -14,12 +14,19 @@ package tree
 type Call struct {
 	// Proc contains the procedure reference and the arguments of the procedure.
 	Proc *FuncExpr
+
+	// AsOf is an optional AS OF SYSTEM TIME clause.
+	AsOf AsOfClause
 }
 
 // Format implements the NodeFormatter interface.
 func (node *Call) Format(ctx *FmtCtx) {
 	ctx.WriteString("CALL ")
 	ctx.FormatNode(node.Proc)
+	if node.AsOf.Expr != nil {
+		ctx.WriteByte(' ')
+		ctx.FormatNode(&node.AsOf)
+	}
 }
 
 var _ Statement = &Call{}


### PR DESCRIPTION
It is now possible to specify an `AS OF SYSTEM TIME` clause for a `CALL` statement as in the following example:
```
CALL f(1, 'foo') AS OF SYSTEM TIME '-1s';
```
As with other cases that allow AOST, this syntax is incompatible with mutations, so it can only be used with read-only stored procedures. In addition, this syntax is only allowed in an explicit transaction if it matches with the transaction's timestamp.

NOTE: The AOST clause applies not only to the body statements within the stored proc - it also applies to resolution of the proc itself. This means that running the above example will fail with an "unknown procedure" error if the proc was created less than one second ago.

Epic: CRDB-34165

Release note (sql change): Introduced an `AS OF SYSTEM TIME` clause to the `CALL` statement like the following: `CALL f() AS OF SYSTEM TIME '-1s';`. NOTE: AOST applies not only to the stored procedure's body statements, but also to resolution of the stored procedure itself. If the supplied timestamp is earlier than the SP's creation time, the SP will not be found.