### PR TITLE
release-23.1: kvserver: acquire `Replica.mu` when returning reproposal error

### DIFF
--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -271,13 +271,14 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(
 		// The tracker wants us to forward the request timestamp, but we can't
 		// do that without re-evaluating, so give up. The error returned here
 		// will go to back to DistSender, so send something it can digest.
-		err := kvpb.NewNotLeaseHolderError(
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		return kvpb.NewError(kvpb.NewNotLeaseHolderError(
 			*r.mu.state.Lease,
 			r.store.StoreID(),
 			r.mu.state.Desc,
 			"reproposal failed due to closed timestamp",
-		)
-		return kvpb.NewError(err)
+		))
 	}
 	// Some tests check for this log message in the trace.
 	log.VEventf(ctx, 2, "retry: proposalIllegalLeaseIndex")


### PR DESCRIPTION
Backport 1/1 commits from #117801.

Release justification: fixes a rare race condition.

/cc @cockroachdb/release

---

Discovered while working on #117612. Looks like it's been there since #42939.

This is a rare error, and these fields are unlikely to change while we're holding the raft mutex, so seems very unlikely to have caused any problems -- I could be convinced we shouldn't backport this, on the off-chance I've missed a potential deadlock.

Epic: none
Release note: None
