### PR TITLE
release: skip cloud-only releases

### DIFF
--- a/pkg/cmd/release/update_releases.go
+++ b/pkg/cmd/release/update_releases.go
@@ -63,6 +63,7 @@ type Release struct {
 	Series    string `yaml:"major_version"`
 	Previous  string `yaml:"previous_release"`
 	Withdrawn bool   `yaml:"withdrawn"`
+	CloudOnly bool   `yaml:"cloud_only"`
 }
 
 // updateReleasesFile downloads the current release data from the docs
@@ -122,6 +123,10 @@ func processReleaseData(data []Release) map[string]release.Series {
 		// interested in beta and rc pre-releases, as we do not support
 		// upgrades from alpha releases.
 		if pre := v.PreRelease(); pre != "" && !strings.HasPrefix(pre, "rc") && !strings.HasPrefix(pre, "beta") {
+			continue
+		}
+		// Skip cloud-only releases, because the binaries are not yet publicly available.
+		if r.CloudOnly {
 			continue
 		}
 


### PR DESCRIPTION
Previously, the mixed version update script bumps the version, even though the binaries are not yet available in case of cloud-only releases. As a result this created unnecessary PRs.

This PR adds a check to skip cloud-only releases.

Epic: none
Release note: None