### PR TITLE
kvclient: simplify EvictionToken

### DIFF
--- a/pkg/kv/kvclient/rangecache/range_cache.go
+++ b/pkg/kv/kvclient/rangecache/range_cache.go
@@ -255,80 +255,46 @@ func (rc *RangeCache) stringLocked() string {
 	return buf.String()
 }
 
-// EvictionToken holds eviction state between calls to Lookup.
+// EvictionToken holds eviction state between calls to Lookup. The lifecycle of
+// an EvictionToken is tied to a single request. Each EvictionToken has a
+// reference to an underlying CacheEntry. The CacheEntry is immutable and shared
+// between multiple EvictionTokens. If the request learns new information from
+// servers, then the Cache is updated through this token and the entry is
+// replaced with a new entry. Other concurrent requests will only learn about
+// the new entry if they re-synchronize using the token. An EvictionToken is
+// created by calling LookupWithEvictionToken with an empty EvictionToken.
 type EvictionToken struct {
 	// rdc is the cache that produced this token - and that will be modified by
-	// Evict().
+	// Evict, EvictAndReplace, EvictLease or SyncTokenAndMaybeUpdateCache.
 	rdc *RangeCache
 
-	// desc, lease, and closedts represent the information retrieved from the
-	// cache. This can advance throughout the life of the token, as various
-	// methods re-synchronize with the cache. However, if it changes, the
-	// descriptor only changes to other "compatible" descriptors (same range id
-	// and key bounds).
-	desc *roachpb.RangeDescriptor
-
-	// The lease can be speculative, in which case it will have an unset sequence
-	// number. This happens when a follower replica knows Raft leader was, but did
-	// not have a valid lease record and did not try to become the Leaseholder.
-	// The leader is the most likely replica to be the next Leaseholder for this
-	// range.
-	lease *roachpb.Lease
-
-	closedts roachpb.RangeClosedTimestampPolicy
-
-	// speculativeDesc, if not nil, is the descriptor that should replace desc if
-	// desc proves to be stale - i.e. speculativeDesc is inserted in the cache
-	// automatically by Evict(). This is used when the range descriptor lookup
-	// that populated the cache returned an intent in addition to the current
-	// descriptor value. The idea is that, if the range lookup was performed in
-	// the middle of a split or a merge and it's seen an intent, it's likely that
-	// the intent will get committed soon and so the client should use it if the
-	// previous version proves stale. This mechanism also has a role for resolving
-	// intents for the split transactions itself where, immediately after the
-	// split's txn record is committed, an intent is the only correct copy of the
-	// LHS' descriptor.
-	//
-	// TODO(andrei): It's weird that speculativeDesc hangs from an EvictionToken,
-	// instead of from a cache entry. Hanging from a particular token, only one
-	// actor has the opportunity to use this speculativeDesc; if another actor
-	// races to evict the respective cache entry and wins, speculativeDesc becomes
-	// useless.
-	speculativeDesc *roachpb.RangeDescriptor
+	// entry points to the immutable information retrieved from the cache which
+	// is shared between multiple EvictionTokens. The reference can be updated
+	// through the life of the token, as various methods re-synchronize with the
+	// cache. If the descriptor within the entry is updated, it will be to a
+	// compatible descriptor, with the same range id and key bounds. If the
+	// descriptor changes in a non-compatible way, this EvictionToken must be
+	// discarded and a new one retrieved from the RangeCache.
+	entry *CacheEntry
 }
 
-func (rc *RangeCache) makeEvictionToken(
-	entry *CacheEntry, speculativeDesc *roachpb.RangeDescriptor,
-) EvictionToken {
-	if speculativeDesc != nil {
-		// speculativeDesc comes from intents. Being uncommitted, it is speculative.
-		// We reset its generation to indicate this fact and allow it to be easily
-		// overwritten. Putting a speculative descriptor in the cache with a
-		// generation might make it hard for the real descriptor with the same
-		// generation to overwrite it, in case the speculation fails.
-		nextCpy := *speculativeDesc
-		nextCpy.Generation = 0
-		speculativeDesc = &nextCpy
-	}
+func (rc *RangeCache) makeEvictionToken(entry *CacheEntry) EvictionToken {
 	return EvictionToken{
-		rdc:             rc,
-		desc:            entry.Desc(),
-		lease:           entry.leaseEvenIfSpeculative(),
-		closedts:        entry.closedts,
-		speculativeDesc: speculativeDesc,
+		rdc:   rc,
+		entry: entry,
 	}
 }
 
 // MakeEvictionToken is the exported ctor. For tests only.
 func (rc *RangeCache) MakeEvictionToken(entry *CacheEntry) EvictionToken {
-	return rc.makeEvictionToken(entry, nil /* speculativeDesc */)
+	return rc.makeEvictionToken(entry)
 }
 
 func (et EvictionToken) String() string {
 	if !et.Valid() {
 		return "<empty>"
 	}
-	return fmt.Sprintf("desc:%s lease:%s spec desc: %v", et.desc, et.lease, et.speculativeDesc)
+	return fmt.Sprintf("et:%s", et.entry)
 }
 
 // Valid returns false if the token does not contain any replicas.
@@ -352,7 +318,7 @@ func (et EvictionToken) Desc() *roachpb.RangeDescriptor {
 	if !et.Valid() {
 		return nil
 	}
-	return et.desc
+	return &et.entry.desc
 }
 
 // Leaseholder returns the cached leaseholder. If the cache didn't have any
@@ -361,19 +327,19 @@ func (et EvictionToken) Desc() *roachpb.RangeDescriptor {
 // If a leaseholder is returned, it will correspond to one of the replicas in
 // et.Desc().
 func (et EvictionToken) Leaseholder() *roachpb.ReplicaDescriptor {
-	if !et.Valid() || et.lease == nil {
+	if !et.Valid() || et.entry.lease.Empty() {
 		return nil
 	}
-	return &et.lease.Replica
+	return &et.entry.lease.Replica
 }
 
 // Lease returns the cached lease. If the cache didn't have any lease
 // information, returns nil. The result is considered immutable.
 func (et EvictionToken) Lease() *roachpb.Lease {
-	if !et.Valid() {
+	if !et.Valid() || et.entry.lease.Empty() {
 		return nil
 	}
-	return et.lease
+	return &et.entry.lease
 }
 
 // LeaseSeq returns the sequence of the cached lease. If no lease is cached, or
@@ -382,10 +348,10 @@ func (et EvictionToken) LeaseSeq() roachpb.LeaseSequence {
 	if !et.Valid() {
 		panic("invalid LeaseSeq() call on empty EvictionToken")
 	}
-	if et.lease == nil {
+	if et.entry.lease.Empty() {
 		return 0
 	}
-	return et.lease.Sequence
+	return et.entry.lease.Sequence
 }
 
 // ClosedTimestampPolicy returns the cache's current understanding of the
@@ -397,10 +363,10 @@ func (et EvictionToken) ClosedTimestampPolicy(
 	if !et.Valid() {
 		panic("invalid ClosedTimestampPolicy() call on empty EvictionToken")
 	}
-	if et.closedts == UnknownClosedTimestampPolicy {
+	if et.entry.closedts == UnknownClosedTimestampPolicy {
 		return _default
 	}
-	return et.closedts
+	return et.entry.closedts
 }
 
 // syncRLocked syncs the token with the cache. If the cache has a newer, but
@@ -410,23 +376,21 @@ func (et EvictionToken) ClosedTimestampPolicy(
 func (et *EvictionToken) syncRLocked(
 	ctx context.Context,
 ) (stillValid bool, cachedEntry *CacheEntry, rawEntry *cache.Entry) {
-	cachedEntry, rawEntry = et.rdc.getCachedRLocked(ctx, et.desc.StartKey, false /* inverted */)
+	cachedEntry, rawEntry = et.rdc.getCachedRLocked(ctx, et.entry.desc.StartKey, false /* inverted */)
 	if cachedEntry == nil || !descsCompatible(cachedEntry.Desc(), et.Desc()) {
 		et.clear()
 		return false, nil, nil
 	}
-	et.desc = cachedEntry.Desc()
-	et.lease = cachedEntry.leaseEvenIfSpeculative()
+	et.entry = cachedEntry
 	return true, cachedEntry, rawEntry
 }
 
 // SyncTokenAndMaybeUpdateCache acts as a synchronization point between the
 // caller and the RangeCache. It updates the EvictionToken with fresher
-// information in case the EvictionToken was no longer up to date with the
-// cache entry from whence it came. The leaseholder and range descriptor for the
-// token's cache entry are updated to the specified lease/range descriptor if
-// they are fresher than what the cache contains (which is reflected in the
-// EvictionToken itself).
+// information in case the EvictionToken was no longer up to date with the cache
+// entry from whence it came. The leaseholder and range descriptor can be
+// updated back to the cache as well if they are fresher than what the cache
+// contains (which is reflected in the EvictionToken itself).
 //
 // The returned bool `updatedLeaseholder` is true if the leaseholder was updated
 // in the cache (i.e the passed-in lease was more recent than the cached lease).
@@ -462,19 +426,19 @@ func (et *EvictionToken) SyncTokenAndMaybeUpdateCache(
 	}
 
 	// Check if the supplied range descriptor is compatible with the one in the
-	// cache. If it isn't, and the supplied range descriptor is newer than what's
-	// in the cache, we simply evict the old descriptor and add the new
-	// descriptor/lease pair. On the other hand, if the supplied range descriptor
-	// is older, we can simply return early.
+	// cache. If it isn't, and the supplied range descriptor is newer than
+	// what's in the cache, we simply evict the old descriptor and add the new
+	// descriptor/lease pair. On the other hand, if the supplied range
+	// descriptor is older, we can simply return early.
 	if !descsCompatible(rangeDesc, et.Desc()) {
-		if rangeDesc.Generation < et.desc.Generation {
+		if rangeDesc.Generation < et.Desc().Generation {
 			return false
 		}
 		// Newer descriptor.
 		ri := roachpb.RangeInfo{
 			Desc:                  *rangeDesc,
 			Lease:                 *l,
-			ClosedTimestampPolicy: et.closedts,
+			ClosedTimestampPolicy: et.entry.ClosedTimestampPolicy(),
 		}
 		et.evictAndReplaceLocked(ctx, ri)
 		return false
@@ -488,10 +452,9 @@ func (et *EvictionToken) SyncTokenAndMaybeUpdateCache(
 	}
 	rdc.swapEntryLocked(ctx, rawEntry, newEntry)
 
-	// Finish syncing the eviction token by updating its fields using the freshest
-	// range descriptor/lease information available in the RangeCache.
-	et.desc = newEntry.Desc()
-	et.lease = newEntry.leaseEvenIfSpeculative()
+	// Finish syncing the eviction token by updating it to the newest
+	// information available in the RangeCache.
+	et.entry = newEntry
 	return updatedLeaseholder
 }
 
@@ -516,11 +479,11 @@ func (et *EvictionToken) EvictLease(ctx context.Context) {
 	et.rdc.rangeCache.Lock()
 	defer et.rdc.rangeCache.Unlock()
 
-	if et.lease == nil {
+	if et.entry.lease.Empty() {
 		log.Fatalf(ctx, "attempting to clear lease from cache entry without lease")
 	}
 
-	lh := et.lease.Replica
+	lh := et.entry.lease.Replica
 	stillValid, cachedEntry, rawEntry := et.syncRLocked(ctx)
 	if !stillValid {
 		return
@@ -529,8 +492,7 @@ func (et *EvictionToken) EvictLease(ctx context.Context) {
 	if !ok {
 		return
 	}
-	et.desc = newEntry.Desc()
-	et.lease = newEntry.leaseEvenIfSpeculative()
+	et.entry = newEntry
 	et.rdc.swapEntryLocked(ctx, rawEntry, newEntry)
 }
 
@@ -575,14 +537,14 @@ func (et *EvictionToken) evictAndReplaceLocked(ctx context.Context, newDescs ...
 	if len(newDescs) > 0 {
 		log.Eventf(ctx, "evicting cached range descriptor with %d replacements", len(newDescs))
 		et.rdc.insertLocked(ctx, newDescs...)
-	} else if et.speculativeDesc != nil {
+	} else if et.entry.speculativeDesc != nil {
 		log.Eventf(ctx, "evicting cached range descriptor with replacement from token")
 		et.rdc.insertLocked(ctx, roachpb.RangeInfo{
-			Desc: *et.speculativeDesc,
+			Desc: *et.entry.speculativeDesc,
 			// We don't know anything about the new lease.
 			Lease: roachpb.Lease{},
 			// The closed timestamp policy likely hasn't changed.
-			ClosedTimestampPolicy: et.closedts,
+			ClosedTimestampPolicy: et.entry.closedts,
 		})
 	} else if evicted {
 		log.Eventf(ctx, "evicting cached range descriptor")
@@ -644,15 +606,7 @@ func (rc *RangeCache) Lookup(ctx context.Context, key roachpb.RKey) (CacheEntry,
 	if err != nil {
 		return CacheEntry{}, err
 	}
-	var e CacheEntry
-	if tok.desc != nil {
-		e.desc = *tok.desc
-	}
-	if tok.lease != nil {
-		e.lease = *tok.lease
-	}
-	e.closedts = tok.closedts
-	return e, nil
+	return *tok.entry, nil
 }
 
 // GetCachedOverlapping returns all the cached entries which overlap a given
@@ -746,7 +700,7 @@ func (rc *RangeCache) tryLookup(
 	rc.rangeCache.RLock()
 	if entry, _ := rc.getCachedRLocked(ctx, key, useReverseScan); entry != nil {
 		rc.rangeCache.RUnlock()
-		returnToken := rc.makeEvictionToken(entry, nil /* nextDesc */)
+		returnToken := rc.makeEvictionToken(entry)
 		return returnToken, nil
 	}
 
@@ -773,15 +727,15 @@ func (rc *RangeCache) tryLookup(
 	if evictToken.Valid() {
 		// Enforce that the causality token actually applies to the key we're
 		// looking up.
-		if (useReverseScan && !evictToken.desc.ContainsKeyInverted(key)) ||
-			(!useReverseScan && !evictToken.desc.ContainsKey(key)) {
+		if (useReverseScan && !evictToken.Desc().ContainsKeyInverted(key)) ||
+			(!useReverseScan && !evictToken.Desc().ContainsKey(key)) {
 			return EvictionToken{}, errors.AssertionFailedf(
 				"invalid eviction token for lookup %v (reverse=%v) does not contain %v",
-				evictToken.desc.RSpan(), useReverseScan, key,
+				evictToken.Desc().RSpan(), useReverseScan, key,
 			)
 		}
 		lookupResultIsStale = func(res lookupResult) bool {
-			return res.Desc().Generation <= evictToken.desc.Generation
+			return res.Desc().Generation <= evictToken.Desc().Generation
 		}
 	}
 
@@ -941,19 +895,32 @@ func tryLookupImpl(
 	rc.rangeCache.Lock()
 	defer rc.rangeCache.Unlock()
 
-	// Insert the descriptor and the prefetched ones. We don't insert rs[1]
-	// (if any), since it overlaps with rs[0]; rs[1] will be handled by
-	// rs[0]'s eviction token. Note that ranges for which the cache has more
-	// up-to-date information will not be clobbered - for example ranges for
-	// which the cache has the prefetched descriptor already plus a lease.
-	newEntries := make([]*CacheEntry, len(preRs)+1)
-	newEntries[0] = &CacheEntry{
+	// We want to insert a new CacheEntry, possibly with a speculativeDesc.
+	// Create the entry based on the lookup and try and insert it into the
+	// cache.
+	newEntry := CacheEntry{
 		desc: rs[0],
 		// We don't have any lease information.
 		lease: roachpb.Lease{},
 		// We don't know the closed timestamp policy.
 		closedts: UnknownClosedTimestampPolicy,
 	}
+	// speculativeDesc comes from intents. Being uncommitted, it is speculative.
+	// We reset its generation to indicate this fact and allow it to be easily
+	// overwritten. Putting a speculative descriptor in the cache with a
+	// generation might make it hard for the real descriptor with the same
+	// generation to overwrite it, in case the speculation fails.
+	if len(rs) > 1 {
+		newEntry.speculativeDesc = &rs[1]
+		newEntry.speculativeDesc.Generation = 0
+	}
+	// Insert the descriptor and the prefetched ones. We don't insert rs[1]
+	// (if any), since it overlaps with rs[0]; rs[1] will be handled by
+	// rs[0]'s eviction token. Note that ranges for which the cache has more
+	// up-to-date information will not be clobbered - for example ranges for
+	// which the cache has the prefetched descriptor already plus a lease.
+	newEntries := make([]*CacheEntry, len(preRs)+1)
+	newEntries[0] = &newEntry
 	for i, preR := range preRs {
 		newEntries[i+1] = &CacheEntry{desc: preR, closedts: UnknownClosedTimestampPolicy}
 	}
@@ -987,17 +954,9 @@ func tryLookupImpl(
 		if consistency == ReadFromFollower {
 			return EvictionToken{}, errFailedToFindNewerDescriptor
 		}
-		entry = &CacheEntry{
-			desc:     rs[0],
-			lease:    roachpb.Lease{},
-			closedts: UnknownClosedTimestampPolicy,
-		}
+		entry = &newEntry
 	}
-	if len(rs) == 1 {
-		lookupRes = rc.makeEvictionToken(entry, nil /* nextDesc */)
-	} else {
-		lookupRes = rc.makeEvictionToken(entry, &rs[1] /* nextDesc */)
-	}
+	lookupRes = rc.makeEvictionToken(entry)
 	return lookupRes, nil
 }
 
@@ -1302,6 +1261,18 @@ func (rc *RangeCache) NumInFlight(name string) int {
 type CacheEntry struct {
 	// desc is always populated.
 	desc roachpb.RangeDescriptor
+	// speculativeDesc, if not nil, is the descriptor that should replace desc if
+	// desc proves to be stale - i.e. speculativeDesc is inserted in the cache
+	// automatically by Evict(). This is used when the range descriptor lookup
+	// that populated the cache returned an intent in addition to the current
+	// descriptor value. The idea is that, if the range lookup was performed in
+	// the middle of a split or a merge and it's seen an intent, it's likely that
+	// the intent will get committed soon and so the client should use it if the
+	// previous version proves stale. This mechanism also has a role for resolving
+	// intents for the split transactions itself where, immediately after the
+	// split's txn record is committed, an intent is the only correct copy of the
+	// LHS' descriptor.
+	speculativeDesc *roachpb.RangeDescriptor
 	// Lease has info on the range's lease. It can be Empty() if no lease
 	// information is known. When a lease is known, it is guaranteed that the
 	// lease comes from Desc's range id (i.e. we'll never put a lease from another
@@ -1341,16 +1312,6 @@ func (e *CacheEntry) Lease() *roachpb.Lease {
 		return nil
 	}
 	if e.LeaseSpeculative() {
-		return nil
-	}
-	return &e.lease
-}
-
-// leaseEvenIfSpeculative is like Lease, except it returns a Lease object even
-// if that lease is speculative. Returns nil if no speculative or non-speculative
-// lease is known.
-func (e *CacheEntry) leaseEvenIfSpeculative() *roachpb.Lease {
-	if e.lease.Empty() {
 		return nil
 	}
 	return &e.lease

--- a/pkg/kv/kvclient/rangecache/range_cache_test.go
+++ b/pkg/kv/kvclient/rangecache/range_cache_test.go
@@ -1553,7 +1553,7 @@ func TestRangeCacheEvictAndReplace(t *testing.T) {
 
 	// EvictAndReplace() with a speculative descriptor. Should update decriptor,
 	// remove lease, and retain closed timestamp policy.
-	tok.speculativeDesc = &desc3
+	tok.entry.speculativeDesc = &desc3
 	tok.EvictAndReplace(ctx)
 	tok, err = cache.LookupWithEvictionToken(ctx, startKey, tok, false /* useReverseScan */)
 	require.NoError(t, err)
@@ -1706,8 +1706,9 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 
 				// Update the cache.
 				cache.Insert(ctx, roachpb.RangeInfo{
-					Desc:  desc2,
-					Lease: roachpb.Lease{},
+					Desc:                  desc2,
+					Lease:                 roachpb.Lease{},
+					ClosedTimestampPolicy: lead,
 				})
 				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCache(
 					ctx, &roachpb.Lease{Replica: rep2, Sequence: 3}, &staleRangeDescriptor,
@@ -1716,7 +1717,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				require.NotNil(t, tok)
 				require.Equal(t, &desc2, tok.Desc())
 				require.Equal(t, &rep2, tok.Leaseholder())
-				require.Equal(t, tok.lease.Replica, rep2)
+				require.Equal(t, tok.Lease().Replica, rep2)
 				require.Equal(t, lead, tok.ClosedTimestampPolicy(lag))
 			},
 		},
@@ -1751,7 +1752,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				require.NotNil(t, tok)
 				require.Equal(t, &desc3, tok.Desc())
 				require.Equal(t, &rep2, tok.Leaseholder())
-				require.Equal(t, tok.lease.Replica, rep2)
+				require.Equal(t, tok.Lease().Replica, rep2)
 				require.Equal(t, lead, tok.ClosedTimestampPolicy(lag))
 			},
 		},
@@ -1780,7 +1781,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				require.NotNil(t, tok)
 				require.Equal(t, &desc2, tok.Desc())
 				require.Equal(t, &rep3, tok.Leaseholder())
-				require.Equal(t, tok.lease.Replica, rep3)
+				require.Equal(t, tok.Lease().Replica, rep3)
 				require.Equal(t, lead, tok.ClosedTimestampPolicy(lag))
 			},
 		},
@@ -1809,7 +1810,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				require.NotNil(t, tok)
 				require.Equal(t, &desc2, tok.Desc())
 				require.Equal(t, &rep3, tok.Leaseholder())
-				require.Equal(t, tok.lease.Replica, rep3)
+				require.Equal(t, tok.Lease().Replica, rep3)
 				require.Equal(t, lead, tok.ClosedTimestampPolicy(lag))
 			},
 		},


### PR DESCRIPTION
Previously the EvictionToken had a copy of the fields of CacheEntry and
the EvicitionToken had a dual role as both a token and a temporary
state. After this change, the EvictionToken has an immutable reference
to the CacheEntry itself, and updates are passed back through Sync and
Evict methods. This seperates concerns between the EvictionTokens and
the CacheEntry. Additionally it reduces a memory copy and will allows
adding new fields in the future to CacheEntries without modifying the
EvictionToken.

Epic: none

Release note: None