### PR TITLE
storage: remove SimpleMVCCIterator forwardOnly option

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -76,7 +76,7 @@ func slurpSSTablesLatestKey(
 			LowerBound: keys.LocalMax,
 			UpperBound: keys.MaxKey,
 		}
-		sst, err := storage.NewSSTIterator([][]sstable.ReadableFile{{file}}, iterOpts, false /* forwardOnly */)
+		sst, err := storage.NewSSTIterator([][]sstable.ReadableFile{{file}}, iterOpts)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/ccl/storageccl/external_sst_reader.go
+++ b/pkg/ccl/storageccl/external_sst_reader.go
@@ -168,10 +168,7 @@ func ExternalSSTReader(
 		}
 		readerLevels = append(readerLevels, []sstable.ReadableFile{reader})
 	}
-	// NB: It's okay to pass forwardOnly=true, because this function returns a
-	// SimpleMVCCIterator which does not provide an interface for reverse
-	// iteration.
-	return storage.NewSSTIterator(readerLevels, iterOpts, true /* forwardOnly */)
+	return storage.NewSSTIterator(readerLevels, iterOpts)
 }
 
 type sstReader struct {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2598,7 +2598,7 @@ func (p *Pebble) ConvertFilesToBatchAndCommit(
 			KeyTypes:   IterKeyTypePointsAndRanges,
 			LowerBound: roachpb.KeyMin,
 			UpperBound: roachpb.KeyMax,
-		}, true)
+		})
 	if err != nil {
 		// TODO(sumeer): we don't call closeFiles() since in the error case some
 		// of the files may be closed. See the code in

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -135,18 +135,13 @@ func newPebbleIteratorByCloning(
 
 // newPebbleSSTIterator creates a new Pebble iterator for the given SSTs.
 func newPebbleSSTIterator(
-	files [][]sstable.ReadableFile, opts IterOptions, forwardOnly bool,
+	files [][]sstable.ReadableFile, opts IterOptions,
 ) (*pebbleIterator, error) {
 	p := pebbleIterPool.Get().(*pebbleIterator)
 	p.reusable = false // defensive
 	p.init(context.Background(), nil, opts, StandardDurability, nil)
 
-	var externalIterOpts []pebble.ExternalIterOption
-	if forwardOnly {
-		externalIterOpts = append(externalIterOpts, pebble.ExternalIterForwardOnly{})
-	}
-
-	iter, err := pebble.NewExternalIter(DefaultPebbleOptions(), &p.options, files, externalIterOpts...)
+	iter, err := pebble.NewExternalIter(DefaultPebbleOptions(), &p.options, files)
 	if err != nil {
 		p.Close()
 		return nil, err

--- a/pkg/storage/pebble_iterator_test.go
+++ b/pkg/storage/pebble_iterator_test.go
@@ -129,7 +129,7 @@ func TestPebbleIterator_ExternalCorruption(t *testing.T) {
 	b[rng.Intn(len(b))]++
 
 	it, err := NewSSTIterator([][]sstable.ReadableFile{{vfs.NewMemFile(b)}},
-		IterOptions{UpperBound: roachpb.KeyMax}, false)
+		IterOptions{UpperBound: roachpb.KeyMax})
 
 	// We may error early, while opening the iterator.
 	if err != nil {

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -44,20 +44,15 @@ var (
 // subarray. The outer slice of levels must be sorted in reverse chronological
 // order: a key in a file in a level at a lower index will shadow the same key
 // contained within a file in a level at a higher index.
-//
-// If the iterator is only going to be used for forward iteration, the caller
-// may pass forwardOnly=true for better performance.
-func NewSSTIterator(
-	files [][]sstable.ReadableFile, opts IterOptions, forwardOnly bool,
-) (MVCCIterator, error) {
-	return newPebbleSSTIterator(files, opts, forwardOnly)
+func NewSSTIterator(files [][]sstable.ReadableFile, opts IterOptions) (MVCCIterator, error) {
+	return newPebbleSSTIterator(files, opts)
 }
 
 // NewSSTEngineIterator is like NewSSTIterator, but returns an EngineIterator.
 func NewSSTEngineIterator(
-	files [][]sstable.ReadableFile, opts IterOptions, forwardOnly bool,
+	files [][]sstable.ReadableFile, opts IterOptions,
 ) (EngineIterator, error) {
-	return newPebbleSSTIterator(files, opts, forwardOnly)
+	return newPebbleSSTIterator(files, opts)
 }
 
 // NewMemSSTIterator returns an MVCCIterator for the provided SST data,
@@ -73,7 +68,7 @@ func NewMultiMemSSTIterator(ssts [][]byte, verify bool, opts IterOptions) (MVCCI
 	for _, sst := range ssts {
 		files = append(files, vfs.NewMemFile(sst))
 	}
-	iter, err := NewSSTIterator([][]sstable.ReadableFile{files}, opts, false /* forwardOnly */)
+	iter, err := NewSSTIterator([][]sstable.ReadableFile{files}, opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Remove the forwardOnly SimpleMVCCIterator option. This option was introduced to allow an optimization during successive SeekGE(k), Next, SeekGE(k2) Next calls moving monotonically forward through the keyspace. This previously was a common pattern within Cockroach, where callers would SeekGE to the next MVCC user key. With the introduction of (*pebble.Iterator).NextPrefix, NextKey implementations use NextPrefix to avoid these successive seeks.

The forwardOnly option came with risk, because violating the contract could result in incorrect results. We believe this SeekGE optimization is no longer necessary or worth the risk.

Epic: none
Release note: none