### PR TITLE
roachtest: add "detection" to existing disk-stalled test names

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -32,7 +32,9 @@ import (
 
 const maxSyncDur = 10 * time.Second
 
-// registerDiskStalledDetection registers the disk stall test.
+// registerDiskStalledDetection registers the disk stall detection tests. These
+// tests assert that a disk stall is detected and the process crashes
+// appropriately.
 func registerDiskStalledDetection(r registry.Registry) {
 	stallers := map[string]func(test.Test, cluster.Cluster) diskStaller{
 		"dmsetup": func(t test.Test, c cluster.Cluster) diskStaller { return &dmsetupDiskStaller{t: t, c: c} },
@@ -50,7 +52,7 @@ func registerDiskStalledDetection(r registry.Registry) {
 	for name, makeStaller := range stallers {
 		name, makeStaller := name, makeStaller
 		r.Add(registry.TestSpec{
-			Name:  fmt.Sprintf("disk-stalled/%s", name),
+			Name:  fmt.Sprintf("disk-stalled/detection/%s", name),
 			Owner: registry.OwnerStorage,
 			// Use PDs in an attempt to work around flakes encountered when using SSDs.
 			// See #97968.


### PR DESCRIPTION
The storage team maintains a suite of roachtests for testing the 'disk stall detector' that detects write operations blocked for X seconds, tears down network connections and fatals the node. This commit adds "/detection/" to these tests' names, which will help disambiguate from future roachtests intended to test WAL failover.

Epic: none
Release note: none