### PR TITLE
roachtest: mark new flaky hibernate and gopg tests; ignore common flake from npgsql

### DIFF
--- a/pkg/cmd/roachtest/tests/gopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/gopg_blocklist.go
@@ -55,4 +55,5 @@ var gopgIgnoreList = blocklist{
 	// These tests sometimes failed and we haven't diagnosed it
 	"pg | DB race | SelectOrInsert with OnConflict is race free":    "unknown",
 	"pg | DB race | SelectOrInsert without OnConflict is race free": "unknown",
+	`pg | ORM | relation with no results does not panic`:            "unknown",
 }

--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -25,6 +25,7 @@ var hibernateSpatialIgnoreList = blocklist{
 
 var hibernateIgnoreList = blocklist{
 	"org.hibernate.orm.test.batch.BatchTest.testBatchInsertUpdate":                                       "flaky",
+	"org.hibernate.orm.test.bulkid.OracleInlineMutationStrategyIdTest.testDeleteFromEngineer":            "flaky",
 	"org.hibernate.serialization.SessionFactorySerializationTest.testUnNamedSessionFactorySerialization": "flaky",
 	"org.hibernate.serialization.SessionFactorySerializationTest.testNamedSessionFactorySerialization":   "flaky",
 	"org.hibernate.test.batch.BatchTest.testBatchInsertUpdate":                                           "flaky",


### PR DESCRIPTION
This allows us to stop marking individual tests as flaky, since these
all flake for the same reason.

fixes https://github.com/cockroachdb/cockroach/issues/117919
fixes https://github.com/cockroachdb/cockroach/issues/117860
fixes https://github.com/cockroachdb/cockroach/issues/117734
fixes https://github.com/cockroachdb/cockroach/issues/117727
fixes https://github.com/cockroachdb/cockroach/issues/117479
fixes https://github.com/cockroachdb/cockroach/issues/117478
fixes https://github.com/cockroachdb/cockroach/issues/117452

Release note: None