### PR TITLE
kvserver: skip multi-store rebalance under stress

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -221,6 +221,11 @@ func TestReplicateQueueRebalanceMultiStore(t *testing.T) {
 	for _, testCase := range testCases {
 
 		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.storesPerNode > 1 {
+				// 8 stores with active rebalancing can lead to failed heartbeats due
+				// to overload. Skip under stress when running the multi-store variant.
+				skip.UnderStress(t)
+			}
 			// Set up a test cluster with multiple stores per node if needed.
 			args := base.TestClusterArgs{
 				ReplicationMode:   base.ReplicationAuto,


### PR DESCRIPTION
`TestReplicateQueueRebalanceMultiStore` will occasionally flake due to failed heartbeats preventing test cluster setup when run under stress. Skip the test under stress.

Resolves: #117796
Release note: None