### PR TITLE
span: Revert "span: Add strict mode" 

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -84,9 +84,6 @@ var envVars = []string{
 	// NB: This is crucial for chaos tests as we expect changefeeds to see
 	// many retries.
 	"COCKROACH_CHANGEFEED_TESTING_FAST_RETRY=true",
-
-	// Enable "strict mode" for span frontier.
-	"COCKROACH_SPAN_FRONTIER_STRICT_MODE_ENABLED=true",
 }
 
 type cdcTester struct {

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -111,11 +111,6 @@ type Operation func(roachpb.Span, hlc.Timestamp) (done OpResult)
 var useBtreeFrontier = envutil.EnvOrDefaultBool("COCKROACH_BTREE_SPAN_FRONTIER_ENABLED",
 	util.ConstantWithMetamorphicTestBool("COCKROACH_BTREE_SPAN_FRONTIER_ENABLED", true))
 
-// Enable additional check that requires the span to be tracked by the frontier
-// in order to be forwarded.  Default mode is "permissive" which allows to
-// span forwarding even if the span is not a subset of this frontier.
-var spanMustBeTracked = envutil.EnvOrDefaultBool("COCKROACH_SPAN_FRONTIER_STRICT_MODE_ENABLED", false)
-
 func enableBtreeFrontier(enabled bool) func() {
 	old := useBtreeFrontier
 	useBtreeFrontier = enabled
@@ -477,9 +472,6 @@ func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error
 		it := f.tree.MakeIter()
 		it.FirstOverlap(todoEntry)
 		if !it.Valid() {
-			if spanMustBeTracked {
-				return errors.Newf("span %s is not a sub-span of this frontier (remaining %s)", span, todoEntry.span())
-			}
 			break
 		}
 
@@ -489,9 +481,6 @@ func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error
 		// Trim todoEntry if it falls outside the span(s) tracked by this btreeFrontier.
 		// This establishes the invariant that overlap start must be at or before todoEntry start.
 		if todoEntry.Start.Compare(overlap.Start) < 0 {
-			if spanMustBeTracked {
-				return errors.Newf("span %s is not a sub-span of this frontier (remaining %s)", span, todoEntry.span())
-			}
 			todoEntry.Start = overlap.Start
 			if todoEntry.isEmptyRange() {
 				break

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -116,14 +116,6 @@ var useBtreeFrontier = envutil.EnvOrDefaultBool("COCKROACH_BTREE_SPAN_FRONTIER_E
 // span forwarding even if the span is not a subset of this frontier.
 var spanMustBeTracked = envutil.EnvOrDefaultBool("COCKROACH_SPAN_FRONTIER_STRICT_MODE_ENABLED", false)
 
-func enableStrictMode(enabled bool) func() {
-	old := spanMustBeTracked
-	spanMustBeTracked = enabled
-	return func() {
-		spanMustBeTracked = old
-	}
-}
-
 func enableBtreeFrontier(enabled bool) func() {
 	old := useBtreeFrontier
 	useBtreeFrontier = enabled
@@ -486,8 +478,7 @@ func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error
 		it.FirstOverlap(todoEntry)
 		if !it.Valid() {
 			if spanMustBeTracked {
-				return errors.Newf("span %s is not a sub-span of this frontier (remaining %s) (frontier %s)",
-					span, todoEntry.span(), f.String())
+				return errors.Newf("span %s is not a sub-span of this frontier (remaining %s)", span, todoEntry.span())
 			}
 			break
 		}
@@ -499,8 +490,7 @@ func (f *btreeFrontier) forward(span roachpb.Span, insertTS hlc.Timestamp) error
 		// This establishes the invariant that overlap start must be at or before todoEntry start.
 		if todoEntry.Start.Compare(overlap.Start) < 0 {
 			if spanMustBeTracked {
-				return errors.Newf("span %s is not a sub-span of this frontier (remaining %s) (frontier %s)",
-					span, todoEntry.span(), f.String())
+				return errors.Newf("span %s is not a sub-span of this frontier (remaining %s)", span, todoEntry.span())
 			}
 			todoEntry.Start = overlap.Start
 			if todoEntry.isEmptyRange() {

--- a/pkg/util/span/frontier_test.go
+++ b/pkg/util/span/frontier_test.go
@@ -75,59 +75,6 @@ func makeFrontierForwarded(
 		}
 	}
 }
-
-func TestSpanFrontierStrictModeBTree(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer enableStrictMode(true)()
-
-	keyA, keyB, keyC := roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c")
-	keyD, keyE, keyF := roachpb.Key("d"), roachpb.Key("e"), roachpb.Key("f")
-	ts0 := hlc.Timestamp{}
-
-	testutils.RunTrueAndFalse(t, "btree", func(t *testing.T, useBtreeFrontier bool) {
-		defer enableBtreeFrontier(useBtreeFrontier)()
-		for i, tc := range []struct {
-			frontier  []roachpb.Span
-			forward   roachpb.Span
-			error     string
-			remaining string
-		}{
-			{
-				frontier: []roachpb.Span{{Key: keyB, EndKey: keyD}},
-				forward:  roachpb.Span{Key: keyC, EndKey: keyE},
-				error:    "span {c-e} is not a sub-span of this frontier (remaining {d-e}) (frontier [{b-d}@0,0])",
-			},
-			{
-				frontier: []roachpb.Span{{Key: keyB, EndKey: keyD}},
-				forward:  roachpb.Span{Key: keyE, EndKey: keyF},
-				error:    "span {e-f} is not a sub-span of this frontier (remaining {e-f}) (frontier [{b-d}@0,0])",
-			},
-			{
-				frontier: []roachpb.Span{{Key: keyB, EndKey: keyD}},
-				forward:  roachpb.Span{Key: keyA, EndKey: keyB},
-				error:    "span {a-b} is not a sub-span of this frontier (remaining {a-b}) (frontier [{b-d}@0,0])",
-			},
-			{
-				frontier: []roachpb.Span{{Key: keyB, EndKey: keyD}},
-				forward:  roachpb.Span{Key: keyA, EndKey: keyE},
-				error:    "span {a-e} is not a sub-span of this frontier (remaining {a-e}) (frontier [{b-d}@0,0])",
-			},
-			{
-				frontier: []roachpb.Span{{Key: keyA, EndKey: keyB}, {Key: keyC, EndKey: keyD}},
-				forward:  roachpb.Span{Key: keyA, EndKey: keyD},
-				error:    "span {a-d} is not a sub-span of this frontier (remaining {b-d}) (frontier [{a-b}@0,0] [{c-d}@0,0])",
-			},
-		} {
-			t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-				f, err := MakeFrontier(tc.frontier...)
-				require.NoError(t, err)
-				_, err = f.Forward(tc.forward, ts0)
-
-				require.EqualError(t, err, tc.error)
-			})
-		}
-	})
-}
 func TestSpanFrontier(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/util/span/frontier_test.go
+++ b/pkg/util/span/frontier_test.go
@@ -93,7 +93,6 @@ func TestSpanFrontier(t *testing.T) {
 
 		f, err := MakeFrontier(spAD)
 		require.NoError(t, err)
-
 		require.Equal(t, hlc.Timestamp{}, f.Frontier())
 		require.Equal(t, `{a-d}@0`, entriesStr(f))
 
@@ -197,40 +196,6 @@ func TestSpanFrontier(t *testing.T) {
 			expectAdvanced(true).
 			expectFrontier(9).
 			expectEntries(`{a-d}@9`)
-	})
-}
-
-func TestForwardOutOfBounds(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	spanMustBeTracked = true
-	defer func() {
-		spanMustBeTracked = false
-	}()
-
-	testutils.RunTrueAndFalse(t, "btree", func(t *testing.T, useBtreeFrontier bool) {
-		defer enableBtreeFrontier(useBtreeFrontier)()
-
-		t.Run("out of bounds", func(t *testing.T) {
-			f, err := MakeFrontier(makeSpan("a", "d"), makeSpan("p", "w"))
-			require.NoError(t, err)
-
-			for _, tc := range []roachpb.Span{
-				makeSpan("A", "Z"),
-				makeSpan("W", "b"),
-				makeSpan("W", "q"),
-				makeSpan("W", "z"),
-				makeSpan("a", "f"),
-				makeSpan("d", "z"),
-			} {
-				s := tc
-				t.Run(s.String(), func(t *testing.T) {
-					// Completely outside of spAD
-					_, err := f.Forward(s, hlc.Timestamp{WallTime: 10})
-					require.Regexp(t, "is not a sub-span", err)
-				})
-			}
-		})
 	})
 }
 

--- a/pkg/util/span/llrb_frontier.go
+++ b/pkg/util/span/llrb_frontier.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
-	"github.com/cockroachdb/errors"
 )
 
 // llrbFrontier is a legacy span btreeFrontier implementation using LLRB tree.
@@ -303,9 +302,6 @@ func (f *llrbFrontier) insert(span roachpb.Span, insertTS hlc.Timestamp) error {
 		// Trim todoRange if it falls outside the span(s) tracked by this frontier.
 		// This establishes the invariant that overlap start must be at or before todoRange start.
 		if todoRange.Start.Compare(overlap.keys.Start) < 0 {
-			if spanMustBeTracked {
-				return StopMatch.asBool()
-			}
 			todoRange.Start = overlap.keys.Start
 		}
 
@@ -355,12 +351,6 @@ func (f *llrbFrontier) insert(span roachpb.Span, insertTS hlc.Timestamp) error {
 
 		return ContinueMatch.asBool()
 	}, span.AsRange())
-
-	if spanMustBeTracked {
-		if todoRange.Start.Compare(todoRange.End) < 0 {
-			return errors.Newf("span %s is not a sub-span of this frontier (remaining %s)", span, todoRange)
-		}
-	}
 
 	// Add remaining pending range.
 	addPending()

--- a/pkg/util/span/llrb_frontier.go
+++ b/pkg/util/span/llrb_frontier.go
@@ -48,7 +48,7 @@ func (s *llrbFrontierEntry) Range() interval.Range {
 }
 
 func (s *llrbFrontierEntry) String() string {
-	return fmt.Sprintf("[%s@%s]", s.span, s.ts)
+	return fmt.Sprintf("[%s @ %s]", s.span, s.ts)
 }
 
 // llrbFrontierHeap implements heap.Interface and holds `llrbFrontierEntry`s. Entries
@@ -358,8 +358,7 @@ func (f *llrbFrontier) insert(span roachpb.Span, insertTS hlc.Timestamp) error {
 
 	if spanMustBeTracked {
 		if todoRange.Start.Compare(todoRange.End) < 0 {
-			return errors.Newf("span %s is not a sub-span of this frontier (remaining {%s-%s}) (frontier %s)",
-				span, todoRange.Start, todoRange.End, f.String())
+			return errors.Newf("span %s is not a sub-span of this frontier (remaining %s)", span, todoRange)
 		}
 	}
 


### PR DESCRIPTION
This reverts commit https://github.com/cockroachdb/cockroach/commit/fc1b120561392191fbc27636cc72a70293c01991.

The strict mode check, while good in spirit, does not
work correctly with the current usage of span frontier.
Namely, changefeed uses single checkpoint which is applied
by all aggregators, regardless of the spans that are
assigned to those aggregators.

In order to keep this check either the checkpoint must
be computed per aggregator, or perhaps a more explicit
method must be introduced to span frontier.
Regardless, it's prudent to revert the check for now,
and re-introduce it if we believe span frontier has
some lurking issues.

Fixes https://github.com/cockroachdb/cockroach/issues/117728

Release note: None