### PR TITLE
stress: upload test results JSON

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+google_credentials="$GOOGLE_CREDENTIALS"
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "$dir/../../../teamcity-support.sh"
+log_into_gcloud
+
 mkdir -p artifacts
 
 # NB: The certs are set up and cleaned up in unconditional build steps before
@@ -9,7 +14,6 @@ mkdir -p artifacts
 ENGFLOW_FLAGS="--config engflow --config crosslinux \
 --jobs 400 --tls_client_certificate=/home/agent/engflow/engflow.crt \
 --tls_client_key=/home/agent/engflow/engflow.key"
-INVOCATION_ID=$(uuidgen)
 
 BES_KEYWORDS_ARGS=
 if [ ! -z "${EXTRA_ISSUE_PARAMS:+$EXTRA_ISSUE_PARAMS}" ]
@@ -20,7 +24,7 @@ fi
 status=0
 bazel test //pkg:all_tests $ENGFLOW_FLAGS --remote_download_minimal \
       --runs_per_test ${RUNS_PER_TEST=30} --verbose_failures --build_event_binary_file=artifacts/eventstream \
-      --profile=artifacts/profile.json.gz --invocation_id=$INVOCATION_ID \
+      --profile=artifacts/profile.json.gz \
       ${EXTRA_TEST_ARGS:+$EXTRA_TEST_ARGS} \
       $BES_KEYWORDS_ARGS \
     || status=$?
@@ -29,8 +33,12 @@ bazel test //pkg:all_tests $ENGFLOW_FLAGS --remote_download_minimal \
 bazel build //pkg/cmd/bazci/process-bep-file $ENGFLOW_FLAGS
 _bazel/bin/pkg/cmd/bazci/process-bep-file/process-bep-file_/process-bep-file \
     -branch $TC_BUILD_BRANCH -eventsfile artifacts/eventstream \
-    -invocation $INVOCATION_ID -cert /home/agent/engflow/engflow.crt \
-    -key /home/agent/engflow/engflow.key \
-    -extra "${EXTRA_ISSUE_PARAMS:+$EXTRA_ISSUE_PARAMS}"
+    -cert /home/agent/engflow/engflow.crt -key /home/agent/engflow/engflow.key \
+    -extra "${EXTRA_ISSUE_PARAMS:+$EXTRA_ISSUE_PARAMS}" \
+    -jsonoutfile test-results.json
+
+gcloud storage cp test-results.json gs://engflow-data/$(date +%F)/$(python3 -c "import json, sys; print(json.load(sys.stdin)['invocation_id'])" < test-results.json).json
+
+rm test-results.json
 
 exit $status


### PR DESCRIPTION
We already publish these JSON files for the CI test job (#117994). We make the same change for the stress nightlies.

Epic: CRDB-8308
Part of: DEVINF-1028
Release note: None