### PR TITLE
sql: prevent panic when collecting a bundle with multiple active portals

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -663,7 +663,7 @@ func (ih *instrumentationHelper) Finish(
 			}
 			bundle = buildStatementBundle(
 				bundleCtx, ih.explainFlags, cfg.DB, ie.(*InternalExecutor),
-				stmtRawSQL, &p.curPlan, planString, trace, placeholders, res.Err(),
+				stmtRawSQL, &p.curPlan, planString, trace, placeholders, res.ErrAllowReleased(),
 				payloadErr, retErr, &p.extendedEvalCtx.Settings.SV, ih.inFlightTraceCollector,
 			)
 			// Include all non-critical errors as warnings. Note that these


### PR DESCRIPTION
Encountered this when working on a different issue. The panic is due to accessing `Err` method of the command result after it has been released. When collecting the bundle `instrumentionHelper.Finish` might be executed during the cleanup phase which would lead to a panic.

Epic: None

Release note: None