### PR TITLE
opt/exec: add retry to distsql_tenant_locality logic test

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
@@ -52,7 +52,7 @@ SELECT id, locality FROM system.sql_instances WHERE locality IS NOT NULL ORDER B
 # - TableReader on SQL Instance 2 to scan Span /106/1/1/0
 # - TableReader on SQL Instance 3 to scan Span /106/1/3/0
 # - TableReader on SQL Instance 1 to scan Span /106/1/5/0.
-query T
+query T retry
 EXPLAIN (DISTSQL) SELECT * FROM t WHERE k IN (1, 3, 5)
 ----
 distribution: full


### PR DESCRIPTION
We're sometimes getting a single TableReader for this plan instead of 3. Add a retry.

Fixes: #117005
Epic: None
Release note: None