### PR TITLE
release-23.2: cluster-ui: enable Explain Plan for tenant clusters

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -40,7 +40,6 @@ enum TabKeysEnum {
 export interface StatementInsightDetailsStateProps {
   insightEventDetails: StmtInsightEvent;
   insightError: Error | null;
-  isTenant?: boolean;
   timeScale?: TimeScale;
   hasAdminRole: boolean;
 }
@@ -73,7 +72,6 @@ export const StatementInsightDetails: React.FC<
   insightEventDetails,
   insightError,
   match,
-  isTenant,
   timeScale,
   hasAdminRole,
   refreshUserSQLRoles,
@@ -96,7 +94,6 @@ export const StatementInsightDetails: React.FC<
 
   const onTabClick = (key: TabKeysEnum) => {
     if (
-      !isTenant &&
       key === TabKeysEnum.EXPLAIN &&
       details?.planGist &&
       !explainPlanState.loaded
@@ -177,34 +174,30 @@ export const StatementInsightDetails: React.FC<
                 hasAdminRole={hasAdminRole}
               />
             </Tabs.TabPane>
-            {!isTenant && (
-              <Tabs.TabPane tab="Explain Plan" key={TabKeysEnum.EXPLAIN}>
-                <section className={cx("section")}>
-                  <Row gutter={24}>
-                    <Col span={24}>
-                      <Loading
-                        loading={
-                          !explainPlanState.loaded &&
-                          details?.planGist?.length > 0
-                        }
-                        page={"stmt_insight_details"}
-                        error={explainPlanState.error}
-                        renderError={() =>
-                          InsightsError(explainPlanState.error?.message)
-                        }
-                      >
-                        <SqlBox
-                          value={
-                            explainPlanState.explainPlan || "Not available."
-                          }
-                          size={SqlBoxSize.custom}
-                        />
-                      </Loading>
-                    </Col>
-                  </Row>
-                </section>
-              </Tabs.TabPane>
-            )}
+            <Tabs.TabPane tab="Explain Plan" key={TabKeysEnum.EXPLAIN}>
+              <section className={cx("section")}>
+                <Row gutter={24}>
+                  <Col span={24}>
+                    <Loading
+                      loading={
+                        !explainPlanState.loaded &&
+                        details?.planGist?.length > 0
+                      }
+                      page={"stmt_insight_details"}
+                      error={explainPlanState.error}
+                      renderError={() =>
+                        InsightsError(explainPlanState.error?.message)
+                      }
+                    >
+                      <SqlBox
+                        value={explainPlanState.explainPlan || "Not available."}
+                        size={SqlBoxSize.custom}
+                      />
+                    </Loading>
+                  </Col>
+                </Row>
+              </section>
+            </Tabs.TabPane>
           </Tabs>
         </Loading>
       </div>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
@@ -20,7 +20,7 @@ import {
   selectStmtInsightDetails,
   selectStmtInsightsError,
 } from "src/store/insights/statementInsights";
-import { selectHasAdminRole, selectIsTenant } from "src/store/uiConfig";
+import { selectHasAdminRole } from "src/store/uiConfig";
 import { TimeScale } from "../../timeScaleDropdown";
 import { actions as sqlStatsActions } from "../../store/sqlStats";
 import { selectTimeScale } from "../../store/utils/selectors";
@@ -35,7 +35,6 @@ const mapStateToProps = (
   return {
     insightEventDetails: insightStatements,
     insightError: insightError,
-    isTenant: selectIsTenant(state),
     timeScale: selectTimeScale(state),
     hasAdminRole: selectHasAdminRole(state),
   };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -77,7 +77,6 @@ export type StatementInsightsViewStateProps = {
   dropDownSelect?: React.ReactElement;
   timeScale?: TimeScale;
   maxSizeApiReached?: boolean;
-  isTenant?: boolean;
 };
 
 export type StatementInsightsViewDispatchProps = {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
@@ -50,7 +50,6 @@ import { TimeScale } from "../../timeScaleDropdown";
 import { StmtInsightsReq, TxnInsightsRequest } from "src/api";
 import { selectTimeScale } from "../../store/utils/selectors";
 import { actions as analyticsActions } from "../../store/analytics";
-import { selectIsTenant } from "../../store/uiConfig";
 
 const transactionMapStateToProps = (
   state: AppState,
@@ -83,7 +82,6 @@ const statementMapStateToProps = (
   timeScale: selectTimeScale(state),
   isLoading: selectStmtInsightsLoading(state),
   maxSizeApiReached: selectStmtInsightsMaxApiReached(state),
-  isTenant: selectIsTenant(state),
 });
 
 const TransactionDispatchProps = (

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.tsx
@@ -38,7 +38,6 @@ import { SortSetting } from "../sortedtable";
 const cx = classNames.bind(styles);
 
 export type ActiveStatementDetailsStateProps = {
-  isTenant?: boolean;
   contentionDetails?: ExecutionContentionDetails;
   statement: ActiveStatement;
   match: match;
@@ -64,7 +63,6 @@ export type ActiveStatementDetailsProps = ActiveStatementDetailsStateProps &
   ActiveStatementDetailsDispatchProps;
 
 export const ActiveStatementDetails: React.FC<ActiveStatementDetailsProps> = ({
-  isTenant,
   contentionDetails,
   statement,
   match,
@@ -93,7 +91,6 @@ export const ActiveStatementDetails: React.FC<ActiveStatementDetailsProps> = ({
 
   const onTabClick = (key: TabKeysEnum) => {
     if (
-      !isTenant &&
       key === TabKeysEnum.EXPLAIN &&
       statement?.planGist &&
       !explainPlanState.loaded
@@ -161,42 +158,40 @@ export const ActiveStatementDetails: React.FC<ActiveStatementDetailsProps> = ({
             contentionDetails={contentionDetails}
           />
         </Tabs.TabPane>
-        {!isTenant && (
-          <Tabs.TabPane tab="Explain Plan" key={TabKeysEnum.EXPLAIN}>
-            <Row gutter={24} className={cx("margin-right")}>
-              <Col className="gutter-row" span={24}>
-                <Loading
-                  loading={
-                    !explainPlanState.loaded && statement?.planGist?.length > 0
-                  }
-                  page={"stmt_insight_details"}
-                  error={explainPlanState.error}
-                  renderError={() =>
-                    LoadingError({
-                      statsType: "explain plan",
-                      error: explainPlanState.error,
-                    })
-                  }
-                >
-                  <SqlBox
-                    value={explainPlanState.explainPlan || "Not available."}
-                    size={SqlBoxSize.custom}
+        <Tabs.TabPane tab="Explain Plan" key={TabKeysEnum.EXPLAIN}>
+          <Row gutter={24} className={cx("margin-right")}>
+            <Col className="gutter-row" span={24}>
+              <Loading
+                loading={
+                  !explainPlanState.loaded && statement?.planGist?.length > 0
+                }
+                page={"stmt_insight_details"}
+                error={explainPlanState.error}
+                renderError={() =>
+                  LoadingError({
+                    statsType: "explain plan",
+                    error: explainPlanState.error,
+                  })
+                }
+              >
+                <SqlBox
+                  value={explainPlanState.explainPlan || "Not available."}
+                  size={SqlBoxSize.custom}
+                />
+                {hasInsights && (
+                  <Insights
+                    idxRecommendations={indexRecommendations}
+                    query={statement.stmtNoConstants}
+                    database={statement.database}
+                    sortSetting={insightsSortSetting}
+                    onChangeSortSetting={setInsightsSortSetting}
+                    hasAdminRole={hasAdminRole}
                   />
-                  {hasInsights && (
-                    <Insights
-                      idxRecommendations={indexRecommendations}
-                      query={statement.stmtNoConstants}
-                      database={statement.database}
-                      sortSetting={insightsSortSetting}
-                      onChangeSortSetting={setInsightsSortSetting}
-                      hasAdminRole={hasAdminRole}
-                    />
-                  )}
-                </Loading>
-              </Col>
-            </Row>
-          </Tabs.TabPane>
-        )}
+                )}
+              </Loading>
+            </Col>
+          </Row>
+        </Tabs.TabPane>
       </Tabs>
     </div>
   );

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsConnected.tsx
@@ -22,7 +22,7 @@ import {
   selecteActiveStatement,
   selectContentionDetailsForStatement,
 } from "src/selectors/activeExecutions.selectors";
-import { selectHasAdminRole, selectIsTenant } from "src/store/uiConfig";
+import { selectHasAdminRole } from "src/store/uiConfig";
 
 // For tenant cases, we don't show information about node, regions and
 // diagnostics.
@@ -34,7 +34,6 @@ const mapStateToProps = (
     contentionDetails: selectContentionDetailsForStatement(state, props),
     statement: selecteActiveStatement(state, props),
     match: props.match,
-    isTenant: selectIsTenant(state),
     hasAdminRole: selectHasAdminRole(state),
   };
 };

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -344,7 +344,7 @@ export function makeStatementsColumns(
     },
   ];
 
-  if (activateDiagnosticsRef && !isTenant && !hasViewActivityRedactedRole) {
+  if (activateDiagnosticsRef && !hasViewActivityRedactedRole) {
     const diagnosticsColumn: ColumnDescriptor<AggregateStatistics> = {
       name: "diagnostics",
       title: statisticsTableTitles.diagnostics(statType),


### PR DESCRIPTION
Backport 2/2 commits from #117958.

/cc @cockroachdb/release

---

Previously, Explain Plan tabs were not available for tenant clusters.
This commit enables them, as there is no technical reason to disable
them at this point. The commit also adds some simple tests for
components that are being modified, as there were no tests before,
making it harder to verify the fixes. It also converts an existing
spec to use the React Testing Library rather than Enzyme, as the RTL
is the preferred testing library going forward.

Part of: https://github.com/cockroachdb/cockroach/issues/83422

Release note: The Explain Plan tab is now shown for statements and
insight pages, for tenant clusters.

Release justification: Low-risk change to enable explain plans for Serverless clusters. Non-tenant clusters should be unaffected.