### PR TITLE
release-23.1: backport pkg/cmd/release changes

### DIFF
--- a/pkg/cmd/release/testdata/release_data.yaml
+++ b/pkg/cmd/release/testdata/release_data.yaml
@@ -176,3 +176,30 @@
     docker_arm: true
   source: true
   previous_release: v23.1.0
+
+- release_name: v23.2.0-beta.1
+  major_version: v23.2
+  release_date: '2023-11-27'
+  release_type: Testing
+  go_version: go1.21
+  sha: 6164c87419fa34e42b349c8206774090fc023af4
+  has_sql_only: true
+  has_sha256sum: true
+  mac:
+    mac_arm: true
+    mac_arm_experimental: true
+    mac_arm_limited_access: false
+  windows: true
+  linux:
+    linux_arm: true
+    linux_arm_experimental: true
+    linux_arm_limited_access: false
+    linux_intel_fips: true
+    linux_arm_fips: false
+  docker:
+    docker_image: cockroachdb/cockroach-unstable
+    docker_arm: true
+    docker_arm_experimental: true
+    docker_arm_limited_access: false
+  source: true
+  previous_release: v23.2.0-alpha.7

--- a/pkg/cmd/release/update_releases.go
+++ b/pkg/cmd/release/update_releases.go
@@ -109,7 +109,7 @@ func processReleaseData(data []Release) map[string]release.Series {
 		// For the purposes of the cockroach_releases file, we are only
 		// interested in beta and rc pre-releases, as we do not support
 		// upgrades from alpha releases.
-		if pre := v.PreRelease(); pre != "" && pre != "rc" && pre != "beta" {
+		if pre := v.PreRelease(); pre != "" && !strings.HasPrefix(pre, "rc") && !strings.HasPrefix(pre, "beta") {
 			continue
 		}
 		// Skip cloud-only releases, because the binaries are not yet publicly available.

--- a/pkg/cmd/release/update_releases.go
+++ b/pkg/cmd/release/update_releases.go
@@ -60,6 +60,7 @@ type Release struct {
 	Series    string `yaml:"major_version"`
 	Previous  string `yaml:"previous_release"`
 	Withdrawn bool   `yaml:"withdrawn"`
+	CloudOnly bool   `yaml:"cloud_only"`
 }
 
 // updateReleasesFile downloads the current release data from the docs
@@ -109,6 +110,10 @@ func processReleaseData(data []Release) map[string]release.Series {
 		// interested in beta and rc pre-releases, as we do not support
 		// upgrades from alpha releases.
 		if pre := v.PreRelease(); pre != "" && pre != "rc" && pre != "beta" {
+			continue
+		}
+		// Skip cloud-only releases, because the binaries are not yet publicly available.
+		if r.CloudOnly {
 			continue
 		}
 

--- a/pkg/cmd/release/update_releases_test.go
+++ b/pkg/cmd/release/update_releases_test.go
@@ -44,6 +44,10 @@ func Test_processReleaseData(t *testing.T) {
 			Predecessor: "22.2",
 			Withdrawn:   []string{"23.1.0"},
 		},
+		"23.2": {
+			Latest:      "23.2.0-beta.1",
+			Predecessor: "23.1",
+		},
 	}
 	require.Equal(t, expectedReleaseData, processReleaseData(data))
 }


### PR DESCRIPTION
Backport:
  * 1/1 commits from "release: skip cloud-only releases" (#118092)
  * 1/1 commits from "release: fix check for valid pre-releases when updating predecessors file" (#115212)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: release automation changes