### PR TITLE
workflows: limit concurrency on EngFlow test runs

### DIFF
--- a/.github/workflows/experimental-github-actions-testing.yml
+++ b/.github/workflows/experimental-github-actions-testing.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, edited ]
     branches: [ master ]
+concurrency:
+  group: ${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 jobs:
   test_job:
     runs-on: [self-hosted, basic_runner_group]


### PR DESCRIPTION
Stop an in-progress build if a new one is queued.

Epic: CRDB-8308
Release note: None