### PR TITLE
comparator: Skip `VALIDATE CONSTRAINT` stmt

### DIFF
--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -859,6 +859,7 @@ func TestCompareLegacyAndDeclarative(t *testing.T) {
 		stmts: []string{
 			// Statements expected to succeed.
 			"SET sql_safe_updates = false;",
+			"SET experimental_enable_unique_without_index_constraints = true",
 			"CREATE DATABASE testdb1; SET DATABASE = testdb1",
 			"CREATE TABLE testdb1.t1 (i INT PRIMARY KEY); CREATE TABLE testdb1.t2 (i INT PRIMARY KEY REFERENCES testdb1.t1(i));",
 			"DROP DATABASE testdb1 CASCADE  -- current db is dropped; expect no post-execution checks",
@@ -948,6 +949,10 @@ func TestCompareLegacyAndDeclarative(t *testing.T) {
 			"ALTER TABLE t10 ALTER PRIMARY KEY USING COLUMNS (i, k) USING HASH;  -- expect to be rewritten to have `DROP COLUMN IF EXISTS old-shard-col` appended to it",
 			"ALTER TABLE t10 ALTER PRIMARY KEY USING COLUMNS (i, k); -- ditto",
 			"ALTER TABLE t10 ALTER PRIMARY KEY USING COLUMNS (j) USING HASH;  -- expect to not be rewritten because old-shard-col is used",
+			"CREATE TABLE t12 (i INT8)",
+			"INSERT INTO t12 VALUES (99), (99);",
+			"ALTER TABLE t12 ADD CONSTRAINT unique_i_1 UNIQUE WITHOUT INDEX (i) NOT VALID, ADD CONSTRAINT unique_i_2 UNIQUE WITHOUT INDEX (i) NOT VALID",
+			"ALTER TABLE t12 VALIDATE CONSTRAINT unique_i_1  -- expect to be skipped",
 		},
 	}
 


### PR DESCRIPTION
`VALIDATE CONSTRAINT` stmt is supported both in LSC and DSC. However, due to implementation detail differences, after the validation, the constraint will have a new constraintID in DSC, whereas the constraint retains the old constraintID in LSC. This has unfortunately come to affect our descriptor state identity check which compares the string output of `SHOW CREATE t` and the *order* of constraints depends on the constraintID, causing a potential descriptor state mismatch.

This commit fixes this issue by skipping VALIDATE CONSTRAINT stmt. Some alternative solution considered are: 1. force this `VALIDATE CONSTRAINT` stmt to be executed in LSC (or DSC) only; 2. bake in this difference into the descriptor identity check. I didn't think of a way to do approach 1 yet, but approach 2 would need careful and possibly a great amount of rewriting. Thus, I decided to go with skipping as a stop gas solution.

Informs #113366
Release note: None