### PR TITLE
catalog/lease: Fix TestLeaseRenewedAutomatically flake

### DIFF
--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -106,7 +106,6 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog",
-        "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/descbuilder",
         "//pkg/sql/catalog/descpb",


### PR DESCRIPTION
Previously TestLeaseRenewedAutomatically, would inject testing knobs into both the actual server and the lease managers it created for testing. This could lead to test flakes if background work on the server renewed or accessed leases (for example statistics collection). To address this, this test is modified so that testing knobs are only injected into the lease managers that the test creates.

Fixes: #112550

Release note: None