### PR TITLE
roachtest: deflake upgrade_skip_version

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upgrade_skip_version
+++ b/pkg/sql/logictest/testdata/logic_test/upgrade_skip_version
@@ -9,7 +9,7 @@ upgrade all
 
 # We have seen that upgrades can take a long time in CI. Give some extra time
 # for the upgrade to complete.
-sleep 30s
+retry_duration 10m
 
 # Verify that the cluster is upgrading to 24.1.
 query T retry


### PR DESCRIPTION
Give more time for the upgrade to complete, since it seems to take a while in CI. This is done by adding an option to customize the retry duration.

fixes https://github.com/cockroachdb/cockroach/issues/118153
Release note: None