### PR TITLE
docs: unlink custom param names from SQL diagrams

### DIFF
--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -519,6 +519,7 @@ var specs = []stmtSpec{
 		name:    "alter_proc",
 		stmt:    "alter_proc_stmt",
 		inline:  []string{"alter_proc_rename_stmt", "alter_proc_owner_stmt", "alter_proc_set_schema_stmt", "function_with_paramtypes", "func_params", "func_params_list"},
+		unlink:  []string{"proc_name", "proc_new_name"},
 		replace: map[string]string{"db_object_name": "proc_name", "'RENAME' 'TO' name": "'RENAME' 'TO' proc_new_name"},
 		nosplit: true,
 	},
@@ -647,6 +648,7 @@ var specs = []stmtSpec{
 	{
 		name:    "call",
 		stmt:    "call_stmt",
+		unlink:  []string{"proc_name", "param_values"},
 		replace: map[string]string{"func_application": "proc_name '(' param_values ')'"},
 	},
 	{
@@ -826,7 +828,7 @@ var specs = []stmtSpec{
 		name:   "create_func",
 		stmt:   "create_func_stmt",
 		inline: []string{"opt_or_replace", "opt_routine_param_with_default_list", "opt_return_set", "opt_create_routine_opt_list", "create_routine_opt_list", "common_routine_opt_item", "create_routine_opt_item", "routine_return_stmt", "routine_param_with_default_list", "routine_param_with_default", "routine_as", "opt_link_sym"},
-		unlink: []string{"opt_or_replace", "opt_routine_param_with_default_list", "opt_return_set", "opt_create_routine_opt_list", "create_routine_opt_list", "create_routine_opt_item", "common_routine_opt_item", "routine_return_stmt", "non_reserved_word_or_sconst", "routine_param_with_default_list", "routine_param_with_default", "a_expr", "routine_as"},
+		unlink: []string{"opt_or_replace", "opt_routine_param_with_default_list", "opt_return_set", "opt_create_routine_opt_list", "create_routine_opt_list", "create_routine_opt_item", "common_routine_opt_item", "routine_return_stmt", "non_reserved_word_or_sconst", "routine_param_with_default_list", "routine_param_with_default", "a_expr", "routine_as", "routine_body_str"},
 		replace: map[string]string{
 			"func_as":                          "'SCONST'",
 			"'AS'":                             "'AS' routine_body_str",
@@ -842,6 +844,7 @@ var specs = []stmtSpec{
 		name:   "create_proc",
 		stmt:   "create_proc_stmt",
 		inline: []string{"opt_or_replace", "opt_routine_param_with_default_list", "routine_param_with_default_list", "routine_param_with_default", "opt_create_routine_opt_list", "create_routine_opt_list", "create_routine_opt_item", "routine_as", "opt_link_sym", "create_routine_opt_item", "routine_return_stmt"},
+		unlink: []string{"routine_body_str"},
 		replace: map[string]string{
 			"'DEFAULT'":                        "",
 			"common_routine_opt_item":          "",
@@ -962,6 +965,7 @@ var specs = []stmtSpec{
 		name:    "drop_proc",
 		stmt:    "drop_proc_stmt",
 		inline:  []string{"function_with_paramtypes_list", "function_with_paramtypes", "opt_drop_behavior", "func_params", "func_params_list"},
+		unlink:  []string{"proc_name"},
 		replace: map[string]string{"db_object_name": "proc_name"},
 		nosplit: true,
 	},


### PR DESCRIPTION
In #117651, I neglected to unlink the custom parameter names that I created for some SQL diagrams. This is now breaking build in the `docs` repo. 

Epic: CRDB-799

Release note: None