### PR TITLE
inverted: fix intersection of SpanExpressions in some cases

### DIFF
--- a/pkg/sql/inverted/testdata/expression
+++ b/pkg/sql/inverted/testdata/expression
@@ -588,3 +588,60 @@ node: <
 to-proto name=none
 ----
 <nil>
+
+# The following set of expressions (up to 'a-and-a-or-b-and-c') is a regression
+# test for incorrectly simplifying 'a AND (a OR (b AND c))' to 'a OR (b AND c)'
+# (#117979).
+
+new-span-leaf name=a tight=true unique=true span=a
+----
+span expression
+ ├── tight: true, unique: true
+ ├── to read: ["a", "a"]
+ └── union spans: ["a", "a"]
+
+new-span-leaf name=c tight=true unique=true span=c
+----
+span expression
+ ├── tight: true, unique: true
+ ├── to read: ["c", "c"]
+ └── union spans: ["c", "c"]
+
+and result=b-and-c left=b right=c
+----
+span expression
+ ├── tight: true, unique: true
+ ├── to read: ["b", "d")
+ ├── union spans: empty
+ └── INTERSECTION
+      ├── span expression
+      │    ├── tight: true, unique: true
+      │    ├── to read: ["b", "b"]
+      │    └── union spans: ["b", "b"]
+      └── span expression
+           ├── tight: true, unique: true
+           ├── to read: ["c", "c"]
+           └── union spans: ["c", "c"]
+
+or result=a-or-b-and-c left=a right=b-and-c
+----
+span expression
+ ├── tight: true, unique: false
+ ├── to read: ["a", "d")
+ ├── union spans: ["a", "a"]
+ └── INTERSECTION
+      ├── span expression
+      │    ├── tight: true, unique: true
+      │    ├── to read: ["b", "b"]
+      │    └── union spans: ["b", "b"]
+      └── span expression
+           ├── tight: true, unique: true
+           ├── to read: ["c", "c"]
+           └── union spans: ["c", "c"]
+
+and result=a-and-a-or-b-and-c left=a right=a-or-b-and-c
+----
+span expression
+ ├── tight: true, unique: false
+ ├── to read: ["a", "a"]
+ └── union spans: ["a", "a"]

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -2044,3 +2044,19 @@ SELECT primes FROM cb WHERE primes && numbers ORDER BY primes
 statement ok
 CREATE TABLE t84569 (name_col NAME NOT NULL, INVERTED INDEX (name_col gin_trgm_ops));
 INSERT INTO t84569 (name_col) VALUES ('X'::NAME)
+
+# Regression test for incorrectly simplifying inverted expressions (#117979).
+statement ok
+CREATE TABLE t117979 (id INT PRIMARY KEY, links text[], INVERTED INDEX idx_links(links));
+INSERT INTO t117979 (id, links) VALUES (1, '{str2,str3}');
+
+query IT
+SELECT *
+FROM t117979@{FORCE_INDEX=idx_links} as t
+WHERE
+    ARRAY['str1'] <@ t.links
+    AND (
+        ARRAY ['str1'] && t.links
+        OR (ARRAY ['str2'] && t.links AND ARRAY ['str3'] && t.links)
+    );
+----

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -3530,3 +3530,47 @@ query T kvtrace
 SELECT k FROM m@i2 WHERE a IN (10, 20) AND b IN (15, 25) AND j @> '{"a": "b"}'
 ----
 Scan /Table/112/3/10/15/"a"/"b"{-/PrefixEnd}, /Table/112/3/10/25/"a"/"b"{-/PrefixEnd}, /Table/112/3/20/15/"a"/"b"{-/PrefixEnd}, /Table/112/3/20/25/"a"/"b"{-/PrefixEnd}
+
+# Regression test for incorrectly simplifying inverted expressions (#117979).
+statement ok
+CREATE TABLE t117979 (id INT PRIMARY KEY, links text[], INVERTED INDEX idx_links(links));
+
+query T
+EXPLAIN (OPT, VERBOSE)
+SELECT *
+FROM t117979@{FORCE_INDEX=idx_links} as t
+WHERE
+    ARRAY['str1'] <@ t.links
+    AND (
+        ARRAY ['str1'] && t.links
+        OR (ARRAY ['str2'] && t.links AND ARRAY ['str3'] && t.links)
+    );
+----
+index-join t117979
+ ├── columns: id:1 links:2
+ ├── immutable
+ ├── stats: [rows=111.1111]
+ ├── cost: 813.615556
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── distribution: test
+ ├── prune: (1)
+ └── inverted-filter
+      ├── columns: id:1
+      ├── inverted expression: /5
+      │    ├── tight: true, unique: false
+      │    └── union spans: ["\x12str1\x00\x01", "\x12str1\x00\x01"]
+      ├── stats: [rows=111.1111]
+      ├── cost: 139.151111
+      ├── key: (1)
+      ├── distribution: test
+      └── scan t117979@idx_links [as=t]
+           ├── columns: id:1 links_inverted_key:5
+           ├── inverted constraint: /5/1
+           │    └── spans: ["\x12str1\x00\x01", "\x12str1\x00\x01"]
+           ├── flags: force-index=idx_links
+           ├── stats: [rows=111.1111, distinct(1)=111.111, null(1)=0, distinct(5)=100, null(5)=0]
+           ├── cost: 138.02
+           ├── key: (1)
+           ├── fd: (1)-->(5)
+           └── distribution: test


### PR DESCRIPTION
This commit fixes the logic for intersecting two SpanExpressions in some cases. In particular, consider the following example:
- left expr is `ARRAY['str1'] <@ t.links` which translates to a SpanExpression in which only FactoredUnionSpans is set to the span containing `str1`
- right expr is `ARRAY ['str1'] && t.links OR ...` which translates to a SpanExpression in which FactoredUnionSpans is set to exactly same span containing `str1` plus some other stuff in children expressions.

In other words, we have `a AND (a OR b)`.

When intersecting SpanExpressions, we intersect their FactoredUnionSpans, and then we update FactoredUnionSpans of expressions to subtract the shared ones. Previously, in the example above this would result in making the left expression empty, so it would be pruned. However, that is incorrect - we have the equivalent of `left AND right`, so we must ensure that `left` expression is satisfied, and previously this wouldn't be the case. The fix is that if one of the children expressions became empty, then intersection of two children is also empty, so instead of promoting non-empty child we now nil non-empty child out. In the example above, previously we would get `a OR b`, and now we'll correctly get `a`.

Fixes: #117979.

Release note (bug fix): Previously, in some cases CockroachDB could incorrectly evaluate queries that scanned an inverted index and had a `WHERE` filter in which two sides of the `AND` expression had "similar" expressions (e.g. `ARRAY['str1'] <@ col AND (ARRAY['str1'] && col OR ...)`), and this is now fixed. The bug has been present since pre-22.2 version.