### PR TITLE
inverted: minor cleanup

### DIFF
--- a/pkg/sql/inverted/testdata/expression
+++ b/pkg/sql/inverted/testdata/expression
@@ -626,7 +626,7 @@ span expression
 or result=a-or-b-and-c left=a right=b-and-c
 ----
 span expression
- ├── tight: true, unique: false
+ ├── tight: true, unique: true
  ├── to read: ["a", "d")
  ├── union spans: ["a", "a"]
  └── INTERSECTION
@@ -642,6 +642,6 @@ span expression
 and result=a-and-a-or-b-and-c left=a right=a-or-b-and-c
 ----
 span expression
- ├── tight: true, unique: false
+ ├── tight: true, unique: true
  ├── to read: ["a", "a"]
  └── union spans: ["a", "a"]

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -3550,27 +3550,17 @@ index-join t117979
  ├── columns: id:1 links:2
  ├── immutable
  ├── stats: [rows=111.1111]
- ├── cost: 813.615556
+ ├── cost: 810.262222
  ├── key: (1)
  ├── fd: (1)-->(2)
  ├── distribution: test
  ├── prune: (1)
- └── inverted-filter
+ └── scan t117979@idx_links [as=t]
       ├── columns: id:1
-      ├── inverted expression: /5
-      │    ├── tight: true, unique: false
-      │    └── union spans: ["\x12str1\x00\x01", "\x12str1\x00\x01"]
-      ├── stats: [rows=111.1111]
-      ├── cost: 139.151111
+      ├── inverted constraint: /5/1
+      │    └── spans: ["\x12str1\x00\x01", "\x12str1\x00\x01"]
+      ├── flags: force-index=idx_links
+      ├── stats: [rows=111.1111, distinct(5)=100, null(5)=0]
+      ├── cost: 135.797778
       ├── key: (1)
-      ├── distribution: test
-      └── scan t117979@idx_links [as=t]
-           ├── columns: id:1 links_inverted_key:5
-           ├── inverted constraint: /5/1
-           │    └── spans: ["\x12str1\x00\x01", "\x12str1\x00\x01"]
-           ├── flags: force-index=idx_links
-           ├── stats: [rows=111.1111, distinct(1)=111.111, null(1)=0, distinct(5)=100, null(5)=0]
-           ├── cost: 138.02
-           ├── key: (1)
-           ├── fd: (1)-->(5)
-           └── distribution: test
+      └── distribution: test

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -425,7 +425,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			indexOrd:         jsonOrd,
 			ok:               true,
 			tight:            false,
-			unique:           false,
+			unique:           true,
 			remainingFilters: "j @> '[[1, 2]]' OR j @> '[3, 4]'",
 		},
 		{
@@ -435,7 +435,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			indexOrd:         jsonOrd,
 			ok:               true,
 			tight:            false,
-			unique:           false,
+			unique:           true,
 			remainingFilters: "j @> '[1, 2]' OR j @> '[[3, 4]]'",
 		},
 		{
@@ -445,7 +445,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			indexOrd: jsonOrd,
 			ok:       true,
 			tight:    true,
-			unique:   false,
+			unique:   true,
 		},
 		{
 			// With AND conditions the remaining filters may be a subset of the
@@ -995,7 +995,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			indexOrd:         jsonOrd,
 			ok:               true,
 			tight:            false,
-			unique:           false,
+			unique:           true,
 			remainingFilters: `j->'a' IN ('[1,2,3]', '[1]')`,
 		},
 		{
@@ -1036,7 +1036,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			indexOrd:         jsonOrd,
 			ok:               true,
 			tight:            false,
-			unique:           false,
+			unique:           true,
 			remainingFilters: `j->'a'->0 IN ('[1,2,3]', '[1]')`,
 		},
 		{
@@ -1109,7 +1109,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			indexOrd:         jsonOrd,
 			ok:               true,
 			tight:            false,
-			unique:           false,
+			unique:           true,
 			remainingFilters: `j = '{"a": "b"}' OR j = '[1, 2, 3]'`,
 		},
 		{
@@ -1156,7 +1156,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			indexOrd:         jsonOrd,
 			ok:               true,
 			tight:            false,
-			unique:           false,
+			unique:           true,
 			remainingFilters: `j IN ('[1, 2, 3]', '{"a": "b"}')`,
 		},
 		{

--- a/pkg/sql/opt/invertedidx/trigram_test.go
+++ b/pkg/sql/opt/invertedidx/trigram_test.go
@@ -95,7 +95,7 @@ func TestTryFilterTrigram(t *testing.T) {
 		// Equality queries.
 		{filters: "s = 'lkjsdlkj'", ok: true, unique: false},
 		{filters: "s = 'lkj'", ok: true, unique: true},
-		{filters: "s = 'lkj' OR s LIKE 'blah'", ok: true, unique: false},
+		{filters: "s = 'lkj' OR s LIKE 'blah'", ok: true, unique: true},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/sql/opt/invertedidx/tsearch_test.go
+++ b/pkg/sql/opt/invertedidx/tsearch_test.go
@@ -86,7 +86,7 @@ func TestTryFilterTSVector(t *testing.T) {
 		// Some sanity checks for more than 2 terms, to make sure that the output
 		// de-uniqueifies as we travel up the tree with more than 1 lexeme seen.
 		{filters: "t @@ '(a & !b) | c'", ok: true, tight: false, unique: false},
-		{filters: "t @@ '(a & b) | c'", ok: true, tight: true, unique: false},
+		{filters: "t @@ '(a & b) | c'", ok: true, tight: true, unique: true},
 		{filters: "t @@ '(a & b) <-> !(c | d)'", ok: true, tight: false, unique: true},
 	}
 

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2827,7 +2827,7 @@ select
  │    └── inverted-filter
  │         ├── columns: k:1!null
  │         ├── inverted expression: /7
- │         │    ├── tight: false, unique: false
+ │         │    ├── tight: false, unique: true
  │         │    ├── union spans: empty
  │         │    └── UNION
  │         │         ├── span expression
@@ -4460,11 +4460,11 @@ project
       │    └── inverted-filter
       │         ├── columns: k:1!null
       │         ├── inverted expression: /7
-      │         │    ├── tight: false, unique: false
+      │         │    ├── tight: false, unique: true
       │         │    ├── union spans: ["7a\x00\x02\x00\x03\x00\x01*\x02\x00", "7a\x00\x02\x00\x03\x00\x01*\x02\x00"]
       │         │    └── UNION
       │         │         ├── span expression
-      │         │         │    ├── tight: false, unique: false
+      │         │         │    ├── tight: false, unique: true
       │         │         │    ├── union spans: empty
       │         │         │    └── INTERSECTION
       │         │         │         ├── span expression
@@ -4855,11 +4855,11 @@ project
       │    └── inverted-filter
       │         ├── columns: k:1!null
       │         ├── inverted expression: /7
-      │         │    ├── tight: false, unique: false
+      │         │    ├── tight: false, unique: true
       │         │    ├── union spans: ["7\x00\x03\x00\x03\x00\x01*\x02\x00", "7\x00\x03\x00\x03\x00\x01*\x02\x00"]
       │         │    └── UNION
       │         │         ├── span expression
-      │         │         │    ├── tight: false, unique: false
+      │         │         │    ├── tight: false, unique: true
       │         │         │    ├── union spans: empty
       │         │         │    └── INTERSECTION
       │         │         │         ├── span expression
@@ -9703,7 +9703,7 @@ select
  │    └── inverted-filter
  │         ├── columns: k:1!null
  │         ├── inverted expression: /9
- │         │    ├── tight: false, unique: false
+ │         │    ├── tight: false, unique: true
  │         │    ├── union spans: ["7\x00\x03\x00\x01*\x06\x00", "7\x00\x03\x00\x01*\x06\x00"]
  │         │    └── INTERSECTION
  │         │         ├── span expression

--- a/pkg/util/tsearch/encoding_test.go
+++ b/pkg/util/tsearch/encoding_test.go
@@ -112,8 +112,8 @@ func TestEncodeTSQueryInvertedIndexSpans(t *testing.T) {
 		{`a:1 b:2`, `a <-> (!b|!c)`, true, false, true},
 		{`a:1 c:2`, `a <-> (!b|!c)`, true, false, true},
 		{`a:1 d:2`, `a <-> (!b|!c)`, true, false, true},
-		{`a:1 b:2 c:3 d:4`, `a <-> ((b <-> c) | d)`, true, false, false},
-		{`a:1 b:2 c:3 d:4`, `a <-> (b | (c <-> d))`, true, false, false},
+		{`a:1 b:2 c:3 d:4`, `a <-> ((b <-> c) | d)`, true, false, true},
+		{`a:1 b:2 c:3 d:4`, `a <-> (b | (c <-> d))`, true, false, true},
 	}
 
 	// runTest checks that evaluating `left @@ right` using keys from


### PR DESCRIPTION
This commit sets `Unique` field when performing a union of two SpanExpressions whenever possible as well as removes an unused function argument.

Epic: None

Release note: None