### PR TITLE
roachtest: fix django tests; update python

### DIFF
--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -91,9 +91,7 @@ func registerAsyncpg(r registry.Registry) {
 
 		if err := repeatRunE(
 			ctx, t, c, node, "update apt-get",
-			`
-				sudo add-apt-repository ppa:deadsnakes/ppa &&
-				sudo apt-get -qq update`,
+			`sudo apt-get -qq update`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -104,15 +102,14 @@ func registerAsyncpg(r registry.Registry) {
 			c,
 			node,
 			"install python and pip",
-			`sudo apt-get -qq install python3.8 python3-pip libpq-dev python3.8-dev python3-virtualenv python3.8-distutils python3-apt python3-setuptools python-setuptools`,
+			`sudo apt-get -qq install python3.10 python3-pip libpq-dev python3.10-dev python3-virtualenv python3.10-distutils python3-apt python3-setuptools python-setuptools`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
-			ctx, t, c, node, "set python3.8 as default", `
-    		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
-    		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2
+			ctx, t, c, node, "set python3.10 as default", `
+    		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
     		sudo update-alternatives --config python3`,
 		); err != nil {
 			t.Fatal(err)
@@ -120,7 +117,7 @@ func registerAsyncpg(r registry.Registry) {
 
 		if err := repeatRunE(
 			ctx, t, c, node, "install pip",
-			`curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.8`,
+			`curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.10`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -60,9 +60,7 @@ func registerDjango(r registry.Registry) {
 
 		if err := repeatRunE(
 			ctx, t, c, node, "update apt-get",
-			`
-				sudo add-apt-repository ppa:deadsnakes/ppa &&
-				sudo apt-get -qq update`,
+			`sudo apt-get -qq update`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -73,15 +71,14 @@ func registerDjango(r registry.Registry) {
 			c,
 			node,
 			"install dependencies",
-			`sudo apt-get -qq install make python3.8 libpq-dev python3.8-dev gcc python3-virtualenv python3-setuptools python-setuptools build-essential python3.8-distutils python3-apt libmemcached-dev`,
+			`sudo apt-get -qq install make python3.10 libpq-dev python3.10-dev gcc python3-virtualenv python3-setuptools python-setuptools build-essential python3.10-distutils python3-apt libmemcached-dev`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
-			ctx, t, c, node, "set python3.8 as default", `
-    		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
-    		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2
+			ctx, t, c, node, "set python3.10 as default", `
+    		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
     		sudo update-alternatives --config python3`,
 		); err != nil {
 			t.Fatal(err)
@@ -89,7 +86,7 @@ func registerDjango(r registry.Registry) {
 
 		if err := repeatRunE(
 			ctx, t, c, node, "install pip",
-			`curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.8`,
+			`curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.10`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -244,7 +241,7 @@ DATABASES = {
         'USER': 'root',
         'PASSWORD': '',
         'HOST': 'localhost',
-        'PORT': 26257,
+        'PORT': {pgport:1},
     },
     'other': {
         'ENGINE': 'django_cockroachdb',
@@ -252,7 +249,7 @@ DATABASES = {
         'USER': 'root',
         'PASSWORD': '',
         'HOST': 'localhost',
-        'PORT': 26257,
+        'PORT': {pgport:1},
     },
 }
 SECRET_KEY = 'django_tests_secret_key'

--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -64,28 +64,26 @@ func runSQLAlchemy(ctx context.Context, t test.Test, c cluster.Cluster) {
 	t.L().Printf("Supported sqlalchemy release is %s.", supportedSQLAlchemyTag)
 
 	if err := repeatRunE(ctx, t, c, node, "update apt-get", `
-		sudo add-apt-repository ppa:deadsnakes/ppa &&
 		sudo apt-get -qq update
 	`); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := repeatRunE(ctx, t, c, node, "install dependencies", `
-		sudo apt-get -qq install make python3.7 libpq-dev python3.7-dev gcc python3-setuptools python-setuptools build-essential python3.7-distutils python3-virtualenv python3-typing-extensions
+		sudo apt-get -qq install make python3.10 libpq-dev python3.10-dev gcc python3-setuptools python-setuptools build-essential python3.10-distutils python3-virtualenv python3-typing-extensions
 	`); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := repeatRunE(ctx, t, c, node, "set python3.7 as default", `
-		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
-		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
+	if err := repeatRunE(ctx, t, c, node, "set python3.10 as default", `
+		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 		sudo update-alternatives --config python3
 	`); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := repeatRunE(ctx, t, c, node, "install pip", `
-		curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.7
+		curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.10
 	`); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The django tests didn't work since they were using a fixed port of 26257 rather than the dyamic one chosen by roachtest.

This also fixes flakes in python roachtests that sometimes had build issues due to how python was installed.

fixes https://github.com/cockroachdb/cockroach/issues/118197
Release note: None