### PR TITLE
rangefeed: improve assertions

### DIFF
--- a/pkg/kv/kvserver/rangefeed/budget.go
+++ b/pkg/kv/kvserver/rangefeed/budget.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -249,10 +250,10 @@ type SharedBudgetAllocation struct {
 // Use increases usage count for the allocation. It should be called by each
 // new consumer that plans to retain allocation after returning to a caller
 // that passed this allocation.
-func (a *SharedBudgetAllocation) Use() {
+func (a *SharedBudgetAllocation) Use(ctx context.Context) {
 	if a != nil {
 		if atomic.AddInt32(&a.refCount, 1) == 1 {
-			panic("unexpected shared memory allocation usage increase after free")
+			log.Fatalf(ctx, "unexpected shared memory allocation usage increase after free")
 		}
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -112,14 +112,8 @@ type Config struct {
 // SetDefaults initializes unset fields in Config to values
 // suitable for use by a Processor.
 func (sc *Config) SetDefaults() {
-	if sc.TxnPusher == nil {
-		if sc.PushTxnsAge != 0 {
-			panic("nil TxnPusher with non-zero PushTxnsAge")
-		}
-	} else {
-		if sc.PushTxnsAge == 0 {
-			sc.PushTxnsAge = defaultPushTxnsAge
-		}
+	if sc.PushTxnsAge == 0 {
+		sc.PushTxnsAge = defaultPushTxnsAge
 	}
 }
 

--- a/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
+++ b/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
@@ -293,8 +293,11 @@ func (rts *resolvedTimestamp) assertOpAboveRTS(
 	ctx context.Context, op enginepb.MVCCLogicalOp, opTS hlc.Timestamp, fatal bool,
 ) {
 	if opTS.LessEq(rts.resolvedTS) {
+		// NB: MVCCLogicalOp.String() is only implemented for pointer receiver.
+		// We shadow the variable to avoid it escaping to the heap.
+		op := op
 		err := errors.AssertionFailedf(
-			"resolved timestamp %s equal to or above timestamp of operation %v", rts.resolvedTS, op)
+			"resolved timestamp %s equal to or above timestamp of operation %v", rts.resolvedTS, &op)
 		if fatal {
 			log.Fatalf(ctx, "%v", err)
 		} else {

--- a/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
+++ b/pkg/kv/kvserver/rangefeed/resolved_timestamp.go
@@ -110,14 +110,14 @@ func (rts *resolvedTimestamp) Get() hlc.Timestamp {
 // closed timestamp. Once initialized, the resolvedTimestamp can begin operating
 // in its steady state. The method returns whether this caused the resolved
 // timestamp to move forward.
-func (rts *resolvedTimestamp) Init() bool {
+func (rts *resolvedTimestamp) Init(ctx context.Context) bool {
 	rts.init = true
 	// Once the resolvedTimestamp is initialized, all prior written intents
 	// should be accounted for, so reference counts for transactions that
 	// would drop below zero will all be due to aborted transactions. These
 	// can all be ignored.
 	rts.intentQ.AllowNegRefCount(false)
-	return rts.recompute()
+	return rts.recompute(ctx)
 }
 
 // IsInit returns whether the resolved timestamp is initialized.
@@ -128,11 +128,11 @@ func (rts *resolvedTimestamp) IsInit() bool {
 // ForwardClosedTS indicates that the closed timestamp that serves as the basis
 // for the resolved timestamp has advanced. The method returns whether this
 // caused the resolved timestamp to move forward.
-func (rts *resolvedTimestamp) ForwardClosedTS(newClosedTS hlc.Timestamp) bool {
+func (rts *resolvedTimestamp) ForwardClosedTS(ctx context.Context, newClosedTS hlc.Timestamp) bool {
 	if rts.closedTS.Forward(newClosedTS) {
-		return rts.recompute()
+		return rts.recompute(ctx)
 	}
-	rts.assertNoChange()
+	rts.assertNoChange(ctx)
 	return false
 }
 
@@ -144,9 +144,9 @@ func (rts *resolvedTimestamp) ConsumeLogicalOp(
 	ctx context.Context, op enginepb.MVCCLogicalOp,
 ) bool {
 	if rts.consumeLogicalOp(ctx, op) {
-		return rts.recompute()
+		return rts.recompute(ctx)
 	}
-	rts.assertNoChange()
+	rts.assertNoChange(ctx)
 	return false
 }
 
@@ -234,20 +234,21 @@ func (rts *resolvedTimestamp) consumeLogicalOp(
 		return rts.intentQ.Del(t.TxnID)
 
 	default:
-		panic(errors.AssertionFailedf("unknown logical op %T", t))
+		log.Fatalf(ctx, "unknown logical op %T", t)
+		return false
 	}
 }
 
 // recompute computes the resolved timestamp based on its respective closed
 // timestamp and the in-flight intents that it is tracking. The method returns
 // whether this caused the resolved timestamp to move forward.
-func (rts *resolvedTimestamp) recompute() bool {
+func (rts *resolvedTimestamp) recompute(ctx context.Context) bool {
 	if !rts.IsInit() {
 		return false
 	}
 	if rts.closedTS.Less(rts.resolvedTS) {
-		panic(fmt.Sprintf("closed timestamp below resolved timestamp: %s < %s",
-			rts.closedTS, rts.resolvedTS))
+		log.Fatalf(ctx, "closed timestamp below resolved timestamp: %s < %s",
+			rts.closedTS, rts.resolvedTS)
 	}
 	newTS := rts.closedTS
 
@@ -255,8 +256,8 @@ func (rts *resolvedTimestamp) recompute() bool {
 	// timestamps cannot be resolved yet.
 	if txn := rts.intentQ.Oldest(); txn != nil {
 		if txn.timestamp.LessEq(rts.resolvedTS) {
-			panic(fmt.Sprintf("unresolved txn equal to or below resolved timestamp: %s <= %s",
-				txn.timestamp, rts.resolvedTS))
+			log.Fatalf(ctx, "unresolved txn equal to or below resolved timestamp: %s <= %s",
+				txn.timestamp, rts.resolvedTS)
 		}
 		// txn.timestamp cannot be resolved, so the resolved timestamp must be Prev.
 		txnTS := txn.timestamp.Prev()
@@ -267,8 +268,8 @@ func (rts *resolvedTimestamp) recompute() bool {
 	newTS.Logical = 0
 
 	if newTS.Less(rts.resolvedTS) {
-		panic(fmt.Sprintf("resolved timestamp regression, was %s, recomputed as %s",
-			rts.resolvedTS, newTS))
+		log.Fatalf(ctx, "resolved timestamp regression, was %s, recomputed as %s",
+			rts.resolvedTS, newTS)
 	}
 	return rts.resolvedTS.Forward(newTS)
 }
@@ -276,12 +277,12 @@ func (rts *resolvedTimestamp) recompute() bool {
 // assertNoChange asserts that a recomputation of the resolved timestamp does
 // not change its value. A violation of this assertion would indicate a logic
 // error in the resolvedTimestamp implementation.
-func (rts *resolvedTimestamp) assertNoChange() {
+func (rts *resolvedTimestamp) assertNoChange(ctx context.Context) {
 	before := rts.resolvedTS
-	changed := rts.recompute()
+	changed := rts.recompute(ctx)
 	if changed || !before.EqOrdering(rts.resolvedTS) {
-		panic(fmt.Sprintf("unexpected resolved timestamp change on recomputation, "+
-			"was %s, recomputed as %s", before, rts.resolvedTS))
+		log.Fatalf(ctx, "unexpected resolved timestamp change on recomputation, "+
+			"was %s, recomputed as %s", before, rts.resolvedTS)
 	}
 }
 
@@ -295,9 +296,7 @@ func (rts *resolvedTimestamp) assertOpAboveRTS(
 		err := errors.AssertionFailedf(
 			"resolved timestamp %s equal to or above timestamp of operation %v", rts.resolvedTS, op)
 		if fatal {
-			// TODO(erikgrinaker): use log.Fatalf. Panic for now, since tests expect
-			// it and to minimize code churn for backports.
-			panic(err)
+			log.Fatalf(ctx, "%v", err)
 		} else {
 			log.Errorf(ctx, "%v", err)
 		}


### PR DESCRIPTION
**rangefeed: use `log.Fatal` instead of panic**

This will include the log tags from the context, aiding with debugging. Involves a bunch of context plumbing, and removing some assertion tests.

A couple of panics were left in, where it didn't appear natural to plumb through a context.

**rangefeed: use pointer receiver in MVCCLogicalOp assertion**

`String()` is only implemented for a pointer receiver, so the formatting breaks otherwise.

Epic: none
Release note: None