### PR TITLE
roachtest: increase max sql disk allowance during restore

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -379,8 +379,8 @@ func registerRestore(r registry.Registry) {
 			}),
 			timeout: 30 * time.Hour,
 			suites:  registry.Suites(registry.Weekly),
-			setUpStmts: []string{
-				`SET CLUSTER SETTING backup.restore_span.target_size = '0'`,
+			extraArgs: []string{
+				"--max-disk-temp-storage", "128GiB",
 			},
 			restoreUptoIncremental: 400,
 		},
@@ -395,8 +395,8 @@ func registerRestore(r registry.Registry) {
 			}),
 			timeout: 30 * time.Hour,
 			suites:  registry.Suites(registry.Weekly),
-			setUpStmts: []string{
-				`SET CLUSTER SETTING backup.restore_span.target_size = '0'`,
+			extraArgs: []string{
+				"--max-disk-temp-storage", "128GiB",
 			},
 			restoreUptoIncremental: 400,
 			skip:                   "a recent gcp pricing policy makes this test very expensive. unskip after #111371 is addressed",
@@ -818,6 +818,9 @@ type restoreSpecs struct {
 
 	setUpStmts []string
 
+	// extraArgs are passed to the cockroach binary at startup.
+	extraArgs []string
+
 	// skip, if non-empty, skips the test with the given reason.
 	skip string
 
@@ -881,7 +884,9 @@ func makeRestoreDriver(t test.Test, c cluster.Cluster, sp restoreSpecs) restoreD
 }
 
 func (rd *restoreDriver) prepareCluster(ctx context.Context) {
-	rd.c.Start(ctx, rd.t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), rd.sp.hardware.getCRDBNodes())
+	opts := option.DefaultStartOptsNoBackups()
+	opts.RoachprodOpts.ExtraArgs = rd.sp.extraArgs
+	rd.c.Start(ctx, rd.t.L(), opts, install.MakeClusterSettings(), rd.sp.hardware.getCRDBNodes())
 	rd.getAOST(ctx)
 }
 


### PR DESCRIPTION
We are seeing

    restore/tpce/32TB/aws/inc-count=400/nodes=15/cpus=16

hit the current max of 32 GiB.  We are still investigating the underlying cause, but would like to see if this test passes if a larger allowance is used.

Informs #113843

Release note: None