### PR TITLE
flowinfra: fix incomplete shutdown in some cases

### DIFF
--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -626,8 +626,9 @@ func (f *FlowBase) MemUsage() int64 {
 func (f *FlowBase) Cancel() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.mu.status == flowFinished {
-		// The Flow is already done, nothing to cancel.
+	if f.mu.status == flowFinished || f.mu.ctxCancel == nil {
+		// The Flow is already done, nothing to cancel. ctxCancel can be nil in
+		// some tests.
 		return
 	}
 	f.mu.ctxCancel()


### PR DESCRIPTION
This commit fixes an incomplete shutdown of distributed plans in face of "no inbound stream connection" errors. Note that "incomplete" here means allowing some parts of the plan run to completion (rather than leaking resources).

Whenever this "no inbound stream connection" error occurs, we send it to the timed out receivers, and eventually the error will make its way to the DistSQLReceiver which transitions the whole plan into the draining state. However, non-timed out streams will only learn about the draining state when they send something on the streams which might not happen for a while (and in case of TTL processors will not happen until completion).

This commit addresses this inefficiency by also cancelling the flow on the node to which some streams didn't connect in time. This triggers ungraceful and quick shutdown of the whole plan, and it seems like a more intuitive behavior given that the whole plan still resulted in an error. The only downside of this change that I can see is that now the resulting error can be "query canceled" rather than "no inbound stream" since there could be a race between the original error and the context cancellation error.

Fixes: #118284.

Release note: None