### PR TITLE
schemachanger: deflate primary index chain logic include UWI constraint

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3495,9 +3495,43 @@ ALTER TABLE t_108974_v DROP COLUMN k;
 subtest end
 
 # Regression test for https://github.com/cockroachdb/cockroach/issues/110629.
+subtest 110629
+
 # Subqueries are not allowed in storage parameters.
 statement ok
 CREATE TABLE t_110629 (a INT PRIMARY KEY);
 
 statement error subqueries are not allowed in table storage parameters
 ALTER TABLE t SET ( 'string' = EXISTS ( TABLE error ) );
+
+subtest end
+
+# Regression test for https://github.com/cockroachdb/cockroach/issues/118246
+subtest 118246
+
+statement ok
+CREATE TABLE t_118246 (i INT PRIMARY KEY);
+INSERT INTO t_118246 VALUES (0);
+
+statement ok
+SET experimental_enable_unique_without_index_constraints = true;
+
+statement ok
+ALTER TABLE t_118246 ADD COLUMN j INT, ADD UNIQUE WITHOUT INDEX (j);
+
+statement ok
+ALTER TABLE t_118246 ADD COLUMN k INT DEFAULT 30, ADD UNIQUE WITHOUT INDEX (k);
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t_118246]
+----
+CREATE TABLE public.t_118246 (
+  i INT8 NOT NULL,
+  j INT8 NULL,
+  k INT8 NULL DEFAULT 30:::INT8,
+  CONSTRAINT t_118246_pkey PRIMARY KEY (i ASC),
+  CONSTRAINT unique_j UNIQUE WITHOUT INDEX (j),
+  CONSTRAINT unique_k UNIQUE WITHOUT INDEX (k)
+)
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -1226,6 +1226,10 @@ func updateElementsToDependOnNewFromOld(
 			if e.IndexIDForValidation == old {
 				e.IndexIDForValidation = new
 			}
+		case *scpb.UniqueWithoutIndexConstraint:
+			if e.IndexIDForValidation == old {
+				e.IndexIDForValidation = new
+			}
 		}
 	})
 }


### PR DESCRIPTION
Previously, stmts like `ADD COLUMN j INT, ADD UNIQUE WIHOUT INDEX (j)` will fail with an internal error because we forget to process those unique-without-index in the DSC if the primary index chain has been inflated and needs to be deflated.

Fixes #118246
Release note (bug fix): Fix a bug where stmts like `ADD COLUMN j INT, ADD UNIQUE WIHOUT INDEX (j)` would fail with an internal error.