### PR TITLE
sql: fix Fingerprint for TSQuery

### DIFF
--- a/pkg/sql/rowenc/encoded_datum.go
+++ b/pkg/sql/rowenc/encoded_datum.go
@@ -322,7 +322,12 @@ func (ed *EncDatum) Fingerprint(
 	var err error
 	memUsageBefore := ed.Size()
 	switch typ.Family() {
-	case types.JsonFamily, types.TSVectorFamily:
+	// Both TSQuery and TSVector types don't have key-encoding, so we must use
+	// the value encoding for them. JSON type now (as of 23.2) has key-encoding
+	// available, but for historical reasons we will keep on using the
+	// value-encoding (Fingerprint is used by hash routers, so changing its
+	// behavior can result in incorrect results in mixed version clusters).
+	case types.JsonFamily, types.TSQueryFamily, types.TSVectorFamily:
 		if err = ed.EnsureDecoded(typ, a); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -82,6 +82,7 @@ go_test(
         "row_sampling_test.go",
         "simple_linear_regression_test.go",
         "stats_cache_test.go",
+        "stats_test.go",
     ],
     embed = [":stats"],
     exec_properties = select({
@@ -107,6 +108,7 @@ go_test(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catpb",
+        "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/desctestutils",
@@ -139,6 +141,7 @@ go_test(
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_lib_pq//oid",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/stats/stats_test.go
+++ b/pkg/sql/stats/stats_test.go
@@ -1,0 +1,83 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package stats
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/lib/pq/oid"
+)
+
+// TestStatsAnyType verifies that table stats collection on a column of any type
+// works.
+func TestStatsAnyType(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	rng, _ := randutil.NewTestRand()
+	ctx := context.Background()
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	st := srv.ApplicationLayer().ClusterSettings()
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+
+	for i := 0; i < 10; i++ {
+		var typ *types.T
+	loop:
+		for {
+			typ = RandType(rng)
+			switch typ.Oid() {
+			case oid.T_int2vector, oid.T_oidvector:
+				// We can't create a table with a column of this type.
+				continue loop
+			case oid.T_regtype:
+				// Casting random integers to REGTYPE might fail.
+				continue loop
+			}
+			if typ.Family() == types.ArrayFamily &&
+				(typ.ArrayContents().Family() == types.FloatFamily || typ.ArrayContents().Family() == types.DecimalFamily) {
+				// Skip arrays of floats and decimals since they might contain
+				// infinities as elements which are a bit annoying to insert below.
+				continue loop
+			}
+			if err := colinfo.ValidateColumnDefType(ctx, st.Version, typ); err == nil {
+				break
+			}
+		}
+		numRows := 1 + rng.Intn(10)
+		t.Logf("picked %s and %d rows", typ.SQLString(), numRows)
+		tableName := fmt.Sprintf("t%d", i)
+		runner.Exec(t, fmt.Sprintf("CREATE TABLE %s(c %s)", tableName, typ.SQLString()))
+		for j := 0; j < numRows; j++ {
+			d := RandDatum(rng, typ, false /* nullOk */)
+			dString := d.String()
+			switch typ.Family() {
+			case types.IntFamily, types.FloatFamily, types.DecimalFamily:
+				dString = "'" + dString + "'"
+			case types.TSQueryFamily, types.TSVectorFamily:
+				dString = "'" + strings.ReplaceAll(dString, "'", "''") + "'"
+			}
+			runner.Exec(t, fmt.Sprintf("INSERT INTO %s VALUES (%s::%s)", tableName, dString, typ.SQLString()))
+		}
+		runner.Exec(t, "ANALYZE "+tableName)
+	}
+}


### PR DESCRIPTION
We have `Fingerprint` method that hashes any datum, and we generally use the key-encoding. However, there are a few types for which we don't have key-encoding available, so for those we use value-encoding. Previously, we forgot to update this function to use value-encoding for TSQuery type which could result in errors whenever this `Fingerprint` function is used (e.g. during sampling rows for stats collection or when needing a hash of the datum for DISTINCT / GROUP BY). This is now fixed.

There is a caveat though. This `Fingerprint` function is also used in the hash routers by both execution engines to decide which output a particular datum should be routed to. Changing the behavior of the `Fingerprint` can change the routing, so if we have a mixed version cluster in which some nodes are running w/ and w/o this fix, some rows might be sent to incorrect nodes producing incorrect results. However, I don't think this should actually happen in practice because all older binaries would hit the error when computing the hash where to route, so the query as a whole would error out. Thus, I think this change should be safe without any version gates (which would be very annoying to plumb into this context).

Fixes: #118292.

Release note (bug fix): Previously, CockroachDB could encounter an error "unable to encode table key: *tree.DTSQuery" when operating on columns of TSQuery type in some contexts (e.g. when collecting table statistics or when performing a DISTINCT operation), and this is now fixed. The bug has been present since 23.1 when support for TSQuery type was added.