### PR TITLE
kv/tscache: implement timestamp cache serialization

### DIFF
--- a/pkg/kv/kvserver/tscache/BUILD.bazel
+++ b/pkg/kv/kvserver/tscache/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/tscache",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv/kvserver/readsummary/rspb",
         "//pkg/roachpb",
         "//pkg/util",
         "//pkg/util/cache",
@@ -43,12 +44,14 @@ go_test(
         "//conditions:default": {"Pool": "default"},
     }),
     deps = [
+        "//pkg/kv/kvserver/readsummary/rspb",
         "//pkg/roachpb",
         "//pkg/testutils",
         "//pkg/util",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/timeutil",
+        "//pkg/util/uint128",
         "//pkg/util/uuid",
         "@com_github_andy_kimball_arenaskl//:arenaskl",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/kv/kvserver/tscache/cache.go
+++ b/pkg/kv/kvserver/tscache/cache.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -66,6 +67,10 @@ type Cache interface {
 	// intervals from any transactions in the cache, the low water timestamp is
 	// returned for the read timestamps.
 	GetMax(ctx context.Context, start, end roachpb.Key) (hlc.Timestamp, uuid.UUID)
+
+	// Serialize returns a serialized representation of the Cache over the
+	// interval spanning from start to end.
+	Serialize(ctx context.Context, start, end roachpb.Key) rspb.Segment
 
 	// Metrics returns the Cache's metrics struct.
 	Metrics() Metrics

--- a/pkg/kv/kvserver/tscache/skl_impl.go
+++ b/pkg/kv/kvserver/tscache/skl_impl.go
@@ -13,6 +13,7 @@ package tscache
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -74,6 +75,14 @@ func (tc *sklImpl) GetMax(ctx context.Context, start, end roachpb.Key) (hlc.Time
 		val = tc.cache.LookupTimestampRange(ctx, nonNil(start), end, excludeTo)
 	}
 	return val.ts, val.txnID
+}
+
+// Serialize implements the Cache interface.
+func (tc *sklImpl) Serialize(ctx context.Context, start, end roachpb.Key) rspb.Segment {
+	if len(end) == 0 {
+		end = start.Next()
+	}
+	return tc.cache.Serialize(ctx, nonNil(start), end)
 }
 
 // boundKeyLengths makes sure that the key lengths provided are well below the


### PR DESCRIPTION
Informs #61986.

This commit adds a new `Serialize` function to `tscache.Cache` implementations. This serialization uses the `readsummary/rspb.Segment` representation added in 0950a1e0. Serialization of the production `sklImpl` uses the Segment merging logic added in e4fc6f1e in order to merge together a partial serializations of each individual `sklPage` in the data structure.

Timestamp cache serialization will be used to address #61986.

Release note: None