### PR TITLE
roachtest: fix lease_preferences configure zone

### DIFF
--- a/pkg/cmd/roachtest/tests/lease_preferences.go
+++ b/pkg/cmd/roachtest/tests/lease_preferences.go
@@ -259,7 +259,7 @@ func runLeasePreferences(
 	})
 
 	t.L().Printf("setting lease preferences: %s", spec.preferences)
-	configureZone(t, ctx, conn, "kv", zoneConfig{
+	configureZone(t, ctx, conn, "DATABASE kv", zoneConfig{
 		replicas:        spec.replFactor,
 		leasePreference: spec.preferences,
 	})


### PR DESCRIPTION
e2a5b35c7f9ba9828536d40fd9c2ccce2cd4a924 updated the `lease_prefernces` roachtest to use `configureZone`
but incorrectly specified just "kv" as the zone target. Update the zone
target to correctly include the database qualifier.

Fixes: https://github.com/cockroachdb/cockroach/issues/118304
Informs: https://github.com/cockroachdb/cockroach/issues/117311
Release note: None