### PR TITLE
roachtest: use latest predecessor version in change repls

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -253,7 +253,12 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 
 	// Set up and run test.
 	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All(), mixedversion.ClusterSettingOption(
-		install.EnvOption{"COCKROACH_SCAN_MAX_IDLE_TIME=10ms"})) // speed up queues
+		// Speed up the queues.
+		install.EnvOption{"COCKROACH_SCAN_MAX_IDLE_TIME=10ms"}),
+		// Avoid repeatedly running into #114549 on earlier minor versions.
+		// TODO(kvoli): Remove in 24.2.
+		mixedversion.AlwaysUseLatestPredecessors,
+	)
 
 	mvt.OnStartup("create test table", createTable)
 	mvt.InMixedVersion("move replicas", moveReplicas)


### PR DESCRIPTION
`change-replicas/mixed-version` could run into a now fixed etcd raft bug where replicas never exited `StateProbe` resolved by #106748. Only use the latest predecessor version to avoid re-diagnosing this bug.

Fixes: #118006
Release note: None