### PR TITLE
kvnemesis: write debug files using DebuggableTempDir

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/sql/catalog/bootstrap",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/testutils/datapathutils",
         "//pkg/util/bufalloc",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",

--- a/pkg/kv/kvnemesis/kvnemesis.go
+++ b/pkg/kv/kvnemesis/kvnemesis.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -58,7 +59,7 @@ func l(ctx context.Context, basename string, format string, args ...interface{})
 	var logger Logger
 	logger, _ = ctx.Value(loggerKey{}).(Logger)
 	if logger == nil {
-		logger = &logLogger{dir: os.TempDir()}
+		logger = &logLogger{dir: datapathutils.DebuggableTempDir()}
 	}
 	logger.Helper()
 

--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -221,9 +222,9 @@ type tBridge struct {
 func newTBridge(t *testing.T) *tBridge {
 	// NB: we're not using t.TempDir() because we want these to survive
 	// on failure.
-	td, err := os.MkdirTemp("", "kvnemesis")
+	td, err := os.MkdirTemp(datapathutils.DebuggableTempDir(), "kvnemesis")
 	if err != nil {
-		td = os.TempDir()
+		td = datapathutils.DebuggableTempDir()
 	}
 	t.Cleanup(func() {
 		if t.Failed() {


### PR DESCRIPTION
Previously, kvnemesis used os.TempDir() to write the various debug files (including the repro steps) to a temp dir. When the test failed on EngFlow, the temp dir was not included in output.zip, which made tests hard to investigate.

This patch uses datapathutils.DebuggableTempDir() instead. If the test is running locally, the behavior is the same as os.TempDir(). If the test is running remotely, it will write the debug files to TEST_UNDECLARED_OUTPUTS_DIR and Bazel will package them up into outputs.zip.

Informs: #118005

Release note: None