### PR TITLE
ttljob: add hint to use PK in delete query

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -143,7 +143,7 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 			return errors.Wrapf(err, "error fetching table relation name for TTL")
 		}
 
-		relationName = tn.FQString()
+		relationName = tn.FQString() + "@" + lexbase.EscapeSQLIdent(primaryIndexDesc.Name)
 		return nil
 	}); err != nil {
 		return err


### PR DESCRIPTION
This will help avoid choosing a plan that scans a secondary index, which can lead to many KV rows being scanned and also lead to contention.

informs https://github.com/cockroachdb/cockroach/issues/82140

Release note (bug fix): Fixed a bug that could cause DELETE queries sent by the row-level TTL job to use a secondary index rather than the primary index to find the rows to delete. This could lead to some DELETE operations taking a much longer time than they should. This bug was present since v22.2.0.