### PR TITLE
release-23.1: ttl: use better defaults for some session variables

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -768,6 +768,15 @@ func applyOverrides(o sessiondata.InternalExecutorOverride, sd *sessiondata.Sess
 	}
 	// We always override the injection knob based on the override struct.
 	sd.InjectRetryErrorsEnabled = o.InjectRetryErrorsEnabled
+	if o.ReorderJoinsLimit != 0 {
+		sd.ReorderJoinsLimit = o.ReorderJoinsLimit
+	}
+	if o.OptimizerUseHistograms {
+		sd.OptimizerUseHistograms = true
+	}
+	if o.OptimizerUseMultiColStats {
+		sd.OptimizerUseMultiColStats = true
+	}
 }
 
 func (ie *InternalExecutor) maybeRootSessionDataOverride(

--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -47,6 +47,15 @@ type InternalExecutorOverride struct {
 	// does **not** propagate further to "nested" executors that are spawned up
 	// by the "top" executor.
 	InjectRetryErrorsEnabled bool
+	// ReorderJoinsLimit indicates the number of joins at which the optimizer
+	// should stop attempting to reorder.
+	ReorderJoinsLimit int64
+	// OptimizerUseHistograms indicates whether we should use histograms for
+	// cardinality estimation in the optimizer.
+	OptimizerUseHistograms bool
+	// OptimizerUseMultiColStats indicates whether we should use multi-column
+	// statistics for cardinality estimation in the optimizer.
+	OptimizerUseMultiColStats bool
 }
 
 // NoSessionDataOverride is the empty InternalExecutorOverride which does not

--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",
         "//pkg/sql/lexbase",
+        "//pkg/sql/opt",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/physicalplan",

--- a/pkg/sql/ttl/ttljob/ttljob_metrics.go
+++ b/pkg/sql/ttl/ttljob/ttljob_metrics.go
@@ -18,11 +18,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
@@ -225,10 +223,7 @@ func (m *rowLevelTTLMetrics) fetchStatistics(
 			ctx,
 			c.opName,
 			nil,
-			sessiondata.InternalExecutorOverride{
-				User:             username.RootUserName(),
-				QualityOfService: &qosLevel,
-			},
+			getInternalExecutorOverride(qosLevel),
 			fmt.Sprintf(c.query, details.TableID, aost.String()),
 			c.args...,
 		)

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -292,6 +292,8 @@ func (t *ttlProcessor) runTTLOnQueryBounds(
 			ctx,
 			"pre-select-delete-statement",
 			nil, /* txn */
+			// This is a test-only knob, so we're ok not specifying custom
+			// InternalExecutorOverride.
 			sessiondata.RootUserSessionDataOverride,
 			preSelectStatement,
 		); err != nil {


### PR DESCRIPTION
This commit fixes some problems that we've seen around internally-executed queries issued by the TTL jobs, present before 23.2. In particular, on 23.1 and prior releases we used Go defaults for the session data parameters for internally-executed queries, which can differ from the defaults set by CRDB. As a result, query plans could be suboptimal as we've seen in a couple of recent escalations. This bug has been fixed on 23.2 proper (we now use CRDB defaults for all session variables except for one), and on 23.1 and prior this commit applies a targeted fix only to the TTL queries. In particular, the following overrides are now set:
- `reorder_joins_limit` to the default value of 8
- `optimizer_use_histograms` and `optimizer_use_multi_col_stats` are both set to `true`.

Fixes: #118129.

Release note (bug fix): Internal queries issued by the TTL jobs should now use optimal plans. The bug has been present since at least 22.2 version.

Release justification: bug fix.