### PR TITLE
engflow,bazci: add failed build actions to the GitHub actions summary 

### DIFF
--- a/pkg/cmd/bazci/process-bep-file/main.go
+++ b/pkg/cmd/bazci/process-bep-file/main.go
@@ -124,7 +124,7 @@ func process() error {
 		return err
 	}
 	defer func() { _ = eventStreamF.Close() }()
-	invocation, err := engflow.LoadTestResults(eventStreamF, *tlsClientCert, *tlsClientKey)
+	invocation, err := engflow.LoadInvocationInfo(eventStreamF, *tlsClientCert, *tlsClientKey)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The previous version of this covered only failed tests. This
additionally covers failed build actions.

Part of: [DEVINF-1031](https://cockroachlabs.atlassian.net/browse/DEVINF-1031)
Epic: [CRDB-8308](https://cockroachlabs.atlassian.net/browse/CRDB-8308)
Release note: None