### PR TITLE
kvclient: misc range cache cleanups

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -815,14 +815,14 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 	n1.QueryRow(t, `SELECT id from system.namespace WHERE name='test'`).Scan(&tableID)
 	tablePrefix := keys.MustAddr(keys.SystemSQLCodec.TablePrefix(tableID))
 	n4Cache := tc.Server(3).DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache()
-	entry := n4Cache.GetCached(ctx, tablePrefix, false /* inverted */)
-	require.NotNil(t, entry)
-	require.False(t, entry.Lease().Empty())
-	require.Equal(t, roachpb.StoreID(1), entry.Lease().Replica.StoreID)
+	entry, err := n4Cache.TestingGetCached(ctx, tablePrefix, false /* inverted */)
+	require.NoError(t, err)
+	require.False(t, entry.Lease.Empty())
+	require.Equal(t, roachpb.StoreID(1), entry.Lease.Replica.StoreID)
 	require.Equal(t, []roachpb.ReplicaDescriptor{
 		{NodeID: 1, StoreID: 1, ReplicaID: 1},
 		{NodeID: 2, StoreID: 2, ReplicaID: 2},
-	}, entry.Desc().Replicas().Descriptors())
+	}, entry.Desc.Replicas().Descriptors())
 
 	// Remove the follower and add a new non-voter to n3. n2 will no longer have a
 	// replica.
@@ -838,19 +838,19 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 	rec := <-recCh
 	require.False(t, kv.OnlyFollowerReads(rec), "query was served through follower reads: %s", rec)
 	// Check that the cache was properly updated.
-	entry = n4Cache.GetCached(ctx, tablePrefix, false /* inverted */)
-	require.NotNil(t, entry)
-	require.False(t, entry.Lease().Empty())
-	require.Equal(t, roachpb.StoreID(1), entry.Lease().Replica.StoreID)
+	entry, err = n4Cache.TestingGetCached(ctx, tablePrefix, false /* inverted */)
+	require.NoError(t, err)
+	require.False(t, entry.Lease.Empty())
+	require.Equal(t, roachpb.StoreID(1), entry.Lease.Replica.StoreID)
 	require.Equal(t, []roachpb.ReplicaDescriptor{
 		{NodeID: 1, StoreID: 1, ReplicaID: 1},
 		{NodeID: 3, StoreID: 3, ReplicaID: 3, Type: roachpb.NON_VOTER},
-	}, entry.Desc().Replicas().Descriptors())
+	}, entry.Desc.Replicas().Descriptors())
 
 	// Make a note of the follower reads metric on n3. We'll check that it was
 	// incremented.
 	var followerReadsCountBefore int64
-	err := tc.Servers[2].GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
+	err = tc.Servers[2].GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
 		followerReadsCountBefore = s.Metrics().FollowerReadsCount.Count()
 		return nil
 	})
@@ -881,14 +881,14 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 	n3 := sqlutils.MakeSQLRunner(tc.Conns[2])
 	n3.Exec(t, "SELECT * from test WHERE k=1")
 	n3Cache := tc.Server(2).DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache()
-	entry = n3Cache.GetCached(ctx, tablePrefix, false /* inverted */)
-	require.NotNil(t, entry)
-	require.False(t, entry.Lease().Empty())
-	require.Equal(t, roachpb.StoreID(1), entry.Lease().Replica.StoreID)
+	entry, err = n3Cache.TestingGetCached(ctx, tablePrefix, false /* inverted */)
+	require.NoError(t, err)
+	require.False(t, entry.Lease.Empty())
+	require.Equal(t, roachpb.StoreID(1), entry.Lease.Replica.StoreID)
 	require.Equal(t, []roachpb.ReplicaDescriptor{
 		{NodeID: 1, StoreID: 1, ReplicaID: 1},
 		{NodeID: 3, StoreID: 3, ReplicaID: 3, Type: roachpb.NON_VOTER},
-	}, entry.Desc().Replicas().Descriptors())
+	}, entry.Desc.Replicas().Descriptors())
 
 	// Enable DistSQL so that we have a distributed plan with a single flow on
 	// n3 (local plans ignore the misplanned ranges).
@@ -1134,15 +1134,15 @@ func TestSecondaryTenantFollowerReadsRouting(t *testing.T) {
 			tenantSQL.Exec(t, `SELECT * FROM t.test WHERE k = 1`)
 			tablePrefix := keys.MustAddr(codec.TenantPrefix())
 			cache := tenants[gatewayNode].DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache()
-			entry := cache.GetCached(ctx, tablePrefix, false /* inverted */)
-			require.NotNil(t, entry)
-			require.False(t, entry.Lease().Empty())
-			require.Equal(t, roachpb.StoreID(1), entry.Lease().Replica.StoreID)
+			entry, err := cache.TestingGetCached(ctx, tablePrefix, false /* inverted */)
+			require.NoError(t, err)
+			require.False(t, entry.Lease.Empty())
+			require.Equal(t, roachpb.StoreID(1), entry.Lease.Replica.StoreID)
 			require.Equal(t, []roachpb.ReplicaDescriptor{
 				{NodeID: 1, StoreID: 1, ReplicaID: 1},
 				{NodeID: 2, StoreID: 2, ReplicaID: 2},
 				{NodeID: 3, StoreID: 3, ReplicaID: 3},
-			}, entry.Desc().Replicas().Descriptors())
+			}, entry.Desc.Replicas().Descriptors())
 
 			tenantSQL.Exec(t, historicalQuery)
 			rec := <-recCh

--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -319,11 +319,11 @@ SET CLUSTER SETTING kv.allocator.min_lease_transfer_interval = '5m'
 				}
 				cache := ds.tc.Server(idx).DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache()
 				tablePrefix := keys.MustAddr(keys.SystemSQLCodec.TablePrefix(tableID))
-				entry := cache.GetCached(ctx, tablePrefix, false /* inverted */)
-				if entry == nil {
-					return errors.Newf("no entry found for %s in cache", tbName).Error()
+				entry, err := cache.TestingGetCached(ctx, tablePrefix, false /* inverted */)
+				if err != nil {
+					return err.Error()
 				}
-				return entry.ClosedTimestampPolicy().String()
+				return entry.ClosedTimestampPolicy.String()
 
 			case "wait-for-zone-config-changes":
 				lookupKey, err := getRangeKeyForInput(t, d, ds.tc)

--- a/pkg/ccl/multiregionccl/roundtrips_test.go
+++ b/pkg/ccl/multiregionccl/roundtrips_test.go
@@ -123,15 +123,15 @@ func TestEnsureLocalReadsOnGlobalTables(t *testing.T) {
 
 			// Check that the cache was indeed populated.
 			cache := tc.Server(i).DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache()
-			entry := cache.GetCached(context.Background(), tablePrefix, false /* inverted */)
-			require.NotNil(t, entry.Lease().Empty())
-			require.NotNil(t, entry)
+			entry, err := cache.TestingGetCached(context.Background(), tablePrefix, false /* inverted */)
+			require.NoError(t, err)
+			require.NotNil(t, entry.Lease.Empty())
 
-			if expected, got := roachpb.LEAD_FOR_GLOBAL_READS, entry.ClosedTimestampPolicy(); got != expected {
+			if expected, got := roachpb.LEAD_FOR_GLOBAL_READS, entry.ClosedTimestampPolicy; got != expected {
 				return errors.Newf("expected closedts policy %s, got %s", expected, got)
 			}
 
-			isLeaseHolder = entry.Lease().Replica.NodeID == tc.Server(i).NodeID()
+			isLeaseHolder = entry.Lease.Replica.NodeID == tc.Server(i).NodeID()
 			return nil
 		})
 

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -449,7 +449,7 @@ func (b *SSTBatcher) flushIfNeeded(ctx context.Context, nextKey roachpb.Key) err
 			if r, err := b.rc.Lookup(ctx, k); err != nil {
 				log.Warningf(ctx, "failed to lookup range cache entry for key %v: %v", k, err)
 			} else {
-				k := r.Desc().EndKey.AsRawKey()
+				k := r.Desc.EndKey.AsRawKey()
 				b.flushKey = k
 				log.VEventf(ctx, 3, "%s building sstable that will flush before %v", b.name, k)
 			}

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -294,7 +294,7 @@ func runTestImport(t *testing.T, batchSizeValue int64) {
 			for _, k := range []int{0, split1} {
 				ent, err := ds.RangeDescriptorCache().Lookup(ctx, keys.MustAddr(key(k)))
 				require.NoError(t, err)
-				mockCache.Insert(ctx, roachpb.RangeInfo{Desc: *ent.Desc()})
+				mockCache.Insert(ctx, ent)
 			}
 
 			t.Logf("splitting at %s", key(split2))

--- a/pkg/kv/kvclient/rangecache/range_cache.go
+++ b/pkg/kv/kvclient/rangecache/range_cache.go
@@ -377,7 +377,7 @@ func (et *EvictionToken) syncRLocked(
 	ctx context.Context,
 ) (stillValid bool, cachedEntry *cacheEntry, rawEntry *cache.Entry) {
 	cachedEntry, rawEntry = et.rdc.getCachedRLocked(ctx, et.entry.desc.StartKey, false /* inverted */)
-	if cachedEntry == nil || !descsCompatible(cachedEntry.Desc(), et.Desc()) {
+	if cachedEntry == nil || !descsCompatible(&cachedEntry.desc, et.Desc()) {
 		et.clear()
 		return false, nil, nil
 	}
@@ -438,7 +438,7 @@ func (et *EvictionToken) SyncTokenAndMaybeUpdateCache(
 		ri := roachpb.RangeInfo{
 			Desc:                  *rangeDesc,
 			Lease:                 *l,
-			ClosedTimestampPolicy: et.entry.ClosedTimestampPolicy(),
+			ClosedTimestampPolicy: et.entry.closedts,
 		}
 		et.evictAndReplaceLocked(ctx, ri)
 		return false
@@ -605,7 +605,7 @@ func (rc *RangeCache) LookupRangeID(
 	if err != nil {
 		return 0, err
 	}
-	return tok.entry.Desc().RangeID, nil
+	return tok.entry.desc.RangeID, nil
 }
 
 // Lookup presents a simpler interface for looking up a RangeDescriptor for a
@@ -640,7 +640,7 @@ func (rc *RangeCache) getCachedOverlappingRLocked(
 	defer from.release()
 	var res []*cache.Entry
 	rc.rangeCache.cache.DoRangeReverseEntry(func(e *cache.Entry) (exit bool) {
-		desc := rc.getValue(e).Desc()
+		desc := rc.getValue(e).desc
 		if desc.StartKey.Equal(span.EndKey) {
 			// Skip over descriptor starting at the end key, who'd supposed to be exclusive.
 			return false
@@ -1013,7 +1013,7 @@ func (rc *RangeCache) evictDescLocked(ctx context.Context, desc *roachpb.RangeDe
 		// Cache is empty; nothing to do.
 		return false
 	}
-	cachedDesc := cachedEntry.Desc()
+	cachedDesc := cachedEntry.desc
 	cachedNewer := cachedDesc.Generation > desc.Generation
 	if cachedNewer {
 		return false
@@ -1096,7 +1096,7 @@ func (rc *RangeCache) getCachedRLocked(
 	}
 
 	// Return nil if the key does not belong to the range.
-	if !containsFn(entry.Desc(), key) {
+	if !containsFn(&entry.desc, key) {
 		return nil, nil
 	}
 	return entry, rawEntry
@@ -1142,7 +1142,7 @@ func (rc *RangeCache) insertLockedInner(ctx context.Context, rs []*cacheEntry) [
 			_, ok := ent.desc.GetReplicaDescriptorByID(replID)
 			if !ok {
 				log.Fatalf(ctx, "leaseholder replicaID: %d not part of descriptor: %s. lease: %s",
-					replID, ent.Desc(), ent.Lease())
+					replID, ent.desc, ent.lease)
 			}
 		}
 		// Note: we append the end key of each range to meta records
@@ -1195,10 +1195,10 @@ func (rc *RangeCache) clearOlderOverlapping(
 func (rc *RangeCache) clearOlderOverlappingLocked(
 	ctx context.Context, newEntry *cacheEntry,
 ) (ok bool, newerEntry *cacheEntry) {
-	log.VEventf(ctx, 2, "clearing entries overlapping %s", newEntry.Desc())
+	log.VEventf(ctx, 2, "clearing entries overlapping %s", newEntry.desc)
 	newest := true
 	var newerFound *cacheEntry
-	overlapping := rc.getCachedOverlappingRLocked(ctx, newEntry.Desc().RSpan())
+	overlapping := rc.getCachedOverlappingRLocked(ctx, newEntry.desc.RSpan())
 	for _, e := range overlapping {
 		entry := rc.getValue(e)
 		if newEntry.overrides(entry) {
@@ -1208,7 +1208,7 @@ func (rc *RangeCache) clearOlderOverlappingLocked(
 			rc.delEntryLocked(e)
 		} else {
 			newest = false
-			if descsCompatible(entry.Desc(), newEntry.Desc()) {
+			if descsCompatible(&entry.desc, &newEntry.desc) {
 				newerFound = entry
 				// We've found a similar descriptor in the cache; there can't be any
 				// other overlapping ones so let's stop the iteration.
@@ -1230,7 +1230,7 @@ func (rc *RangeCache) swapEntryLocked(
 ) {
 	if newEntry != nil {
 		old := rc.getValue(oldEntry)
-		if !descsCompatible(old.Desc(), newEntry.Desc()) {
+		if !descsCompatible(&old.desc, &newEntry.desc) {
 			log.Fatalf(ctx, "attempting to swap non-compatible descs: %s vs %s",
 				old, newEntry)
 		}
@@ -1244,7 +1244,7 @@ func (rc *RangeCache) swapEntryLocked(
 }
 
 func (rc *RangeCache) addEntryLocked(entry *cacheEntry) {
-	key := newRangeCacheKey(entry.Desc().StartKey)
+	key := newRangeCacheKey(entry.desc.StartKey)
 	rc.rangeCache.cache.Add(key, entry)
 }
 
@@ -1300,45 +1300,6 @@ type cacheEntry struct {
 	closedts roachpb.RangeClosedTimestampPolicy
 }
 
-func (e cacheEntry) String() string {
-	return fmt.Sprintf("desc:%s, lease:%s", e.Desc(), e.lease)
-}
-
-// Desc returns the cached descriptor. Note that, besides being possibly stale,
-// this descriptor also might not represent a descriptor that was ever
-// committed. See DescSpeculative().
-func (e *cacheEntry) Desc() *roachpb.RangeDescriptor {
-	return &e.desc
-}
-
-// Leaseholder returns the cached leaseholder replica, if known. Returns nil if
-// the leaseholder is not known.
-func (e *cacheEntry) Leaseholder() *roachpb.ReplicaDescriptor {
-	if e.lease.Empty() {
-		return nil
-	}
-	return &e.lease.Replica
-}
-
-// Lease returns the cached lease, if known. Returns nil if no lease is known.
-// It's possible for a leaseholder to be known, but not a full lease, in which
-// case Leaseholder() returns non-nil but Lease() returns nil.
-func (e *cacheEntry) Lease() *roachpb.Lease {
-	if e.lease.Empty() {
-		return nil
-	}
-	if e.LeaseSpeculative() {
-		return nil
-	}
-	return &e.lease
-}
-
-// ClosedTimestampPolicy returns the cached understanding of the range's closed
-// timestamp policy. If no policy is known, LAG_BY_CLUSTER_SETTING is returned.
-func (e *cacheEntry) ClosedTimestampPolicy() roachpb.RangeClosedTimestampPolicy {
-	return e.closedts
-}
-
 // DescSpeculative returns true if the descriptor in the entry is "speculative"
 // - i.e. it doesn't correspond to a committed value. Such descriptors have been
 // inserted in the cache with Generation=0.
@@ -1358,11 +1319,15 @@ func (e *cacheEntry) LeaseSpeculative() bool {
 	return e.lease.Speculative()
 }
 
+func (e cacheEntry) String() string {
+	return fmt.Sprintf("desc:%s, lease:%s", e.desc, e.lease)
+}
+
 func (e *cacheEntry) toRangeInfo() roachpb.RangeInfo {
 	return roachpb.RangeInfo{
 		Desc:                  e.desc,
 		Lease:                 e.lease,
-		ClosedTimestampPolicy: e.ClosedTimestampPolicy(),
+		ClosedTimestampPolicy: e.closedts,
 	}
 }
 
@@ -1381,8 +1346,8 @@ func (e *cacheEntry) toRangeInfo() roachpb.RangeInfo {
 // "speculative" (sequence=0).
 func (e *cacheEntry) overrides(o *cacheEntry) bool {
 	if util.RaceEnabled {
-		if _, err := e.Desc().RSpan().Intersect(o.Desc().RSpan()); err != nil {
-			panic(fmt.Sprintf("descriptors don't intersect: %s vs %s", e.Desc(), o.Desc()))
+		if _, err := e.desc.RSpan().Intersect(o.desc.RSpan()); err != nil {
+			panic(fmt.Sprintf("descriptors don't intersect: %s vs %s", e.desc, o.desc))
 		}
 	}
 
@@ -1395,9 +1360,9 @@ func (e *cacheEntry) overrides(o *cacheEntry) bool {
 	// If two RangeDescriptors overlap and have the same Generation, they must
 	// be referencing the same range, in which case their lease sequences are
 	// comparable.
-	if e.Desc().RangeID != o.Desc().RangeID {
+	if e.desc.RangeID != o.desc.RangeID {
 		panic(fmt.Sprintf("overlapping descriptors with same gen but different IDs: %s vs %s",
-			e.Desc(), o.Desc()))
+			e.desc, o.desc))
 	}
 
 	if res := compareEntryLeases(o, e); res != 0 {
@@ -1421,8 +1386,8 @@ func (e *cacheEntry) overrides(o *cacheEntry) bool {
 // older; this matches the semantics of b.overrides(a).
 func compareEntryDescs(a, b *cacheEntry) int {
 	if util.RaceEnabled {
-		if _, err := a.Desc().RSpan().Intersect(b.Desc().RSpan()); err != nil {
-			panic(fmt.Sprintf("descriptors don't intersect: %s vs %s", a.Desc(), b.Desc()))
+		if _, err := a.desc.RSpan().Intersect(b.desc.RSpan()); err != nil {
+			panic(fmt.Sprintf("descriptors don't intersect: %s vs %s", a.desc, b.desc))
 		}
 	}
 
@@ -1434,10 +1399,10 @@ func compareEntryDescs(a, b *cacheEntry) int {
 		return -1
 	}
 
-	if a.Desc().Generation < b.Desc().Generation {
+	if a.desc.Generation < b.desc.Generation {
 		return -1
 	}
-	if a.Desc().Generation > b.Desc().Generation {
+	if a.desc.Generation > b.desc.Generation {
 		return 1
 	}
 	return 0
@@ -1467,10 +1432,10 @@ func compareEntryLeases(a, b *cacheEntry) int {
 		return -1
 	}
 
-	if a.Lease().Sequence < b.Lease().Sequence {
+	if a.lease.Sequence < b.lease.Sequence {
 		return -1
 	}
-	if a.Lease().Sequence > b.Lease().Sequence {
+	if a.lease.Sequence > b.lease.Sequence {
 		return 1
 	}
 	return 0
@@ -1502,9 +1467,9 @@ func compareEntryLeases(a, b *cacheEntry) int {
 func (e *cacheEntry) maybeUpdate(
 	ctx context.Context, l *roachpb.Lease, rangeDesc *roachpb.RangeDescriptor,
 ) (updated, updatedLease bool, newEntry *cacheEntry) {
-	if !descsCompatible(e.Desc(), rangeDesc) {
+	if !descsCompatible(&e.desc, rangeDesc) {
 		log.Fatalf(ctx, "attempting to update by comparing non-compatible descs: %s vs %s",
-			e.Desc(), rangeDesc)
+			e.desc, rangeDesc)
 	}
 
 	newEntry = &cacheEntry{
@@ -1562,7 +1527,7 @@ func (e *cacheEntry) maybeUpdate(
 			2,
 			"incompatible leaseholder id: %d/descriptor %v pair; eliding lease update to the cache",
 			newEntry.lease.Replica.ReplicaID,
-			newEntry.Desc(),
+			newEntry.desc,
 		)
 		newEntry.lease = roachpb.Lease{}
 		updatedLease = false

--- a/pkg/kv/kvclient/rangecache/range_cache.go
+++ b/pkg/kv/kvclient/rangecache/range_cache.go
@@ -278,18 +278,6 @@ type EvictionToken struct {
 	entry *cacheEntry
 }
 
-func (rc *RangeCache) makeEvictionToken(entry *cacheEntry) EvictionToken {
-	return EvictionToken{
-		rdc:   rc,
-		entry: entry,
-	}
-}
-
-// MakeEvictionToken is the exported ctor. For tests only.
-func (rc *RangeCache) MakeEvictionToken(entry *cacheEntry) EvictionToken {
-	return rc.makeEvictionToken(entry)
-}
-
 func (et EvictionToken) String() string {
 	if !et.Valid() {
 		return "<empty>"
@@ -622,7 +610,9 @@ func (rc *RangeCache) Lookup(ctx context.Context, key roachpb.RKey) (roachpb.Ran
 
 // GetCachedOverlapping returns all the cached entries which overlap a given
 // span [Key, EndKey). The results are sorted ascendingly.
-func (rc *RangeCache) GetCachedOverlapping(ctx context.Context, span roachpb.RSpan) []roachpb.RangeInfo {
+func (rc *RangeCache) GetCachedOverlapping(
+	ctx context.Context, span roachpb.RSpan,
+) []roachpb.RangeInfo {
 	rc.rangeCache.RLock()
 	defer rc.rangeCache.RUnlock()
 	rawEntries := rc.getCachedOverlappingRLocked(ctx, span)
@@ -711,7 +701,7 @@ func (rc *RangeCache) tryLookup(
 	rc.rangeCache.RLock()
 	if entry, _ := rc.getCachedRLocked(ctx, key, useReverseScan); entry != nil {
 		rc.rangeCache.RUnlock()
-		returnToken := rc.makeEvictionToken(entry)
+		returnToken := EvictionToken{rdc: rc, entry: entry}
 		return returnToken, nil
 	}
 
@@ -967,7 +957,7 @@ func tryLookupImpl(
 		}
 		entry = &newEntry
 	}
-	lookupRes = rc.makeEvictionToken(entry)
+	lookupRes = EvictionToken{rdc: rc, entry: entry}
 	return lookupRes, nil
 }
 

--- a/pkg/kv/kvclient/rangecache/range_cache.go
+++ b/pkg/kv/kvclient/rangecache/range_cache.go
@@ -622,13 +622,13 @@ func (rc *RangeCache) Lookup(ctx context.Context, key roachpb.RKey) (roachpb.Ran
 
 // GetCachedOverlapping returns all the cached entries which overlap a given
 // span [Key, EndKey). The results are sorted ascendingly.
-func (rc *RangeCache) GetCachedOverlapping(ctx context.Context, span roachpb.RSpan) []*cacheEntry {
+func (rc *RangeCache) GetCachedOverlapping(ctx context.Context, span roachpb.RSpan) []roachpb.RangeInfo {
 	rc.rangeCache.RLock()
 	defer rc.rangeCache.RUnlock()
 	rawEntries := rc.getCachedOverlappingRLocked(ctx, span)
-	entries := make([]*cacheEntry, len(rawEntries))
+	entries := make([]roachpb.RangeInfo, len(rawEntries))
 	for i, e := range rawEntries {
-		entries[i] = rc.getValue(e)
+		entries[i] = rc.getValue(e).toRangeInfo()
 	}
 	return entries
 }

--- a/pkg/kv/kvclient/rangecache/range_cache_test.go
+++ b/pkg/kv/kvclient/rangecache/range_cache_test.go
@@ -1037,26 +1037,26 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	cache.addEntryLocked(&cacheEntry{desc: *defDesc})
 
 	// Now, add a new, overlapping set of descriptors.
-	minToBDesc := &roachpb.RangeDescriptor{
+	minToBDesc := roachpb.RangeDescriptor{
 		StartKey:   roachpb.RKeyMin,
 		EndKey:     roachpb.RKey("b"),
 		Generation: 1,
 	}
-	bToMaxDesc := &roachpb.RangeDescriptor{
+	bToMaxDesc := roachpb.RangeDescriptor{
 		StartKey:   roachpb.RKey("b"),
 		EndKey:     roachpb.RKeyMax,
 		Generation: 1,
 	}
 	curGeneration := roachpb.RangeGeneration(1)
-	require.True(t, clearOlderOverlapping(ctx, cache, minToBDesc))
-	cache.addEntryLocked(&cacheEntry{desc: *minToBDesc})
+	require.True(t, clearOlderOverlapping(ctx, cache, &minToBDesc))
+	cache.addEntryLocked(&cacheEntry{desc: minToBDesc})
 	_, err := cache.TestingGetCached(ctx, roachpb.RKey("b"), false)
 	require.Error(t, err)
 
-	require.True(t, clearOlderOverlapping(ctx, cache, bToMaxDesc))
-	cache.addEntryLocked(&cacheEntry{desc: *bToMaxDesc})
+	require.True(t, clearOlderOverlapping(ctx, cache, &bToMaxDesc))
+	cache.addEntryLocked(&cacheEntry{desc: bToMaxDesc})
 	ce, _ := cache.getCachedRLocked(ctx, roachpb.RKey("b"), false)
-	require.Equal(t, bToMaxDesc, ce.Desc())
+	require.Equal(t, bToMaxDesc, ce.desc)
 
 	// Add default descriptor back which should remove two split descriptors.
 	defDescCpy := *defDesc
@@ -1066,20 +1066,20 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	cache.addEntryLocked(&cacheEntry{desc: defDescCpy})
 	for _, key := range []roachpb.RKey{roachpb.RKey("a"), roachpb.RKey("b")} {
 		ce, _ = cache.getCachedRLocked(ctx, key, false)
-		require.Equal(t, &defDescCpy, ce.Desc())
+		require.Equal(t, defDescCpy, ce.desc)
 	}
 
 	// Insert ["b", "c") and then insert ["a", b"). Verify that the former is not evicted by the latter.
 	curGeneration++
-	bToCDesc := &roachpb.RangeDescriptor{
+	bToCDesc := roachpb.RangeDescriptor{
 		StartKey:   roachpb.RKey("b"),
 		EndKey:     roachpb.RKey("c"),
 		Generation: curGeneration,
 	}
-	require.True(t, clearOlderOverlapping(ctx, cache, bToCDesc))
-	cache.addEntryLocked(&cacheEntry{desc: *bToCDesc})
+	require.True(t, clearOlderOverlapping(ctx, cache, &bToCDesc))
+	cache.addEntryLocked(&cacheEntry{desc: bToCDesc})
 	ce, _ = cache.getCachedRLocked(ctx, roachpb.RKey("c"), true)
-	require.Equal(t, bToCDesc, ce.Desc())
+	require.Equal(t, bToCDesc, ce.desc)
 
 	curGeneration++
 	aToBDesc := &roachpb.RangeDescriptor{
@@ -1090,7 +1090,7 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	require.True(t, clearOlderOverlapping(ctx, cache, aToBDesc))
 	cache.addEntryLocked(ce)
 	ce, _ = cache.getCachedRLocked(ctx, roachpb.RKey("c"), true)
-	require.Equal(t, bToCDesc, ce.Desc())
+	require.Equal(t, bToCDesc, ce.desc)
 }
 
 // Test The ClearOlderOverlapping. There's also the older
@@ -1156,7 +1156,7 @@ func TestRangeCacheClearOlderOverlapping(t *testing.T) {
 		expNewest   bool
 		// If expNewest is false, expNewer indicates the expected 2nd ret val of
 		// clearOlderOverlapping().
-		expNewer *roachpb.RangeDescriptor
+		expNewer roachpb.RangeDescriptor
 	}{
 		{
 			cachedDescs: nil,
@@ -1175,7 +1175,7 @@ func TestRangeCacheClearOlderOverlapping(t *testing.T) {
 			clearDesc:   descAB1,
 			expCache:    []roachpb.RangeDescriptor{descAB2, descBC2, descCD2},
 			expNewest:   false,
-			expNewer:    &descAB2,
+			expNewer:    descAB2,
 		},
 		{
 			cachedDescs: []roachpb.RangeDescriptor{descAB2, descBC2, descCD2},
@@ -1219,12 +1219,12 @@ func TestRangeCacheClearOlderOverlapping(t *testing.T) {
 			if len(all) != 0 {
 				allDescs = make([]roachpb.RangeDescriptor, len(all))
 				for i, e := range all {
-					allDescs[i] = *e.Desc()
+					allDescs[i] = e.desc
 				}
 			}
-			var newerDesc *roachpb.RangeDescriptor
+			var newerDesc roachpb.RangeDescriptor
 			if newer != nil {
-				newerDesc = newer.Desc()
+				newerDesc = newer.desc
 			}
 
 			assert.Equal(t, tc.expCache, allDescs)
@@ -1307,42 +1307,39 @@ func TestGetCachedRangeDescriptorInverted(t *testing.T) {
 
 	testCases := []struct {
 		queryKey roachpb.RKey
-		rng      *roachpb.RangeDescriptor
+		rng      roachpb.RangeDescriptor
 	}{
 		{
 			// Check range start key.
 			queryKey: roachpb.RKey("l"),
-			rng:      nil,
 		},
 		{
 			// Check some key in first range.
 			queryKey: roachpb.RKey("0"),
-			rng:      &roachpb.RangeDescriptor{StartKey: roachpb.RKeyMin, EndKey: roachpb.RKey("a")},
+			rng:      roachpb.RangeDescriptor{StartKey: roachpb.RKeyMin, EndKey: roachpb.RKey("a")},
 		},
 		{
 			// Check end key of first range.
 			queryKey: roachpb.RKey("a"),
-			rng:      &roachpb.RangeDescriptor{StartKey: roachpb.RKeyMin, EndKey: roachpb.RKey("a")},
+			rng:      roachpb.RangeDescriptor{StartKey: roachpb.RKeyMin, EndKey: roachpb.RKey("a")},
 		},
 		{
 			// Check range end key.
 			queryKey: roachpb.RKey("c"),
-			rng:      &roachpb.RangeDescriptor{StartKey: roachpb.RKey("a"), EndKey: roachpb.RKey("c")},
+			rng:      roachpb.RangeDescriptor{StartKey: roachpb.RKey("a"), EndKey: roachpb.RKey("c")},
 		},
 		{
 			// Check range middle key.
 			queryKey: roachpb.RKey("d"),
-			rng:      &roachpb.RangeDescriptor{StartKey: roachpb.RKey("c"), EndKey: roachpb.RKey("e")},
+			rng:      roachpb.RangeDescriptor{StartKey: roachpb.RKey("c"), EndKey: roachpb.RKey("e")},
 		},
 		{
 			// Check miss range key.
 			queryKey: roachpb.RKey("f"),
-			rng:      nil,
 		},
 		{
 			// Check range start key with previous range miss.
 			queryKey: roachpb.RKey("l"),
-			rng:      nil,
 		},
 	}
 
@@ -1352,11 +1349,11 @@ func TestGetCachedRangeDescriptorInverted(t *testing.T) {
 			targetRange, _ := cache.getCachedRLocked(ctx, test.queryKey, true /* inverted */)
 			cache.rangeCache.RUnlock()
 
-			if test.rng == nil {
+			if !test.rng.IsInitialized() {
 				require.Nil(t, targetRange)
 			} else {
 				require.NotNil(t, targetRange)
-				require.Equal(t, test.rng, targetRange.Desc())
+				require.Equal(t, test.rng, targetRange.desc)
 			}
 		})
 	}
@@ -2019,149 +2016,143 @@ func TestRangeCacheEntryMaybeUpdate(t *testing.T) {
 	}
 
 	// Check that some lease overwrites an empty lease.
-	l := &roachpb.Lease{
+	l := roachpb.Lease{
 		Replica:  rep1,
 		Sequence: 1,
 	}
-	updated, updatedLease, e := e.maybeUpdate(ctx, l, &desc)
+	updated, updatedLease, e := e.maybeUpdate(ctx, &l, &desc)
 	require.True(t, updated)
 	require.True(t, updatedLease)
-	require.True(t, l.Equal(e.Lease()))
-	require.True(t, desc.Equal(e.Desc()))
+	require.True(t, l.Equal(e.lease))
+	require.True(t, desc.Equal(e.desc))
 
 	// Check that another lease with no seq num overwrites any other lease when
 	// the associated range descriptor isn't stale.
-	l = &roachpb.Lease{
+	l = roachpb.Lease{
 		Replica:  rep2,
 		Sequence: 0,
 	}
-	updated, updatedLease, e = e.maybeUpdate(ctx, l, &desc)
+	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc)
 	require.True(t, updated)
 	require.True(t, updatedLease)
-	require.NotNil(t, e.Leaseholder())
-	require.True(t, l.Replica.Equal(*e.Leaseholder()))
-	require.True(t, desc.Equal(e.Desc()))
-	// Check that Seq=0 leases are not returned by Lease().
-	require.Nil(t, e.Lease())
+	require.Equal(t, l.Replica, e.lease.Replica)
+	require.Equal(t, desc, e.desc)
+	// Check that the lease is Speculative.
+	require.True(t, e.lease.Speculative())
 
 	// Check that another lease with no sequence number overwrites a lease with no
 	// sequence num as long as the associated range descriptor isn't stale.
-	l = &roachpb.Lease{
+	l = roachpb.Lease{
 		Replica:  rep1,
 		Sequence: 0,
 	}
-	updated, updatedLease, e = e.maybeUpdate(ctx, l, &desc)
+	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc)
 	require.True(t, updated)
 	require.True(t, updatedLease)
-	require.NotNil(t, e.Leaseholder())
-	require.True(t, l.Replica.Equal(*e.Leaseholder()))
-	require.True(t, desc.Equal(e.Desc()))
-	// Check that Seq=0 leases are not returned by Lease().
-	require.Nil(t, e.Lease())
+	require.Equal(t, l.Replica, e.lease.Replica)
+	require.Equal(t, desc, e.desc)
+	// Check that the lease is Speculative.
+	require.True(t, e.lease.Speculative())
 
 	oldL := l
-	l = &roachpb.Lease{
+	l = roachpb.Lease{
 		Replica:  repStaleMember,
 		Sequence: 0,
 	}
 	// Ensure that a speculative lease is not overwritten when accompanied by a
 	// stale range descriptor.
-	updated, updatedLease, e = e.maybeUpdate(ctx, l, &staleDesc)
+	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &staleDesc)
 	require.False(t, updated)
 	require.False(t, updatedLease)
-	require.NotNil(t, e.Leaseholder())
-	require.True(t, oldL.Replica.Equal(*e.Leaseholder()))
-	require.True(t, desc.Equal(e.Desc()))
+	require.Equal(t, oldL.Replica, e.lease.Replica)
+	require.Equal(t, desc, e.desc)
 	// The old lease is still speculative; ensure it isn't returned by Lease().
-	require.Nil(t, e.Lease())
+	require.True(t, e.lease.Speculative())
 
 	// Ensure a speculative lease is not overwritten by a "real" lease if the
 	// accompanying range descriptor is stale.
-	l = &roachpb.Lease{
+	l = roachpb.Lease{
 		Replica:  rep1,
 		Sequence: 1,
 	}
-	updated, updatedLease, e = e.maybeUpdate(ctx, l, &staleDesc)
+	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &staleDesc)
 	require.False(t, updated)
 	require.False(t, updatedLease)
-	require.NotNil(t, e.Leaseholder())
-	require.True(t, oldL.Replica.Equal(*e.Leaseholder()))
-	require.True(t, desc.Equal(e.Desc()))
+	require.Equal(t, oldL.Replica, e.lease.Replica)
+	require.Equal(t, desc, e.desc)
 
 	// Empty out the lease and ensure that it is overwritten by a lease even if
 	// the accompanying range descriptor is stale.
 	e.lease = roachpb.Lease{}
-	updated, updatedLease, e = e.maybeUpdate(ctx, l, &staleDesc)
+	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &staleDesc)
 	require.True(t, updated)
 	require.True(t, updatedLease)
-	require.NotNil(t, e.Leaseholder())
-	require.True(t, oldL.Replica.Equal(*e.Leaseholder()))
-	require.True(t, e.Lease().Equal(l))
+	require.Equal(t, oldL.Replica, e.lease.Replica)
+	require.Equal(t, l, e.lease)
 	// The range descriptor shouldn't be updated because the one supplied was
 	// stale.
-	require.True(t, desc.Equal(e.Desc()))
+	require.Equal(t, desc, e.desc)
 
 	// Ensure that a newer lease overwrites an older lease.
-	l = &roachpb.Lease{
+	l = roachpb.Lease{
 		Replica:  rep2,
 		Sequence: 2,
 	}
-	updated, updatedLease, e = e.maybeUpdate(ctx, l, &desc)
+	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc)
 	require.True(t, updated)
 	require.True(t, updatedLease)
-	require.NotNil(t, e.Leaseholder())
-	require.True(t, l.Equal(*e.Lease()))
-	require.True(t, desc.Equal(e.Desc()))
+	require.Equal(t, l, e.lease)
+	require.Equal(t, desc, e.desc)
 
 	// Check that updating to an older lease doesn't work.
-	l = &roachpb.Lease{
+	l = roachpb.Lease{
 		Replica:  rep1,
 		Sequence: 1,
 	}
-	updated, updatedLease, e = e.maybeUpdate(ctx, l, &desc)
+	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc)
 	require.False(t, updated)
 	require.False(t, updatedLease)
-	require.False(t, l.Equal(*e.Lease()))
+	require.NotEqual(t, l, e.lease)
 
 	// Check that updating to an older descriptor doesn't work.
-	updated, updatedLease, e = e.maybeUpdate(ctx, l, &staleDesc)
+	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &staleDesc)
 	require.False(t, updated)
 	require.False(t, updatedLease)
-	require.True(t, desc.Equal(e.Desc()))
+	require.Equal(t, desc, e.desc)
 
 	// Check that updating to the same lease returns false.
-	l = &roachpb.Lease{
+	l = roachpb.Lease{
 		Replica:  rep2,
 		Sequence: 2,
 	}
-	require.True(t, l.Equal(e.Lease()))
-	updated, updatedLease, e = e.maybeUpdate(ctx, l, &desc)
+	require.Equal(t, l, e.lease)
+	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc)
 	require.False(t, updated)
 	require.False(t, updatedLease)
-	require.True(t, l.Equal(e.Lease()))
-	require.True(t, desc.Equal(e.Desc()))
+	require.Equal(t, l, e.lease)
+	require.Equal(t, desc, e.desc)
 
 	// Check that updating just the descriptor to a newer descriptor returns the
 	// correct values for updated and updatedLease.
-	updated, updatedLease, e = e.maybeUpdate(ctx, l, &desc2)
+	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc2)
 	require.True(t, updated)
 	require.False(t, updatedLease)
-	require.True(t, l.Equal(e.Lease()))
-	require.True(t, desc2.Equal(e.Desc()))
+	require.Equal(t, l, e.lease)
+	require.Equal(t, desc2, e.desc)
 
 	// Check that  updating the cache entry to a newer descriptor such that it
 	// makes the (freshest) lease incompatible clears out the lease on the
 	// returned cache entry.
-	l = &roachpb.Lease{
+	l = roachpb.Lease{
 		Replica:  rep1,
 		Sequence: 1,
 	}
-	require.Equal(t, roachpb.LeaseSequence(2), e.Lease().Sequence)
-	updated, updatedLease, e = e.maybeUpdate(ctx, l, &desc3)
+	require.Equal(t, roachpb.LeaseSequence(2), e.lease.Sequence)
+	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc3)
 	require.True(t, updated)
 	require.False(t, updatedLease)
-	require.Nil(t, e.Lease())
-	require.True(t, desc3.Equal(e.Desc()))
+	require.True(t, e.lease.Empty())
+	require.Equal(t, desc3, e.desc)
 }
 
 func TestRangeCacheEntryOverrides(t *testing.T) {

--- a/pkg/kv/kvclient/rangecache/range_cache_test.go
+++ b/pkg/kv/kvclient/rangecache/range_cache_test.go
@@ -1219,7 +1219,7 @@ func TestRangeCacheClearOlderOverlapping(t *testing.T) {
 			if len(all) != 0 {
 				allDescs = make([]roachpb.RangeDescriptor, len(all))
 				for i, e := range all {
-					allDescs[i] = e.desc
+					allDescs[i] = e.Desc
 				}
 			}
 			var newerDesc roachpb.RangeDescriptor
@@ -1877,8 +1877,8 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 					ctx, roachpb.RSpan{Key: roachpb.RKeyMin, EndKey: roachpb.RKeyMax},
 				)
 				require.Equal(t, 1, len(entries))
-				require.Equal(t, incompatibleDescriptor, entries[0].desc)
-				require.Equal(t, l, entries[0].lease)
+				require.Equal(t, incompatibleDescriptor, entries[0].Desc)
+				require.Equal(t, l, entries[0].Lease)
 			},
 		},
 		{
@@ -1911,8 +1911,8 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 					ctx, roachpb.RSpan{Key: roachpb.RKeyMin, EndKey: roachpb.RKeyMax},
 				)
 				require.Equal(t, 1, len(entries))
-				require.Equal(t, desc2, entries[0].desc)
-				require.Equal(t, l, entries[0].lease)
+				require.Equal(t, desc2, entries[0].Desc)
+				require.Equal(t, l, entries[0].Lease)
 			},
 		},
 		{

--- a/pkg/kv/kvserver/intentresolver/BUILD.bazel
+++ b/pkg/kv/kvserver/intentresolver/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/internal/client/requestbatcher",
         "//pkg/keys",
         "//pkg/kv",
-        "//pkg/kv/kvclient/rangecache",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/batcheval/result",
         "//pkg/kv/kvserver/kvserverbase",

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -256,10 +256,10 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 	}
 
 	for i := range descs {
-		ri := rangeCache.GetCached(ctx, descs[i].StartKey, false /* inclusive */)
-		require.NotNilf(t, ri, "failed to find range for key: %s", descs[i].StartKey)
-		require.Equal(t, &descs[i], ri.Desc())
-		require.NotNil(t, ri.Lease())
+		ri, err := rangeCache.TestingGetCached(ctx, descs[i].StartKey, false /* inclusive */)
+		require.NoError(t, err)
+		require.Equal(t, descs[i], ri.Desc)
+		require.NotNil(t, ri.Lease)
 	}
 }
 

--- a/pkg/sql/execinfra/readerbase.go
+++ b/pkg/sql/execinfra/readerbase.go
@@ -66,24 +66,20 @@ func MisplannedRanges(
 		overlapping := rdc.GetCachedOverlapping(ctx, rSpan)
 
 		for _, ri := range overlapping {
-			if _, ok := misplanned[ri.Desc().RangeID]; ok {
+			if _, ok := misplanned[ri.Desc.RangeID]; ok {
 				// We're already returning info about this range.
 				continue
 			}
 			// Ranges with unknown leases are not returned, as the current node might
 			// actually have the lease without the local cache knowing about it.
-			l := ri.Lease()
-			if l != nil && l.Replica.NodeID != nodeID {
-				misplannedRanges = append(misplannedRanges, roachpb.RangeInfo{
-					Desc:                  *ri.Desc(),
-					Lease:                 *l,
-					ClosedTimestampPolicy: ri.ClosedTimestampPolicy(),
-				})
+			l := ri.Lease
+			if !l.Empty() && l.Replica.NodeID != nodeID {
+				misplannedRanges = append(misplannedRanges, ri)
 
 				if misplanned == nil {
 					misplanned = make(map[roachpb.RangeID]struct{})
 				}
-				misplanned[ri.Desc().RangeID] = struct{}{}
+				misplanned[ri.Desc.RangeID] = struct{}{}
 			}
 		}
 	}


### PR DESCRIPTION
Numerous small cleanups to the range cache. 

After these changes, The RangeCache and related classes have a much simpler interface with some nice usability benefits:

1) CacheEntry is no longer public. This is good because it is intended to be immutable and it is now easier to audit its usage.
2) Test only methods are more clearly changed to designate them that way. This will prevent new code from using them incorrectly
3) Unused methods are removed from the interface.