### PR TITLE
roachtest,floatcmp: fix float comparison so 0 always matches -0

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -529,6 +529,7 @@ func (h *queryComparisonHelper) makeError(err error, msg string) error {
 	return errors.Wrapf(err, "%s. %d statements run", msg, h.stmtNo)
 }
 
+// joinAndSortRows sorts rows using string comparison.
 func joinAndSortRows(rowMatrix1, rowMatrix2 [][]string, sep string) (rows1, rows2 []string) {
 	for _, row := range rowMatrix1 {
 		rows1 = append(rows1, strings.Join(row[:], sep))
@@ -539,6 +540,38 @@ func joinAndSortRows(rowMatrix1, rowMatrix2 [][]string, sep string) (rows1, rows
 	sort.Strings(rows1)
 	sort.Strings(rows2)
 	return rows1, rows2
+}
+
+// sortRowsWithFloatComp is similar to joinAndSortRows, but it uses float
+// comparison for float columns (and decimal columns when on s390x).
+func sortRowsWithFloatComp(rowMatrix1, rowMatrix2 [][]string, colTypes []string) {
+	floatsLess := func(i, j int, rowMatrix [][]string) bool {
+		for idx := range colTypes {
+			if (runtime.GOARCH == "s390x" && colTypes[idx] == "DECIMAL") ||
+				colTypes[idx] == "FLOAT4" || colTypes[idx] == "FLOAT8" {
+				res, err := floatcmp.FloatsCmp(rowMatrix[i][idx], rowMatrix[j][idx])
+				if err != nil {
+					panic(errors.NewAssertionErrorWithWrappedErrf(err, "error comparing floats %s and %s",
+						rowMatrix[i][idx], rowMatrix[j][idx]))
+				}
+				if res != 0 {
+					return res == -1
+				}
+			} else {
+				if rowMatrix[i][idx] != rowMatrix[j][idx] {
+					return rowMatrix[i][idx] < rowMatrix[j][idx]
+				}
+			}
+		}
+		return false
+	}
+
+	sort.Slice(rowMatrix1, func(i, j int) bool {
+		return floatsLess(i, j, rowMatrix1)
+	})
+	sort.Slice(rowMatrix2, func(i, j int) bool {
+		return floatsLess(i, j, rowMatrix2)
+	})
 }
 
 // unsortedMatricesDiffWithFloatComp sorts and compares the rows in rowMatrix1
@@ -570,15 +603,10 @@ func unsortedMatricesDiffWithFloatComp(
 	if !needApproxMatch {
 		return result, nil
 	}
-	// Use an unlikely string as a separator so that we can make a comparison
-	// using sorted rows. We don't use the rows sorted above because splitting
-	// the rows could be ambiguous.
-	sep := ",unsortedMatricesDiffWithFloatComp separator,"
-	rows1, rows2 = joinAndSortRows(rowMatrix1, rowMatrix2, sep)
-	for i := range rows1 {
-		// Split the sorted rows.
-		row1 := strings.Split(rows1[i], sep)
-		row2 := strings.Split(rows2[i], sep)
+	sortRowsWithFloatComp(rowMatrix1, rowMatrix2, colTypes)
+	for i := range rowMatrix1 {
+		row1 := rowMatrix1[i]
+		row2 := rowMatrix2[i]
 
 		for j := range row1 {
 			if runtime.GOARCH == "s390x" && colTypes[j] == "DECIMAL" {

--- a/pkg/cmd/roachtest/tests/query_comparison_util_test.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util_test.go
@@ -113,6 +113,14 @@ func TestUnsortedMatricesDiff(t *testing.T) {
 			t2:         [][]string{{"world", "1.2345678901234560"}, {"hello", "1.2345678901234567"}},
 			exactMatch: true,
 		},
+		{
+			name:        "multi row 0 matches -0",
+			colTypes:    []string{"FLOAT4"},
+			t1:          [][]string{{"+Inf"}, {"1e-45"}, {"0"}, {"0"}, {"-0.0039"}, {"-Inf"}},
+			t2:          [][]string{{"+Inf"}, {"1e-45"}, {"-0"}, {"0"}, {"-0.0039"}, {"-Inf"}},
+			exactMatch:  false,
+			approxMatch: true,
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/testutils/floatcmp/floatcmp.go
+++ b/pkg/testutils/floatcmp/floatcmp.go
@@ -90,11 +90,46 @@ func FloatsMatchApprox(expectedString, actualString string) (bool, error) {
 		// Default to string matching for NULL, since it can't be parsed as a float.
 		return expectedString == actualString, nil
 	}
-	expected, actual, err := parseExpectedAndActualFloats(expectedString, actualString)
+	expected, actual, err := parseTwoFloats(expectedString, actualString)
 	if err != nil {
 		return false, err
 	}
 	return EqualApprox(expected, actual, CloseFraction, CloseMargin), nil
+}
+
+// FloatsCmp returns -1 if aString is less than bString, 0 if they are equal,
+// and 1 otherwise when aString and bString are parsed as SQL floats. NULL
+// sorts before NaN, which sorts before all other numbers.
+func FloatsCmp(aString, bString string) (int, error) {
+	if aString == "NULL" {
+		if bString != "NULL" {
+			return -1, nil
+		}
+		return 0, nil
+	} else if bString == "NULL" {
+		return 1, nil
+	}
+
+	a, b, err := parseTwoFloats(aString, bString)
+	if err != nil {
+		return 0, err
+	}
+	if math.IsNaN(a) {
+		if !math.IsNaN(b) {
+			return -1, nil
+		}
+		return 0, nil
+	} else if math.IsNaN(b) {
+		return 1, nil
+	}
+
+	if a < b {
+		return -1, nil
+	} else if a == b {
+		return 0, nil
+	} else {
+		return 1, nil
+	}
 }
 
 // FloatsMatch returns whether two floating point numbers represented as
@@ -105,11 +140,11 @@ func FloatsMatch(expectedString, actualString string) (bool, error) {
 		// Default to string matching for NULL, since it can't be parsed as a float.
 		return expectedString == actualString, nil
 	}
-	expected, actual, err := parseExpectedAndActualFloats(expectedString, actualString)
+	expected, actual, err := parseTwoFloats(expectedString, actualString)
 	if err != nil {
 		return false, err
 	}
-	// Check special values - NaN, +Inf, -Inf, 0.
+	// Check special values - NaN, +Inf, -Inf, 0, -0.
 	if math.IsNaN(expected) || math.IsNaN(actual) {
 		return math.IsNaN(expected) == math.IsNaN(actual), nil
 	}
@@ -187,16 +222,15 @@ func ParseRoundInStringsDirective(directive string) (int, error) {
 	return strconv.Atoi(kv[1])
 }
 
-// parseExpectedAndActualFloats converts the strings expectedString and
-// actualString to float64 values.
-func parseExpectedAndActualFloats(expectedString, actualString string) (float64, float64, error) {
-	expected, err := strconv.ParseFloat(expectedString, 64 /* bitSize */)
+// parseTwoFloats converts the strings aString and bString to float64 values.
+func parseTwoFloats(aString, bString string) (float64, float64, error) {
+	a, err := strconv.ParseFloat(aString, 64 /* bitSize */)
 	if err != nil {
-		return 0, 0, errors.Wrap(err, "when parsing expected")
+		return 0, 0, errors.Wrap(err, "when parsing aString")
 	}
-	actual, err := strconv.ParseFloat(actualString, 64 /* bitSize */)
+	b, err := strconv.ParseFloat(bString, 64 /* bitSize */)
 	if err != nil {
-		return 0, 0, errors.Wrap(err, "when parsing actual")
+		return 0, 0, errors.Wrap(err, "when parsing bString")
 	}
-	return expected, actual, nil
+	return a, b, nil
 }


### PR DESCRIPTION
This commit should eliminate a class of test flakes in which `costfuzz` and `unoptimized-query-oracle` sometimes fail due to one query result containing a row with 0 and the other query result containing a row with -0. This class of failures was caused by the fact that the rows were first sorted using string comparison before they were compared with float comparison. Although 0 equals -0 with float comparison, this doesn't matter if they are not considered equal during sorting. This commit fixes the sorting so that 0 and -0 are considered equal.

Thanks @DrewKimball for helping track this down during our pair programming session!

Fixes #117806

Release note: None