### PR TITLE
mixedversion: introduce longer delays in concurrent steps

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -38,6 +38,12 @@ var (
 	TestBuildVersion *version.Version
 
 	currentBranch = os.Getenv("TC_BUILD_BRANCH")
+
+	// CurrentVersionString is how we represent the binary or cluster
+	// versions associated with the current binary (the one being
+	// tested). Note that, in TeamCity, we use the branch name to make
+	// it even clearer.
+	CurrentVersionString = "<current>"
 )
 
 // Version is a thin wrapper around the `version.Version` struct that
@@ -57,7 +63,7 @@ func (v *Version) String() string {
 			return currentBranch
 		}
 
-		return "<current>"
+		return CurrentVersionString
 	}
 
 	return v.Version.String()

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -753,16 +753,17 @@ func (s startStep) Run(ctx context.Context, l *logger.Logger, c cluster.Cluster,
 // the cluster and equal to the binary version of the first node in
 // the `nodes` field.
 type waitForStableClusterVersionStep struct {
-	nodes   option.NodeListOption
-	timeout time.Duration
+	nodes          option.NodeListOption
+	desiredVersion string
+	timeout        time.Duration
 }
 
 func (s waitForStableClusterVersionStep) Background() shouldStop { return nil }
 
 func (s waitForStableClusterVersionStep) Description() string {
 	return fmt.Sprintf(
-		"wait for nodes %v to all have the same cluster version (same as binary version of node %d)",
-		s.nodes, s.nodes[0],
+		"wait for nodes %v to reach cluster version %s",
+		s.nodes, s.desiredVersion,
 	)
 }
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/basic_test_mixed_version_hooks
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/basic_test_mixed_version_hooks
@@ -28,12 +28,12 @@ mixed-version test plan for upgrading from "v22.2.8" to "<current>":
 ├── start cluster at version "v22.2.8" (2)
 ├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (3)
 ├── run startup hooks concurrently
-│   ├── run "initialize bank workload", after 0s delay (4)
-│   └── run "initialize rand workload", after 0s delay (5)
+│   ├── run "initialize bank workload", after 100ms delay (4)
+│   └── run "initialize rand workload", after 30s delay (5)
 ├── start background hooks concurrently
-│   ├── run "bank workload", after 500ms delay (6)
-│   ├── run "rand workload", after 50ms delay (7)
-│   └── run "csv server", after 0s delay (8)
+│   ├── run "bank workload", after 0s delay (6)
+│   ├── run "rand workload", after 30s delay (7)
+│   └── run "csv server", after 500ms delay (8)
 └── upgrade cluster from "v22.2.8" to "<current>"
    ├── prevent auto-upgrades by setting `preserve_downgrade_option` (9)
    ├── upgrade nodes :1-4 from "v22.2.8" to "<current>"

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/basic_test_mixed_version_hooks
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/basic_test_mixed_version_hooks
@@ -26,7 +26,7 @@ plan
 mixed-version test plan for upgrading from "v22.2.8" to "<current>":
 ├── install fixtures for version "v22.2.8" (1)
 ├── start cluster at version "v22.2.8" (2)
-├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (3)
+├── wait for nodes :1-4 to reach cluster version '22.2' (3)
 ├── run startup hooks concurrently
 │   ├── run "initialize bank workload", after 100ms delay (4)
 │   └── run "initialize rand workload", after 30s delay (5)
@@ -45,4 +45,4 @@ mixed-version test plan for upgrading from "v22.2.8" to "<current>":
    │   └── restart node 3 with binary version <current> (15)
    ├── finalize upgrade by resetting `preserve_downgrade_option` (16)
    ├── run "mixed-version 2" (17)
-   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (18)
+   └── wait for nodes :1-4 to reach cluster version <current> (18)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/local_runs_reduced_wait_time
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/local_runs_reduced_wait_time
@@ -53,15 +53,15 @@ mixed-version test plan for upgrading from "v22.2.3" to "v23.1.4" to "v23.2.0" t
 │   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (19)
 ├── run "initialize bank workload" (20)
 ├── start background hooks concurrently
-│   ├── run "bank workload", after 50ms delay (21)
+│   ├── run "bank workload", after 18s delay (21)
 │   └── run "csv server", after 0s delay (22)
 ├── upgrade cluster from "v23.1.4" to "v23.2.0"
 │   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (23)
 │   ├── upgrade nodes :1-4 from "v23.1.4" to "v23.2.0"
 │   │   ├── restart node 4 with binary version v23.2.0 (24)
 │   │   ├── run mixed-version hooks concurrently
-│   │   │   ├── run "mixed-version 1", after 100ms delay (25)
-│   │   │   └── run "mixed-version 2", after 100ms delay (26)
+│   │   │   ├── run "mixed-version 1", after 10ms delay (25)
+│   │   │   └── run "mixed-version 2", after 50ms delay (26)
 │   │   ├── restart node 1 with binary version v23.2.0 (27)
 │   │   ├── restart node 2 with binary version v23.2.0 (28)
 │   │   └── restart node 3 with binary version v23.2.0 (29)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/local_runs_reduced_wait_time
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/local_runs_reduced_wait_time
@@ -29,7 +29,7 @@ plan
 ----
 mixed-version test plan for upgrading from "v22.2.3" to "v23.1.4" to "v23.2.0" to "<current>":
 ├── start cluster at version "v22.2.3" (1)
-├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (2)
+├── wait for nodes :1-4 to reach cluster version '22.2' (2)
 ├── upgrade cluster from "v22.2.3" to "v23.1.4"
 │   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (3)
 │   ├── upgrade nodes :1-4 from "v22.2.3" to "v23.1.4"
@@ -50,7 +50,7 @@ mixed-version test plan for upgrading from "v22.2.3" to "v23.1.4" to "v23.2.0" t
 │   │   ├── restart node 4 with binary version v23.1.4 (16)
 │   │   └── restart node 2 with binary version v23.1.4 (17)
 │   ├── finalize upgrade by resetting `preserve_downgrade_option` (18)
-│   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (19)
+│   └── wait for nodes :1-4 to reach cluster version '23.1' (19)
 ├── run "initialize bank workload" (20)
 ├── start background hooks concurrently
 │   ├── run "bank workload", after 18s delay (21)
@@ -66,7 +66,7 @@ mixed-version test plan for upgrading from "v22.2.3" to "v23.1.4" to "v23.2.0" t
 │   │   ├── restart node 2 with binary version v23.2.0 (28)
 │   │   └── restart node 3 with binary version v23.2.0 (29)
 │   ├── finalize upgrade by resetting `preserve_downgrade_option` (30)
-│   ├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (31)
+│   ├── wait for nodes :1-4 to reach cluster version '23.2' (31)
 │   └── run "validate upgrade" (32)
 └── upgrade cluster from "v23.2.0" to "<current>"
    ├── prevent auto-upgrades by setting `preserve_downgrade_option` (33)
@@ -93,5 +93,5 @@ mixed-version test plan for upgrading from "v22.2.3" to "v23.1.4" to "v23.2.0" t
    │   └── restart node 3 with binary version <current> (51)
    ├── finalize upgrade by resetting `preserve_downgrade_option` (52)
    ├── run "mixed-version 2" (53)
-   ├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (54)
+   ├── wait for nodes :1-4 to reach cluster version <current> (54)
    └── run "validate upgrade" (55)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/minimum_supported_version
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/minimum_supported_version
@@ -73,8 +73,8 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (35)
 ├── run "initialize bank workload" (36)
 ├── start background hooks concurrently
-│   ├── run "bank workload", after 50ms delay (37)
-│   └── run "csv server", after 200ms delay (38)
+│   ├── run "bank workload", after 0s delay (37)
+│   └── run "csv server", after 5s delay (38)
 ├── upgrade cluster from "v23.1.4" to "v23.2.0"
 │   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (39)
 │   ├── upgrade nodes :1-4 from "v23.1.4" to "v23.2.0"
@@ -102,7 +102,7 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
    │   ├── restart node 3 with binary version v23.2.0 (58)
    │   ├── run mixed-version hooks concurrently
    │   │   ├── run "mixed-version 1", after 0s delay (59)
-   │   │   └── run "mixed-version 2", after 0s delay (60)
+   │   │   └── run "mixed-version 2", after 500ms delay (60)
    │   └── restart node 1 with binary version v23.2.0 (61)
    ├── upgrade nodes :1-4 from "v23.2.0" to "<current>"
    │   ├── restart node 2 with binary version <current> (62)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/minimum_supported_version
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/minimum_supported_version
@@ -29,7 +29,7 @@ plan
 ----
 mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" to "v23.1.4" to "v23.2.0" to "<current>":
 ├── start cluster at version "v21.2.11" (1)
-├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (2)
+├── wait for nodes :1-4 to reach cluster version '21.2' (2)
 ├── upgrade cluster from "v21.2.11" to "v22.1.8"
 │   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (3)
 │   ├── upgrade nodes :1-4 from "v21.2.11" to "v22.1.8"
@@ -50,7 +50,7 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   ├── restart node 4 with binary version v22.1.8 (16)
 │   │   └── restart node 2 with binary version v22.1.8 (17)
 │   ├── finalize upgrade by resetting `preserve_downgrade_option` (18)
-│   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (19)
+│   └── wait for nodes :1-4 to reach cluster version '22.1' (19)
 ├── upgrade cluster from "v22.1.8" to "v22.2.3"
 │   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (20)
 │   ├── upgrade nodes :1-4 from "v22.1.8" to "v22.2.3"
@@ -60,7 +60,7 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   ├── restart node 2 with binary version v22.2.3 (24)
 │   │   └── restart node 3 with binary version v22.2.3 (25)
 │   ├── finalize upgrade by resetting `preserve_downgrade_option` (26)
-│   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (27)
+│   └── wait for nodes :1-4 to reach cluster version '22.2' (27)
 ├── upgrade cluster from "v22.2.3" to "v23.1.4"
 │   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (28)
 │   ├── upgrade nodes :1-4 from "v22.2.3" to "v23.1.4"
@@ -70,7 +70,7 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   ├── restart node 4 with binary version v23.1.4 (32)
 │   │   └── wait for 10m0s (33)
 │   ├── finalize upgrade by resetting `preserve_downgrade_option` (34)
-│   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (35)
+│   └── wait for nodes :1-4 to reach cluster version '23.1' (35)
 ├── run "initialize bank workload" (36)
 ├── start background hooks concurrently
 │   ├── run "bank workload", after 0s delay (37)
@@ -85,7 +85,7 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   ├── run "mixed-version 2" (44)
 │   │   └── restart node 3 with binary version v23.2.0 (45)
 │   ├── finalize upgrade by resetting `preserve_downgrade_option` (46)
-│   ├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (47)
+│   ├── wait for nodes :1-4 to reach cluster version '23.2' (47)
 │   └── run "validate upgrade" (48)
 └── upgrade cluster from "v23.2.0" to "<current>"
    ├── prevent auto-upgrades by setting `preserve_downgrade_option` (49)
@@ -113,5 +113,5 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
    │   └── restart node 1 with binary version <current> (67)
    ├── finalize upgrade by resetting `preserve_downgrade_option` (68)
    ├── run "mixed-version 1" (69)
-   ├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (70)
+   ├── wait for nodes :1-4 to reach cluster version <current> (70)
    └── run "validate upgrade" (71)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/multiple_upgrades
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/multiple_upgrades
@@ -17,7 +17,7 @@ plan
 ----
 mixed-version test plan for upgrading from "v22.1.8" to "v22.2.3" to "v23.1.4" to "<current>":
 ├── start cluster at version "v22.1.8" (1)
-├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (2)
+├── wait for nodes :1-4 to reach cluster version '22.1' (2)
 ├── upgrade cluster from "v22.1.8" to "v22.2.3"
 │   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (3)
 │   ├── upgrade nodes :1-4 from "v22.1.8" to "v22.2.3"
@@ -38,7 +38,7 @@ mixed-version test plan for upgrading from "v22.1.8" to "v22.2.3" to "v23.1.4" t
 │   │   ├── restart node 4 with binary version v22.2.3 (16)
 │   │   └── restart node 2 with binary version v22.2.3 (17)
 │   ├── finalize upgrade by resetting `preserve_downgrade_option` (18)
-│   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (19)
+│   └── wait for nodes :1-4 to reach cluster version '22.2' (19)
 ├── run "initialize bank workload" (20)
 ├── run "bank workload" (21)
 ├── upgrade cluster from "v22.2.3" to "v23.1.4"
@@ -51,7 +51,7 @@ mixed-version test plan for upgrading from "v22.1.8" to "v22.2.3" to "v23.1.4" t
 │   │   └── restart node 3 with binary version v23.1.4 (27)
 │   ├── finalize upgrade by resetting `preserve_downgrade_option` (28)
 │   ├── run "mixed-version 1" (29)
-│   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (30)
+│   └── wait for nodes :1-4 to reach cluster version '23.1' (30)
 └── upgrade cluster from "v23.1.4" to "<current>"
    ├── prevent auto-upgrades by setting `preserve_downgrade_option` (31)
    ├── upgrade nodes :1-4 from "v23.1.4" to "<current>"
@@ -73,4 +73,4 @@ mixed-version test plan for upgrading from "v22.1.8" to "v22.2.3" to "v23.1.4" t
    │   └── restart node 2 with binary version <current> (45)
    ├── finalize upgrade by resetting `preserve_downgrade_option` (46)
    ├── run "mixed-version 1" (47)
-   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (48)
+   └── wait for nodes :1-4 to reach cluster version <current> (48)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/step_stages
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/step_stages
@@ -63,8 +63,8 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (27) [stage=running-upgrade-migrations]
 ├── run "initialize bank workload" (28) [stage=on-startup]
 ├── start background hooks concurrently
-│   ├── run "bank workload", after 100ms delay (29) [stage=background]
-│   └── run "csv server", after 200ms delay (30) [stage=background]
+│   ├── run "bank workload", after 30s delay (29) [stage=background]
+│   └── run "csv server", after 500ms delay (30) [stage=background]
 ├── upgrade cluster from "v22.2.3" to "v23.1.4"
 │   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (31) [stage=init]
 │   ├── upgrade nodes :1-4 from "v22.2.3" to "v23.1.4"

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/step_stages
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/step_stages
@@ -29,7 +29,7 @@ plan debug=true
 ----
 mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" to "v23.1.4" to "v23.2.0" to "<current>":
 ├── start cluster at version "v21.2.11" (1) [stage=cluster-setup]
-├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (2) [stage=cluster-setup]
+├── wait for nodes :1-4 to reach cluster version '21.2' (2) [stage=cluster-setup]
 ├── upgrade cluster from "v21.2.11" to "v22.1.8"
 │   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (3) [stage=init]
 │   ├── upgrade nodes :1-4 from "v21.2.11" to "v22.1.8"
@@ -50,7 +50,7 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   ├── restart node 4 with binary version v22.1.8 (16) [stage=last-upgrade]
 │   │   └── restart node 2 with binary version v22.1.8 (17) [stage=last-upgrade]
 │   ├── finalize upgrade by resetting `preserve_downgrade_option` (18) [stage=running-upgrade-migrations]
-│   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (19) [stage=running-upgrade-migrations]
+│   └── wait for nodes :1-4 to reach cluster version '22.1' (19) [stage=running-upgrade-migrations]
 ├── upgrade cluster from "v22.1.8" to "v22.2.3"
 │   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (20) [stage=init]
 │   ├── upgrade nodes :1-4 from "v22.1.8" to "v22.2.3"
@@ -60,7 +60,7 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   ├── restart node 2 with binary version v22.2.3 (24) [stage=last-upgrade]
 │   │   └── restart node 3 with binary version v22.2.3 (25) [stage=last-upgrade]
 │   ├── finalize upgrade by resetting `preserve_downgrade_option` (26) [stage=running-upgrade-migrations]
-│   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (27) [stage=running-upgrade-migrations]
+│   └── wait for nodes :1-4 to reach cluster version '22.2' (27) [stage=running-upgrade-migrations]
 ├── run "initialize bank workload" (28) [stage=on-startup]
 ├── start background hooks concurrently
 │   ├── run "bank workload", after 30s delay (29) [stage=background]
@@ -76,7 +76,7 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   └── run "mixed-version 2" (37) [stage=last-upgrade]
 │   ├── finalize upgrade by resetting `preserve_downgrade_option` (38) [stage=running-upgrade-migrations]
 │   ├── run "mixed-version 1" (39) [stage=running-upgrade-migrations]
-│   ├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (40) [stage=running-upgrade-migrations]
+│   ├── wait for nodes :1-4 to reach cluster version '23.1' (40) [stage=running-upgrade-migrations]
 │   └── run "validate upgrade" (41) [stage=after-upgrade-finished]
 ├── upgrade cluster from "v23.1.4" to "v23.2.0"
 │   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (42) [stage=init]
@@ -102,7 +102,7 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
 │   │   ├── run "mixed-version 1" (59) [stage=last-upgrade]
 │   │   └── restart node 4 with binary version v23.2.0 (60) [stage=last-upgrade]
 │   ├── finalize upgrade by resetting `preserve_downgrade_option` (61) [stage=running-upgrade-migrations]
-│   ├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (62) [stage=running-upgrade-migrations]
+│   ├── wait for nodes :1-4 to reach cluster version '23.2' (62) [stage=running-upgrade-migrations]
 │   └── run "validate upgrade" (63) [stage=after-upgrade-finished]
 └── upgrade cluster from "v23.2.0" to "<current>"
    ├── prevent auto-upgrades by setting `preserve_downgrade_option` (64) [stage=init]
@@ -129,5 +129,5 @@ mixed-version test plan for upgrading from "v21.2.11" to "v22.1.8" to "v22.2.3" 
    │   └── run "mixed-version 1" (82) [stage=last-upgrade]
    ├── finalize upgrade by resetting `preserve_downgrade_option` (83) [stage=running-upgrade-migrations]
    ├── run "mixed-version 2" (84) [stage=running-upgrade-migrations]
-   ├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (85) [stage=running-upgrade-migrations]
+   ├── wait for nodes :1-4 to reach cluster version <current> (85) [stage=running-upgrade-migrations]
    └── run "validate upgrade" (86) [stage=after-upgrade-finished]


### PR DESCRIPTION
When a sequence of steps runs concurrently in a mixedversion test, the
framework adds a random, artificial delay between each step to explore
different interleavings of the steps. However, the duration of these
random delays was fairly short: prior to this commit, the delay would
be no longer than 500ms.

Since a lot (maybe most) mixedversion tests running every night have
fairly long running mixed-version hooks (in the order of minutes), it
makes sense to introduce longer delays between steps, to simulate
things happening in the middle of a certain step, as opposed to its
first moments.

In this commit, we update the range of possible delays from 0 (no
delay) to 3 minutes.

**mixedversion: include version running on gateway node in SQL methods**
A small debugging improvement: we are able to quickly see what version
is running on the gateway node without having to check the test plan
or the header of the current log file.

**mixedversion: simplify step that waits for migrations to finish**
This changes the wording on that step's description to mention that we
are waiting for a specific cluster version. This makes it a little
less tied to the actual implementation of the step, and highlights the
actual cluster version the cluster should be at by the time the step
ends.