### PR TITLE
backupccl,storage: disable value blocks for backup files

### DIFF
--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -176,7 +176,12 @@ func (s *fileSSTSink) open(ctx context.Context) error {
 		s.out = e
 	}
 	// TODO(dt): make ExternalStorage.Writer return objstorage.Writable.
-	s.sst = storage.MakeIngestionSSTWriter(ctx, s.dest.Settings(), storage.NoopFinishAbortWritable(s.out))
+	//
+	// Value blocks are disabled since such SSTs can be huge (e.g. 750MB in the
+	// mixed_version_backup.go roachtest), which can cause OOMs due to value
+	// block buffering.
+	s.sst = storage.MakeIngestionSSTWriterWithValueBlockOverride(
+		ctx, s.dest.Settings(), storage.NoopFinishAbortWritable(s.out), true)
 
 	return nil
 }

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -125,12 +125,27 @@ func MakeBackupSSTWriter(ctx context.Context, cs *cluster.Settings, f io.Writer)
 }
 
 // MakeIngestionSSTWriter creates a new SSTWriter tailored for ingestion SSTs.
-// These SSTs have bloom filters enabled (as set in DefaultPebbleOptions) and
-// format set to RocksDBv2.
+// These SSTs have bloom filters enabled (as set in DefaultPebbleOptions). If
+// the cluster settings permit value blocks, the SST may contain value blocks.
 func MakeIngestionSSTWriter(
 	ctx context.Context, cs *cluster.Settings, w objstorage.Writable,
 ) SSTWriter {
+	return MakeIngestionSSTWriterWithValueBlockOverride(ctx, cs, w, false)
+}
+
+// MakeIngestionSSTWriterWithValueBlockOverride creates a new SSTWriter
+// tailored for ingestion SSTs. These SSTs have bloom filters enabled (as set
+// in DefaultPebbleOptions) and format set to the highest permissible by the
+// cluster settings. Callers that expect to write huge SSTs, say 200+MB, which
+// could contain multiple versions for the same key, should set
+// disableValueBlocks to true. This is because value blocks are buffered
+// in-memory while writing the SST (see
+// https://github.com/cockroachdb/cockroach/issues/117113).
+func MakeIngestionSSTWriterWithValueBlockOverride(
+	ctx context.Context, cs *cluster.Settings, w objstorage.Writable, disableValueBlocks bool,
+) SSTWriter {
 	opts := MakeIngestionWriterOptions(ctx, cs)
+	opts.DisableValueBlocks = disableValueBlocks
 	return SSTWriter{
 		fw:                sstable.NewWriter(w, opts),
 		supportsRangeKeys: opts.TableFormat >= sstable.TableFormatPebblev2,


### PR DESCRIPTION
Fixes #117113

Epic: none

Release note: None