### PR TITLE
rowenc: return assertion errors in test builds around encoding

### DIFF
--- a/pkg/sql/rowenc/keyside/BUILD.bazel
+++ b/pkg/sql/rowenc/keyside/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/bitarray",
+        "//pkg/util/buildutil",
         "//pkg/util/duration",
         "//pkg/util/encoding",
         "//pkg/util/ipaddr",

--- a/pkg/sql/rowenc/keyside/decode.go
+++ b/pkg/sql/rowenc/keyside/decode.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
@@ -304,7 +305,10 @@ func Decode(
 		rkey := key[len:]
 		return a.NewDEncodedKey(tree.DEncodedKey(key[:len])), rkey, nil
 	default:
-		return nil, nil, errors.Errorf("unable to decode table key: %s", valType)
+		if buildutil.CrdbTestBuild {
+			return nil, nil, errors.AssertionFailedf("unable to decode table key: %s", valType.SQLStringForError())
+		}
+		return nil, nil, errors.Errorf("unable to decode table key: %s", valType.SQLStringForError())
 	}
 }
 

--- a/pkg/sql/rowenc/keyside/encode.go
+++ b/pkg/sql/rowenc/keyside/encode.go
@@ -12,6 +12,7 @@ package keyside
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/errors"
 )
@@ -179,6 +180,9 @@ func Encode(b []byte, val tree.Datum, dir encoding.Direction) ([]byte, error) {
 		return append(b, []byte(*t)...), nil
 	case *tree.DJSON:
 		return encodeJSONKey(b, t, dir)
+	}
+	if buildutil.CrdbTestBuild {
+		return nil, errors.AssertionFailedf("unable to encode table key: %T", val)
 	}
 	return nil, errors.Errorf("unable to encode table key: %T", val)
 }

--- a/pkg/sql/rowenc/valueside/BUILD.bazel
+++ b/pkg/sql/rowenc/valueside/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/sql/pgrepl/lsn",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/buildutil",
         "//pkg/util/encoding",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/ipaddr",

--- a/pkg/sql/rowenc/valueside/decode.go
+++ b/pkg/sql/rowenc/valueside/decode.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgrepl/lsn"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
@@ -252,7 +253,10 @@ func DecodeUntaggedDatum(
 	case types.VoidFamily:
 		return a.NewDVoid(), buf, nil
 	default:
-		return nil, buf, errors.Errorf("couldn't decode type %s", t.SQLStringForError())
+		if buildutil.CrdbTestBuild {
+			return nil, buf, errors.AssertionFailedf("unable to decode table value %s", t.SQLStringForError())
+		}
+		return nil, buf, errors.Errorf("unable to decode table value %s", t.SQLStringForError())
 	}
 }
 

--- a/pkg/sql/rowenc/valueside/encode.go
+++ b/pkg/sql/rowenc/valueside/encode.go
@@ -13,6 +13,7 @@ package valueside
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/tsearch"
@@ -112,6 +113,9 @@ func Encode(appendTo []byte, colID ColumnIDDelta, val tree.Datum, scratch []byte
 	case *tree.DVoid:
 		return encoding.EncodeVoidValue(appendTo, uint32(colID)), nil
 	default:
+		if buildutil.CrdbTestBuild {
+			return nil, errors.AssertionFailedf("unable to encode table value: %T", t)
+		}
 		return nil, errors.Errorf("unable to encode table value: %T", t)
 	}
 }


### PR DESCRIPTION
This might have caught the recently-fixed bug around Fingerprint method using key-encoding for TSQuery type even though it's not available.

I think that for value encoding it should be non-flaky to add these assertions, but for key encoding it might result in some noise, so we might revert this change later.

Epic: None

Release note: None