### PR TITLE
roachetest/mixedversion: reduce wait times in local runs

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -287,9 +287,11 @@ type (
 		// may choose to always use the latest predecessor as well.
 		predecessorFunc predecessorFunc
 
-		// test-only field, allowing tests to simulate cluster
-		// architectures without passing a cluster.Cluster implementation.
-		_arch *vm.CPUArch
+		// the following are test-only fields, allowing tests to simulate
+		// cluster properties without passing a cluster.Cluster
+		// implementation.
+		_arch    *vm.CPUArch
+		_isLocal *bool
 	}
 
 	shouldStop chan struct{}
@@ -580,6 +582,7 @@ func (t *Test) plan() (*TestPlan, error) {
 		currentContext: newInitialContext(initialRelease, t.crdbNodes),
 		options:        t.options,
 		rt:             t.rt,
+		isLocal:        t.isLocal(),
 		crdbNodes:      t.crdbNodes,
 		hooks:          t.hooks,
 		prng:           t.prng,
@@ -595,6 +598,14 @@ func (t *Test) clusterArch() vm.CPUArch {
 	}
 
 	return t.cluster.Architecture()
+}
+
+func (t *Test) isLocal() bool {
+	if t._isLocal != nil {
+		return *t._isLocal
+	}
+
+	return t.cluster.IsLocal()
 }
 
 func (t *Test) runCommandFunc(nodes option.NodeListOption, cmd string) userFunc {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -60,6 +60,7 @@ type (
 		currentContext *Context
 		crdbNodes      option.NodeListOption
 		rt             test.Test
+		isLocal        bool
 		options        testOptions
 		hooks          *testHooks
 		prng           *rand.Rand
@@ -305,6 +306,12 @@ func (p *testPlanner) changeVersionSteps(
 			// operations to run.
 			possibleWaitMinutes := []int{1, 5, 10}
 			waitDur := time.Duration(possibleWaitMinutes[p.prng.Intn(len(possibleWaitMinutes))]) * time.Minute
+			if p.isLocal {
+				// Reduce wait duration in local runs, as some tests run as
+				// part of CI and we can't to spend too much time waiting in
+				// that context.
+				waitDur = waitDur / 10
+			}
 			steps = append(steps, p.newSingleStep(waitStep{dur: waitDur}))
 		}
 	}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/local_runs_reduced_wait_time
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/local_runs_reduced_wait_time
@@ -1,0 +1,97 @@
+# Test that wait times while upgrading from older versions is reduced
+# in local runs.
+
+mixed-version-test predecessors=(22.2.3, 23.1.4, 23.2.0) num_upgrades=3 minimum_supported_version=v23.1.0 is_local=true
+----
+ok
+
+in-mixed-version name=(mixed-version 1)
+----
+ok
+
+in-mixed-version name=(mixed-version 2)
+----
+ok
+
+workload name=bank
+----
+ok
+
+background-command name=(csv server)
+----
+ok
+
+after-upgrade-finalized name=(validate upgrade)
+----
+ok
+
+plan
+----
+mixed-version test plan for upgrading from "v22.2.3" to "v23.1.4" to "v23.2.0" to "<current>":
+├── start cluster at version "v22.2.3" (1)
+├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (2)
+├── upgrade cluster from "v22.2.3" to "v23.1.4"
+│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (3)
+│   ├── upgrade nodes :1-4 from "v22.2.3" to "v23.1.4"
+│   │   ├── restart node 3 with binary version v23.1.4 (4)
+│   │   ├── restart node 1 with binary version v23.1.4 (5)
+│   │   ├── restart node 2 with binary version v23.1.4 (6)
+│   │   ├── wait for 1m0s (7)
+│   │   └── restart node 4 with binary version v23.1.4 (8)
+│   ├── downgrade nodes :1-4 from "v23.1.4" to "v22.2.3"
+│   │   ├── restart node 1 with binary version v22.2.3 (9)
+│   │   ├── restart node 4 with binary version v22.2.3 (10)
+│   │   ├── restart node 3 with binary version v22.2.3 (11)
+│   │   └── restart node 2 with binary version v22.2.3 (12)
+│   ├── upgrade nodes :1-4 from "v22.2.3" to "v23.1.4"
+│   │   ├── restart node 3 with binary version v23.1.4 (13)
+│   │   ├── restart node 1 with binary version v23.1.4 (14)
+│   │   ├── wait for 30s (15)
+│   │   ├── restart node 4 with binary version v23.1.4 (16)
+│   │   └── restart node 2 with binary version v23.1.4 (17)
+│   ├── finalize upgrade by resetting `preserve_downgrade_option` (18)
+│   └── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (19)
+├── run "initialize bank workload" (20)
+├── start background hooks concurrently
+│   ├── run "bank workload", after 50ms delay (21)
+│   └── run "csv server", after 0s delay (22)
+├── upgrade cluster from "v23.1.4" to "v23.2.0"
+│   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (23)
+│   ├── upgrade nodes :1-4 from "v23.1.4" to "v23.2.0"
+│   │   ├── restart node 4 with binary version v23.2.0 (24)
+│   │   ├── run mixed-version hooks concurrently
+│   │   │   ├── run "mixed-version 1", after 100ms delay (25)
+│   │   │   └── run "mixed-version 2", after 100ms delay (26)
+│   │   ├── restart node 1 with binary version v23.2.0 (27)
+│   │   ├── restart node 2 with binary version v23.2.0 (28)
+│   │   └── restart node 3 with binary version v23.2.0 (29)
+│   ├── finalize upgrade by resetting `preserve_downgrade_option` (30)
+│   ├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (31)
+│   └── run "validate upgrade" (32)
+└── upgrade cluster from "v23.2.0" to "<current>"
+   ├── prevent auto-upgrades by setting `preserve_downgrade_option` (33)
+   ├── upgrade nodes :1-4 from "v23.2.0" to "<current>"
+   │   ├── restart node 2 with binary version <current> (34)
+   │   ├── restart node 4 with binary version <current> (35)
+   │   ├── restart node 1 with binary version <current> (36)
+   │   ├── run "mixed-version 2" (37)
+   │   ├── restart node 3 with binary version <current> (38)
+   │   └── run "mixed-version 1" (39)
+   ├── downgrade nodes :1-4 from "<current>" to "v23.2.0"
+   │   ├── restart node 3 with binary version v23.2.0 (40)
+   │   ├── run "mixed-version 1" (41)
+   │   ├── restart node 4 with binary version v23.2.0 (42)
+   │   ├── restart node 2 with binary version v23.2.0 (43)
+   │   ├── run "mixed-version 2" (44)
+   │   └── restart node 1 with binary version v23.2.0 (45)
+   ├── upgrade nodes :1-4 from "v23.2.0" to "<current>"
+   │   ├── restart node 4 with binary version <current> (46)
+   │   ├── run "mixed-version 1" (47)
+   │   ├── restart node 1 with binary version <current> (48)
+   │   ├── run "mixed-version 2" (49)
+   │   ├── restart node 2 with binary version <current> (50)
+   │   └── restart node 3 with binary version <current> (51)
+   ├── finalize upgrade by resetting `preserve_downgrade_option` (52)
+   ├── run "mixed-version 2" (53)
+   ├── wait for nodes :1-4 to all have the same cluster version (same as binary version of node 1) (54)
+   └── run "validate upgrade" (55)


### PR DESCRIPTION
In #117794, we started splitting upgrades that happen before and after the test's minimum supported version. During upgrades _before_ that version, we insert randomized wait times to let the cluster stay in those older versions (and run background jobs) for at least a few minutes.

However, the wait times could be prohibitively long for local runs in CI. To address that issue, this commit reduces wait time 10x in local runs.

Epic: none

Release note: None