### PR TITLE
sqlstats: fix update job to top sql activity stats

### DIFF
--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -182,16 +182,34 @@ type sqlActivityUpdater struct {
 	db           isql.DB
 }
 
+// TransferStatsToActivity call upsert stats function to current and prior hour.
 func (u *sqlActivityUpdater) TransferStatsToActivity(ctx context.Context) error {
+	// To improve performance we don't recalculate the entire top activity table everytime.
+	// Only update the latest hour and the one prior.
+	// We still need to recalculate the prior hour because the flush could happen during the switch of hours, and
+	// we could miss some executions completed on the prior hour.
+	aggTs := u.computeAggregatedTs(&u.st.SV)
+
+	err := u.upsertStatsForAggregatedTs(ctx, aggTs)
+	if err != nil {
+		return err
+	}
+	return u.upsertStatsForAggregatedTs(ctx, aggTs.Add(-time.Hour))
+}
+
+// upsertStatsForAggregatedTs calculates the top sql stats and update the activity table accordingly.
+func (u *sqlActivityUpdater) upsertStatsForAggregatedTs(
+	ctx context.Context, aggTs time.Time,
+) error {
 	// Get the config and pass it around to avoid any issue of it changing
 	// in the middle of the execution.
 	maxRowPersistedRows := sqlStatsActivityMaxPersistedRows.Get(&u.st.SV)
 	topLimit := sqlStatsActivityTopCount.Get(&u.st.SV)
-	aggTs := u.computeAggregatedTs(&u.st.SV)
 
 	// The counts are using AS OF SYSTEM TIME so the values may be slightly
 	// off. This is acceptable to increase the performance.
-	stmtRowCount, txnRowCount, totalEstimatedStmtClusterExecSeconds, totalEstimatedTxnClusterExecSeconds, err := u.getAostRowCountAndTotalClusterExecSeconds(ctx, aggTs)
+	stmtRowCount, txnRowCount, totalEstimatedStmtClusterExecSeconds, totalEstimatedTxnClusterExecSeconds,
+		err := u.getAostRowCountAndTotalClusterExecSeconds(ctx, aggTs)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -11,9 +11,11 @@
 package sql
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -38,8 +40,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
 )
 
@@ -477,6 +481,9 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 	}
 }
 
+// TestSqlActivityJobRunsAfterStatsFlush verifies that the
+// correct data is updated on current and prior hour when new stats are
+// added to either or both of them.
 func TestSqlActivityJobRunsAfterStatsFlush(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -726,6 +733,119 @@ func TestActivityStatusCombineAPI(t *testing.T) {
 	require.NotEmpty(t, resp.Statements)
 	require.Greater(t, resp.StmtsTotalRuntimeSecs, float32(0))
 	require.Greater(t, resp.TxnsTotalRuntimeSecs, float32(0))
+}
+
+type timeMutex struct {
+	syncutil.RWMutex
+	stubTime time.Time
+}
+
+func (mu *timeMutex) setStubTime(time time.Time) {
+	mu.Lock()
+	defer mu.Unlock()
+	mu.stubTime = time
+}
+
+func TestFlushToActivityWithDifferentAggTs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	var muStubTime timeMutex
+	muStubTime.setStubTime(timeutil.Now().Truncate(time.Hour))
+
+	sqlStatsKnobs := sqlstats.CreateTestingKnobs()
+	sqlStatsKnobs.StubTimeNow = func() time.Time {
+		muStubTime.RLock()
+		defer muStubTime.RUnlock()
+		return muStubTime.stubTime
+	}
+
+	// Start the cluster.
+	// Disable the job since it is called manually from a new instance to avoid
+	// any race conditions.
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Insecure: true,
+		Knobs: base.TestingKnobs{
+			SQLStatsKnobs: sqlStatsKnobs,
+			UpgradeManager: &upgradebase.TestingKnobs{
+				DontUseJobs:                       true,
+				SkipUpdateSQLActivityJobBootstrap: true,
+			}}})
+	defer srv.Stopper().Stop(context.Background())
+	defer sqlDB.Close()
+	ts := srv.ApplicationLayer()
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Start with empty activity tables.
+	execCfg := ts.ExecutorConfig().(ExecutorConfig)
+	st := cluster.MakeTestingClusterSettings()
+	updater := newSqlActivityUpdater(st, execCfg.InternalDB, sqlStatsKnobs)
+	require.NoError(t, updater.TransferStatsToActivity(ctx))
+	verifyActivityTablesAreEmpty(t, db)
+
+	// Use random name to keep isolated during stress tests.
+	rng, _ := randutil.NewTestRand()
+	appName := fmt.Sprintf("TestFlushToActivityWithDifferentAggTs-%d", rng.Int())
+
+	datadriven.RunTest(t, "testdata/sql_activity_update_job", func(t *testing.T, d *datadriven.TestData) string {
+		var buf bytes.Buffer
+		timeLayout := "2006-01-02 15:04:05"
+		switch d.Cmd {
+		case "update-time":
+			for _, arg := range d.CmdArgs {
+				switch arg.Key {
+				case "time":
+					time, err := time.Parse(timeLayout, arg.Vals[0])
+					require.NoError(t, err)
+					muStubTime.setStubTime(timeutil.FromUnixNanos(time.UnixNano()))
+				}
+			}
+		case "update-app":
+			for _, arg := range d.CmdArgs {
+				switch arg.Key {
+				case "ignore":
+					useIgnoreApp, err := strconv.ParseBool(arg.Vals[0])
+					require.NoError(t, err)
+					if useIgnoreApp {
+						db.Exec(t, "SET SESSION application_name=$1", "randomIgnore")
+					} else {
+						db.Exec(t, "SET SESSION application_name=$1", appName)
+					}
+				}
+			}
+		case "run-sql":
+			useAppName := false
+			var rows [][]string
+			var err error
+			for _, arg := range d.CmdArgs {
+				switch arg.Key {
+				case "useApp":
+					useAppName, err = strconv.ParseBool(arg.Vals[0])
+					require.NoError(t, err)
+				}
+			}
+			if useAppName {
+				rows = db.QueryStr(t, d.Input, appName)
+			} else {
+				rows = db.QueryStr(t, d.Input)
+			}
+
+			for _, row := range rows {
+				fmt.Fprintf(&buf, "%s\n", strings.Join(row, ","))
+			}
+		case "flush-stats":
+			ts.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
+		case "update-top-activity":
+			// Populate the Top Activity. This will use the transfer all scenarios
+			// with there only being a few rows.
+			require.NoError(t, updater.TransferStatsToActivity(ctx))
+		}
+
+		return buf.String()
+	})
 }
 
 // duplicateRowHelper duplicates a single row in each statistics table, but slightly

--- a/pkg/sql/testdata/sql_activity_update_job
+++ b/pkg/sql/testdata/sql_activity_update_job
@@ -1,0 +1,151 @@
+# On this test we will first start by adding fingerprint A and B to time X
+# Then we will add more executions of A into time X and also time X+1, and a new fingerprint C to time X+1
+# The goal is to check the top activity table will get properly updated for both X and X+1 for all different
+# fingerprint cases.
+# For this test we use:
+# A= SELECT 1
+# B: SELECT 1 WHERE 1=1
+# C: SELECT 1 WHERE 1=1 and 2=2
+# X: 2024-01-01 1:00 (and consequently X+1 will be 2024-01-01 2:00)
+
+# Add Stats for X:00
+update-time time=(2024-01-01 1:00:00)
+----
+
+# Set an application to make easier for look for specific cases during the check.
+update-app ignore=false
+----
+
+run-sql
+SELECT 1
+----
+1
+
+run-sql
+SELECT 1 WHERE 1=1
+----
+1
+
+flush-stats
+----
+
+update-top-activity
+----
+
+# Change the application so all the queries used for checking values do not influence the results.
+update-app ignore=true
+----
+
+# Check the values got properly added to the system tables.
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'query' as query, statistics -> 'statistics' -> 'cnt' as count FROM
+system.statement_statistics WHERE app_name = $1 ORDER BY aggregated_ts, metadata -> 'query'
+----
+2024-01-01 01:00:00 +0000 UTC,"SELECT _",1
+2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
+
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM
+system.transaction_statistics WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
+----
+2024-01-01 01:00:00 +0000 UTC,["834459cc775811bf"],1
+2024-01-01 01:00:00 +0000 UTC,["df3c70bf7729b433"],1
+
+# Check the values got properly added to the top activity tables.
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'query' as query, statistics -> 'statistics' -> 'cnt' as count FROM
+system.statement_activity WHERE app_name = $1 ORDER BY aggregated_ts, metadata -> 'query'
+----
+2024-01-01 01:00:00 +0000 UTC,"SELECT _",1
+2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
+
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM
+system.transaction_activity WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
+----
+2024-01-01 01:00:00 +0000 UTC,["834459cc775811bf"],1
+2024-01-01 01:00:00 +0000 UTC,["df3c70bf7729b433"],1
+
+# Change the app name back, so new stats can be added.
+update-app ignore=false
+----
+
+# Add more Stats for X:00
+run-sql
+SELECT 1
+----
+1
+
+run-sql
+SELECT 1
+----
+1
+
+flush-stats
+----
+
+# Add Stats for X+1:00
+update-time time=(2024-01-01 2:00:00)
+----
+
+run-sql
+SELECT 1
+----
+1
+
+run-sql
+SELECT 1 WHERE 1=1 AND 2=2
+----
+1
+
+flush-stats
+----
+
+update-top-activity
+----
+
+# Change the application so all the queries used for checking values do not influence the results.
+update-app ignore=true
+----
+
+# Check the values got properly added to the system tables
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'query' as query, statistics -> 'statistics' -> 'cnt' as count FROM
+system.statement_statistics WHERE app_name = $1 ORDER BY aggregated_ts, metadata -> 'query'
+----
+2024-01-01 01:00:00 +0000 UTC,"SELECT _",3
+2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
+2024-01-01 01:00:00 +0000 UTC,"SET application_name = $1",1
+2024-01-01 02:00:00 +0000 UTC,"SELECT _",1
+2024-01-01 02:00:00 +0000 UTC,"SELECT _ WHERE (_ = _) AND (_ = _)",1
+
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM
+system.transaction_statistics WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
+----
+2024-01-01 01:00:00 +0000 UTC,["834459cc775811bf"],1
+2024-01-01 01:00:00 +0000 UTC,["df3c70bf7729b433"],3
+2024-01-01 01:00:00 +0000 UTC,["6434c26660c3efee"],1
+2024-01-01 02:00:00 +0000 UTC,["df3c70bf7729b433"],1
+2024-01-01 02:00:00 +0000 UTC,["0a8121f073e118d9"],1
+
+# Check the values got properly added to the top activity tables
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'query' as query, statistics -> 'statistics' -> 'cnt' as count FROM
+system.statement_activity WHERE app_name = $1 ORDER BY aggregated_ts, metadata -> 'query'
+----
+2024-01-01 01:00:00 +0000 UTC,"SELECT _",3
+2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
+2024-01-01 01:00:00 +0000 UTC,"SET application_name = $1",1
+2024-01-01 02:00:00 +0000 UTC,"SELECT _",1
+2024-01-01 02:00:00 +0000 UTC,"SELECT _ WHERE (_ = _) AND (_ = _)",1
+
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM
+system.transaction_activity WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
+----
+2024-01-01 01:00:00 +0000 UTC,["834459cc775811bf"],1
+2024-01-01 01:00:00 +0000 UTC,["df3c70bf7729b433"],3
+2024-01-01 01:00:00 +0000 UTC,["6434c26660c3efee"],1
+2024-01-01 02:00:00 +0000 UTC,["df3c70bf7729b433"],1
+2024-01-01 02:00:00 +0000 UTC,["0a8121f073e118d9"],1


### PR DESCRIPTION
Previously, the job to update the top sql activity table was only recalculating the current hour to improve on performance and avoid the recalculation of the entire table.
This was causing a problem during the change of hour where stats from the prior hour could not have been added to the top activity table.
This commit fixes this issue by always recalculating the current and priror hour.
It also adds tests to confirm this fix (I was able to confirm the tests fail without this fix).

Fixes #118326

Release note (bug fix): Recalculate properly the value from current and past hour on top Activity table, fixing the issue where we were missing data on sql stats and consequently missing data on the SQL Activity page.