### PR TITLE
cmd/reduce: add sort to -costfuzz and -unoptimized-query-oracle cmp

### DIFF
--- a/pkg/cmd/reduce/BUILD.bazel
+++ b/pkg/cmd/reduce/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/cmd/reduce/reduce/reducesql",
         "//pkg/util/envutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_google_go_cmp//cmp",
     ],
 )
 


### PR DESCRIPTION
When reducing costfuzz and unoptimized-query-oracle failures, we compare two query results to find a failure. This comparison was producing false positives for rows with a different ordering. Add a sort before the comparison to eliminate some false positives.

This doesn't exactly match the comparison used by costfuzz and unoptimized-query-oracle, but that comparison relies on a proper SQL driver which we don't have in reduce. This comparison with sort seems like a good enough improvement for now, which we can revisit if costfuzz or unoptimized-query-oracle find another case that cannot be reduced.

Informs: #118273

Release note: None