### PR TITLE
roachtest: add roachtest.Operation and run-operation command

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -1157,6 +1157,8 @@ GO_TARGETS = [
     "//pkg/cmd/roachtest/clusterstats:clusterstats",
     "//pkg/cmd/roachtest/clusterstats:clusterstats_test",
     "//pkg/cmd/roachtest/grafana:grafana",
+    "//pkg/cmd/roachtest/operation:operation",
+    "//pkg/cmd/roachtest/operations:operations",
     "//pkg/cmd/roachtest/option:option",
     "//pkg/cmd/roachtest/option:option_test",
     "//pkg/cmd/roachtest/registry:registry",

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/build",
         "//pkg/cmd/internal/issues",
         "//pkg/cmd/roachtest/cluster",
+        "//pkg/cmd/roachtest/operations",
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/roachtestflags",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -316,11 +316,15 @@ func initBinariesAndLibraries() {
 	cockroachPath := roachtestflags.CockroachPath
 	cockroachEAPath := roachtestflags.CockroachEAPath
 	workloadPath := roachtestflags.WorkloadPath
-	cockroach[defaultArch], _ = resolveBinary("cockroach", cockroachPath, defaultArch, true, false)
-	workload[defaultArch], _ = resolveBinary("workload", workloadPath, defaultArch, true, false)
-	cockroachEA[defaultArch], err = resolveBinary("cockroach-ea", cockroachEAPath, defaultArch, false, true)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARN: unable to find %q for %q: %s\n", "cockroach-ea", defaultArch, err)
+	// If a remote cockroach binary has been specified, we don't need to resolve
+	// cockroach/workload binaries.
+	if roachtestflags.CockroachBinaryPath == "" {
+		cockroach[defaultArch], _ = resolveBinary("cockroach", cockroachPath, defaultArch, true, false)
+		workload[defaultArch], _ = resolveBinary("workload", workloadPath, defaultArch, true, false)
+		cockroachEA[defaultArch], err = resolveBinary("cockroach-ea", cockroachEAPath, defaultArch, false, true)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARN: unable to find %q for %q: %s\n", "cockroach-ea", defaultArch, err)
+		}
 	}
 
 	if roachtestflags.ARM64Probability > 0 && defaultArch != vm.ArchARM64 {
@@ -973,8 +977,9 @@ func (f *clusterFactory) newCluster(
 type attachOpt struct {
 	skipValidation bool
 	// Implies skipWipe.
-	skipStop bool
-	skipWipe bool
+	skipStop                   bool
+	skipWipe                   bool
+	tolerateRegistrationErrors bool
 }
 
 // attachToExistingCluster creates a cluster object based on machines that have
@@ -1011,7 +1016,7 @@ func attachToExistingCluster(
 		}
 	}
 
-	if err := r.registerCluster(c); err != nil {
+	if err := r.registerCluster(c); err != nil && !opt.tolerateRegistrationErrors {
 		return nil, err
 	}
 
@@ -1066,7 +1071,7 @@ func (c *clusterImpl) StopCockroachGracefullyOnNode(
 
 // Save marks the cluster as "saved" so that it doesn't get destroyed.
 func (c *clusterImpl) Save(ctx context.Context, msg string, l *logger.Logger) {
-	l.PrintfCtx(ctx, "saving cluster %s for debugging (--debug specified)", c)
+	l.PrintfCtx(ctx, "saving cluster %s (--debug specified or running operation)", c)
 	c.r.markClusterAsSaved(c, msg)
 	c.destroyState.mu.Lock()
 	c.destroyState.mu.saved = true
@@ -1820,17 +1825,18 @@ func (c *clusterImpl) PutE(
 // nodes in the cluster. By default, we randomly upload a binary with or without
 // runtime assertions enabled. Note that we upload to all nodes even if they
 // don't use the binary, so that the test runner can always fetch logs.
-func (c *clusterImpl) PutCockroach(ctx context.Context, l *logger.Logger, t *testImpl) error {
-	switch t.spec.CockroachBinary {
+func (c *clusterImpl) PutCockroach(ctx context.Context, l *logger.Logger, t test.Test) error {
+	binaryType := t.(*testImpl).spec.CockroachBinary
+	switch binaryType {
 	case registry.RandomizedCockroach:
 		if tests.UsingRuntimeAssertions(t) {
-			t.l.Printf("To reproduce the same set of metamorphic constants, run this test with %s=%d", test.EnvAssertionsEnabledSeed, c.cockroachRandomSeed())
+			t.L().Printf("To reproduce the same set of metamorphic constants, run this test with %s=%d", test.EnvAssertionsEnabledSeed, c.cockroachRandomSeed())
 		}
 		return c.PutE(ctx, l, t.Cockroach(), test.DefaultCockroachPath, c.All())
 	case registry.StandardCockroach:
 		return c.PutE(ctx, l, t.StandardCockroach(), test.DefaultCockroachPath, c.All())
 	case registry.RuntimeAssertionsCockroach:
-		t.l.Printf("To reproduce the same set of metamorphic constants, run this test with %s=%d", test.EnvAssertionsEnabledSeed, c.cockroachRandomSeed())
+		t.L().Printf("To reproduce the same set of metamorphic constants, run this test with %s=%d", test.EnvAssertionsEnabledSeed, c.cockroachRandomSeed())
 		return c.PutE(ctx, l, t.RuntimeAssertionsCockroach(), test.DefaultCockroachPath, c.All())
 	default:
 		return errors.Errorf("Specified cockroach binary does not exist.")
@@ -2861,6 +2867,12 @@ func (c *clusterImpl) MaybeExtendCluster(
 	ctx context.Context, l *logger.Logger, testSpec *registry.TestSpec,
 ) error {
 	timeout := testTimeout(testSpec)
+	return c.MaybeExtendClusterForTimeout(ctx, l, timeout)
+}
+
+func (c *clusterImpl) MaybeExtendClusterForTimeout(
+	ctx context.Context, l *logger.Logger, timeout time.Duration,
+) error {
 	minExp := timeutil.Now().Add(timeout + time.Hour)
 	if c.expiration.Before(minExp) {
 		extend := minExp.Sub(c.expiration)

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operations"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests"
@@ -179,9 +180,31 @@ the cluster nodes on start.
 	}
 	roachtestflags.AddRunFlags(benchCmd.Flags())
 
+	var runOperationCmd = &cobra.Command{
+		// Don't display usage when tests fail.
+		SilenceUsage: true,
+		Use:          "run-operation [regex...]",
+		Short:        "run operations on cockroach cluster",
+		Long:         `Run automated operations on existing clusters.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := initRunFlagsBinariesAndLibraries(cmd); err != nil {
+				return err
+			}
+			filter, err := makeTestFilter(args)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("\nRunning %s.\n\n", filter.String())
+			cmd.SilenceUsage = true
+			return runOperations(operations.RegisterOperations, filter)
+		},
+	}
+	roachtestflags.AddRunOpsFlags(runOperationCmd.Flags())
+
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(benchCmd)
+	rootCmd.AddCommand(runOperationCmd)
 
 	var err error
 	config.OSUser, err = user.Current()
@@ -261,6 +284,94 @@ func testsToRun(
 	}
 
 	return selectSpecs(notSkipped, selectProbability, true, print), nil
+}
+
+func opsToRun(
+	r testRegistryImpl,
+	filter *registry.TestFilter,
+	runSkipped bool,
+	selectProbability float64,
+	print bool,
+) ([]registry.OperationSpec, error) {
+	specs := filter.FilterOps(r.AllOperations())
+	if len(specs) == 0 {
+		return nil, errors.New("no matching operations to run")
+	}
+
+	var notSkipped []registry.OperationSpec
+	for _, s := range specs {
+		if s.Skip == "" || runSkipped {
+			notSkipped = append(notSkipped, s)
+		} else {
+			if print && roachtestflags.TeamCity {
+				fmt.Fprintf(os.Stdout, "##teamcity[testIgnored name='%s' message='%s']\n",
+					s.Name, TeamCityEscape(s.Skip))
+			}
+			if print {
+				fmt.Fprintf(os.Stdout, "--- SKIP: %s (%s)\n\t%s\n", s.Name, "0.00s", s.Skip)
+			}
+		}
+	}
+
+	if print {
+		// We want to show information about all operations which match the
+		// pattern(s) but were excluded for other reasons.
+		relaxedFilter := registry.TestFilter{
+			Name: filter.Name,
+		}
+		for _, s := range relaxedFilter.FilterOps(r.AllOperations()) {
+			if matches, r := filter.MatchesOp(&s); !matches {
+				reason := filter.MatchFailReasonString(r)
+				// This test matches the "relaxed" filter but not the original filter.
+				if roachtestflags.TeamCity {
+					fmt.Fprintf(os.Stdout, "##teamcity[testIgnored name='%s' message='%s']\n", s.Name, reason)
+				}
+				fmt.Fprintf(os.Stdout, "--- SKIP: %s (%s)\n\t%s\n", s.Name, "0.00s", reason)
+			}
+		}
+	}
+
+	return selectOpSpecs(notSkipped, selectProbability, print), nil
+}
+
+func selectOpSpecs(
+	specs []registry.OperationSpec, samplePct float64, print bool,
+) []registry.OperationSpec {
+	if samplePct == 1 || len(specs) == 0 {
+		return specs
+	}
+
+	var sampled []registry.OperationSpec
+	var selectedIdxs []int
+
+	// Selects one random spec from the range [start, end) and appends it to sampled.
+	for i, s := range specs {
+		if rand.Float64() < samplePct {
+			sampled = append(sampled, s)
+			selectedIdxs = append(selectedIdxs, i)
+			continue
+		}
+	}
+
+	p := 0
+	// This loop depends on an ordered list as we are essentially
+	// skipping all values in between the selected indexes.
+	for _, i := range selectedIdxs {
+		for j := p; j < i; j++ {
+			s := specs[j]
+			if print && roachtestflags.TeamCity {
+				fmt.Fprintf(os.Stdout, "##teamcity[testIgnored name='%s' message='excluded via sampling']\n",
+					s.Name)
+			}
+
+			if print {
+				fmt.Fprintf(os.Stdout, "--- SKIP: %s (%s)\n\texcluded via sampling\n", s.Name, "0.00s")
+			}
+		}
+		p = i + 1
+	}
+
+	return sampled
 }
 
 // selectSpecs returns a random sample of the given test specs.

--- a/pkg/cmd/roachtest/operation/BUILD.bazel
+++ b/pkg/cmd/roachtest/operation/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "operation",
+    srcs = ["operation_interface.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/cmd/roachtest/test"],
+)

--- a/pkg/cmd/roachtest/operation/operation_interface.go
+++ b/pkg/cmd/roachtest/operation/operation_interface.go
@@ -1,0 +1,22 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package operation
+
+import "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+
+type Operation interface {
+	// TODO(bilal): Instead of encapsulating test.Test, copy over the small
+	// set of relevant methods, ideally moving them to a shared interface.
+	test.Test
+
+	GetCleanupState(string) string
+	SetCleanupState(string, string)
+}

--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "operations",
+    srcs = [
+        "add_column.go",
+        "add_index.go",
+        "register.go",
+        "utils.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operations",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/cmd/roachtest/cluster",
+        "//pkg/cmd/roachtest/operation",
+        "//pkg/cmd/roachtest/option",
+        "//pkg/cmd/roachtest/registry",
+        "//pkg/cmd/roachtest/roachtestflags",
+        "//pkg/cmd/roachtest/test",
+        "//pkg/util/randutil",
+    ],
+)

--- a/pkg/cmd/roachtest/operations/add_column.go
+++ b/pkg/cmd/roachtest/operations/add_column.go
@@ -1,0 +1,74 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func runAddColumn(ctx context.Context, o operation.Operation, c cluster.Cluster) {
+	conn := c.Conn(ctx, o.L(), 1, option.TenantName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	rng, _ := randutil.NewPseudoRand()
+	dbName := pickRandomDB(ctx, o, conn)
+	tableName := pickRandomTable(ctx, o, conn, dbName)
+	o.SetCleanupState("db", dbName)
+	o.SetCleanupState("table", tableName)
+
+	colName := fmt.Sprintf("add_column_op_%d", rng.Uint32())
+	o.Status(fmt.Sprintf("adding column %s to table %s.%s", colName, dbName, tableName))
+	addColStmt := fmt.Sprintf("ALTER TABLE %s.%s ADD COLUMN %s VARCHAR DEFAULT 'default'", dbName, tableName, colName)
+	_, err := conn.ExecContext(ctx, addColStmt)
+	if err != nil {
+		o.Fatal(err)
+	}
+	o.SetCleanupState("column", colName)
+
+	o.Status(fmt.Sprintf("column %s created", colName))
+}
+
+func cleanupAddColumn(ctx context.Context, o operation.Operation, c cluster.Cluster) {
+	conn := c.Conn(ctx, o.L(), 1, option.TenantName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	dbName := o.GetCleanupState("db")
+	tableName := o.GetCleanupState("table")
+	columnName := o.GetCleanupState("column")
+
+	o.Status(fmt.Sprintf("dropping column %s", columnName))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s.%s DROP COLUMN %s CASCADE", dbName, tableName, columnName))
+	if err != nil {
+		o.Fatal(err)
+	}
+}
+
+func registerAddColumn(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:             "add-column",
+		Owner:            registry.OwnerSQLFoundations,
+		Timeout:          24 * time.Hour,
+		CompatibleClouds: registry.AllClouds,
+		Dependency:       registry.OperationRequiresDatabaseSchema,
+		Run:              runAddColumn,
+		CleanupWaitTime:  5 * time.Minute,
+		Cleanup:          cleanupAddColumn,
+	})
+}

--- a/pkg/cmd/roachtest/operations/add_index.go
+++ b/pkg/cmd/roachtest/operations/add_index.go
@@ -1,0 +1,87 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func runAddIndex(ctx context.Context, o operation.Operation, c cluster.Cluster) {
+	conn := c.Conn(ctx, o.L(), 1, option.TenantName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	rng, _ := randutil.NewPseudoRand()
+	dbName := pickRandomDB(ctx, o, conn)
+	tableName := pickRandomTable(ctx, o, conn, dbName)
+	o.SetCleanupState("db", dbName)
+	o.SetCleanupState("table", tableName)
+
+	rows, err := conn.QueryContext(ctx, fmt.Sprintf("SELECT column_name FROM [SHOW COLUMNS FROM %s.%s]", dbName, tableName))
+	if err != nil {
+		o.Fatal(err)
+	}
+	rows.Next()
+	if !rows.Next() {
+		o.Fatalf("not enough columns in table %s.%s", dbName, tableName)
+	}
+	var colName string
+	if err := rows.Scan(&colName); err != nil {
+		o.Fatal(err)
+	}
+
+	indexName := fmt.Sprintf("add_index_op_%d", rng.Uint32())
+	o.Status(fmt.Sprintf("adding index to column %s", colName))
+	createIndexStmt := fmt.Sprintf("CREATE INDEX %s ON %s.%s (%s)", indexName, dbName, tableName, colName)
+	_, err = conn.ExecContext(ctx, createIndexStmt)
+	if err != nil {
+		o.Fatal(err)
+	}
+	o.SetCleanupState("index", indexName)
+
+	o.Status(fmt.Sprintf("index %s created", indexName))
+}
+
+func cleanupAddIndex(ctx context.Context, o operation.Operation, c cluster.Cluster) {
+	conn := c.Conn(ctx, o.L(), 1, option.TenantName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	dbName := o.GetCleanupState("db")
+	tableName := o.GetCleanupState("table")
+	indexName := o.GetCleanupState("index")
+
+	o.Status(fmt.Sprintf("dropping index %s", indexName))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP INDEX %s.%s@%s", dbName, tableName, indexName))
+	if err != nil {
+		o.Fatal(err)
+	}
+}
+
+func registerAddIndex(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:             "add-index",
+		Owner:            registry.OwnerSQLFoundations,
+		Timeout:          24 * time.Hour,
+		CompatibleClouds: registry.AllClouds,
+		Dependency:       registry.OperationRequiresDatabaseSchema,
+		Run:              runAddIndex,
+		CleanupWaitTime:  5 * time.Minute,
+		Cleanup:          cleanupAddIndex,
+	})
+}

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -1,0 +1,19 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package operations
+
+import "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+
+// RegisterOperations registers all tests to the Registry. This powers `roachtest run-operations`.
+func RegisterOperations(r registry.Registry) {
+	registerAddIndex(r)
+	registerAddColumn(r)
+}

--- a/pkg/cmd/roachtest/operations/utils.go
+++ b/pkg/cmd/roachtest/operations/utils.go
@@ -1,0 +1,78 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package operations
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func pickRandomDB(ctx context.Context, o test.Test, conn *gosql.DB) string {
+	rng, _ := randutil.NewPseudoRand()
+
+	// Pick a random table.
+	dbs, err := conn.QueryContext(ctx, "SELECT database_name FROM [SHOW DATABASES]")
+	if err != nil {
+		o.Fatal(err)
+		return ""
+	}
+	var dbNames []string
+	for dbs.Next() {
+		var dbName string
+		if err := dbs.Scan(&dbName); err != nil {
+			o.Fatal(err)
+			return ""
+		}
+		if dbName == "system" || dbName == "information_schema" || dbName == "crdb_internal" || dbName == "defaultdb" || dbName == "postgres" {
+			continue
+		}
+		dbNames = append(dbNames, dbName)
+	}
+	if len(dbNames) == 0 {
+		o.Fatalf("unexpected zero active dbs found in cluster")
+		return ""
+	}
+	return dbNames[rng.Intn(len(dbNames))]
+}
+
+func pickRandomTable(ctx context.Context, o test.Test, conn *gosql.DB, dbName string) string {
+	rng, _ := randutil.NewPseudoRand()
+
+	// Pick a random table.
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE %s", dbName)); err != nil {
+		o.Fatal(err)
+		return ""
+	}
+
+	tables, err := conn.QueryContext(ctx, "SELECT table_name FROM [SHOW TABLES]")
+	if err != nil {
+		o.Fatal(err)
+		return ""
+	}
+	var tableNames []string
+	for tables.Next() {
+		var tableName string
+		if err := tables.Scan(&tableName); err != nil {
+			o.Fatal(err)
+			return ""
+		}
+		tableNames = append(tableNames, tableName)
+	}
+	if len(tableNames) == 0 {
+		o.Fatalf("unexpected zero active tables found in db %s", dbName)
+		return ""
+	}
+	return tableNames[rng.Intn(len(tableNames))]
+}

--- a/pkg/cmd/roachtest/registry/BUILD.bazel
+++ b/pkg/cmd/roachtest/registry/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "encryption.go",
         "errors.go",
         "filter.go",
+        "operation_spec.go",
         "owners.go",
         "registry_interface.go",
         "tag.go",
@@ -15,6 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cmd/roachtest/cluster",
+        "//pkg/cmd/roachtest/operation",
         "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/test",
         "//pkg/internal/team",

--- a/pkg/cmd/roachtest/registry/operation_spec.go
+++ b/pkg/cmd/roachtest/registry/operation_spec.go
@@ -1,0 +1,130 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+)
+
+// OperationDependency specifies what an operation requires
+type OperationDependency int
+
+const (
+	OperationRequiresNodes OperationDependency = iota
+	OperationRequiresSqlConnection
+	OperationRequiresDatabaseSchema
+	OperationRequiresPopulatedDatabase
+)
+
+// OperationSpec is a spec for a roachtest operation.
+type OperationSpec struct {
+	Skip string // if non-empty, operation will be skipped
+
+	Name string
+	// Owner is the name of the team responsible for signing off on failures of
+	// this operation that happen in the release process. This must be one of a limited
+	// set of values (the keys in the roachtestTeams map).
+	Owner Owner
+	// The maximum duration the operation is allowed to run before it is considered
+	// failed.
+	Timeout time.Duration
+
+	// CompatibleClouds is the set of clouds this test can run on (e.g. AllClouds,
+	// OnlyGCE, etc). Must be set.
+	CompatibleClouds CloudSet
+
+	// Dependency specify the types of resources required for this roachtest
+	// operation to work. This will be used to match this operation up with
+	// eligible clusters to run.
+	//
+	// TODO(bilal): Unused.
+	Dependency OperationDependency
+
+	// CanRunConcurrently specifies whether this operation is safe to run
+	// concurrently with other operations that have CanRunConcurrently = true.
+	// For instance, two random-index additions are safe to run concurrently,
+	// while a drop would need to run on its own and will have
+	// CanRunConcurrently = false.
+	//
+	// TODO(bilal): Unused.
+	CanRunConcurrently bool
+
+	// RequiresLicense indicates that the operation requires an
+	// enterprise license to run correctly. Use this to ensure
+	// operation will fail-early if COCKROACH_DEV_LICENSE is not set
+	// in the environment.
+	RequiresLicense bool
+
+	// Run is the operation function.
+	Run func(ctx context.Context, o operation.Operation, c cluster.Cluster)
+
+	// CleanupWaitTime is the min time to wait before running the Cleanup method.
+	CleanupWaitTime time.Duration
+
+	// Cleanup is the operation cleanup function, if defined.
+	Cleanup func(ctx context.Context, o operation.Operation, c cluster.Cluster)
+}
+
+// TestSpec() converts this operation to a TestSpec for use with roachtest run-operation.
+func (s *OperationSpec) TestSpec() TestSpec {
+	return TestSpec{
+		Skip:              s.Skip,
+		Name:              s.Name,
+		Owner:             s.Owner,
+		Timeout:           s.Timeout,
+		Benchmark:         false,
+		Cluster:           spec.ClusterSpec{NodeCount: 1},
+		CompatibleClouds:  AllClouds,
+		NonReleaseBlocker: true,
+		Operation:         true,
+		RequiresLicense:   s.RequiresLicense,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			wrapper := &operationWrapper{Test: t, cleanupState: make(map[string]string)}
+			s.Run(ctx, wrapper, c)
+
+			if s.Cleanup != nil {
+				t.Status(fmt.Sprintf("operation ran successfully; waiting %s before cleanup", s.CleanupWaitTime.String()))
+				if s.CleanupWaitTime != 0 {
+					select {
+					case <-ctx.Done():
+						t.Status("bailing due to cancellation")
+						return
+					case <-time.After(s.CleanupWaitTime):
+					}
+				}
+
+				s.Cleanup(ctx, wrapper, c)
+			}
+		},
+		CockroachBinary: StandardCockroach,
+	}
+}
+
+// operationWrapper turns a test.Test into an operation.Operation.
+type operationWrapper struct {
+	test.Test
+	cleanupState map[string]string
+}
+
+func (o *operationWrapper) SetCleanupState(key, value string) {
+	o.cleanupState[key] = value
+}
+
+func (o *operationWrapper) GetCleanupState(key string) string {
+	return o.cleanupState[key]
+}

--- a/pkg/cmd/roachtest/registry/registry_interface.go
+++ b/pkg/cmd/roachtest/registry/registry_interface.go
@@ -20,5 +20,6 @@ import (
 type Registry interface {
 	MakeClusterSpec(nodeCount int, opts ...spec.Option) spec.ClusterSpec
 	Add(TestSpec)
+	AddOperation(OperationSpec)
 	PromFactory() promauto.Factory
 }

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -55,6 +55,12 @@ type TestSpec struct {
 	// Thus, they must be opted into explicitly via this field.
 	Benchmark bool
 
+	// Denotes whether this test is a roachtest Operation. If true, the test is
+	// expected to not do any setup/teardown and is likely already running with a
+	// Cockroach process. Furthermore, a Cockroach/workload binary should *not*
+	// be loaded onto this node.
+	Operation bool
+
 	// CompatibleClouds is the set of clouds this test can run on (e.g. AllClouds,
 	// OnlyGCE, etc). Must be set.
 	CompatibleClouds CloudSet

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -65,8 +65,8 @@ var (
 		Usage: `Include tests that are not marked as compatible with the cloud used`,
 	})
 
-	ClusterNames string
-	_            = registerRunFlag(&ClusterNames, FlagInfo{
+	ClusterNames    string
+	clusterFlagInfo = FlagInfo{
 		Name:      "cluster",
 		Shorthand: "c",
 		Usage: `
@@ -74,7 +74,9 @@ var (
 			tests. If fewer than --parallelism names are specified, then the
 			parallelism is capped to the number of clusters specified. When a cluster
 			does not exist yet, it is created according to the spec.`,
-	})
+	}
+	_ = registerRunFlag(&ClusterNames, clusterFlagInfo)
+	_ = registerRunOpsFlag(&ClusterNames, clusterFlagInfo)
 
 	Local bool
 	_     = registerRunFlag(&Local, FlagInfo{
@@ -96,6 +98,24 @@ var (
 	_             = registerRunFlag(&CockroachPath, FlagInfo{
 		Name:  "cockroach",
 		Usage: `Absolute path to cockroach binary to use`,
+	})
+
+	CockroachBinaryPath string
+	_                   = registerRunOpsFlag(&CockroachBinaryPath, FlagInfo{
+		Name:  "cockroach-binary",
+		Usage: `Relative path to cockroach binary to use, on the cluster specified in --cluster`,
+	})
+
+	CertsDir string
+	_        = registerRunOpsFlag(&CertsDir, FlagInfo{
+		Name:  "certs-dir",
+		Usage: `Absolute path to certificates directory, if the cluster specified in --cluster is secure`,
+	})
+
+	VirtualCluster string
+	_              = registerRunOpsFlag(&VirtualCluster, FlagInfo{
+		Name:  "virtual-cluster",
+		Usage: `Specifies virtual cluster to connect to, within the specified --cluster.`,
 	})
 
 	CockroachEAPath string
@@ -141,11 +161,13 @@ var (
 
 	// ArtifactsDir is a path to a local dir where the test logs and artifacts
 	// collected from cluster will be placed.
-	ArtifactsDir string = "artifacts"
-	_                   = registerRunFlag(&ArtifactsDir, FlagInfo{
+	ArtifactsDir  string = "artifacts"
+	ArtifactsFlag        = FlagInfo{
 		Name:  "artifacts",
 		Usage: `Path to artifacts directory`,
-	})
+	}
+	_ = registerRunFlag(&ArtifactsDir, ArtifactsFlag)
+	_ = registerRunOpsFlag(&ArtifactsDir, ArtifactsFlag)
 
 	// LiteralArtifactsDir is a path to the literal on-agent directory where
 	// artifacts are stored. May be different from `artifacts`. Only used for
@@ -242,11 +264,12 @@ var (
 			https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes)`,
 	})
 
-	CPUQuota int = 300
-	_            = registerRunFlag(&CPUQuota, FlagInfo{
+	CPUQuota         int = 300
+	cpuQuotaFlagInfo     = FlagInfo{
 		Name:  "cpu-quota",
 		Usage: `The number of cloud CPUs roachtest is allowed to use at any one time.`,
-	})
+	}
+	_ = registerRunFlag(&CPUQuota, cpuQuotaFlagInfo)
 
 	HTTPPort int = 0
 	_            = registerRunFlag(&HTTPPort, FlagInfo{
@@ -405,6 +428,12 @@ func AddRunFlags(cmdFlags *pflag.FlagSet) {
 	globalMan.AddFlagsToCommand(runCmdID, cmdFlags)
 }
 
+// AddRunOpsFlags adds all flags registered for the run-operations command to
+// the given command flag set.
+func AddRunOpsFlags(cmdFlags *pflag.FlagSet) {
+	globalMan.AddFlagsToCommand(runOpsCmdID, cmdFlags)
+}
+
 // Changed returns true if a flag associated with a given value was present.
 //
 // For example: roachtestflags.Changed(&roachtestflags.Cloud) returns true if
@@ -423,5 +452,10 @@ func registerListFlag(valPtr interface{}, info FlagInfo) struct{} {
 
 func registerRunFlag(valPtr interface{}, info FlagInfo) struct{} {
 	globalMan.RegisterFlag(runCmdID, valPtr, info)
+	return struct{}{}
+}
+
+func registerRunOpsFlag(valPtr interface{}, info FlagInfo) struct{} {
+	globalMan.RegisterFlag(runOpsCmdID, valPtr, info)
 	return struct{}{}
 }

--- a/pkg/cmd/roachtest/roachtestflags/manager.go
+++ b/pkg/cmd/roachtest/roachtestflags/manager.go
@@ -23,6 +23,7 @@ type cmdID int
 const (
 	listCmdID cmdID = iota
 	runCmdID
+	runOpsCmdID
 	numCmdIDs
 )
 

--- a/pkg/cmd/roachtest/slack.go
+++ b/pkg/cmd/roachtest/slack.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/slack-go/slack"
 )
 
@@ -50,13 +51,13 @@ func findChannel(client *slack.Client, name string, nextCursor string) (string, 
 	return "", fmt.Errorf("not found")
 }
 
-func sortTests(tests []*testImpl) {
+func sortTests(tests []test.Test) {
 	sort.Slice(tests, func(i, j int) bool {
 		return tests[i].Name() < tests[j].Name()
 	})
 }
 
-func postSlackReport(pass, fail, skip map[*testImpl]struct{}) {
+func postSlackReport(pass, fail, skip map[test.Test]struct{}) {
 	client := makeSlackClient()
 	if client == nil {
 		return
@@ -104,7 +105,7 @@ func postSlackReport(pass, fail, skip map[*testImpl]struct{}) {
 	}
 
 	data := []struct {
-		tests map[*testImpl]struct{}
+		tests map[test.Test]struct{}
 		title string
 		color string
 	}{
@@ -113,7 +114,7 @@ func postSlackReport(pass, fail, skip map[*testImpl]struct{}) {
 		{skip, "Skipped", "warning"},
 	}
 	for _, d := range data {
-		tests := make([]*testImpl, 0, len(d.tests))
+		tests := make([]test.Test, 0, len(d.tests))
 		for t := range d.tests {
 			tests = append(tests, t)
 		}

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -155,6 +156,13 @@ func (t *testImpl) Cockroach() string {
 	// as it will slow down performance.
 	if t.spec.Benchmark {
 		t.l.Printf("Benchmark test, running with standard cockroach")
+		return t.StandardCockroach()
+	}
+	if t.spec.Operation {
+		t.l.Printf("Operation, running with passed-in Cockroach")
+		if roachtestflags.CockroachBinaryPath != "" {
+			return roachtestflags.CockroachBinaryPath
+		}
 		return t.StandardCockroach()
 	}
 	t.randomCockroachOnce.Do(func() {

--- a/pkg/cmd/roachtest/tests/restore_test.go
+++ b/pkg/cmd/roachtest/tests/restore_test.go
@@ -36,6 +36,10 @@ func (m *mockRegistry) Add(spec registry.TestSpec) {
 	m.testNames = append(m.testNames, spec.Name)
 }
 
+func (m *mockRegistry) AddOperation(spec registry.OperationSpec) {
+	// No-op for now.
+}
+
 func (m *mockRegistry) PromFactory() promauto.Factory {
 	return promauto.With(nil)
 }


### PR DESCRIPTION
This change adds the ability to write roachtest Operations that, unlike a full-on roachtest.Test, do not require an ephemeral cluster to be spun up or down. These operations are expected to have as few logical side effects as possible and can be run on a cluster with running workloads. Running an Operation using `roachtest run-operation` also guarantees that the Cockroach/Workload binaries on that node will not be swapped with local ones, and that the cluster won't be wiped unintentionally at the end or in case of error.

This change also adds add-index and add-column as two example operations that operate in SQL land and demonstrate the purpose of an Operation.

Epic: none.

Release note: None.