### PR TITLE
sql: prevent connection closure with nested arrays and binary format

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3950,8 +3950,12 @@ func (ex *connExecutor) handleWaitingForConcurrentSchemaChanges(
 func (ex *connExecutor) initStatementResult(
 	ctx context.Context, res RestrictedCommandResult, ast tree.Statement, cols colinfo.ResultColumns,
 ) error {
-	for _, c := range cols {
-		if err := checkResultType(c.Typ); err != nil {
+	for i, c := range cols {
+		fmtCode, err := res.GetFormatCode(i)
+		if err != nil {
+			return err
+		}
+		if err = checkResultType(c.Typ, fmtCode); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -837,6 +837,10 @@ type RestrictedCommandResult interface {
 	// ClientComm.createStatementResult.
 	ResetStmtType(stmt tree.Statement)
 
+	// GetFormatCode returns the format code that will be used to serialize the
+	// data in the provided column when sending messages to the client.
+	GetFormatCode(colIdx int) (pgwirebase.FormatCode, error)
+
 	// AddRow accumulates a result row.
 	//
 	// The implementation cannot hold on to the row slice; it needs to make a
@@ -1103,6 +1107,13 @@ func (r *streamingCommandResult) SendNotice(ctx context.Context, notice pgnotice
 // ResetStmtType is part of the RestrictedCommandResult interface.
 func (r *streamingCommandResult) ResetStmtType(stmt tree.Statement) {
 	panic("unimplemented")
+}
+
+// GetFormatCode is part of the sql.RestrictedCommandResult interface.
+func (r *streamingCommandResult) GetFormatCode(colIdx int) (pgwirebase.FormatCode, error) {
+	// Rows aren't serialized in the streamingCommandResult, so this format code
+	// doesn't really matter - return the default.
+	return pgwirebase.FormatText, nil
 }
 
 // AddRow is part of the RestrictedCommandResult interface.

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -216,6 +216,29 @@ func (r *commandResult) SetError(err error) {
 	r.err = err
 }
 
+// GetFormatCode is part of the sql.RestrictedCommandResult interface.
+func (r *commandResult) GetFormatCode(colIdx int) (pgwirebase.FormatCode, error) {
+	fmtCode := pgwirebase.FormatText
+	if r.formatCodes != nil {
+		if colIdx >= len(r.formatCodes) {
+			if len(r.formatCodes) == 1 && r.cmdCompleteTag == "EXPLAIN" {
+				// For EXPLAIN ANALYZE statements the format codes describe how
+				// to serialize the EXPLAIN ANALYZE output (which has just one
+				// column) and not the result of the query being executed (which
+				// can have any number of columns). In such a scenario we won't
+				// serialize the data rows (since we will produce stringified
+				// EXPLAIN ANALYZE output and the rows will be actually
+				// discarded by the DistSQLReceiver), so the format code here
+				// doesn't matter.
+				return fmtCode, nil
+			}
+			return 0, errors.AssertionFailedf("could not find format code for column %d in %v", colIdx, r.formatCodes)
+		}
+		fmtCode = r.formatCodes[colIdx]
+	}
+	return fmtCode, nil
+}
+
 // beforeAdd should be called before rows are buffered.
 func (r *commandResult) beforeAdd() error {
 	r.assertNotReleased()

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -881,12 +881,9 @@ func (c *conn) bufferRow(ctx context.Context, row tree.Datums, r *commandResult)
 	c.msgBuilder.initMsg(pgwirebase.ServerMsgDataRow)
 	c.msgBuilder.putInt16(int16(len(row)))
 	for i, col := range row {
-		fmtCode := pgwirebase.FormatText
-		if r.formatCodes != nil {
-			if i >= len(r.formatCodes) {
-				return errors.AssertionFailedf("could not find format code for column %d in %v", i, r.formatCodes)
-			}
-			fmtCode = r.formatCodes[i]
+		fmtCode, err := r.GetFormatCode(i)
+		if err != nil {
+			return err
 		}
 		switch fmtCode {
 		case pgwirebase.FormatText:
@@ -926,12 +923,9 @@ func (c *conn) bufferBatch(ctx context.Context, batch coldata.Batch, r *commandR
 			c.msgBuilder.initMsg(pgwirebase.ServerMsgDataRow)
 			c.msgBuilder.putInt16(width)
 			for vecIdx := 0; vecIdx < len(c.vecsScratch.Vecs); vecIdx++ {
-				fmtCode := pgwirebase.FormatText
-				if r.formatCodes != nil {
-					if vecIdx >= len(r.formatCodes) {
-						return errors.AssertionFailedf("could not find format code for column %d in %v", vecIdx, r.formatCodes)
-					}
-					fmtCode = r.formatCodes[vecIdx]
+				fmtCode, err := r.GetFormatCode(vecIdx)
+				if err != nil {
+					return err
 				}
 				switch fmtCode {
 				case pgwirebase.FormatText:

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -898,10 +898,10 @@ func (c *conn) bufferRow(ctx context.Context, row tree.Datums, r *commandResult)
 		}
 	}
 	if err := c.msgBuilder.finishMsg(&c.writerState.buf); err != nil {
-		return errors.NewAssertionErrorWithWrappedErrf(err, "unexpected err from buffer")
+		return err
 	}
 	if err := c.maybeFlush(r.pos, r.bufferingDisabled); err != nil {
-		return errors.NewAssertionErrorWithWrappedErrf(err, "unexpected err from buffer")
+		return err
 	}
 	c.maybeReallocate()
 	return nil
@@ -943,7 +943,7 @@ func (c *conn) bufferBatch(ctx context.Context, batch coldata.Batch, r *commandR
 				}
 			}
 			if err := c.msgBuilder.finishMsg(&c.writerState.buf); err != nil {
-				panic(fmt.Sprintf("unexpected err from buffer: %s", err))
+				return err
 			}
 			if err := c.maybeFlush(r.pos, r.bufferingDisabled); err != nil {
 				return err

--- a/pkg/sql/pgwire/testdata/pgtest/array
+++ b/pkg/sql/pgwire/testdata/pgtest/array
@@ -30,3 +30,31 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"{key1,subkey1}"},{"text":"{11,22}"},{"text":"{UnQuoted,Quoted}"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Regression test for panicking due to not having binary serialization of
+# multidimensional arrays (#118206).
+# "ResultFormatCodes": [1] = binary
+send
+Parse {"Name": "s", "Query": "SELECT ARRAY[ARRAY[1], ARRAY[2]]"}
+Bind {"PreparedStatement": "s", "ResultFormatCodes": [1]}
+Execute
+Sync
+----
+
+until crdb_only
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ErrorResponse","Code":"0A000"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"binary":"0000000200000000000000170000000200000001000000010000000100000004000000010000000400000002"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/prepare
+++ b/pkg/sql/pgwire/testdata/pgtest/prepare
@@ -105,10 +105,42 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"EXPLAIN"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+# "ResultFormatCodes": [1] = binary
+send
+Parse {"Name": "e2", "Query": "EXPLAIN SELECT i, i + 1, i + 2 FROM generate_series(1,10) AS g(i);"}
+Bind {"DestinationPortal": "pe2", "PreparedStatement": "e2", "ResultFormatCodes": [1]}
+Execute {"Portal": "pe2"}
+Sync
+----
+
+until ignore=DataRow
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"EXPLAIN"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
 send
 Parse {"Name": "ea", "Query": "EXPLAIN ANALYZE SELECT generate_series(1,10);"}
 Bind {"DestinationPortal": "pea", "PreparedStatement": "ea"}
 Execute {"Portal": "pea"}
+Sync
+----
+
+until ignore=DataRow
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"EXPLAIN"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# "ResultFormatCodes": [1] = binary
+send
+Parse {"Name": "ea2", "Query": "EXPLAIN ANALYZE SELECT i, i + 1, i + 2 FROM generate_series(1,10) AS g(i);"}
+Bind {"DestinationPortal": "pea2", "PreparedStatement": "ea2", "ResultFormatCodes": [1]}
+Execute {"Portal": "pea2"}
 Sync
 ----
 

--- a/pkg/sql/pgwire/write_buffer.go
+++ b/pkg/sql/pgwire/write_buffer.go
@@ -143,7 +143,9 @@ func (b *writeBuffer) putInt64(v int64) {
 }
 
 func (b *writeBuffer) putInt32AtIndex(index int, v int32) {
-	binary.BigEndian.PutUint32(b.wrapped.Bytes()[index:index+4], uint32(v))
+	if b.err == nil {
+		binary.BigEndian.PutUint32(b.wrapped.Bytes()[index:index+4], uint32(v))
+	}
 }
 
 func (b *writeBuffer) putErrFieldMsg(field pgwirebase.ServerErrFieldType) {


### PR DESCRIPTION
Currently, whenever the multidimensional arrays gets serialized into the binary format, an error is returned, and because it's considered a "communication error", it results in the connection shutdown. Until recently we simply prohibited creating statement results with nested arrays, but now we allow it. This commit fixes the ungraceful connection closure by reverting to the old behavior of returning an error in `checkResultType` function for nested arrays whenever binary formatting is requested.

Fixes: #118206.

Release note: None