### PR TITLE
changefeedccl: match nil metrics behaviour

### DIFF
--- a/pkg/ccl/changefeedccl/sink_external_connection.go
+++ b/pkg/ccl/changefeedccl/sink_external_connection.go
@@ -78,7 +78,7 @@ func validateExternalConnectionSinkURI(
 	// TODO(adityamaru): When we add `CREATE EXTERNAL CONNECTION ... WITH` support
 	// to accept JSONConfig we should validate that here too.
 	_, err := getSink(ctx, serverCfg, jobspb.ChangefeedDetails{SinkURI: uri}, nil, env.Username,
-		jobspb.JobID(0), nil)
+		jobspb.JobID(0), (*sliMetrics)(nil))
 	if err != nil {
 		return errors.Wrap(err, "invalid changefeed sink URI")
 	}


### PR DESCRIPTION
Previously, `validateExternalConnectionSinkURI` would validate the changefeed
sink URI by creating a fake sink and passing `nil` for `metricsRecorder`. This
is usually not problematic since the sink is never used. A new patch, #117693,
is now changing this and calling `metricsBuilder` interface method inside
`makeKafkaSink`. To resolve this, this patch changes getSink in
`validateExternalConnectionSinkURI` to pass in `(*sliMetrics)(nil)` to avoid
calling methods on a nil interface.

See also: https://github.com/cockroachdb/cockroach/pull/117693 
Release note: none
Epic: none
