### PR TITLE
roachprod: create MIG clusters on GCE

### DIFF
--- a/pkg/roachprod/vm/gce/BUILD.bazel
+++ b/pkg/roachprod/vm/gce/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_masterminds_semver_v3//:semver",
         "@com_github_spf13_pflag//:pflag",
         "@org_golang_google_api//cloudbilling/v1beta",
         "@org_golang_x_exp//maps",

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1545,8 +1545,123 @@ func propagateDiskLabels(
 	return g.Wait()
 }
 
-// Delete TODO(peter): document
+type jsonManagedInstanceGroup struct {
+	Name string `json:"name"`
+	Zone string `json:"zone"`
+}
+
+// listManagedInstanceGroups returns a list of managed instance groups for a
+// given group name. Groups may exist in multiple zones with the same name. This
+// function returns a list of all groups with the given name.
+func listManagedInstanceGroups(project, groupName string) ([]jsonManagedInstanceGroup, error) {
+	args := []string{"compute", "instance-groups", "list", "--only-managed",
+		"--project", project, "--format", "json", "--filter", fmt.Sprintf("name=%s", groupName)}
+	var groups []jsonManagedInstanceGroup
+	if err := runJSONCommand(args, &groups); err != nil {
+		return nil, err
+	}
+	return groups, nil
+}
+
+// deleteInstanceTemplate deletes the instance template for the cluster.
+func deleteInstanceTemplate(project string, clusterName string) error {
+	templateName := instanceTemplateName(clusterName)
+	args := []string{"compute", "instance-templates", "delete", "--project", project, "--quiet", templateName}
+	cmd := exec.Command("gcloud", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+	}
+	return nil
+}
+
+// isManaged returns true if the cluster is part of a managed instance group.
+// This function makes the assumption that a cluster is either completely
+// managed or not at all.
+func isManaged(vms vm.List) bool {
+	firstVM := vms[0]
+	for k, v := range firstVM.Labels {
+		if k == ManagedLabel && v == "true" {
+			return true
+		}
+	}
+	return false
+}
+
+// Delete is part of the vm.Provider interface.
 func (p *Provider) Delete(l *logger.Logger, vms vm.List) error {
+	switch {
+	case isManaged(vms):
+		return p.deleteManaged(l, vms)
+	default:
+		return p.deleteUnmanaged(l, vms)
+	}
+}
+
+// deleteManaged deletes the managed instance group for the given VMs. It also
+// deletes any instance templates that were used to create the managed instance
+// group.
+func (p *Provider) deleteManaged(l *logger.Logger, vms vm.List) error {
+	projectClusterMap := make(map[string]map[string]struct{})
+	for _, v := range vms {
+		if v.Provider != ProviderName {
+			return errors.Errorf("%s received VM instance from %s", ProviderName, v.Provider)
+		}
+		clusterName, err := v.ClusterName()
+		if err != nil {
+			return err
+		}
+		if projectClusterMap[v.Project] == nil {
+			projectClusterMap[v.Project] = make(map[string]struct{})
+		}
+		projectClusterMap[v.Project][clusterName] = struct{}{}
+	}
+
+	var g errgroup.Group
+	for project, clusters := range projectClusterMap {
+		for cluster := range clusters {
+			// Multiple instance groups can exist for a single cluster, one for each zone.
+			projectGroups, err := listManagedInstanceGroups(project, instanceGroupName(cluster))
+			if err != nil {
+				return err
+			}
+			for _, group := range projectGroups {
+				argsWithZone := []string{"compute", "instance-groups", "managed", "delete", "--quiet",
+					"--project", project,
+					"--zone", group.Zone,
+					group.Name}
+				g.Go(func() error {
+					cmd := exec.Command("gcloud", argsWithZone...)
+					output, err := cmd.CombinedOutput()
+					if err != nil {
+						return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", argsWithZone, output)
+					}
+					return nil
+				})
+			}
+		}
+	}
+	err := g.Wait()
+	if err != nil {
+		return err
+	}
+
+	// All instance groups have to be deleted before the instance templates can be
+	// deleted.
+	g = errgroup.Group{}
+	for project, clusters := range projectClusterMap {
+		for cluster := range clusters {
+			project, cluster := project, cluster
+			g.Go(func() error {
+				return deleteInstanceTemplate(project, cluster)
+			})
+		}
+	}
+	return g.Wait()
+}
+
+// deleteUnmanaged deletes the given VMs that are not part of a managed instance group.
+func (p *Provider) deleteUnmanaged(l *logger.Logger, vms vm.List) error {
 	// Map from project to map of zone to list of machines in that project/zone.
 	projectZoneMap := make(map[string]map[string][]string)
 	for _, v := range vms {

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -24,6 +24,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
@@ -1334,6 +1335,7 @@ func waitForGroupStability(project, groupName string, zones []string) error {
 func (p *Provider) Create(
 	l *logger.Logger, names []string, opts vm.CreateOpts, vmProviderOpts vm.ProviderOpts,
 ) error {
+	providerOpts := vmProviderOpts.(*ProviderOpts)
 	project := p.GetProject()
 	var gcJob bool
 	for _, prj := range projectsWithGC {
@@ -1346,8 +1348,11 @@ func (p *Provider) Create(
 		l.Printf("WARNING: --lifetime functionality requires "+
 			"`roachprod gc --gce-project=%s` cronjob", project)
 	}
-
-	providerOpts := vmProviderOpts.(*ProviderOpts)
+	if providerOpts.Managed {
+		if err := checkSDKVersion("450.0.0" /* minVersion */, "required by managed instance groups"); err != nil {
+			return err
+		}
+	}
 
 	instanceArgs, cleanUpFn, err := p.computeInstanceArgs(l, opts, providerOpts)
 	if cleanUpFn != nil {
@@ -2111,4 +2116,28 @@ func (p *Provider) ProjectActive(project string) bool {
 func lastComponent(url string) string {
 	s := strings.Split(url, "/")
 	return s[len(s)-1]
+}
+
+// checkSDKVersion checks that the gcloud SDK version is at least minVersion.
+// If it is not, it returns an error with the given message.
+func checkSDKVersion(minVersion, message string) error {
+	var jsonVersion struct {
+		GoogleCloudSDK string `json:"Google Cloud SDK"`
+	}
+	err := runJSONCommand([]string{"version", "--format", "json"}, &jsonVersion)
+	if err != nil {
+		return err
+	}
+	v, err := semver.NewVersion(jsonVersion.GoogleCloudSDK)
+	if err != nil {
+		return errors.Wrapf(err, "invalid gcloud version %q", jsonVersion.GoogleCloudSDK)
+	}
+	minConstraint, err := semver.NewConstraint(">= " + minVersion)
+	if err != nil {
+		return err
+	}
+	if !minConstraint.Check(v) {
+		return errors.Errorf("gcloud version %s is below minimum required version %s: %s", v, minVersion, message)
+	}
+	return nil
 }


### PR DESCRIPTION
Previously, cluster creation only supported creating VMs individually that were loosely tied by name and labels. This change introduces the ability to pass '--gce-managed' when creating clusters using the Google Cloud provider.

Setting the `managed` flag changes the way a cluster is created in a couple of ways. First an instance template is created that will serve as the template for all VMs that will be created as part of the cluster. The template is specific to the cluster and named as such. After template creation a managed instance group (MIG) is created for each zone requested.

The instance groups, in each region, are then instructed to create the desired number of VMs. Roachprod will then also wait for each instance group to reach a stable state before proceeding.

See: #118207
Epic: CRDB-33832

Release Note: None