### PR TITLE
changefeedccl: make changefeed random expressions test deterministic

### DIFF
--- a/pkg/ccl/backupccl/backuprand/backup_rand_test.go
+++ b/pkg/ccl/backupccl/backuprand/backup_rand_test.go
@@ -86,7 +86,7 @@ database_name = 'rand' AND schema_name = 'public'`)
 		// Note: we do not care how many rows successfully populate
 		// the given table
 		if _, err := randgen.PopulateTableWithRandData(rng, tc.Conns[0], tableName,
-			numInserts); err != nil {
+			numInserts, nil); err != nil {
 			t.Fatal(err)
 		}
 		tableNames = append(tableNames, tableName)

--- a/pkg/sql/importer/exportparquet_test.go
+++ b/pkg/sql/importer/exportparquet_test.go
@@ -223,7 +223,7 @@ func TestRandomParquetExports(t *testing.T) {
 
 		for i = 0; i < numTables; i++ {
 			tableName = string(stmts[i].(*tree.CreateTable).Table.ObjectName)
-			numRows, err := randgen.PopulateTableWithRandData(rng, db, tableName, 20)
+			numRows, err := randgen.PopulateTableWithRandData(rng, db, tableName, 20, nil)
 			require.NoError(t, err)
 			if numRows > 5 {
 				// Ensure the table only contains columns supported by EXPORT Parquet. If an

--- a/pkg/sql/importer/read_import_avro_logical_test.go
+++ b/pkg/sql/importer/read_import_avro_logical_test.go
@@ -281,7 +281,7 @@ func TestImportAvroLogicalTypes(t *testing.T) {
 	rng, _ := randutil.NewTestRand()
 	success := false
 	for i := 1; i <= 5; i++ {
-		numRowsInserted, err := randgen.PopulateTableWithRandData(rng, db, origTableName, 30)
+		numRowsInserted, err := randgen.PopulateTableWithRandData(rng, db, origTableName, 30, nil)
 		require.NoError(t, err)
 		if numRowsInserted > 5 {
 			success = true

--- a/pkg/sql/randgen/schema_test.go
+++ b/pkg/sql/randgen/schema_test.go
@@ -68,7 +68,7 @@ func TestPopulateTableWithRandData(t *testing.T) {
 	for i := 0; i < numTables; i++ {
 		tableName := string(stmts[i].(*tree.CreateTable).Table.ObjectName)
 		numRows := 30
-		numRowsInserted, err := randgen.PopulateTableWithRandData(rng, dbConn, tableName, numRows)
+		numRowsInserted, err := randgen.PopulateTableWithRandData(rng, dbConn, tableName, numRows, nil)
 		require.NoError(t, err)
 		res := sqlDB.QueryStr(t, fmt.Sprintf("SELECT count(*) FROM %s", tree.NameString(tableName)))
 		require.Equal(t, fmt.Sprint(numRowsInserted), res[0][0])


### PR DESCRIPTION
Before this change, it was difficult to reproduce errors from TestChangefeedRandomExpressions because the test setup involved non-deterministic queries. This PR both improves the test's determinism, logs setup information for easier reproducibility, and reduces the number of initial inserts to populate the test table.

Epic: None
Informs: #118061

Release note: none