### PR TITLE
release-23.1: sqlstats: fix update job to top sql activity stats

### DIFF
--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -177,16 +177,34 @@ type sqlActivityUpdater struct {
 	db           isql.DB
 }
 
+// TransferStatsToActivity call upsert stats function to current and prior hour.
 func (u *sqlActivityUpdater) TransferStatsToActivity(ctx context.Context) error {
+	// To improve performance we don't recalculate the entire top activity table everytime.
+	// Only update the latest hour and the one prior.
+	// We still need to recalculate the prior hour because the flush could happen during the switch of hours, and
+	// we could miss some executions completed on the prior hour.
+	aggTs := u.computeAggregatedTs(&u.st.SV)
+
+	err := u.upsertStatsForAggregatedTs(ctx, aggTs)
+	if err != nil {
+		return err
+	}
+	return u.upsertStatsForAggregatedTs(ctx, aggTs.Add(-time.Hour))
+}
+
+// upsertStatsForAggregatedTs calculates the top sql stats and update the activity table accordingly.
+func (u *sqlActivityUpdater) upsertStatsForAggregatedTs(
+	ctx context.Context, aggTs time.Time,
+) error {
 	// Get the config and pass it around to avoid any issue of it changing
 	// in the middle of the execution.
 	maxRowPersistedRows := sqlStatsActivityMaxPersistedRows.Get(&u.st.SV)
 	topLimit := sqlStatsActivityTopCount.Get(&u.st.SV)
-	aggTs := u.computeAggregatedTs(&u.st.SV)
 
 	// The counts are using AS OF SYSTEM TIME so the values may be slightly
 	// off. This is acceptable to increase the performance.
-	stmtRowCount, txnRowCount, totalEstimatedStmtClusterExecSeconds, totalEstimatedTxnClusterExecSeconds, err := u.getAostRowCountAndTotalClusterExecSeconds(ctx, aggTs)
+	stmtRowCount, txnRowCount, totalEstimatedStmtClusterExecSeconds, totalEstimatedTxnClusterExecSeconds,
+		err := u.getAostRowCountAndTotalClusterExecSeconds(ctx, aggTs)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/testdata/sql_activity_update_job
+++ b/pkg/sql/testdata/sql_activity_update_job
@@ -1,0 +1,151 @@
+# On this test we will first start by adding fingerprint A and B to time X
+# Then we will add more executions of A into time X and also time X+1, and a new fingerprint C to time X+1
+# The goal is to check the top activity table will get properly updated for both X and X+1 for all different
+# fingerprint cases.
+# For this test we use:
+# A= SELECT 1
+# B: SELECT 1 WHERE 1=1
+# C: SELECT 1 WHERE 1=1 and 2=2
+# X: 2024-01-01 1:00 (and consequently X+1 will be 2024-01-01 2:00)
+
+# Add Stats for X:00
+update-time time=(2024-01-01 1:00:00)
+----
+
+# Set an application to make easier for look for specific cases during the check.
+update-app ignore=false
+----
+
+run-sql
+SELECT 1
+----
+1
+
+run-sql
+SELECT 1 WHERE 1=1
+----
+1
+
+flush-stats
+----
+
+update-top-activity
+----
+
+# Change the application so all the queries used for checking values do not influence the results.
+update-app ignore=true
+----
+
+# Check the values got properly added to the system tables.
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'query' as query, statistics -> 'statistics' -> 'cnt' as count FROM
+system.statement_statistics WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
+----
+2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
+2024-01-01 01:00:00 +0000 UTC,"SELECT _",1
+
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM
+system.transaction_statistics WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
+----
+2024-01-01 01:00:00 +0000 UTC,["834459cc775811bf"],1
+2024-01-01 01:00:00 +0000 UTC,["df3c70bf7729b433"],1
+
+# Check the values got properly added to the top activity tables.
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'query' as query, statistics -> 'statistics' -> 'cnt' as count FROM
+system.statement_activity WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
+----
+2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
+2024-01-01 01:00:00 +0000 UTC,"SELECT _",1
+
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM
+system.transaction_activity WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
+----
+2024-01-01 01:00:00 +0000 UTC,["834459cc775811bf"],1
+2024-01-01 01:00:00 +0000 UTC,["df3c70bf7729b433"],1
+
+# Change the app name back, so new stats can be added.
+update-app ignore=false
+----
+
+# Add more Stats for X:00
+run-sql
+SELECT 1
+----
+1
+
+run-sql
+SELECT 1
+----
+1
+
+flush-stats
+----
+
+# Add Stats for X+1:00
+update-time time=(2024-01-01 2:00:00)
+----
+
+run-sql
+SELECT 1
+----
+1
+
+run-sql
+SELECT 1 WHERE 1=1 AND 2=2
+----
+1
+
+flush-stats
+----
+
+update-top-activity
+----
+
+# Change the application so all the queries used for checking values do not influence the results.
+update-app ignore=true
+----
+
+# Check the values got properly added to the system tables
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'query' as query, statistics -> 'statistics' -> 'cnt' as count FROM
+system.statement_statistics WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
+----
+2024-01-01 01:00:00 +0000 UTC,"SET application_name = $1",1
+2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
+2024-01-01 01:00:00 +0000 UTC,"SELECT _",3
+2024-01-01 02:00:00 +0000 UTC,"SELECT _ WHERE (_ = _) AND (_ = _)",1
+2024-01-01 02:00:00 +0000 UTC,"SELECT _",1
+
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM
+system.transaction_statistics WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
+----
+2024-01-01 01:00:00 +0000 UTC,["834459cc775811bf"],1
+2024-01-01 01:00:00 +0000 UTC,["df3c70bf7729b433"],3
+2024-01-01 01:00:00 +0000 UTC,["6434c26660c3efee"],1
+2024-01-01 02:00:00 +0000 UTC,["df3c70bf7729b433"],1
+2024-01-01 02:00:00 +0000 UTC,["0a8121f073e118d9"],1
+
+# Check the values got properly added to the top activity tables
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'query' as query, statistics -> 'statistics' -> 'cnt' as count FROM
+system.statement_activity WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
+----
+2024-01-01 01:00:00 +0000 UTC,"SET application_name = $1",1
+2024-01-01 01:00:00 +0000 UTC,"SELECT _ WHERE _ = _",1
+2024-01-01 01:00:00 +0000 UTC,"SELECT _",3
+2024-01-01 02:00:00 +0000 UTC,"SELECT _ WHERE (_ = _) AND (_ = _)",1
+2024-01-01 02:00:00 +0000 UTC,"SELECT _",1
+
+run-sql useApp=true
+SELECT aggregated_ts, metadata -> 'stmtFingerprintIDs', statistics -> 'statistics' -> 'cnt' as count FROM
+system.transaction_activity WHERE app_name = $1 ORDER BY aggregated_ts, fingerprint_id
+----
+2024-01-01 01:00:00 +0000 UTC,["834459cc775811bf"],1
+2024-01-01 01:00:00 +0000 UTC,["df3c70bf7729b433"],3
+2024-01-01 01:00:00 +0000 UTC,["6434c26660c3efee"],1
+2024-01-01 02:00:00 +0000 UTC,["df3c70bf7729b433"],1
+2024-01-01 02:00:00 +0000 UTC,["0a8121f073e118d9"],1


### PR DESCRIPTION
Backport 1/1 commits from #118357.

/cc @cockroachdb/release

---

Previously, the job to update the top sql activity table was only recalculating the current hour to improve on performance and avoid the recalculation of the entire table.
This was causing a problem during the change of hour where stats from the prior hour could not have been added to the top activity table.
This commit fixes this issue by always recalculating the current and priror hour.
It also adds tests to confirm this fix (I was able to confirm the tests fail without this fix).

Fixes #118326

Release note (bug fix): Recalculate properly the value from current and past hour on top Activity table, fixing the issue where we were missing data on sql stats and consequently missing data on the SQL Activity page.

----

Release justification: bug fix
