### PR TITLE
release-23.2: sql,cli: improve statement bundles for prepared statements

### DIFF
--- a/pkg/cli/interactive_tests/test_explain_analyze_debug.tcl
+++ b/pkg/cli/interactive_tests/test_explain_analyze_debug.tcl
@@ -24,7 +24,7 @@ eexpect root@
 send "EXPLAIN ANALYZE (DEBUG) SELECT 1;\r"
 eexpect "Statement diagnostics bundle generated."
 expect -re "SQL shell: \\\\statement-diag download (\\d+)" {
-  set id $expect_out(1,string)
+  set id1 $expect_out(1,string)
 }
 
 expect {
@@ -42,15 +42,15 @@ expect {
 
 send "\\statement-diag list\r"
 eexpect "Statement diagnostics bundles:"
-eexpect "$id"
+eexpect "$id1"
 eexpect "EXPLAIN"
 eexpect root@
 
-send "\\statement-diag download $id\r"
+send "\\statement-diag download $id1\r"
 eexpect "Bundle saved to"
 eexpect root@
 
-file_exists "stmt-bundle-$id.zip"
+file_exists "stmt-bundle-$id1.zip"
 
 send_eof
 eexpect eof
@@ -64,11 +64,67 @@ start_test "Ensure that a bundle can be restarted from."
 set python "python2.7"
 set pyfile [file join [file dirname $argv0] unzip.py]
 system "mkdir bundle"
-system "$python $pyfile stmt-bundle-$id.zip bundle"
+system "$python $pyfile stmt-bundle-$id1.zip bundle"
 
 spawn $argv debug statement-bundle recreate bundle
 eexpect "Statement was:"
 eexpect "SELECT"
+eexpect root@
+
+send_eof
+eexpect eof
+
+end_test
+
+start_test "Ensure that 'statement-bundle recreate' replaces placeholders with their values"
+
+start_server $argv
+
+# Spawn a sql shell.
+spawn $argv sql --no-line-editor
+set client_spawn_id $spawn_id
+eexpect root@
+
+# Delete bundles from the previous stmts if there are any.
+send "DELETE FROM system.statement_diagnostics WHERE true;\r"
+eexpect root@
+
+send "CREATE TABLE t (k INT PRIMARY KEY);\r"
+eexpect root@
+
+send "PREPARE p AS SELECT * FROM t WHERE k = \$1;\r"
+eexpect root@
+
+send "SELECT crdb_internal.request_statement_bundle('SELECT * FROM t WHERE k = \$1', 0::FLOAT, 0::INTERVAL, 0::INTERVAL);\r"
+eexpect root@
+
+send "EXECUTE p(1);\r"
+eexpect root@
+
+# Figure out the ID of the bundle we just collected.
+send "SELECT id FROM system.statement_diagnostics LIMIT 1;\r"
+eexpect "LIMIT 1;"
+expect -re "\r\n *(\\d+)" {
+  set id2 $expect_out(1,string)
+}
+eexpect root@
+
+send "\\statement-diag download $id2\r"
+eexpect "Bundle saved to"
+eexpect root@
+
+file_exists "stmt-bundle-$id2.zip"
+
+stop_server $argv
+
+set python "python2.7"
+set pyfile [file join [file dirname $argv0] unzip.py]
+system "mkdir bundle2"
+system "$python $pyfile stmt-bundle-$id2.zip bundle2"
+
+spawn $argv debug statement-bundle recreate bundle2
+eexpect "Statement (had 1 placeholder) was:"
+eexpect "SELECT * FROM t WHERE k = 1:::INT8;"
 eexpect root@
 
 send_eof
@@ -91,7 +147,7 @@ eexpect root@
 send "EXPLAIN ANALYZE (DEBUG) SELECT 1;\r"
 eexpect "Statement diagnostics bundle generated."
 expect -re "SQL shell: \\\\statement-diag download (\\d+)" {
-  set id $expect_out(1,string)
+  set id3 $expect_out(1,string)
 }
 
 expect {
@@ -109,15 +165,15 @@ expect {
 
 send "\\statement-diag list\r"
 eexpect "Statement diagnostics bundles:"
-eexpect "$id"
+eexpect "$id3"
 eexpect "EXPLAIN"
 eexpect root@
 
-send "\\statement-diag download $id\r"
+send "\\statement-diag download $id3\r"
 eexpect "Bundle saved to"
 eexpect root@
 
-file_exists "stmt-bundle-$id.zip"
+file_exists "stmt-bundle-$id3.zip"
 
 send_eof
 eexpect eof

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExplainAnalyzeDebugWithTxnRetries(t *testing.T) {
@@ -547,5 +548,52 @@ func checkBundle(
 	sort.Strings(expList)
 	if fmt.Sprint(files) != fmt.Sprint(expList) {
 		t.Errorf("unexpected list of files:\n  %v\nexpected:\n  %v", files, expList)
+	}
+}
+
+func TestReplacePlaceholdersWithValuesForBundle(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, tc := range []struct {
+		statement          string
+		stmtNoPlaceholders string
+		numPlaceholders    int
+	}{
+		{
+			statement:          `SELECT 1;`,
+			stmtNoPlaceholders: `SELECT 1;`,
+			numPlaceholders:    0,
+		},
+		{
+			statement: `
+SELECT * FROM t WHERE k = $1;
+
+-- Arguments:
+--  $1: 1
+`,
+			stmtNoPlaceholders: `SELECT * FROM t WHERE k = 1;`,
+			numPlaceholders:    1,
+		},
+		// This test case abuses the notation a bit (by omitting some of the
+		// placeholder values) and tests that substring collisions like $1 vs
+		// $10 are handled correctly.
+		{
+			statement: `
+SELECT a || $1 FROM t WHERE k = ($2 - $10);
+
+-- Arguments:
+--  $1: 'foo'
+--  $2: 42
+--  $10: 17
+`,
+			stmtNoPlaceholders: `SELECT a || 'foo' FROM t WHERE k = (42 - 17);`,
+			numPlaceholders:    3,
+		},
+	} {
+		s, p, err := ReplacePlaceholdersWithValuesForBundle(tc.statement)
+		require.NoError(t, err)
+		require.Equal(t, tc.stmtNoPlaceholders, s)
+		require.Equal(t, tc.numPlaceholders, p)
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #118316.

/cc @cockroachdb/release

---

This commits adds a couple of new files to the stmt bundles that were collected for prepared statements:
- `statement-prepared.sql` contains `PREPARE` and `EXECUTE` statements that can be copy-pasted to reproduce how the original statement was executed
- `statement-no-placeholders.sql` contains the original statement in which all placeholders were replaces with their values.

Additionally, `debug statement-bundle recreate` command has been taught to parse `statement.sql` and replace placeholders with their values before printing out the statement into the sql shell (which is the last step of the recreating the bundle). This approach will work even on bundles that were collected on older binaries without this change.

These improvements should make debugging prepared statements a bit easier.

Fixes: #114356.
Epic: CRDB-34181.

Release note: None

Release justification: low-risk debugging improvement.