### PR TITLE
storage: enforce MaxLockConflicts on MVCCIncrementalIterator

### DIFF
--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -2002,6 +2002,10 @@ func cmdIterNewIncremental(e *evalCtx) error {
 		e.iter.Close()
 	}
 
+	if e.hasArg("maxLockConflicts") {
+		e.scanArg("maxLockConflicts", &opts.MaxLockConflicts)
+	}
+
 	r := e.newReader()
 	mvccIter, err := storage.NewMVCCIncrementalIterator(context.Background(), r, opts)
 	if err != nil {

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -124,6 +124,14 @@ type MVCCIncrementalIterator struct {
 
 	// Optional collection of intents created on demand when first intent encountered.
 	intents []roachpb.Intent
+
+	// maxLockConflicts is a maximum number of conflicting locks collected before
+	// returning LockConflictError. This setting only works under
+	// MVCCIncrementalIterIntentPolicyAggregate. Caller must call TryGetIntentError
+	// even when the collected intents is less than the threshold.
+	//
+	// The zero value indicates no limit.
+	maxLockConflicts uint64
 }
 
 var _ SimpleMVCCIterator = &MVCCIncrementalIterator{}
@@ -142,8 +150,10 @@ const (
 	// first encountered intent, but will proceed further. All
 	// found intents will be aggregated into a single
 	// LockConflictError which would be updated during
-	// iteration. Consumer would be free to decide if it wants to
-	// keep collecting entries and intents or skip entries.
+	// iteration. The LockConflictError's intents size is
+	// constrained by MaxLockConflicts setting. Consumer would
+	// be free to decide if it wants to keep collecting entries
+	// and intents or skip entries.
 	MVCCIncrementalIterIntentPolicyAggregate
 	// MVCCIncrementalIterIntentPolicyEmit will return intents to
 	// the caller if they are inside or outside the time range.
@@ -174,6 +184,14 @@ type MVCCIncrementalIterOptions struct {
 	// ReadCategory is used to map to a user-understandable category string, for
 	// stats aggregation and metrics, and a Pebble-understandable QoS.
 	ReadCategory ReadCategory
+
+	// MaxLockConflicts is a maximum number of conflicting locks collected before
+	// returning LockConflictError. This setting only work under
+	// MVCCIncrementalIterIntentPolicyAggregate. Caller must call TryGetIntentError
+	// when the collected intents is less that the Threshold.
+	//
+	// The zero value indicates no limit.
+	MaxLockConflicts uint64
 }
 
 // NewMVCCIncrementalIterator creates an MVCCIncrementalIterator with the
@@ -249,11 +267,12 @@ func NewMVCCIncrementalIterator(
 	}
 
 	return &MVCCIncrementalIterator{
-		iter:          iter,
-		startTime:     opts.StartTime,
-		endTime:       opts.EndTime,
-		timeBoundIter: timeBoundIter,
-		intentPolicy:  opts.IntentPolicy,
+		iter:             iter,
+		startTime:        opts.StartTime,
+		endTime:          opts.EndTime,
+		timeBoundIter:    timeBoundIter,
+		intentPolicy:     opts.IntentPolicy,
+		maxLockConflicts: opts.MaxLockConflicts,
 	}, nil
 }
 
@@ -462,10 +481,14 @@ func (i *MVCCIncrementalIterator) updateMeta() error {
 			i.valid = false
 			return i.err
 		case MVCCIncrementalIterIntentPolicyAggregate:
-			// We are collecting intents, so we need to save it and advance to its proposed value.
-			// Caller could then use a value key to update proposed row counters for the sake of bookkeeping
-			// and advance more.
+			// We are collecting intents, so we need to save it and advance to its proposed value. Caller could then use a
+			// value key to update proposed row counters for the sake of bookkeeping and advance more.
 			i.intents = append(i.intents, roachpb.MakeIntent(i.meta.Txn, i.iter.UnsafeKey().Key.Clone()))
+			if i.maxLockConflicts > 0 && uint64(len(i.intents)) >= i.maxLockConflicts {
+				i.valid = false
+				i.err = i.TryGetIntentError()
+				return i.err
+			}
 			return nil
 		case MVCCIncrementalIterIntentPolicyEmit:
 			// We will emit this intent to the caller.
@@ -771,13 +794,6 @@ func (i *MVCCIncrementalIterator) NextKeyIgnoringTime() {
 // bounds.
 func (i *MVCCIncrementalIterator) IgnoringTime() bool {
 	return i.ignoringTime
-}
-
-// NumCollectedIntents returns number of intents encountered during iteration.
-// This is only the case when intent aggregation is enabled, otherwise it is
-// always 0.
-func (i *MVCCIncrementalIterator) NumCollectedIntents() int {
-	return len(i.intents)
 }
 
 // TryGetIntentError returns kvpb.LockConflictError if intents were encountered

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -83,7 +83,13 @@ func iterateExpectErr(
 		t.Helper()
 
 		t.Run("aggregate-intents", func(t *testing.T) {
-			assertExpectErrs(t, e, startKey, endKey, startTime, endTime, revisions, intents)
+			assertExpectErrs(t, e, startKey, endKey, startTime, endTime, revisions, intents, MaxConflictsPerLockConflictErrorDefault)
+		})
+		// Test case to check if iterator enforces maxLockConflict.
+		t.Run("aggregate-intents-with-limit", func(t *testing.T) {
+			if len(intents) > 0 {
+				assertExpectErrs(t, e, startKey, endKey, startTime, endTime, revisions, intents[:1], 1)
+			}
 		})
 		t.Run("first-intent", func(t *testing.T) {
 			assertExpectErr(t, e, startKey, endKey, startTime, endTime, revisions, intents[0])
@@ -141,12 +147,14 @@ func assertExpectErrs(
 	startTime, endTime hlc.Timestamp,
 	revisions bool,
 	expectedIntents []roachpb.Intent,
+	maxLockConflicts uint64,
 ) {
 	iter, err := NewMVCCIncrementalIterator(context.Background(), e, MVCCIncrementalIterOptions{
-		EndKey:       endKey,
-		StartTime:    startTime,
-		EndTime:      endTime,
-		IntentPolicy: MVCCIncrementalIterIntentPolicyAggregate,
+		EndKey:           endKey,
+		StartTime:        startTime,
+		EndTime:          endTime,
+		IntentPolicy:     MVCCIncrementalIterIntentPolicyAggregate,
+		MaxLockConflicts: maxLockConflicts,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -165,8 +173,8 @@ func assertExpectErrs(
 		// pass
 	}
 
-	if iter.NumCollectedIntents() != len(expectedIntents) {
-		t.Fatalf("Expected %d intents but found %d", len(expectedIntents), iter.NumCollectedIntents())
+	if len(iter.intents) != len(expectedIntents) {
+		t.Fatalf("Expected %d intents but found %d", len(expectedIntents), len(iter.intents))
 	}
 	err = iter.TryGetIntentError()
 	if lcErr := (*kvpb.LockConflictError)(nil); errors.As(err, &lcErr) {
@@ -372,10 +380,11 @@ func assertIteratedKVs(
 	expected []MVCCKeyValue,
 ) {
 	iter, err := NewMVCCIncrementalIterator(context.Background(), e, MVCCIncrementalIterOptions{
-		EndKey:       endKey,
-		StartTime:    startTime,
-		EndTime:      endTime,
-		IntentPolicy: MVCCIncrementalIterIntentPolicyAggregate,
+		EndKey:           endKey,
+		StartTime:        startTime,
+		EndTime:          endTime,
+		IntentPolicy:     MVCCIncrementalIterIntentPolicyAggregate,
+		MaxLockConflicts: MaxConflictsPerLockConflictErrorDefault,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -394,7 +403,7 @@ func assertIteratedKVs(
 		} else if !ok || iter.UnsafeKey().Key.Compare(endKey) >= 0 {
 			break
 		}
-		if iter.NumCollectedIntents() > 0 {
+		if len(iter.intents) > 0 {
 			t.Fatal("got unexpected intent error")
 		}
 		v, err := iter.UnsafeValue()

--- a/pkg/storage/testdata/mvcc_histories/export
+++ b/pkg/storage/testdata/mvcc_histories/export
@@ -86,6 +86,11 @@ data: "o"/7.000000000,0 -> /BYTES/n7
 run error
 export k=a end=z
 ----
+error: (*kvpb.LockConflictError:) conflicting locks on "a", "d", "j", "l", "o"
+
+run error
+export k=a end=z maxLockConflicts=1
+----
 error: (*kvpb.LockConflictError:) conflicting locks on "a"
 
 run error

--- a/pkg/storage/testdata/mvcc_histories/export_fingerprint
+++ b/pkg/storage/testdata/mvcc_histories/export_fingerprint
@@ -86,6 +86,11 @@ data: "o"/7.000000000,0 -> /BYTES/n7
 run error
 export fingerprint k=a end=z
 ----
+error: (*kvpb.LockConflictError:) conflicting locks on "a", "d", "j", "l", "o"
+
+run error
+export fingerprint k=a end=z maxLockConflicts=1
+----
 error: (*kvpb.LockConflictError:) conflicting locks on "a"
 
 run error

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
@@ -932,6 +932,36 @@ iter_scan: err=conflicting locks on "a"
 error: (*kvpb.LockConflictError:) conflicting locks on "a"
 
 run error
+iter_new_incremental types=pointsAndRanges k=a end=z intents=aggregate maxLockConflicts=3
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: err=conflicting locks on "a", "d", "j"
+error: (*kvpb.LockConflictError:) conflicting locks on "a", "d", "j"
+
+run error
 iter_new_incremental types=pointsAndRanges k=a end=z intents=aggregate
 iter_seek_ge k=a
 iter_scan
@@ -1070,7 +1100,7 @@ iter_next_ignoring_time: err=conflicting locks on "d"
 error: (*kvpb.LockConflictError:) conflicting locks on "d"
 
 run ok
-iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=error
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=error maxLockConflicts=100
 iter_seek_ge k=c
 iter_next_key_ignoring_time
 ----


### PR DESCRIPTION
This commit enforce the MaxLockConflicts setting inside MVCCIncrementalIterator to make sure intents size cannot surpass the threshold under MVCCIncrementalIterIntentPolicyAggregate. This is done by iterator checking MaxLockConflicts before append to intent collection, and iterator will be invalidated with LockConflictError if the threashold is reached.

Fixes: https://github.com/cockroachdb/cockroach/issues/118404

Release note: None