### PR TITLE
release-23.2: stats: skip TSQuery until stats collection is fixed

### DIFF
--- a/pkg/sql/stats/stats_test.go
+++ b/pkg/sql/stats/stats_test.go
@@ -54,6 +54,10 @@ func TestStatsAnyType(t *testing.T) {
 				// Casting random integers to REGTYPE might fail.
 				continue loop
 			}
+			if typ.Family() == types.TSQueryFamily {
+				// Skipped until #118436 is fixed.
+				continue loop
+			}
 			if err := colinfo.ValidateColumnDefType(ctx, st.Version, typ); err == nil {
 				break
 			}


### PR DESCRIPTION
Recently introduced test exposed another problem with TSQuery datum: we're still using non-existent key-encoding for histogram bounds on 23.2 and prior versions. Skip this type in the test until that issue is fixed.

Epic: None

Release note: None

Release justification: test-only change.