### PR TITLE
opt: add assertion for scanning write-only and delete-only columns

### DIFF
--- a/pkg/sql/opt/cat/column.go
+++ b/pkg/sql/opt/cat/column.go
@@ -191,6 +191,24 @@ const (
 	Inverted
 )
 
+// String returns a string representation of the ColumnKind.
+func (k ColumnKind) String() string {
+	switch k {
+	case Ordinary:
+		return "ordinary"
+	case WriteOnly:
+		return "write-only"
+	case DeleteOnly:
+		return "delete-only"
+	case System:
+		return "system"
+	case Inverted:
+		return "inverted"
+	default:
+		return "unknown"
+	}
+}
+
 // ColumnVisibility controls if a column is visible for queries and if it is
 // part of the star expansion.
 type ColumnVisibility uint8

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -85,6 +85,14 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 				))
 			}
 		}
+		tab := m.Metadata().Table(t.Table)
+		for c, ok := t.Cols.Next(0); ok; c, ok = t.Cols.Next(c + 1) {
+			ord := t.Table.ColumnOrdinal(c)
+			switch k := tab.Column(ord).Kind(); k {
+			case cat.WriteOnly, cat.DeleteOnly:
+				panic(errors.AssertionFailedf("unexpected scan of %s column", k))
+			}
+		}
 
 	case *ProjectExpr:
 		if !t.Passthrough.SubsetOf(t.Input.Relational().OutputCols) {


### PR DESCRIPTION
Columns in the write-only or delete-only states should never be read
from a table. This commit adds a test-build-only assertion to the
optimizer to ensure this. This may help uncover interesting bugs in the
schema changer or opt catalog where columns are in invalid states.

Release note: None
