### PR TITLE
release-22.2: batcheval: add `PushTxnResponse.AmbiguousAbort`

### DIFF
--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -108,6 +108,7 @@ go_test(
         "cmd_get_test.go",
         "cmd_is_span_empty_test.go",
         "cmd_lease_test.go",
+        "cmd_push_txn_test.go",
         "cmd_query_intent_test.go",
         "cmd_query_resolved_timestamp_test.go",
         "cmd_recover_txn_test.go",

--- a/pkg/kv/kvserver/batcheval/cmd_push_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn.go
@@ -169,6 +169,10 @@ func PushTxn(
 		// then we know we're in either the second or the third case.
 		reply.PusheeTxn = SynthesizeTxnFromMeta(ctx, cArgs.EvalCtx, args.PusheeTxn)
 		if reply.PusheeTxn.Status == roachpb.ABORTED {
+			// The transaction may actually have committed and already removed its
+			// intents and txn record, or it may have aborted and done the same. We
+			// can't know, so mark the abort as ambiguous.
+			reply.AmbiguousAbort = true
 			// If the transaction is uncommittable, we don't even need to
 			// persist an ABORTED transaction record, we can just consider it
 			// aborted. This is good because it allows us to obey the invariant

--- a/pkg/kv/kvserver/batcheval/cmd_push_txn_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn_test.go
@@ -1,0 +1,103 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package batcheval_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPushTxnAmbiguousAbort tests PushTxn behavior when the transaction record
+// is missing. In this case, the timestamp cache can tell us whether the
+// transaction record may have existed in the past -- if we know it hasn't, then
+// the transaction is still pending (e.g. before the record is written), but
+// otherwise the transaction record is pessimistically assumed to have aborted.
+// However, this state is ambiguous, as the transaction may in fact have
+// committed already and GCed its transaction record. Make sure this is
+// reflected in the AmbiguousAbort field.
+//
+// TODO(erikgrinaker): generalize this to test PushTxn more broadly.
+func TestPushTxnAmbiguousAbort(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	clock := hlc.NewClock(timeutil.NewManualTime(timeutil.Now()), 0 /* maxOffset */)
+	now := clock.Now()
+	engine := storage.NewDefaultInMemForTesting()
+	defer engine.Close()
+
+	testutils.RunTrueAndFalse(t, "CanCreateTxnRecord", func(t *testing.T, canCreateTxnRecord bool) {
+		evalCtx := (&batcheval.MockEvalCtx{
+			Clock: clock,
+			CanCreateTxn: func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
+				return canCreateTxnRecord, hlc.Timestamp{}, 0 // PushTxn doesn't care about the reason
+			},
+		}).EvalContext()
+
+		key := roachpb.Key("foo")
+		pusheeTxnMeta := enginepb.TxnMeta{
+			ID:           uuid.MakeV4(),
+			Key:          key,
+			MinTimestamp: now,
+		}
+
+		resp := roachpb.PushTxnResponse{}
+		res, err := batcheval.PushTxn(ctx, engine, batcheval.CommandArgs{
+			EvalCtx: evalCtx,
+			Header: roachpb.Header{
+				Timestamp: clock.Now(),
+			},
+			Args: &roachpb.PushTxnRequest{
+				RequestHeader: roachpb.RequestHeader{Key: key},
+				PusheeTxn:     pusheeTxnMeta,
+			},
+		}, &resp)
+		require.NoError(t, err)
+
+		// There is no txn record (the engine is empty). If we can't create a txn
+		// record, it's because the timestamp cache can't confirm that it didn't
+		// exist in the past. This will return an ambiguous abort.
+		var expectUpdatedTxns []*roachpb.Transaction
+		expectTxn := roachpb.Transaction{
+			TxnMeta:       pusheeTxnMeta,
+			LastHeartbeat: pusheeTxnMeta.MinTimestamp,
+		}
+		if !canCreateTxnRecord {
+			expectTxn.Status = roachpb.ABORTED
+			expectUpdatedTxns = append(expectUpdatedTxns, &expectTxn)
+		}
+
+		require.Equal(t, result.Result{
+			Local: result.LocalResult{
+				UpdatedTxns: expectUpdatedTxns,
+			},
+		}, res)
+		require.Equal(t, roachpb.PushTxnResponse{
+			PusheeTxn:      expectTxn,
+			AmbiguousAbort: !canCreateTxnRecord,
+		}, resp)
+	})
+}

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -122,7 +122,7 @@ type IntentResolver interface {
 	// pushed successfully.
 	PushTransaction(
 		context.Context, *enginepb.TxnMeta, roachpb.Header, roachpb.PushTxnType,
-	) (*roachpb.Transaction, *Error)
+	) (*roachpb.Transaction, bool, *Error)
 
 	// ResolveIntent synchronously resolves the provided intent.
 	ResolveIntent(context.Context, roachpb.LockUpdate, intentresolver.ResolveOptions) *Error
@@ -516,7 +516,7 @@ func (w *lockTableWaiterImpl) pushLockTxn(
 		log.Fatalf(ctx, "unexpected WaitPolicy: %v", req.WaitPolicy)
 	}
 
-	pusheeTxn, err := w.ir.PushTransaction(ctx, ws.txn, h, pushType)
+	pusheeTxn, _, err := w.ir.PushTransaction(ctx, ws.txn, h, pushType)
 	if err != nil {
 		// If pushing with an Error WaitPolicy and the push fails, then the lock
 		// holder is still active. Transform the error into a WriteIntentError.
@@ -697,7 +697,7 @@ func (w *lockTableWaiterImpl) pushRequestTxn(
 	pushType := roachpb.PUSH_ABORT
 	log.VEventf(ctx, 3, "pushing txn %s to detect request deadlock", ws.txn.ID.Short())
 
-	_, err := w.ir.PushTransaction(ctx, ws.txn, h, pushType)
+	_, _, err := w.ir.PushTransaction(ctx, ws.txn, h, pushType)
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -118,7 +118,7 @@ func (tp *rangefeedTxnPusher) PushTxns(
 		},
 	}
 
-	pushedTxnMap, pErr := tp.ir.MaybePushTransactions(
+	pushedTxnMap, _, pErr := tp.ir.MaybePushTransactions(
 		ctx, pushTxnMap, h, roachpb.PUSH_TIMESTAMP, false, /* skipIfInFlight */
 	)
 	if pErr != nil {

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1095,6 +1095,15 @@ message PushTxnResponse {
   // TODO(tschottdorf): Maybe this can be a TxnMeta instead; probably requires
   // factoring out the new Priority.
   Transaction pushee_txn = 2 [(gogoproto.nullable) = false];
+  // ambiguous_abort is true if pushee_txn has status ABORTED, but the
+  // transaction may in fact have been committed and GCed already. Concretely,
+  // this means that the transaction record does not exist, but it may have
+  // existed in the past (according to the timestamp cache), and we can't know
+  // whether it committed or aborted so we pessimistically assume it aborted.
+  //
+  // NB: this field was added in a patch release, and is not guaranteed to be
+  // populated prior to 24.1.
+  bool ambiguous_abort = 3;
 }
 
 // A RecoverTxnRequest is arguments to the RecoverTxn() method. It is sent


### PR DESCRIPTION
This is part of a https://github.com/cockroachdb/cockroach/pull/117612 backport.

There are no behavioral changes, only a new API that is unused for now.

---

Backport 1/1 commits from #117969.

Release justification: prerequisite for backporting https://github.com/cockroachdb/cockroach/pull/117612.

/cc @cockroachdb/release

---

This indicates to the caller that the `ABORTED` status of the pushed transaction is ambiguous, and the transaction may in fact have been committed and GCed already. This information is also plumbed through the `IntentResolver` txn push APIs.

Touches #104309.
Epic: none
Release note: None