### PR TITLE
cli: improve debug zip output for crdb_internal.transaction_contentio…

### DIFF
--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -561,6 +561,28 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 		},
 	},
 	"crdb_internal.transaction_contention_events": {
+		customQueryUnredacted: `
+SELECT collection_ts,
+       contention_duration,
+       waiting_txn_id,
+       waiting_txn_fingerprint_id,
+       waiting_stmt_fingerprint_id,
+       s.metadata ->> 'query'                      AS waiting_stmt_query,
+       blocking_txn_id,
+       blocking_txn_fingerprint_id,
+       array_agg(distinct ss.metadata ->> 'query') AS blocking_txn_queries_unordered,
+       contending_pretty_key,
+       index_name,
+       table_name,
+       database_name
+FROM crdb_internal.transaction_contention_events
+         LEFT JOIN system.statement_statistics AS s ON waiting_stmt_fingerprint_id = s.fingerprint_id
+         LEFT JOIN system.statement_statistics AS ss ON ss.transaction_fingerprint_id = blocking_txn_fingerprint_id
+WHERE ss.transaction_fingerprint_id != '\x0000000000000000' AND s.fingerprint_id != '\x0000000000000000'
+GROUP BY collection_ts, contention_duration, waiting_txn_id, waiting_txn_fingerprint_id, blocking_txn_id,
+         blocking_txn_fingerprint_id, waiting_stmt_fingerprint_id, contending_pretty_key, s.metadata ->> 'query',
+         index_name, table_name, database_name
+`,
 		// `contending_key` column contains the contended key, which may
 		// contain sensitive row-level data. So, we will only fetch if the
 		// table is under the system schema.


### PR DESCRIPTION
…n_events

This commit adds the following columns to the output for crdb_internal.transaction_contention_events:
- waiting_stmt_query: query of the waiting stmt
- blocking_txn_queries_unordered: unordered list of the blocking txn's queries

Epic: CRDB-29563

Release note (ops change): In (unredacted) debug zips, the crdb_internal.transaction_contention_events table file has 2 new columns:
- waiting_stmt_query: query of the waiting stmt
- blocking_txn_queries_unordered: unordered list of the blocking txn's queries


Example output
```
collection_ts	contention_duration	waiting_txn_id	waiting_txn_fingerprint_id	waiting_stmt_fingerprint_id	waiting_stmt_query	blocking_txn_id	blocking_txn_fingerprint_id	blocking_txn_queries_unordered	contending_pretty_key	index_name	table_name	database_name
2024-01-30 20:51:09.427592+00	00:00:00.011317	fe97a98b-0ea5-4319-9daf-76307ba0917e	\x9f816b33d2783c34	\x30e2d67f54798beb	SELECT * FROM usertable WHERE ycsb_key = $1	dc06c7ce-5dc5-43e8-82d3-7effff6b9150	\xb144446965f48afb	"{""UPDATE usertable SET field2 = $1 WHERE ycsb_key = $1""}"	"/Table/106/1/""user16390143479181108970""/3/1"	usertable_pkey	usertable	ycsb
2024-01-30 20:51:16.649751+00	00:00:00.00735	906b067d-8722-4043-b421-2644bdedef44	\x9f816b33d2783c34	\x30e2d67f54798beb	SELECT * FROM usertable WHERE ycsb_key = $1	67c775d3-cb35-47fd-80f6-70af709db29e	\xb144446965f48afb	"{""UPDATE usertable SET field2 = $1 WHERE ycsb_key = $1""}"	"/Table/106/1/""user16390143479181108970""/3/1"	usertable_pkey	usertable	ycsb
2024-01-30 20:51:10.440136+00	00:00:00.0084	ae6a5d2d-6095-45ab-b5bb-74eb454d6492	\x9f816b33d2783c34	\x30e2d67f54798beb	SELECT * FROM usertable WHERE ycsb_key = $1	a91c387a-9700-4751-9bf1-06c02d4ce0a6	\x0eeab22cd868c6fe	"{""UPDATE usertable SET field9 = $1 WHERE ycsb_key = $1""}"	"/Table/106/1/""user12161962213042174405""/10/1"	usertable_pkey	usertable	ycsb
2024-01-30 20:51:11.752812+00	00:00:00.009507	6d4acad9-4476-447c-94c4-cb7f186c9856	\x9f816b33d2783c34	\x30e2d67f54798beb	SELECT * FROM usertable WHERE ycsb_key = $1	f78e469a-1ad4-4e91-bc5c-0be53dffe1f4	\x1e214a1f3783c9e4	"{""UPDATE usertable SET field7 = $1 WHERE ycsb_key = $1""}"	"/Table/106/1/""user12161962213042174405""/8/1"	usertable_pkey	usertable	ycsb
2024-01-30 20:51:20.420477+00	00:00:00.006348	565aef0c-14f2-4330-b9c4-a46f641a0986	\x9f816b33d2783c34	\x30e2d67f54798beb	SELECT * FROM usertable WHERE ycsb_key = $1	25153fa6-b7b5-4f50-be5c-4040eecd3858	\x734843f54c4f5988	"{""UPDATE usertable SET field3 = $1 WHERE ycsb_key = $1""}"	"/Table/106/1/""user12161962213042174405""/4/1"	usertable_pkey	usertable	ycsb
2024-01-30 20:51:12.413665+00	00:00:00.007923	1c948907-4a0e-43c6-8ae7-719c5d9ece3f	\x9f816b33d2783c34	\x30e2d67f54798beb	SELECT * FROM usertable WHERE ycsb_key = $1	89846d47-2703-4f83-b1bf-292f86a1cf1f	\xb7c74f3005577915	"{""UPDATE usertable SET field4 = $1 WHERE ycsb_key = $1""}"	"/Table/106/1/""user12161962213042174405""/5/1"	usertable_pkey	usertable	ycsb
```