### PR TITLE
roachpb: increase test make priority trials

### DIFF
--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -929,7 +929,7 @@ func TestMakePriority(t *testing.T) {
 	}
 
 	// Generate values for all priorities.
-	const trials = 750000
+	const trials = 1000000
 	values := make([][trials]enginepb.TxnPriority, len(userPs))
 	for i, userPri := range userPs {
 		for tr := 0; tr < trials; tr++ {


### PR DESCRIPTION
`TestMakePriority` could (very) rarely flake due to slight differences in the sampled vs underlying distribution. Increase the trial runs by 33% from 750k to 1000k to reduce the likelihood of this occurring.

Fixes: #118399
Release note: None