### PR TITLE
release-23.2: roachtest: update tpce tests with new connection options

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1421,12 +1421,12 @@ func newHealthStatusResult(node int, status int, body []byte, err error) *Health
 
 // HealthStatus returns the result of the /health?ready=1 endpoint for each node.
 func (c *clusterImpl) HealthStatus(
-	ctx context.Context, l *logger.Logger, node option.NodeListOption,
+	ctx context.Context, l *logger.Logger, nodes option.NodeListOption,
 ) ([]*HealthStatusResult, error) {
-	if len(node) < 1 {
+	if len(nodes) < 1 {
 		return nil, nil // unit tests
 	}
-	adminAddrs, err := c.ExternalAdminUIAddr(ctx, l, node)
+	adminAddrs, err := c.ExternalAdminUIAddr(ctx, l, nodes)
 	if err != nil {
 		return nil, errors.WithDetail(err, "Unable to get admin UI address(es)")
 	}
@@ -2462,7 +2462,7 @@ func (c *clusterImpl) loggerForCmd(
 	return l, logFile, nil
 }
 
-// pgURLErr returns the Postgres endpoint for the specified node. It accepts a
+// pgURLErr returns the Postgres endpoint for the specified nodes. It accepts a
 // flag specifying whether the URL should include the node's internal or
 // external IP address. In general, inter-cluster communication and should use
 // internal IPs and communication from a test driver to nodes in a cluster
@@ -2470,12 +2470,12 @@ func (c *clusterImpl) loggerForCmd(
 func (c *clusterImpl) pgURLErr(
 	ctx context.Context,
 	l *logger.Logger,
-	node option.NodeListOption,
+	nodes option.NodeListOption,
 	external bool,
 	tenant string,
 	sqlInstance int,
 ) ([]string, error) {
-	urls, err := roachprod.PgURL(ctx, l, c.MakeNodes(node), c.localCertsDir, roachprod.PGURLOptions{
+	urls, err := roachprod.PgURL(ctx, l, c.MakeNodes(nodes), c.localCertsDir, roachprod.PGURLOptions{
 		External:           external,
 		Secure:             c.localCertsDir != "",
 		VirtualClusterName: tenant,
@@ -2492,9 +2492,13 @@ func (c *clusterImpl) pgURLErr(
 
 // InternalPGUrl returns the internal Postgres endpoint for the specified nodes.
 func (c *clusterImpl) InternalPGUrl(
-	ctx context.Context, l *logger.Logger, node option.NodeListOption, tenant string, sqlInstance int,
+	ctx context.Context,
+	l *logger.Logger,
+	nodes option.NodeListOption,
+	tenant string,
+	sqlInstance int,
 ) ([]string, error) {
-	return c.pgURLErr(ctx, l, node, false, tenant, sqlInstance)
+	return c.pgURLErr(ctx, l, nodes, false, tenant, sqlInstance)
 }
 
 // Silence unused warning.
@@ -2502,9 +2506,13 @@ var _ = (&clusterImpl{}).InternalPGUrl
 
 // ExternalPGUrl returns the external Postgres endpoint for the specified nodes.
 func (c *clusterImpl) ExternalPGUrl(
-	ctx context.Context, l *logger.Logger, node option.NodeListOption, tenant string, sqlInstance int,
+	ctx context.Context,
+	l *logger.Logger,
+	nodes option.NodeListOption,
+	tenant string,
+	sqlInstance int,
 ) ([]string, error) {
-	return c.pgURLErr(ctx, l, node, true, tenant, sqlInstance)
+	return c.pgURLErr(ctx, l, nodes, true, tenant, sqlInstance)
 }
 
 func addrToAdminUIAddr(addr string) (string, error) {
@@ -2548,32 +2556,46 @@ func addrToHostPort(addr string) (string, int, error) {
 }
 
 // InternalAdminUIAddr returns the internal Admin UI address in the form host:port
-// for the specified node.
+// for the specified nodes.
 func (c *clusterImpl) InternalAdminUIAddr(
-	ctx context.Context, l *logger.Logger, node option.NodeListOption,
+	ctx context.Context, l *logger.Logger, nodes option.NodeListOption,
 ) ([]string, error) {
-	return c.adminUIAddr(ctx, l, node, false)
+	return c.adminUIAddr(ctx, l, nodes, false)
 }
 
 // ExternalAdminUIAddr returns the external Admin UI address in the form host:port
-// for the specified node.
+// for the specified nodes.
 func (c *clusterImpl) ExternalAdminUIAddr(
-	ctx context.Context, l *logger.Logger, node option.NodeListOption,
+	ctx context.Context, l *logger.Logger, nodes option.NodeListOption,
 ) ([]string, error) {
-	return c.adminUIAddr(ctx, l, node, true)
+	return c.adminUIAddr(ctx, l, nodes, true)
+}
+
+func (c *clusterImpl) SQLPorts(
+	ctx context.Context,
+	l *logger.Logger,
+	nodes option.NodeListOption,
+	tenant string,
+	sqlInstance int,
+) ([]int, error) {
+	return roachprod.SQLPorts(ctx, l, c.MakeNodes(nodes), c.IsSecure(), tenant, sqlInstance)
 }
 
 func (c *clusterImpl) AdminUIPorts(
-	ctx context.Context, l *logger.Logger, nodes option.NodeListOption,
+	ctx context.Context,
+	l *logger.Logger,
+	nodes option.NodeListOption,
+	tenant string,
+	sqlInstance int,
 ) ([]int, error) {
-	return roachprod.AdminPorts(ctx, l, c.MakeNodes(nodes), c.IsSecure())
+	return roachprod.AdminPorts(ctx, l, c.MakeNodes(nodes), c.IsSecure(), tenant, sqlInstance)
 }
 
 func (c *clusterImpl) adminUIAddr(
-	ctx context.Context, l *logger.Logger, node option.NodeListOption, external bool,
+	ctx context.Context, l *logger.Logger, nodes option.NodeListOption, external bool,
 ) ([]string, error) {
 	var addrs []string
-	adminURLs, err := roachprod.AdminURL(ctx, l, c.MakeNodes(node), "", 0, "",
+	adminURLs, err := roachprod.AdminURL(ctx, l, c.MakeNodes(nodes), "", 0, "",
 		external, false, false)
 	if err != nil {
 		return nil, err
@@ -2594,32 +2616,32 @@ func (c *clusterImpl) adminUIAddr(
 
 // InternalIP returns the internal IP addresses for the specified nodes.
 func (c *clusterImpl) InternalIP(
-	ctx context.Context, l *logger.Logger, node option.NodeListOption,
+	ctx context.Context, l *logger.Logger, nodes option.NodeListOption,
 ) ([]string, error) {
-	return roachprod.IP(l, c.MakeNodes(node), false)
+	return roachprod.IP(l, c.MakeNodes(nodes), false)
 }
 
 // InternalAddr returns the internal address in the form host:port for the
 // specified nodes.
 func (c *clusterImpl) InternalAddr(
-	ctx context.Context, l *logger.Logger, node option.NodeListOption,
+	ctx context.Context, l *logger.Logger, nodes option.NodeListOption,
 ) ([]string, error) {
-	return c.addr(ctx, l, node, false)
+	return c.addr(ctx, l, nodes, false)
 }
 
 // ExternalAddr returns the external address in the form host:port for the
-// specified node.
+// specified nodes.
 func (c *clusterImpl) ExternalAddr(
-	ctx context.Context, l *logger.Logger, node option.NodeListOption,
+	ctx context.Context, l *logger.Logger, nodes option.NodeListOption,
 ) ([]string, error) {
-	return c.addr(ctx, l, node, true)
+	return c.addr(ctx, l, nodes, true)
 }
 
 func (c *clusterImpl) addr(
-	ctx context.Context, l *logger.Logger, node option.NodeListOption, external bool,
+	ctx context.Context, l *logger.Logger, nodes option.NodeListOption, external bool,
 ) ([]string, error) {
 	var addrs []string
-	urls, err := c.pgURLErr(ctx, l, node, external, "" /* tenant */, 0 /* sqlInstance */)
+	urls, err := c.pgURLErr(ctx, l, nodes, external, "" /* tenant */, 0 /* sqlInstance */)
 	if err != nil {
 		return nil, err
 	}
@@ -2633,12 +2655,12 @@ func (c *clusterImpl) addr(
 	return addrs, nil
 }
 
-// ExternalIP returns the external IP addresses for the specified node.
+// ExternalIP returns the external IP addresses for the specified nodes.
 func (c *clusterImpl) ExternalIP(
-	ctx context.Context, l *logger.Logger, node option.NodeListOption,
+	ctx context.Context, l *logger.Logger, nodes option.NodeListOption,
 ) ([]string, error) {
 	var ips []string
-	addrs, err := c.ExternalAddr(ctx, l, node)
+	addrs, err := c.ExternalAddr(ctx, l, nodes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -75,6 +75,7 @@ type Cluster interface {
 	InternalIP(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)
 	ExternalAddr(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)
 	ExternalIP(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)
+	SQLPorts(ctx context.Context, l *logger.Logger, node option.NodeListOption, tenant string, sqlInstance int) ([]int, error)
 
 	// SQL connection strings.
 
@@ -90,7 +91,7 @@ type Cluster interface {
 
 	InternalAdminUIAddr(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)
 	ExternalAdminUIAddr(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)
-	AdminUIPorts(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]int, error)
+	AdminUIPorts(ctx context.Context, l *logger.Logger, node option.NodeListOption, tenant string, sqlInstance int) ([]int, error)
 
 	// Running commands on nodes.
 

--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -425,7 +425,7 @@ SELECT count(replicas)
 	t.L().Printf("killing all nodes\n")
 	c.Stop(ctx, t.L(), option.DefaultStopOpts())
 
-	adminPorts, err := c.AdminUIPorts(ctx, t.L(), c.Node(1))
+	adminPorts, err := c.AdminUIPorts(ctx, t.L(), c.Node(1), "" /* tenant */, 0 /* sqlInstance */)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -731,8 +731,10 @@ func (tpce tpceRestore) init(
 ) {
 	spec := tpce.getSpec(ctx, t, c, sp)
 	spec.init(ctx, t, c, tpceCmdOptions{
-		customers: tpce.customers,
-		racks:     sp.nodes})
+		customers:      tpce.customers,
+		racks:          sp.nodes,
+		connectionOpts: defaultTPCEConnectionOpts(),
+	})
 }
 
 func (tpce tpceRestore) run(
@@ -741,10 +743,12 @@ func (tpce tpceRestore) run(
 	spec := tpce.getSpec(ctx, t, c, sp)
 	_, err := spec.run(ctx, t, c, tpceCmdOptions{
 		// Set the duration to be a week to ensure the workload never exits early.
-		duration:  time.Hour * 7 * 24,
-		customers: tpce.customers,
-		racks:     sp.nodes,
-		threads:   sp.cpus * sp.nodes})
+		duration:       time.Hour * 7 * 24,
+		customers:      tpce.customers,
+		racks:          sp.nodes,
+		threads:        sp.cpus * sp.nodes,
+		connectionOpts: defaultTPCEConnectionOpts(),
+	})
 	return err
 }
 

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -516,8 +516,10 @@ func (c *SyncedCluster) NodeURL(
 }
 
 // NodePort returns the system tenant's SQL port for the given node.
-func (c *SyncedCluster) NodePort(ctx context.Context, node Node) (int, error) {
-	desc, err := c.DiscoverService(ctx, node, SystemInterfaceName, ServiceTypeSQL, 0)
+func (c *SyncedCluster) NodePort(
+	ctx context.Context, node Node, virtualClusterName string, sqlInstance int,
+) (int, error) {
+	desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
 	if err != nil {
 		return 0, err
 	}
@@ -525,8 +527,10 @@ func (c *SyncedCluster) NodePort(ctx context.Context, node Node) (int, error) {
 }
 
 // NodeUIPort returns the system tenant's AdminUI port for the given node.
-func (c *SyncedCluster) NodeUIPort(ctx context.Context, node Node) (int, error) {
-	desc, err := c.DiscoverService(ctx, node, SystemInterfaceName, ServiceTypeUI, 0)
+func (c *SyncedCluster) NodeUIPort(
+	ctx context.Context, node Node, virtualClusterName string, sqlInstance int,
+) (int, error) {
+	desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeUI, sqlInstance)
 	if err != nil {
 		return 0, err
 	}
@@ -1159,7 +1163,7 @@ func (c *SyncedCluster) generateClusterSettingCmd(
 		pathPrefix = fmt.Sprintf("%s_", virtualCluster)
 	}
 	path := fmt.Sprintf("%s/%ssettings-initialized", c.NodeDir(node, 1 /* storeIndex */), pathPrefix)
-	port, err := c.NodePort(ctx, node)
+	port, err := c.NodePort(ctx, node, "" /* virtualClusterName */, 0 /* sqlInstance */)
 	if err != nil {
 		return "", err
 	}
@@ -1181,7 +1185,7 @@ func (c *SyncedCluster) generateInitCmd(ctx context.Context, node Node) (string,
 	}
 
 	path := fmt.Sprintf("%s/%s", c.NodeDir(node, 1 /* storeIndex */), "cluster-bootstrapped")
-	port, err := c.NodePort(ctx, node)
+	port, err := c.NodePort(ctx, node, "" /* virtualClusterName */, 0 /* sqlInstance */)
 	if err != nil {
 		return "", err
 	}
@@ -1388,7 +1392,7 @@ func (c *SyncedCluster) createFixedBackupSchedule(
 
 	node := c.Nodes[0]
 	binary := cockroachNodeBinary(c, node)
-	port, err := c.NodePort(ctx, node)
+	port, err := c.NodePort(ctx, node, "" /* virtualClusterName */, 0 /* sqlInstance */)
 	if err != nil {
 		return err
 	}

--- a/pkg/roachprod/install/expander.go
+++ b/pkg/roachprod/install/expander.go
@@ -229,7 +229,7 @@ func (e *expander) maybeExpandUIPort(
 		e.uiPorts = make(map[Node]string, len(c.VMs))
 		for _, node := range allNodes(len(c.VMs)) {
 			// TODO(herko): Add support for separate-process services.
-			e.uiPorts[node] = fmt.Sprint(c.NodeUIPort(ctx, node))
+			e.uiPorts[node] = fmt.Sprint(c.NodeUIPort(ctx, node, "" /* virtualClusterName */, 0 /* sqlInstance */))
 		}
 	}
 

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -40,7 +40,7 @@ func StartServiceForVirtualCluster(
 
 	var kvAddrs []string
 	for _, node := range sc.Nodes {
-		port, err := sc.NodePort(ctx, node)
+		port, err := sc.NodePort(ctx, node, "" /* virtualClusterName */, 0 /* sqlInstance */)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Backport 1/1 commits from #117983.

/cc @cockroachdb/release

---

The tpc-e driver has been updated to accept options for a fixture bucket, port, username and password. This change adds those options accordingly to the tpce tests.

Previously, tpce hardcoded the sql port as 26257. Now that tpce can accept a port option, we can instead discover the port and pass it.

This change also includes a new SQLPort function that returns the sql port of the given nodes, as well as fixes miscellaneous function signatures to correctly say nodes instead of node.

Release note: None
Epic: None
Fixes: #117567

---

Release justification: test only change