### PR TITLE
util/span: use bazel for codegen, regenerate

### DIFF
--- a/build/bazelutil/check.sh
+++ b/build/bazelutil/check.sh
@@ -43,7 +43,7 @@ pkg/util/log/channels.go://go:generate go run gen/main.go logpb/log.proto log_ch
 pkg/util/log/channels.go://go:generate go run gen/main.go logpb/log.proto logging.md ../../../docs/generated/logging.md
 pkg/util/log/channels.go://go:generate go run gen/main.go logpb/log.proto severity.go severity/severity_generated.go
 pkg/util/log/sinks.go://go:generate mockgen -package=log -destination=mocks_generated_test.go --mock_names=TestingLogSink=MockLogSink . TestingLogSink
-pkg/util/span/frontier.go://go:generate ../interval/generic/gen.sh *frontierEntry span
+pkg/util/span/frontier.go://go:generate ../interval/generic/gen.sh *btreeFrontierEntry span
 pkg/util/timeutil/zoneinfo.go://go:generate go run gen/main.go
 pkg/internal/team/team.go://go:generate cp ../../../TEAMS.yaml TEAMS.yaml
 "

--- a/pkg/gen/misc.bzl
+++ b/pkg/gen/misc.bzl
@@ -35,5 +35,7 @@ MISC_SRCS = [
     "//pkg/util/log/logpb:json_encode_generated.go",
     "//pkg/util/log/severity:severity_generated.go",
     "//pkg/util/log:log_channels_generated.go",
+    "//pkg/util/span:btreefrontierentry_interval_btree.go",
+    "//pkg/util/span:btreefrontierentry_interval_btree_test.go",
     "//pkg/util/timeutil:lowercase_timezones_generated.go",
 ]

--- a/pkg/util/span/BUILD.bazel
+++ b/pkg/util/span/BUILD.bazel
@@ -4,6 +4,7 @@ load("//pkg/util/interval/generic:gen.bzl", "gen_interval_btree")
 go_library(
     name = "span",
     srcs = [
+        "doc.go",
         "frontier.go",
         "llrb_frontier.go",
         ":btreefrontierentry_interval_btree.go",  #keep

--- a/pkg/util/span/BUILD.bazel
+++ b/pkg/util/span/BUILD.bazel
@@ -1,11 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//pkg/util/interval/generic:gen.bzl", "gen_interval_btree")
 
 go_library(
     name = "span",
     srcs = [
         "frontier.go",
-        "frontierentry_interval_btree.go",  #keep
         "llrb_frontier.go",
+        ":btreefrontierentry_interval_btree.go",  #keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/span",
     visibility = ["//visibility:public"],
@@ -27,7 +28,7 @@ go_test(
     size = "large",
     srcs = [
         "frontier_test.go",
-        "frontierentry_interval_btree_test.go",  #keep
+        ":btreefrontierentry_interval_btree_test.go",  #keep
     ],
     data = glob(["testdata/**"]),
     embed = [":span"],
@@ -47,4 +48,10 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
+)
+
+gen_interval_btree(
+    name = "frontier_interval_btree",
+    package = "span",
+    type = "*btreeFrontierEntry",
 )

--- a/pkg/util/span/btreefrontierentry_interval_btree.go
+++ b/pkg/util/span/btreefrontierentry_interval_btree.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"unsafe"
 )
 
 // nilT is a nil instance of the Template type.
@@ -99,43 +98,45 @@ func upperBound(c *btreeFrontierEntry) keyBound {
 	return keyBound{key: c.Key(), inc: true}
 }
 
-type leafNode struct {
+type node struct {
 	ref   int32
 	count int16
-	leaf  bool
-	max   keyBound
+
+	// These fields form a keyBound, but by inlining them into node we can avoid
+	// the extra word that would be needed to pad out maxInc if it were part of
+	// its own struct.
+	maxInc bool
+	maxKey []byte
+
 	items [maxItems]*btreeFrontierEntry
+
+	// The children array pointer is only populated for interior nodes; it is nil
+	// for leaf nodes.
+	children *childrenArray
 }
 
-type node struct {
-	leafNode
-	children [maxItems + 1]*node
-}
-
-//go:nocheckptr casts a ptr to a smaller struct to a ptr to a larger struct.
-func leafToNode(ln *leafNode) *node {
-	return (*node)(unsafe.Pointer(ln))
-}
-
-func nodeToLeaf(n *node) *leafNode {
-	return (*leafNode)(unsafe.Pointer(n))
-}
+type childrenArray = [maxItems + 1]*node
 
 var leafPool = sync.Pool{
-	New: func() interface{} {
-		return new(leafNode)
-	},
-}
-
-var nodePool = sync.Pool{
 	New: func() interface{} {
 		return new(node)
 	},
 }
 
+var nodePool = sync.Pool{
+	New: func() interface{} {
+		type interiorNode struct {
+			node
+			children childrenArray
+		}
+		n := new(interiorNode)
+		n.node.children = &n.children
+		return &n.node
+	},
+}
+
 func newLeafNode() *node {
-	n := leafToNode(leafPool.Get().(*leafNode))
-	n.leaf = true
+	n := leafPool.Get().(*node)
 	n.ref = 1
 	return n
 }
@@ -172,6 +173,25 @@ func mut(n **node) *node {
 	return *n
 }
 
+// leaf returns true if this is a leaf node.
+func (n *node) leaf() bool {
+	return n.children == nil
+}
+
+// max returns the maximum keyBound in the subtree rooted at this node.
+func (n *node) max() keyBound {
+	return keyBound{
+		key: n.maxKey,
+		inc: n.maxInc,
+	}
+}
+
+// setMax sets the maximum keyBound for the subtree rooted at this node.
+func (n *node) setMax(k keyBound) {
+	n.maxKey = k.key
+	n.maxInc = k.inc
+}
+
 // incRef acquires a reference to the node.
 func (n *node) incRef() {
 	atomic.AddInt32(&n.ref, 1)
@@ -185,10 +205,9 @@ func (n *node) decRef(recursive bool) {
 		return
 	}
 	// Clear and release node into memory pool.
-	if n.leaf {
-		ln := nodeToLeaf(n)
-		*ln = leafNode{}
-		leafPool.Put(ln)
+	if n.leaf() {
+		*n = node{}
+		leafPool.Put(n)
 	} else {
 		// Release child references first, if requested.
 		if recursive {
@@ -196,7 +215,8 @@ func (n *node) decRef(recursive bool) {
 				n.children[i].decRef(true /* recursive */)
 			}
 		}
-		*n = node{}
+		*n = node{children: n.children}
+		*n.children = childrenArray{}
 		nodePool.Put(n)
 	}
 }
@@ -204,7 +224,7 @@ func (n *node) decRef(recursive bool) {
 // clone creates a clone of the receiver with a single reference count.
 func (n *node) clone() *node {
 	var c *node
-	if n.leaf {
+	if n.leaf() {
 		c = newLeafNode()
 	} else {
 		c = newNode()
@@ -212,11 +232,12 @@ func (n *node) clone() *node {
 	// NB: copy field-by-field without touching n.ref to avoid
 	// triggering the race detector and looking like a data race.
 	c.count = n.count
-	c.max = n.max
+	c.maxKey = n.maxKey
+	c.maxInc = n.maxInc
 	c.items = n.items
-	if !c.leaf {
+	if !c.leaf() {
 		// Copy children and increase each refcount.
-		c.children = n.children
+		*c.children = *n.children
 		for i := int16(0); i <= c.count; i++ {
 			c.children[i].incRef()
 		}
@@ -227,12 +248,12 @@ func (n *node) clone() *node {
 func (n *node) insertAt(index int, item *btreeFrontierEntry, nd *node) {
 	if index < int(n.count) {
 		copy(n.items[index+1:n.count+1], n.items[index:n.count])
-		if !n.leaf {
+		if !n.leaf() {
 			copy(n.children[index+2:n.count+2], n.children[index+1:n.count+1])
 		}
 	}
 	n.items[index] = item
-	if !n.leaf {
+	if !n.leaf() {
 		n.children[index+1] = nd
 	}
 	n.count++
@@ -240,14 +261,14 @@ func (n *node) insertAt(index int, item *btreeFrontierEntry, nd *node) {
 
 func (n *node) pushBack(item *btreeFrontierEntry, nd *node) {
 	n.items[n.count] = item
-	if !n.leaf {
+	if !n.leaf() {
 		n.children[n.count+1] = nd
 	}
 	n.count++
 }
 
 func (n *node) pushFront(item *btreeFrontierEntry, nd *node) {
-	if !n.leaf {
+	if !n.leaf() {
 		copy(n.children[1:n.count+2], n.children[:n.count+1])
 		n.children[0] = nd
 	}
@@ -256,11 +277,11 @@ func (n *node) pushFront(item *btreeFrontierEntry, nd *node) {
 	n.count++
 }
 
-// removeAt removes a value at a given heapIdx, pulling all subsequent values
+// removeAt removes a value at a given index, pulling all subsequent values
 // back.
 func (n *node) removeAt(index int) (*btreeFrontierEntry, *node) {
 	var child *node
-	if !n.leaf {
+	if !n.leaf() {
 		child = n.children[index+1]
 		copy(n.children[index+1:n.count], n.children[index+2:n.count+1])
 		n.children[n.count] = nil
@@ -277,7 +298,7 @@ func (n *node) popBack() (*btreeFrontierEntry, *node) {
 	n.count--
 	out := n.items[n.count]
 	n.items[n.count] = nilT
-	if n.leaf {
+	if n.leaf() {
 		return out, nil
 	}
 	child := n.children[n.count+1]
@@ -289,7 +310,7 @@ func (n *node) popBack() (*btreeFrontierEntry, *node) {
 func (n *node) popFront() (*btreeFrontierEntry, *node) {
 	n.count--
 	var child *node
-	if !n.leaf {
+	if !n.leaf() {
 		child = n.children[0]
 		copy(n.children[:n.count+1], n.children[1:n.count+2])
 		n.children[n.count+1] = nil
@@ -300,9 +321,9 @@ func (n *node) popFront() (*btreeFrontierEntry, *node) {
 	return out, child
 }
 
-// find returns the heapIdx where the given item should be inserted into this
+// find returns the index where the given item should be inserted into this
 // list. 'found' is true if the item already exists in the list at the given
-// heapIdx.
+// index.
 func (n *node) find(item *btreeFrontierEntry) (index int, found bool) {
 	// Logic copied from sort.Search. Inlining this gave
 	// an 11% speedup on BenchmarkBTreeDeleteInsert.
@@ -322,8 +343,8 @@ func (n *node) find(item *btreeFrontierEntry) (index int, found bool) {
 	return i, false
 }
 
-// split splits the given node at the given heapIdx. The current node shrinks,
-// and this function returns the item that existed at that heapIdx and a new
+// split splits the given node at the given index. The current node shrinks,
+// and this function returns the item that existed at that index and a new
 // node containing all items/children after it.
 //
 // Before:
@@ -346,7 +367,7 @@ func (n *node) find(item *btreeFrontierEntry) (index int, found bool) {
 func (n *node) split(i int) (*btreeFrontierEntry, *node) {
 	out := n.items[i]
 	var next *node
-	if n.leaf {
+	if n.leaf() {
 		next = newLeafNode()
 	} else {
 		next = newNode()
@@ -356,7 +377,7 @@ func (n *node) split(i int) (*btreeFrontierEntry, *node) {
 	for j := int16(i); j < n.count; j++ {
 		n.items[j] = nilT
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		copy(next.children[:], n.children[i+1:n.count+1])
 		for j := int16(i + 1); j <= n.count; j++ {
 			n.children[j] = nil
@@ -364,12 +385,14 @@ func (n *node) split(i int) (*btreeFrontierEntry, *node) {
 	}
 	n.count = int16(i)
 
-	next.max = next.findUpperBound()
-	if n.max.compare(next.max) != 0 && n.max.compare(upperBound(out)) != 0 {
+	nextMax := next.findUpperBound()
+	next.setMax(nextMax)
+	nMax := n.max()
+	if nMax.compare(nextMax) != 0 && nMax.compare(upperBound(out)) != 0 {
 		// If upper bound wasn't from new node or item
-		// at heapIdx i, it must still be from old node.
+		// at index i, it must still be from old node.
 	} else {
-		n.max = n.findUpperBound()
+		n.setMax(n.findUpperBound())
 	}
 	return out, next
 }
@@ -384,7 +407,7 @@ func (n *node) insert(item *btreeFrontierEntry) (replaced, newBound bool) {
 		n.items[i] = item
 		return true, false
 	}
-	if n.leaf {
+	if n.leaf() {
 		n.insertAt(i, item, nil)
 		return false, n.adjustUpperBoundOnInsertion(item, nil)
 	}
@@ -412,7 +435,7 @@ func (n *node) insert(item *btreeFrontierEntry) (replaced, newBound bool) {
 // removeMax removes and returns the maximum item from the subtree rooted at
 // this node.
 func (n *node) removeMax() *btreeFrontierEntry {
-	if n.leaf {
+	if n.leaf() {
 		n.count--
 		out := n.items[n.count]
 		n.items[n.count] = nilT
@@ -437,7 +460,7 @@ func (n *node) removeMax() *btreeFrontierEntry {
 // the node's upper bound changes.
 func (n *node) remove(item *btreeFrontierEntry) (out *btreeFrontierEntry, newBound bool) {
 	i, found := n.find(item)
-	if n.leaf {
+	if n.leaf() {
 		if found {
 			out, _ = n.removeAt(i)
 			return out, n.adjustUpperBoundOnRemoval(out, nil)
@@ -578,7 +601,7 @@ func (n *node) rebalanceOrMerge(i int) {
 		mergeLa, mergeChild := n.removeAt(i)
 		child.items[child.count] = mergeLa
 		copy(child.items[child.count+1:], mergeChild.items[:mergeChild.count])
-		if !child.leaf {
+		if !child.leaf() {
 			copy(child.children[child.count+1:], mergeChild.children[:mergeChild.count+1])
 		}
 		child.count += mergeChild.count + 1
@@ -598,9 +621,9 @@ func (n *node) findUpperBound() keyBound {
 			max = up
 		}
 	}
-	if !n.leaf {
+	if !n.leaf() {
 		for i := int16(0); i <= n.count; i++ {
-			up := n.children[i].max
+			up := n.children[i].max()
 			if max.compare(up) < 0 {
 				max = up
 			}
@@ -615,12 +638,12 @@ func (n *node) findUpperBound() keyBound {
 func (n *node) adjustUpperBoundOnInsertion(item *btreeFrontierEntry, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
-		if up.compare(child.max) < 0 {
-			up = child.max
+		if childMax := child.max(); up.compare(childMax) < 0 {
+			up = childMax
 		}
 	}
-	if n.max.compare(up) < 0 {
-		n.max = up
+	if n.max().compare(up) < 0 {
+		n.setMax(up)
 		return true
 	}
 	return false
@@ -632,22 +655,23 @@ func (n *node) adjustUpperBoundOnInsertion(item *btreeFrontierEntry, child *node
 func (n *node) adjustUpperBoundOnRemoval(item *btreeFrontierEntry, child *node) bool {
 	up := upperBound(item)
 	if child != nil {
-		if up.compare(child.max) < 0 {
-			up = child.max
+		if childMax := child.max(); up.compare(childMax) < 0 {
+			up = childMax
 		}
 	}
-	if n.max.compare(up) == 0 {
+	if n.max().compare(up) == 0 {
 		// up was previous upper bound of n.
-		n.max = n.findUpperBound()
-		return n.max.compare(up) != 0
+		max := n.findUpperBound()
+		n.setMax(max)
+		return max.compare(up) != 0
 	}
 	return false
 }
 
-// btree is an implementation of an augmented rng B-Tree.
+// btree is an implementation of an augmented interval B-Tree.
 //
 // btree stores items in an ordered structure, allowing easy insertion,
-// removal, and iteration. It represents intervals and permits an rng
+// removal, and iteration. It represents intervals and permits an interval
 // search operation following the approach laid out in CLRS, Chapter 14.
 // The B-Tree stores items in order based on their start key and each
 // B-Tree node maintains the upper-bound end key of all items in its
@@ -705,7 +729,7 @@ func (t *btree) Delete(item *btreeFrontierEntry) {
 	}
 	if t.root.count == 0 {
 		old := t.root
-		if t.root.leaf {
+		if t.root.leaf() {
 			t.root = nil
 		} else {
 			t.root = t.root.children[0]
@@ -726,7 +750,7 @@ func (t *btree) Set(item *btreeFrontierEntry) {
 		newRoot.items[0] = splitLa
 		newRoot.children[0] = t.root
 		newRoot.children[1] = splitNode
-		newRoot.max = newRoot.findUpperBound()
+		newRoot.setMax(newRoot.findUpperBound())
 		t.root = newRoot
 	}
 	if replaced, _ := mut(&t.root).insert(item); !replaced {
@@ -748,7 +772,7 @@ func (t *btree) Height() int {
 	}
 	h := 1
 	n := t.root
-	for !n.leaf {
+	for !n.leaf() {
 		n = n.children[0]
 		h++
 	}
@@ -772,7 +796,7 @@ func (t *btree) String() string {
 }
 
 func (n *node) writeString(b *strings.Builder) {
-	if n.leaf {
+	if n.leaf() {
 		for i := int16(0); i < n.count; i++ {
 			if i != 0 {
 				b.WriteString(",")
@@ -889,7 +913,7 @@ func (i *iterator) SeekGE(item *btreeFrontierEntry) {
 		if found {
 			return
 		}
-		if i.n.leaf {
+		if i.n.leaf() {
 			if i.pos == i.n.count {
 				i.Next()
 			}
@@ -908,7 +932,7 @@ func (i *iterator) SeekLT(item *btreeFrontierEntry) {
 	for {
 		pos, found := i.n.find(item)
 		i.pos = int16(pos)
-		if found || i.n.leaf {
+		if found || i.n.leaf() {
 			i.Prev()
 			return
 		}
@@ -922,7 +946,7 @@ func (i *iterator) First() {
 	if i.n == nil {
 		return
 	}
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, 0)
 	}
 	i.pos = 0
@@ -934,7 +958,7 @@ func (i *iterator) Last() {
 	if i.n == nil {
 		return
 	}
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, i.n.count)
 	}
 	i.pos = i.n.count - 1
@@ -947,7 +971,7 @@ func (i *iterator) Next() {
 		return
 	}
 
-	if i.n.leaf {
+	if i.n.leaf() {
 		i.pos++
 		if i.pos < i.n.count {
 			return
@@ -959,7 +983,7 @@ func (i *iterator) Next() {
 	}
 
 	i.descend(i.n, i.pos+1)
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, 0)
 	}
 	i.pos = 0
@@ -972,7 +996,7 @@ func (i *iterator) Prev() {
 		return
 	}
 
-	if i.n.leaf {
+	if i.n.leaf() {
 		i.pos--
 		if i.pos >= 0 {
 			return
@@ -985,7 +1009,7 @@ func (i *iterator) Prev() {
 	}
 
 	i.descend(i.n, i.pos)
-	for !i.n.leaf {
+	for !i.n.leaf() {
 		i.descend(i.n, i.n.count)
 	}
 	i.pos = i.n.count - 1
@@ -1003,21 +1027,21 @@ func (i *iterator) Cur() *btreeFrontierEntry {
 }
 
 // An overlap scan is a scan over all items that overlap with the provided
-// item in order of the overlapping items' start rng. The goal of the scan
+// item in order of the overlapping items' start keys. The goal of the scan
 // is to minimize the number of key comparisons performed in total. The
 // algorithm operates based on the following two invariants maintained by
-// augmented rng btree:
+// augmented interval btree:
 //  1. all items are sorted in the btree based on their start key.
 //  2. all btree nodes maintain the upper bound end key of all items
 //     in their subtree.
 //
 // The scan algorithm starts in "unconstrained minimum" and "unconstrained
 // maximum" states. To enter a "constrained minimum" state, the scan must reach
-// items in the tree with start rng above the search range's start key.
+// items in the tree with start keys above the search range's start key.
 // Because items in the tree are sorted by start key, once the scan enters the
 // "constrained minimum" state it will remain there. To enter a "constrained
 // maximum" state, the scan must determine the first child btree node in a given
-// subtree that can have items with start rng above the search range's end
+// subtree that can have items with start keys above the search range's end
 // key. The scan then remains in the "constrained maximum" state until it
 // traverse into this child node, at which point it moves to the "unconstrained
 // maximum" state again.
@@ -1030,18 +1054,18 @@ func (i *iterator) Cur() *btreeFrontierEntry {
 //  2. when tranversing into a child node in the lower or upper bound constraint
 //     position, the constraint is refined by searching the child's items.
 //  3. the initial traversal down the tree follows the left-most children
-//     whose upper bound end rng are equal to or greater than the start key
+//     whose upper bound end keys are equal to or greater than the start key
 //     of the search range. The children followed will be equal to or less
 //     than the soft lower bound constraint.
 //  4. once the initial tranversal completes and the scan is in the left-most
 //     btree node whose upper bound overlaps the search range, key comparisons
 //     must be performed with each item in the tree. This is necessary because
-//     any of these items may have end rng that cause them to overlap with the
+//     any of these items may have end keys that cause them to overlap with the
 //     search range.
 //  5. once the scan reaches the lower bound constraint position (the first item
 //     with a start key equal to or greater than the search range's start key),
 //     it can begin scaning without performing key comparisons. This is allowed
-//     because all items from this point forward will have end rng that are
+//     because all items from this point forward will have end keys that are
 //     greater than the search range's start key.
 //  6. once the scan reaches the upper bound constraint position, it terminates.
 //     It does so because the item at this position is the first item with a
@@ -1104,9 +1128,9 @@ func (i *iterator) findNextOverlap(item *btreeFrontierEntry) {
 		if i.pos > i.n.count {
 			// Iterate up tree.
 			i.ascend()
-		} else if !i.n.leaf {
+		} else if !i.n.leaf() {
 			// Iterate down tree.
-			if i.o.constrMinReached || i.n.children[i.pos].max.contains(item) {
+			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
 				par := i.n
 				pos := i.pos
 				i.descend(par, pos)
@@ -1138,7 +1162,7 @@ func (i *iterator) findNextOverlap(item *btreeFrontierEntry) {
 			// Check for overlapping item.
 			if i.o.constrMinReached {
 				// Fast-path to avoid span comparison. i.o.constrMinReached
-				// tells us that all items have end rng above our search
+				// tells us that all items have end keys above our search
 				// span's start key.
 				return
 			}

--- a/pkg/util/span/doc.go
+++ b/pkg/util/span/doc.go
@@ -1,0 +1,12 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package span contains utilities for working with sets of spans.
+package span

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -192,7 +192,7 @@ type btreeFrontierEntry struct {
 	spanCopy roachpb.Span
 }
 
-//go:generate ../interval/generic/gen.sh *frontierEntry span
+//go:generate ../interval/generic/gen.sh *btreeFrontierEntry span
 
 // AddSpansAt adds the provided spans to the btreeFrontier at the provided timestamp.
 // AddSpansAt deletes any overlapping spans already in the frontier.


### PR DESCRIPTION
In #110516, the code started used a generated btree. Unfortunately, the code did not adopt bazel code generation, so missed a regeneration when the changes in #116663 merged.

Also, it seems, the change rotted such that regenerating didn't work because the entry was renamed from `frontierEntry` to `btreeFrontierEntry` without updating the go:generate comment. I imagine somebody did a manual rename.

This fixes the problem by adopting bazel generation.

Epic: None

Release note: None