### PR TITLE
gcjob_test: deflake TestSchemaChangeGCJob

### DIFF
--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -234,9 +234,18 @@ func doTestSchemaChangeGCJob(t *testing.T, dropItem DropItem, ttlTime TTLTime) {
 	// Check that the job started.
 	jobIDStr := strconv.Itoa(int(job.ID()))
 	testutils.SucceedsSoon(t, func() error {
-		return jobutils.VerifyRunningSystemJob(
+		if err := jobutils.VerifyRunningSystemJob(
 			t, sqlDB, 0, jobspb.TypeSchemaChangeGC, sql.RunningStatusWaitingGC, lookupJR,
-		)
+		); err != nil {
+			// Since the intervals are set very low, the GC TTL job may have already
+			// started. If so, the status will be "deleting data" since "waiting for
+			// GC TTL" will have completed already.
+			if testutils.IsError(err, "expected running status waiting for GC TTL, got deleting data") {
+				return nil
+			}
+			return err
+		}
+		return nil
 	})
 
 	if ttlTime != FUTURE {


### PR DESCRIPTION
This updates a test assertion so that if the GC TTL already began, the test does not fail.

fixes https://github.com/cockroachdb/cockroach/issues/117485
fixes https://github.com/cockroachdb/cockroach/issues/118467
Release note: None