### PR TITLE
sql/row: include pretty key in value decode error message

### DIFF
--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -826,13 +826,17 @@ func (rf *Fetcher) processKV(
 ) (prettyKey string, prettyValue string, err error) {
 	table := &rf.table
 
-	if rf.args.TraceKV {
-		prettyKey = fmt.Sprintf(
+	mkPrettyKey := func() string {
+		return fmt.Sprintf(
 			"/%s/%s%s",
 			table.spec.TableName,
 			table.spec.IndexName,
 			rf.prettyKeyDatums(table.spec.KeyAndSuffixColumns, table.keyVals),
 		)
+	}
+
+	if rf.args.TraceKV {
+		prettyKey = mkPrettyKey()
 	}
 
 	// Either this is the first key of the fetch or the first key of a new
@@ -930,7 +934,11 @@ func (rf *Fetcher) processKV(
 					if kv.Value.GetTag() == roachpb.ValueType_UNKNOWN {
 						// Tombstone for a secondary column family, nothing needs to be done.
 					} else {
-						return "", "", errors.Errorf("single entry value with no default column id")
+						if prettyKey == "" {
+							prettyKey = mkPrettyKey()
+						}
+						return "", "",
+							errors.Errorf("single entry value with no default column id for key %s", prettyKey)
 					}
 				} else {
 					prettyKey, prettyValue, err = rf.processValueSingle(ctx, table, defaultColumnID, kv, prettyKey)


### PR DESCRIPTION
Previously, in issues #117112, it's very difficult to determine the cause of value decoding errors such as `single entry value with no default column id for key`. This change generates a pretty key if it has not been done so already and includes it in the error message.

Closes: https://github.com/cockroachdb/cockroach/issues/117112
Epic: none
Release note: None
