### PR TITLE
regionliveness: fix flakes inside TestRegionLivenessProber

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -86,7 +86,6 @@ go_test(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlinstance/instancestorage",
         "//pkg/sql/sqlliveness",
-        "//pkg/sql/sqlliveness/slbase",
         "//pkg/sql/sqlliveness/slstorage",
         "//pkg/sql/sqltestutils",
         "//pkg/testutils",


### PR DESCRIPTION
Previously, the cancellation generated by timeouts set by region liveness probing could potentially fail with "context deadline exceeded". This could happen in code paths where the cancellation checker isn't used for example within the region liveness code when pure KV calls are used. To address this, this patch allow context cancelled errors to be treated as timeouts. Additionally, the region liveness tests are cleaned up and have the sqlliveness TTL increased to reduce the risk of flakes. Also the reduced probing timeouts are only setup for short periods of time when failures are expected to reduce risk of intermittent failures.

Fixes: #118465
fixes #118464

Release note: None