### PR TITLE
roachprod: remove ubuntu version override

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -887,9 +887,6 @@ func (f *clusterFactory) newCluster(
 		providerOptsContainer.SetProviderOpts(cloud, providerOpts)
 	}
 
-	if cfg.spec.UbuntuVersion.IsOverridden() {
-		createVMOpts.UbuntuVersion = cfg.spec.UbuntuVersion
-	}
 	createFlagsOverride(&createVMOpts)
 	// Make sure expiration is changed if --lifetime override flag
 	// is passed.

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -93,7 +93,6 @@ type ClusterSpec struct {
 	Lifetime             time.Duration
 	ReusePolicy          clusterReusePolicy
 	TerminateOnMigration bool
-	UbuntuVersion        vm.UbuntuVersion
 	// Use a spot instance or equivalent of a cloud provider.
 	UseSpotVMs bool
 	// FileSystem determines the underlying FileSystem

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -266,10 +266,3 @@ func AWSZones(zones string) Option {
 		spec.AWS.Zones = zones
 	}
 }
-
-// UbuntuVersion controls what Ubuntu Version is used to create the cluster.
-func UbuntuVersion(version vm.UbuntuVersion) Option {
-	return func(spec *ClusterSpec) {
-		spec.UbuntuVersion = version
-	}
-}

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -142,11 +142,7 @@ sudo sh -c 'echo "MaxStartups 64:30:128" >> /etc/ssh/sshd_config'
 # Crank up the logging for issues such as:
 # https://github.com/cockroachdb/cockroach/issues/36929
 sudo sed -i'' 's/LogLevel.*$/LogLevel DEBUG3/' /etc/ssh/sshd_config
-# N.B. RSA SHA1 is no longer supported in the latest versions of OpenSSH. Existing tooling, e.g.,
-# jepsen still relies on it for authentication. If we are on Ubuntu 22.04 or newer, we need to enable it.
-{{ if .EnableRSAForSSH }}
 sudo sh -c 'echo "PubkeyAcceptedAlgorithms +ssh-rsa" >> /etc/ssh/sshd_config'
-{{ end }}
 sudo service sshd restart
 # increase the default maximum number of open file descriptors for
 # root and non-root users. Load generators running a lot of concurrent
@@ -248,16 +244,13 @@ sudo touch /mnt/data1/.roachprod-initialized
 // extraMountOpts, if not empty, is appended to the default mount options. It is
 // a comma-separated list of options for the "mount -o" flag.
 func writeStartupScript(
-	extraMountOpts string, fileSystem string, useMultiple bool, enableFIPS bool, enableRSAForSSH bool,
+	extraMountOpts string, fileSystem string, useMultiple bool, enableFIPS bool,
 ) (string, error) {
 	type tmplParams struct {
 		ExtraMountOpts   string
 		UseMultipleDisks bool
 		Zfs              bool
 		EnableFIPS       bool
-		// TODO(DarrylWong): In the future, when all tests are run on Ubuntu 22.04, we can remove this check and default true.
-		// See: https://github.com/cockroachdb/cockroach/issues/112112
-		EnableRSAForSSH bool
 	}
 
 	args := tmplParams{
@@ -265,7 +258,6 @@ func writeStartupScript(
 		UseMultipleDisks: useMultiple,
 		Zfs:              fileSystem == vm.Zfs,
 		EnableFIPS:       enableFIPS,
-		EnableRSAForSSH:  enableRSAForSSH,
 	}
 
 	tmpfile, err := os.CreateTemp("", "gce-startup-script")

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -278,7 +278,6 @@ type CreateOpts struct {
 
 	GeoDistributed bool
 	Arch           string
-	UbuntuVersion  UbuntuVersion
 	VMProviders    []string
 	SSDOpts        struct {
 		UseLocalSSD bool
@@ -707,25 +706,4 @@ func SanitizeLabel(label string) string {
 	// Remove any leading or trailing hyphens
 	label = strings.Trim(label, "-")
 	return label
-}
-
-// UbuntuVersion specifies the version of Ubuntu used. Note that a default
-// version is already provided and this is only for overriding that default.
-// TODO(Darryl): Remove after all tests are upgraded to Ubuntu 22.04.
-// See: https://github.com/cockroachdb/cockroach/issues/112112.
-type UbuntuVersion string
-
-type UbuntuImages struct {
-	DefaultImage string
-	ARM64Image   string
-	FIPSImage    string
-}
-
-const (
-	FocalFossa UbuntuVersion = "20.04"
-)
-
-// IsOverridden returns true if an Ubuntu version was specified.
-func (u UbuntuVersion) IsOverridden() bool {
-	return u != ""
 }


### PR DESCRIPTION
Now that all tests are running on ubuntu 22.04,
we can remove the option to override the version.

Release note: none
Epic: none
Fixes: #112112