### PR TITLE
sql/schemachanger: remove alter table add column limitations with not null constraints

### DIFF
--- a/pkg/ccl/schemachangerccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_generated_test.go
@@ -39,6 +39,13 @@ func TestBackupRollbacks_base_add_column_default_unique(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_add_column_default_unique_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_add_column_no_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -407,6 +414,13 @@ func TestBackupRollbacksMixedVersion_base_add_column_default_unique(t *testing.T
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_add_column_default_unique_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -781,6 +795,13 @@ func TestBackupSuccess_base_add_column_default_unique(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_add_column_default_unique_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_add_column_no_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1149,6 +1170,13 @@ func TestBackupSuccessMixedVersion_base_add_column_default_unique(t *testing.T) 
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_add_column_default_unique_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/ccl/schemachangerccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_generated_test.go
@@ -46,6 +46,13 @@ func TestBackupRollbacks_base_add_column_no_default(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_add_column_virtual_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_add_column_with_stored(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -407,6 +414,13 @@ func TestBackupRollbacksMixedVersion_base_add_column_no_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_add_column_virtual_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -774,6 +788,13 @@ func TestBackupSuccess_base_add_column_no_default(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_add_column_virtual_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_add_column_with_stored(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1135,6 +1156,13 @@ func TestBackupSuccessMixedVersion_base_add_column_no_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_add_column_virtual_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2679,6 +2679,11 @@ statement error pgcode 23502 (null value in column "j" violates not-null constra
 ALTER TABLE t_add_column_not_null ADD COLUMN j INT GENERATED ALWAYS AS (NULL:::INT) STORED NOT NULL;
 
 # Note that the UNIQUE here leads to a secondary index being built which will fail.
+skipif config local-legacy-schema-changer
+statement error pgcode 23502 validation of column "j" NOT NULL failed on row: i=1, j=NULL
+ALTER TABLE t_add_column_not_null ADD COLUMN j INT GENERATED ALWAYS AS (NULL::INT) VIRTUAL NOT NULL UNIQUE;
+
+onlyif config local-legacy-schema-changer
 statement error pgcode 23502 null value in column "j" violates not-null constraint
 ALTER TABLE t_add_column_not_null ADD COLUMN j INT GENERATED ALWAYS AS (NULL::INT) VIRTUAL NOT NULL UNIQUE;
 

--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -209,6 +209,11 @@ func TestAlterTableDMLInjection(t *testing.T) {
 			schemaChange: "ALTER TABLE tbl DROP COLUMN new_col",
 		},
 		{
+			desc:         "add column virtual NOT NULL",
+			schemaChange: "ALTER TABLE tbl ADD COLUMN new_col TEXT NOT NULL AS (NULL::TEXT) VIRTUAL",
+			expectedErr:  "validation of column \"new_col\" NOT NULL failed on row: insert_phase_ordinal='pre-schema-change', operation_phase_ordinal='n/a', operation='n/a', val=1, new_col=NULL",
+		},
+		{
 			desc:         "add column virtual",
 			schemaChange: "ALTER TABLE tbl ADD COLUMN new_col TEXT NOT NULL AS (insert_phase_ordinal) VIRTUAL",
 		},

--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -186,6 +186,11 @@ func TestAlterTableDMLInjection(t *testing.T) {
 			skipIssue:    87699,
 		},
 		{
+			desc:         "add column unique not null",
+			schemaChange: "ALTER TABLE tbl ADD COLUMN new_col TEXT NOT NULL UNIQUE",
+			expectedErr:  "null value in column \"new_col\" violates not-null constraint",
+		},
+		{
 			desc:         "add column default unique",
 			schemaChange: "ALTER TABLE tbl ADD COLUMN new_col TEXT NOT NULL UNIQUE DEFAULT insert_phase_ordinal || operation_phase_ordinal || operation",
 			expectedErr:  "variable sub-expressions are not allowed in DEFAULT",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -334,12 +334,6 @@ func addColumn(b BuildCtx, spec addColumnSpec, n tree.NodeFormatter) (backing *s
 	addColumnIgnoringNotNull := func(
 		b BuildCtx, spec addColumnSpec, n tree.NodeFormatter,
 	) (backing *scpb.PrimaryIndex) {
-		if spec.def == nil && spec.colType.ComputeExpr == nil && spec.notNull && spec.unique {
-			panic(scerrors.NotImplementedErrorf(n,
-				"`ADD COLUMN NOT NULL UNIQUE` is problematic with "+
-					"concurrent insert. See issue #90174"))
-		}
-
 		b.Add(spec.col)
 		if spec.fam != nil {
 			b.Add(spec.fam)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -49,7 +49,6 @@ func alterTableAddColumn(
 	// throw an unsupported error.
 	fallBackIfSubZoneConfigExists(b, t, tbl.TableID)
 	fallBackIfRegionalByRowTable(b, t, tbl.TableID)
-	fallBackIfVirtualColumnWithNotNullConstraint(t)
 	// Version gates functionally that is implemented after the statement is
 	// publicly published.
 	fallbackIfAddColDropColAlterPKInOneAlterTableStmtBeforeV232(b, tbl.TableID, t)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -876,20 +876,6 @@ func fallBackIfSubZoneConfigExists(b BuildCtx, n tree.NodeFormatter, id catid.De
 	}
 }
 
-// fallBackIfVirtualColumnWithNotNullConstraint throws an unimplemented error
-// if the to-be-added column `d` is a virtual column with not null constraint.
-// This is a quick, temporary fix for the following troubled stmt in the
-// declarative schema changer:
-// `ALTER TABLE t ADD COLUMN j INT AS (NULL::INT) VIRTUAL NOT NULL;` succeeded
-// but expectedly failed in the legacy schema changer.
-func fallBackIfVirtualColumnWithNotNullConstraint(t *tree.AlterTableAddColumn) {
-	d := t.ColumnDef
-	if d.IsVirtual() && d.Nullable.Nullability == tree.NotNull {
-		panic(scerrors.NotImplementedErrorf(t,
-			"virtual column with NOT NULL constraint is not supported"))
-	}
-}
-
 // ExtractColumnIDsInExpr extracts column IDs used in expr. It's similar to
 // schemaexpr.ExtractColumnIDs but this function can also extract columns
 // added in the same transaction (e.g. for `ADD COLUMN j INT CHECK (j > 0);`,

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
@@ -21,10 +21,6 @@ ALTER TABLE defaultdb.foo ALTER COLUMN i SET DATA TYPE STRING
 ----
 
 unimplemented
-ALTER TABLE defaultdb.foo ADD COLUMN p INT NOT NULL UNIQUE
-----
-
-unimplemented
 ALTER TABLE defaultdb.foo ALTER COLUMN i DROP NOT NULL
 ----
 

--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -216,9 +216,9 @@ func ExecuteWithDMLInjection(t *testing.T, relPath string, factory TestServerFac
 							}
 						}
 						usedStages[key.AsInt()] = struct{}{}
-						t.Logf("Completed stage: %+v", key)
+						t.Logf("Completed stage: %s", &key)
 					} else {
-						t.Logf("Retrying stage: %+v", key)
+						t.Logf("Retrying stage: %s", &key)
 					}
 				}
 				return nil

--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -115,11 +115,11 @@ func (s *stageKey) AsInt() int {
 // String implements fmt.Stringer
 func (s *stageKey) String() string {
 	if s.minOrdinal == s.maxOrdinal {
-		return fmt.Sprintf("(phase = %s stageOrdinal=%d)",
-			s.phase, s.minOrdinal)
+		return fmt.Sprintf("(phase = %s stageOrdinal=%d rollback=%t)",
+			s.phase, s.minOrdinal, s.rollback)
 	}
-	return fmt.Sprintf("(phase = %s stageMinOrdinal=%d stageMaxOrdinal=%d),",
-		s.phase, s.minOrdinal, s.maxOrdinal)
+	return fmt.Sprintf("(phase = %s stageMinOrdinal=%d stageMaxOrdinal=%d rollback=%t),",
+		s.phase, s.minOrdinal, s.maxOrdinal, s.rollback)
 }
 
 // IsEmpty detects if a stage key is empty.
@@ -152,7 +152,7 @@ func makeStageExecStmtMap() *stageExecStmtMap {
 func (m *stageExecStmtMap) getExecStmts(targetKey stageKey) []*stageExecStmt {
 	var stmts []*stageExecStmt
 	if targetKey.minOrdinal != targetKey.maxOrdinal {
-		panic(fmt.Sprintf("only a single ordinal key can be looked up %v ", targetKey))
+		panic(fmt.Sprintf("only a single ordinal key can be looked up %s ", &targetKey))
 	}
 	for _, key := range m.entries {
 		if key.stageKey.phase == targetKey.phase &&
@@ -485,9 +485,9 @@ func (e *stageExecStmt) Exec(
 			if e.expectedOutput != actualOutput {
 				if !rewrite {
 					t.Fatalf(
-						"query '%s' ($stageKey=%d,$successfulStageCount=%d): expected:\n%v\ngot:\n%v\n",
+						"query '%s' ($stageKey=%s,$successfulStageCount=%d): expected:\n%v\ngot:\n%v\n",
 						stmt,
-						stageVariables.stage.AsInt()*1000,
+						stageVariables.stage.String(),
 						stageVariables.successfulStageCount,
 						e.expectedOutput,
 						actualOutput,

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -48,6 +48,13 @@ func TestEndToEndSideEffects_add_column_no_default(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_add_column_virtual_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_add_column_with_stored(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -409,6 +416,13 @@ func TestExecuteWithDMLInjection_add_column_no_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_add_column_virtual_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -776,6 +790,13 @@ func TestGenerateSchemaChangeCorpus_add_column_no_default(t *testing.T) {
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_add_column_virtual_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_add_column_with_stored(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1137,6 +1158,13 @@ func TestPause_add_column_no_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_add_column_virtual_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1504,6 +1532,13 @@ func TestPauseMixedVersion_add_column_no_default(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_add_column_virtual_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_add_column_with_stored(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1865,6 +1900,13 @@ func TestRollback_add_column_no_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_add_column_virtual_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -41,6 +41,13 @@ func TestEndToEndSideEffects_add_column_default_unique(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_add_column_default_unique_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_add_column_no_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -409,6 +416,13 @@ func TestExecuteWithDMLInjection_add_column_default_unique(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_add_column_default_unique_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -783,6 +797,13 @@ func TestGenerateSchemaChangeCorpus_add_column_default_unique(t *testing.T) {
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_add_column_default_unique_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_add_column_no_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1151,6 +1172,13 @@ func TestPause_add_column_default_unique(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_add_column_default_unique_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1525,6 +1553,13 @@ func TestPauseMixedVersion_add_column_default_unique(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_add_column_default_unique_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_add_column_no_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1893,6 +1928,13 @@ func TestRollback_add_column_default_unique(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_add_column_default_unique_not_null(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null.definition
@@ -1,0 +1,30 @@
+setup
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+----
+
+stage-exec phase=PostCommitPhase stage=1  schemaChangeExecErrorForRollback=(.*validation of column \"j\" NOT NULL failed on row.*)
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey + 1);
+----
+
+stage-exec phase=PostCommitPhase stage=2:7
+INSERT INTO db.public.tbl VALUES($stageKey);
+----
+pq: failed to satisfy CHECK constraint \(j IS NOT NULL\)
+
+stage-exec phase=PostCommitPhase stage=8:
+INSERT INTO db.public.tbl VALUES($stageKey);
+----
+.*duplicate key value violates unique constraint \"tbl_j_key\".*
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=1
+INSERT INTO db.public.tbl VALUES($stageKey);
+----
+.*duplicate key value violates unique constraint \"tbl_j_key\".*
+
+# Add a column which will have a unique index and a not null constraint at
+# the same time.
+test
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE NOT NULL;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null.explain
@@ -1,0 +1,166 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+
+/* test */
+EXPLAIN (DDL) ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE NOT NULL;
+----
+Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 9 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 106 (tbl), ColumnID: 2 (j+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 1 (tbl_pkey)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 2 (tbl_j_key+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+)}
+ │         │    └── ABSENT → PUBLIC        IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key+)}
+ │         ├── 3 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 3}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+ │         └── 11 Mutation operations
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":2,"TableID":106}}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":106}
+ │              ├── SetAddedColumnType {"ColumnType":{"ColumnID":2,"TableID":106}}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── SetIndexName {"IndexID":2,"Name":"tbl_j_key","TableID":106}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"TableID":106}
+ │              └── AddColumnToIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 9 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j+)}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j+)}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 1 (tbl_pkey)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 2 (tbl_j_key+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key+)}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+ │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+)}
+ │    │    │    └── PUBLIC        → ABSENT IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key+)}
+ │    │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 3}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
+ │    │    │    └── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 9 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 106 (tbl), ColumnID: 2 (j+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 1 (tbl_pkey)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 2 (tbl_j_key+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+)}
+ │         │    └── ABSENT → PUBLIC        IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key+)}
+ │         ├── 3 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 3}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+ │         └── 15 Mutation operations
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":2,"TableID":106}}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":106}
+ │              ├── SetAddedColumnType {"ColumnType":{"ColumnID":2,"TableID":106}}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":106}
+ │              ├── SetIndexName {"IndexID":2,"Name":"tbl_j_key","TableID":106}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── MaybeAddSplitForIndex {"IndexID":3,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":106,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ ├── PostCommitPhase
+ │    ├── Stage 1 of 8 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j+)}
+ │    │    │    └── ABSENT      → WRITE_ONLY ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 1 (tbl_pkey)}
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 106 (tbl), IndexID: 3}
+ │    │    └── 5 Mutation operations
+ │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":2,"TableID":106}
+ │    │         ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":2,"TableID":106}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":3,"TableID":106}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 2 of 8 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+ │    │    └── 1 Backfill operation
+ │    │         └── BackfillIndex {"IndexID":2,"SourceIndexID":1,"TableID":106}
+ │    ├── Stage 3 of 8 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 1 (tbl_pkey)}
+ │    │    └── 1 Validation operation
+ │    │         └── ValidateColumnNotNull {"ColumnID":2,"IndexIDForValidation":1,"TableID":106}
+ │    ├── Stage 4 of 8 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── VALIDATED  → PUBLIC      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 1 (tbl_pkey)}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":106}
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":2,"TableID":106}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 5 of 8 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":2,"TableID":106}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 6 of 8 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+ │    │    └── 1 Backfill operation
+ │    │         └── MergeIndex {"BackfilledIndexID":2,"TableID":106,"TemporaryIndexID":3}
+ │    ├── Stage 7 of 8 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":2,"TableID":106}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    └── Stage 8 of 8 in PostCommitPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+ │         └── 1 Validation operation
+ │              └── ValidateIndex {"IndexID":2,"TableID":106}
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── WRITE_ONLY            → PUBLIC           Column:{DescID: 106 (tbl), ColumnID: 2 (j+)}
+           │    └── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+           ├── 4 elements transitioning toward TRANSIENT_ABSENT
+           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 3}
+           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
+           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+           │    └── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
+           └── 10 Mutation operations
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":106}
+                ├── RefreshStats {"TableID":106}
+                ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":106}
+                ├── RefreshStats {"TableID":106}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null.explain_shape
@@ -1,0 +1,18 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE NOT NULL;
+----
+Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
+ ├── execute 2 system table mutations transactions
+ ├── backfill using primary index tbl_pkey in relation tbl
+ │    └── into tbl_j_key+ (j+: i)
+ ├── validate NOT NULL constraint on column j+ in index tbl_pkey in relation tbl
+ ├── execute 2 system table mutations transactions
+ ├── merge temporary indexes into backfilled indexes in relation tbl
+ │    └── from tbl@[3] into tbl_j_key+
+ ├── execute 1 system table mutations transaction
+ ├── validate UNIQUE constraint backed by index tbl_j_key+ in relation tbl
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null.side_effects
@@ -1,0 +1,587 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+----
+...
++database {0 0 db} -> 104
++schema {104 0 public} -> 105
++object {104 105 tbl} -> 106
+
+/* test */
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE NOT NULL;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.add_column
+increment telemetry for sql.schema.new_column_type.int8
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 106
+    statement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE
+    tag: ALTER TABLE
+    user: root
+  tableName: db.public.tbl
+## StatementPhase stage 1 of 1 with 11 MutationType ops
+upsert descriptor #106
+  ...
+     - columnIds:
+       - 1
+  +    - 2
+       columnNames:
+       - i
+  +    - j
+  +    defaultColumnId: 2
+       name: primary
+     formatVersion: 3
+     id: 106
+     modificationTime: {}
+  +  mutations:
+  +  - column:
+  +      id: 2
+  +      name: j
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 2
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - j
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: tbl_j_key
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 3
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 3
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - j
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: crdb_internal_index_3_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: tbl
+  -  nextColumnId: 2
+  -  nextConstraintId: 2
+  +  nextColumnId: 3
+  +  nextConstraintId: 4
+     nextFamilyId: 1
+  -  nextIndexId: 2
+  +  nextIndexId: 4
+     nextMutationId: 1
+     parentId: 104
+  ...
+       partitioning: {}
+       sharded: {}
+  +    storeColumnIds:
+  +    - 2
+  +    storeColumnNames:
+  +    - j
+       unique: true
+       version: 4
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 15 MutationType ops
+upsert descriptor #106
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      columns:
+  +        "1": i
+  +        "2": j
+  +        "4294967294": tableoid
+  +        "4294967295": crdb_internal_mvcc_timestamp
+  +      families:
+  +        "0": primary
+  +      id: 106
+  +      indexes:
+  +        "1": tbl_pkey
+  +        "2": tbl_j_key
+  +      name: tbl
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE
+  +        statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL UNIQUE
+  +        statementTag: ALTER TABLE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+       - 1
+  +    - 2
+       columnNames:
+       - i
+  +    - j
+  +    defaultColumnId: 2
+       name: primary
+     formatVersion: 3
+     id: 106
+     modificationTime: {}
+  +  mutations:
+  +  - column:
+  +      id: 2
+  +      name: j
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 2
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - j
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: tbl_j_key
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 3
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 3
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - j
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: crdb_internal_index_3_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: tbl
+  -  nextColumnId: 2
+  -  nextConstraintId: 2
+  +  nextColumnId: 3
+  +  nextConstraintId: 4
+     nextFamilyId: 1
+  -  nextIndexId: 2
+  +  nextIndexId: 4
+     nextMutationId: 1
+     parentId: 104
+  ...
+       partitioning: {}
+       sharded: {}
+  +    storeColumnIds:
+  +    - 2
+  +    storeColumnNames:
+  +    - j
+       unique: true
+       version: 4
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL UNIQUE"
+  descriptor IDs: [106]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 8 with 5 MutationType ops
+upsert descriptor #106
+   table:
+  +  checks:
+  +  - columnIds:
+  +    - 2
+  +    expr: j IS NOT NULL
+  +    isNonNullConstraint: true
+  +    name: j_auto_not_null
+  +    validity: Validating
+     columns:
+     - id: 1
+  ...
+       direction: ADD
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 2
+  +        expr: j IS NOT NULL
+  +        isNonNullConstraint: true
+  +        name: j_auto_not_null
+  +        validity: Validating
+  +      constraintType: NOT_NULL
+  +      foreignKey: {}
+  +      name: j_auto_not_null
+  +      notNullColumn: 2
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     name: tbl
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 2 of 8 with 1 BackfillType op pending"
+commit transaction #3
+begin transaction #4
+## PostCommitPhase stage 2 of 8 with 1 BackfillType op
+backfill indexes [2] from index #1 in table #106
+commit transaction #4
+begin transaction #5
+## PostCommitPhase stage 3 of 8 with 1 ValidationType op
+validate CHECK constraint j_auto_not_null in table #106
+commit transaction #5
+begin transaction #6
+## PostCommitPhase stage 4 of 8 with 4 MutationType ops
+upsert descriptor #106
+   table:
+  -  checks:
+  -  - columnIds:
+  -    - 2
+  -    expr: j IS NOT NULL
+  -    isNonNullConstraint: true
+  -    name: j_auto_not_null
+  -    validity: Validating
+  +  checks: []
+     columns:
+     - id: 1
+  ...
+         id: 2
+         name: j
+  -      nullable: true
+         type:
+           family: IntFamily
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 2
+  -        expr: j IS NOT NULL
+  -        isNonNullConstraint: true
+  -        name: j_auto_not_null
+  -        validity: Validating
+  -      constraintType: NOT_NULL
+  -      foreignKey: {}
+  -      name: j_auto_not_null
+  -      notNullColumn: 2
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     name: tbl
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "3"
+  +  version: "4"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 5 of 8 with 1 MutationType op pending"
+commit transaction #6
+begin transaction #7
+## PostCommitPhase stage 5 of 8 with 3 MutationType ops
+upsert descriptor #106
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "4"
+  +  version: "5"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 6 of 8 with 1 BackfillType op pending"
+commit transaction #7
+begin transaction #8
+## PostCommitPhase stage 6 of 8 with 1 BackfillType op
+merge temporary indexes [3] into backfilled indexes [2] in table #106
+commit transaction #8
+begin transaction #9
+## PostCommitPhase stage 7 of 8 with 4 MutationType ops
+upsert descriptor #106
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 3
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: tbl
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "5"
+  +  version: "6"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 8 of 8 with 1 ValidationType op pending"
+commit transaction #9
+begin transaction #10
+## PostCommitPhase stage 8 of 8 with 1 ValidationType op
+validate forward indexes [2] in table #106
+commit transaction #10
+begin transaction #11
+## PostCommitNonRevertiblePhase stage 1 of 1 with 10 MutationType ops
+upsert descriptor #106
+  ...
+         oid: 20
+         width: 64
+  +  - id: 2
+  +    name: j
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": i
+  -        "2": j
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      families:
+  -        "0": primary
+  -      id: 106
+  -      indexes:
+  -        "1": tbl_pkey
+  -        "2": tbl_j_key
+  -      name: tbl
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE
+  -        statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL UNIQUE
+  -        statementTag: ALTER TABLE
+  -    revertible: true
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     formatVersion: 3
+     id: 106
+  +  indexes:
+  +  - constraintId: 2
+  +    createdAtNanos: "1640998800000000000"
+  +    createdExplicitly: true
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 2
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    keyColumnIds:
+  +    - 2
+  +    keyColumnNames:
+  +    - j
+  +    keySuffixColumnIds:
+  +    - 1
+  +    name: tbl_j_key
+  +    partitioning: {}
+  +    sharded: {}
+  +    storeColumnNames: []
+  +    unique: true
+  +    version: 4
+     modificationTime: {}
+  -  mutations:
+  -  - column:
+  -      id: 2
+  -      name: j
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 2
+  -      createdAtNanos: "1640998800000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - j
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: tbl_j_key
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      unique: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 3
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 3
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - j
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_3_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  +  mutations: []
+     name: tbl
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "6"
+  +  version: "7"
+persist all catalog changes to storage
+adding table for stats refresh: 106
+create job #2 (non-cancelable: true): "GC for ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL UNIQUE"
+  descriptor IDs: [106]
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 106
+commit transaction #11
+notified job registry to adopt jobs: [2]
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_1_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_1_of_8.explain
@@ -1,0 +1,38 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+
+/* test */
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 1 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+           │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
+           │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
+           │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+           │    ├── PUBLIC        → ABSENT IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
+           │    └── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+           └── 13 Mutation operations
+                ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
+                ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_2_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_2_of_8.explain
@@ -1,0 +1,51 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+
+/* test */
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 2 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+      │    └── 13 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
+      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 5 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
+           └── 6 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_3_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_3_of_8.explain
@@ -1,0 +1,51 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+
+/* test */
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 3 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+      │    └── 13 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
+      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 5 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
+           └── 6 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_4_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_4_of_8.explain
@@ -1,0 +1,51 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+
+/* test */
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 4 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+      │    └── 13 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
+      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 5 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
+           └── 6 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_5_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_5_of_8.explain
@@ -1,0 +1,58 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+
+/* test */
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 5 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC      → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── PUBLIC      → VALIDATED   ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
+      │    │    └── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+      │    └── 12 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
+      │         ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 5 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+      │    │    └── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 3}
+      │    └── 7 Mutation operations
+      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
+      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
+      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
+           └── 3 Mutation operations
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_6_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_6_of_8.explain
@@ -1,0 +1,60 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+
+/* test */
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 6 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── PUBLIC     → VALIDATED   ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+      │    └── 12 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
+      │         ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+      │    │    └── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 3}
+      │    └── 8 Mutation operations
+      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
+      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
+           └── 3 Mutation operations
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_7_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_7_of_8.explain
@@ -1,0 +1,60 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+
+/* test */
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 7 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── PUBLIC     → VALIDATED   ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+      │    └── 12 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
+      │         ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+      │    │    └── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 3}
+      │    └── 8 Mutation operations
+      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
+      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
+           └── 3 Mutation operations
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_8_of_8.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique_not_null/add_column_default_unique_not_null__rollback_8_of_8.explain
@@ -1,0 +1,58 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+
+/* test */
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 8 of 8;
+----
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL UNIQUE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
+      │    │    └── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (tbl_pkey)}
+      │    └── 12 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
+      │         ├── MakePublicColumnNotNullValidated {"ColumnID":2,"TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 5 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 1 (tbl_pkey)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (tbl_pkey), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+      │    │    └── PUBLIC      → ABSENT      IndexData:{DescID: 106 (tbl), IndexID: 3}
+      │    └── 7 Mutation operations
+      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
+           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-)}
+           └── 3 Mutation operations
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null.definition
@@ -1,0 +1,63 @@
+setup
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
+CREATE SEQUENCE db.public.sq1;
+----
+
+# Each insert will be injected twice per stage, plus 1 extra.
+stage-query phase=PostCommitNonRevertiblePhase stage=: rollback=true
+SELECT count(*)=($successfulStageCount*2)+1 FROM db.public.tbl;
+----
+true
+
+# On the first stage all IUD operations will be allowed because the not
+# null constraint is not yet enforced.
+stage-exec phase=PostCommitPhase stage=1 schemaChangeExecError=(.*validation of column "j" NOT NULL failed on row:.*)
+INSERT INTO db.public.tbl VALUES($stageKey, 1);
+INSERT INTO db.public.tbl VALUES($stageKey + 1, 1);
+UPDATE db.public.tbl SET k=$stageKey WHERE i <> -7;
+UPDATE db.public.tbl SET k=i WHERE i <> -7;
+DELETE FROM db.public.tbl WHERE i=-1;
+DELETE FROM db.public.tbl WHERE i=$stageKey;
+INSERT INTO db.public.tbl VALUES($stageKey, 1);
+INSERT INTO db.public.tbl VALUES(-1, -1);
+----
+
+# We only expect 3 rows, 2 from the stage above and the one extra
+# -1, -1.
+stage-query phase=PostCommitPhase stage=1
+SELECT count(*)=($successfulStageCount*2)+1 FROM db.public.tbl;
+----
+true
+
+# On any later stages the not null constraint is enforced, hence
+# all insert operations should fail.
+stage-exec phase=PostCommitPhase stage=2:
+INSERT INTO db.public.tbl VALUES($stageKey, 1);
+----
+.*pq: failed to satisfy CHECK constraint \(j IS NOT NULL\).*
+
+
+# Only the second stage inserts will be executed, which will get blocked by
+# the not null constraint
+stage-query phase=PostCommitPhase stage=2:
+SELECT count(*)=0 FROM db.public.tbl;
+----
+true
+
+# On any later stages the not null constraint is enforced, hence
+# all insert operations should fail.
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO db.public.tbl VALUES($stageKey, 1);
+----
+.*pq: failed to satisfy CHECK constraint \(j IS NOT NULL\).*
+
+# No inserts before this will succeed because of the not null constraint.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=0 FROM db.public.tbl;
+----
+true
+
+test
+ALTER TABLE db.public.tbl ADD COLUMN j INT AS (NULL::INT) VIRTUAL NOT NULL;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null.explain
@@ -1,0 +1,64 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
+CREATE SEQUENCE db.public.sq1;
+
+/* test */
+EXPLAIN (DDL) ALTER TABLE db.public.tbl ADD COLUMN j INT AS (NULL::INT) VIRTUAL NOT NULL;
+----
+Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL AS (‹NULL›::INT8) VIRTUAL;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 3 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 3 (j+)}
+ │         │    ├── ABSENT → PUBLIC      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 3 (j+)}
+ │         │    └── ABSENT → PUBLIC      ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 3 (j+)}
+ │         └── 3 Mutation operations
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":3,"TableID":106}}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"j","TableID":106}
+ │              └── SetAddedColumnType {"ColumnType":{"ColumnID":3,"IsVirtual":true,"TableID":106}}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 3 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 3 (j+)}
+ │    │    │    ├── PUBLIC      → ABSENT ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 3 (j+)}
+ │    │    │    └── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 3 (j+)}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 3 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 3 (j+)}
+ │         │    ├── ABSENT → PUBLIC      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 3 (j+)}
+ │         │    └── ABSENT → PUBLIC      ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 3 (j+)}
+ │         └── 5 Mutation operations
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":3,"TableID":106}}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"j","TableID":106}
+ │              ├── SetAddedColumnType {"ColumnType":{"ColumnID":3,"IsVirtual":true,"TableID":106}}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":106,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ ├── PostCommitPhase
+ │    ├── Stage 1 of 2 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 106 (tbl), ColumnID: 3 (j+)}
+ │    │    │    └── ABSENT      → WRITE_ONLY ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j+), IndexID: 1 (tbl_pkey)}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":3,"TableID":106}
+ │    │         ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":3,"TableID":106}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    └── Stage 2 of 2 in PostCommitPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j+), IndexID: 1 (tbl_pkey)}
+ │         └── 1 Validation operation
+ │              └── ValidateColumnNotNull {"ColumnID":3,"IndexIDForValidation":1,"TableID":106}
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── WRITE_ONLY → PUBLIC Column:{DescID: 106 (tbl), ColumnID: 3 (j+)}
+           │    └── VALIDATED  → PUBLIC ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j+), IndexID: 1 (tbl_pkey)}
+           └── 5 Mutation operations
+                ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":106}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":106}
+                ├── RefreshStats {"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null.explain_shape
@@ -1,0 +1,12 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
+CREATE SEQUENCE db.public.sq1;
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TABLE db.public.tbl ADD COLUMN j INT AS (NULL::INT) VIRTUAL NOT NULL;
+----
+Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL AS (‹NULL›::INT8) VIRTUAL;
+ ├── execute 2 system table mutations transactions
+ ├── validate NOT NULL constraint on column j+ in index tbl_pkey in relation tbl
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null.side_effects
@@ -1,0 +1,286 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
+CREATE SEQUENCE db.public.sq1;
+----
+...
++database {0 0 db} -> 104
++schema {104 0 public} -> 105
++object {104 105 tbl} -> 106
++object {104 105 sq1} -> 107
+
+/* test */
+ALTER TABLE db.public.tbl ADD COLUMN j INT AS (NULL::INT) VIRTUAL NOT NULL;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.add_column
+increment telemetry for sql.schema.qualifcation.virtual
+increment telemetry for sql.schema.new_column_type.int8
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 106
+    statement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL AS (‹NULL›::INT8) VIRTUAL
+    tag: ALTER TABLE
+    user: root
+  tableName: db.public.tbl
+## StatementPhase stage 1 of 1 with 3 MutationType ops
+upsert descriptor #106
+  ...
+     id: 106
+     modificationTime: {}
+  +  mutations:
+  +  - column:
+  +      computeExpr: NULL::INT8
+  +      id: 3
+  +      name: j
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +      virtual: true
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: tbl
+  -  nextColumnId: 3
+  +  nextColumnId: 4
+     nextConstraintId: 2
+     nextFamilyId: 1
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 5 MutationType ops
+upsert descriptor #106
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      columns:
+  +        "1": i
+  +        "2": k
+  +        "3": j
+  +        "4294967294": tableoid
+  +        "4294967295": crdb_internal_mvcc_timestamp
+  +      families:
+  +        "0": primary
+  +      id: 106
+  +      indexes:
+  +        "1": tbl_pkey
+  +      name: tbl
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL AS (‹NULL›::INT8) VIRTUAL
+  +        statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL AS (NULL::INT8) VIRTUAL
+  +        statementTag: ALTER TABLE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     id: 106
+     modificationTime: {}
+  +  mutations:
+  +  - column:
+  +      computeExpr: NULL::INT8
+  +      id: 3
+  +      name: j
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +      virtual: true
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: tbl
+  -  nextColumnId: 3
+  +  nextColumnId: 4
+     nextConstraintId: 2
+     nextFamilyId: 1
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL AS (NULL::INT8) VIRTUAL"
+  descriptor IDs: [106]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 2 with 4 MutationType ops
+upsert descriptor #106
+   table:
+  +  checks:
+  +  - columnIds:
+  +    - 3
+  +    expr: j IS NOT NULL
+  +    isNonNullConstraint: true
+  +    name: j_auto_not_null
+  +    validity: Validating
+     columns:
+     - id: 1
+  ...
+       direction: ADD
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 3
+  +        expr: j IS NOT NULL
+  +        isNonNullConstraint: true
+  +        name: j_auto_not_null
+  +        validity: Validating
+  +      constraintType: NOT_NULL
+  +      foreignKey: {}
+  +      name: j_auto_not_null
+  +      notNullColumn: 3
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     name: tbl
+     nextColumnId: 4
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 2 of 2 with 1 ValidationType op pending"
+commit transaction #3
+begin transaction #4
+## PostCommitPhase stage 2 of 2 with 1 ValidationType op
+validate CHECK constraint j_auto_not_null in table #106
+commit transaction #4
+begin transaction #5
+## PostCommitNonRevertiblePhase stage 1 of 1 with 5 MutationType ops
+upsert descriptor #106
+   table:
+  -  checks:
+  -  - columnIds:
+  -    - 3
+  -    expr: j IS NOT NULL
+  -    isNonNullConstraint: true
+  -    name: j_auto_not_null
+  -    validity: Validating
+  +  checks: []
+     columns:
+     - id: 1
+  ...
+         oid: 20
+         width: 64
+  +  - computeExpr: NULL::INT8
+  +    id: 3
+  +    name: j
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +    virtual: true
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": i
+  -        "2": k
+  -        "3": j
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      families:
+  -        "0": primary
+  -      id: 106
+  -      indexes:
+  -        "1": tbl_pkey
+  -      name: tbl
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL AS (‹NULL›::INT8) VIRTUAL
+  -        statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL AS (NULL::INT8) VIRTUAL
+  -        statementTag: ALTER TABLE
+  -    revertible: true
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     id: 106
+     modificationTime: {}
+  -  mutations:
+  -  - column:
+  -      computeExpr: NULL::INT8
+  -      id: 3
+  -      name: j
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -      virtual: true
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 3
+  -        expr: j IS NOT NULL
+  -        isNonNullConstraint: true
+  -        name: j_auto_not_null
+  -        validity: Validating
+  -      constraintType: NOT_NULL
+  -      foreignKey: {}
+  -      name: j_auto_not_null
+  -      notNullColumn: 3
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  +  mutations: []
+     name: tbl
+     nextColumnId: 4
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "3"
+  +  version: "4"
+persist all catalog changes to storage
+adding table for stats refresh: 106
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 106
+commit transaction #5
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null__rollback_1_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null__rollback_1_of_2.explain
@@ -1,0 +1,21 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
+CREATE SEQUENCE db.public.sq1;
+
+/* test */
+ALTER TABLE db.public.tbl ADD COLUMN j INT AS (NULL::INT) VIRTUAL NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 1 of 2;
+----
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL AS (‹NULL›::INT8) VIRTUAL;
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 3 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 3 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 3 (j-)}
+           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 3 (j-)}
+           └── 4 Mutation operations
+                ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null__rollback_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_virtual_not_null/add_column_virtual_not_null__rollback_2_of_2.explain
@@ -1,0 +1,30 @@
+/* setup */
+CREATE DATABASE db;
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
+CREATE SEQUENCE db.public.sq1;
+
+/* test */
+ALTER TABLE db.public.tbl ADD COLUMN j INT AS (NULL::INT) VIRTUAL NOT NULL;
+EXPLAIN (DDL) rollback at post-commit stage 2 of 2;
+----
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL AS (‹NULL›::INT8) VIRTUAL;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 3 (j-)}
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 3 (j-)}
+      │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106 (tbl), ColumnID: 3 (j-), IndexID: 1 (tbl_pkey)}
+      │    └── 5 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 3 (j-)}
+           │    └── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 3 (j-)}
+           └── 3 Mutation operations
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}


### PR DESCRIPTION
Previously we had the following limitations with ALTER TABLE ADD COLUMN:

1. We disallowed ADD COLUMN ... VIRTUAL NOT NULL since our implementation did not do validation properly allowing this statement to succeed when it should fail.
2. We disallowed  ADD COLUMN .... UNIQUE NOT NULL because there was a risk of data loss in our index implementation. This was resolved by allowing multiple table mutations in a single statement.

This patch enables both of these statements after adding validation inside the end to end testing to ensure that DML injected scenarios work correctly. This patch also enhances some of the output generated from the DML injection tests to make things easier to diagnose.

Fixes: #117647



