### PR TITLE
release-23.2: workload/schemachanger: fix intermittent transaction re-use errors

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -422,7 +422,7 @@ GROUP BY name;
 				// No choice but to rollback, expression is malformed.
 				rollbackErr := evalTxn.Rollback(ctx)
 				if rollbackErr != nil {
-					return false, err
+					return false, errors.CombineErrors(err, rollbackErr)
 				}
 				var pgErr *pgconn.PgError
 				if !errors.As(err, &pgErr) {
@@ -449,23 +449,28 @@ GROUP BY name;
 					continue
 				}
 			}
-			// Skip if any null values exist in the expression
-			if hasNullValues {
-				continue
-			}
-			exists, err := og.scanBool(ctx, evalTxn, query.String())
-			if err != nil {
-				skipConstraint, err := handleEvalTxnError(err)
+			// If it has null values, we are going to skip later on,
+			// so skip this operation.
+			var exists bool
+			if !hasNullValues {
+				exists, err = og.scanBool(ctx, evalTxn, query.String())
 				if err != nil {
-					return false, generatedCodes, err
-				}
-				if skipConstraint {
-					continue
+					skipConstraint, err := handleEvalTxnError(err)
+					if err != nil {
+						return false, generatedCodes, err
+					}
+					if skipConstraint {
+						continue
+					}
 				}
 			}
 			err = evalTxn.Commit(ctx)
 			if err != nil {
 				return false, nil, err
+			}
+			// Proceed to the next constraint if it has NULL values.
+			if hasNullValues {
+				continue
 			}
 			if exists {
 				return true, nil, nil
@@ -644,8 +649,8 @@ func (og *operationGenerator) validateGeneratedExpressionsForInsert(
 		if err != nil {
 			var pgErr *pgconn.PgError
 			if !errors.As(err, &pgErr) {
-				_ = evalTx.Rollback(ctx)
-				return err
+				rbkErr := evalTx.Rollback(ctx)
+				return errors.CombineErrors(err, rbkErr)
 			}
 			if !isValidGenerationError(pgErr.Code) {
 				return err
@@ -663,8 +668,8 @@ func (og *operationGenerator) validateGeneratedExpressionsForInsert(
 			if _, err := og.scanBool(ctx, evalTx, queryEvalOrderCheck.String()); err != nil {
 				var pgErr *pgconn.PgError
 				if !errors.As(err, &pgErr) {
-					_ = evalTx.Rollback(ctx)
-					return err
+					rbkErr := evalTx.Rollback(ctx)
+					return errors.CombineErrors(err, rbkErr)
 				}
 				// Note: Invalid errors are allowed, since this is a heuristic. We replaced
 				// random NULL values with zero.

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -195,7 +195,10 @@ func (og *operationGenerator) randOp(
 		og.resetOpState(useDeclarativeSchemaChanger)
 		stmt, err = opFuncs[op](og, ctx, tx)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			// We can only ignore this error, if no other PgErrors
+			// were set in the clean up process.
+			if errors.Is(err, pgx.ErrNoRows) &&
+				!errors.Is(err, &pgconn.PgError{}) {
 				continue
 			}
 			// Table select had a primary key swap, so no statement
@@ -3106,7 +3109,7 @@ func (og *operationGenerator) randParentColumnForFkRelation(
 	)`, subQuery.String())).Scan(&tableSchema, &tableName, &columnName, &typName, &nullable)
 	if err != nil {
 		if rbErr := nestedTxn.Rollback(ctx); rbErr != nil {
-			err = errors.CombineErrors(err, rbErr)
+			err = errors.CombineErrors(rbErr, err)
 		}
 		return nil, nil, err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #118455.

/cc @cockroachdb/release

Release justification: test only change 

---

Previously, the schema changer workload would fail because we could combine ErrNoRows with transaction errors from rollbacks when generating with foreign key operations. The operation generator code would detect the no rows error and attempt to keep using the txn, which was incorrect. To address this, this patch avoids wrapping the error when no rows and rollback errors occur within the same txn. It also fixes error handling in other cases involving txn's to avoid masking other bugs.

Fixes: #117473
fixes #117774 
fixes #118263
Release note: None
