### PR TITLE
cluster-ui: bump the cluster-ui package version

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "23.2.3",
+  "version": "23.2.4",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We backported two changes that enable statement bundles and explain plans on Serverless (#117529 and #118169). Now we need to publish those changes so that the managed-service can pick them up, which requires bumping the package version.

 Part of: #83422

Release justification: Low-risk change that triggers publishing of the cluster-ui package for external use. There should be no impact to CRDB itself.

Release note: None