### PR TITLE
rowenc: fix Fingerprint for tuples with some types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -1002,3 +1002,15 @@ ORDER BY 1
 1.00
 
 subtest end
+
+# Regression test for not using value-encoding for JSON when fingerprinting a
+# tuple (#118380).
+query T rowsort
+WITH cte1 AS (SELECT * FROM (VALUES
+  (('1':::JSON, 1)),
+  (('2':::JSON, 2))
+) AS tab (col1))
+SELECT * FROM cte1 GROUP BY cte1.col1;
+----
+(1,1)
+(2,2)

--- a/pkg/sql/logictest/testdata/logic_test/tsvector
+++ b/pkg/sql/logictest/testdata/logic_test/tsvector
@@ -435,3 +435,25 @@ true
 # TODO(#75101): The error should be "syntax error in TSQuery".
 statement error pgcode 22023 unsupported comparison operator: <tsvector> @@ <string>
 SELECT 'fat rats'::tsvector @@ 'fat cats chased fat, out of shape rats'
+
+# Regression test for incorrectly using key-encoding on tuples that contain
+# TSQueries and TSVectors (which don't have key-encoding available, #118380).
+query T rowsort
+WITH cte1 AS (SELECT * FROM (VALUES
+  (('1':::TSQUERY, 1)),
+  (('2':::TSQUERY, 2))
+) AS tab (col1))
+SELECT * FROM cte1 GROUP BY cte1.col1;
+----
+('1',1)
+('2',2)
+
+query T rowsort
+WITH cte1 AS (SELECT * FROM (VALUES
+  (('':::TSVECTOR, 1)),
+  (('':::TSVECTOR, 2))
+) AS tab (col1))
+SELECT * FROM cte1 GROUP BY cte1.col1;
+----
+("",1)
+("",2)


### PR DESCRIPTION
This commit is a follow up to 5c23b94dce91d022b573744a2978e3192681822f which recently fixed the `Fingerprint` function to use the value-encoding for TSQuery type. We also need to use value-encoding on tuples that have TSQueries and TSVectors in contents (previously we would hit the same error.

Additionally, this commit applies the fix to tuples containing JSON. Note that we do have key-encoding of JSON available as of 23.2, but on prior releases tuples with JSONs would run into the encoding error. Technically, this commit _might_ make it possible to produce incorrect results for queries operating on tuples containing JSON in the mixed-version 23.2.0 - 23.2.1+ cluster (assuming this fix is included into 23.2.1). However, given that on pre-23.2 versions we haven't received any complaints about queries erroring out, it seems unlikely that the incorrect results would occur in practice (especially so given that it would require 23.2.0 version specifically to be a part of the mix). Alternative approach would be to let 23.1.x versions keep failing and then continue using key-encoding of JSONs when they are part of the tuple (like 23.2.0) does.

I decided to not include a release note given the recent fix already included it.

Fixes: #118380.

Release note: None