### PR TITLE
importer: disallow subqueries in function arguments for pg_dump

### DIFF
--- a/pkg/sql/importer/read_import_pgdump.go
+++ b/pkg/sql/importer/read_import_pgdump.go
@@ -784,6 +784,7 @@ func readPostgresStmt(
 				case *tree.FuncExpr:
 					// Look for function calls that mutate schema (this is actually a thing).
 					semaCtx := tree.MakeSemaContext()
+					semaCtx.Properties.Require("pg_dump function arguments", tree.RejectSubqueries)
 					if _, err := expr.TypeCheck(ctx, &semaCtx, nil /* desired */); err != nil {
 						// If the expression does not type check, it may be a case of using
 						// a column that does not exist yet in a setval call (as is the case


### PR DESCRIPTION
Some functions can modify the db schema, and so can be included in a pg_dump file. The pg_dump importer logic type-checks such functions, which can lead to a nil-pointer panic in cases like the following: `SELECT addgeometrycolumn('t', 'foo', 4326, (SELECT 'POINT'), 2)` This is because subqueries cannot be type-checked outside the optbuilder, which sets the type annotation for the subquery.

This patch explicitly disallows subqueries in the type-checking that happens for processing a pg_dump file. This will ensure that users get an expected `subqueries are not allowed in pg_dump function arguments` error, instead of the panic.

Fixes #117724

Release note (bug fix): Fixed a rare panic that could happen during a pg_dump import that contains a function like `SELECT addgeometrycolumn(...)`. Now, attempting to import a pg_dump with a function that has a subquery in one of its arguments results in an expected error.