### PR TITLE
kvserver: skip rebalance multi-store under remote exec

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -223,8 +223,10 @@ func TestReplicateQueueRebalanceMultiStore(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			if testCase.storesPerNode > 1 {
 				// 8 stores with active rebalancing can lead to failed heartbeats due
-				// to overload. Skip under stress when running the multi-store variant.
+				// to overload. Skip under stress and remote  execution when running
+				// the multi-store variant.
 				skip.UnderStress(t)
+				skip.UnderRemoteExecutionWithIssue(t, 118347)
 			}
 			// Set up a test cluster with multiple stores per node if needed.
 			args := base.TestClusterArgs{


### PR DESCRIPTION
`TestReplicateQueueRebalanceMultiStore` has repeatedly failed under remote execution due to stalls and the test generally being large. Skip under remote execution.

Resolves: #118347
Release note: None