### PR TITLE
schemachanger: Prep work for ALTER DATABASE ... CONFIGURE ZONE

### DIFF
--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/zone"
 	"github.com/cockroachdb/cockroach/pkg/sql/decodeusername"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -2217,7 +2218,7 @@ type alterDatabaseSetZoneConfigExtensionNode struct {
 	n          *tree.AlterDatabaseSetZoneConfigExtension
 	desc       *dbdesc.Mutable
 	yamlConfig tree.TypedExpr
-	options    map[tree.Name]optionValue
+	options    map[tree.Name]zone.OptionValue
 }
 
 // AlterDatabaseSetZoneConfigExtension transforms a

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -1103,10 +1103,7 @@ func insufficientPrivilegeError(
 			"user %s does not have %s system privilege",
 			user, kind)
 	}
-
-	return pgerror.Newf(pgcode.InsufficientPrivilege,
-		"user %s does not have %s privilege on %s %s",
-		user, kind, objTypeStr, object.GetName())
+	return sqlerrors.NewInsufficientPrivilegeOnDescriptorError(user, []privilege.Kind{kind}, objTypeStr, object.GetName())
 }
 
 // IsInsufficientPrivilegeError returns true if the error is a pgerror

--- a/pkg/sql/catalog/zone/BUILD.bazel
+++ b/pkg/sql/catalog/zone/BUILD.bazel
@@ -2,12 +2,23 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "zone",
-    srcs = ["zone_config.go"],
+    srcs = [
+        "zone_config.go",
+        "zones.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/zone",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base",
+        "//pkg/config",
         "//pkg/config/zonepb",
+        "//pkg/settings/cluster",
         "//pkg/sql/catalog",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/types",
         "//pkg/util/protoutil",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_gogo_protobuf//proto",
+        "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/pkg/sql/catalog/zone/zones.go
+++ b/pkg/sql/catalog/zone/zones.go
@@ -1,0 +1,148 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package zone
+
+import (
+	"context"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+	"github.com/gogo/protobuf/proto"
+	yaml "gopkg.in/yaml.v2"
+)
+
+type OptionValue struct {
+	InheritValue  bool
+	ExplicitValue tree.TypedExpr
+}
+
+// ZoneConfigOption describes a Field one can set on a ZoneConfig.
+type ZoneConfigOption struct {
+	Field        config.Field
+	RequiredType *types.T
+	Setter       func(*zonepb.ZoneConfig, tree.Datum)
+	CheckAllowed func(context.Context, *cluster.Settings, tree.Datum) error
+}
+
+func loadYAML(dst interface{}, yamlString string) {
+	if err := yaml.UnmarshalStrict([]byte(yamlString), dst); err != nil {
+		panic(err)
+	}
+}
+
+// SupportedZoneConfigOptions indicates how to translate SQL variable
+// assignments in ALTER CONFIGURE ZONE to assignments to the member
+// fields of zonepb.ZoneConfig.
+var SupportedZoneConfigOptions map[tree.Name]ZoneConfigOption
+
+// ZoneOptionKeys contains the keys from suportedZoneConfigOptions in
+// deterministic order. Needed to make the event log output
+// deterministic.
+var ZoneOptionKeys []string
+
+func init() {
+	opts := []ZoneConfigOption{
+		{
+			Field:        config.RangeMinBytes,
+			RequiredType: types.Int,
+			Setter:       func(c *zonepb.ZoneConfig, d tree.Datum) { c.RangeMinBytes = proto.Int64(int64(tree.MustBeDInt(d))) },
+		},
+		{
+			Field:        config.RangeMaxBytes,
+			RequiredType: types.Int,
+			Setter:       func(c *zonepb.ZoneConfig, d tree.Datum) { c.RangeMaxBytes = proto.Int64(int64(tree.MustBeDInt(d))) },
+		},
+		{
+			Field:        config.GlobalReads,
+			RequiredType: types.Bool,
+			Setter:       func(c *zonepb.ZoneConfig, d tree.Datum) { c.GlobalReads = proto.Bool(bool(tree.MustBeDBool(d))) },
+			CheckAllowed: func(ctx context.Context, settings *cluster.Settings, d tree.Datum) error {
+				if !tree.MustBeDBool(d) {
+					// Always allow the value to be unset.
+					return nil
+				}
+				return base.CheckEnterpriseEnabled(
+					settings,
+					"global_reads",
+				)
+			},
+		},
+		{
+			Field:        config.NumReplicas,
+			RequiredType: types.Int,
+			Setter:       func(c *zonepb.ZoneConfig, d tree.Datum) { c.NumReplicas = proto.Int32(int32(tree.MustBeDInt(d))) },
+		},
+		{
+			Field:        config.NumVoters,
+			RequiredType: types.Int,
+			Setter:       func(c *zonepb.ZoneConfig, d tree.Datum) { c.NumVoters = proto.Int32(int32(tree.MustBeDInt(d))) },
+		},
+		{
+			Field:        config.GCTTL,
+			RequiredType: types.Int,
+			Setter: func(c *zonepb.ZoneConfig, d tree.Datum) {
+				c.GC = &zonepb.GCPolicy{TTLSeconds: int32(tree.MustBeDInt(d))}
+			},
+		},
+		{
+			Field:        config.Constraints,
+			RequiredType: types.String,
+			Setter: func(c *zonepb.ZoneConfig, d tree.Datum) {
+				constraintsList := zonepb.ConstraintsList{
+					Constraints: c.Constraints,
+					Inherited:   c.InheritedConstraints,
+				}
+				loadYAML(&constraintsList, string(tree.MustBeDString(d)))
+				c.Constraints = constraintsList.Constraints
+				c.InheritedConstraints = false
+			},
+		},
+		{
+			Field:        config.VoterConstraints,
+			RequiredType: types.String,
+			Setter: func(c *zonepb.ZoneConfig, d tree.Datum) {
+				voterConstraintsList := zonepb.ConstraintsList{
+					Constraints: c.VoterConstraints,
+					Inherited:   c.InheritedVoterConstraints(),
+				}
+				loadYAML(&voterConstraintsList, string(tree.MustBeDString(d)))
+				c.VoterConstraints = voterConstraintsList.Constraints
+				c.NullVoterConstraintsIsEmpty = true
+			},
+		},
+		{
+			Field:        config.LeasePreferences,
+			RequiredType: types.String,
+			Setter: func(c *zonepb.ZoneConfig, d tree.Datum) {
+				loadYAML(&c.LeasePreferences, string(tree.MustBeDString(d)))
+				c.InheritedLeasePreferences = false
+			},
+		},
+	}
+	SupportedZoneConfigOptions = make(map[tree.Name]ZoneConfigOption, len(opts))
+	ZoneOptionKeys = make([]string, len(opts))
+	for i, opt := range opts {
+		name := opt.Field.String()
+		key := tree.Name(name)
+		if _, exists := SupportedZoneConfigOptions[key]; exists {
+			panic(errors.AssertionFailedf("duplicate entry for key %s", name))
+		}
+		SupportedZoneConfigOptions[key] = opt
+		ZoneOptionKeys[i] = name
+	}
+	sort.Strings(ZoneOptionKeys)
+}

--- a/pkg/sql/logictest/testdata/logic_test/grant_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/grant_sequence
@@ -12,7 +12,7 @@ SET ROLE readwrite
 statement error pq: user readwrite does not have SELECT privilege on relation a
 SELECT * FROM a;
 
-statement error pq: nextval\(\): user readwrite does not have UPDATE or USAGE privilege on relation a
+statement error pq: nextval\(\): user readwrite does not have USAGE or UPDATE privilege on relation a
 SELECT nextval('a')
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -932,7 +932,7 @@ user testuser
 statement error pq: user testuser does not have SELECT privilege on relation priv_test
 SELECT * FROM priv_test
 
-statement error pq: nextval\(\): user testuser does not have UPDATE or USAGE privilege on relation priv_test
+statement error pq: nextval\(\): user testuser does not have USAGE or UPDATE privilege on relation priv_test
 SELECT nextval('priv_test')
 
 statement error pq: setval\(\): user testuser does not have UPDATE privilege on relation priv_test

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2573,6 +2573,7 @@ set_zone_config:
   {
     $$.val = &tree.SetZoneConfig{
       ZoneConfigSettings: tree.ZoneConfigSettings {
+        Discard: true,
         YAMLConfig: tree.DNull,
       },
     }

--- a/pkg/sql/sem/tree/zone.go
+++ b/pkg/sql/sem/tree/zone.go
@@ -123,9 +123,10 @@ func (*SetZoneConfig) modifiesSchema() bool { return true }
 
 // ZoneConfigSettings represents info needed for zone config setting.
 type ZoneConfigSettings struct {
-	SetDefault bool
-	YAMLConfig Expr
-	Options    KVOptions
+	Discard    bool      // True for `CONFIGURE ZONE DISCARD` stmt
+	SetDefault bool      // True for `CONFIGURE ZONE USING DEFAULT` stmt
+	YAMLConfig Expr      // (Deprecated) Non-empty for `CONFIGURE ZONE = '<...yaml...>'` or `CONFIGURE ZONE = NULL` stmt
+	Options    KVOptions // Non-empty for `CONFIGURE ZONE USING var_set_list` stmt
 }
 
 // Format implements the NodeFormatter interface.

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -108,10 +108,8 @@ func incrementSequenceHelper(
 		}
 	}
 	if !hasRequiredPriviledge {
-
-		return 0, pgerror.Newf(pgcode.InsufficientPrivilege,
-			"user %s does not have UPDATE or USAGE privilege on %s %s",
-			p.User(), descriptor.DescriptorType(), descriptor.GetName())
+		return 0, sqlerrors.NewInsufficientPrivilegeOnDescriptorError(p.User(), requiredPrivileges,
+			string(descriptor.DescriptorType()), descriptor.GetName())
 	}
 
 	var err error

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -319,9 +319,8 @@ func checkPrivilegeForSetZoneConfig(ctx context.Context, p *planner, zs tree.Zon
 			return nil
 		}
 
-		return pgerror.Newf(pgcode.InsufficientPrivilege,
-			"user %s does not have %s or %s privilege on %s %s",
-			p.SessionData().User(), privilege.ZONECONFIG, privilege.CREATE, dbDesc.DescriptorType(), dbDesc.GetName())
+		return sqlerrors.NewInsufficientPrivilegeOnDescriptorError(p.SessionData().User(),
+			[]privilege.Kind{privilege.ZONECONFIG, privilege.CREATE}, string(dbDesc.DescriptorType()), dbDesc.GetName())
 	}
 	tableDesc, err := p.resolveTableForZone(ctx, &zs)
 	if err != nil {
@@ -342,9 +341,8 @@ func checkPrivilegeForSetZoneConfig(ctx context.Context, p *planner, zs tree.Zon
 		return nil
 	}
 
-	return pgerror.Newf(pgcode.InsufficientPrivilege,
-		"user %s does not have %s or %s privilege on %s %s",
-		p.SessionData().User(), privilege.ZONECONFIG, privilege.CREATE, tableDesc.DescriptorType(), tableDesc.GetName())
+	return sqlerrors.NewInsufficientPrivilegeOnDescriptorError(p.SessionData().User(),
+		[]privilege.Kind{privilege.ZONECONFIG, privilege.CREATE}, string(tableDesc.DescriptorType()), tableDesc.GetName())
 }
 
 // setZoneConfigRun contains the run-time state of setZoneConfigNode during local execution.

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -13,11 +13,8 @@ package sql
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -41,140 +38,17 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
-	"github.com/gogo/protobuf/proto"
 	yaml "gopkg.in/yaml.v2"
 )
-
-type optionValue struct {
-	inheritValue  bool
-	explicitValue tree.TypedExpr
-}
 
 type setZoneConfigNode struct {
 	zoneSpecifier tree.ZoneSpecifier
 	allIndexes    bool
 	yamlConfig    tree.TypedExpr
-	options       map[tree.Name]optionValue
+	options       map[tree.Name]zone.OptionValue
 	setDefault    bool
 
 	run setZoneConfigRun
-}
-
-// zoneConfigOption describes a field one can set on a ZoneConfig.
-type zoneConfigOption struct {
-	field        config.Field
-	requiredType *types.T
-	setter       func(*zonepb.ZoneConfig, tree.Datum)
-	checkAllowed func(context.Context, *ExecutorConfig, tree.Datum) error
-}
-
-// supportedZoneConfigOptions indicates how to translate SQL variable
-// assignments in ALTER CONFIGURE ZONE to assignments to the member
-// fields of zonepb.ZoneConfig.
-var supportedZoneConfigOptions map[tree.Name]zoneConfigOption
-
-// zoneOptionKeys contains the keys from suportedZoneConfigOptions in
-// deterministic order. Needed to make the event log output
-// deterministic.
-var zoneOptionKeys []string
-
-func init() {
-	opts := []zoneConfigOption{
-		{
-			field:        config.RangeMinBytes,
-			requiredType: types.Int,
-			setter:       func(c *zonepb.ZoneConfig, d tree.Datum) { c.RangeMinBytes = proto.Int64(int64(tree.MustBeDInt(d))) },
-		},
-		{
-			field:        config.RangeMaxBytes,
-			requiredType: types.Int,
-			setter:       func(c *zonepb.ZoneConfig, d tree.Datum) { c.RangeMaxBytes = proto.Int64(int64(tree.MustBeDInt(d))) },
-		},
-		{
-			field:        config.GlobalReads,
-			requiredType: types.Bool,
-			setter:       func(c *zonepb.ZoneConfig, d tree.Datum) { c.GlobalReads = proto.Bool(bool(tree.MustBeDBool(d))) },
-			checkAllowed: func(ctx context.Context, execCfg *ExecutorConfig, d tree.Datum) error {
-				if !tree.MustBeDBool(d) {
-					// Always allow the value to be unset.
-					return nil
-				}
-				return base.CheckEnterpriseEnabled(
-					execCfg.Settings,
-					"global_reads",
-				)
-			},
-		},
-		{
-			field:        config.NumReplicas,
-			requiredType: types.Int,
-			setter:       func(c *zonepb.ZoneConfig, d tree.Datum) { c.NumReplicas = proto.Int32(int32(tree.MustBeDInt(d))) },
-		},
-		{
-			field:        config.NumVoters,
-			requiredType: types.Int,
-			setter:       func(c *zonepb.ZoneConfig, d tree.Datum) { c.NumVoters = proto.Int32(int32(tree.MustBeDInt(d))) },
-		},
-		{
-			field:        config.GCTTL,
-			requiredType: types.Int,
-			setter: func(c *zonepb.ZoneConfig, d tree.Datum) {
-				c.GC = &zonepb.GCPolicy{TTLSeconds: int32(tree.MustBeDInt(d))}
-			},
-		},
-		{
-			field:        config.Constraints,
-			requiredType: types.String,
-			setter: func(c *zonepb.ZoneConfig, d tree.Datum) {
-				constraintsList := zonepb.ConstraintsList{
-					Constraints: c.Constraints,
-					Inherited:   c.InheritedConstraints,
-				}
-				loadYAML(&constraintsList, string(tree.MustBeDString(d)))
-				c.Constraints = constraintsList.Constraints
-				c.InheritedConstraints = false
-			},
-		},
-		{
-			field:        config.VoterConstraints,
-			requiredType: types.String,
-			setter: func(c *zonepb.ZoneConfig, d tree.Datum) {
-				voterConstraintsList := zonepb.ConstraintsList{
-					Constraints: c.VoterConstraints,
-					Inherited:   c.InheritedVoterConstraints(),
-				}
-				loadYAML(&voterConstraintsList, string(tree.MustBeDString(d)))
-				c.VoterConstraints = voterConstraintsList.Constraints
-				c.NullVoterConstraintsIsEmpty = true
-			},
-		},
-		{
-			field:        config.LeasePreferences,
-			requiredType: types.String,
-			setter: func(c *zonepb.ZoneConfig, d tree.Datum) {
-				loadYAML(&c.LeasePreferences, string(tree.MustBeDString(d)))
-				c.InheritedLeasePreferences = false
-			},
-		},
-	}
-	supportedZoneConfigOptions = make(map[tree.Name]zoneConfigOption, len(opts))
-	zoneOptionKeys = make([]string, len(opts))
-	for i, opt := range opts {
-		name := opt.field.String()
-		key := tree.Name(name)
-		if _, exists := supportedZoneConfigOptions[key]; exists {
-			panic(errors.AssertionFailedf("duplicate entry for key %s", name))
-		}
-		supportedZoneConfigOptions[key] = opt
-		zoneOptionKeys[i] = name
-	}
-	sort.Strings(zoneOptionKeys)
-}
-
-func loadYAML(dst interface{}, yamlString string) {
-	if err := yaml.UnmarshalStrict([]byte(yamlString), dst); err != nil {
-		panic(err)
-	}
 }
 
 func (p *planner) getUpdatedZoneConfigYamlConfig(
@@ -210,21 +84,21 @@ func (p *planner) getUpdatedZoneConfigYamlConfig(
 
 func (p *planner) getUpdatedZoneConfigOptions(
 	ctx context.Context, n tree.KVOptions, telemetryName string,
-) (map[tree.Name]optionValue, error) {
+) (map[tree.Name]zone.OptionValue, error) {
 
-	var options map[tree.Name]optionValue
+	var options map[tree.Name]zone.OptionValue
 	if n != nil {
 		// We have a CONFIGURE ZONE USING ... assignment.
 		// Here we are constrained by the supported ZoneConfig fields,
 		// as described by supportedZoneConfigOptions above.
 
-		options = make(map[tree.Name]optionValue)
+		options = make(map[tree.Name]zone.OptionValue)
 		for _, opt := range n {
 			if _, alreadyExists := options[opt.Key]; alreadyExists {
 				return nil, pgerror.Newf(pgcode.InvalidParameterValue,
 					"duplicate zone config parameter: %q", tree.ErrString(&opt.Key))
 			}
-			req, ok := supportedZoneConfigOptions[opt.Key]
+			req, ok := zone.SupportedZoneConfigOptions[opt.Key]
 			if !ok {
 				return nil, pgerror.Newf(pgcode.InvalidParameterValue,
 					"unsupported zone config parameter: %q", tree.ErrString(&opt.Key))
@@ -236,15 +110,15 @@ func (p *planner) getUpdatedZoneConfigOptions(
 				),
 			)
 			if opt.Value == nil {
-				options[opt.Key] = optionValue{inheritValue: true, explicitValue: nil}
+				options[opt.Key] = zone.OptionValue{InheritValue: true, ExplicitValue: nil}
 				continue
 			}
 			valExpr, err := p.analyzeExpr(
-				ctx, opt.Value, tree.IndexedVarHelper{}, req.requiredType, true /*requireType*/, string(opt.Key))
+				ctx, opt.Value, tree.IndexedVarHelper{}, req.RequiredType, true /*requireType*/, string(opt.Key))
 			if err != nil {
 				return nil, err
 			}
-			options[opt.Key] = optionValue{inheritValue: false, explicitValue: valExpr}
+			options[opt.Key] = zone.OptionValue{InheritValue: false, ExplicitValue: valExpr}
 		}
 	}
 	return options, nil
@@ -379,7 +253,7 @@ func evaluateYAMLConfig(expr tree.TypedExpr, params runParams) (string, bool, er
 }
 
 func evaluateZoneOptions(
-	options map[tree.Name]optionValue, params runParams,
+	options map[tree.Name]zone.OptionValue, params runParams,
 ) (
 	optionsStr []string,
 	copyFromParentList []tree.Name,
@@ -392,8 +266,8 @@ func evaluateZoneOptions(
 		// We iterate over zoneOptionKeys instead of iterating over
 		// n.options directly so that the optionStr string constructed for
 		// the event log remains deterministic.
-		for i := range zoneOptionKeys {
-			name := (*tree.Name)(&zoneOptionKeys[i])
+		for i := range zone.ZoneOptionKeys {
+			name := (*tree.Name)(&zone.ZoneOptionKeys[i])
 			val, ok := options[*name]
 			if !ok {
 				continue
@@ -403,7 +277,7 @@ func evaluateZoneOptions(
 			// value would apply to the zone and setting that value explicitly.
 			// Instead we add the fields to a list that we use at a later time
 			// to copy values over.
-			inheritVal, expr := val.inheritValue, val.explicitValue
+			inheritVal, expr := val.InheritValue, val.ExplicitValue
 			if inheritVal {
 				copyFromParentList = append(copyFromParentList, *name)
 				optionsStr = append(optionsStr, fmt.Sprintf("%s = COPY FROM PARENT", name))
@@ -417,13 +291,13 @@ func evaluateZoneOptions(
 				return nil, nil, nil, pgerror.Newf(pgcode.InvalidParameterValue,
 					"unsupported NULL value for %q", tree.ErrString(name))
 			}
-			opt := supportedZoneConfigOptions[*name]
-			if opt.checkAllowed != nil {
-				if err := opt.checkAllowed(params.ctx, params.ExecCfg(), datum); err != nil {
+			opt := zone.SupportedZoneConfigOptions[*name]
+			if opt.CheckAllowed != nil {
+				if err := opt.CheckAllowed(params.ctx, params.ExecCfg().Settings, datum); err != nil {
 					return nil, nil, nil, err
 				}
 			}
-			setter := opt.setter
+			setter := opt.Setter
 			setters = append(setters, func(c *zonepb.ZoneConfig) { setter(c, datum) })
 			optionsStr = append(optionsStr, fmt.Sprintf("%s = %s", name, datum))
 		}

--- a/pkg/sql/sqlerrors/BUILD.bazel
+++ b/pkg/sql/sqlerrors/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/privilege",
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -361,6 +362,22 @@ func NewInvalidVolatilityError(err error) error {
 func NewCannotModifyVirtualSchemaError(schema string) error {
 	return pgerror.Newf(pgcode.InsufficientPrivilege,
 		"%s is a virtual schema and cannot be modified", tree.ErrNameString(schema))
+}
+
+// NewInsufficientPrivilegeOnDescriptorError creates an InsufficientPrivilege
+// error saying the `user` does not have any of the privilege in `orPrivs` on
+// the descriptor.
+func NewInsufficientPrivilegeOnDescriptorError(
+	user username.SQLUsername, orPrivs []privilege.Kind, descType string, descName string,
+) error {
+	orPrivsInStr := make([]string, 0, len(orPrivs))
+	for _, priv := range orPrivs {
+		orPrivsInStr = append(orPrivsInStr, string(priv.DisplayName()))
+	}
+	privsStr := strings.Join(orPrivsInStr, " or ")
+	return pgerror.Newf(pgcode.InsufficientPrivilege,
+		"user %s does not have %s privilege on %s %s",
+		user, privsStr, descType, descName)
 }
 
 // QueryTimeoutError is an error representing a query timeout.


### PR DESCRIPTION
This PR contains three preparation commits for supporting zone configs in DSC. They should be rather uncontroversial and easy to review. See commit message for details.

Informs: #117574
Epic: CRDB-31473