### PR TITLE
sql: add a error pgcode to circular dependency restriction

### DIFF
--- a/pkg/sql/catalog/funcdesc/BUILD.bazel
+++ b/pkg/sql/catalog/funcdesc/BUILD.bazel
@@ -19,6 +19,8 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/funcinfo",
         "//pkg/sql/parser",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/privilege",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/sem/catid",

--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -19,6 +19,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
@@ -552,7 +554,7 @@ func (desc *Mutable) SetParentSchemaID(id descpb.ID) {
 func (desc *Mutable) AddConstraintReference(id descpb.ID, constraintID descpb.ConstraintID) error {
 	for _, dep := range desc.DependsOn {
 		if dep == id {
-			return errors.Errorf(
+			return pgerror.Newf(pgcode.InvalidFunctionDefinition,
 				"cannot add dependency from descriptor %d to function %s (%d) because there will be a dependency cycle", id, desc.GetName(), desc.GetID(),
 			)
 		}
@@ -596,7 +598,7 @@ func (desc *Mutable) RemoveConstraintReference(id descpb.ID, constraintID descpb
 func (desc *Mutable) AddColumnReference(id descpb.ID, colID descpb.ColumnID) error {
 	for _, dep := range desc.DependsOn {
 		if dep == id {
-			return errors.Errorf(
+			return pgerror.Newf(pgcode.InvalidFunctionDefinition,
 				"cannot add dependency from descriptor %d to function %s (%d) because there will be a dependency cycle", id, desc.GetName(), desc.GetID(),
 			)
 		}

--- a/pkg/sql/logictest/testdata/logic_test/udf_in_column_defaults
+++ b/pkg/sql/logictest/testdata/logic_test/udf_in_column_defaults
@@ -506,5 +506,5 @@ statement ok
 CREATE TABLE t_circle(a INT PRIMARY KEY, b INT);
 CREATE FUNCTION f_circle() RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM t_circle $$;
 
-statement error pgcode XXUUU pq: cannot add dependency from descriptor \d+ to function f_circle \(\d+\) because there will be a dependency cycle
+statement error pgcode 42P13 pq: cannot add dependency from descriptor \d+ to function f_circle \(\d+\) because there will be a dependency cycle
 ALTER TABLE t_circle ALTER COLUMN b SET DEFAULT f_circle();


### PR DESCRIPTION
sql: add a error pgcode to circular dependency restriction 
This PR adds a PostgreSQL error code to the test case, along with changes in logictest.
Please review this PR and let me know if any further changes or adjustments are required.
fixes: #108223
Release note: None