### PR TITLE
catalog: copy aliased type from descriptor in AsTypesT

### DIFF
--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -784,7 +784,8 @@ type TypeDescriptor interface {
 	IsCompatibleWith(other TypeDescriptor) error
 	// AsTypesT returns a reference to a types.T corresponding to this type
 	// descriptor. No guarantees are provided as to whether this object is a
-	// singleton or not, or whether it's hydrated or not.
+	// singleton or not, or whether it's hydrated or not. The returned type can be
+	// hydrated by the caller.
 	AsTypesT() *types.T
 	// GetKind returns the kind of this type.
 	GetKind() descpb.TypeDescriptor_Kind

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -754,7 +754,8 @@ func (desc *immutable) AsTypesT() *types.T {
 	case descpb.TypeDescriptor_ENUM, descpb.TypeDescriptor_MULTIREGION_ENUM:
 		return types.MakeEnum(catid.TypeIDToOID(desc.GetID()), catid.TypeIDToOID(desc.ArrayTypeID))
 	case descpb.TypeDescriptor_ALIAS:
-		return desc.Alias
+		cpy := *desc.Alias
+		return &cpy
 	case descpb.TypeDescriptor_COMPOSITE:
 		contents := make([]*types.T, len(desc.Composite.Elements))
 		labels := make([]string, len(desc.Composite.Elements))


### PR DESCRIPTION
This commit modifies the `immutable.AsTypesT` method to copy the aliased type when the descriptor is an alias. This ensures that in all code paths, the caller can safely hydrate the returned type.

Fixes #118267

Release note: None