### PR TITLE
roachtest: log when tests use spot VMs

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -654,6 +654,7 @@ func (r *testRunner) runWorker(
 
 		//  TODO(babusrithar): remove this once we see enough data in nightly runs. This is a temp logic to test spot VMs.
 		if roachtestflags.Cloud == spec.GCE && testToRun.spec.Benchmark && rand.Float64() <= 0.5 {
+			l.PrintfCtx(ctx, "using spot VMs to run test %s", testToRun.spec.Name)
 			testToRun.spec.Cluster.UseSpotVMs = true
 		}
 


### PR DESCRIPTION
It's currently not easy to determine which tests used spot VMs in a nightly run. This commit updates the test runner so that, when we decide to run a test with spot VMs, we log that decision. This should make it trivial to check which  tests ran on spot VMs in any given run and compare that to the failures observed to get a sense of the failure ratio.

Epic: none

Release note: None