### PR TITLE
sql: minor cleanups to virtual table declarations

### DIFF
--- a/pkg/cli/clisqlshell/describe.go
+++ b/pkg/cli/clisqlshell/describe.go
@@ -296,7 +296,7 @@ func describeFunctions(
 	buf.WriteString(`
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-    WHERE TRUE `)
+    WHERE TRUE`)
 	// TODO(sql-sessions): Filtering based on argument types like
 	// in PostgreSQL.
 	// TODO(sql-sessions): join on pg_language when verbose; pg_language

--- a/pkg/cli/clisqlshell/testdata/describe
+++ b/pkg/cli/clisqlshell/testdata/describe
@@ -532,8 +532,8 @@ https://www.postgresql.org/docs/12/catalog-pg-attribute.html"
 pg_catalog,pg_attribute_attrelid_idx,index,node,NULL,permanent,prefix,
 pg_catalog,pg_auth_members,table,node,NULL,permanent,prefix,"role membership
 https://www.postgresql.org/docs/9.5/catalog-pg-auth-members.html"
-pg_catalog,pg_authid,table,node,NULL,permanent,prefix,"authorization identifiers - differs from postgres as we do not display passwords, 
-and thus do not require admin privileges for access. 
+pg_catalog,pg_authid,table,node,NULL,permanent,prefix,"authorization identifiers - differs from postgres as we do not display passwords,
+and thus do not require admin privileges for access.
 https://www.postgresql.org/docs/9.5/catalog-pg-authid.html"
 pg_catalog,pg_available_extension_versions,table,node,NULL,permanent,prefix,pg_available_extension_versions was created for compatibility and is currently unimplemented
 pg_catalog,pg_available_extensions,table,node,NULL,permanent,prefix,"available extensions
@@ -637,7 +637,7 @@ pg_catalog,pg_settings,table,node,NULL,permanent,prefix,"session variables (inco
 https://www.postgresql.org/docs/9.5/catalog-pg-settings.html"
 pg_catalog,pg_shadow,table,node,NULL,permanent,prefix,"pg_shadow lists properties for roles that are marked as rolcanlogin in pg_authid
 https://www.postgresql.org/docs/13/view-pg-shadow.html"
-pg_catalog,pg_shdepend,table,node,NULL,permanent,prefix,"Shared Dependencies (Roles depending on objects). 
+pg_catalog,pg_shdepend,table,node,NULL,permanent,prefix,"Shared Dependencies (Roles depending on objects).
 https://www.postgresql.org/docs/9.6/catalog-pg-shdepend.html"
 pg_catalog,pg_shdescription,view,node,NULL,permanent,NULL,"shared object comments
 https://www.postgresql.org/docs/9.5/catalog-pg-shdescription.html"
@@ -2098,7 +2098,7 @@ List of functions:
          END AS "Type"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-    WHERE TRUE 
+    WHERE TRUE
       AND n.nspname !~ '^pg_'
       AND n.nspname <> 'information_schema'
       AND n.nspname <> 'crdb_internal'
@@ -2123,7 +2123,7 @@ List of functions:
          END AS "Type"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-    WHERE TRUE  AND p.proname LIKE 'abs' ORDER BY 1, 2, 4
+    WHERE TRUE AND p.proname LIKE 'abs' ORDER BY 1, 2, 4
 Schema,Name,Result data type,Argument data types,Type
 pg_catalog,abs,float8,float8,func
 pg_catalog,abs,int8,int8,func
@@ -2156,7 +2156,7 @@ List of functions:
        pg_catalog.obj_description(p.oid, 'pg_proc') AS "Description"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-    WHERE TRUE  AND p.proname LIKE 'abs' ORDER BY 1, 2, 4
+    WHERE TRUE AND p.proname LIKE 'abs' ORDER BY 1, 2, 4
 Schema,Name,Result data type,Argument data types,Type,Volatility,Owner,Security,Access privileges,Source code,Description
 pg_catalog,abs,float8,float8,func,i,NULL,invoker,,abs,Calculates the absolute value of `val`.
 pg_catalog,abs,int8,int8,func,i,NULL,invoker,,abs,Calculates the absolute value of `val`.
@@ -2179,7 +2179,7 @@ List of functions:
          END AS "Type"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-    WHERE TRUE  AND (FALSE OR p.proiswindow) AND p.proname LIKE '%rank%' ORDER BY 1, 2, 4
+    WHERE TRUE AND (FALSE OR p.proiswindow) AND p.proname LIKE '%rank%' ORDER BY 1, 2, 4
 Schema,Name,Result data type,Argument data types,Type
 pg_catalog,dense_rank,int8,,window
 pg_catalog,percent_rank,float8,,window
@@ -2212,7 +2212,7 @@ List of functions:
        pg_catalog.obj_description(p.oid, 'pg_proc') AS "Description"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-    WHERE TRUE  AND (FALSE OR p.proiswindow) AND p.proname LIKE '%rank%' ORDER BY 1, 2, 4
+    WHERE TRUE AND (FALSE OR p.proiswindow) AND p.proname LIKE '%rank%' ORDER BY 1, 2, 4
 Schema,Name,Result data type,Argument data types,Type,Volatility,Owner,Security,Access privileges,Source code,Description
 pg_catalog,dense_rank,int8,,window,i,NULL,invoker,,dense_rank,Calculates the rank of the current row without gaps; this function counts peer groups.
 pg_catalog,percent_rank,float8,,window,i,NULL,invoker,,percent_rank,Calculates the relative rank of the current row: (rank - 1) / (total rows - 1).
@@ -2235,7 +2235,7 @@ List of functions:
          END AS "Type"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-    WHERE TRUE  AND (FALSE OR p.proisagg) AND p.proname LIKE 'xor%' ORDER BY 1, 2, 4
+    WHERE TRUE AND (FALSE OR p.proisagg) AND p.proname LIKE 'xor%' ORDER BY 1, 2, 4
 Schema,Name,Result data type,Argument data types,Type
 pg_catalog,xor_agg,bytea,bytea,agg
 pg_catalog,xor_agg,int8,int8,agg
@@ -2267,7 +2267,7 @@ List of functions:
        pg_catalog.obj_description(p.oid, 'pg_proc') AS "Description"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-    WHERE TRUE  AND (FALSE OR p.proisagg) AND p.proname LIKE 'xor%' ORDER BY 1, 2, 4
+    WHERE TRUE AND (FALSE OR p.proisagg) AND p.proname LIKE 'xor%' ORDER BY 1, 2, 4
 Schema,Name,Result data type,Argument data types,Type,Volatility,Owner,Security,Access privileges,Source code,Description
 pg_catalog,xor_agg,bytea,bytea,agg,i,NULL,invoker,,xor_agg,Calculates the bitwise XOR of the selected values.
 pg_catalog,xor_agg,int8,int8,agg,i,NULL,invoker,,xor_agg,Calculates the bitwise XOR of the selected values.
@@ -2289,7 +2289,7 @@ List of functions:
          END AS "Type"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-    WHERE TRUE  AND NOT p.proisagg AND (p.prokind IS NULL OR p.prokind <> 'p') AND NOT p.proiswindow
+    WHERE TRUE AND NOT p.proisagg AND (p.prokind IS NULL OR p.prokind <> 'p') AND NOT p.proiswindow
       AND n.nspname !~ '^pg_'
       AND n.nspname <> 'information_schema'
       AND n.nspname <> 'crdb_internal'
@@ -2324,7 +2324,7 @@ List of functions:
        pg_catalog.obj_description(p.oid, 'pg_proc') AS "Description"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-    WHERE TRUE  AND NOT p.proisagg AND (p.prokind IS NULL OR p.prokind <> 'p') AND NOT p.proiswindow
+    WHERE TRUE AND NOT p.proisagg AND (p.prokind IS NULL OR p.prokind <> 'p') AND NOT p.proiswindow
       AND n.nspname !~ '^pg_'
       AND n.nspname <> 'information_schema'
       AND n.nspname <> 'crdb_internal'
@@ -2349,7 +2349,7 @@ List of functions:
          END AS "Type"
      FROM pg_catalog.pg_proc p
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-    WHERE TRUE  AND (FALSE OR p.proisagg OR p.proiswindow) AND p.proname LIKE '%tile%' ORDER BY 1, 2, 4
+    WHERE TRUE AND (FALSE OR p.proisagg OR p.proiswindow) AND p.proname LIKE '%tile%' ORDER BY 1, 2, 4
 Schema,Name,Result data type,Argument data types,Type
 pg_catalog,ntile,int8,int8,window
 pg_catalog,percentile_cont,_interval,_float8,agg

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -684,7 +684,7 @@ CREATE TABLE crdb_internal.pg_catalog_table_is_implemented (
   name                     STRING NOT NULL,
   implemented              BOOL
 )`,
-	generator: func(ctx context.Context, p *planner, dbDesc catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
+	generator: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
 		row := make(tree.Datums, 2)
 		worker := func(ctx context.Context, pusher rowPusher) error {
 			addDesc := func(table *virtualDefEntry, dbName tree.Datum, scName string) error {
@@ -868,9 +868,7 @@ CREATE TABLE crdb_internal.leases (
   expiration  TIMESTAMP NOT NULL,
   deleted     BOOL NOT NULL
 )`,
-	populate: func(
-		ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
-	) error {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID() // zero if not available
 		var iterErr error
 		p.LeaseMgr().VisitLeases(func(desc catalog.Descriptor, takenOffline bool, _ int, expiration tree.DTimestamp) (wantMore bool) {
@@ -921,7 +919,7 @@ const (
 WITH
 	latestpayload AS (SELECT job_id, value FROM system.job_info AS payload WHERE info_key = 'legacy_payload' ORDER BY written DESC),
 	latestprogress AS (SELECT job_id, value FROM system.job_info AS progress WHERE info_key = 'legacy_progress' ORDER BY written DESC)
-	SELECT 
+	SELECT
 		DISTINCT(id), status, created, payload.value AS payload, progress.value AS progress,
 		created_by_type, created_by_id, claim_session_id, claim_instance_id, num_runs, last_run, job_type
 	FROM system.jobs AS j
@@ -1375,7 +1373,7 @@ const crdbInternalKVProtectedTSTableQuery = `
 		  	'cockroach.protectedts.Target',
 		  	target,
 		    false /* emit defaults */,
-		    false /* include redaction marker */ 
+		    false /* include redaction marker */
 		          /* NB: redactions in the debug zip are handled elsewhere by marking columns as sensitive */
 		) as decoded_targets,
 	    crdb_internal_mvcc_timestamp
@@ -1394,16 +1392,16 @@ CREATE TABLE crdb_internal.kv_protected_ts_records (
    num_spans 			INT8 NOT NULL,
    spans     			BYTES NOT NULL, -- We do not decode this column since it is deprecated in 22.2+.
    verified  			BOOL NOT NULL,
-   target    			BYTES,  
+   target    			BYTES,
    decoded_meta 		JSON,   -- Decoded data from the meta column above.
-                                -- This data can have different structures depending on the meta_type. 
+                                -- This data can have different structures depending on the meta_type.
    decoded_target 		JSON,   -- Decoded data from the target column above.
-   internal_meta        JSON,   -- Additional metadata added by this virtual table (ex. job owner for job meta_type) 
+   internal_meta        JSON,   -- Additional metadata added by this virtual table (ex. job owner for job meta_type)
    num_ranges  			INT,     -- Number of ranges protected by this PTS record.
    last_updated         DECIMAL -- crdb_internal_mvcc_timestamp of the row
 )`,
 	comment: `decoded protected timestamp metadata from system.protected_ts_records (KV scan). does not decode `,
-	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
 		defer func() {
 			err = pgerror.Wrap(err, pgcode.Internal, "internal pts table")
 		}()
@@ -1564,7 +1562,7 @@ CREATE TABLE crdb_internal.kv_session_based_leases (
 );
 `,
 	comment: `reads from the internal session based leases table (before the table format is converted)`,
-	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
 		return p.InternalSQLTxn().WithSyntheticDescriptors(catalog.Descriptors{systemschema.LeaseTable_V24_1()},
 			func() error {
 				rows, err := p.InternalSQLTxn().QueryBuffered(
@@ -2214,7 +2212,7 @@ CREATE TABLE crdb_internal.cluster_inflight_traces (
   INDEX(trace_id)
 )`,
 	indexes: []virtualIndex{{populate: func(ctx context.Context, unwrappedConstraint tree.Datum, p *planner,
-		db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (matched bool, err error) {
+		_ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (matched bool, err error) {
 		var traceID tracingpb.TraceID
 		switch t := unwrappedConstraint.(type) {
 		case *tree.DInt:
@@ -3256,9 +3254,9 @@ func populateDistSQLFlowsTable(
 var crdbInternalLocalMetricsTable = virtualSchemaTable{
 	comment: "current values for metrics (RAM; local node only)",
 	schema: `CREATE TABLE crdb_internal.node_metrics (
-  store_id 	         INT NULL,         -- the store, if any, for this metric
-  name               STRING NOT NULL,  -- name of the metric
-  value							 FLOAT NOT NULL    -- value of the metric
+  store_id  INT NULL,         -- the store, if any, for this metric
+  name      STRING NOT NULL,  -- name of the metric
+  value     FLOAT NOT NULL    -- value of the metric
 )`,
 	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		if err := p.CheckPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWCLUSTERMETADATA); err != nil {
@@ -4135,10 +4133,7 @@ CREATE TABLE crdb_internal.backward_dependencies (
   dependson_details  STRING
 )
 `,
-	populate: func(
-		ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor,
-		addRow func(...tree.Datum) error,
-	) error {
+	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		fkDep := tree.NewDString("fk")
 		viewDep := tree.NewDString("view")
 		sequenceDep := tree.NewDString("sequence")
@@ -4238,7 +4233,7 @@ CREATE TABLE crdb_internal.feature_usage (
   usage_count           INT NOT NULL
 )
 `,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		for feature, count := range telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ReadOnly) {
 			if count == 0 {
 				// Skip over empty counters to avoid polluting the output.
@@ -5695,9 +5690,7 @@ CREATE TABLE crdb_internal.kv_catalog_descriptor (
   id            INT NOT NULL,
   descriptor    JSON NOT NULL
 )`,
-	populate: func(
-		ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
-	) error {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		all, err := p.Descriptors().GetAll(ctx, p.Txn())
 		if err != nil {
 			return err
@@ -5731,9 +5724,7 @@ CREATE TABLE crdb_internal.kv_catalog_zones (
   id        INT NOT NULL,
   config    JSON NOT NULL
 )`,
-	populate: func(
-		ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
-	) error {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		all, err := p.Descriptors().GetAll(ctx, p.Txn())
 		if err != nil {
 			return err
@@ -5770,9 +5761,7 @@ CREATE TABLE crdb_internal.kv_catalog_namespace (
   name             STRING NOT NULL,
   id               INT NOT NULL
 )`,
-	populate: func(
-		ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
-	) error {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		all, err := p.Descriptors().GetAll(ctx, p.Txn())
 		if err != nil {
 			return err
@@ -5801,9 +5790,7 @@ CREATE TABLE crdb_internal.kv_catalog_namespace (
 var crdbInternalCatalogCommentsTable = virtualSchemaTable{
 	comment: `like system.comments but overlaid with in-txn in-memory changes and including virtual objects`,
 	schema:  vtable.CrdbInternalCatalogComments,
-	populate: func(
-		ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
-	) error {
+	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		all, err := p.Descriptors().GetAllComments(ctx, p.Txn(), dbContext)
 		if err != nil {
@@ -6019,9 +6006,7 @@ CREATE TABLE crdb_internal.invalid_objects (
   error         STRING,
   error_redactable STRING NOT VISIBLE
 )`,
-	populate: func(
-		ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
-	) error {
+	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// The internalLookupContext will only have descriptors in the current
 		// database. To deal with this, we fall through.
 		c, err := p.Descriptors().GetAllFromStorageUnvalidated(ctx, p.txn)
@@ -6413,7 +6398,7 @@ CREATE TABLE crdb_internal.lost_descriptors_with_data (
 	descID
 		INTEGER NOT NULL
 );`,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		minID := descpb.ID(keys.MaxReservedDescID + 1)
 		maxID, err := p.ExecCfg().DescIDGenerator.PeekNextUniqueDescID(ctx)
 		if err != nil {
@@ -6580,7 +6565,7 @@ CREATE TABLE crdb_internal.default_privileges (
 	privilege_type  STRING NOT NULL,
 	is_grantable    BOOL
 );`,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 
 		// Cache roles ahead of time to avoid role lookup inside loop.
 		var roles []catpb.DefaultPrivilegesRole
@@ -6785,7 +6770,7 @@ CREATE TABLE crdb_internal.cluster_statement_statistics (
     aggregation_interval       INTERVAL NOT NULL,
     index_recommendations      STRING[] NOT NULL
 );`,
-	generator: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
+	generator: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
 		// TODO(azhng): we want to eventually implement memory accounting within the
 		//  RPC handlers. See #69032.
 		acc := p.Mon().MakeBoundAccount()
@@ -7020,7 +7005,7 @@ CREATE VIEW crdb_internal.statement_activity AS
 				contention_time_avg_seconds,
 				cpu_sql_avg_nanos,
 				service_latency_avg_seconds,
-				service_latency_p99_seconds 
+				service_latency_p99_seconds
       FROM
           system.statement_activity`,
 	resultColumns: colinfo.ResultColumns{
@@ -7191,7 +7176,7 @@ CREATE TABLE crdb_internal.cluster_transaction_statistics (
     statistics            JSONB NOT NULL,
     aggregation_interval  INTERVAL NOT NULL
 );`,
-	generator: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
+	generator: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
 		// TODO(azhng): we want to eventually implement memory accounting within the
 		//  RPC handlers. See #69032.
 		acc := p.Mon().MakeBoundAccount()
@@ -7502,17 +7487,17 @@ CREATE TABLE crdb_internal.transaction_contention_events (
     contention_duration          INTERVAL NOT NULL,
     contending_key               BYTES NOT NULL,
     contending_pretty_key     	 STRING NOT NULL,
-		    
+
     waiting_stmt_id              string NOT NULL,
     waiting_stmt_fingerprint_id  BYTES NOT NULL,
-    
+
     database_name                STRING NOT NULL,
     schema_name                  STRING NOT NULL,
     table_name                   STRING NOT NULL,
     index_name                   STRING,
     contention_type              STRING NOT NULL
 );`,
-	generator: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
+	generator: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
 		// Check permission first before making RPC fanout.
 		// If a user has VIEWACTIVITYREDACTED role option but the user does not
 		// have the ADMIN role option, then the contending key should be redacted.
@@ -7630,7 +7615,7 @@ CREATE TABLE crdb_internal.index_spans (
 );`,
 	indexes: []virtualIndex{
 		{
-			populate: func(ctx context.Context, constraint tree.Datum, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (matched bool, err error) {
+			populate: func(ctx context.Context, constraint tree.Datum, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (matched bool, err error) {
 				descID := catid.DescID(tree.MustBeDInt(constraint))
 				var table catalog.TableDescriptor
 				// We need to include offline tables, like in
@@ -7682,7 +7667,7 @@ CREATE TABLE crdb_internal.table_spans (
 );`,
 	indexes: []virtualIndex{
 		{
-			populate: func(ctx context.Context, constraint tree.Datum, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (matched bool, err error) {
+			populate: func(ctx context.Context, constraint tree.Datum, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (matched bool, err error) {
 				descID := catid.DescID(tree.MustBeDInt(constraint))
 				var table catalog.TableDescriptor
 				// We need to include offline tables, like in
@@ -8098,7 +8083,7 @@ CREATE TABLE crdb_internal.%s (
 var crdbInternalClusterTxnExecutionInsightsTable = virtualSchemaTable{
 	schema:  fmt.Sprintf(txnExecutionInsightsSchemaPattern, "cluster_txn_execution_insights"),
 	comment: `Cluster transaction execution insights`,
-	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
 		return populateTxnExecutionInsights(ctx, p, addRow, &serverpb.ListExecutionInsightsRequest{})
 	},
 }
@@ -8106,7 +8091,7 @@ var crdbInternalClusterTxnExecutionInsightsTable = virtualSchemaTable{
 var crdbInternalNodeTxnExecutionInsightsTable = virtualSchemaTable{
 	schema:  fmt.Sprintf(txnExecutionInsightsSchemaPattern, "node_txn_execution_insights"),
 	comment: `Node transaction execution insights`,
-	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
 		return populateTxnExecutionInsights(ctx, p, addRow, &serverpb.ListExecutionInsightsRequest{NodeID: "local"})
 	},
 }
@@ -8280,7 +8265,7 @@ CREATE TABLE crdb_internal.%s (
 var crdbInternalClusterExecutionInsightsTable = virtualSchemaTable{
 	schema:  fmt.Sprintf(executionInsightsSchemaPattern, "cluster_execution_insights"),
 	comment: `Cluster-wide statement execution insights`,
-	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
 		return populateStmtInsights(ctx, p, addRow, &serverpb.ListExecutionInsightsRequest{})
 	},
 }
@@ -8288,7 +8273,7 @@ var crdbInternalClusterExecutionInsightsTable = virtualSchemaTable{
 var crdbInternalNodeExecutionInsightsTable = virtualSchemaTable{
 	schema:  fmt.Sprintf(executionInsightsSchemaPattern, "node_execution_insights"),
 	comment: `Node statement execution insights`,
-	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) (err error) {
 		return populateStmtInsights(ctx, p, addRow, &serverpb.ListExecutionInsightsRequest{NodeID: "local"})
 	},
 }

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -229,9 +229,7 @@ var informationSchemaAdministrableRoleAuthorizations = virtualSchemaTable{
 ` + docs.URL("information-schema.html#administrable_role_authorizations") + `
 https://www.postgresql.org/docs/9.5/infoschema-administrable-role-authorizations.html`,
 	schema: vtable.InformationSchemaAdministrableRoleAuthorizations,
-	populate: func(
-		ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
-	) error {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return populateRoleHierarchy(ctx, p, addRow, true /* onlyIsAdmin */)
 	},
 }
@@ -241,9 +239,7 @@ var informationSchemaApplicableRoles = virtualSchemaTable{
 ` + docs.URL("information-schema.html#applicable_roles") + `
 https://www.postgresql.org/docs/9.5/infoschema-applicable-roles.html`,
 	schema: vtable.InformationSchemaApplicableRoles,
-	populate: func(
-		ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
-	) error {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return populateRoleHierarchy(ctx, p, addRow, false /* onlyIsAdmin */)
 	},
 }
@@ -322,7 +318,7 @@ var informationSchemaCharacterSets = virtualSchemaTable{
 ` + docs.URL("information-schema.html#character_sets") + `
 https://www.postgresql.org/docs/9.5/infoschema-character-sets.html`,
 	schema: vtable.InformationSchemaCharacterSets,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachDatabaseDesc(ctx, p, nil /* all databases */, true, /* requiresPrivileges */
 			func(db catalog.DatabaseDescriptor) error {
 				return addRow(
@@ -1749,7 +1745,7 @@ var informationSchemaCollations = virtualSchemaTable{
 	comment: `shows the collations available in the current database
 https://www.postgresql.org/docs/current/infoschema-collations.html`,
 	schema: vtable.InformationSchemaCollations,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		dbNameStr := tree.NewDString(p.CurrentDatabase())
 		add := func(collName string) error {
 			return addRow(
@@ -1772,12 +1768,12 @@ https://www.postgresql.org/docs/current/infoschema-collations.html`,
 // Postgres: https://www.postgresql.org/docs/current/infoschema-collation-character-set-applicab.html
 // MySQL:    https://dev.mysql.com/doc/refman/8.0/en/information-schema-collation-character-set-applicability-table.html
 var informationSchemaCollationCharacterSetApplicability = virtualSchemaTable{
-	comment: `identifies which character set the available collations are 
+	comment: `identifies which character set the available collations are
 applicable to. As UTF-8 is the only available encoding this table does not
 provide much useful information.
 https://www.postgresql.org/docs/current/infoschema-collation-character-set-applicab.html`,
 	schema: vtable.InformationSchemaCollationCharacterSetApplicability,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		dbNameStr := tree.NewDString(p.CurrentDatabase())
 		add := func(collName string) error {
 			return addRow(
@@ -1823,11 +1819,9 @@ var informationSchemaSessionVariables = virtualSchemaTable{
 }
 
 var informationSchemaRoutinePrivilegesTable = virtualSchemaTable{
-	comment: "routine_privileges was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaRoutinePrivileges,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "routine_privileges was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaRoutinePrivileges,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
@@ -1959,497 +1953,387 @@ var informationSchemaRoleRoutineGrantsTable = virtualSchemaTable{
 }
 
 var informationSchemaElementTypesTable = virtualSchemaTable{
-	comment: "element_types was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaElementTypes,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "element_types was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaElementTypes,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaRoleUdtGrantsTable = virtualSchemaTable{
-	comment: "role_udt_grants was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaRoleUdtGrants,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "role_udt_grants was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaRoleUdtGrants,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaColumnOptionsTable = virtualSchemaTable{
-	comment: "column_options was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaColumnOptions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "column_options was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaColumnOptions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaForeignDataWrapperOptionsTable = virtualSchemaTable{
-	comment: "foreign_data_wrapper_options was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaForeignDataWrapperOptions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "foreign_data_wrapper_options was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaForeignDataWrapperOptions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaTransformsTable = virtualSchemaTable{
-	comment: "transforms was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaTransforms,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "transforms was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaTransforms,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaViewColumnUsageTable = virtualSchemaTable{
-	comment: "view_column_usage was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaViewColumnUsage,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "view_column_usage was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaViewColumnUsage,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaInformationSchemaCatalogNameTable = virtualSchemaTable{
-	comment: "information_schema_catalog_name was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaInformationSchemaCatalogName,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "information_schema_catalog_name was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaInformationSchemaCatalogName,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaForeignTablesTable = virtualSchemaTable{
-	comment: "foreign_tables was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaForeignTables,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "foreign_tables was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaForeignTables,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaViewRoutineUsageTable = virtualSchemaTable{
-	comment: "view_routine_usage was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaViewRoutineUsage,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "view_routine_usage was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaViewRoutineUsage,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaRoleColumnGrantsTable = virtualSchemaTable{
-	comment: "role_column_grants was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaRoleColumnGrants,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "role_column_grants was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaRoleColumnGrants,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaDomainConstraintsTable = virtualSchemaTable{
-	comment: "domain_constraints was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaDomainConstraints,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "domain_constraints was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaDomainConstraints,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaUserMappingsTable = virtualSchemaTable{
-	comment: "user_mappings was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaUserMappings,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "user_mappings was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaUserMappings,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaCheckConstraintRoutineUsageTable = virtualSchemaTable{
-	comment: "check_constraint_routine_usage was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaCheckConstraintRoutineUsage,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "check_constraint_routine_usage was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaCheckConstraintRoutineUsage,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaColumnDomainUsageTable = virtualSchemaTable{
-	comment: "column_domain_usage was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaColumnDomainUsage,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "column_domain_usage was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaColumnDomainUsage,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaForeignDataWrappersTable = virtualSchemaTable{
-	comment: "foreign_data_wrappers was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaForeignDataWrappers,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "foreign_data_wrappers was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaForeignDataWrappers,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaColumnColumnUsageTable = virtualSchemaTable{
-	comment: "column_column_usage was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaColumnColumnUsage,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "column_column_usage was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaColumnColumnUsage,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaSQLSizingTable = virtualSchemaTable{
-	comment: "sql_sizing was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaSQLSizing,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "sql_sizing was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaSQLSizing,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaUsagePrivilegesTable = virtualSchemaTable{
-	comment: "usage_privileges was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaUsagePrivileges,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "usage_privileges was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaUsagePrivileges,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaDomainsTable = virtualSchemaTable{
-	comment: "domains was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaDomains,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "domains was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaDomains,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaSQLImplementationInfoTable = virtualSchemaTable{
-	comment: "sql_implementation_info was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaSQLImplementationInfo,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "sql_implementation_info was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaSQLImplementationInfo,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaUdtPrivilegesTable = virtualSchemaTable{
-	comment: "udt_privileges was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaUdtPrivileges,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "udt_privileges was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaUdtPrivileges,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaPartitionsTable = virtualSchemaTable{
-	comment: "partitions was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaPartitions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "partitions was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaPartitions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaTablespacesExtensionsTable = virtualSchemaTable{
-	comment: "tablespaces_extensions was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaTablespacesExtensions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "tablespaces_extensions was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaTablespacesExtensions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaResourceGroupsTable = virtualSchemaTable{
-	comment: "resource_groups was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaResourceGroups,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "resource_groups was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaResourceGroups,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaForeignServerOptionsTable = virtualSchemaTable{
-	comment: "foreign_server_options was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaForeignServerOptions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "foreign_server_options was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaForeignServerOptions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaStUnitsOfMeasureTable = virtualSchemaTable{
-	comment: "st_units_of_measure was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaStUnitsOfMeasure,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "st_units_of_measure was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaStUnitsOfMeasure,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaSchemataExtensionsTable = virtualSchemaTable{
-	comment: "schemata_extensions was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaSchemataExtensions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "schemata_extensions was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaSchemataExtensions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaColumnStatisticsTable = virtualSchemaTable{
-	comment: "column_statistics was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaColumnStatistics,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "column_statistics was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaColumnStatistics,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaConstraintTableUsageTable = virtualSchemaTable{
-	comment: "constraint_table_usage was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaConstraintTableUsage,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "constraint_table_usage was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaConstraintTableUsage,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaDataTypePrivilegesTable = virtualSchemaTable{
-	comment: "data_type_privileges was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaDataTypePrivileges,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "data_type_privileges was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaDataTypePrivileges,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaRoleUsageGrantsTable = virtualSchemaTable{
-	comment: "role_usage_grants was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaRoleUsageGrants,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "role_usage_grants was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaRoleUsageGrants,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaFilesTable = virtualSchemaTable{
-	comment: "files was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaFiles,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "files was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaFiles,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaEnginesTable = virtualSchemaTable{
-	comment: "engines was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaEngines,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "engines was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaEngines,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaForeignTableOptionsTable = virtualSchemaTable{
-	comment: "foreign_table_options was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaForeignTableOptions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "foreign_table_options was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaForeignTableOptions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaEventsTable = virtualSchemaTable{
-	comment: "events was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaEvents,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "events was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaEvents,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaDomainUdtUsageTable = virtualSchemaTable{
-	comment: "domain_udt_usage was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaDomainUdtUsage,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "domain_udt_usage was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaDomainUdtUsage,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaUserAttributesTable = virtualSchemaTable{
-	comment: "user_attributes was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaUserAttributes,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "user_attributes was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaUserAttributes,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaKeywordsTable = virtualSchemaTable{
-	comment: "keywords was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaKeywords,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "keywords was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaKeywords,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaUserMappingOptionsTable = virtualSchemaTable{
-	comment: "user_mapping_options was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaUserMappingOptions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "user_mapping_options was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaUserMappingOptions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaOptimizerTraceTable = virtualSchemaTable{
-	comment: "optimizer_trace was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaOptimizerTrace,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "optimizer_trace was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaOptimizerTrace,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaTableConstraintsExtensionsTable = virtualSchemaTable{
-	comment: "table_constraints_extensions was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaTableConstraintsExtensions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "table_constraints_extensions was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaTableConstraintsExtensions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaColumnsExtensionsTable = virtualSchemaTable{
-	comment: "columns_extensions was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaColumnsExtensions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "columns_extensions was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaColumnsExtensions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaSQLFeaturesTable = virtualSchemaTable{
-	comment: "sql_features was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaSQLFeatures,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "sql_features was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaSQLFeatures,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaStGeometryColumnsTable = virtualSchemaTable{
-	comment: "st_geometry_columns was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaStGeometryColumns,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "st_geometry_columns was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaStGeometryColumns,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaSQLPartsTable = virtualSchemaTable{
-	comment: "sql_parts was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaSQLParts,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "sql_parts was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaSQLParts,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaPluginsTable = virtualSchemaTable{
-	comment: "plugins was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaPlugins,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "plugins was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaPlugins,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaStSpatialReferenceSystemsTable = virtualSchemaTable{
-	comment: "st_spatial_reference_systems was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaStSpatialReferenceSystems,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "st_spatial_reference_systems was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaStSpatialReferenceSystems,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaProcesslistTable = virtualSchemaTable{
-	comment: "processlist was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaProcesslist,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "processlist was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaProcesslist,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaForeignServersTable = virtualSchemaTable{
-	comment: "foreign_servers was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaForeignServers,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "foreign_servers was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaForeignServers,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaTriggeredUpdateColumnsTable = virtualSchemaTable{
-	comment: "triggered_update_columns was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaTriggeredUpdateColumns,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "triggered_update_columns was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaTriggeredUpdateColumns,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaTriggersTable = virtualSchemaTable{
-	comment: "triggers was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaTriggers,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "triggers was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaTriggers,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaTablesExtensionsTable = virtualSchemaTable{
-	comment: "tables_extensions was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaTablesExtensions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "tables_extensions was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaTablesExtensions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaProfilingTable = virtualSchemaTable{
-	comment: "profiling was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaProfiling,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "profiling was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaProfiling,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaTablespacesTable = virtualSchemaTable{
-	comment: "tablespaces was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaTablespaces,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "tablespaces was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaTablespaces,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var informationSchemaViewTableUsageTable = virtualSchemaTable{
-	comment: "view_table_usage was created for compatibility and is currently unimplemented",
-	schema:  vtable.InformationSchemaViewTableUsage,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "view_table_usage was created for compatibility and is currently unimplemented",
+	schema:        vtable.InformationSchemaViewTableUsage,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
@@ -2912,7 +2796,7 @@ FROM
 	system.users AS u
 	LEFT JOIN system.role_options AS ro ON
 			ro.username = u.username
-  LEFT JOIN system.database_role_settings AS drs ON 
+  LEFT JOIN system.database_role_settings AS drs ON
 			drs.role_name = u.username AND drs.database_id = 0
 GROUP BY
 	u.username, "isRole", drs.settings;

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -277,7 +277,7 @@ var pgCatalogAmTable = virtualSchemaTable{
 	comment: `index access methods (incomplete)
 https://www.postgresql.org/docs/9.5/catalog-pg-am.html`,
 	schema: vtable.PGCatalogAm,
-	populate: func(_ context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// add row for forward indexes
 		if err := addRow(
 			forwardIndexOid,                      // oid - all versions
@@ -365,7 +365,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-attrdef.html`,
 	vtable.PGCatalogAttrDef,
 	virtualMany, false, /* includesIndexEntries */
 	func(ctx context.Context, p *planner, h oidHasher,
-		db catalog.DatabaseDescriptor, sc catalog.SchemaDescriptor, table catalog.TableDescriptor,
+		_ catalog.DatabaseDescriptor, sc catalog.SchemaDescriptor, table catalog.TableDescriptor,
 		lookup simpleSchemaResolver,
 		addRow func(...tree.Datum) error,
 	) error {
@@ -575,7 +575,7 @@ var pgCatalogCastTable = virtualSchemaTable{
 	comment: `casts (empty - needs filling out)
 https://www.postgresql.org/docs/9.6/catalog-pg-cast.html`,
 	schema: vtable.PGCatalogCast,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		cast.ForEachCast(func(src, tgt oid.Oid, cCtx cast.Context, ctxOrigin cast.ContextOrigin, _ volatility.V) {
 			if ctxOrigin == cast.ContextOriginPgCast {
@@ -609,8 +609,8 @@ func userIsSuper(
 }
 
 var pgCatalogAuthIDTable = virtualSchemaTable{
-	comment: `authorization identifiers - differs from postgres as we do not display passwords, 
-and thus do not require admin privileges for access. 
+	comment: `authorization identifiers - differs from postgres as we do not display passwords,
+and thus do not require admin privileges for access.
 https://www.postgresql.org/docs/9.5/catalog-pg-authid.html`,
 	schema: vtable.PGCatalogAuthID,
 	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
@@ -682,11 +682,8 @@ https://www.postgresql.org/docs/9.5/catalog-pg-auth-members.html`,
 var pgCatalogAvailableExtensionsTable = virtualSchemaTable{
 	comment: `available extensions
 https://www.postgresql.org/docs/9.6/view-pg-available-extensions.html`,
-	schema: vtable.PGCatalogAvailableExtensions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		// We support no extensions.
-		return nil
-	},
+	schema:        vtable.PGCatalogAvailableExtensions,
+	populate:      emptyVirtualTable, // we support no extensions
 	unimplemented: true,
 }
 
@@ -1326,10 +1323,8 @@ func colIDArrayToVector(arr []descpb.ColumnID) (tree.Datum, error) {
 var pgCatalogConversionTable = virtualSchemaTable{
 	comment: `encoding conversions (empty - unimplemented)
 https://www.postgresql.org/docs/9.6/catalog-pg-conversion.html`,
-	schema: vtable.PGCatalogConversion,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	schema:        vtable.PGCatalogConversion,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
@@ -1370,7 +1365,7 @@ var pgCatalogDefaultACLTable = virtualSchemaTable{
 	comment: `default ACLs; these are the privileges that will be assigned to newly created objects
 https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 	schema: vtable.PGCatalogDefaultACL,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, _ *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		f := func(defaultPrivilegesForRole catpb.DefaultPrivilegesForRole) error {
 			objectTypes := privilege.GetTargetObjectTypes()
@@ -1824,7 +1819,7 @@ var pgCatalogEventTriggerTable = virtualSchemaTable{
 	comment: `event triggers (empty - feature does not exist)
 https://www.postgresql.org/docs/9.6/catalog-pg-event-trigger.html`,
 	schema: vtable.PGCatalogEventTrigger,
-	populate: func(_ context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Event triggers are not currently supported.
 		return nil
 	},
@@ -1835,7 +1830,7 @@ var pgCatalogExtensionTable = virtualSchemaTable{
 	comment: `installed extensions (empty - feature does not exist)
 https://www.postgresql.org/docs/9.5/catalog-pg-extension.html`,
 	schema: vtable.PGCatalogExtension,
-	populate: func(_ context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Extensions are not supported.
 		return nil
 	},
@@ -1846,7 +1841,7 @@ var pgCatalogForeignDataWrapperTable = virtualSchemaTable{
 	comment: `foreign data wrappers (empty - feature does not exist)
 https://www.postgresql.org/docs/9.5/catalog-pg-foreign-data-wrapper.html`,
 	schema: vtable.PGCatalogForeignDataWrapper,
-	populate: func(_ context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Foreign data wrappers are not supported.
 		return nil
 	},
@@ -1857,7 +1852,7 @@ var pgCatalogForeignServerTable = virtualSchemaTable{
 	comment: `foreign servers (empty - feature does not exist)
 https://www.postgresql.org/docs/9.5/catalog-pg-foreign-server.html`,
 	schema: vtable.PGCatalogForeignServer,
-	populate: func(_ context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Foreign servers are not supported.
 		return nil
 	},
@@ -1868,7 +1863,7 @@ var pgCatalogForeignTableTable = virtualSchemaTable{
 	comment: `foreign tables (empty  - feature does not exist)
 https://www.postgresql.org/docs/9.5/catalog-pg-foreign-table.html`,
 	schema: vtable.PGCatalogForeignTable,
-	populate: func(_ context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Foreign tables are not supported.
 		return nil
 	},
@@ -2080,7 +2075,7 @@ var pgCatalogInheritsTable = virtualSchemaTable{
 	comment: `table inheritance hierarchy (empty - feature does not exist)
 https://www.postgresql.org/docs/9.5/catalog-pg-inherits.html`,
 	schema: vtable.PGCatalogInherits,
-	populate: func(_ context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Table inheritance is not supported.
 		return nil
 	},
@@ -2096,7 +2091,7 @@ var pgCatalogLanguageTable = virtualSchemaTable{
 	comment: `available languages
 https://www.postgresql.org/docs/9.5/catalog-pg-language.html`,
 	schema: vtable.PGCatalogLanguage,
-	populate: func(_ context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		for _, lang := range []*tree.DOid{languageInternalOid, languageSqlOid, languagePlpgsqlOid} {
 			isPl := tree.DBoolFalse
@@ -2129,10 +2124,8 @@ https://www.postgresql.org/docs/9.5/catalog-pg-language.html`,
 var pgCatalogLocksTable = virtualSchemaTable{
 	comment: `locks held by active processes (empty - feature does not exist)
 https://www.postgresql.org/docs/9.6/view-pg-locks.html`,
-	schema: vtable.PGCatalogLocks,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	schema:        vtable.PGCatalogLocks,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
@@ -2282,10 +2275,8 @@ var (
 var pgCatalogOpclassTable = virtualSchemaTable{
 	comment: `opclass (empty - Operator classes not supported yet)
 https://www.postgresql.org/docs/12/catalog-pg-opclass.html`,
-	schema: vtable.PGCatalogOpclass,
-	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	schema:        vtable.PGCatalogOpclass,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
@@ -2293,7 +2284,7 @@ var pgCatalogOperatorTable = virtualSchemaTable{
 	comment: `operators (incomplete)
 https://www.postgresql.org/docs/9.5/catalog-pg-operator.html`,
 	schema: vtable.PGCatalogOperator,
-	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		nspOid := tree.NewDOid(catconstants.PgCatalogID)
 		addOp := func(opName string, kind tree.Datum, params tree.TypeList, returnTyper tree.ReturnTyper) error {
@@ -2393,10 +2384,8 @@ var (
 var pgCatalogPreparedXactsTable = virtualSchemaTable{
 	comment: `prepared transactions (empty - feature does not exist)
 https://www.postgresql.org/docs/9.6/view-pg-prepared-xacts.html`,
-	schema: vtable.PGCatalogPreparedXacts,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	schema:        vtable.PGCatalogPreparedXacts,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
@@ -2409,7 +2398,7 @@ var pgCatalogPreparedStatementsTable = virtualSchemaTable{
 	comment: `prepared statements
 https://www.postgresql.org/docs/9.6/view-pg-prepared-statements.html`,
 	schema: vtable.PGCatalogPreparedStatements,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		for name, stmt := range p.preparedStatements.List() {
 			placeholderTypes := stmt.PrepareMetadata.PlaceholderTypesInfo.Types
 			paramTypes := tree.NewDArray(types.RegType)
@@ -2771,7 +2760,7 @@ var pgCatalogRangeTable = virtualSchemaTable{
 	comment: `range types (empty - feature does not exist)
 https://www.postgresql.org/docs/9.5/catalog-pg-range.html`,
 	schema: vtable.PGCatalogRange,
-	populate: func(_ context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(_ context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// We currently do not support any range types, so this table is empty.
 		// This table should be populated when any range types are added to
 		// oidToDatum (and therefore pg_type).
@@ -2877,10 +2866,8 @@ https://www.postgresql.org/docs/9.5/view-pg-roles.html`,
 var pgCatalogSecLabelsTable = virtualSchemaTable{
 	comment: `security labels (empty)
 https://www.postgresql.org/docs/9.6/view-pg-seclabels.html`,
-	schema: vtable.PGCatalogSecLabels,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	schema:        vtable.PGCatalogSecLabels,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
@@ -2976,7 +2963,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-settings.html`,
 }
 
 var pgCatalogShdependTable = virtualSchemaTable{
-	comment: `Shared Dependencies (Roles depending on objects). 
+	comment: `Shared Dependencies (Roles depending on objects).
 https://www.postgresql.org/docs/9.6/catalog-pg-shdepend.html`,
 	schema: vtable.PGCatalogShdepend,
 	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
@@ -3146,7 +3133,7 @@ var pgCatalogTablespaceTable = virtualSchemaTable{
 	comment: `available tablespaces (incomplete; concept inapplicable to CockroachDB)
 https://www.postgresql.org/docs/9.5/catalog-pg-tablespace.html`,
 	schema: vtable.PGCatalogTablespace,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return addRow(
 			oidZero,                       // oid
 			tree.NewDString("pg_default"), // spcname
@@ -3162,7 +3149,7 @@ var pgCatalogTriggerTable = virtualSchemaTable{
 	comment: `triggers (empty - feature does not exist)
 https://www.postgresql.org/docs/9.5/catalog-pg-trigger.html`,
 	schema: vtable.PGCatalogTrigger,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Triggers are unsupported.
 		return nil
 	},
@@ -3677,7 +3664,7 @@ var pgCatalogUserMappingTable = virtualSchemaTable{
 	comment: `local to remote user mapping (empty - feature does not exist)
 https://www.postgresql.org/docs/9.5/catalog-pg-user-mapping.html`,
 	schema: vtable.PGCatalogUserMapping,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// This table stores the mapping to foreign server users.
 		// Foreign servers are not supported.
 		return nil
@@ -3688,30 +3675,24 @@ https://www.postgresql.org/docs/9.5/catalog-pg-user-mapping.html`,
 var pgCatalogStatActivityTable = virtualSchemaTable{
 	comment: `backend access statistics (empty - monitoring works differently in CockroachDB)
 https://www.postgresql.org/docs/9.6/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW`,
-	schema: vtable.PGCatalogStatActivity,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	schema:        vtable.PGCatalogStatActivity,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogSecurityLabelTable = virtualSchemaTable{
 	comment: `security labels (empty - feature does not exist)
 https://www.postgresql.org/docs/9.5/catalog-pg-seclabel.html`,
-	schema: vtable.PGCatalogSecurityLabel,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	schema:        vtable.PGCatalogSecurityLabel,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogSharedSecurityLabelTable = virtualSchemaTable{
 	comment: `shared security labels (empty - feature not supported)
 https://www.postgresql.org/docs/9.5/catalog-pg-shseclabel.html`,
-	schema: vtable.PGCatalogSharedSecurityLabel,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	schema:        vtable.PGCatalogSharedSecurityLabel,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
@@ -3922,263 +3903,205 @@ https://www.postgresql.org/docs/13/view-pg-sequences.html
 }
 
 var pgCatalogInitPrivsTable = virtualSchemaTable{
-	comment: "pg_init_privs was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogInitPrivs,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_init_privs was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogInitPrivs,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatProgressCreateIndexTable = virtualSchemaTable{
-	comment: "pg_stat_progress_create_index was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatProgressCreateIndex,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_progress_create_index was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatProgressCreateIndex,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogOpfamilyTable = virtualSchemaTable{
-	comment: "pg_opfamily was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogOpfamily,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_opfamily was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogOpfamily,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatioAllSequencesTable = virtualSchemaTable{
-	comment: "pg_statio_all_sequences was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatioAllSequences,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_statio_all_sequences was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatioAllSequences,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogPoliciesTable = virtualSchemaTable{
-	comment: "pg_policies was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogPolicies,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_policies was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogPolicies,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatsExtTable = virtualSchemaTable{
-	comment: "pg_stats_ext was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatsExt,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stats_ext was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatsExt,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogUserMappingsTable = virtualSchemaTable{
-	comment: "pg_user_mappings was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogUserMappings,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_user_mappings was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogUserMappings,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatGssapiTable = virtualSchemaTable{
-	comment: "pg_stat_gssapi was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatGssapi,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_gssapi was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatGssapi,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatDatabaseTable = virtualSchemaTable{
-	comment: "pg_stat_database was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatDatabase,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_database was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatDatabase,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatioUserIndexesTable = virtualSchemaTable{
-	comment: "pg_statio_user_indexes was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatioUserIndexes,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_statio_user_indexes was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatioUserIndexes,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatSslTable = virtualSchemaTable{
-	comment: "pg_stat_ssl was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatSsl,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_ssl was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatSsl,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatioAllIndexesTable = virtualSchemaTable{
-	comment: "pg_statio_all_indexes was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatioAllIndexes,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_statio_all_indexes was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatioAllIndexes,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogTimezoneAbbrevsTable = virtualSchemaTable{
-	comment: "pg_timezone_abbrevs was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogTimezoneAbbrevs,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_timezone_abbrevs was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogTimezoneAbbrevs,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatSysTablesTable = virtualSchemaTable{
-	comment: "pg_stat_sys_tables was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatSysTables,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_sys_tables was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatSysTables,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatioSysSequencesTable = virtualSchemaTable{
-	comment: "pg_statio_sys_sequences was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatioSysSequences,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_statio_sys_sequences was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatioSysSequences,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatAllTablesTable = virtualSchemaTable{
-	comment: "pg_stat_all_tables was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatAllTables,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_all_tables was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatAllTables,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatioSysTablesTable = virtualSchemaTable{
-	comment: "pg_statio_sys_tables was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatioSysTables,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_statio_sys_tables was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatioSysTables,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogTsConfigTable = virtualSchemaTable{
-	comment: "pg_ts_config was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogTsConfig,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_ts_config was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogTsConfig,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatsTable = virtualSchemaTable{
-	comment: "pg_stats was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStats,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stats was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStats,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatProgressBasebackupTable = virtualSchemaTable{
-	comment: "pg_stat_progress_basebackup was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatProgressBasebackup,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_progress_basebackup was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatProgressBasebackup,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogPolicyTable = virtualSchemaTable{
-	comment: "pg_policy was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogPolicy,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_policy was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogPolicy,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatArchiverTable = virtualSchemaTable{
-	comment: "pg_stat_archiver was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatArchiver,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_archiver was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatArchiver,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatXactUserFunctionsTable = virtualSchemaTable{
-	comment: "pg_stat_xact_user_functions was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatXactUserFunctions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_xact_user_functions was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatXactUserFunctions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatUserFunctionsTable = virtualSchemaTable{
-	comment: "pg_stat_user_functions was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatUserFunctions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_user_functions was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatUserFunctions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogPublicationTable = virtualSchemaTable{
-	comment: "pg_publication was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogPublication,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_publication was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogPublication,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogAmprocTable = virtualSchemaTable{
-	comment: "pg_amproc was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogAmproc,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_amproc was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogAmproc,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatProgressAnalyzeTable = virtualSchemaTable{
-	comment: "pg_stat_progress_analyze was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatProgressAnalyze,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_progress_analyze was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatProgressAnalyze,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatXactAllTablesTable = virtualSchemaTable{
-	comment: "pg_stat_xact_all_tables was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatXactAllTables,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_xact_all_tables was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatXactAllTables,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogHbaFileRulesTable = virtualSchemaTable{
-	comment: "pg_hba_file_rules was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogHbaFileRules,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_hba_file_rules was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogHbaFileRules,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
@@ -4208,101 +4131,79 @@ https://www.postgresql.org/docs/14/view-pg-cursors.html`,
 }
 
 var pgCatalogStatSlruTable = virtualSchemaTable{
-	comment: "pg_stat_slru was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatSlru,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_slru was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatSlru,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogFileSettingsTable = virtualSchemaTable{
-	comment: "pg_file_settings was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogFileSettings,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_file_settings was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogFileSettings,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatUserIndexesTable = virtualSchemaTable{
-	comment: "pg_stat_user_indexes was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatUserIndexes,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_user_indexes was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatUserIndexes,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogRulesTable = virtualSchemaTable{
-	comment: "pg_rules was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogRules,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_rules was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogRules,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatioUserSequencesTable = virtualSchemaTable{
-	comment: "pg_statio_user_sequences was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatioUserSequences,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_statio_user_sequences was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatioUserSequences,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatAllIndexesTable = virtualSchemaTable{
-	comment: "pg_stat_all_indexes was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatAllIndexes,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_all_indexes was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatAllIndexes,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogTsConfigMapTable = virtualSchemaTable{
-	comment: "pg_ts_config_map was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogTsConfigMap,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_ts_config_map was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogTsConfigMap,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatBgwriterTable = virtualSchemaTable{
-	comment: "pg_stat_bgwriter was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatBgwriter,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_bgwriter was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatBgwriter,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogTransformTable = virtualSchemaTable{
-	comment: "pg_transform was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogTransform,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_transform was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogTransform,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatXactUserTablesTable = virtualSchemaTable{
-	comment: "pg_stat_xact_user_tables was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatXactUserTables,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_xact_user_tables was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatXactUserTables,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogPublicationTablesTable = virtualSchemaTable{
-	comment: "pg_publication_tables was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogPublicationTables,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_publication_tables was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogPublicationTables,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
@@ -4316,20 +4217,16 @@ var pgCatalogStatProgressClusterTable = virtualSchemaTable{
 }
 
 var pgCatalogGroupTable = virtualSchemaTable{
-	comment: "pg_group was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogGroup,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_group was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogGroup,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogLargeobjectMetadataTable = virtualSchemaTable{
-	comment: "pg_largeobject_metadata was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogLargeobjectMetadata,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_largeobject_metadata was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogLargeobjectMetadata,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
@@ -4343,65 +4240,51 @@ var pgCatalogReplicationSlotsTable = virtualSchemaTable{
 }
 
 var pgCatalogSubscriptionRelTable = virtualSchemaTable{
-	comment: "pg_subscription_rel was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogSubscriptionRel,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_subscription_rel was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogSubscriptionRel,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogTsParserTable = virtualSchemaTable{
-	comment: "pg_ts_parser was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogTsParser,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_ts_parser was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogTsParser,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatisticExtDataTable = virtualSchemaTable{
-	comment: "pg_statistic_ext_data was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatisticExtData,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_statistic_ext_data was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatisticExtData,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogPartitionedTableTable = virtualSchemaTable{
-	comment: "pg_partitioned_table was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogPartitionedTable,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_partitioned_table was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogPartitionedTable,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatioSysIndexesTable = virtualSchemaTable{
-	comment: "pg_statio_sys_indexes was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatioSysIndexes,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_statio_sys_indexes was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatioSysIndexes,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogConfigTable = virtualSchemaTable{
-	comment: "pg_config was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogConfig,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_config was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogConfig,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatioUserTablesTable = virtualSchemaTable{
-	comment: "pg_statio_user_tables was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatioUserTables,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_statio_user_tables was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatioUserTables,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
@@ -4448,182 +4331,142 @@ func addRowForTimezoneNames(tz string, t time.Time, addRow func(...tree.Datum) e
 }
 
 var pgCatalogTsDictTable = virtualSchemaTable{
-	comment: "pg_ts_dict was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogTsDict,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_ts_dict was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogTsDict,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatUserTablesTable = virtualSchemaTable{
-	comment: "pg_stat_user_tables was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatUserTables,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_user_tables was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatUserTables,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogSubscriptionTable = virtualSchemaTable{
-	comment: "pg_subscription was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogSubscription,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_subscription was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogSubscription,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogShmemAllocationsTable = virtualSchemaTable{
-	comment: "pg_shmem_allocations was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogShmemAllocations,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_shmem_allocations was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogShmemAllocations,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatWalReceiverTable = virtualSchemaTable{
-	comment: "pg_stat_wal_receiver was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatWalReceiver,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_wal_receiver was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatWalReceiver,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatSubscriptionTable = virtualSchemaTable{
-	comment: "pg_stat_subscription was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatSubscription,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_subscription was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatSubscription,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogLargeobjectTable = virtualSchemaTable{
-	comment: "pg_largeobject was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogLargeobject,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_largeobject was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogLargeobject,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogReplicationOriginStatusTable = virtualSchemaTable{
-	comment: "pg_replication_origin_status was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogReplicationOriginStatus,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_replication_origin_status was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogReplicationOriginStatus,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogAmopTable = virtualSchemaTable{
-	comment: "pg_amop was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogAmop,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_amop was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogAmop,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatProgressVacuumTable = virtualSchemaTable{
-	comment: "pg_stat_progress_vacuum was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatProgressVacuum,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_progress_vacuum was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatProgressVacuum,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatSysIndexesTable = virtualSchemaTable{
-	comment: "pg_stat_sys_indexes was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatSysIndexes,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_sys_indexes was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatSysIndexes,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatioAllTablesTable = virtualSchemaTable{
-	comment: "pg_statio_all_tables was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatioAllTables,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_statio_all_tables was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatioAllTables,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatDatabaseConflictsTable = virtualSchemaTable{
-	comment: "pg_stat_database_conflicts was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatDatabaseConflicts,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_database_conflicts was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatDatabaseConflicts,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogReplicationOriginTable = virtualSchemaTable{
-	comment: "pg_replication_origin was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogReplicationOrigin,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_replication_origin was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogReplicationOrigin,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatisticTable = virtualSchemaTable{
-	comment: "pg_statistic was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatistic,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_statistic was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatistic,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatXactSysTablesTable = virtualSchemaTable{
-	comment: "pg_stat_xact_sys_tables was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatXactSysTables,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_xact_sys_tables was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatXactSysTables,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogTsTemplateTable = virtualSchemaTable{
-	comment: "pg_ts_template was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogTsTemplate,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_ts_template was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogTsTemplate,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogStatReplicationTable = virtualSchemaTable{
-	comment: "pg_stat_replication was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogStatReplication,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_stat_replication was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogStatReplication,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogPublicationRelTable = virtualSchemaTable{
-	comment: "pg_publication_rel was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogPublicationRel,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_publication_rel was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogPublicationRel,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 
 var pgCatalogAvailableExtensionVersionsTable = virtualSchemaTable{
-	comment: "pg_available_extension_versions was created for compatibility and is currently unimplemented",
-	schema:  vtable.PgCatalogAvailableExtensionVersions,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		return nil
-	},
+	comment:       "pg_available_extension_versions was created for compatibility and is currently unimplemented",
+	schema:        vtable.PgCatalogAvailableExtensionVersions,
+	populate:      emptyVirtualTable,
 	unimplemented: true,
 }
 

--- a/pkg/sql/pg_extension.go
+++ b/pkg/sql/pg_extension.go
@@ -161,7 +161,7 @@ CREATE TABLE pg_extension.spatial_ref_sys (
 	srtext varchar(2048),
 	proj4text varchar(2048)
 )`,
-	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		for _, projection := range geoprojbase.AllProjections() {
 			if err := addRow(
 				tree.NewDInt(tree.DInt(projection.SRID)),

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -139,6 +139,15 @@ type virtualSchemaTable struct {
 	resultColumns colinfo.ResultColumns
 }
 
+// emptyVirtualTable is a populate function to use when a virtual table is
+// always empty, as is the case for many pg_catalog and information_schema
+// tables.
+func emptyVirtualTable(
+	_ context.Context, _ *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
+) error {
+	return nil
+}
+
 // virtualSchemaView represents a view within a virtualSchema
 type virtualSchemaView struct {
 	schema        string


### PR DESCRIPTION
If the `*planner` or `catalog.DatabaseDescriptor` parameters to populate
functions are not used, use the `_` name to make that clear. Some populate
functions were previously doing that, now they all are.

Define an `emptyVirtualTable` populate function and use it throughout
`pg_catalog` and `information_schema` for virtual tables that are empty
because they aren't implemented.

Epic: none
Release note: None
