### PR TITLE
gceworker bootstrap: fix checksum for go download

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -45,7 +45,7 @@ sudo tar -C /usr --strip-components=1 -zxf /tmp/cmake.tgz && rm /tmp/cmake.tgz
 trap 'rm -f /tmp/go.tgz' EXIT
 curl -fsSL https://dl.google.com/go/go1.21.5.linux-amd64.tar.gz > /tmp/go.tgz
 sha256sum -c - <<EOF
-a2e1d5743e896e5fe1e7d96479c0a769254aed18cf216cf8f4c3a2300a9b3923  /tmp/go.tgz
+e2bc0b3e4b64111ec117295c088bde5f00eeed1567999ff77bc859d7df70078e  /tmp/go.tgz
 EOF
 sudo tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz
 


### PR DESCRIPTION
On the last go version upgrade to cockroach, the wrong checksum was entered in the gceworker bootstrap script for the downloaded tar file. This fixes it to be the correct checksum.

Epic: none
Release note: None