### PR TITLE
opt: eliminate unnecessary group-by expressions

### DIFF
--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -133,8 +133,8 @@
 )
 
 # EliminateDistinct discards a DistinctOn operator that is eliminating duplicate
-# rows by using grouping columns that are statically known to form a strong key.
-# By definition, a strong key does not allow duplicate values, so the GroupBy is
+# rows by using grouping columns that are statically known to form a strict key.
+# By definition, a strict key does not allow duplicate values, so the GroupBy is
 # redundant and can be eliminated.
 #
 # Since a DistinctOn operator can serve as a projection operator, we need to
@@ -162,6 +162,32 @@
 )
 =>
 (Project $input [] (GroupingOutputCols $groupingPrivate $aggs))
+
+# EliminateGroupBy is similar to EliminateDistinct, but it operates on GroupBy
+# expressions where the grouping columns are statically known to form a strict
+# key in the GroupBy's input.
+#
+# It only applies if all the aggregate functions are ConstAgg, ConstNotNullAgg,
+# or AnyNotNullAgg. These aggregate functions all evaluate to the first non-NULL
+# value encountered, and NULL if there are no such values. Because the input is
+# guaranteed to produce one row per group, these aggregate functions are
+# equivalent to projecting their input column.
+[EliminateGroupBy, Normalize]
+(GroupBy
+    $input:*
+    $aggs:* & (AreAllAnyNotNullAggs $aggs)
+    $groupingPrivate:* &
+        (ColsAreStrictKey (GroupingCols $groupingPrivate) $input)
+)
+=>
+(Project
+    $input
+    (ConvertAnyNotNullAggsToProjections $aggs)
+    (IntersectionCols
+        (GroupingOutputCols $groupingPrivate $aggs)
+        (OutputCols $input)
+    )
+)
 
 # ReduceGroupingCols eliminates redundant grouping columns from the GroupBy
 # operator and replaces them by ConstAgg aggregate functions. A grouping

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -2031,7 +2031,7 @@ CREATE TABLE tab_orig (
 )
 ----
 
-norm expect=TryDecorrelateGroupBy disable=InlineWith
+norm expect=TryDecorrelateGroupBy disable=(InlineWith,EliminateGroupBy)
 SELECT
   NULL
 FROM
@@ -4662,68 +4662,50 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
-      ├── columns: k:1!null i:2 f:3 s:4 j:5 column16:16 true_agg:18
+      ├── columns: k:1!null i:2 f:3 s:4 j:5 x:12 column16:16 true:17
       ├── key: (1)
-      ├── fd: (1)-->(2-5,16,18)
-      ├── group-by (hash)
-      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 column16:16 true_agg:18
-      │    ├── grouping columns: k:1!null
+      ├── fd: (1)-->(2-5,12,16,17)
+      ├── left-join (hash)
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:12 column16:16 true:17
+      │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,16,18)
-      │    ├── left-join (hash)
-      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:12 column16:16 true:17
-      │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      │    ├── fd: (1)-->(2-5,12,16,17)
+      │    ├── left-join (cross)
+      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 column16:16
+      │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-5,12,16,17)
-      │    │    ├── left-join (cross)
-      │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 column16:16
-      │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+      │    │    ├── fd: (1)-->(2-5,16)
+      │    │    ├── scan a
+      │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-5,16)
-      │    │    │    ├── scan a
-      │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    └── fd: (1)-->(2-5)
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: column16:16!null
+      │    │    │    └── fd: (1)-->(2-5)
+      │    │    ├── project
+      │    │    │    ├── columns: column16:16!null
+      │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(16)
+      │    │    │    ├── limit
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(16)
-      │    │    │    │    ├── limit
-      │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── scan xy
-      │    │    │    │    │    │    └── limit hint: 1.00
-      │    │    │    │    │    └── 1
-      │    │    │    │    └── projections
-      │    │    │    │         └── true [as=column16:16]
-      │    │    │    └── filters (true)
-      │    │    ├── project
-      │    │    │    ├── columns: true:17!null x:12!null
-      │    │    │    ├── key: (12)
-      │    │    │    ├── fd: ()-->(17)
-      │    │    │    ├── scan xy
-      │    │    │    │    ├── columns: x:12!null
-      │    │    │    │    └── key: (12)
+      │    │    │    │    ├── scan xy
+      │    │    │    │    │    └── limit hint: 1.00
+      │    │    │    │    └── 1
       │    │    │    └── projections
-      │    │    │         └── true [as=true:17]
-      │    │    └── filters
-      │    │         └── x:12 = k:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
-      │    └── aggregations
-      │         ├── const-not-null-agg [as=true_agg:18, outer=(17)]
-      │         │    └── true:17
-      │         ├── const-agg [as=i:2, outer=(2)]
-      │         │    └── i:2
-      │         ├── const-agg [as=f:3, outer=(3)]
-      │         │    └── f:3
-      │         ├── const-agg [as=s:4, outer=(4)]
-      │         │    └── s:4
-      │         ├── const-agg [as=j:5, outer=(5)]
-      │         │    └── j:5
-      │         └── const-agg [as=column16:16, outer=(16)]
-      │              └── column16:16
+      │    │    │         └── true [as=column16:16]
+      │    │    └── filters (true)
+      │    ├── project
+      │    │    ├── columns: true:17!null x:12!null
+      │    │    ├── key: (12)
+      │    │    ├── fd: ()-->(17)
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:12!null
+      │    │    │    └── key: (12)
+      │    │    └── projections
+      │    │         └── true [as=true:17]
+      │    └── filters
+      │         └── x:12 = k:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
       └── filters
-           └── COALESCE(column16:16, false) OR (true_agg:18 IS NOT NULL) [outer=(16,18)]
+           └── COALESCE(column16:16, false) OR (true:17 IS NOT NULL) [outer=(16,17)]
 
 # Hoist an uncorrelated equality subquery.
 norm expect=HoistSelectSubquery
@@ -5641,36 +5623,28 @@ project
       │    ├── columns: exists:18!null x:8!null
       │    ├── key: (8)
       │    ├── fd: (8)-->(18)
-      │    ├── group-by (hash)
-      │    │    ├── columns: x:8!null true_agg:17
-      │    │    ├── grouping columns: x:8!null
+      │    ├── left-join (hash)
+      │    │    ├── columns: x:8!null y:9 u:12 true:16
+      │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    │    ├── key: (8)
-      │    │    ├── fd: (8)-->(17)
-      │    │    ├── left-join (hash)
-      │    │    │    ├── columns: x:8!null y:9 u:12 true:16
-      │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+      │    │    ├── fd: (8)-->(9,12,16)
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:8!null y:9
       │    │    │    ├── key: (8)
-      │    │    │    ├── fd: (8)-->(9,12,16)
-      │    │    │    ├── scan xy
-      │    │    │    │    ├── columns: x:8!null y:9
-      │    │    │    │    ├── key: (8)
-      │    │    │    │    └── fd: (8)-->(9)
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: true:16!null u:12!null
-      │    │    │    │    ├── key: (12)
-      │    │    │    │    ├── fd: ()-->(16)
-      │    │    │    │    ├── scan uv
-      │    │    │    │    │    ├── columns: u:12!null
-      │    │    │    │    │    └── key: (12)
-      │    │    │    │    └── projections
-      │    │    │    │         └── true [as=true:16]
-      │    │    │    └── filters
-      │    │    │         └── u:12 = y:9 [outer=(9,12), constraints=(/9: (/NULL - ]; /12: (/NULL - ]), fd=(9)==(12), (12)==(9)]
-      │    │    └── aggregations
-      │    │         └── const-not-null-agg [as=true_agg:17, outer=(16)]
-      │    │              └── true:16
+      │    │    │    └── fd: (8)-->(9)
+      │    │    ├── project
+      │    │    │    ├── columns: true:16!null u:12!null
+      │    │    │    ├── key: (12)
+      │    │    │    ├── fd: ()-->(16)
+      │    │    │    ├── scan uv
+      │    │    │    │    ├── columns: u:12!null
+      │    │    │    │    └── key: (12)
+      │    │    │    └── projections
+      │    │    │         └── true [as=true:16]
+      │    │    └── filters
+      │    │         └── u:12 = y:9 [outer=(9,12), constraints=(/9: (/NULL - ]; /12: (/NULL - ]), fd=(9)==(12), (12)==(9)]
       │    └── projections
-      │         └── true_agg:17 IS NOT NULL [as=exists:18, outer=(17)]
+      │         └── true:16 IS NOT NULL [as=exists:18, outer=(16)]
       └── filters
            └── exists:18 OR (k:1 = x:8) [outer=(1,8,18)]
 
@@ -5795,35 +5769,27 @@ SELECT (VALUES (EXISTS(SELECT * FROM xy WHERE x=k))) FROM a
 ----
 project
  ├── columns: column1:16!null
- ├── group-by (hash)
- │    ├── columns: k:1!null true_agg:14
- │    ├── grouping columns: k:1!null
+ ├── left-join (hash)
+ │    ├── columns: k:1!null x:8 true:13
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  │    ├── key: (1)
- │    ├── fd: (1)-->(14)
- │    ├── left-join (hash)
- │    │    ├── columns: k:1!null x:8 true:13
- │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(8,13)
- │    │    ├── scan a
- │    │    │    ├── columns: k:1!null
- │    │    │    └── key: (1)
- │    │    ├── project
- │    │    │    ├── columns: true:13!null x:8!null
- │    │    │    ├── key: (8)
- │    │    │    ├── fd: ()-->(13)
- │    │    │    ├── scan xy
- │    │    │    │    ├── columns: x:8!null
- │    │    │    │    └── key: (8)
- │    │    │    └── projections
- │    │    │         └── true [as=true:13]
- │    │    └── filters
- │    │         └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
- │    └── aggregations
- │         └── const-not-null-agg [as=true_agg:14, outer=(13)]
- │              └── true:13
+ │    ├── fd: (1)-->(8,13)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null
+ │    │    └── key: (1)
+ │    ├── project
+ │    │    ├── columns: true:13!null x:8!null
+ │    │    ├── key: (8)
+ │    │    ├── fd: ()-->(13)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:8!null
+ │    │    │    └── key: (8)
+ │    │    └── projections
+ │    │         └── true [as=true:13]
+ │    └── filters
+ │         └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
  └── projections
-      └── true_agg:14 IS NOT NULL [as=column1:16, outer=(14)]
+      └── true:13 IS NOT NULL [as=column1:16, outer=(13)]
 
 # Any in values row.
 norm expect=HoistValuesSubquery

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -1056,6 +1056,204 @@ upsert xy
                      └── x:25 = r2:30 [outer=(25,30), constraints=(/25: (/NULL - ]; /30: (/NULL - ]), fd=(25)==(30), (30)==(25)]
 
 # --------------------------------------------------
+# EliminateGroupBy
+# --------------------------------------------------
+
+# Eliminate the GroupBy when the aggregate functions produce the same column as
+# their input column.
+exprnorm expect=EliminateGroupBy
+(GroupBy
+    (Scan [ (Table "a") (Cols "k,i,f,s") ])
+    [
+        (AggregationsItem (ConstAgg (Var "i")) (LookupColumn "i"))
+        (AggregationsItem (ConstNotNullAgg (Var "f")) (LookupColumn "f"))
+        (AggregationsItem (AnyNotNullAgg (Var "s")) (LookupColumn "s"))
+    ]
+    [ (GroupingCols "k") ]
+)
+----
+scan a
+ ├── columns: k:1!null i:2!null f:3 s:4!null
+ ├── key: (1)
+ └── fd: (1)-->(2-4), (2,4)-->(1,3), (2,3)~~>(1,4)
+
+# Eliminate the GroupBy when the aggregate functions produce a new column.
+exprnorm expect=EliminateGroupBy
+(GroupBy
+    (Scan [ (Table "a") (Cols "k,i,f,s") ])
+    [
+        (AggregationsItem (ConstAgg (Var "i")) (NewColumn "i_agg" "int"))
+        (AggregationsItem (ConstNotNullAgg (Var "f")) (NewColumn "f_agg" "float"))
+        (AggregationsItem (AnyNotNullAgg (Var "s")) (NewColumn "s_agg" "string"))
+    ]
+    [ (GroupingCols "k") ]
+)
+----
+project
+ ├── columns: i_agg:8!null f_agg:9 s_agg:10!null k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(8-10), (8,10)-->(1,9), (8,9)~~>(1,10)
+ ├── scan a
+ │    ├── columns: k:1!null i:2!null f:3 s:4!null
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4), (2,4)-->(1,3), (2,3)~~>(1,4)
+ └── projections
+      ├── i:2 [as=i_agg:8, outer=(2)]
+      ├── f:3 [as=f_agg:9, outer=(3)]
+      └── s:4 [as=s_agg:10, outer=(4)]
+
+# Eliminate the GroupBy when there is a compound key.
+exprnorm expect=EliminateGroupBy
+(GroupBy
+    (Scan [ (Table "a") (Cols "i,f,s,j") ])
+    [
+        (AggregationsItem (ConstAgg (Var "f")) (LookupColumn "f"))
+        (AggregationsItem (ConstNotNullAgg (Var "j")) (NewColumn "j_agg" "json"))
+    ]
+    [ (GroupingCols "i,s") ]
+)
+----
+project
+ ├── columns: j_agg:8 i:2!null f:3 s:4!null
+ ├── key: (2,4)
+ ├── fd: (2,4)-->(3,8), (2,3)~~>(4,8)
+ ├── scan a
+ │    ├── columns: i:2!null f:3 s:4!null j:5
+ │    ├── key: (2,4)
+ │    └── fd: (2,4)-->(3,5), (2,3)~~>(4,5)
+ └── projections
+      └── j:5 [as=j_agg:8, outer=(5)]
+
+# Eliminate unnecessary GroupBy generated during join decorrelation.
+norm expect=EliminateGroupBy
+SELECT CASE WHEN EXISTS (
+    SELECT 1 FROM a WHERE k = x AND i = 1
+) THEN 'Y' ELSE 'N' END
+FROM xy
+WHERE y = 2
+----
+project
+ ├── columns: case:13!null
+ ├── left-join (hash)
+ │    ├── columns: x:1!null y:2!null k:5 true:14
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(5,14)
+ │    ├── select
+ │    │    ├── columns: x:1!null y:2!null
+ │    │    ├── key: (1)
+ │    │    ├── fd: ()-->(2)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:1!null y:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── y:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
+ │    ├── project
+ │    │    ├── columns: true:14!null k:5!null
+ │    │    ├── key: (5)
+ │    │    ├── fd: ()-->(14)
+ │    │    ├── select
+ │    │    │    ├── columns: k:5!null i:6!null
+ │    │    │    ├── key: (5)
+ │    │    │    ├── fd: ()-->(6)
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:5!null i:6!null
+ │    │    │    │    ├── key: (5)
+ │    │    │    │    └── fd: (5)-->(6)
+ │    │    │    └── filters
+ │    │    │         └── i:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+ │    │    └── projections
+ │    │         └── true [as=true:14]
+ │    └── filters
+ │         └── k:5 = x:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ └── projections
+      └── CASE WHEN true:14 IS NOT NULL THEN 'Y' ELSE 'N' END [as=case:13, outer=(14)]
+
+# Don't eliminate the GroupBy if there is an aggregate function other than
+# ConstAgg, ConstNotNullAgg, or AnyNotNullAgg.
+exprnorm expect-not=EliminateGroupBy
+(GroupBy
+    (Scan [ (Table "a") (Cols "k,i,f,s") ])
+    [
+        (AggregationsItem (Sum (Var "i")) (NewColumn "sum" "int"))
+        (AggregationsItem (ConstNotNullAgg (Var "f")) (NewColumn "f_agg" "float"))
+        (AggregationsItem (AnyNotNullAgg (Var "s")) (NewColumn "s_agg" "string"))
+    ]
+    [ (GroupingCols "k") ]
+)
+----
+group-by (hash)
+ ├── columns: k:1!null sum:8!null f_agg:9 s_agg:10!null
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(8-10)
+ ├── scan a
+ │    ├── columns: k:1!null i:2!null f:3 s:4!null
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-4), (2,4)-->(1,3), (2,3)~~>(1,4)
+ └── aggregations
+      ├── sum [as=sum:8, outer=(2)]
+      │    └── i:2
+      ├── const-not-null-agg [as=f_agg:9, outer=(3)]
+      │    └── f:3
+      └── any-not-null-agg [as=s_agg:10, outer=(4)]
+           └── s:4
+
+# Don't eliminate the GroupBy if the grouping columns do not form a key in the
+# input.
+exprnorm expect-not=EliminateGroupBy
+(GroupBy
+    (Scan [ (Table "a") (Cols "i,f,s") ])
+    [
+        (AggregationsItem (ConstNotNullAgg (Var "f")) (NewColumn "f_agg" "float"))
+        (AggregationsItem (AnyNotNullAgg (Var "s")) (NewColumn "s_agg" "string"))
+    ]
+    [ (GroupingCols "i") ]
+)
+----
+group-by (hash)
+ ├── columns: i:2!null f_agg:8 s_agg:9!null
+ ├── grouping columns: i:2!null
+ ├── key: (2)
+ ├── fd: (2)-->(8,9)
+ ├── scan a
+ │    ├── columns: i:2!null f:3 s:4!null
+ │    ├── key: (2,4)
+ │    └── fd: (2,4)-->(3), (2,3)~~>(4)
+ └── aggregations
+      ├── const-not-null-agg [as=f_agg:8, outer=(3)]
+      │    └── f:3
+      └── any-not-null-agg [as=s_agg:9, outer=(4)]
+           └── s:4
+
+# Don't eliminate the GroupBy if the grouping columns form a lax key.
+exprnorm expect-not=EliminateGroupBy
+(GroupBy
+    (Scan [ (Table "a") (Cols "i,f,s,j") ])
+    [
+        (AggregationsItem (ConstAgg (Var "s")) (LookupColumn "s"))
+        (AggregationsItem (ConstNotNullAgg (Var "j")) (NewColumn "j_agg" "json"))
+    ]
+    [ (GroupingCols "i,f") ]
+)
+----
+group-by (hash)
+ ├── columns: i:2!null f:3 s:4!null j_agg:8
+ ├── grouping columns: i:2!null f:3
+ ├── key: (2,4)
+ ├── fd: (2,4)-->(3,8), (2,3)-->(4,8)
+ ├── scan a
+ │    ├── columns: i:2!null f:3 s:4!null j:5
+ │    ├── key: (2,4)
+ │    └── fd: (2,4)-->(3,5), (2,3)~~>(4,5)
+ └── aggregations
+      ├── const-agg [as=s:4, outer=(4)]
+      │    └── s:4
+      └── const-not-null-agg [as=j_agg:8, outer=(5)]
+           └── j:5
+
+# --------------------------------------------------
 # EliminateGroupByProject
 # --------------------------------------------------
 norm expect=EliminateGroupByProject disable=ConvertUnionToDistinctUnionAll

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -163,104 +163,67 @@ project
  ├── key: (29)
  ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
       ├── key columns: [29] = [29]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (29)
-      ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
+      ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
       │    ├── key columns: [1] = [32]
       │    ├── immutable, has-placeholder
       │    ├── key: (29)
-      │    ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30), (30)-->(29)
+      │    ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30), (30)-->(29)
       │    ├── limit
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-12,14,15,27)
+      │    │    ├── fd: ()-->(1-12,14,15,19,26)
       │    │    ├── offset
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-12,14,15,27)
+      │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-12,14,15,27)
-      │    │    │    │    ├── group-by (streaming)
-      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: true:26 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,27)
-      │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:26 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
+      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
+      │    │    │    │    │    │    ├── key columns: [1] = [19]
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
-      │    │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
-      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
-      │    │    │    │    │    │    │    ├── key columns: [1] = [19]
+      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
+      │    │    │    │    │    │    │    ├── scan flavors
       │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    │    │    ├── scan flavors
-      │    │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         └── flavorid:7 = $2 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
+      │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-      │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:26, outer=(19)]
-      │    │    │    │    │    └── aggregations
-      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:27, outer=(26)]
-      │    │    │    │    │         │    └── true:26
-      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │    │         │    └── name:2
-      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │    │         │    └── memory_mb:3
-      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │    │         │    └── vcpus:4
-      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │    │         │    └── root_gb:5
-      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │    │         │    └── flavorid:7
-      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │    │         │    └── swap:8
-      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │    │         │    └── disabled:11
-      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │    │         │    └── is_public:12
-      │    │    │    │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-      │    │    │    │    │         │    └── flavors.created_at:14
-      │    │    │    │    │         ├── const-agg [as=flavors.updated_at:15, outer=(15)]
-      │    │    │    │    │         │    └── flavors.updated_at:15
-      │    │    │    │    │         └── const-agg [as=flavors.id:1, outer=(1)]
-      │    │    │    │    │              └── flavors.id:1
+      │    │    │    │    │    │    │         └── flavorid:7 = $2 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:26, outer=(19)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true_agg:27 IS NOT NULL) [outer=(12,27)]
+      │    │    │    │         └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
       │    │    │    └── $3
       │    │    └── $4
       │    └── filters (true)
@@ -333,190 +296,117 @@ sort
       ├── key: (1,40)
       ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (40)-->(41-45), (41,43)-->(40,42,44,45)
       └── right-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:38 flavor_extra_specs_1.id:40 key:41 value:42 flavor_extra_specs_1.flavor_id:43 flavor_extra_specs_1.created_at:44 flavor_extra_specs_1.updated_at:45
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:34 true:37 flavor_extra_specs_1.id:40 key:41 value:42 flavor_extra_specs_1.flavor_id:43 flavor_extra_specs_1.created_at:44 flavor_extra_specs_1.updated_at:45
            ├── immutable, has-placeholder
            ├── key: (1,40)
-           ├── fd: ()-->(11), (1)-->(2-10,12,14,15,38), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (40)-->(41-45), (41,43)-->(40,42,44,45)
+           ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,34,37), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (40)-->(41-45), (41,43)-->(40,42,44,45)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
            │    ├── columns: flavor_extra_specs_1.id:40!null key:41!null value:42 flavor_extra_specs_1.flavor_id:43!null flavor_extra_specs_1.created_at:44 flavor_extra_specs_1.updated_at:45
            │    ├── key: (40)
            │    └── fd: (40)-->(41-45), (41,43)-->(40,42,44,45)
            ├── limit
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:38
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:34 true:37
            │    ├── internal-ordering: +7 opt(11)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,38), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,34,37), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    ├── offset
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:38
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:34 true:37
            │    │    ├── internal-ordering: +7 opt(11)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,38), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,34,37), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    ├── ordering: +7 opt(11) [actual: +7]
            │    │    ├── sort
-           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:38
+           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:34 true:37
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,38), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,34,37), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │    ├── ordering: +7 opt(11) [actual: +7]
            │    │    │    └── select
-           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:38
+           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:34 true:37
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,38), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-           │    │    │         ├── group-by (streaming)
-           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:38
-           │    │    │         │    ├── grouping columns: flavors.id:1!null
-           │    │    │         │    ├── internal-ordering: +1 opt(11)
+           │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,34,37), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         ├── left-join (merge)
+           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:34 true:37
+           │    │    │         │    ├── left ordering: +1
+           │    │    │         │    ├── right ordering: +27
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(11), (1)-->(2-12,14,15,38), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-           │    │    │         │    ├── left-join (merge)
-           │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:27 true_agg:35 true:37
-           │    │    │         │    │    ├── left ordering: +1
-           │    │    │         │    │    ├── right ordering: +27
+           │    │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,34,37), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    ├── select
+           │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:34
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (1)
-           │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,27,35,37), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,34), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
-           │    │    │         │    │    ├── select
-           │    │    │         │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:35
+           │    │    │         │    │    ├── left-join (merge)
+           │    │    │         │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:34
+           │    │    │         │    │    │    ├── left ordering: +1
+           │    │    │         │    │    │    ├── right ordering: +19
            │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,35), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,34), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
-           │    │    │         │    │    │    ├── group-by (streaming)
-           │    │    │         │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:35
-           │    │    │         │    │    │    │    ├── grouping columns: flavors.id:1!null
-           │    │    │         │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── select
+           │    │    │         │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15
            │    │    │         │    │    │    │    ├── key: (1)
-           │    │    │         │    │    │    │    ├── fd: ()-->(11), (1)-->(2-12,14,15,35), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-           │    │    │         │    │    │    │    ├── ordering: +1
-           │    │    │         │    │    │    │    ├── left-join (merge)
-           │    │    │         │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:34
-           │    │    │         │    │    │    │    │    ├── left ordering: +1
-           │    │    │         │    │    │    │    │    ├── right ordering: +19
-           │    │    │         │    │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
+           │    │    │         │    │    │    │    ├── scan flavors
+           │    │    │         │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
            │    │    │         │    │    │    │    │    ├── key: (1)
-           │    │    │         │    │    │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,34), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-           │    │    │         │    │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
-           │    │    │         │    │    │    │    │    ├── select
-           │    │    │         │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15
-           │    │    │         │    │    │    │    │    │    ├── key: (1)
-           │    │    │         │    │    │    │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
-           │    │    │         │    │    │    │    │    │    ├── ordering: +1 opt(11) [actual: +1]
-           │    │    │         │    │    │    │    │    │    ├── scan flavors
-           │    │    │         │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-           │    │    │         │    │    │    │    │    │    │    ├── key: (1)
-           │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │         │    │    │    │    │    │    │    └── ordering: +1
-           │    │    │         │    │    │    │    │    │    └── filters
-           │    │    │         │    │    │    │    │    │         └── NOT disabled:11 [outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
-           │    │    │         │    │    │    │    │    ├── project
-           │    │    │         │    │    │    │    │    │    ├── columns: true:34!null flavor_projects.flavor_id:19!null
-           │    │    │         │    │    │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    │    │    ├── key: (19)
-           │    │    │         │    │    │    │    │    │    ├── fd: ()-->(34)
-           │    │    │         │    │    │    │    │    │    ├── ordering: +19 opt(34) [actual: +19]
-           │    │    │         │    │    │    │    │    │    ├── select
-           │    │    │         │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │    │         │    │    │    │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    │    │    │    ├── key: (19)
-           │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(20)
-           │    │    │         │    │    │    │    │    │    │    ├── ordering: +19 opt(20) [actual: +19]
-           │    │    │         │    │    │    │    │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
-           │    │    │         │    │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │    │         │    │    │    │    │    │    │    │    ├── key: (19,20)
-           │    │    │         │    │    │    │    │    │    │    │    └── ordering: +19
-           │    │    │         │    │    │    │    │    │    │    └── filters
-           │    │    │         │    │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-           │    │    │         │    │    │    │    │    │    └── projections
-           │    │    │         │    │    │    │    │    │         └── true [as=true:34]
-           │    │    │         │    │    │    │    │    └── filters (true)
-           │    │    │         │    │    │    │    └── aggregations
-           │    │    │         │    │    │    │         ├── const-not-null-agg [as=true_agg:35, outer=(34)]
-           │    │    │         │    │    │    │         │    └── true:34
-           │    │    │         │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-           │    │    │         │    │    │    │         │    └── name:2
-           │    │    │         │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-           │    │    │         │    │    │    │         │    └── memory_mb:3
-           │    │    │         │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-           │    │    │         │    │    │    │         │    └── vcpus:4
-           │    │    │         │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-           │    │    │         │    │    │    │         │    └── root_gb:5
-           │    │    │         │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-           │    │    │         │    │    │    │         │    └── ephemeral_gb:6
-           │    │    │         │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-           │    │    │         │    │    │    │         │    └── flavorid:7
-           │    │    │         │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-           │    │    │         │    │    │    │         │    └── swap:8
-           │    │    │         │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-           │    │    │         │    │    │    │         │    └── rxtx_factor:9
-           │    │    │         │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-           │    │    │         │    │    │    │         │    └── vcpu_weight:10
-           │    │    │         │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-           │    │    │         │    │    │    │         │    └── disabled:11
-           │    │    │         │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-           │    │    │         │    │    │    │         │    └── is_public:12
-           │    │    │         │    │    │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-           │    │    │         │    │    │    │         │    └── flavors.created_at:14
-           │    │    │         │    │    │    │         └── const-agg [as=flavors.updated_at:15, outer=(15)]
-           │    │    │         │    │    │    │              └── flavors.updated_at:15
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         └── is_public:12 OR (true_agg:35 IS NOT NULL) [outer=(12,35)]
-           │    │    │         │    │    ├── project
-           │    │    │         │    │    │    ├── columns: true:37!null flavor_projects.flavor_id:27!null
+           │    │    │         │    │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    │    │    │    │    └── ordering: +1
+           │    │    │         │    │    │    │    └── filters
+           │    │    │         │    │    │    │         └── NOT disabled:11 [outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
+           │    │    │         │    │    │    ├── project
+           │    │    │         │    │    │    │    ├── columns: true:34!null flavor_projects.flavor_id:19!null
+           │    │    │         │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    ├── key: (19)
+           │    │    │         │    │    │    │    ├── fd: ()-->(34)
+           │    │    │         │    │    │    │    ├── ordering: +19 opt(34) [actual: +19]
+           │    │    │         │    │    │    │    ├── select
+           │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
+           │    │    │         │    │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    │    ├── key: (19)
+           │    │    │         │    │    │    │    │    ├── fd: ()-->(20)
+           │    │    │         │    │    │    │    │    ├── ordering: +19 opt(20) [actual: +19]
+           │    │    │         │    │    │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
+           │    │    │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
+           │    │    │         │    │    │    │    │    │    ├── key: (19,20)
+           │    │    │         │    │    │    │    │    │    └── ordering: +19
+           │    │    │         │    │    │    │    │    └── filters
+           │    │    │         │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
+           │    │    │         │    │    │    │    └── projections
+           │    │    │         │    │    │    │         └── true [as=true:34]
+           │    │    │         │    │    │    └── filters (true)
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         └── is_public:12 OR (true:34 IS NOT NULL) [outer=(12,34)]
+           │    │    │         │    ├── project
+           │    │    │         │    │    ├── columns: true:37!null flavor_projects.flavor_id:27!null
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── key: (27)
+           │    │    │         │    │    ├── fd: ()-->(37)
+           │    │    │         │    │    ├── ordering: +27 opt(37) [actual: +27]
+           │    │    │         │    │    ├── select
+           │    │    │         │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
            │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (27)
-           │    │    │         │    │    │    ├── fd: ()-->(37)
-           │    │    │         │    │    │    ├── ordering: +27 opt(37) [actual: +27]
-           │    │    │         │    │    │    ├── select
+           │    │    │         │    │    │    ├── fd: ()-->(28)
+           │    │    │         │    │    │    ├── ordering: +27 opt(28) [actual: +27]
+           │    │    │         │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
            │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
-           │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (27)
-           │    │    │         │    │    │    │    ├── fd: ()-->(28)
-           │    │    │         │    │    │    │    ├── ordering: +27 opt(28) [actual: +27]
-           │    │    │         │    │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
-           │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
-           │    │    │         │    │    │    │    │    ├── key: (27,28)
-           │    │    │         │    │    │    │    │    └── ordering: +27
-           │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         └── project_id:28 = $2 [outer=(28), constraints=(/28: (/NULL - ]), fd=()-->(28)]
-           │    │    │         │    │    │    └── projections
-           │    │    │         │    │    │         └── true [as=true:37]
-           │    │    │         │    │    └── filters (true)
-           │    │    │         │    └── aggregations
-           │    │    │         │         ├── const-not-null-agg [as=true_agg:38, outer=(37)]
-           │    │    │         │         │    └── true:37
-           │    │    │         │         ├── const-agg [as=name:2, outer=(2)]
-           │    │    │         │         │    └── name:2
-           │    │    │         │         ├── const-agg [as=memory_mb:3, outer=(3)]
-           │    │    │         │         │    └── memory_mb:3
-           │    │    │         │         ├── const-agg [as=vcpus:4, outer=(4)]
-           │    │    │         │         │    └── vcpus:4
-           │    │    │         │         ├── const-agg [as=root_gb:5, outer=(5)]
-           │    │    │         │         │    └── root_gb:5
-           │    │    │         │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-           │    │    │         │         │    └── ephemeral_gb:6
-           │    │    │         │         ├── const-agg [as=flavorid:7, outer=(7)]
-           │    │    │         │         │    └── flavorid:7
-           │    │    │         │         ├── const-agg [as=swap:8, outer=(8)]
-           │    │    │         │         │    └── swap:8
-           │    │    │         │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-           │    │    │         │         │    └── rxtx_factor:9
-           │    │    │         │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-           │    │    │         │         │    └── vcpu_weight:10
-           │    │    │         │         ├── const-agg [as=disabled:11, outer=(11)]
-           │    │    │         │         │    └── disabled:11
-           │    │    │         │         ├── const-agg [as=is_public:12, outer=(12)]
-           │    │    │         │         │    └── is_public:12
-           │    │    │         │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-           │    │    │         │         │    └── flavors.created_at:14
-           │    │    │         │         └── const-agg [as=flavors.updated_at:15, outer=(15)]
-           │    │    │         │              └── flavors.updated_at:15
+           │    │    │         │    │    │    │    ├── key: (27,28)
+           │    │    │         │    │    │    │    └── ordering: +27
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         └── project_id:28 = $2 [outer=(28), constraints=(/28: (/NULL - ]), fd=()-->(28)]
+           │    │    │         │    │    └── projections
+           │    │    │         │    │         └── true [as=true:37]
+           │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true_agg:38 IS NOT NULL) [outer=(12,38)]
+           │    │    │              └── is_public:12 OR (true:37 IS NOT NULL) [outer=(12,37)]
            │    │    └── $3
            │    └── $4
            └── filters
@@ -593,124 +483,11 @@ sort
       ├── immutable, has-placeholder
       ├── key: (1,32)
       ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
-      └── left-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
-           ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+      └── right-join (hash)
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
            ├── immutable, has-placeholder
            ├── key: (1,32)
-           ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
-           ├── limit
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
-           │    ├── internal-ordering: +7,+1 opt(13)
-           │    ├── immutable, has-placeholder
-           │    ├── key: (1)
-           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    ├── offset
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
-           │    │    ├── internal-ordering: +7,+1 opt(13)
-           │    │    ├── has-placeholder
-           │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
-           │    │    ├── sort
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
-           │    │    │    ├── has-placeholder
-           │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
-           │    │    │    └── select
-           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
-           │    │    │         ├── has-placeholder
-           │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         ├── group-by (streaming)
-           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
-           │    │    │         │    ├── grouping columns: instance_types.id:1!null
-           │    │    │         │    ├── internal-ordering: +1 opt(13)
-           │    │    │         │    ├── has-placeholder
-           │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    ├── left-join (merge)
-           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
-           │    │    │         │    │    ├── left ordering: +1
-           │    │    │         │    │    ├── right ordering: +20
-           │    │    │         │    │    ├── has-placeholder
-           │    │    │         │    │    ├── key: (1)
-           │    │    │         │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    ├── ordering: +1 opt(13) [actual: +1]
-           │    │    │         │    │    ├── select
-           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    ├── ordering: +1 opt(13) [actual: +1]
-           │    │    │         │    │    │    ├── scan instance_types
-           │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-           │    │    │         │    │    │    │    ├── key: (1)
-           │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    │    └── ordering: +1
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-           │    │    │         │    │    ├── project
-           │    │    │         │    │    │    ├── columns: true:29!null instance_type_projects.instance_type_id:20!null
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── key: (20)
-           │    │    │         │    │    │    ├── fd: ()-->(29)
-           │    │    │         │    │    │    ├── ordering: +20 opt(29) [actual: +20]
-           │    │    │         │    │    │    ├── select
-           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
-           │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (20)
-           │    │    │         │    │    │    │    ├── fd: ()-->(21,22)
-           │    │    │         │    │    │    │    ├── ordering: +20 opt(21,22) [actual: +20]
-           │    │    │         │    │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
-           │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
-           │    │    │         │    │    │    │    │    ├── lax-key: (20-22)
-           │    │    │         │    │    │    │    │    └── ordering: +20
-           │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:22 = $3 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-           │    │    │         │    │    │    │         └── project_id:21 = $4 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-           │    │    │         │    │    │    └── projections
-           │    │    │         │    │    │         └── true [as=true:29]
-           │    │    │         │    │    └── filters (true)
-           │    │    │         │    └── aggregations
-           │    │    │         │         ├── const-not-null-agg [as=true_agg:30, outer=(29)]
-           │    │    │         │         │    └── true:29
-           │    │    │         │         ├── const-agg [as=name:2, outer=(2)]
-           │    │    │         │         │    └── name:2
-           │    │    │         │         ├── const-agg [as=memory_mb:3, outer=(3)]
-           │    │    │         │         │    └── memory_mb:3
-           │    │    │         │         ├── const-agg [as=vcpus:4, outer=(4)]
-           │    │    │         │         │    └── vcpus:4
-           │    │    │         │         ├── const-agg [as=root_gb:5, outer=(5)]
-           │    │    │         │         │    └── root_gb:5
-           │    │    │         │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-           │    │    │         │         │    └── ephemeral_gb:6
-           │    │    │         │         ├── const-agg [as=flavorid:7, outer=(7)]
-           │    │    │         │         │    └── flavorid:7
-           │    │    │         │         ├── const-agg [as=swap:8, outer=(8)]
-           │    │    │         │         │    └── swap:8
-           │    │    │         │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-           │    │    │         │         │    └── rxtx_factor:9
-           │    │    │         │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-           │    │    │         │         │    └── vcpu_weight:10
-           │    │    │         │         ├── const-agg [as=disabled:11, outer=(11)]
-           │    │    │         │         │    └── disabled:11
-           │    │    │         │         ├── const-agg [as=is_public:12, outer=(12)]
-           │    │    │         │         │    └── is_public:12
-           │    │    │         │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-           │    │    │         │         │    └── instance_types.deleted:13
-           │    │    │         │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-           │    │    │         │         │    └── instance_types.deleted_at:14
-           │    │    │         │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-           │    │    │         │         │    └── instance_types.created_at:15
-           │    │    │         │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
-           │    │    │         │              └── instance_types.updated_at:16
-           │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true_agg:30 IS NOT NULL) [outer=(12,30)]
-           │    │    └── $5
-           │    └── $6
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
            ├── select
            │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36!null instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
            │    ├── has-placeholder
@@ -722,6 +499,77 @@ sort
            │    │    └── fd: (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
            │    └── filters
            │         └── instance_type_extra_specs_1.deleted:36 = $7 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
+           ├── limit
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    ├── internal-ordering: +7,+1 opt(13)
+           │    ├── immutable, has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── offset
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    ├── internal-ordering: +7,+1 opt(13)
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
+           │    │    ├── sort
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
+           │    │    │    └── select
+           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │         ├── has-placeholder
+           │    │    │         ├── key: (1)
+           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── left-join (merge)
+           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │         │    ├── left ordering: +1
+           │    │    │         │    ├── right ordering: +20
+           │    │    │         │    ├── has-placeholder
+           │    │    │         │    ├── key: (1)
+           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── select
+           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── key: (1)
+           │    │    │         │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    ├── ordering: +1 opt(13) [actual: +1]
+           │    │    │         │    │    ├── scan instance_types
+           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+           │    │    │         │    │    │    ├── key: (1)
+           │    │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    │    └── ordering: +1
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+           │    │    │         │    ├── project
+           │    │    │         │    │    ├── columns: true:29!null instance_type_projects.instance_type_id:20!null
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── key: (20)
+           │    │    │         │    │    ├── fd: ()-->(29)
+           │    │    │         │    │    ├── ordering: +20 opt(29) [actual: +20]
+           │    │    │         │    │    ├── select
+           │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (20)
+           │    │    │         │    │    │    ├── fd: ()-->(21,22)
+           │    │    │         │    │    │    ├── ordering: +20 opt(21,22) [actual: +20]
+           │    │    │         │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
+           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
+           │    │    │         │    │    │    │    ├── lax-key: (20-22)
+           │    │    │         │    │    │    │    └── ordering: +20
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+           │    │    │         │    │    │         ├── instance_type_projects.deleted:22 = $3 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+           │    │    │         │    │    │         └── project_id:21 = $4 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+           │    │    │         │    │    └── projections
+           │    │    │         │    │         └── true [as=true:29]
+           │    │    │         │    └── filters (true)
+           │    │    │         └── filters
+           │    │    │              └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
+           │    │    └── $5
+           │    └── $6
            └── filters
                 └── instance_type_extra_specs_1.instance_type_id:35 = instance_types.id:1 [outer=(1,35), constraints=(/1: (/NULL - ]; /35: (/NULL - ]), fd=(1)==(35), (35)==(1)]
 
@@ -774,102 +622,11 @@ sort
       ├── has-placeholder
       ├── key: (1,19)
       ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (19)-->(20-22,24-26), (20,22,23)~~>(19,21,24-26), (1,19)-->(23)
-      └── left-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:19 key:20 value:21 instance_type_extra_specs_1.instance_type_id:22 instance_type_extra_specs_1.deleted:23 instance_type_extra_specs_1.deleted_at:24 instance_type_extra_specs_1.created_at:25 instance_type_extra_specs_1.updated_at:26 true_agg:40
-           ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+      └── right-join (hash)
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:19 key:20 value:21 instance_type_extra_specs_1.instance_type_id:22 instance_type_extra_specs_1.deleted:23 instance_type_extra_specs_1.deleted_at:24 instance_type_extra_specs_1.created_at:25 instance_type_extra_specs_1.updated_at:26 instance_type_projects.instance_type_id:30 true:39
            ├── has-placeholder
            ├── key: (1,19)
-           ├── fd: ()-->(13), (1)-->(2-12,14-16,40), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (19)-->(20-22,24-26), (20,22,23)~~>(19,21,24-26), (1,19)-->(23)
-           ├── select
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
-           │    ├── has-placeholder
-           │    ├── key: (1)
-           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,40), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    ├── group-by (streaming)
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
-           │    │    ├── grouping columns: instance_types.id:1!null
-           │    │    ├── internal-ordering: +1 opt(13)
-           │    │    ├── has-placeholder
-           │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(13), (1)-->(2-16,40), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    ├── left-join (merge)
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:30 true:39
-           │    │    │    ├── left ordering: +1
-           │    │    │    ├── right ordering: +30
-           │    │    │    ├── has-placeholder
-           │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30,39), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │    ├── ordering: +1 opt(13) [actual: +1]
-           │    │    │    ├── select
-           │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-           │    │    │    │    ├── has-placeholder
-           │    │    │    │    ├── key: (1)
-           │    │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │    │    ├── ordering: +1 opt(13) [actual: +1]
-           │    │    │    │    ├── scan instance_types
-           │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-           │    │    │    │    │    ├── key: (1)
-           │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │    │    │    └── ordering: +1
-           │    │    │    │    └── filters
-           │    │    │    │         └── instance_types.deleted:13 = $2 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-           │    │    │    ├── project
-           │    │    │    │    ├── columns: true:39!null instance_type_projects.instance_type_id:30!null
-           │    │    │    │    ├── has-placeholder
-           │    │    │    │    ├── key: (30)
-           │    │    │    │    ├── fd: ()-->(39)
-           │    │    │    │    ├── ordering: +30 opt(39) [actual: +30]
-           │    │    │    │    ├── select
-           │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31!null instance_type_projects.deleted:32!null
-           │    │    │    │    │    ├── has-placeholder
-           │    │    │    │    │    ├── key: (30)
-           │    │    │    │    │    ├── fd: ()-->(31,32)
-           │    │    │    │    │    ├── ordering: +30 opt(31,32) [actual: +30]
-           │    │    │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
-           │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31 instance_type_projects.deleted:32
-           │    │    │    │    │    │    ├── lax-key: (30-32)
-           │    │    │    │    │    │    └── ordering: +30
-           │    │    │    │    │    └── filters
-           │    │    │    │    │         ├── instance_type_projects.deleted:32 = $3 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
-           │    │    │    │    │         └── project_id:31 = $4 [outer=(31), constraints=(/31: (/NULL - ]), fd=()-->(31)]
-           │    │    │    │    └── projections
-           │    │    │    │         └── true [as=true:39]
-           │    │    │    └── filters (true)
-           │    │    └── aggregations
-           │    │         ├── const-not-null-agg [as=true_agg:40, outer=(39)]
-           │    │         │    └── true:39
-           │    │         ├── const-agg [as=name:2, outer=(2)]
-           │    │         │    └── name:2
-           │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-           │    │         │    └── memory_mb:3
-           │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-           │    │         │    └── vcpus:4
-           │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-           │    │         │    └── root_gb:5
-           │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-           │    │         │    └── ephemeral_gb:6
-           │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-           │    │         │    └── flavorid:7
-           │    │         ├── const-agg [as=swap:8, outer=(8)]
-           │    │         │    └── swap:8
-           │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-           │    │         │    └── rxtx_factor:9
-           │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-           │    │         │    └── vcpu_weight:10
-           │    │         ├── const-agg [as=disabled:11, outer=(11)]
-           │    │         │    └── disabled:11
-           │    │         ├── const-agg [as=is_public:12, outer=(12)]
-           │    │         │    └── is_public:12
-           │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-           │    │         │    └── instance_types.deleted:13
-           │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-           │    │         │    └── instance_types.deleted_at:14
-           │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-           │    │         │    └── instance_types.created_at:15
-           │    │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
-           │    │              └── instance_types.updated_at:16
-           │    └── filters
-           │         └── is_public:12 OR (true_agg:40 IS NOT NULL) [outer=(12,40)]
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,30,39), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (19)-->(20-22,24-26), (20,22,23)~~>(19,21,24-26), (1,19)-->(23)
            ├── select
            │    ├── columns: instance_type_extra_specs_1.id:19!null key:20 value:21 instance_type_extra_specs_1.instance_type_id:22!null instance_type_extra_specs_1.deleted:23!null instance_type_extra_specs_1.deleted_at:24 instance_type_extra_specs_1.created_at:25 instance_type_extra_specs_1.updated_at:26
            │    ├── has-placeholder
@@ -881,6 +638,55 @@ sort
            │    │    └── fd: (19)-->(20-26), (20,22,23)~~>(19,21,24-26)
            │    └── filters
            │         └── instance_type_extra_specs_1.deleted:23 = $1 [outer=(23), constraints=(/23: (/NULL - ]), fd=()-->(23)]
+           ├── select
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:30 true:39
+           │    ├── has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30,39), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── left-join (merge)
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:30 true:39
+           │    │    ├── left ordering: +1
+           │    │    ├── right ordering: +30
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30,39), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── select
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── ordering: +1 opt(13) [actual: +1]
+           │    │    │    ├── scan instance_types
+           │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+           │    │    │    │    ├── key: (1)
+           │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    │    └── ordering: +1
+           │    │    │    └── filters
+           │    │    │         └── instance_types.deleted:13 = $2 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+           │    │    ├── project
+           │    │    │    ├── columns: true:39!null instance_type_projects.instance_type_id:30!null
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: (30)
+           │    │    │    ├── fd: ()-->(39)
+           │    │    │    ├── ordering: +30 opt(39) [actual: +30]
+           │    │    │    ├── select
+           │    │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31!null instance_type_projects.deleted:32!null
+           │    │    │    │    ├── has-placeholder
+           │    │    │    │    ├── key: (30)
+           │    │    │    │    ├── fd: ()-->(31,32)
+           │    │    │    │    ├── ordering: +30 opt(31,32) [actual: +30]
+           │    │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
+           │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31 instance_type_projects.deleted:32
+           │    │    │    │    │    ├── lax-key: (30-32)
+           │    │    │    │    │    └── ordering: +30
+           │    │    │    │    └── filters
+           │    │    │    │         ├── instance_type_projects.deleted:32 = $3 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
+           │    │    │    │         └── project_id:31 = $4 [outer=(31), constraints=(/31: (/NULL - ]), fd=()-->(31)]
+           │    │    │    └── projections
+           │    │    │         └── true [as=true:39]
+           │    │    └── filters (true)
+           │    └── filters
+           │         └── is_public:12 OR (true:39 IS NOT NULL) [outer=(12,39)]
            └── filters
                 └── instance_type_extra_specs_1.instance_type_id:22 = instance_types.id:1 [outer=(1,22), constraints=(/1: (/NULL - ]; /22: (/NULL - ]), fd=(1)==(22), (22)==(1)]
 
@@ -947,117 +753,76 @@ project
  ├── key: (32)
  ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+      ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
       ├── key columns: [32] = [32]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (32)
-      ├── fd: ()-->(1-16,30,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
+      ├── fd: ()-->(1-16,20,29,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
+      │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
       │    ├── key columns: [1] = [35]
       │    ├── immutable, has-placeholder
       │    ├── key: (32)
-      │    ├── fd: ()-->(1-16,30,35,36), (32)-->(33), (33,35,36)~~>(32)
+      │    ├── fd: ()-->(1-16,20,29,35,36), (32)-->(33), (33,35,36)~~>(32)
       │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-16,30)
+      │    │    ├── fd: ()-->(1-16,20,29)
       │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-16,30)
+      │    │    │    ├── fd: ()-->(1-16,20,29)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-16,30)
-      │    │    │    │    ├── group-by (streaming)
-      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: true:29 instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-16,30)
-      │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:29 instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
+      │    │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
+      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
+      │    │    │    │    │    │    ├── key columns: [1] = [20]
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-16,20,29)
-      │    │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
-      │    │    │    │    │    │    │    ├── key columns: [1] = [20]
+      │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
+      │    │    │    │    │    │    ├── index-join instance_types
+      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    │    │    │    │    ├── index-join instance_types
-      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
-      │    │    │    │    │    │    │    │    └── select
-      │    │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2!null instance_types.deleted:13!null
-      │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    │         ├── has-placeholder
-      │    │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │    │         ├── fd: ()-->(1,2,13)
-      │    │    │    │    │    │    │    │         ├── scan instance_types@instance_types_name_deleted_key
-      │    │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null name:2!null instance_types.deleted:13
-      │    │    │    │    │    │    │    │         │    ├── constraint: /2/13: (/NULL - ]
-      │    │    │    │    │    │    │    │         │    ├── key: (1)
-      │    │    │    │    │    │    │    │         │    └── fd: (1)-->(2,13), (2,13)~~>(1)
-      │    │    │    │    │    │    │    │         └── filters
-      │    │    │    │    │    │    │    │              ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-      │    │    │    │    │    │    │    │              └── name:2 = $4 [outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-      │    │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-      │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:29, outer=(20)]
-      │    │    │    │    │    └── aggregations
-      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:30, outer=(29)]
-      │    │    │    │    │         │    └── true:29
-      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │    │         │    └── name:2
-      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │    │         │    └── memory_mb:3
-      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │    │         │    └── vcpus:4
-      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │    │         │    └── root_gb:5
-      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │    │         │    └── flavorid:7
-      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │    │         │    └── swap:8
-      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │    │         │    └── disabled:11
-      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │    │         │    └── is_public:12
-      │    │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-      │    │    │    │    │         │    └── instance_types.deleted:13
-      │    │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-      │    │    │    │    │         │    └── instance_types.deleted_at:14
-      │    │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-      │    │    │    │    │         │    └── instance_types.created_at:15
-      │    │    │    │    │         ├── const-agg [as=instance_types.updated_at:16, outer=(16)]
-      │    │    │    │    │         │    └── instance_types.updated_at:16
-      │    │    │    │    │         └── const-agg [as=instance_types.id:1, outer=(1)]
-      │    │    │    │    │              └── instance_types.id:1
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
+      │    │    │    │    │    │    │    └── select
+      │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2!null instance_types.deleted:13!null
+      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │    │         ├── fd: ()-->(1,2,13)
+      │    │    │    │    │    │    │         ├── scan instance_types@instance_types_name_deleted_key
+      │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null name:2!null instance_types.deleted:13
+      │    │    │    │    │    │    │         │    ├── constraint: /2/13: (/NULL - ]
+      │    │    │    │    │    │    │         │    ├── key: (1)
+      │    │    │    │    │    │    │         │    └── fd: (1)-->(2,13), (2,13)~~>(1)
+      │    │    │    │    │    │    │         └── filters
+      │    │    │    │    │    │    │              ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+      │    │    │    │    │    │    │              └── name:2 = $4 [outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+      │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:29, outer=(20)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true_agg:30 IS NOT NULL) [outer=(12,30)]
+      │    │    │    │         └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
       │    │    │    └── $5
       │    │    └── $6
       │    └── filters
@@ -1127,111 +892,70 @@ project
  ├── key: (32)
  ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
       ├── key columns: [32] = [32]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (32)
-      ├── fd: ()-->(1-16,30,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
+      ├── fd: ()-->(1-16,20,29,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
+      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
       │    ├── key columns: [1] = [35]
       │    ├── immutable, has-placeholder
       │    ├── key: (32)
-      │    ├── fd: ()-->(1-16,30,35,36), (32)-->(33), (33,35,36)~~>(32)
+      │    ├── fd: ()-->(1-16,20,29,35,36), (32)-->(33), (33,35,36)~~>(32)
       │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-16,30)
+      │    │    ├── fd: ()-->(1-16,20,29)
       │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-16,30)
+      │    │    │    ├── fd: ()-->(1-16,20,29)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-16,30)
-      │    │    │    │    ├── group-by (streaming)
-      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: true:29 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-16,30)
-      │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:29 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
+      │    │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
+      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
+      │    │    │    │    │    │    ├── key columns: [1] = [20]
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-16,20,29)
-      │    │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
-      │    │    │    │    │    │    │    ├── key columns: [1] = [20]
+      │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
-      │    │    │    │    │    │    │    │    ├── scan instance_types
-      │    │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-      │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         ├── instance_types.id:1 = $4 [outer=(1), constraints=(/1: (/NULL - ]), fd=()-->(1)]
-      │    │    │    │    │    │    │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
+      │    │    │    │    │    │    │    ├── scan instance_types
+      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+      │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    └── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-      │    │    │    │    │    │    │         ├── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-      │    │    │    │    │    │    │         └── instance_type_projects.instance_type_id:20 = $4 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-      │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:29, outer=(20)]
-      │    │    │    │    │    └── aggregations
-      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:30, outer=(29)]
-      │    │    │    │    │         │    └── true:29
-      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │    │         │    └── name:2
-      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │    │         │    └── memory_mb:3
-      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │    │         │    └── vcpus:4
-      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │    │         │    └── root_gb:5
-      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │    │         │    └── flavorid:7
-      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │    │         │    └── swap:8
-      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │    │         │    └── disabled:11
-      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │    │         │    └── is_public:12
-      │    │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-      │    │    │    │    │         │    └── instance_types.deleted:13
-      │    │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-      │    │    │    │    │         │    └── instance_types.deleted_at:14
-      │    │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-      │    │    │    │    │         │    └── instance_types.created_at:15
-      │    │    │    │    │         ├── const-agg [as=instance_types.updated_at:16, outer=(16)]
-      │    │    │    │    │         │    └── instance_types.updated_at:16
-      │    │    │    │    │         └── const-agg [as=instance_types.id:1, outer=(1)]
-      │    │    │    │    │              └── instance_types.id:1
+      │    │    │    │    │    │    │         ├── instance_types.id:1 = $4 [outer=(1), constraints=(/1: (/NULL - ]), fd=()-->(1)]
+      │    │    │    │    │    │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+      │    │    │    │    │    │         ├── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+      │    │    │    │    │    │         └── instance_type_projects.instance_type_id:20 = $4 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:29, outer=(20)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true_agg:30 IS NOT NULL) [outer=(12,30)]
+      │    │    │    │         └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
       │    │    │    └── $5
       │    │    └── $6
       │    └── filters
@@ -1292,104 +1016,67 @@ project
  ├── key: (29)
  ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
       ├── key columns: [29] = [29]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (29)
-      ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
+      ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
       │    ├── key columns: [1] = [32]
       │    ├── immutable, has-placeholder
       │    ├── key: (29)
-      │    ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30), (30)-->(29)
+      │    ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30), (30)-->(29)
       │    ├── limit
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-12,14,15,27)
+      │    │    ├── fd: ()-->(1-12,14,15,19,26)
       │    │    ├── offset
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-12,14,15,27)
+      │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-12,14,15,27)
-      │    │    │    │    ├── group-by (streaming)
-      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: true:26 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,27)
-      │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:26 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
+      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
+      │    │    │    │    │    │    ├── key columns: [1] = [19]
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
-      │    │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
-      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
-      │    │    │    │    │    │    │    ├── key columns: [1] = [19]
+      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
+      │    │    │    │    │    │    │    ├── scan flavors
       │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    │    │    ├── scan flavors
-      │    │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         └── name:2 = $2 [outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
+      │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-      │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:26, outer=(19)]
-      │    │    │    │    │    └── aggregations
-      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:27, outer=(26)]
-      │    │    │    │    │         │    └── true:26
-      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │    │         │    └── name:2
-      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │    │         │    └── memory_mb:3
-      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │    │         │    └── vcpus:4
-      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │    │         │    └── root_gb:5
-      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │    │         │    └── flavorid:7
-      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │    │         │    └── swap:8
-      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │    │         │    └── disabled:11
-      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │    │         │    └── is_public:12
-      │    │    │    │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-      │    │    │    │    │         │    └── flavors.created_at:14
-      │    │    │    │    │         ├── const-agg [as=flavors.updated_at:15, outer=(15)]
-      │    │    │    │    │         │    └── flavors.updated_at:15
-      │    │    │    │    │         └── const-agg [as=flavors.id:1, outer=(1)]
-      │    │    │    │    │              └── flavors.id:1
+      │    │    │    │    │    │    │         └── name:2 = $2 [outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:26, outer=(19)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true_agg:27 IS NOT NULL) [outer=(12,27)]
+      │    │    │    │         └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
       │    │    │    └── $3
       │    │    └── $4
       │    └── filters (true)
@@ -1449,104 +1136,67 @@ project
  ├── key: (29)
  ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
       ├── key columns: [29] = [29]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (29)
-      ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
+      ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
       │    ├── key columns: [1] = [32]
       │    ├── immutable, has-placeholder
       │    ├── key: (29)
-      │    ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30), (30)-->(29)
+      │    ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30), (30)-->(29)
       │    ├── limit
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-12,14,15,27)
+      │    │    ├── fd: ()-->(1-12,14,15,19,26)
       │    │    ├── offset
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-12,14,15,27)
+      │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-12,14,15,27)
-      │    │    │    │    ├── group-by (streaming)
-      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: true:26 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,27)
-      │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:26 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
+      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
+      │    │    │    │    │    │    ├── key columns: [1] = [19]
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
-      │    │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
-      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
-      │    │    │    │    │    │    │    ├── key columns: [1] = [19]
+      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
+      │    │    │    │    │    │    │    ├── scan flavors
       │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    │    │    ├── scan flavors
-      │    │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         └── flavorid:7 = $2 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
+      │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-      │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:26, outer=(19)]
-      │    │    │    │    │    └── aggregations
-      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:27, outer=(26)]
-      │    │    │    │    │         │    └── true:26
-      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │    │         │    └── name:2
-      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │    │         │    └── memory_mb:3
-      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │    │         │    └── vcpus:4
-      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │    │         │    └── root_gb:5
-      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │    │         │    └── flavorid:7
-      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │    │         │    └── swap:8
-      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │    │         │    └── disabled:11
-      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │    │         │    └── is_public:12
-      │    │    │    │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-      │    │    │    │    │         │    └── flavors.created_at:14
-      │    │    │    │    │         ├── const-agg [as=flavors.updated_at:15, outer=(15)]
-      │    │    │    │    │         │    └── flavors.updated_at:15
-      │    │    │    │    │         └── const-agg [as=flavors.id:1, outer=(1)]
-      │    │    │    │    │              └── flavors.id:1
+      │    │    │    │    │    │    │         └── flavorid:7 = $2 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:26, outer=(19)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true_agg:27 IS NOT NULL) [outer=(12,27)]
+      │    │    │    │         └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
       │    │    │    └── $3
       │    │    └── $4
       │    └── filters (true)
@@ -1616,118 +1266,81 @@ sort
       ├── key: (1,29)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
       └── right-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
            ├── immutable, has-placeholder
            ├── key: (1,29)
-           ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+           ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
            │    ├── columns: flavor_extra_specs_1.id:29!null key:30!null value:31 flavor_extra_specs_1.flavor_id:32!null flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
            │    ├── key: (29)
            │    └── fd: (29)-->(30-34), (30,32)-->(29,31,33,34)
            ├── limit
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
            │    ├── internal-ordering: +7
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    ├── offset
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
            │    │    ├── internal-ordering: +7
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    ├── ordering: +7
            │    │    ├── sort
-           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │    ├── ordering: +7
            │    │    │    └── select
-           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │         ├── group-by (streaming)
-           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
-           │    │    │         │    ├── grouping columns: flavors.id:1!null
-           │    │    │         │    ├── internal-ordering: +1
+           │    │    │         ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         ├── left-join (merge)
+           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    │         │    ├── left ordering: +1
+           │    │    │         │    ├── right ordering: +19
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │         │    ├── left-join (merge)
-           │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
-           │    │    │         │    │    ├── left ordering: +1
-           │    │    │         │    │    ├── right ordering: +19
+           │    │    │         │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    ├── select
+           │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (1)
-           │    │    │         │    │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │         │    │    ├── ordering: +1
-           │    │    │         │    │    ├── select
+           │    │    │         │    │    ├── scan flavors
            │    │    │         │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-           │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (1)
            │    │    │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │         │    │    │    ├── ordering: +1
-           │    │    │         │    │    │    ├── scan flavors
-           │    │    │         │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-           │    │    │         │    │    │    │    ├── key: (1)
-           │    │    │         │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │         │    │    │    │    └── ordering: +1
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         └── (flavorid:7 > $2) OR ((flavorid:7 = $3) AND (flavors.id:1 > $4)) [outer=(1,7), constraints=(/7: (/NULL - ])]
-           │    │    │         │    │    ├── project
-           │    │    │         │    │    │    ├── columns: true:26!null flavor_projects.flavor_id:19!null
+           │    │    │         │    │    │    └── ordering: +1
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         └── (flavorid:7 > $2) OR ((flavorid:7 = $3) AND (flavors.id:1 > $4)) [outer=(1,7), constraints=(/7: (/NULL - ])]
+           │    │    │         │    ├── project
+           │    │    │         │    │    ├── columns: true:26!null flavor_projects.flavor_id:19!null
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── key: (19)
+           │    │    │         │    │    ├── fd: ()-->(26)
+           │    │    │         │    │    ├── ordering: +19 opt(26) [actual: +19]
+           │    │    │         │    │    ├── select
+           │    │    │         │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
            │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (19)
-           │    │    │         │    │    │    ├── fd: ()-->(26)
-           │    │    │         │    │    │    ├── ordering: +19 opt(26) [actual: +19]
-           │    │    │         │    │    │    ├── select
+           │    │    │         │    │    │    ├── fd: ()-->(20)
+           │    │    │         │    │    │    ├── ordering: +19 opt(20) [actual: +19]
+           │    │    │         │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
            │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (19)
-           │    │    │         │    │    │    │    ├── fd: ()-->(20)
-           │    │    │         │    │    │    │    ├── ordering: +19 opt(20) [actual: +19]
-           │    │    │         │    │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
-           │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │    │         │    │    │    │    │    ├── key: (19,20)
-           │    │    │         │    │    │    │    │    └── ordering: +19
-           │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-           │    │    │         │    │    │    └── projections
-           │    │    │         │    │    │         └── true [as=true:26]
-           │    │    │         │    │    └── filters (true)
-           │    │    │         │    └── aggregations
-           │    │    │         │         ├── const-not-null-agg [as=true_agg:27, outer=(26)]
-           │    │    │         │         │    └── true:26
-           │    │    │         │         ├── const-agg [as=name:2, outer=(2)]
-           │    │    │         │         │    └── name:2
-           │    │    │         │         ├── const-agg [as=memory_mb:3, outer=(3)]
-           │    │    │         │         │    └── memory_mb:3
-           │    │    │         │         ├── const-agg [as=vcpus:4, outer=(4)]
-           │    │    │         │         │    └── vcpus:4
-           │    │    │         │         ├── const-agg [as=root_gb:5, outer=(5)]
-           │    │    │         │         │    └── root_gb:5
-           │    │    │         │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-           │    │    │         │         │    └── ephemeral_gb:6
-           │    │    │         │         ├── const-agg [as=flavorid:7, outer=(7)]
-           │    │    │         │         │    └── flavorid:7
-           │    │    │         │         ├── const-agg [as=swap:8, outer=(8)]
-           │    │    │         │         │    └── swap:8
-           │    │    │         │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-           │    │    │         │         │    └── rxtx_factor:9
-           │    │    │         │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-           │    │    │         │         │    └── vcpu_weight:10
-           │    │    │         │         ├── const-agg [as=disabled:11, outer=(11)]
-           │    │    │         │         │    └── disabled:11
-           │    │    │         │         ├── const-agg [as=is_public:12, outer=(12)]
-           │    │    │         │         │    └── is_public:12
-           │    │    │         │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-           │    │    │         │         │    └── flavors.created_at:14
-           │    │    │         │         └── const-agg [as=flavors.updated_at:15, outer=(15)]
-           │    │    │         │              └── flavors.updated_at:15
+           │    │    │         │    │    │    │    ├── key: (19,20)
+           │    │    │         │    │    │    │    └── ordering: +19
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
+           │    │    │         │    │    └── projections
+           │    │    │         │    │         └── true [as=true:26]
+           │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true_agg:27 IS NOT NULL) [outer=(12,27)]
+           │    │    │              └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
            │    │    └── $5
            │    └── $6
            └── filters
@@ -1803,123 +1416,11 @@ sort
       ├── immutable, has-placeholder
       ├── key: (1,32)
       ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
-      └── left-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
-           ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+      └── right-join (hash)
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
            ├── immutable, has-placeholder
            ├── key: (1,32)
-           ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
-           ├── limit
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
-           │    ├── internal-ordering: +7,+1 opt(13)
-           │    ├── immutable, has-placeholder
-           │    ├── key: (1)
-           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    ├── offset
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
-           │    │    ├── internal-ordering: +7,+1 opt(13)
-           │    │    ├── has-placeholder
-           │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
-           │    │    ├── sort
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
-           │    │    │    ├── has-placeholder
-           │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
-           │    │    │    └── select
-           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
-           │    │    │         ├── has-placeholder
-           │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         ├── group-by (streaming)
-           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
-           │    │    │         │    ├── grouping columns: instance_types.id:1!null
-           │    │    │         │    ├── internal-ordering: +1 opt(13)
-           │    │    │         │    ├── has-placeholder
-           │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-16,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    ├── left-join (merge)
-           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
-           │    │    │         │    │    ├── left ordering: +1
-           │    │    │         │    │    ├── right ordering: +20
-           │    │    │         │    │    ├── has-placeholder
-           │    │    │         │    │    ├── key: (1)
-           │    │    │         │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    ├── ordering: +1 opt(13) [actual: +1]
-           │    │    │         │    │    ├── select
-           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    ├── ordering: +1 opt(13) [actual: +1]
-           │    │    │         │    │    │    ├── scan instance_types
-           │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-           │    │    │         │    │    │    │    ├── key: (1)
-           │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    │    └── ordering: +1
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-           │    │    │         │    │    ├── project
-           │    │    │         │    │    │    ├── columns: true:29!null instance_type_projects.instance_type_id:20!null
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── key: (20)
-           │    │    │         │    │    │    ├── fd: ()-->(29)
-           │    │    │         │    │    │    ├── ordering: +20 opt(29) [actual: +20]
-           │    │    │         │    │    │    ├── select
-           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
-           │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (20)
-           │    │    │         │    │    │    │    ├── fd: ()-->(21,22)
-           │    │    │         │    │    │    │    ├── ordering: +20 opt(21,22) [actual: +20]
-           │    │    │         │    │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
-           │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
-           │    │    │         │    │    │    │    │    ├── lax-key: (20-22)
-           │    │    │         │    │    │    │    │    └── ordering: +20
-           │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-           │    │    │         │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-           │    │    │         │    │    │    └── projections
-           │    │    │         │    │    │         └── true [as=true:29]
-           │    │    │         │    │    └── filters (true)
-           │    │    │         │    └── aggregations
-           │    │    │         │         ├── const-not-null-agg [as=true_agg:30, outer=(29)]
-           │    │    │         │         │    └── true:29
-           │    │    │         │         ├── const-agg [as=name:2, outer=(2)]
-           │    │    │         │         │    └── name:2
-           │    │    │         │         ├── const-agg [as=memory_mb:3, outer=(3)]
-           │    │    │         │         │    └── memory_mb:3
-           │    │    │         │         ├── const-agg [as=vcpus:4, outer=(4)]
-           │    │    │         │         │    └── vcpus:4
-           │    │    │         │         ├── const-agg [as=root_gb:5, outer=(5)]
-           │    │    │         │         │    └── root_gb:5
-           │    │    │         │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-           │    │    │         │         │    └── ephemeral_gb:6
-           │    │    │         │         ├── const-agg [as=flavorid:7, outer=(7)]
-           │    │    │         │         │    └── flavorid:7
-           │    │    │         │         ├── const-agg [as=swap:8, outer=(8)]
-           │    │    │         │         │    └── swap:8
-           │    │    │         │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-           │    │    │         │         │    └── rxtx_factor:9
-           │    │    │         │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-           │    │    │         │         │    └── vcpu_weight:10
-           │    │    │         │         ├── const-agg [as=disabled:11, outer=(11)]
-           │    │    │         │         │    └── disabled:11
-           │    │    │         │         ├── const-agg [as=is_public:12, outer=(12)]
-           │    │    │         │         │    └── is_public:12
-           │    │    │         │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-           │    │    │         │         │    └── instance_types.deleted:13
-           │    │    │         │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-           │    │    │         │         │    └── instance_types.deleted_at:14
-           │    │    │         │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-           │    │    │         │         │    └── instance_types.created_at:15
-           │    │    │         │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
-           │    │    │         │              └── instance_types.updated_at:16
-           │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true_agg:30 IS NOT NULL) [outer=(12,30)]
-           │    │    └── $4
-           │    └── $5
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
            ├── select
            │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36!null instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
            │    ├── has-placeholder
@@ -1931,6 +1432,76 @@ sort
            │    │    └── fd: (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
            │    └── filters
            │         └── instance_type_extra_specs_1.deleted:36 = $6 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
+           ├── limit
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    ├── internal-ordering: +7,+1 opt(13)
+           │    ├── immutable, has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── offset
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    ├── internal-ordering: +7,+1 opt(13)
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
+           │    │    ├── sort
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
+           │    │    │    └── select
+           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │         ├── has-placeholder
+           │    │    │         ├── key: (1)
+           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── left-join (merge)
+           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │         │    ├── left ordering: +1
+           │    │    │         │    ├── right ordering: +20
+           │    │    │         │    ├── has-placeholder
+           │    │    │         │    ├── key: (1)
+           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── select
+           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── key: (1)
+           │    │    │         │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    ├── ordering: +1 opt(13) [actual: +1]
+           │    │    │         │    │    ├── scan instance_types
+           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
+           │    │    │         │    │    │    ├── key: (1)
+           │    │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    │    └── ordering: +1
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+           │    │    │         │    ├── project
+           │    │    │         │    │    ├── columns: true:29!null instance_type_projects.instance_type_id:20!null
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── key: (20)
+           │    │    │         │    │    ├── fd: ()-->(29)
+           │    │    │         │    │    ├── ordering: +20 opt(29) [actual: +20]
+           │    │    │         │    │    ├── select
+           │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (20)
+           │    │    │         │    │    │    ├── fd: ()-->(21,22)
+           │    │    │         │    │    │    ├── ordering: +20 opt(21,22) [actual: +20]
+           │    │    │         │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
+           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
+           │    │    │         │    │    │    │    ├── lax-key: (20-22)
+           │    │    │         │    │    │    │    └── ordering: +20
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+           │    │    │         │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+           │    │    │         │    │    └── projections
+           │    │    │         │    │         └── true [as=true:29]
+           │    │    │         │    └── filters (true)
+           │    │    │         └── filters
+           │    │    │              └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
+           │    │    └── $4
+           │    └── $5
            └── filters
                 └── instance_type_extra_specs_1.instance_type_id:35 = instance_types.id:1 [outer=(1,35), constraints=(/1: (/NULL - ]; /35: (/NULL - ]), fd=(1)==(35), (35)==(1)]
 
@@ -1997,117 +1568,76 @@ project
  ├── key: (32)
  ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
       ├── key columns: [32] = [32]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (32)
-      ├── fd: ()-->(1-16,30,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
+      ├── fd: ()-->(1-16,20,29,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
+      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
       │    ├── key columns: [1] = [35]
       │    ├── immutable, has-placeholder
       │    ├── key: (32)
-      │    ├── fd: ()-->(1-16,30,35,36), (32)-->(33), (33,35,36)~~>(32)
+      │    ├── fd: ()-->(1-16,20,29,35,36), (32)-->(33), (33,35,36)~~>(32)
       │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-16,30)
+      │    │    ├── fd: ()-->(1-16,20,29)
       │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-16,30)
+      │    │    │    ├── fd: ()-->(1-16,20,29)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-16,30)
-      │    │    │    │    ├── group-by (streaming)
-      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: true:29 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-16,30)
-      │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:29 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
+      │    │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
+      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
+      │    │    │    │    │    │    ├── key columns: [1] = [20]
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-16,20,29)
-      │    │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
-      │    │    │    │    │    │    │    ├── key columns: [1] = [20]
+      │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
+      │    │    │    │    │    │    ├── index-join instance_types
+      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    │    │    │    │    ├── index-join instance_types
-      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
-      │    │    │    │    │    │    │    │    └── select
-      │    │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null
-      │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    │         ├── has-placeholder
-      │    │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │    │         ├── fd: ()-->(1,7,13)
-      │    │    │    │    │    │    │    │         ├── scan instance_types@instance_types_flavorid_deleted_key
-      │    │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13
-      │    │    │    │    │    │    │    │         │    ├── constraint: /7/13: (/NULL - ]
-      │    │    │    │    │    │    │    │         │    ├── key: (1)
-      │    │    │    │    │    │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
-      │    │    │    │    │    │    │    │         └── filters
-      │    │    │    │    │    │    │    │              ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-      │    │    │    │    │    │    │    │              └── flavorid:7 = $4 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-      │    │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-      │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:29, outer=(20)]
-      │    │    │    │    │    └── aggregations
-      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:30, outer=(29)]
-      │    │    │    │    │         │    └── true:29
-      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │    │         │    └── name:2
-      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │    │         │    └── memory_mb:3
-      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │    │         │    └── vcpus:4
-      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │    │         │    └── root_gb:5
-      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │    │         │    └── flavorid:7
-      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │    │         │    └── swap:8
-      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │    │         │    └── disabled:11
-      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │    │         │    └── is_public:12
-      │    │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-      │    │    │    │    │         │    └── instance_types.deleted:13
-      │    │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-      │    │    │    │    │         │    └── instance_types.deleted_at:14
-      │    │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-      │    │    │    │    │         │    └── instance_types.created_at:15
-      │    │    │    │    │         ├── const-agg [as=instance_types.updated_at:16, outer=(16)]
-      │    │    │    │    │         │    └── instance_types.updated_at:16
-      │    │    │    │    │         └── const-agg [as=instance_types.id:1, outer=(1)]
-      │    │    │    │    │              └── instance_types.id:1
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
+      │    │    │    │    │    │    │    └── select
+      │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null
+      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │    │         ├── fd: ()-->(1,7,13)
+      │    │    │    │    │    │    │         ├── scan instance_types@instance_types_flavorid_deleted_key
+      │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13
+      │    │    │    │    │    │    │         │    ├── constraint: /7/13: (/NULL - ]
+      │    │    │    │    │    │    │         │    ├── key: (1)
+      │    │    │    │    │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
+      │    │    │    │    │    │    │         └── filters
+      │    │    │    │    │    │    │              ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+      │    │    │    │    │    │    │              └── flavorid:7 = $4 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+      │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:29, outer=(20)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true_agg:30 IS NOT NULL) [outer=(12,30)]
+      │    │    │    │         └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
       │    │    │    └── $5
       │    │    └── $6
       │    └── filters
@@ -2156,93 +1686,55 @@ sort
       ├── has-placeholder
       ├── key: (1,18)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (18)-->(19-23), (19,21)-->(18,20,22,23)
-      └── left-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:18 key:19 value:20 flavor_extra_specs_1.flavor_id:21 flavor_extra_specs_1.created_at:22 flavor_extra_specs_1.updated_at:23 true_agg:35
-           ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+      └── right-join (hash)
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:18 key:19 value:20 flavor_extra_specs_1.flavor_id:21 flavor_extra_specs_1.created_at:22 flavor_extra_specs_1.updated_at:23 flavor_projects.flavor_id:27 true:34
            ├── has-placeholder
            ├── key: (1,18)
-           ├── fd: (1)-->(2-12,14,15,35), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (18)-->(19-23), (19,21)-->(18,20,22,23)
-           ├── select
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:35
-           │    ├── has-placeholder
-           │    ├── key: (1)
-           │    ├── fd: (1)-->(2-12,14,15,35), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    ├── group-by (streaming)
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:35
-           │    │    ├── grouping columns: flavors.id:1!null
-           │    │    ├── internal-ordering: +1
-           │    │    ├── has-placeholder
-           │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-12,14,15,35), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    ├── left-join (merge)
-           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:27 true:34
-           │    │    │    ├── left ordering: +1
-           │    │    │    ├── right ordering: +27
-           │    │    │    ├── has-placeholder
-           │    │    │    ├── key: (1)
-           │    │    │    ├── fd: (1)-->(2-12,14,15,27,34), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │    ├── ordering: +1
-           │    │    │    ├── scan flavors
-           │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-           │    │    │    │    ├── key: (1)
-           │    │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │    │    └── ordering: +1
-           │    │    │    ├── project
-           │    │    │    │    ├── columns: true:34!null flavor_projects.flavor_id:27!null
-           │    │    │    │    ├── has-placeholder
-           │    │    │    │    ├── key: (27)
-           │    │    │    │    ├── fd: ()-->(34)
-           │    │    │    │    ├── ordering: +27 opt(34) [actual: +27]
-           │    │    │    │    ├── select
-           │    │    │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
-           │    │    │    │    │    ├── has-placeholder
-           │    │    │    │    │    ├── key: (27)
-           │    │    │    │    │    ├── fd: ()-->(28)
-           │    │    │    │    │    ├── ordering: +27 opt(28) [actual: +27]
-           │    │    │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
-           │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
-           │    │    │    │    │    │    ├── key: (27,28)
-           │    │    │    │    │    │    └── ordering: +27
-           │    │    │    │    │    └── filters
-           │    │    │    │    │         └── project_id:28 = $1 [outer=(28), constraints=(/28: (/NULL - ]), fd=()-->(28)]
-           │    │    │    │    └── projections
-           │    │    │    │         └── true [as=true:34]
-           │    │    │    └── filters (true)
-           │    │    └── aggregations
-           │    │         ├── const-not-null-agg [as=true_agg:35, outer=(34)]
-           │    │         │    └── true:34
-           │    │         ├── const-agg [as=name:2, outer=(2)]
-           │    │         │    └── name:2
-           │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-           │    │         │    └── memory_mb:3
-           │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-           │    │         │    └── vcpus:4
-           │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-           │    │         │    └── root_gb:5
-           │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-           │    │         │    └── ephemeral_gb:6
-           │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-           │    │         │    └── flavorid:7
-           │    │         ├── const-agg [as=swap:8, outer=(8)]
-           │    │         │    └── swap:8
-           │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-           │    │         │    └── rxtx_factor:9
-           │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-           │    │         │    └── vcpu_weight:10
-           │    │         ├── const-agg [as=disabled:11, outer=(11)]
-           │    │         │    └── disabled:11
-           │    │         ├── const-agg [as=is_public:12, outer=(12)]
-           │    │         │    └── is_public:12
-           │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-           │    │         │    └── flavors.created_at:14
-           │    │         └── const-agg [as=flavors.updated_at:15, outer=(15)]
-           │    │              └── flavors.updated_at:15
-           │    └── filters
-           │         └── is_public:12 OR (true_agg:35 IS NOT NULL) [outer=(12,35)]
+           ├── fd: (1)-->(2-12,14,15,27,34), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (18)-->(19-23), (19,21)-->(18,20,22,23)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
            │    ├── columns: flavor_extra_specs_1.id:18!null key:19!null value:20 flavor_extra_specs_1.flavor_id:21!null flavor_extra_specs_1.created_at:22 flavor_extra_specs_1.updated_at:23
            │    ├── key: (18)
            │    └── fd: (18)-->(19-23), (19,21)-->(18,20,22,23)
+           ├── select
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:27 true:34
+           │    ├── has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-12,14,15,27,34), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    ├── left-join (merge)
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:27 true:34
+           │    │    ├── left ordering: +1
+           │    │    ├── right ordering: +27
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: (1)-->(2-12,14,15,27,34), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    ├── scan flavors
+           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    └── ordering: +1
+           │    │    ├── project
+           │    │    │    ├── columns: true:34!null flavor_projects.flavor_id:27!null
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: (27)
+           │    │    │    ├── fd: ()-->(34)
+           │    │    │    ├── ordering: +27 opt(34) [actual: +27]
+           │    │    │    ├── select
+           │    │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
+           │    │    │    │    ├── has-placeholder
+           │    │    │    │    ├── key: (27)
+           │    │    │    │    ├── fd: ()-->(28)
+           │    │    │    │    ├── ordering: +27 opt(28) [actual: +27]
+           │    │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
+           │    │    │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
+           │    │    │    │    │    ├── key: (27,28)
+           │    │    │    │    │    └── ordering: +27
+           │    │    │    │    └── filters
+           │    │    │    │         └── project_id:28 = $1 [outer=(28), constraints=(/28: (/NULL - ]), fd=()-->(28)]
+           │    │    │    └── projections
+           │    │    │         └── true [as=true:34]
+           │    │    └── filters (true)
+           │    └── filters
+           │         └── is_public:12 OR (true:34 IS NOT NULL) [outer=(12,34)]
            └── filters
                 └── flavor_extra_specs_1.flavor_id:21 = flavors.id:1 [outer=(1,21), constraints=(/1: (/NULL - ]; /21: (/NULL - ]), fd=(1)==(21), (21)==(1)]
 
@@ -2320,10 +1812,10 @@ sort
       ├── key: (1,32)
       ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
       └── right-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
            ├── immutable, has-placeholder
            ├── key: (1,32)
-           ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
            ├── select
            │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36!null instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
            │    ├── has-placeholder
@@ -2336,115 +1828,74 @@ sort
            │    └── filters
            │         └── instance_type_extra_specs_1.deleted:36 = $9 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
            ├── limit
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
            │    ├── internal-ordering: +7 opt(13)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
            │    │    ├── internal-ordering: +7 opt(13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    ├── ordering: +7 opt(13) [actual: +7]
            │    │    ├── sort
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │    ├── ordering: +7 opt(13) [actual: +7]
            │    │    │    └── select
-           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         ├── group-by (streaming)
-           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
-           │    │    │         │    ├── grouping columns: instance_types.id:1!null
-           │    │    │         │    ├── internal-ordering: +1 opt(13)
+           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── left-join (merge)
+           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │         │    ├── left ordering: +1
+           │    │    │         │    ├── right ordering: +20
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-16,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    ├── left-join (merge)
-           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
-           │    │    │         │    │    ├── left ordering: +1
-           │    │    │         │    │    ├── right ordering: +20
+           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── select
+           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (1)
-           │    │    │         │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         │    │    ├── ordering: +1 opt(13) [actual: +1]
-           │    │    │         │    │    ├── select
-           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    ├── scan instance_types
+           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    ├── ordering: +1 opt(13) [actual: +1]
-           │    │    │         │    │    │    ├── scan instance_types
-           │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-           │    │    │         │    │    │    │    ├── key: (1)
-           │    │    │         │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    │    └── ordering: +1
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-           │    │    │         │    │    │         └── (flavorid:7 > $4) OR ((flavorid:7 = $5) AND (instance_types.id:1 > $6)) [outer=(1,7), constraints=(/7: (/NULL - ])]
-           │    │    │         │    │    ├── project
-           │    │    │         │    │    │    ├── columns: true:29!null instance_type_projects.instance_type_id:20!null
+           │    │    │         │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    │    └── ordering: +1
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+           │    │    │         │    │         └── (flavorid:7 > $4) OR ((flavorid:7 = $5) AND (instance_types.id:1 > $6)) [outer=(1,7), constraints=(/7: (/NULL - ])]
+           │    │    │         │    ├── project
+           │    │    │         │    │    ├── columns: true:29!null instance_type_projects.instance_type_id:20!null
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── key: (20)
+           │    │    │         │    │    ├── fd: ()-->(29)
+           │    │    │         │    │    ├── ordering: +20 opt(29) [actual: +20]
+           │    │    │         │    │    ├── select
+           │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
            │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (20)
-           │    │    │         │    │    │    ├── fd: ()-->(29)
-           │    │    │         │    │    │    ├── ordering: +20 opt(29) [actual: +20]
-           │    │    │         │    │    │    ├── select
-           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
-           │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (20)
-           │    │    │         │    │    │    │    ├── fd: ()-->(21,22)
-           │    │    │         │    │    │    │    ├── ordering: +20 opt(21,22) [actual: +20]
-           │    │    │         │    │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
-           │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
-           │    │    │         │    │    │    │    │    ├── lax-key: (20-22)
-           │    │    │         │    │    │    │    │    └── ordering: +20
-           │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-           │    │    │         │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-           │    │    │         │    │    │    └── projections
-           │    │    │         │    │    │         └── true [as=true:29]
-           │    │    │         │    │    └── filters (true)
-           │    │    │         │    └── aggregations
-           │    │    │         │         ├── const-not-null-agg [as=true_agg:30, outer=(29)]
-           │    │    │         │         │    └── true:29
-           │    │    │         │         ├── const-agg [as=name:2, outer=(2)]
-           │    │    │         │         │    └── name:2
-           │    │    │         │         ├── const-agg [as=memory_mb:3, outer=(3)]
-           │    │    │         │         │    └── memory_mb:3
-           │    │    │         │         ├── const-agg [as=vcpus:4, outer=(4)]
-           │    │    │         │         │    └── vcpus:4
-           │    │    │         │         ├── const-agg [as=root_gb:5, outer=(5)]
-           │    │    │         │         │    └── root_gb:5
-           │    │    │         │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-           │    │    │         │         │    └── ephemeral_gb:6
-           │    │    │         │         ├── const-agg [as=flavorid:7, outer=(7)]
-           │    │    │         │         │    └── flavorid:7
-           │    │    │         │         ├── const-agg [as=swap:8, outer=(8)]
-           │    │    │         │         │    └── swap:8
-           │    │    │         │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-           │    │    │         │         │    └── rxtx_factor:9
-           │    │    │         │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-           │    │    │         │         │    └── vcpu_weight:10
-           │    │    │         │         ├── const-agg [as=disabled:11, outer=(11)]
-           │    │    │         │         │    └── disabled:11
-           │    │    │         │         ├── const-agg [as=is_public:12, outer=(12)]
-           │    │    │         │         │    └── is_public:12
-           │    │    │         │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-           │    │    │         │         │    └── instance_types.deleted:13
-           │    │    │         │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-           │    │    │         │         │    └── instance_types.deleted_at:14
-           │    │    │         │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-           │    │    │         │         │    └── instance_types.created_at:15
-           │    │    │         │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
-           │    │    │         │              └── instance_types.updated_at:16
+           │    │    │         │    │    │    ├── fd: ()-->(21,22)
+           │    │    │         │    │    │    ├── ordering: +20 opt(21,22) [actual: +20]
+           │    │    │         │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
+           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
+           │    │    │         │    │    │    │    ├── lax-key: (20-22)
+           │    │    │         │    │    │    │    └── ordering: +20
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+           │    │    │         │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+           │    │    │         │    │    └── projections
+           │    │    │         │    │         └── true [as=true:29]
+           │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true_agg:30 IS NOT NULL) [outer=(12,30)]
+           │    │    │              └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
            │    │    └── $7
            │    └── $8
            └── filters
@@ -2510,114 +1961,76 @@ sort
       ├── immutable, has-placeholder
       ├── key: (1,29)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
-      └── left-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
-           ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+      └── right-join (hash)
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
            ├── immutable, has-placeholder
            ├── key: (1,29)
-           ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
-           ├── limit
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
-           │    ├── internal-ordering: +7
-           │    ├── immutable, has-placeholder
-           │    ├── key: (1)
-           │    ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    ├── offset
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
-           │    │    ├── internal-ordering: +7
-           │    │    ├── has-placeholder
-           │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    ├── ordering: +7
-           │    │    ├── sort
-           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
-           │    │    │    ├── has-placeholder
-           │    │    │    ├── key: (1)
-           │    │    │    ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │    ├── ordering: +7
-           │    │    │    └── select
-           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
-           │    │    │         ├── has-placeholder
-           │    │    │         ├── key: (1)
-           │    │    │         ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │         ├── group-by (streaming)
-           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
-           │    │    │         │    ├── grouping columns: flavors.id:1!null
-           │    │    │         │    ├── internal-ordering: +1
-           │    │    │         │    ├── has-placeholder
-           │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: (1)-->(2-12,14,15,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │         │    ├── left-join (merge)
-           │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
-           │    │    │         │    │    ├── left ordering: +1
-           │    │    │         │    │    ├── right ordering: +19
-           │    │    │         │    │    ├── has-placeholder
-           │    │    │         │    │    ├── key: (1)
-           │    │    │         │    │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │         │    │    ├── ordering: +1
-           │    │    │         │    │    ├── scan flavors
-           │    │    │         │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-           │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-           │    │    │         │    │    │    └── ordering: +1
-           │    │    │         │    │    ├── project
-           │    │    │         │    │    │    ├── columns: true:26!null flavor_projects.flavor_id:19!null
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── key: (19)
-           │    │    │         │    │    │    ├── fd: ()-->(26)
-           │    │    │         │    │    │    ├── ordering: +19 opt(26) [actual: +19]
-           │    │    │         │    │    │    ├── select
-           │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (19)
-           │    │    │         │    │    │    │    ├── fd: ()-->(20)
-           │    │    │         │    │    │    │    ├── ordering: +19 opt(20) [actual: +19]
-           │    │    │         │    │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
-           │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │    │         │    │    │    │    │    ├── key: (19,20)
-           │    │    │         │    │    │    │    │    └── ordering: +19
-           │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-           │    │    │         │    │    │    └── projections
-           │    │    │         │    │    │         └── true [as=true:26]
-           │    │    │         │    │    └── filters (true)
-           │    │    │         │    └── aggregations
-           │    │    │         │         ├── const-not-null-agg [as=true_agg:27, outer=(26)]
-           │    │    │         │         │    └── true:26
-           │    │    │         │         ├── const-agg [as=name:2, outer=(2)]
-           │    │    │         │         │    └── name:2
-           │    │    │         │         ├── const-agg [as=memory_mb:3, outer=(3)]
-           │    │    │         │         │    └── memory_mb:3
-           │    │    │         │         ├── const-agg [as=vcpus:4, outer=(4)]
-           │    │    │         │         │    └── vcpus:4
-           │    │    │         │         ├── const-agg [as=root_gb:5, outer=(5)]
-           │    │    │         │         │    └── root_gb:5
-           │    │    │         │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-           │    │    │         │         │    └── ephemeral_gb:6
-           │    │    │         │         ├── const-agg [as=flavorid:7, outer=(7)]
-           │    │    │         │         │    └── flavorid:7
-           │    │    │         │         ├── const-agg [as=swap:8, outer=(8)]
-           │    │    │         │         │    └── swap:8
-           │    │    │         │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-           │    │    │         │         │    └── rxtx_factor:9
-           │    │    │         │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-           │    │    │         │         │    └── vcpu_weight:10
-           │    │    │         │         ├── const-agg [as=disabled:11, outer=(11)]
-           │    │    │         │         │    └── disabled:11
-           │    │    │         │         ├── const-agg [as=is_public:12, outer=(12)]
-           │    │    │         │         │    └── is_public:12
-           │    │    │         │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-           │    │    │         │         │    └── flavors.created_at:14
-           │    │    │         │         └── const-agg [as=flavors.updated_at:15, outer=(15)]
-           │    │    │         │              └── flavors.updated_at:15
-           │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true_agg:27 IS NOT NULL) [outer=(12,27)]
-           │    │    └── $2
-           │    └── $3
+           ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
            │    ├── columns: flavor_extra_specs_1.id:29!null key:30!null value:31 flavor_extra_specs_1.flavor_id:32!null flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
            │    ├── key: (29)
            │    └── fd: (29)-->(30-34), (30,32)-->(29,31,33,34)
+           ├── limit
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    ├── internal-ordering: +7
+           │    ├── immutable, has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    ├── offset
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    ├── internal-ordering: +7
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    ├── ordering: +7
+           │    │    ├── sort
+           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: (1)
+           │    │    │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    ├── ordering: +7
+           │    │    │    └── select
+           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    │         ├── has-placeholder
+           │    │    │         ├── key: (1)
+           │    │    │         ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         ├── left-join (merge)
+           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    │         │    ├── left ordering: +1
+           │    │    │         │    ├── right ordering: +19
+           │    │    │         │    ├── has-placeholder
+           │    │    │         │    ├── key: (1)
+           │    │    │         │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    ├── scan flavors
+           │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
+           │    │    │         │    │    ├── key: (1)
+           │    │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    │    └── ordering: +1
+           │    │    │         │    ├── project
+           │    │    │         │    │    ├── columns: true:26!null flavor_projects.flavor_id:19!null
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── key: (19)
+           │    │    │         │    │    ├── fd: ()-->(26)
+           │    │    │         │    │    ├── ordering: +19 opt(26) [actual: +19]
+           │    │    │         │    │    ├── select
+           │    │    │         │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
+           │    │    │         │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    ├── key: (19)
+           │    │    │         │    │    │    ├── fd: ()-->(20)
+           │    │    │         │    │    │    ├── ordering: +19 opt(20) [actual: +19]
+           │    │    │         │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
+           │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
+           │    │    │         │    │    │    │    ├── key: (19,20)
+           │    │    │         │    │    │    │    └── ordering: +19
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
+           │    │    │         │    │    └── projections
+           │    │    │         │    │         └── true [as=true:26]
+           │    │    │         │    └── filters (true)
+           │    │    │         └── filters
+           │    │    │              └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
+           │    │    └── $2
+           │    └── $3
            └── filters
                 └── flavor_extra_specs_1.flavor_id:32 = flavors.id:1 [outer=(1,32), constraints=(/1: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(32), (32)==(1)]
 
@@ -2700,10 +2113,10 @@ sort
       ├── key: (1,45)
       ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (45)-->(46-48,50-52), (46,48,49)~~>(45,47,50-52), (1,45)-->(49)
       └── right-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:43 instance_type_extra_specs_1.id:45 key:46 value:47 instance_type_extra_specs_1.instance_type_id:48 instance_type_extra_specs_1.deleted:49 instance_type_extra_specs_1.deleted_at:50 instance_type_extra_specs_1.created_at:51 instance_type_extra_specs_1.updated_at:52
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:39 true:42 instance_type_extra_specs_1.id:45 key:46 value:47 instance_type_extra_specs_1.instance_type_id:48 instance_type_extra_specs_1.deleted:49 instance_type_extra_specs_1.deleted_at:50 instance_type_extra_specs_1.created_at:51 instance_type_extra_specs_1.updated_at:52
            ├── immutable, has-placeholder
            ├── key: (1,45)
-           ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,43), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (45)-->(46-48,50-52), (46,48,49)~~>(45,47,50-52), (1,45)-->(49)
+           ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,39,42), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (45)-->(46-48,50-52), (46,48,49)~~>(45,47,50-52), (1,45)-->(49)
            ├── select
            │    ├── columns: instance_type_extra_specs_1.id:45!null key:46 value:47 instance_type_extra_specs_1.instance_type_id:48!null instance_type_extra_specs_1.deleted:49!null instance_type_extra_specs_1.deleted_at:50 instance_type_extra_specs_1.created_at:51 instance_type_extra_specs_1.updated_at:52
            │    ├── has-placeholder
@@ -2716,194 +2129,113 @@ sort
            │    └── filters
            │         └── instance_type_extra_specs_1.deleted:49 = $9 [outer=(49), constraints=(/49: (/NULL - ]), fd=()-->(49)]
            ├── limit
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:43
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:39 true:42
            │    ├── internal-ordering: +7,+1 opt(11,13)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,43), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,39,42), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    ├── offset
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:43
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:39 true:42
            │    │    ├── internal-ordering: +7,+1 opt(11,13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,43), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,39,42), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
            │    │    ├── sort
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:43
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:39 true:42
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,43), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,39,42), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
            │    │    │    └── select
-           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:43
+           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:39 true:42
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,43), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-           │    │    │         ├── group-by (streaming)
-           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:43
-           │    │    │         │    ├── grouping columns: instance_types.id:1!null
-           │    │    │         │    ├── internal-ordering: +1 opt(11,13)
+           │    │    │         ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,39,42), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         ├── left-join (merge)
+           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:39 true:42
+           │    │    │         │    ├── left ordering: +1
+           │    │    │         │    ├── right ordering: +30
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(11,13), (1)-->(2-16,43), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-           │    │    │         │    ├── left-join (merge)
-           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:30 true_agg:40 true:42
-           │    │    │         │    │    ├── left ordering: +1
-           │    │    │         │    │    ├── right ordering: +30
+           │    │    │         │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,39,42), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    ├── select
+           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:39
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (1)
-           │    │    │         │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,30,40,42), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,39), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │         │    │    ├── ordering: +1 opt(11,13) [actual: +1]
-           │    │    │         │    │    ├── select
-           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
+           │    │    │         │    │    ├── left-join (merge)
+           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:39
+           │    │    │         │    │    │    ├── left ordering: +1
+           │    │    │         │    │    │    ├── right ordering: +20
            │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,39), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │         │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
-           │    │    │         │    │    │    ├── group-by (streaming)
-           │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:40
-           │    │    │         │    │    │    │    ├── grouping columns: instance_types.id:1!null
+           │    │    │         │    │    │    ├── select
+           │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    │    │    ├── has-placeholder
            │    │    │         │    │    │    │    ├── key: (1)
-           │    │    │         │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-16,40), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-           │    │    │         │    │    │    │    ├── ordering: +1
-           │    │    │         │    │    │    │    ├── left-join (merge)
-           │    │    │         │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:39
-           │    │    │         │    │    │    │    │    ├── left ordering: +1
-           │    │    │         │    │    │    │    │    ├── right ordering: +20
-           │    │    │         │    │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
+           │    │    │         │    │    │    │    ├── scan instance_types
+           │    │    │         │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    │    │    │    ├── key: (1)
-           │    │    │         │    │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,39), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-           │    │    │         │    │    │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
-           │    │    │         │    │    │    │    │    ├── select
-           │    │    │         │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-           │    │    │         │    │    │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    │    │    ├── key: (1)
-           │    │    │         │    │    │    │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
-           │    │    │         │    │    │    │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
-           │    │    │         │    │    │    │    │    │    ├── scan instance_types
-           │    │    │         │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13 instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-           │    │    │         │    │    │    │    │    │    │    ├── key: (1)
-           │    │    │         │    │    │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
-           │    │    │         │    │    │    │    │    │    │    └── ordering: +1
-           │    │    │         │    │    │    │    │    │    └── filters
-           │    │    │         │    │    │    │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-           │    │    │         │    │    │    │    │    │         └── NOT disabled:11 [outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
-           │    │    │         │    │    │    │    │    ├── project
-           │    │    │         │    │    │    │    │    │    ├── columns: true:39!null instance_type_projects.instance_type_id:20!null
-           │    │    │         │    │    │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    │    │    ├── key: (20)
-           │    │    │         │    │    │    │    │    │    ├── fd: ()-->(39)
-           │    │    │         │    │    │    │    │    │    ├── ordering: +20 opt(39) [actual: +20]
-           │    │    │         │    │    │    │    │    │    ├── select
-           │    │    │         │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
-           │    │    │         │    │    │    │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    │    │    │    ├── key: (20)
-           │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(21,22)
-           │    │    │         │    │    │    │    │    │    │    ├── ordering: +20 opt(21,22) [actual: +20]
-           │    │    │         │    │    │    │    │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
-           │    │    │         │    │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
-           │    │    │         │    │    │    │    │    │    │    │    ├── lax-key: (20-22)
-           │    │    │         │    │    │    │    │    │    │    │    └── ordering: +20
-           │    │    │         │    │    │    │    │    │    │    └── filters
-           │    │    │         │    │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-           │    │    │         │    │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-           │    │    │         │    │    │    │    │    │    └── projections
-           │    │    │         │    │    │    │    │    │         └── true [as=true:39]
-           │    │    │         │    │    │    │    │    └── filters (true)
-           │    │    │         │    │    │    │    └── aggregations
-           │    │    │         │    │    │    │         ├── const-not-null-agg [as=true_agg:40, outer=(39)]
-           │    │    │         │    │    │    │         │    └── true:39
-           │    │    │         │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-           │    │    │         │    │    │    │         │    └── name:2
-           │    │    │         │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-           │    │    │         │    │    │    │         │    └── memory_mb:3
-           │    │    │         │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-           │    │    │         │    │    │    │         │    └── vcpus:4
-           │    │    │         │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-           │    │    │         │    │    │    │         │    └── root_gb:5
-           │    │    │         │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-           │    │    │         │    │    │    │         │    └── ephemeral_gb:6
-           │    │    │         │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-           │    │    │         │    │    │    │         │    └── flavorid:7
-           │    │    │         │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-           │    │    │         │    │    │    │         │    └── swap:8
-           │    │    │         │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-           │    │    │         │    │    │    │         │    └── rxtx_factor:9
-           │    │    │         │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-           │    │    │         │    │    │    │         │    └── vcpu_weight:10
-           │    │    │         │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-           │    │    │         │    │    │    │         │    └── disabled:11
-           │    │    │         │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-           │    │    │         │    │    │    │         │    └── is_public:12
-           │    │    │         │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-           │    │    │         │    │    │    │         │    └── instance_types.deleted:13
-           │    │    │         │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-           │    │    │         │    │    │    │         │    └── instance_types.deleted_at:14
-           │    │    │         │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-           │    │    │         │    │    │    │         │    └── instance_types.created_at:15
-           │    │    │         │    │    │    │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
-           │    │    │         │    │    │    │              └── instance_types.updated_at:16
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         └── is_public:12 OR (true_agg:40 IS NOT NULL) [outer=(12,40)]
-           │    │    │         │    │    ├── project
-           │    │    │         │    │    │    ├── columns: true:42!null instance_type_projects.instance_type_id:30!null
+           │    │    │         │    │    │    │    │    ├── fd: (1)-->(2-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    │    │    │    │    └── ordering: +1
+           │    │    │         │    │    │    │    └── filters
+           │    │    │         │    │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+           │    │    │         │    │    │    │         └── NOT disabled:11 [outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
+           │    │    │         │    │    │    ├── project
+           │    │    │         │    │    │    │    ├── columns: true:39!null instance_type_projects.instance_type_id:20!null
+           │    │    │         │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    ├── key: (20)
+           │    │    │         │    │    │    │    ├── fd: ()-->(39)
+           │    │    │         │    │    │    │    ├── ordering: +20 opt(39) [actual: +20]
+           │    │    │         │    │    │    │    ├── select
+           │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
+           │    │    │         │    │    │    │    │    ├── has-placeholder
+           │    │    │         │    │    │    │    │    ├── key: (20)
+           │    │    │         │    │    │    │    │    ├── fd: ()-->(21,22)
+           │    │    │         │    │    │    │    │    ├── ordering: +20 opt(21,22) [actual: +20]
+           │    │    │         │    │    │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
+           │    │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
+           │    │    │         │    │    │    │    │    │    ├── lax-key: (20-22)
+           │    │    │         │    │    │    │    │    │    └── ordering: +20
+           │    │    │         │    │    │    │    │    └── filters
+           │    │    │         │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+           │    │    │         │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+           │    │    │         │    │    │    │    └── projections
+           │    │    │         │    │    │    │         └── true [as=true:39]
+           │    │    │         │    │    │    └── filters (true)
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         └── is_public:12 OR (true:39 IS NOT NULL) [outer=(12,39)]
+           │    │    │         │    ├── project
+           │    │    │         │    │    ├── columns: true:42!null instance_type_projects.instance_type_id:30!null
+           │    │    │         │    │    ├── has-placeholder
+           │    │    │         │    │    ├── key: (30)
+           │    │    │         │    │    ├── fd: ()-->(42)
+           │    │    │         │    │    ├── ordering: +30 opt(42) [actual: +30]
+           │    │    │         │    │    ├── select
+           │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31!null instance_type_projects.deleted:32!null
            │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (30)
-           │    │    │         │    │    │    ├── fd: ()-->(42)
-           │    │    │         │    │    │    ├── ordering: +30 opt(42) [actual: +30]
-           │    │    │         │    │    │    ├── select
-           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31!null instance_type_projects.deleted:32!null
-           │    │    │         │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    ├── key: (30)
-           │    │    │         │    │    │    │    ├── fd: ()-->(31,32)
-           │    │    │         │    │    │    │    ├── ordering: +30 opt(31,32) [actual: +30]
-           │    │    │         │    │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
-           │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31 instance_type_projects.deleted:32
-           │    │    │         │    │    │    │    │    ├── lax-key: (30-32)
-           │    │    │         │    │    │    │    │    └── ordering: +30
-           │    │    │         │    │    │    │    └── filters
-           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:32 = $4 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
-           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:32 = $5 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
-           │    │    │         │    │    │    │         └── project_id:31 = $6 [outer=(31), constraints=(/31: (/NULL - ]), fd=()-->(31)]
-           │    │    │         │    │    │    └── projections
-           │    │    │         │    │    │         └── true [as=true:42]
-           │    │    │         │    │    └── filters (true)
-           │    │    │         │    └── aggregations
-           │    │    │         │         ├── const-not-null-agg [as=true_agg:43, outer=(42)]
-           │    │    │         │         │    └── true:42
-           │    │    │         │         ├── const-agg [as=name:2, outer=(2)]
-           │    │    │         │         │    └── name:2
-           │    │    │         │         ├── const-agg [as=memory_mb:3, outer=(3)]
-           │    │    │         │         │    └── memory_mb:3
-           │    │    │         │         ├── const-agg [as=vcpus:4, outer=(4)]
-           │    │    │         │         │    └── vcpus:4
-           │    │    │         │         ├── const-agg [as=root_gb:5, outer=(5)]
-           │    │    │         │         │    └── root_gb:5
-           │    │    │         │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-           │    │    │         │         │    └── ephemeral_gb:6
-           │    │    │         │         ├── const-agg [as=flavorid:7, outer=(7)]
-           │    │    │         │         │    └── flavorid:7
-           │    │    │         │         ├── const-agg [as=swap:8, outer=(8)]
-           │    │    │         │         │    └── swap:8
-           │    │    │         │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-           │    │    │         │         │    └── rxtx_factor:9
-           │    │    │         │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-           │    │    │         │         │    └── vcpu_weight:10
-           │    │    │         │         ├── const-agg [as=disabled:11, outer=(11)]
-           │    │    │         │         │    └── disabled:11
-           │    │    │         │         ├── const-agg [as=is_public:12, outer=(12)]
-           │    │    │         │         │    └── is_public:12
-           │    │    │         │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-           │    │    │         │         │    └── instance_types.deleted:13
-           │    │    │         │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-           │    │    │         │         │    └── instance_types.deleted_at:14
-           │    │    │         │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-           │    │    │         │         │    └── instance_types.created_at:15
-           │    │    │         │         └── const-agg [as=instance_types.updated_at:16, outer=(16)]
-           │    │    │         │              └── instance_types.updated_at:16
+           │    │    │         │    │    │    ├── fd: ()-->(31,32)
+           │    │    │         │    │    │    ├── ordering: +30 opt(31,32) [actual: +30]
+           │    │    │         │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
+           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31 instance_type_projects.deleted:32
+           │    │    │         │    │    │    │    ├── lax-key: (30-32)
+           │    │    │         │    │    │    │    └── ordering: +30
+           │    │    │         │    │    │    └── filters
+           │    │    │         │    │    │         ├── instance_type_projects.deleted:32 = $4 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
+           │    │    │         │    │    │         ├── instance_type_projects.deleted:32 = $5 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
+           │    │    │         │    │    │         └── project_id:31 = $6 [outer=(31), constraints=(/31: (/NULL - ]), fd=()-->(31)]
+           │    │    │         │    │    └── projections
+           │    │    │         │    │         └── true [as=true:42]
+           │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true_agg:43 IS NOT NULL) [outer=(12,43)]
+           │    │    │              └── is_public:12 OR (true:42 IS NOT NULL) [outer=(12,42)]
            │    │    └── $7
            │    └── $8
            └── filters
@@ -2975,117 +2307,76 @@ project
  ├── key: (32)
  ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
       ├── key columns: [32] = [32]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (32)
-      ├── fd: ()-->(1-16,30,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
+      ├── fd: ()-->(1-16,20,29,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
+      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
       │    ├── key columns: [1] = [35]
       │    ├── immutable, has-placeholder
       │    ├── key: (32)
-      │    ├── fd: ()-->(1-16,30,35,36), (32)-->(33), (33,35,36)~~>(32)
+      │    ├── fd: ()-->(1-16,20,29,35,36), (32)-->(33), (33,35,36)~~>(32)
       │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-16,30)
+      │    │    ├── fd: ()-->(1-16,20,29)
       │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-16,30)
+      │    │    │    ├── fd: ()-->(1-16,20,29)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-16,30)
-      │    │    │    │    ├── group-by (streaming)
-      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 true_agg:30
+      │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: true:29 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-16,30)
-      │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:29 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
+      │    │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
+      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
+      │    │    │    │    │    │    ├── key columns: [1] = [20]
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-16,20,29)
-      │    │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
-      │    │    │    │    │    │    │    ├── key columns: [1] = [20]
+      │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
+      │    │    │    │    │    │    ├── index-join instance_types
+      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    │    │    │    │    ├── index-join instance_types
-      │    │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
-      │    │    │    │    │    │    │    │    └── select
-      │    │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null
-      │    │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    │         ├── has-placeholder
-      │    │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │    │         ├── fd: ()-->(1,7,13)
-      │    │    │    │    │    │    │    │         ├── scan instance_types@instance_types_flavorid_deleted_key
-      │    │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13
-      │    │    │    │    │    │    │    │         │    ├── constraint: /7/13: (/NULL - ]
-      │    │    │    │    │    │    │    │         │    ├── key: (1)
-      │    │    │    │    │    │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
-      │    │    │    │    │    │    │    │         └── filters
-      │    │    │    │    │    │    │    │              ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-      │    │    │    │    │    │    │    │              └── flavorid:7 = $4 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
-      │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-      │    │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-      │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:29, outer=(20)]
-      │    │    │    │    │    └── aggregations
-      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:30, outer=(29)]
-      │    │    │    │    │         │    └── true:29
-      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │    │         │    └── name:2
-      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │    │         │    └── memory_mb:3
-      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │    │         │    └── vcpus:4
-      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │    │         │    └── root_gb:5
-      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │    │         │    └── flavorid:7
-      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │    │         │    └── swap:8
-      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │    │         │    └── disabled:11
-      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │    │         │    └── is_public:12
-      │    │    │    │    │         ├── const-agg [as=instance_types.deleted:13, outer=(13)]
-      │    │    │    │    │         │    └── instance_types.deleted:13
-      │    │    │    │    │         ├── const-agg [as=instance_types.deleted_at:14, outer=(14)]
-      │    │    │    │    │         │    └── instance_types.deleted_at:14
-      │    │    │    │    │         ├── const-agg [as=instance_types.created_at:15, outer=(15)]
-      │    │    │    │    │         │    └── instance_types.created_at:15
-      │    │    │    │    │         ├── const-agg [as=instance_types.updated_at:16, outer=(16)]
-      │    │    │    │    │         │    └── instance_types.updated_at:16
-      │    │    │    │    │         └── const-agg [as=instance_types.id:1, outer=(1)]
-      │    │    │    │    │              └── instance_types.id:1
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
+      │    │    │    │    │    │    │    └── select
+      │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null
+      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │    │         ├── fd: ()-->(1,7,13)
+      │    │    │    │    │    │    │         ├── scan instance_types@instance_types_flavorid_deleted_key
+      │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13
+      │    │    │    │    │    │    │         │    ├── constraint: /7/13: (/NULL - ]
+      │    │    │    │    │    │    │         │    ├── key: (1)
+      │    │    │    │    │    │    │         │    └── fd: (1)-->(7,13), (7,13)~~>(1)
+      │    │    │    │    │    │    │         └── filters
+      │    │    │    │    │    │    │              ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
+      │    │    │    │    │    │    │              └── flavorid:7 = $4 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+      │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:29, outer=(20)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true_agg:30 IS NOT NULL) [outer=(12,30)]
+      │    │    │    │         └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
       │    │    │    └── $5
       │    │    └── $6
       │    └── filters
@@ -3146,105 +2437,68 @@ project
  ├── key: (29)
  ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
       ├── key columns: [29] = [29]
       ├── lookup columns are key
       ├── immutable, has-placeholder
       ├── key: (29)
-      ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
+      ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
       │    ├── key columns: [1] = [32]
       │    ├── immutable, has-placeholder
       │    ├── key: (29)
-      │    ├── fd: ()-->(1-12,14,15,27,32), (29)-->(30), (30)-->(29)
+      │    ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30), (30)-->(29)
       │    ├── limit
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-12,14,15,27)
+      │    │    ├── fd: ()-->(1-12,14,15,19,26)
       │    │    ├── offset
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-12,14,15,27)
+      │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-12,14,15,27)
-      │    │    │    │    ├── group-by (streaming)
-      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 true_agg:27
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: true:26 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,27)
-      │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:26 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
+      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
+      │    │    │    │    │    │    ├── key columns: [1] = [19]
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
-      │    │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
-      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
-      │    │    │    │    │    │    │    ├── key columns: [1] = [19]
+      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
+      │    │    │    │    │    │    │    ├── scan flavors
       │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    │    │    ├── scan flavors
-      │    │    │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
-      │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         └── flavors.id:1 = $2 [outer=(1), constraints=(/1: (/NULL - ]), fd=()-->(1)]
+      │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │    └── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
       │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │         ├── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-      │    │    │    │    │    │    │         └── flavor_projects.flavor_id:19 = $2 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
-      │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:26, outer=(19)]
-      │    │    │    │    │    └── aggregations
-      │    │    │    │    │         ├── const-not-null-agg [as=true_agg:27, outer=(26)]
-      │    │    │    │    │         │    └── true:26
-      │    │    │    │    │         ├── const-agg [as=name:2, outer=(2)]
-      │    │    │    │    │         │    └── name:2
-      │    │    │    │    │         ├── const-agg [as=memory_mb:3, outer=(3)]
-      │    │    │    │    │         │    └── memory_mb:3
-      │    │    │    │    │         ├── const-agg [as=vcpus:4, outer=(4)]
-      │    │    │    │    │         │    └── vcpus:4
-      │    │    │    │    │         ├── const-agg [as=root_gb:5, outer=(5)]
-      │    │    │    │    │         │    └── root_gb:5
-      │    │    │    │    │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-      │    │    │    │    │         │    └── ephemeral_gb:6
-      │    │    │    │    │         ├── const-agg [as=flavorid:7, outer=(7)]
-      │    │    │    │    │         │    └── flavorid:7
-      │    │    │    │    │         ├── const-agg [as=swap:8, outer=(8)]
-      │    │    │    │    │         │    └── swap:8
-      │    │    │    │    │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-      │    │    │    │    │         │    └── rxtx_factor:9
-      │    │    │    │    │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-      │    │    │    │    │         │    └── vcpu_weight:10
-      │    │    │    │    │         ├── const-agg [as=disabled:11, outer=(11)]
-      │    │    │    │    │         │    └── disabled:11
-      │    │    │    │    │         ├── const-agg [as=is_public:12, outer=(12)]
-      │    │    │    │    │         │    └── is_public:12
-      │    │    │    │    │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-      │    │    │    │    │         │    └── flavors.created_at:14
-      │    │    │    │    │         ├── const-agg [as=flavors.updated_at:15, outer=(15)]
-      │    │    │    │    │         │    └── flavors.updated_at:15
-      │    │    │    │    │         └── const-agg [as=flavors.id:1, outer=(1)]
-      │    │    │    │    │              └── flavors.id:1
+      │    │    │    │    │    │    │         └── flavors.id:1 = $2 [outer=(1), constraints=(/1: (/NULL - ]), fd=()-->(1)]
+      │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │         ├── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
+      │    │    │    │    │    │         └── flavor_projects.flavor_id:19 = $2 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:26, outer=(19)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true_agg:27 IS NOT NULL) [outer=(12,27)]
+      │    │    │    │         └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
       │    │    │    └── $3
       │    │    └── $4
       │    └── filters (true)
@@ -3311,107 +2565,67 @@ sort
       ├── immutable, has-placeholder
       ├── key: (1,29)
       ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (29)-->(30-34), (30,32)-->(29,31,33,34)
-      └── left-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 true_agg:27 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
-           ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+      └── right-join (hash)
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
            ├── immutable, has-placeholder
            ├── key: (1,29)
-           ├── fd: (1)-->(2-15,27), (7)-->(1-6,8-15), (2)-->(1,3-15), (29)-->(30-34), (30,32)-->(29,31,33,34)
-           ├── limit
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 true_agg:27
-           │    ├── internal-ordering: +7
-           │    ├── immutable, has-placeholder
-           │    ├── key: (1)
-           │    ├── fd: (1)-->(2-15,27), (7)-->(1-6,8-15), (2)-->(1,3-15)
-           │    ├── sort
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 true_agg:27
-           │    │    ├── has-placeholder
-           │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-15,27), (7)-->(1-6,8-15), (2)-->(1,3-15)
-           │    │    ├── ordering: +7
-           │    │    └── select
-           │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 true_agg:27
-           │    │         ├── has-placeholder
-           │    │         ├── key: (1)
-           │    │         ├── fd: (1)-->(2-15,27), (7)-->(1-6,8-15), (2)-->(1,3-15)
-           │    │         ├── group-by (streaming)
-           │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 true_agg:27
-           │    │         │    ├── grouping columns: flavors.id:1!null
-           │    │         │    ├── internal-ordering: +1
-           │    │         │    ├── has-placeholder
-           │    │         │    ├── key: (1)
-           │    │         │    ├── fd: (1)-->(2-15,27), (7)-->(1-6,8-15), (2)-->(1,3-15)
-           │    │         │    ├── left-join (merge)
-           │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
-           │    │         │    │    ├── left ordering: +1
-           │    │         │    │    ├── right ordering: +19
-           │    │         │    │    ├── has-placeholder
-           │    │         │    │    ├── key: (1)
-           │    │         │    │    ├── fd: (1)-->(2-15,19,26), (7)-->(1-6,8-15), (2)-->(1,3-15)
-           │    │         │    │    ├── ordering: +1
-           │    │         │    │    ├── scan flavors
-           │    │         │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15
-           │    │         │    │    │    ├── key: (1)
-           │    │         │    │    │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15)
-           │    │         │    │    │    └── ordering: +1
-           │    │         │    │    ├── project
-           │    │         │    │    │    ├── columns: true:26!null flavor_projects.flavor_id:19!null
-           │    │         │    │    │    ├── has-placeholder
-           │    │         │    │    │    ├── key: (19)
-           │    │         │    │    │    ├── fd: ()-->(26)
-           │    │         │    │    │    ├── ordering: +19 opt(26) [actual: +19]
-           │    │         │    │    │    ├── select
-           │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │         │    │    │    │    ├── has-placeholder
-           │    │         │    │    │    │    ├── key: (19)
-           │    │         │    │    │    │    ├── fd: ()-->(20)
-           │    │         │    │    │    │    ├── ordering: +19 opt(20) [actual: +19]
-           │    │         │    │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
-           │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │         │    │    │    │    │    ├── key: (19,20)
-           │    │         │    │    │    │    │    └── ordering: +19
-           │    │         │    │    │    │    └── filters
-           │    │         │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-           │    │         │    │    │    └── projections
-           │    │         │    │    │         └── true [as=true:26]
-           │    │         │    │    └── filters (true)
-           │    │         │    └── aggregations
-           │    │         │         ├── const-not-null-agg [as=true_agg:27, outer=(26)]
-           │    │         │         │    └── true:26
-           │    │         │         ├── const-agg [as=name:2, outer=(2)]
-           │    │         │         │    └── name:2
-           │    │         │         ├── const-agg [as=memory_mb:3, outer=(3)]
-           │    │         │         │    └── memory_mb:3
-           │    │         │         ├── const-agg [as=vcpus:4, outer=(4)]
-           │    │         │         │    └── vcpus:4
-           │    │         │         ├── const-agg [as=root_gb:5, outer=(5)]
-           │    │         │         │    └── root_gb:5
-           │    │         │         ├── const-agg [as=ephemeral_gb:6, outer=(6)]
-           │    │         │         │    └── ephemeral_gb:6
-           │    │         │         ├── const-agg [as=flavorid:7, outer=(7)]
-           │    │         │         │    └── flavorid:7
-           │    │         │         ├── const-agg [as=swap:8, outer=(8)]
-           │    │         │         │    └── swap:8
-           │    │         │         ├── const-agg [as=rxtx_factor:9, outer=(9)]
-           │    │         │         │    └── rxtx_factor:9
-           │    │         │         ├── const-agg [as=vcpu_weight:10, outer=(10)]
-           │    │         │         │    └── vcpu_weight:10
-           │    │         │         ├── const-agg [as=disabled:11, outer=(11)]
-           │    │         │         │    └── disabled:11
-           │    │         │         ├── const-agg [as=is_public:12, outer=(12)]
-           │    │         │         │    └── is_public:12
-           │    │         │         ├── const-agg [as=description:13, outer=(13)]
-           │    │         │         │    └── description:13
-           │    │         │         ├── const-agg [as=flavors.created_at:14, outer=(14)]
-           │    │         │         │    └── flavors.created_at:14
-           │    │         │         └── const-agg [as=flavors.updated_at:15, outer=(15)]
-           │    │         │              └── flavors.updated_at:15
-           │    │         └── filters
-           │    │              └── is_public:12 OR (true_agg:27 IS NOT NULL) [outer=(12,27)]
-           │    └── $2
+           ├── fd: (1)-->(2-15,19,26), (7)-->(1-6,8-15), (2)-->(1,3-15), (29)-->(30-34), (30,32)-->(29,31,33,34)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
            │    ├── columns: flavor_extra_specs_1.id:29!null key:30!null value:31 flavor_extra_specs_1.flavor_id:32!null flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
            │    ├── key: (29)
            │    └── fd: (29)-->(30-34), (30,32)-->(29,31,33,34)
+           ├── limit
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    ├── internal-ordering: +7
+           │    ├── immutable, has-placeholder
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-15,19,26), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    ├── sort
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    ├── has-placeholder
+           │    │    ├── key: (1)
+           │    │    ├── fd: (1)-->(2-15,19,26), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │    ├── ordering: +7
+           │    │    └── select
+           │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │         ├── has-placeholder
+           │    │         ├── key: (1)
+           │    │         ├── fd: (1)-->(2-15,19,26), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │         ├── left-join (merge)
+           │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │         │    ├── left ordering: +1
+           │    │         │    ├── right ordering: +19
+           │    │         │    ├── has-placeholder
+           │    │         │    ├── key: (1)
+           │    │         │    ├── fd: (1)-->(2-15,19,26), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │         │    ├── scan flavors
+           │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15
+           │    │         │    │    ├── key: (1)
+           │    │         │    │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │         │    │    └── ordering: +1
+           │    │         │    ├── project
+           │    │         │    │    ├── columns: true:26!null flavor_projects.flavor_id:19!null
+           │    │         │    │    ├── has-placeholder
+           │    │         │    │    ├── key: (19)
+           │    │         │    │    ├── fd: ()-->(26)
+           │    │         │    │    ├── ordering: +19 opt(26) [actual: +19]
+           │    │         │    │    ├── select
+           │    │         │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
+           │    │         │    │    │    ├── has-placeholder
+           │    │         │    │    │    ├── key: (19)
+           │    │         │    │    │    ├── fd: ()-->(20)
+           │    │         │    │    │    ├── ordering: +19 opt(20) [actual: +19]
+           │    │         │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
+           │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
+           │    │         │    │    │    │    ├── key: (19,20)
+           │    │         │    │    │    │    └── ordering: +19
+           │    │         │    │    │    └── filters
+           │    │         │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
+           │    │         │    │    └── projections
+           │    │         │    │         └── true [as=true:26]
+           │    │         │    └── filters (true)
+           │    │         └── filters
+           │    │              └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
+           │    └── $2
            └── filters
                 └── flavor_extra_specs_1.flavor_id:32 = flavors.id:1 [outer=(1,32), constraints=(/1: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(32), (32)==(1)]


### PR DESCRIPTION
This commit adds a rule, `EliminateGroupBy`, which eliminates GroupBy
expressions with grouping columns that form a strict key in the input of
the GroupBy. See the rule description for more details.

Co-authored by @DrewKimball.

Informs #117546

Release note: None