### PR TITLE
cli/debug: add start and end time files

### DIFF
--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -286,6 +286,10 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 				prefix:           debugBase + prefix,
 			}
 
+			if err := zc.collectStartTime(ctx); err != nil {
+				return err
+			}
+
 			// Fetch the cluster-wide details.
 			// For a SQL only server, the nodeList will be a list of SQL nodes
 			// and livenessByNodeID is null. For a KV server, the nodeList will
@@ -343,6 +347,10 @@ done
 					return err
 				}
 			}
+			if err := zc.collectEndTime(ctx); err != nil {
+				return err
+			}
+
 			return nil
 		}(); err != nil {
 			return err

--- a/pkg/cli/zip_cluster_wide.go
+++ b/pkg/cli/zip_cluster_wide.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -69,6 +70,14 @@ func makeClusterWideZipRequests(
 			pathName: prefix + problemRangesName,
 		},
 	}
+}
+
+func (zc *debugZipContext) collectStartTime(ctx context.Context) error {
+	return zc.z.createRaw(zc.clusterPrinter, debugBase+"/debug_zip_started.txt", []byte(timeutil.Now().String()))
+}
+
+func (zc *debugZipContext) collectEndTime(ctx context.Context) error {
+	return zc.z.createRaw(zc.clusterPrinter, debugBase+"/debug_zip_finished.txt", []byte(timeutil.Now().String()))
 }
 
 // collectClusterData runs the data collection that only needs to


### PR DESCRIPTION
Sometimes collecting the zip takes considerable time, with different files in the zip being collected at different points in that interval, and knowing the time range cover which their collection could have taken place can make it easier to determine what is being observed.

Release note: none.
Epic: none.