### PR TITLE
release-22.2: kvnemesis: fix `Barrier` error handling

### DIFF
--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -434,7 +434,7 @@ func (v *validator) processOp(txnID *string, op Operation) {
 		}
 	case *BarrierOperation:
 		if op.Barrier.WithLeaseAppliedIndex &&
-			resultIsError(t.Result, &roachpb.RangeKeyMismatchError{}) {
+			errors.HasType(errorFromResult(t.Result), (*roachpb.RangeKeyMismatchError)(nil)) {
 			// Barriers requesting LAIs can't span ranges. The generator will
 			// optimistically try to fit the barrier inside one of the current ranges,
 			// but this may race with a split, so we ignore the error in this case and


### PR DESCRIPTION
Release justification: test-only fix.

Resolves #118636.
Resolves #118637.
Epic: none
Release note: None