### PR TITLE
sql: fix usages of internal executor to delegate from user transaction

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -200,7 +200,7 @@ func ingestionPlanHook(
 		destinationTenantID, err = sql.CreateTenantRecord(
 			ctx, p.ExecCfg().Codec, p.ExecCfg().Settings,
 			p.InternalSQLTxn(),
-			p.ExecCfg().SpanConfigKVAccessor.WithTxn(ctx, p.Txn()),
+			p.ExecCfg().SpanConfigKVAccessor.WithISQLTxn(ctx, p.InternalSQLTxn()),
 			tenantInfo, initialTenantZoneConfig,
 			ingestionStmt.IfNotExists,
 			p.ExecCfg().TenantTestingKnobs,

--- a/pkg/kv/kvclient/kvtenant/BUILD.bazel
+++ b/pkg/kv/kvclient/kvtenant/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/server/settingswatcher",
         "//pkg/settings",
         "//pkg/spanconfig",
+        "//pkg/sql/isql",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/ts/tspb",

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/settingswatcher"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
@@ -916,6 +917,11 @@ func (c *connector) DownloadSpan(
 
 // WithTxn implements the spanconfig.KVAccessor interface.
 func (c *connector) WithTxn(context.Context, *kv.Txn) spanconfig.KVAccessor {
+	panic("not applicable")
+}
+
+// WithISQLTxn is part of the spanconfig.KVAccessor interface.
+func (c *connector) WithISQLTxn(context.Context, isql.Txn) spanconfig.KVAccessor {
 	panic("not applicable")
 }
 

--- a/pkg/spanconfig/BUILD.bazel
+++ b/pkg/spanconfig/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/systemschema",
+        "//pkg/sql/isql",
         "//pkg/sql/sqlliveness",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -61,6 +62,11 @@ type KVAccessor interface {
 	// its operations discarded if aborted, valid only if committed). If nil, a
 	// transaction is created internally for every operation.
 	WithTxn(context.Context, *kv.Txn) KVAccessor
+
+	// WithISQLTxn returns a KVAccessor that runs using the given isql.Txn (with
+	// its operations discarded if aborted, valid only if committed). This makes
+	// it possible to use the KVAccessor in the context of a SQL transaction.
+	WithISQLTxn(context.Context, isql.Txn) KVAccessor
 }
 
 // KVSubscriber presents a consistent[1] snapshot of a StoreReader and

--- a/pkg/spanconfig/spanconfigkvaccessor/dummy.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/dummy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 )
@@ -60,5 +61,10 @@ func (k dummyKVAccessor) GetAllSystemSpanConfigsThatApply(
 }
 
 func (k dummyKVAccessor) WithTxn(context.Context, *kv.Txn) spanconfig.KVAccessor {
+	return k
+}
+
+// WithISQLTxn is part of the KVAccessor interface.
+func (k dummyKVAccessor) WithISQLTxn(ctx context.Context, txn isql.Txn) spanconfig.KVAccessor {
 	return k
 }

--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor.go
@@ -88,6 +88,14 @@ func (k *KVAccessor) WithTxn(ctx context.Context, txn *kv.Txn) spanconfig.KVAcce
 	return newKVAccessor(k.db, k.ie, k.settings, k.clock, k.configurationsTableFQN, k.knobs, txn)
 }
 
+// WithISQLTxn is part of the KVAccessor interface.
+func (k *KVAccessor) WithISQLTxn(ctx context.Context, txn isql.Txn) spanconfig.KVAccessor {
+	if k.optionalTxn != nil {
+		log.Fatalf(ctx, "KVAccessor already scoped to txn (was .WithISQLTxn(...) chained multiple times?)")
+	}
+	return newKVAccessor(txn.KV().DB(), txn, k.settings, k.clock, k.configurationsTableFQN, k.knobs, txn.KV())
+}
+
 // GetAllSystemSpanConfigsThatApply is part of the spanconfig.KVAccessor
 // interface.
 func (k *KVAccessor) GetAllSystemSpanConfigsThatApply(

--- a/pkg/spanconfig/spanconfigtestutils/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigtestutils/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/spanconfig",
         "//pkg/spanconfig/spanconfigbounds",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/isql",
         "//pkg/util/hlc",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/spanconfig/spanconfigtestutils/recorder.go
+++ b/pkg/spanconfig/spanconfigtestutils/recorder.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -102,6 +103,11 @@ func (r *KVAccessorRecorder) GetAllSystemSpanConfigsThatApply(
 
 // WithTxn is part of the KVAccessor interface.
 func (r *KVAccessorRecorder) WithTxn(context.Context, *kv.Txn) spanconfig.KVAccessor {
+	panic("unimplemented")
+}
+
+// WithISQLTxn is part of the KVAccessor interface.
+func (k *KVAccessorRecorder) WithISQLTxn(context.Context, isql.Txn) spanconfig.KVAccessor {
 	panic("unimplemented")
 }
 

--- a/pkg/sql/gcjob/BUILD.bazel
+++ b/pkg/sql/gcjob/BUILD.bazel
@@ -79,6 +79,7 @@ go_test(
         "//pkg/server",
         "//pkg/spanconfig",
         "//pkg/sql",
+        "//pkg/sql/isql",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/sql/gcjob/gc_protected_timestamp_test.go
+++ b/pkg/sql/gcjob/gc_protected_timestamp_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -265,6 +266,11 @@ func (m *manualKVAccessor) UpdateSpanConfigRecords(
 }
 
 func (m *manualKVAccessor) WithTxn(context.Context, *kv.Txn) spanconfig.KVAccessor {
+	panic("unimplemented")
+}
+
+// WithISQLTxn is part of the KVAccessor interface.
+func (k *manualKVAccessor) WithISQLTxn(context.Context, isql.Txn) spanconfig.KVAccessor {
 	panic("unimplemented")
 }
 

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -480,7 +480,7 @@ func TestGCTenant(t *testing.T) {
 		_, err := sql.CreateTenantRecord(
 			ctx, execCfg.Codec, execCfg.Settings,
 			txn,
-			execCfg.SpanConfigKVAccessor.WithTxn(ctx, txn.KV()),
+			execCfg.SpanConfigKVAccessor.WithISQLTxn(ctx, txn),
 			&mtinfopb.TenantInfoWithUsage{
 				SQLInfo: mtinfopb.SQLInfo{ID: activeTenID},
 			},
@@ -495,7 +495,7 @@ func TestGCTenant(t *testing.T) {
 		_, err := sql.CreateTenantRecord(
 			ctx, execCfg.Codec, execCfg.Settings,
 			txn,
-			execCfg.SpanConfigKVAccessor.WithTxn(ctx, txn.KV()),
+			execCfg.SpanConfigKVAccessor.WithISQLTxn(ctx, txn),
 			&mtinfopb.TenantInfoWithUsage{
 				SQLInfo: mtinfopb.SQLInfo{
 					ID:        dropTenID,

--- a/pkg/sql/resolve_oid.go
+++ b/pkg/sql/resolve_oid.go
@@ -30,10 +30,9 @@ import (
 func (p *planner) ResolveOIDFromString(
 	ctx context.Context, resultType *types.T, toResolve *tree.DString,
 ) (_ *tree.DOid, errSafeToIgnore bool, _ error) {
-	ie := p.ExecCfg().InternalDB.NewInternalExecutor(p.SessionData())
 	return resolveOID(
 		ctx, p.Txn(),
-		ie,
+		p.InternalSQLTxn(),
 		resultType, toResolve,
 	)
 }
@@ -42,10 +41,9 @@ func (p *planner) ResolveOIDFromString(
 func (p *planner) ResolveOIDFromOID(
 	ctx context.Context, resultType *types.T, toResolve *tree.DOid,
 ) (_ *tree.DOid, errSafeToIgnore bool, _ error) {
-	ie := p.ExecCfg().InternalDB.NewInternalExecutor(p.SessionData())
 	return resolveOID(
 		ctx, p.Txn(),
-		ie,
+		p.InternalSQLTxn(),
 		resultType, toResolve,
 	)
 }

--- a/pkg/sql/tenant_creation.go
+++ b/pkg/sql/tenant_creation.go
@@ -133,7 +133,7 @@ func (p *planner) createTenantInternal(
 		p.ExecCfg().Codec,
 		p.ExecCfg().Settings,
 		p.InternalSQLTxn(),
-		p.ExecCfg().SpanConfigKVAccessor.WithTxn(ctx, p.Txn()),
+		p.ExecCfg().SpanConfigKVAccessor.WithISQLTxn(ctx, p.InternalSQLTxn()),
 		info,
 		initialTenantZoneConfig,
 		ctcfg.IfNotExists,

--- a/pkg/sql/tenant_gc.go
+++ b/pkg/sql/tenant_gc.go
@@ -78,7 +78,7 @@ func GCTenantSync(ctx context.Context, execCfg *ExecutorConfig, info *mtinfopb.T
 		if err != nil {
 			return err
 		}
-		scKVAccessor := execCfg.SpanConfigKVAccessor.WithTxn(ctx, txn.KV())
+		scKVAccessor := execCfg.SpanConfigKVAccessor.WithISQLTxn(ctx, txn)
 		records, err := scKVAccessor.GetSpanConfigRecords(
 			ctx, []spanconfig.Target{
 				spanconfig.MakeTargetFromSpan(tenantSpan),

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -96,8 +96,8 @@ WHERE s.descriptor_id = $1
   AND s.end_key > r.start_key
   AND r.start_key >= s.start_key -- only consider split points inside the table keyspace.
   AND split_enforced_until IS NOT NULL`
-	ie := params.p.ExecCfg().InternalDB.NewInternalExecutor(params.SessionData())
-	it, err := ie.QueryIteratorEx(
+
+	it, err := params.p.InternalSQLTxn().QueryIteratorEx(
 		params.ctx, "split points query", params.p.txn, sessiondata.NoSessionDataOverride,
 		statement,
 		n.tableDesc.GetID(),


### PR DESCRIPTION
These commits fix a few usages of the internal executor to use the new interface which delegates to an internal executor that shares the outer txn's state.

For ease of review, the testing for this is in a separate PR (where the bugs were discovered): https://github.com/cockroachdb/cockroach/pull/107990

informs #100178