### PR TITLE
catalog/lease: handle retryable replica errors properly

### DIFF
--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/quotapool",
         "//pkg/util/retry",
+        "//pkg/util/startup",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/syncutil/singleflight",


### PR DESCRIPTION
Previously, the expiration based leasing mechanism was used, which was more lenient for duplicate rows in the system.lease table. Certain retryable errors like replica errors could lead to rows being written, but not being cleaned up with the assumption nothing was written. In the session based model we are strict and require a single row per descriptor, version and session, so any errors not handled properly will lead to future failures. To address this, this patch with treat both ambiguous result errors and replica errors as retryable.  When these are hit the lease will be deleted and re-inserted in case an existing one was persisted.

Fixes: #118520

Release note: None