### PR TITLE
roachtest: increase `version-upgrade` timeout in remote runs

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -81,7 +81,7 @@ func registerAcceptance(r registry.Registry) {
 			{
 				name:          "version-upgrade",
 				fn:            runVersionUpgrade,
-				timeout:       30 * time.Minute,
+				timeout:       2 * time.Hour, // actually lower in local runs; see `runVersionUpgrade`
 				defaultLeases: true,
 			},
 		},

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -100,8 +100,16 @@ DROP TABLE splitmerge.t;
 }
 
 func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
+	testCtx := ctx
+	if c.IsLocal() {
+		localTimeout := 30 * time.Minute
+		var cancel context.CancelFunc
+		testCtx, cancel = context.WithTimeout(ctx, localTimeout)
+		defer cancel()
+	}
+
 	mvt := mixedversion.NewTest(
-		ctx, t, t.L(), c, c.All(),
+		testCtx, t, t.L(), c, c.All(),
 		mixedversion.AlwaysUseFixtures, mixedversion.AlwaysUseLatestPredecessors,
 	)
 	mvt.OnStartup(


### PR DESCRIPTION
With recent changes in the `mixedversion` framework, we could be waiting for background workloads a little longer than usual in remote runs, which could cause timeouts in that setting.

To avoid that, we increase the test's timeout in remote runs to 2 hours, keeping the existing 30 minute timeout in local (CI) runs. This is safe because the framework itself reduces wait time when run in local mode.

Fixes: #118619

Release note: None