### PR TITLE
release 23.1: roachtest: skip c2c/Disconnect

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1241,6 +1241,7 @@ func registerClusterReplicationDisconnect(r registry.Registry) {
 		maxAcceptedLatency: 12 * time.Minute,
 		clouds:             registry.AllExceptAWS,
 		suites:             registry.Suites(registry.Nightly),
+		skip:               "test flakes on 23.1, but c2c shouldn't be used on 23.1 ;)",
 	}
 	c2cRegisterWrapper(r, sp, func(ctx context.Context, t test.Test, c cluster.Cluster) {
 		rd := makeReplicationDriver(t, c, sp)


### PR DESCRIPTION
c2c/Disconnect has begun flaking on 23.1, but since no one should be using c2c on 23.1, this patch skips the test.

Fixes #118351

Release note: none