### PR TITLE
kv: [DNM] approximate MVCCStats during splits

### DIFF
--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -130,6 +130,11 @@ message SplitTrigger {
   RangeDescriptor right_desc = 2 [(gogoproto.nullable) = false];
 
   reserved 3, 4;
+
+  storage.enginepb.MVCCStats left_mvcc_stats_estimates = 5 [
+    (gogoproto.customname) = "LeftMVCCStatsEstimates",
+    (gogoproto.nullable) = false
+  ];
 }
 
 // A MergeTrigger is run after a successful commit of an AdminMerge


### PR DESCRIPTION
Instead of computing accurate MVCCStats for the LHS and RHS of a split while holding latches, compute the LHS stats in AdminSplit and pass it to the splitTrigger, where the RHS stats are derived by subtracting the passed in LHS stats from the total. This produces inaccurate stats because it doesn't account for writes to the LHS concurrent with the split.

Do not merge, this is an experiment.