### PR TITLE
sql: keep track of per-stmt read committed retries

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1633,8 +1633,6 @@ func (ex *connExecutor) dispatchReadCommittedStmtToExecutionEngine(
 		return err
 	}
 
-	// TODO(rafi): Figure out observability for these retries. We might want to
-	// add a new field similar to ex.state.mu.autoRetryCounter.
 	maxRetries := int(ex.sessionData().MaxRetriesForReadCommitted)
 	for attemptNum := 0; ; attemptNum++ {
 		bufferPos := res.BufferedResultsLen()
@@ -1689,6 +1687,8 @@ func (ex *connExecutor) dispatchReadCommittedStmtToExecutionEngine(
 		if err := ex.state.mu.txn.PrepareForPartialRetry(ctx); err != nil {
 			return err
 		}
+		ex.state.mu.autoRetryCounter++
+		ex.state.mu.autoRetryReason = txnRetryErr
 	}
 	return nil
 }

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -69,13 +69,16 @@ type txnState struct {
 		// has executed.
 		stmtCount int
 
-		// autoRetryReason records the error causing an auto-retryable error event if
-		// the current transaction is being automatically retried. This is used in
-		// statement traces to give more information in statement diagnostic bundles.
+		// autoRetryReason records the error causing an auto-retryable error event
+		// if the current transaction is being automatically retried. This is used
+		// in statement traces to give more information in statement diagnostic
+		// bundles, and also is surfaced in the DB Console.
 		autoRetryReason error
 
-		// autoRetryCounter keeps track of the which iteration of a transaction
-		// auto-retry we're currently in. It's 0 whenever the transaction state is not
+		// autoRetryCounter keeps track of the number of automatic retries that have
+		// occurred. It includes per-statement retries performed under READ
+		// COMMITTED as well as transaction retries for serialization failures under
+		// SNAPSHOT and SERIALIZABLE. It's 0 whenever the transaction state is not
 		// stateOpen.
 		autoRetryCounter int32
 	}


### PR DESCRIPTION
This change makes it possible to view automatic retries performed under read committed txns in the DB Console.

fixes https://github.com/cockroachdb/cockroach/issues/113986
Release note: None