### PR TITLE
server/status: silence missing CPU cgroup error

### DIFF
--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -528,10 +528,7 @@ func (rsr *RuntimeStatSampler) SampleEnvironment(
 	if err != nil {
 		log.Ops.Errorf(ctx, "unable to get process CPU usage: %v", err)
 	}
-	cpuCapacity, err := getCPUCapacity()
-	if err != nil {
-		log.Ops.Errorf(ctx, "unable to get CPU capacity: %v", err)
-	}
+	cpuCapacity := getCPUCapacity()
 	cpuUsageStats, err := cpu.Times(false /* percpu */)
 	if err != nil {
 		log.Ops.Errorf(ctx, "unable to get system CPU usage: %v", err)
@@ -842,19 +839,20 @@ func GetProcCPUTime(ctx context.Context) (userTimeMillis, sysTimeMillis int64, e
 // getCPUCapacity returns the number of logical CPU processors available for
 // use by the process. The capacity accounts for cgroup constraints, GOMAXPROCS
 // and the number of host processors.
-func getCPUCapacity() (float64, error) {
+func getCPUCapacity() float64 {
 	numProcs := float64(runtime.GOMAXPROCS(0 /* read only */))
 	cgroupCPU, err := cgroups.GetCgroupCPU()
 	if err != nil {
-		// Return the GOMAXPROCS value if unable to read the cgroup settings, in
-		// practice this is not likely to occur.
-		return numProcs, err
+		// Return the GOMAXPROCS value if unable to read the cgroup settings. This
+		// can happen if cockroach is not running inside a CPU cgroup, which is a
+		// supported deployment mode. We could log here, but we don't to avoid spam.
+		return numProcs
 	}
 	cpuShare := cgroupCPU.CPUShares()
 	// Take the minimum of the CPU shares and the GOMAXPROCS value. The most CPU
 	// the process could use is the lesser of the two.
 	if cpuShare > numProcs {
-		return numProcs, nil
+		return numProcs
 	}
-	return cpuShare, nil
+	return cpuShare
 }


### PR DESCRIPTION
Fixes #111648.

This commit eliminates log spam when a CPU cgroup is not configured for the cockroach process. This is a supported deployment mode, but since `v22.2.11`/`v23.1.3`/`v23.2.0` (df55958d), we've been spamming the logs with "unable to get CPU capacity" errors every 10 seconds when running outside of a CPU cgroup.

I considered reducing the severity of the log message from ERROR to INFO, but even that seemed loud for a log message every 10s in a supported deployment mode. For now, we remove the log message.

Release note (bug fix): Cockroach will no longer spam the logs with "unable to get CPU capacity" errors every 10 seconds when running outside of a CPU cgroup.