### PR TITLE
kv: don't mutate tscache arena when serializing

### DIFF
--- a/pkg/kv/kvserver/readsummary/rspb/BUILD.bazel
+++ b/pkg/kv/kvserver/readsummary/rspb/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/buildutil",
+        "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/uuid",
     ],

--- a/pkg/kv/kvserver/readsummary/rspb/merge_spans.go
+++ b/pkg/kv/kvserver/readsummary/rspb/merge_spans.go
@@ -13,6 +13,7 @@ package rspb
 import (
 	"bytes"
 
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -176,7 +177,7 @@ func mergeSpans[V ratchetingValue[V], S span[V], SPtr spanPtr[V, S]](a, b []S) [
 						long.setKey(shortEndKey)
 					} else {
 						// short is a point span, so start long at the next key.
-						long.setKey(append(short.key(), 0)) // Key.Next()
+						long.setKey(encoding.BytesNext(short.key())) // Key.Next()
 					}
 				}
 			}

--- a/pkg/kv/kvserver/tscache/BUILD.bazel
+++ b/pkg/kv/kvserver/tscache/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/cache",
         "//pkg/util/container/list",
+        "//pkg/util/encoding",
         "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/interval",

--- a/pkg/kv/kvserver/tscache/interval_skl.go
+++ b/pkg/kv/kvserver/tscache/interval_skl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/container/list"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -688,7 +689,7 @@ func (p *sklPage) serialize(from, to []byte) rspb.Segment {
 			if opt&hasKey == 0 {
 				// The value is a gap value with no key value. This means that the value
 				// has an exclusive start key, so we advance the key to the next key.
-				key = append(key, 0) // Key.Next()
+				key = encoding.BytesNext(key) // Key.Next()
 			}
 			lastSpan = rspb.ReadSpan{
 				Key:       key,


### PR DESCRIPTION
Fixes #118614.
Fixes #118620.
Fixes #118618.

This commit fixes a bug where a call to `sklPage.serialize` could unintentionally mutate other keys in the sklPage's skiplist. This was possible because the append was called on a key that unexpectedly had extra capacity.

We could use `slices.Clip` to fix this and mandate a memory copy, but we instead use `encoding.BytesNext`, which has a useful fast-path.

While here, we do the same thing in `mergeSpans` to avoid an similar issues.

Release note: None