### PR TITLE
kv: mark kvnemesis tests as "large" sized

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -60,7 +60,7 @@ go_library(
 
 go_test(
     name = "kvnemesis_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "applier_test.go",
         "engine_test.go",


### PR DESCRIPTION
We've recently seen these time out exclusively on eng flow. In all those instances, we can see the test is making some progress from the stack traces -- it's slow though. We mark KVNemesis tests as large, which in turn bumps their timeout in CI.

Closes #118624
Closes #118005

Release note: None