### PR TITLE
ui: remove warning when auto refresh enable

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
@@ -219,6 +219,7 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
   const onSubmitToggleAutoRefresh = () => {
     // Refresh immediately when toggling auto-refresh on.
     if (!isAutoRefreshEnabled) {
+      setDisplayRefreshAlert(false);
       refreshLiveWorkload();
     }
     onAutoRefreshToggle(!isAutoRefreshEnabled);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
@@ -218,6 +218,7 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
   const onSubmitToggleAutoRefresh = () => {
     // Refresh immediately when toggling auto-refresh on.
     if (!isAutoRefreshEnabled) {
+      setDisplayRefreshAlert(false);
       refreshLiveWorkload();
     }
     onAutoRefreshToggle(!isAutoRefreshEnabled);


### PR DESCRIPTION
The warning being displayed about old active executions was not bein properly removed when the auto refresh was turned back on.
This commit fixes this for both Statements and Transactions pages, on Active Executions.

Fixes CRDB-35837

https://www.loom.com/share/76b57eba17ab44758fe81f178f07fecd

Release note (ui change): Properly remove warning of old date on Active Executions when auto refresh is enabled.