### PR TITLE
sql: minor improvements around estimated row count

### DIFF
--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -201,9 +201,12 @@ func NewHashAggregator(
 ) colexecop.ResettableOperator {
 	initialAllocSize, maxAllocSize := int64(1), int64(hashAggregatorAllocSize)
 	if args.EstimatedRowCount != 0 {
-		initialAllocSize = int64(args.EstimatedRowCount)
-		if initialAllocSize > maxAllocSize {
+		// Use uint64s for comparison to prevent overflow in case
+		// args.EstimatedRowCount is larger than MaxInt64.
+		if args.EstimatedRowCount >= uint64(maxAllocSize) {
 			initialAllocSize = maxAllocSize
+		} else {
+			initialAllocSize = int64(args.EstimatedRowCount)
 		}
 	}
 	aggFnsAlloc, inputArgsConverter, toClose, err := colexecagg.NewAggregateFuncsAlloc(

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -286,7 +286,7 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 			spans:             spans,
 			reverse:           params.Reverse,
 			parallelize:       params.Parallelize,
-			estimatedRowCount: uint64(params.EstimatedRowCount),
+			estimatedRowCount: params.EstimatedRowCount,
 			reqOrdering:       ReqOrdering(reqOrdering),
 		},
 	)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -646,9 +646,9 @@ func (b *Builder) scanParams(
 	// statement or was stored in the query cache, the column stats would have
 	// been removed by DetachMemo. Update that function if the column stats are
 	// needed here in the future.
-	var rowCount float64
+	var rowCount uint64
 	if relProps.Statistics().Available {
-		rowCount = relProps.Statistics().RowCount
+		rowCount = uint64(math.Ceil(relProps.Statistics().RowCount))
 	}
 
 	if scan.PartitionConstrainedScan {
@@ -1643,7 +1643,7 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 		orderType := exec.GroupingOrderType(groupBy.GroupingOrderType(&groupBy.RequiredPhysical().Ordering))
 		var rowCount uint64
 		if relProps := groupBy.Relational(); relProps.Statistics().Available {
-			rowCount = uint64(relProps.Statistics().RowCount)
+			rowCount = uint64(math.Ceil(relProps.Statistics().RowCount))
 		}
 		ep.root, err = b.factory.ConstructGroupBy(
 			input.root, groupingColIdx, groupingColOrder, aggInfos, reqOrdering, orderType, rowCount,

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -66,7 +66,9 @@ type ScanParams struct {
 	// Row-level locking properties.
 	Locking opt.Locking
 
-	EstimatedRowCount float64
+	// EstimatedRowCount, if set, is the estimated number of rows that will be
+	// scanned, rounded up.
+	EstimatedRowCount uint64
 
 	// If true, we are performing a locality optimized search. In order for this
 	// to work correctly, the execution engine must create a local DistSQL plan

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -143,7 +143,8 @@ define GroupBy {
     # NoStreaming).
     groupingOrderType exec.GroupingOrderType
 
-    # If set, the estimated number of rows that this GroupBy will output.
+    # If set, the estimated number of rows that this GroupBy will output
+    # (rounded up).
     estimatedRowCount uint64
 }
 

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -167,7 +167,7 @@ func (ef *execFactory) ConstructScan(
 		return nil, err
 	}
 	scan.reqOrdering = ReqOrdering(reqOrdering)
-	scan.estimatedRowCount = uint64(params.EstimatedRowCount)
+	scan.estimatedRowCount = params.EstimatedRowCount
 	scan.lockingStrength = descpb.ToScanLockingStrength(params.Locking.Strength)
 	scan.lockingWaitPolicy = descpb.ToScanLockingWaitPolicy(params.Locking.WaitPolicy)
 	scan.lockingDurability = descpb.ToScanLockingDurability(params.Locking.Durability)


### PR DESCRIPTION
This commit makes it so that we use the ceiling of the estimated row count in scans and aggregation. It also fixes recently-introduced bug that could cause integer overflow in the agg alloc code.

Fixes: #118724.

Epic: None

Release note: None