### PR TITLE
ui: change start and end values on stmt details charts

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/index.tsx
@@ -32,9 +32,16 @@ export type BarGraphTimeSeriesProps = {
   tooltip?: React.ReactNode;
   uPlotOptions: Partial<Options>;
   yAxisUnits: AxisUnits;
+  xScale?: XScale;
+};
+
+export type XScale = {
+  graphTsStartMillis: number;
+  graphTsEndMillis: number;
 };
 
 // Currently this component only supports stacked multi-series bars.
+// The value of xScale will take precedent over the start and end of the data provided.
 export const BarGraphTimeSeries: React.FC<BarGraphTimeSeriesProps> = ({
   alignedData,
   colourPalette,
@@ -43,6 +50,7 @@ export const BarGraphTimeSeries: React.FC<BarGraphTimeSeriesProps> = ({
   tooltip,
   uPlotOptions,
   yAxisUnits,
+  xScale,
 }) => {
   const graphRef = useRef<HTMLDivElement>(null);
   const samplingIntervalMillis =
@@ -52,9 +60,15 @@ export const BarGraphTimeSeries: React.FC<BarGraphTimeSeriesProps> = ({
   useEffect(() => {
     if (!alignedData) return;
 
+    const start = xScale.graphTsStartMillis
+      ? xScale.graphTsStartMillis
+      : alignedData[0][0];
+    const end = xScale.graphTsEndMillis
+      ? xScale.graphTsEndMillis
+      : alignedData[0][alignedData[0].length - 1];
     const xAxisDomain = calculateXAxisDomainBarChart(
-      alignedData[0][0], // startMillis
-      alignedData[0][alignedData[0].length - 1], // endMillis
+      start, // startMillis
+      end, // endMillis
       samplingIntervalMillis,
       timezone,
     );
@@ -87,6 +101,7 @@ export const BarGraphTimeSeries: React.FC<BarGraphTimeSeriesProps> = ({
     yAxisUnits,
     samplingIntervalMillis,
     timezone,
+    xScale,
   ]);
 
   return (

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -23,7 +23,7 @@ import { Helmet } from "react-helmet";
 import { Link, RouteComponentProps } from "react-router-dom";
 import classNames from "classnames/bind";
 import { PageConfig, PageConfigItem } from "src/pageConfig";
-import { BarGraphTimeSeries } from "../graphs/bargraph";
+import { BarGraphTimeSeries, XScale } from "../graphs/bargraph";
 import { AxisUnits } from "../graphs";
 import { AlignedData, Options } from "uplot";
 
@@ -702,6 +702,11 @@ export class StatementDetails extends React.Component<
     }
 
     const duration = (v: number) => Duration(v * 1e9);
+    const [chartsStart, chartsEnd] = toRoundedDateRange(this.props.timeScale);
+    const xScale = {
+      graphTsStartMillis: chartsStart.valueOf,
+      graphTsEndMillis: chartsEnd.valueOf,
+    } as unknown as XScale;
 
     return (
       <>
@@ -868,6 +873,7 @@ export class StatementDetails extends React.Component<
                 alignedData={executionAndPlanningTimeseries}
                 uPlotOptions={executionAndPlanningOps}
                 yAxisUnits={AxisUnits.Duration}
+                xScale={xScale}
               />
             </Col>
             <Col className="gutter-row" span={12}>
@@ -876,6 +882,7 @@ export class StatementDetails extends React.Component<
                 alignedData={rowsProcessedTimeseries}
                 uPlotOptions={rowsProcessedOps}
                 yAxisUnits={AxisUnits.Count}
+                xScale={xScale}
               />
             </Col>
           </Row>
@@ -886,6 +893,7 @@ export class StatementDetails extends React.Component<
                 alignedData={execRetriesTimeseries}
                 uPlotOptions={execRetriesOps}
                 yAxisUnits={AxisUnits.Count}
+                xScale={xScale}
               />
             </Col>
             <Col className="gutter-row" span={12}>
@@ -894,6 +902,7 @@ export class StatementDetails extends React.Component<
                 alignedData={execCountTimeseries}
                 uPlotOptions={execCountOps}
                 yAxisUnits={AxisUnits.Count}
+                xScale={xScale}
               />
             </Col>
           </Row>
@@ -905,6 +914,7 @@ export class StatementDetails extends React.Component<
                 uPlotOptions={contentionOps}
                 tooltip={unavailableTooltip}
                 yAxisUnits={AxisUnits.Duration}
+                xScale={xScale}
               />
             </Col>
             <Col className="gutter-row" span={12}>
@@ -914,6 +924,7 @@ export class StatementDetails extends React.Component<
                 uPlotOptions={cpuOps}
                 tooltip={unavailableTooltip}
                 yAxisUnits={AxisUnits.Duration}
+                xScale={xScale}
               />
             </Col>
           </Row>
@@ -939,6 +950,7 @@ export class StatementDetails extends React.Component<
                 alignedData={clientWaitTimeseries}
                 uPlotOptions={clientWaitOps}
                 yAxisUnits={AxisUnits.Duration}
+                xScale={xScale}
               />
             </Col>
           </Row>


### PR DESCRIPTION
Previously, we were using the data values to define the start and end date of charts, which could cause confusion, since users might think that is a bug of now showing data, when instead there is no data to show.
This commit forces the start and end of the chart to be the selected period, this way we always show the correct period even if we don't have data to show.

Fixes #102214

https://www.loom.com/share/3f463d82407b4ab186a5b0c1e1ab2369

Release note (ui change): On Statement Details page always show the entire selected period, instead of just the period that had data.