### PR TITLE
sem/tree: remove IndexedVarContainer format method

### DIFF
--- a/pkg/sql/catalog/schemaexpr/computed_exprs.go
+++ b/pkg/sql/catalog/schemaexpr/computed_exprs.go
@@ -50,11 +50,6 @@ func (*RowIndexedVarContainer) IndexedVarResolvedType(idx int) *types.T {
 	panic("unsupported")
 }
 
-// IndexedVarNodeFormatter implements tree.IndexedVarContainer.
-func (*RowIndexedVarContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return nil
-}
-
 // CannotWriteToComputedColError constructs a write error for a computed column.
 func CannotWriteToComputedColError(colName string) error {
 	return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -410,11 +410,6 @@ func (nrc *nameResolverIVarContainer) IndexedVarResolvedType(idx int) *types.T {
 	return nrc.cols[idx].GetType()
 }
 
-// IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
-func (nrc *nameResolverIVarContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return nil
-}
-
 // SanitizeVarFreeExpr verifies that an expression is valid, has the correct
 // type and contains no variable expressions. It returns the type-checked and
 // constant-folded expression.

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -395,15 +395,7 @@ type nameResolverIVarContainer struct {
 	cols []catalog.Column
 }
 
-var _ eval.IndexedVarContainer = &nameResolverIVarContainer{}
-
-// IndexedVarEval implements the eval.IndexedVarContainer interface.
-// Evaluation is not supported, so this function panics.
-func (nrc *nameResolverIVarContainer) IndexedVarEval(
-	ctx context.Context, idx int, e tree.ExprEvaluator,
-) (tree.Datum, error) {
-	panic("unsupported")
-}
+var _ tree.IndexedVarContainer = &nameResolverIVarContainer{}
 
 // IndexedVarResolvedType implements the tree.IndexedVarContainer interface.
 func (nrc *nameResolverIVarContainer) IndexedVarResolvedType(idx int) *types.T {

--- a/pkg/sql/colexec/colexectestutils/proj_utils.go
+++ b/pkg/sql/colexec/colexectestutils/proj_utils.go
@@ -44,12 +44,6 @@ func (p *MockTypeContext) IndexedVarResolvedType(idx int) *types.T {
 	return p.Typs[idx]
 }
 
-// IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
-func (p *MockTypeContext) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	n := tree.Name(fmt.Sprintf("$%d", idx))
-	return &n
-}
-
 // CreateTestProjectingOperator creates a projecting operator that performs
 // projectingExpr on input that has inputTypes as its output columns. It does
 // so by making a noop processor core with post-processing step that passes

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2817,7 +2817,7 @@ func (dsp *DistSQLPlanner) planAggregators(
 		if needRender {
 			// Build rendering expressions.
 			renderExprs := make([]execinfrapb.Expression, len(info.aggregations))
-			h := tree.MakeTypesOnlyIndexedVarHelper(finalPreRenderTypes)
+			h := tree.MakeIndexedVarHelperWithTypes(finalPreRenderTypes)
 			// finalIdx is an index inside finalAggs. It is used to
 			// keep track of the finalAggs results that correspond
 			// to each aggregation.

--- a/pkg/sql/execinfrapb/expr.go
+++ b/pkg/sql/execinfrapb/expr.go
@@ -12,7 +12,6 @@ package execinfrapb
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -293,12 +292,6 @@ func (eh *exprHelper) IndexedVarEval(
 		return nil, err
 	}
 	return eh.row[idx].Datum.Eval(ctx, e)
-}
-
-// IndexedVarNodeFormatter is part of the tree.IndexedVarContainer interface.
-func (eh *exprHelper) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	n := tree.Name(fmt.Sprintf("$%d", idx))
-	return &n
 }
 
 // init initializes the exprHelper.

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -43,11 +43,6 @@ func (f *filterNode) IndexedVarResolvedType(idx int) *types.T {
 	return f.source.columns[idx].Typ
 }
 
-// IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
-func (f *filterNode) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return f.source.columns.Name(idx)
-}
-
 func (f *filterNode) startExec(runParams) error {
 	return nil
 }

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -124,14 +124,6 @@ func (p *joinPredicate) IndexedVarResolvedType(idx int) *types.T {
 	return p.rightCols[idx-p.numLeftCols].Typ
 }
 
-// IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
-func (p *joinPredicate) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	if idx < p.numLeftCols {
-		return p.leftCols.Name(idx)
-	}
-	return p.rightCols.Name(idx - p.numLeftCols)
-}
-
 // eval for joinPredicate runs the on condition across the columns that do
 // not participate in the equality (the equality columns are checked
 // in the join algorithm already).

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -394,8 +394,3 @@ func (c *mdVarContainer) IndexedVarEval(
 func (c *mdVarContainer) IndexedVarResolvedType(idx int) *types.T {
 	return c.md.ColumnMeta(opt.ColumnID(idx + 1)).Type
 }
-
-// IndexedVarNodeFormatter is part of the IndexedVarContainer interface.
-func (c *mdVarContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return nil
-}

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -381,14 +381,7 @@ type mdVarContainer struct {
 	md *opt.Metadata
 }
 
-var _ eval.IndexedVarContainer = &mdVarContainer{}
-
-// IndexedVarEval is part of the eval.IndexedVarContainer interface.
-func (c *mdVarContainer) IndexedVarEval(
-	ctx context.Context, idx int, e tree.ExprEvaluator,
-) (tree.Datum, error) {
-	return nil, errors.AssertionFailedf("no eval allowed in mdVarContainer")
-}
+var _ tree.IndexedVarContainer = &mdVarContainer{}
 
 // IndexedVarResolvedType is part of the IndexedVarContainer interface.
 func (c *mdVarContainer) IndexedVarResolvedType(idx int) *types.T {

--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -959,12 +959,6 @@ func (g *geoDatumsToInvertedExpr) IndexedVarResolvedType(idx int) *types.T {
 	return g.colTypes[idx]
 }
 
-// IndexedVarNodeFormatter is part of the IndexedVarContainer interface.
-func (g *geoDatumsToInvertedExpr) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	n := tree.Name(fmt.Sprintf("$%d", idx))
-	return &n
-}
-
 // NewGeoDatumsToInvertedExpr returns a new geoDatumsToInvertedExpr.
 func NewGeoDatumsToInvertedExpr(
 	ctx context.Context,

--- a/pkg/sql/opt/invertedidx/json_array.go
+++ b/pkg/sql/opt/invertedidx/json_array.go
@@ -223,12 +223,6 @@ func (g *jsonOrArrayDatumsToInvertedExpr) IndexedVarResolvedType(idx int) *types
 	return g.colTypes[idx]
 }
 
-// IndexedVarNodeFormatter is part of the IndexedVarContainer interface.
-func (g *jsonOrArrayDatumsToInvertedExpr) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	n := tree.Name(fmt.Sprintf("$%d", idx))
-	return &n
-}
-
 // NewJSONOrArrayDatumsToInvertedExpr returns a new
 // jsonOrArrayDatumsToInvertedExpr.
 func NewJSONOrArrayDatumsToInvertedExpr(

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1655,11 +1655,6 @@ func (s *scope) IndexedVarResolvedType(idx int) *types.T {
 	return s.cols[idx].typ
 }
 
-// IndexedVarNodeFormatter is part of the IndexedVarContainer interface.
-func (s *scope) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	panic(errors.AssertionFailedf("unimplemented: scope.IndexedVarNodeFormatter"))
-}
-
 // newAmbiguousSourceError returns an error with a helpful error message to be
 // used in case of an ambiguous table name.
 func newAmbiguousSourceError(tn *tree.TableName) error {

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1633,14 +1633,7 @@ func (*scope) VisitPost(expr tree.Expr) tree.Expr {
 // scope implements the IndexedVarContainer interface so it can be used as
 // semaCtx.IVarContainer. This allows tree.TypeCheck to determine the correct
 // type for any IndexedVars.
-var _ eval.IndexedVarContainer = &scope{}
-
-// IndexedVarEval is part of the eval.IndexedVarContainer interface.
-func (s *scope) IndexedVarEval(
-	ctx context.Context, idx int, e tree.ExprEvaluator,
-) (tree.Datum, error) {
-	panic(errors.AssertionFailedf("unimplemented: scope.IndexedVarEval"))
-}
+var _ tree.IndexedVarContainer = &scope{}
 
 // IndexedVarResolvedType is part of the IndexedVarContainer interface.
 func (s *scope) IndexedVarResolvedType(idx int) *types.T {

--- a/pkg/sql/physicalplan/aggregator_funcs_test.go
+++ b/pkg/sql/physicalplan/aggregator_funcs_test.go
@@ -222,7 +222,7 @@ func checkDistAggregationInfo(
 	// First run a flow that aggregates all the rows without any local stages.
 	nonDistFinalOutputTypes := finalOutputTypes
 	if info.FinalRendering != nil {
-		h := tree.MakeTypesOnlyIndexedVarHelper(finalOutputTypes)
+		h := tree.MakeIndexedVarHelperWithTypes(finalOutputTypes)
 		renderExpr, err := info.FinalRendering(&h, varIdxs)
 		if err != nil {
 			t.Fatal(err)
@@ -326,7 +326,7 @@ func checkDistAggregationInfo(
 	}
 
 	if info.FinalRendering != nil {
-		h := tree.MakeTypesOnlyIndexedVarHelper(finalOutputTypes)
+		h := tree.MakeIndexedVarHelperWithTypes(finalOutputTypes)
 		renderExpr, err := info.FinalRendering(&h, varIdxs)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -72,11 +72,6 @@ func (r *renderNode) IndexedVarResolvedType(idx int) *types.T {
 	return r.source.columns[idx].Typ
 }
 
-// IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
-func (r *renderNode) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return r.source.columns.Name(idx)
-}
-
 func (r *renderNode) startExec(runParams) error {
 	panic("renderNode can't be run in local mode")
 }

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -58,14 +57,7 @@ type renderNode struct {
 	reqOrdering ReqOrdering
 }
 
-var _ eval.IndexedVarContainer = &renderNode{}
-
-// IndexedVarEval implements the eval.IndexedVarContainer interface.
-func (r *renderNode) IndexedVarEval(
-	ctx context.Context, idx int, e tree.ExprEvaluator,
-) (tree.Datum, error) {
-	panic("renderNode can't be run in local mode")
-}
+var _ tree.IndexedVarContainer = &renderNode{}
 
 // IndexedVarResolvedType implements the tree.IndexedVarContainer interface.
 func (r *renderNode) IndexedVarResolvedType(idx int) *types.T {

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -150,11 +150,6 @@ func (n *scanNode) IndexedVarResolvedType(idx int) *types.T {
 	return n.resultColumns[idx].Typ
 }
 
-// IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
-func (n *scanNode) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return n.resultColumns.Name(idx)
-}
-
 func (n *scanNode) startExec(params runParams) error {
 	panic("scanNode can't be run in local mode")
 }

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -136,14 +135,7 @@ func (p *planner) Scan() *scanNode {
 }
 
 // scanNode implements eval.IndexedVarContainer.
-var _ eval.IndexedVarContainer = &scanNode{}
-
-// IndexedVarEval implements the eval.IndexedVarContainer interface.
-func (n *scanNode) IndexedVarEval(
-	ctx context.Context, idx int, e tree.ExprEvaluator,
-) (tree.Datum, error) {
-	panic("scanNode can't be run in local mode")
-}
+var _ tree.IndexedVarContainer = &scanNode{}
 
 // IndexedVarResolvedType implements the tree.IndexedVarContainer interface.
 func (n *scanNode) IndexedVarResolvedType(idx int) *types.T {

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -106,10 +106,6 @@ const (
 	// resolutions.
 	fmtDisambiguateDatumTypes
 
-	// fmtSymbolicVars indicates that IndexedVars must be pretty-printed
-	// using numeric notation (@123).
-	fmtSymbolicVars
-
 	// fmtUnicodeStrings prints strings and JSON using the Go string
 	// formatter. This is used e.g. for emitting values to CSV files.
 	fmtRawStrings
@@ -216,8 +212,7 @@ const (
 	//  - user defined types and datums of user defined types are formatted
 	//    using static representations to avoid name resolution and invalidation
 	//    due to changes in the underlying type.
-	FmtCheckEquivalence = fmtSymbolicVars |
-		fmtDisambiguateDatumTypes |
+	FmtCheckEquivalence = fmtDisambiguateDatumTypes |
 		FmtParsableNumerics |
 		fmtStaticallyFormatUserDefinedTypes
 

--- a/pkg/sql/sem/tree/indexed_vars.go
+++ b/pkg/sql/sem/tree/indexed_vars.go
@@ -199,10 +199,10 @@ func (tc *typeContainer) IndexedVarResolvedType(idx int) *types.T {
 	return tc.types[idx]
 }
 
-// MakeTypesOnlyIndexedVarHelper creates an IndexedVarHelper which provides
+// MakeIndexedVarHelperWithTypes creates an IndexedVarHelper which provides
 // the given types for indexed vars. It does not support evaluation, unless
 // RebindTyped is used with another container which supports evaluation.
-func MakeTypesOnlyIndexedVarHelper(types []*types.T) IndexedVarHelper {
+func MakeIndexedVarHelperWithTypes(types []*types.T) IndexedVarHelper {
 	c := &typeContainer{types: types}
 	return MakeIndexedVarHelper(c, len(types))
 }


### PR DESCRIPTION
#### sem/tree: remove IndexedVarContainer format method

`IndexedVarContainer.IndexedVarNodeFormatter` is a vestigial interface
method that is no longer needed. All indexed vars can be formatted in
the canonical representation: "@%d". This cuts the size of the
`IndexedVar` struct in half.

Informs #117546

Release note: None

#### sql: remove implementations of eval.IndexedVarContainer

This commit removes some unnecessary implementations of
`eval.IndexedVarContainer`. It also renames
`tree.MakeTypesOnlyIndexedVarHelper` to
`tree.MakeIndexedVarHelperWithTypes.

Release note: None

#### sem/tree: remove fmtSymbolicVars format flag

The `fmtSymbolicVars` format flag is no longer used and has been
removed.

Release note: None