### PR TITLE
cli/demo: make demo:// shorthand more powerful

### DIFF
--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -1591,7 +1591,13 @@ func (c *transientCluster) getNetworkURLForServerAndUser(
 		u.WithTransport(pgurl.TransportTLS(
 			pgurl.TLSRequire, filepath.Join(c.demoDir, certnames.CACertFilename())))
 
-		u.WithAuthn(pgurl.AuthnPassword(true, password))
+		if password != "" {
+			u.WithAuthn(pgurl.AuthnPassword(true, password))
+		} else {
+			clientCert := filepath.Join(c.demoDir, certnames.ClientCertFilename(user))
+			clientKey := filepath.Join(c.demoDir, certnames.ClientKeyFilename(user))
+			u.WithAuthn(pgurl.AuthnClientCert(clientCert, clientKey))
+		}
 	}
 	return u, nil
 }
@@ -2058,7 +2064,7 @@ func (c *transientCluster) ExpandShortDemoURLs(s string) string {
 		}
 
 		// By default we'll connect to the default demo user/pw, but use an explicit
-		// user/pw if specified.
+		// user/pw if specified. An empty pw will switch to client-cert auth.
 		user, password := c.adminUser, c.adminPassword
 		if parsed.User != nil {
 			user, err = username.MakeSQLUsernameFromUserInput(parsed.User.Username(), username.PurposeValidation)

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -2037,14 +2037,21 @@ func (c *transientCluster) ExpandShortDemoURLs(s string) string {
 		return s
 	}
 
-	for _, match := range regexp.MustCompile(`demo://[a-zA-Z0-9]+`).FindAllString(s, -1) {
+	for _, match := range regexp.MustCompile(`demo://[a-zA-Z0-9:]+`).FindAllString(s, -1) {
 		parsed, err := url.Parse(match)
 		if err != nil {
 			continue
 		}
+
+		// If a node number if specified (using port number), use it.
+		idx := 0
+		if i, err := strconv.Atoi(parsed.Port()); err == nil && i > 0 && i <= len(c.servers) {
+			idx = i - 1
+		}
+
 		// Generate the new URL, then replace the demo one with it.
 		replaced, err := c.getNetworkURLForServer(context.Background(),
-			0, false, serverSelection(parsed.Hostname()),
+			idx, false, serverSelection(parsed.Hostname()),
 		)
 		if err != nil {
 			continue

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -1547,7 +1547,7 @@ func (c *transientCluster) generateCerts(ctx context.Context, certsDir string) (
 func (c *transientCluster) getNetworkURLForServer(
 	ctx context.Context, serverIdx int, includeAppName bool, target serverSelection,
 ) (*pgurl.URL, error) {
-	return c.getNetworkURLForServerAndUser(ctx, serverIdx, includeAppName, c.adminUser, c.adminPassword, target)
+	return c.getNetworkURLForServerAndUser(ctx, serverIdx, includeAppName, c.adminUser, c.adminPassword, target, "")
 }
 
 func (c *transientCluster) getNetworkURLForServerAndUser(
@@ -1557,6 +1557,7 @@ func (c *transientCluster) getNetworkURLForServerAndUser(
 	user username.SQLUsername,
 	password string,
 	target serverSelection,
+	database string,
 ) (*pgurl.URL, error) {
 	u := pgurl.New()
 	if includeAppName {
@@ -1565,12 +1566,14 @@ func (c *transientCluster) getNetworkURLForServerAndUser(
 		}
 	}
 	sqlAddr := c.servers[serverIdx].AdvSQLAddr()
-	database := c.defaultDB
 	if target != forSystemTenant {
 		sqlAddr = c.tenantServers[serverIdx].SQLAddr()
 	}
-	if (target == forSystemTenant) && c.demoCtx.Multitenant {
-		database = catalogkeys.DefaultDatabaseName
+	if database == "" {
+		database = c.defaultDB
+		if (target == forSystemTenant) && c.demoCtx.Multitenant {
+			database = catalogkeys.DefaultDatabaseName
+		}
 	}
 
 	if err := c.extendURLWithTargetCluster(u, target); err != nil {
@@ -2051,7 +2054,7 @@ func (c *transientCluster) ExpandShortDemoURLs(s string) string {
 		return s
 	}
 
-	for _, match := range regexp.MustCompile(`demo://[a-zA-Z0-9:@]+`).FindAllString(s, -1) {
+	for _, match := range regexp.MustCompile(`demo://[a-zA-Z0-9:@/]+`).FindAllString(s, -1) {
 		parsed, err := url.Parse(match)
 		if err != nil {
 			continue
@@ -2076,7 +2079,7 @@ func (c *transientCluster) ExpandShortDemoURLs(s string) string {
 
 		// Generate the new URL, then replace the demo one with it.
 		replaced, err := c.getNetworkURLForServerAndUser(context.Background(),
-			idx, false, user, password, serverSelection(parsed.Hostname()),
+			idx, false, user, password, serverSelection(parsed.Hostname()), strings.TrimPrefix(parsed.Path, "/"),
 		)
 		if err != nil {
 			continue

--- a/pkg/cli/interactive_tests/test_demo_cli_integration.tcl
+++ b/pkg/cli/interactive_tests/test_demo_cli_integration.tcl
@@ -112,9 +112,9 @@ send "\\connect cluster:system/postgres - - - autocerts\r"
 eexpect root@
 eexpect "system/postgres>"
 
-send "\\c demo://demo@demoapp"
+send "\\c demo://demo@demoapp/system"
 eexpect demo@
-eexpect "demoapp/defaultdb>"
+eexpect "demoapp/system>"
 
 send "\\c demo://root@system"
 eexpect root@

--- a/pkg/cli/interactive_tests/test_demo_cli_integration.tcl
+++ b/pkg/cli/interactive_tests/test_demo_cli_integration.tcl
@@ -112,6 +112,14 @@ send "\\connect cluster:system/postgres - - - autocerts\r"
 eexpect root@
 eexpect "system/postgres>"
 
+send "\\c demo://demo@demoapp"
+eexpect demo@
+eexpect "demoapp/defaultdb>"
+
+send "\\c demo://root@system"
+eexpect root@
+eexpect "system/defaultdb>"
+
 end_test
 
 send "\\q\r"
@@ -148,6 +156,11 @@ eexpect "2 rows"
 eexpect "system/defaultdb>"
 send "\\q\r"
 eexpect eof
+
+send "\\c demo://root:abc@system"
+eexpect root@
+eexpect "system/defaultdb>"
+
 end_test
 
 spawn /bin/bash


### PR DESCRIPTION
This extends the `demo://` shorthand in `demo` to support:
* specifying which "node" via the port number
* specifying the user and optionally password to use, or to use cert-based auth instead
* specifying which database to use

The URL generation is also cleaned up a bit, now preferring to parameterize the existing generation function rather than simply modifying the string it produced with find-and-replace, to better support these additional behaviors.