### PR TITLE
sql: allow usage of table stats on system.jobs

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/featureflag"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -206,21 +205,9 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 		)
 	}
 
-	if tableDesc.GetID() == keys.TableStatisticsTableID {
-		return nil, pgerror.New(
-			pgcode.WrongObjectType, "cannot create statistics on system.table_statistics",
-		)
-	}
-
-	if tableDesc.GetID() == keys.LeaseTableID {
-		return nil, pgerror.New(
-			pgcode.WrongObjectType, "cannot create statistics on system.lease",
-		)
-	}
-
-	if tableDesc.GetID() == keys.ScheduledJobsTableID {
-		return nil, pgerror.New(
-			pgcode.WrongObjectType, "cannot create statistics on system.scheduled_jobs",
+	if stats.DisallowedOnSystemTable(tableDesc.GetID()) {
+		return nil, pgerror.Newf(
+			pgcode.WrongObjectType, "cannot create statistics on system.%s", tableDesc.GetName(),
 		)
 	}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -1,7 +1,4 @@
-# LogicTest: 5node
-
-# Tests that verify we retrieve the stats correctly. Note that we can't create
-# statistics if distsql mode is OFF.
+# LogicTest: local
 
 statement ok
 CREATE TABLE uv (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
@@ -373,3 +370,42 @@ limit
  │    └── filters
  │         └── j:1 IS NULL [outer=(1), immutable, constraints=(/1: [/NULL - /NULL]; tight), fd=()-->(1)]
  └── 1
+
+# Ensure we can run ALTER statements on the system.jobs table.
+statement ok
+INSERT INTO system.users VALUES ('node', NULL, true, 3);
+
+statement ok
+GRANT node TO root;
+
+# Ensure that stats on the system.jobs table are being used.
+statement ok
+ALTER TABLE system.jobs INJECT STATISTICS '[
+    {
+        "avg_size": 7,
+        "columns": [
+            "id"
+        ],
+        "created_at": "2024-02-02 22:56:02.854028",
+        "distinct_count": 19,
+        "histo_col_type": "INT8",
+        "histo_version": 3,
+        "null_count": 0,
+        "row_count": 19
+    }
+]';
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT * FROM system.jobs;
+----
+scan jobs
+ ├── columns: id:1 status:2 created:3 created_by_type:4 created_by_id:5 claim_session_id:6 claim_instance_id:7 num_runs:8 last_run:9 job_type:10
+ ├── partial index predicates
+ │    └── jobs_run_stats_idx: filters
+ │         └── status:2 IN ('cancel-requested', 'pause-requested', 'pending', 'reverting', 'running') [outer=(2), constraints=(/2: [/'cancel-requested' - /'cancel-requested'] [/'pause-requested' - /'pause-requested'] [/'pending' - /'pending'] [/'reverting' - /'reverting'] [/'running' - /'running']; tight)]
+ ├── stats: [rows=19]
+ ├── cost: 59.49
+ ├── key: (1)
+ ├── fd: (1)-->(2-10)
+ ├── distribution: test
+ └── prune: (1-10)

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 29,
+    shard_count = 28,
     tags = [
         "cpu:3",
     ],

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
@@ -288,10 +288,3 @@ func TestExecBuild_scan_parallel(
 	defer leaktest.AfterTest(t)()
 	runExecBuildLogicTest(t, "scan_parallel")
 }
-
-func TestExecBuild_stats(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runExecBuildLogicTest(t, "stats")
-}

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -590,6 +590,13 @@ func TestExecBuild_srfs(
 	runExecBuildLogicTest(t, "srfs")
 }
 
+func TestExecBuild_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "stats")
+}
+
 func TestExecBuild_straight_join(
 	t *testing.T,
 ) {


### PR DESCRIPTION
In 23.1 (in a6e2818085a8c9097a2a1251d88f0d80533106b6, also fixed in fe2e2508ab6f34d82a53cc3ad599538c3a9b5a62) we allowed stats collection on `system.jobs` table. However, we forgot to update another place where the jobs table ID was mentioned - whether auto collection on the jobs table is allowed and whether usage (by the optimizer) of the table stats on jobs table is allowed. This is now fixed.

Additionally, this commit performs a minor cleanup of tests around this. In particular, `stats` execbuilder test now runs in the local mode (previously it was using 5node due to some peculiar historical reasons).

Epic: None

Release note: None