### PR TITLE
types: implement recursive copy for type hydration

### DIFF
--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -754,8 +754,7 @@ func (desc *immutable) AsTypesT() *types.T {
 	case descpb.TypeDescriptor_ENUM, descpb.TypeDescriptor_MULTIREGION_ENUM:
 		return types.MakeEnum(catid.TypeIDToOID(desc.GetID()), catid.TypeIDToOID(desc.ArrayTypeID))
 	case descpb.TypeDescriptor_ALIAS:
-		cpy := *desc.Alias
-		return &cpy
+		return desc.Alias.CopyForHydrate()
 	case descpb.TypeDescriptor_COMPOSITE:
 		contents := make([]*types.T, len(desc.Composite.Elements))
 		labels := make([]string, len(desc.Composite.Elements))


### PR DESCRIPTION
We attempted to fix a data race due to type hydration in #118585, but this was insufficient because tuple and array types recursively reference other types. This patch adds (and calls) the `CopyForHydrate` method to copy both a type and any types it references internally.

Fixes #118691

Release note: None