### PR TITLE
sql: replace context.TODO with proper contexts

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -114,5 +114,5 @@ exp,benchmark
 3,UDFResolution/select_from_udf
 1,VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1,VirtualTableQueries/select_crdb_internal.tables_with_1_fk
-9,VirtualTableQueries/virtual_table_cache_with_point_lookups
+11,VirtualTableQueries/virtual_table_cache_with_point_lookups
 15,VirtualTableQueries/virtual_table_cache_with_schema_change

--- a/pkg/ccl/multiregionccl/unique_test.go
+++ b/pkg/ccl/multiregionccl/unique_test.go
@@ -102,7 +102,9 @@ CREATE TABLE u (
 		require.NoError(t, err)
 		require.Equal(t, 1, len(primaryIndexEntry))
 		secondaryIndexEntry, err := rowenc.EncodeSecondaryIndex(
-			keys.SystemSQLCodec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
+			context.Background(), keys.SystemSQLCodec, tableDesc, secondaryIndex,
+			colIDtoRowIndex, values, true, /* includeEmpty */
+		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(secondaryIndexEntry))
 

--- a/pkg/ccl/partitionccl/scrub_test.go
+++ b/pkg/ccl/partitionccl/scrub_test.go
@@ -77,7 +77,10 @@ INSERT INTO db.t VALUES (1, 2, 1), (2, 3, 2);
 	}
 
 	secondaryIndex := tableDesc.PublicNonPrimaryIndexes()[0]
-	secondaryIndexKey, err := rowenc.EncodeSecondaryIndex(codec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true)
+	secondaryIndexKey, err := rowenc.EncodeSecondaryIndex(
+		context.Background(), codec, tableDesc, secondaryIndex,
+		colIDtoRowIndex, values, true, /* includeEmpty */
+	)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
@@ -163,7 +166,10 @@ INSERT INTO db.t VALUES (1, 2, 1), (2, NULL, 2);
 	}
 
 	secondaryIndex := tableDesc.PublicNonPrimaryIndexes()[0]
-	secondaryIndexKey, err := rowenc.EncodeSecondaryIndex(codec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true)
+	secondaryIndexKey, err := rowenc.EncodeSecondaryIndex(
+		context.Background(), codec, tableDesc, secondaryIndex,
+		colIDtoRowIndex, values, true, /* includeEmpty */
+	)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
@@ -236,12 +242,16 @@ INSERT INTO db.t VALUES (1, 3), (2, 4);
 	oldValues := []tree.Datum{tree.NewDInt(1), tree.NewDInt(3)}
 	secondaryIndex := tableDesc.PublicNonPrimaryIndexes()[0]
 	secondaryIndexDelKey, err := rowenc.EncodeSecondaryIndex(
-		codec, tableDesc, secondaryIndex, colIDtoRowIndex, oldValues, true /* includeEmpty */)
+		context.Background(), codec, tableDesc, secondaryIndex,
+		colIDtoRowIndex, oldValues, true, /* includeEmpty */
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	secondaryIndexKey, err := rowenc.EncodeSecondaryIndex(
-		codec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
+		context.Background(), codec, tableDesc, secondaryIndex,
+		colIDtoRowIndex, values, true, /* includeEmpty */
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -319,7 +329,9 @@ INSERT INTO db.t VALUES (1, 2, 1), (2, 3, 2), (3, 5, 1), (4, 6, 2);
 
 	// Modify the secondary index with a duplicate constrained value.
 	secondaryIndexKey, err := rowenc.EncodeSecondaryIndex(
-		codec, tableDesc, secondaryIndex, colIDtoRowIndex, valuesConstrained, true /* includeEmpty */)
+		context.Background(), codec, tableDesc, secondaryIndex,
+		colIDtoRowIndex, valuesConstrained, true, /* includeEmpty */
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -346,7 +358,9 @@ INSERT INTO db.t VALUES (1, 2, 1), (2, 3, 2), (3, 5, 1), (4, 6, 2);
 	// Modify the secondary index with a duplicate value not in the constrained
 	// range.
 	secondaryIndexKey, err = rowenc.EncodeSecondaryIndex(
-		codec, tableDesc, secondaryIndex, colIDtoRowIndex, valuesNotConstrained, true /* includeEmpty */)
+		context.Background(), codec, tableDesc, secondaryIndex,
+		colIDtoRowIndex, valuesNotConstrained, true, /* includeEmpty */
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -437,7 +451,9 @@ INSERT INTO db.t VALUES (1, 1, 2, 1);
 	// Modify the secondary index with the duplicate value.
 	secondaryIndex := tableDesc.PublicNonPrimaryIndexes()[0]
 	secondaryIndexKey, err := rowenc.EncodeSecondaryIndex(
-		codec, tableDesc, secondaryIndex, colIDtoRowIndex, values, true /* includeEmpty */)
+		context.Background(), codec, tableDesc, secondaryIndex,
+		colIDtoRowIndex, values, true, /* includeEmpty */
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/pkg/sql/catalog/bootstrap/kv_writer.go
+++ b/pkg/sql/catalog/bootstrap/kv_writer.go
@@ -69,7 +69,7 @@ func (w KVWriter) RecordToKeyValues(values ...tree.Datum) (ret []roachpb.KeyValu
 	// Encode the secondary index rows.
 	for _, idx := range w.tableDesc.PublicNonPrimaryIndexes() {
 		indexEntries, err := rowenc.EncodeSecondaryIndex(
-			w.codec, w.tableDesc, idx, w.colIDtoRowIndex, values, true, /* includeEmpty */
+			context.Background(), w.codec, w.tableDesc, idx, w.colIDtoRowIndex, values, true, /* includeEmpty */
 		)
 		if err != nil {
 			return nil, errors.NewAssertionErrorWithWrappedErrf(

--- a/pkg/sql/colenc/encode.go
+++ b/pkg/sql/colenc/encode.go
@@ -436,7 +436,7 @@ func (b *BatchEncoder) encodeSecondaryIndex(ctx context.Context, ind catalog.Ind
 	if ind.GetType() == descpb.IndexDescriptor_INVERTED {
 		// Since the inverted indexes generate multiple keys per row just handle them
 		// separately.
-		return b.encodeInvertedSecondaryIndex(ind, kys, b.extraKeys)
+		return b.encodeInvertedSecondaryIndex(ctx, ind, kys, b.extraKeys)
 	} else {
 		keyAndSuffixCols := b.rh.TableDesc.IndexFetchSpecKeyAndSuffixColumns(ind)
 		keyCols := keyAndSuffixCols[:ind.NumKeyColumns()]

--- a/pkg/sql/colenc/inverted.go
+++ b/pkg/sql/colenc/inverted.go
@@ -11,6 +11,8 @@
 package colenc
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -44,7 +46,7 @@ func invertedColToDatum(vec coldata.Vec, row int) tree.Datum {
 // doesn't attempt to do bulk KV operations. TODO(cucaroach): optimize
 // inverted index encoding to do bulk allocations and bulk KV puts.
 func (b *BatchEncoder) encodeInvertedSecondaryIndex(
-	index catalog.Index, kys []roachpb.Key, extraKeys [][]byte,
+	ctx context.Context, index catalog.Index, kys []roachpb.Key, extraKeys [][]byte,
 ) error {
 	var err error
 	if kys, err = b.encodeInvertedIndexPrefixKeys(kys, index); err != nil {
@@ -62,7 +64,7 @@ func (b *BatchEncoder) encodeInvertedSecondaryIndex(
 		var keys [][]byte
 		val := invertedColToDatum(vec, row+b.start)
 		if !indexGeoConfig.IsEmpty() {
-			if keys, err = rowenc.EncodeGeoInvertedIndexTableKeys(val, kys[row], indexGeoConfig); err != nil {
+			if keys, err = rowenc.EncodeGeoInvertedIndexTableKeys(ctx, val, kys[row], indexGeoConfig); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/sql/evalcatalog/geo_inverted_index_entries.go
+++ b/pkg/sql/evalcatalog/geo_inverted_index_entries.go
@@ -39,7 +39,7 @@ func (ec *Builtins) NumGeometryInvertedIndexEntries(
 			"index_id %d is not a geography inverted index", indexID,
 		)
 	}
-	keys, err := rowenc.EncodeGeoInvertedIndexTableKeys(g, nil, geoConfig)
+	keys, err := rowenc.EncodeGeoInvertedIndexTableKeys(ctx, g, nil, geoConfig)
 	if err != nil {
 		return 0, err
 	}
@@ -61,7 +61,7 @@ func (ec *Builtins) NumGeographyInvertedIndexEntries(
 			"index_id %d is not a geography inverted index", indexID,
 		)
 	}
-	keys, err := rowenc.EncodeGeoInvertedIndexTableKeys(g, nil, geoConfig)
+	keys, err := rowenc.EncodeGeoInvertedIndexTableKeys(ctx, g, nil, geoConfig)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/execinfrapb/testutils.go
+++ b/pkg/sql/execinfrapb/testutils.go
@@ -46,7 +46,7 @@ func StartMockDistSQLServer(
 	ctx context.Context, clock *hlc.Clock, stopper *stop.Stopper, sqlInstanceID base.SQLInstanceID,
 ) (uuid.UUID, *MockDistSQLServer, net.Addr, error) {
 	rpcContext := newInsecureRPCContext(ctx, stopper)
-	rpcContext.NodeID.Set(context.TODO(), roachpb.NodeID(sqlInstanceID))
+	rpcContext.NodeID.Set(ctx, roachpb.NodeID(sqlInstanceID))
 	server, err := rpc.NewServer(ctx, rpcContext)
 	if err != nil {
 		return uuid.Nil, nil, nil, err

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -414,7 +414,9 @@ func (ep *DummyEvalPlanner) ResolveTableName(
 }
 
 // GetTypeFromValidSQLSyntax is part of the eval.Planner interface.
-func (ep *DummyEvalPlanner) GetTypeFromValidSQLSyntax(sql string) (*types.T, error) {
+func (ep *DummyEvalPlanner) GetTypeFromValidSQLSyntax(
+	ctx context.Context, sql string,
+) (*types.T, error) {
 	return nil, errors.WithStack(errEvalPlanner)
 }
 

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2228,7 +2228,7 @@ func (b *Builder) indexColumnNames(
 		col := index.Column(i)
 		ord := col.Ordinal()
 		colID := tableMeta.MetaID.ColumnID(ord)
-		colName := b.mem.Metadata().QualifiedAlias(colID, false /* fullyQualify */, true /* alwaysQualify */, b.catalog)
+		colName := b.mem.Metadata().QualifiedAlias(b.ctx, colID, false /* fullyQualify */, true /* alwaysQualify */, b.catalog)
 		sb.WriteString(colName)
 	}
 	return sb.String()
@@ -3636,7 +3636,7 @@ func (b *Builder) getEnvData() (exec.ExplainEnvData, error) {
 	envOpts.Tables, envOpts.Sequences, envOpts.Views, err = b.mem.Metadata().AllDataSourceNames(
 		b.ctx, b.catalog,
 		func(ds cat.DataSource) (cat.DataSourceName, error) {
-			return b.catalog.FullyQualifiedName(context.TODO(), ds)
+			return b.catalog.FullyQualifiedName(b.ctx, ds)
 		},
 		true, /* includeVirtualTables */
 	)

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -102,7 +102,7 @@ func (b *Builder) buildExplainOpt(explain *memo.ExplainExpr) (execPlan, error) {
 	if explain.Options.Flags[tree.ExplainFlagCatalog] {
 		for _, t := range b.mem.Metadata().AllTables() {
 			tp := treeprinter.New()
-			cat.FormatTable(b.catalog, t.Table, tp, redactValues)
+			cat.FormatTable(b.ctx, b.catalog, t.Table, tp, redactValues)
 			catStr := tp.String()
 			if redactValues {
 				catStr = string(redact.RedactableString(catStr).Redact())

--- a/pkg/sql/opt/exec/execbuilder/testdata/geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/geospatial
@@ -26,6 +26,7 @@ INSERT INTO b VALUES
   (1, 'POINT(1.0 1.0)', 'POINT(2.0 2.0)'),
   (2, 'LINESTRING(1.0 1.0, 2.0 2.0)', 'POINT(1.0 1.0)')
 ----
+Scan /Table/20/1/10{6-7}
 CPut /Table/106/1/1/0 -> /TUPLE/
 CPut /Table/106/1/2/0 -> /TUPLE/
 
@@ -34,6 +35,7 @@ INSERT INTO c VALUES
   (1, 'POINT(1.0 1.0)', 'POINT(2.0 2.0)'),
   (2, 'LINESTRING(1.0 1.0, 2.0 2.0)', 'POINT(1.0 1.0)')
 ----
+Scan /Table/20/1/10{7-8}
 CPut /Table/107/1/1/0 -> /TUPLE/
 InitPut /Table/107/2/"B\xfd\x10\x01D\x15@\x80K\xd5\x01?\x91\xdfF\xa2R\x9d9?\x91\xdfF\xa2R\x9d9\x89\x88" -> /BYTES/
 InitPut /Table/107/3/"B\xfd\x10\x00\x00\x00\x00\x00\x00\x01\x01@\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x00\x89\x88" -> /BYTES/

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -106,6 +106,7 @@ Del /Table/106/1/4/0
 query T kvtrace
 INSERT INTO e VALUES(0, ARRAY[7,0,0,1,NULL,10,0,1,7,NULL])
 ----
+Scan /Table/20/1/10{7-8}
 CPut /Table/107/1/0/0 -> /TUPLE/
 InitPut /Table/107/2/NULL/0/0 -> /BYTES/
 InitPut /Table/107/2/0/0/0 -> /BYTES/
@@ -199,6 +200,7 @@ vectorized: true
 query T kvtrace
 INSERT INTO f VALUES(0, ARRAY[7,0,0,1.000,10,0,1,7,1.0,1.00])
 ----
+Scan /Table/20/1/10{8-9}
 CPut /Table/108/1/0/0 -> /TUPLE/
 InitPut /Table/108/2/0/0/0 -> /BYTES/
 InitPut /Table/108/2/1/0/0 -> /BYTES/
@@ -3231,6 +3233,7 @@ CREATE INVERTED INDEX ON t(y)
 query T kvtrace
 INSERT INTO t VALUES (1.00, ARRAY[1,2])
 ----
+Scan /Table/20/1/109{-/PrefixEnd}
 CPut /Table/109/1/1/0 -> /TUPLE/1:1:Decimal/1.00/
 InitPut /Table/109/2/1/1/0 -> /BYTES/0x1503348964
 InitPut /Table/109/2/2/1/0 -> /BYTES/0x1503348964
@@ -3509,6 +3512,7 @@ CREATE TABLE m (
 query T kvtrace
 SELECT k FROM m@i1 WHERE a = 10 AND j @> '{"a": "b"}'
 ----
+Scan /Table/20/1/11{2-3}
 Scan /Table/112/2/10/"a"/"b"{-/PrefixEnd}
 
 # Combine multiple constraint spans with the inverted constraint.

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
@@ -14,6 +14,7 @@ CREATE TABLE t (
 query T kvtrace
 SELECT k FROM t WHERE i = 10 AND j @> '1'
 ----
+Scan /Table/20/1/10{6-7}
 Scan /Table/106/2/10/1{-/PrefixEnd}, /Table/106/2/10/Arr/1{-/PrefixEnd}
 
 query T kvtrace

--- a/pkg/sql/opt/exec/execbuilder/testdata/json
+++ b/pkg/sql/opt/exec/execbuilder/testdata/json
@@ -251,6 +251,7 @@ query T kvtrace
 INSERT INTO composite VALUES (1, '1.00'::JSONB), (2, '1'::JSONB), (3, '2'::JSONB),
  (4, '3.0'::JSONB), (5, '"a"'::JSONB)
 ----
+Scan /Table/20/1/10{8-9}
 CPut /Table/108/1/1/0 -> /TUPLE/
 InitPut /Table/108/2/"H*\x02\x00\x00\x89\x88" -> /BYTES/0x2f0f0c200000002000000403348964
 CPut /Table/108/1/2/0 -> /TUPLE/

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -203,6 +203,7 @@ CREATE TABLE u (
 query T kvtrace
 SELECT a FROM t WHERE a > b AND c = 'foo'
 ----
+Scan /Table/20/1/11{2-3}
 Scan /Table/112/4/"foo"{-/PrefixEnd}
 
 query T kvtrace
@@ -246,6 +247,7 @@ InitPut /Table/112/4/"foo"/12/0 -> /BYTES/
 query T kvtrace
 INSERT INTO u VALUES (1, 2, 3)
 ----
+Scan /Table/20/1/11{3-4}
 CPut /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
 
 # Inserted row matches partial index with predicate column that is not indexed.

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -303,7 +303,7 @@ func (f *PlanGistFactory) decodeTable() cat.Table {
 		return &unknownTable{}
 	}
 	id := f.decodeID()
-	ds, _, err := f.catalog.ResolveDataSourceByID(context.TODO(), cat.Flags{}, id)
+	ds, _, err := f.catalog.ResolveDataSourceByID(f.Ctx(), cat.Flags{}, id)
 	if err == nil {
 		return ds.(cat.Table)
 	}

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1530,7 +1530,7 @@ func (f *ExprFmtCtx) formatColSimpleToBuffer(buf *bytes.Buffer, label string, id
 		if f.Memo != nil {
 			md := f.Memo.metadata
 			fullyQualify := !f.HasFlags(ExprFmtHideQualifications)
-			label = md.QualifiedAlias(id, fullyQualify, false /* alwaysQualify */, f.Catalog)
+			label = md.QualifiedAlias(f.Ctx, id, fullyQualify, false /* alwaysQualify */, f.Catalog)
 		} else {
 			label = fmt.Sprintf("unknown%d", id)
 		}
@@ -1816,7 +1816,7 @@ func tableName(f *ExprFmtCtx, tabID opt.TableID) string {
 	if f.HasFlags(ExprFmtHideQualifications) {
 		return string(tabMeta.Table.Name())
 	}
-	tn, err := f.Catalog.FullyQualifiedName(context.TODO(), tabMeta.Table)
+	tn, err := f.Catalog.FullyQualifiedName(f.Ctx, tabMeta.Table)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -797,7 +797,7 @@ func (md *Metadata) ColumnMeta(colID ColumnID) *ColumnMeta {
 //     name: "tabName.columnAlias". If alwaysQualify is true, then the column
 //     alias is always prefixed with the table alias.
 func (md *Metadata) QualifiedAlias(
-	colID ColumnID, fullyQualify, alwaysQualify bool, catalog cat.Catalog,
+	ctx context.Context, colID ColumnID, fullyQualify, alwaysQualify bool, catalog cat.Catalog,
 ) string {
 	cm := md.ColumnMeta(colID)
 	if cm.Table == 0 {
@@ -839,7 +839,7 @@ func (md *Metadata) QualifiedAlias(
 
 	var sb strings.Builder
 	if fullyQualify {
-		tn, err := catalog.FullyQualifiedName(context.TODO(), md.TableMeta(cm.Table).Table)
+		tn, err := catalog.FullyQualifiedName(ctx, md.TableMeta(cm.Table).Table)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -364,7 +364,7 @@ func (tc *Catalog) Schema() *Schema {
 
 // Table returns the test table that was previously added with the given name.
 func (tc *Catalog) Table(name *tree.TableName) *Table {
-	ds, _, err := tc.ResolveDataSource(context.TODO(), cat.Flags{}, name)
+	ds, _, err := tc.ResolveDataSource(context.Background(), cat.Flags{}, name)
 	if err != nil {
 		panic(err)
 	}
@@ -378,7 +378,7 @@ func (tc *Catalog) Table(name *tree.TableName) *Table {
 // LookupTable returns the test table that was previously added with the given
 // name but returns an error if the name does not exist instead of panicking.
 func (tc *Catalog) LookupTable(name *tree.TableName) (*Table, error) {
-	ds, _, err := tc.ResolveDataSource(context.TODO(), cat.Flags{}, name)
+	ds, _, err := tc.ResolveDataSource(context.Background(), cat.Flags{}, name)
 	if err != nil {
 		return nil, err
 	}
@@ -412,7 +412,7 @@ func (tc *Catalog) AddTable(tab *Table) {
 
 // View returns the test view that was previously added with the given name.
 func (tc *Catalog) View(name *cat.DataSourceName) *View {
-	ds, _, err := tc.ResolveDataSource(context.TODO(), cat.Flags{}, name)
+	ds, _, err := tc.ResolveDataSource(context.Background(), cat.Flags{}, name)
 	if err != nil {
 		panic(err)
 	}
@@ -765,7 +765,7 @@ var _ cat.Table = &Table{}
 
 func (tt *Table) String() string {
 	tp := treeprinter.New()
-	cat.FormatTable(tt.Catalog, tt, tp, false /* redactableValues */)
+	cat.FormatTable(context.Background(), tt.Catalog, tt, tp, false /* redactableValues */)
 	return tp.String()
 }
 

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -559,7 +559,7 @@ func (oc *optCatalog) dataSourceForTable(
 	var tableStats []*stats.TableStatistic
 	if !flags.NoTableStats {
 		var err error
-		tableStats, err = oc.planner.execCfg.TableStatsCache.GetTableStats(context.TODO(), desc)
+		tableStats, err = oc.planner.execCfg.TableStatsCache.GetTableStats(ctx, desc)
 		if err != nil {
 			// Ignore any error. We still want to be able to run queries even if we lose
 			// access to the statistics table.

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -678,12 +678,12 @@ func (p *planner) SpanStatsConsumer() keyvisualizer.SpanStatsConsumer {
 
 // GetTypeFromValidSQLSyntax implements the eval.Planner interface.
 // We define this here to break the dependency from eval.go to the parser.
-func (p *planner) GetTypeFromValidSQLSyntax(sql string) (*types.T, error) {
+func (p *planner) GetTypeFromValidSQLSyntax(ctx context.Context, sql string) (*types.T, error) {
 	ref, err := parser.GetTypeFromValidSQLSyntax(sql)
 	if err != nil {
 		return nil, err
 	}
-	return tree.ResolveType(context.TODO(), ref, p.semaCtx.GetTypeResolver())
+	return tree.ResolveType(ctx, ref, p.semaCtx.GetTypeResolver())
 }
 
 // ResolveTableName implements the eval.DatabaseCatalog interface.

--- a/pkg/sql/randgen/mutator.go
+++ b/pkg/sql/randgen/mutator.go
@@ -12,6 +12,7 @@ package randgen
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"math/rand"
 	"regexp"
@@ -359,9 +360,9 @@ func encodeInvertedIndexHistogramUpperBounds(colType *types.T, val tree.Datum) (
 	var err error
 	switch colType.Family() {
 	case types.GeometryFamily:
-		keys, err = rowenc.EncodeGeoInvertedIndexTableKeys(val, nil, *geoindex.DefaultGeometryIndexConfig())
+		keys, err = rowenc.EncodeGeoInvertedIndexTableKeys(context.Background(), val, nil, *geoindex.DefaultGeometryIndexConfig())
 	case types.GeographyFamily:
-		keys, err = rowenc.EncodeGeoInvertedIndexTableKeys(val, nil, *geoindex.DefaultGeographyIndexConfig())
+		keys, err = rowenc.EncodeGeoInvertedIndexTableKeys(context.Background(), val, nil, *geoindex.DefaultGeographyIndexConfig())
 	default:
 		keys, err = rowenc.EncodeInvertedIndexTableKeys(val, nil, descpb.LatestIndexDescriptorVersion)
 	}

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -119,6 +119,7 @@ func (rd *Deleter) DeleteRow(
 
 		// We want to include empty k/v pairs because we want to delete all k/v's for this row.
 		entries, err := rowenc.EncodeSecondaryIndex(
+			ctx,
 			rd.Helper.Codec,
 			rd.Helper.TableDesc,
 			rd.Helper.Indexes[i],

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -125,6 +125,7 @@ func NewRowHelper(
 // encodeSecondaryIndexes. includeEmpty details whether the results should
 // include empty secondary index k/v pairs.
 func (rh *RowHelper) encodeIndexes(
+	ctx context.Context,
 	colIDtoRowIndex catalog.TableColMap,
 	values []tree.Datum,
 	ignoreIndexes intsets.Fast,
@@ -138,7 +139,7 @@ func (rh *RowHelper) encodeIndexes(
 	if err != nil {
 		return nil, nil, err
 	}
-	secondaryIndexEntries, err = rh.encodeSecondaryIndexes(colIDtoRowIndex, values, ignoreIndexes, includeEmpty)
+	secondaryIndexEntries, err = rh.encodeSecondaryIndexes(ctx, colIDtoRowIndex, values, ignoreIndexes, includeEmpty)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -180,6 +181,7 @@ func (rh *RowHelper) encodePrimaryIndex(
 // includeEmpty details whether the results should include empty secondary index
 // k/v pairs.
 func (rh *RowHelper) encodeSecondaryIndexes(
+	ctx context.Context,
 	colIDtoRowIndex catalog.TableColMap,
 	values []tree.Datum,
 	ignoreIndexes intsets.Fast,
@@ -197,7 +199,7 @@ func (rh *RowHelper) encodeSecondaryIndexes(
 	for i := range rh.Indexes {
 		index := rh.Indexes[i]
 		if !ignoreIndexes.Contains(int(index.GetID())) {
-			entries, err := rowenc.EncodeSecondaryIndex(rh.Codec, rh.TableDesc, index, colIDtoRowIndex, values, includeEmpty)
+			entries, err := rowenc.EncodeSecondaryIndex(ctx, rh.Codec, rh.TableDesc, index, colIDtoRowIndex, values, includeEmpty)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -151,7 +151,8 @@ func (ri *Inserter) InsertRow(
 	// We don't want to insert empty k/v's like this, so we
 	// set includeEmpty to false.
 	primaryIndexKey, secondaryIndexEntries, err := ri.Helper.encodeIndexes(
-		ri.InsertColIDtoRowIndex, values, pm.IgnoreForPut, false /* includeEmpty */)
+		ctx, ri.InsertColIDtoRowIndex, values, pm.IgnoreForPut, false, /* includeEmpty */
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -233,7 +233,8 @@ func (ru *Updater) UpdateRow(
 		// compromise in order to avoid having to read all values of
 		// the row that is being updated.
 		_, deleteOldSecondaryIndexEntries, err = ru.DeleteHelper.encodeIndexes(
-			ru.FetchColIDtoRowIndex, oldValues, pm.IgnoreForDel, true /* includeEmpty */)
+			ctx, ru.FetchColIDtoRowIndex, oldValues, pm.IgnoreForDel, true, /* includeEmpty */
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -283,6 +284,7 @@ func (ru *Updater) UpdateRow(
 			ru.oldIndexEntries[i] = nil
 		} else {
 			ru.oldIndexEntries[i], err = rowenc.EncodeSecondaryIndex(
+				ctx,
 				ru.Helper.Codec,
 				ru.Helper.TableDesc,
 				index,
@@ -298,6 +300,7 @@ func (ru *Updater) UpdateRow(
 			ru.newIndexEntries[i] = nil
 		} else {
 			ru.newIndexEntries[i], err = rowenc.EncodeSecondaryIndex(
+				ctx,
 				ru.Helper.Codec,
 				ru.Helper.TableDesc,
 				index,

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -607,7 +607,11 @@ func (a ByID) Less(i, j int) bool { return a[i].ColID < a[j].ColID }
 // concatenating keyPrefix with the encodings of the column in the
 // index.
 func EncodeInvertedIndexKeys(
-	index catalog.Index, colMap catalog.TableColMap, values []tree.Datum, keyPrefix []byte,
+	ctx context.Context,
+	index catalog.Index,
+	colMap catalog.TableColMap,
+	values []tree.Datum,
+	keyPrefix []byte,
 ) (key [][]byte, err error) {
 	keyPrefix, err = EncodeInvertedIndexPrefixKeys(index, colMap, values, keyPrefix)
 	if err != nil {
@@ -622,7 +626,7 @@ func EncodeInvertedIndexKeys(
 	}
 	indexGeoConfig := index.GetGeoConfig()
 	if !indexGeoConfig.IsEmpty() {
-		return EncodeGeoInvertedIndexTableKeys(val, keyPrefix, indexGeoConfig)
+		return EncodeGeoInvertedIndexTableKeys(ctx, val, keyPrefix, indexGeoConfig)
 	}
 	return EncodeInvertedIndexTableKeys(val, keyPrefix, index.GetVersion())
 }
@@ -1058,7 +1062,7 @@ func EncodeTrigramSpans(s string, allMustMatch bool) (inverted.Expression, error
 // EncodeGeoInvertedIndexTableKeys is the equivalent of EncodeInvertedIndexTableKeys
 // for Geography and Geometry.
 func EncodeGeoInvertedIndexTableKeys(
-	val tree.Datum, inKey []byte, indexGeoConfig geopb.Config,
+	ctx context.Context, val tree.Datum, inKey []byte, indexGeoConfig geopb.Config,
 ) (key [][]byte, err error) {
 	if val == tree.DNull {
 		return nil, nil
@@ -1066,14 +1070,14 @@ func EncodeGeoInvertedIndexTableKeys(
 	switch val.ResolvedType().Family() {
 	case types.GeographyFamily:
 		index := geoindex.NewS2GeographyIndex(*indexGeoConfig.S2Geography)
-		intKeys, bbox, err := index.InvertedIndexKeys(context.TODO(), val.(*tree.DGeography).Geography)
+		intKeys, bbox, err := index.InvertedIndexKeys(ctx, val.(*tree.DGeography).Geography)
 		if err != nil {
 			return nil, err
 		}
 		return encodeGeoKeys(encoding.EncodeGeoInvertedAscending(inKey), intKeys, bbox)
 	case types.GeometryFamily:
 		index := geoindex.NewS2GeometryIndex(*indexGeoConfig.S2Geometry)
-		intKeys, bbox, err := index.InvertedIndexKeys(context.TODO(), val.(*tree.DGeometry).Geometry)
+		intKeys, bbox, err := index.InvertedIndexKeys(ctx, val.(*tree.DGeometry).Geometry)
 		if err != nil {
 			return nil, err
 		}
@@ -1289,6 +1293,7 @@ func MakeNullPKError(
 // empty values. For forward indexes the returned list of
 // index entries is in family sorted order.
 func EncodeSecondaryIndex(
+	ctx context.Context,
 	codec keys.SQLCodec,
 	tableDesc catalog.TableDescriptor,
 	secondaryIndex catalog.Index,
@@ -1307,7 +1312,7 @@ func EncodeSecondaryIndex(
 	var secondaryKeys [][]byte
 	var err error
 	if secondaryIndex.GetType() == descpb.IndexDescriptor_INVERTED {
-		secondaryKeys, err = EncodeInvertedIndexKeys(secondaryIndex, colMap, values, secondaryIndexKeyPrefix)
+		secondaryKeys, err = EncodeInvertedIndexKeys(ctx, secondaryIndex, colMap, values, secondaryIndexKeyPrefix)
 	} else {
 		var secondaryIndexKey []byte
 		secondaryIndexKey, containsNull, err = EncodeIndexKey(
@@ -1600,7 +1605,7 @@ func EncodeSecondaryIndexes(
 	const sizeOfIndexEntry = int64(unsafe.Sizeof(IndexEntry{}))
 
 	for i := range indexes {
-		entries, err := EncodeSecondaryIndex(codec, tableDesc, indexes[i], colMap, values, includeEmpty)
+		entries, err := EncodeSecondaryIndex(ctx, codec, tableDesc, indexes[i], colMap, values, includeEmpty)
 		if err != nil {
 			return secondaryIndexEntries, 0, err
 		}

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -298,7 +298,9 @@ func TestIndexKey(t *testing.T) {
 		primaryIndexKV := kv.KeyValue{Key: primaryKey, Value: &primaryValue}
 
 		secondaryIndexEntry, err := EncodeSecondaryIndex(
-			codec, tableDesc, tableDesc.PublicNonPrimaryIndexes()[0], colMap, testValues, true /* includeEmpty */)
+			context.Background(), codec, tableDesc, tableDesc.PublicNonPrimaryIndexes()[0],
+			colMap, testValues, true, /* includeEmpty */
+		)
 		if len(secondaryIndexEntry) != 1 {
 			t.Fatalf("expected 1 index entry, got %d. got %#v", len(secondaryIndexEntry), secondaryIndexEntry)
 		}
@@ -449,7 +451,9 @@ func TestInvertedIndexKey(t *testing.T) {
 		codec := keys.SystemSQLCodec
 
 		secondaryIndexEntries, err := EncodeSecondaryIndex(
-			codec, tableDesc, tableDesc.PublicNonPrimaryIndexes()[0], colMap, testValues, true /* includeEmpty */)
+			context.Background(), codec, tableDesc, tableDesc.PublicNonPrimaryIndexes()[0],
+			colMap, testValues, true, /* includeEmpty */
+		)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -346,7 +346,7 @@ func (s *samplerProcessor) mainLoop(
 			}
 			switch s.outTypes[col].Family() {
 			case types.GeographyFamily, types.GeometryFamily:
-				invKeys, err = rowenc.EncodeGeoInvertedIndexTableKeys(row[col].Datum, nil /* inKey */, index.GeoConfig)
+				invKeys, err = rowenc.EncodeGeoInvertedIndexTableKeys(ctx, row[col].Datum, nil /* inKey */, index.GeoConfig)
 			default:
 				invKeys, err = rowenc.EncodeInvertedIndexTableKeys(row[col].Datum, nil /* inKey */, index.Version)
 			}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -11,7 +11,6 @@
 package scbuildstmt
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -86,7 +85,7 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 			b.IncrementSchemaChangeIndexCounter("multi_column_inverted")
 		}
 	}
-	activeVersion := b.EvalCtx().Settings.Version.ActiveVersion(context.TODO())
+	activeVersion := b.EvalCtx().Settings.Version.ActiveVersion(b)
 	if !activeVersion.IsActive(clusterversion.V23_2) &&
 		n.Invisibility.Value > 0.0 && n.Invisibility.Value < 1.0 {
 		panic(unimplemented.New("partially visible indexes", "partially visible indexes are not yet supported"))

--- a/pkg/sql/scrub_test.go
+++ b/pkg/sql/scrub_test.go
@@ -225,7 +225,9 @@ func indexEntryForDatums(
 		colIDtoRowIndex.Set(c.GetID(), i)
 	}
 	indexEntries, err := rowenc.EncodeSecondaryIndex(
-		keys.SystemSQLCodec, tableDesc, index, colIDtoRowIndex, row, true /* includeEmpty */)
+		context.Background(), keys.SystemSQLCodec, tableDesc, index,
+		colIDtoRowIndex, row, true, /* includeEmpty */
+	)
 	if err != nil {
 		return rowenc.IndexEntry{}, err
 	}

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -216,7 +216,7 @@ type Planner interface {
 	// GetTypeFromValidSQLSyntax parses a column type when the input
 	// string uses the parseable SQL representation of a type name, e.g.
 	// `INT(13)`, `mytype`, `"mytype"`, `pg_catalog.int4` or `"public".mytype`.
-	GetTypeFromValidSQLSyntax(sql string) (*types.T, error)
+	GetTypeFromValidSQLSyntax(ctx context.Context, sql string) (*types.T, error)
 
 	// EvalSubquery returns the Datum for the given subquery node.
 	EvalSubquery(expr *tree.Subquery) (tree.Datum, error)

--- a/pkg/sql/sem/eval/parse_doid.go
+++ b/pkg/sql/sem/eval/parse_doid.go
@@ -140,7 +140,7 @@ func ParseDOid(ctx context.Context, evalCtx *Context, s string, t *types.T) (*tr
 		}
 		return tree.NewDOidWithTypeAndName(ol.Oid, t, fd.Name), nil
 	case oid.T_regtype:
-		parsedTyp, err := evalCtx.Planner.GetTypeFromValidSQLSyntax(s)
+		parsedTyp, err := evalCtx.Planner.GetTypeFromValidSQLSyntax(ctx, s)
 		if err == nil {
 			return tree.NewDOidWithTypeAndName(
 				parsedTyp.Oid(), t, parsedTyp.SQLStandardName(),


### PR DESCRIPTION
One of these made debugging a deadlock in a test more difficult, so I decided to clean things up a bit.

Epic: None

Release note: None