### PR TITLE
Storage: show in logs when crdb_internal.compact_engine_span is called #111954

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6918,6 +6918,7 @@ Parameters:` + randgencfg.ConfigDoc,
 				storeID := int32(tree.MustBeDInt(args[1]))
 				startKey := []byte(tree.MustBeDBytes(args[2]))
 				endKey := []byte(tree.MustBeDBytes(args[3]))
+				log.Infof(ctx, "crdb_internal.compact_engine_span called for nodeID=%d, storeID=%d, range[startKey=%s, endKey=%s]", nodeID, storeID, startKey, endKey)
 				if err := evalCtx.CompactEngineSpan(
 					ctx, nodeID, storeID, startKey, endKey); err != nil {
 					return nil, err


### PR DESCRIPTION
**Fixes**: #111954 

**Description**
This PR introduces log entries to indicate when crdb_internal.compact_engine_span is called. This improvement aims to facilitate debugging escalations.

**Changes**
Adding log statements whenever crdb_internal.compact_engine_span builtin is called

Release Note: None
Epic: none