### PR TITLE
sql: don't parallelize *any* FK and unique checks containing locking

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4889,7 +4889,7 @@ func (dsp *DistSQLPlanner) NewPlanningCtxWithOracle(
 		if planner == nil ||
 			evalCtx.SessionData().Internal ||
 			planner.curPlan.flags.IsSet(planFlagContainsMutation) ||
-			planner.curPlan.flags.IsSet(planFlagContainsNonDefaultLocking) {
+			planner.curPlan.flags.IsSet(planFlagContainsLocking) {
 			// Don't parallelize the scans if we have a local plan if
 			// - we don't have a planner which is the case when we are not on
 			// the main query path;
@@ -4900,7 +4900,7 @@ func (dsp *DistSQLPlanner) NewPlanningCtxWithOracle(
 			// any synchronization (see #116039);
 			// - the plan contains a mutation operation - we currently don't
 			// support any parallelism when mutations are present;
-			// - the plan uses non-default key locking strength (see #94290).
+			// - the plan uses locking (see #94290).
 			return planCtx
 		}
 		prohibitParallelization, hasScanNodeToParallelize := checkScanParallelizationIfLocal(ctx, &planner.curPlan.planComponents)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -740,15 +740,14 @@ func (dsp *DistSQLPlanner) Run(
 			// during the flow setup, we need to populate leafInputState below,
 			// so we tell the localState that there is concurrency.
 
-			// At the moment, we disable the usage of the Streamer API for local
-			// plans when non-default key locking modes are requested on some of
-			// the processors. This is the case since the lock spans propagation
-			// doesn't happen for the leaf txns which can result in excessive
-			// contention for future reads (since the acquired locks are not
-			// cleaned up properly when the txn commits).
-			// TODO(yuzefovich): fix the propagation of the lock spans with the
-			// leaf txns and remove this check. See #94290.
-			containsNonDefaultLocking := planCtx.planner != nil && planCtx.planner.curPlan.flags.IsSet(planFlagContainsNonDefaultLocking)
+			// At the moment, we disable the usage of the Streamer API for local plans
+			// when locking is used by any of the processors. This is the case since
+			// the lock spans propagation doesn't happen for the leaf txns which can
+			// result in excessive contention for future reads (since the acquired
+			// locks are not cleaned up properly when the txn commits).
+			// TODO(yuzefovich): fix the propagation of the lock spans with the leaf
+			// txns and remove this check. See #94290.
+			containsLocking := planCtx.planner != nil && planCtx.planner.curPlan.flags.IsSet(planFlagContainsLocking)
 
 			// We also currently disable the usage of the Streamer API whenever
 			// we have a wrapped planNode. This is done to prevent scenarios
@@ -769,7 +768,7 @@ func (dsp *DistSQLPlanner) Run(
 				}
 				return false
 			}()
-			if !containsNonDefaultLocking && !mustUseRootTxn {
+			if !containsLocking && !mustUseRootTxn {
 				if evalCtx.SessionData().StreamerEnabled {
 					for _, proc := range plan.Processors {
 						if jr := proc.Spec.Core.JoinReader; jr != nil {
@@ -2072,7 +2071,7 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 		return getDefaultSaveFlowsFunc(ctx, planner, planComponentTypePostquery)
 	}
 
-	checksContainLocking := planner.curPlan.flags.IsSet(planFlagCheckContainsNonDefaultLocking)
+	checksContainLocking := planner.curPlan.flags.IsSet(planFlagCheckContainsLocking)
 
 	// We treat plan.cascades as a queue.
 	for i := 0; i < len(plan.cascades); i++ {
@@ -2140,7 +2139,7 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 		// Collect any new checks.
 		if len(cp.checkPlans) > 0 {
 			plan.checkPlans = append(plan.checkPlans, cp.checkPlans...)
-			if cp.flags.IsSet(planFlagCheckContainsNonDefaultLocking) {
+			if cp.flags.IsSet(planFlagCheckContainsLocking) {
 				checksContainLocking = true
 			}
 		}

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -873,6 +873,7 @@ func (e *distSQLSpecExecFactory) ConstructPlan(
 	cascades []exec.Cascade,
 	checks []exec.Node,
 	rootRowCount int64,
+	flags exec.PlanFlags,
 ) (exec.Plan, error) {
 	if len(subqueries) != 0 {
 		return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: subqueries")
@@ -888,7 +889,7 @@ func (e *distSQLSpecExecFactory) ConstructPlan(
 	} else {
 		p.physPlan.onClose = e.planCtx.getCleanupFunc()
 	}
-	return constructPlan(e.planner, root, subqueries, cascades, checks, rootRowCount)
+	return constructPlan(e.planner, root, subqueries, cascades, checks, rootRowCount, flags)
 }
 
 func (e *distSQLSpecExecFactory) ConstructExplainOpt(

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -32,6 +32,7 @@ func constructPlan(
 	cascades []exec.Cascade,
 	checks []exec.Node,
 	rootRowCount int64,
+	flags exec.PlanFlags,
 ) (exec.Plan, error) {
 	res := &planComponents{}
 	assignPlan := func(plan *planMaybePhysical, node exec.Node) {
@@ -80,6 +81,30 @@ func constructPlan(
 		for i := range checks {
 			assignPlan(&res.checkPlans[i].plan, checks[i])
 		}
+	}
+	if flags.IsSet(exec.PlanFlagIsDDL) {
+		res.flags.Set(planFlagIsDDL)
+	}
+	if flags.IsSet(exec.PlanFlagContainsFullTableScan) {
+		res.flags.Set(planFlagContainsFullTableScan)
+	}
+	if flags.IsSet(exec.PlanFlagContainsFullIndexScan) {
+		res.flags.Set(planFlagContainsFullIndexScan)
+	}
+	if flags.IsSet(exec.PlanFlagContainsLargeFullTableScan) {
+		res.flags.Set(planFlagContainsLargeFullTableScan)
+	}
+	if flags.IsSet(exec.PlanFlagContainsLargeFullIndexScan) {
+		res.flags.Set(planFlagContainsLargeFullIndexScan)
+	}
+	if flags.IsSet(exec.PlanFlagContainsMutation) {
+		res.flags.Set(planFlagContainsMutation)
+	}
+	if flags.IsSet(exec.PlanFlagContainsNonDefaultKeyLocking) {
+		res.flags.Set(planFlagContainsNonDefaultLocking)
+	}
+	if flags.IsSet(exec.PlanFlagCheckContainsNonDefaultKeyLocking) {
+		res.flags.Set(planFlagCheckContainsNonDefaultLocking)
 	}
 
 	return res, nil

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -100,11 +100,11 @@ func constructPlan(
 	if flags.IsSet(exec.PlanFlagContainsMutation) {
 		res.flags.Set(planFlagContainsMutation)
 	}
-	if flags.IsSet(exec.PlanFlagContainsNonDefaultKeyLocking) {
-		res.flags.Set(planFlagContainsNonDefaultLocking)
+	if flags.IsSet(exec.PlanFlagContainsLocking) {
+		res.flags.Set(planFlagContainsLocking)
 	}
-	if flags.IsSet(exec.PlanFlagCheckContainsNonDefaultKeyLocking) {
-		res.flags.Set(planFlagCheckContainsNonDefaultLocking)
+	if flags.IsSet(exec.PlanFlagCheckContainsLocking) {
+		res.flags.Set(planFlagCheckContainsLocking)
 	}
 
 	return res, nil

--- a/pkg/sql/logictest/testdata/logic_test/fk_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/fk_read_committed
@@ -29,7 +29,7 @@ statement ok
 DELETE FROM jars WHERE j = 2
 
 # Test that we do not use parallel FK checks under RC (see #111888).
-subtest parallelFK
+subtest no-parallel-fk-checks
 
 statement ok
 CREATE TABLE a (a PRIMARY KEY) AS SELECT 1
@@ -48,7 +48,7 @@ CREATE TABLE e (e PRIMARY KEY) AS SELECT 1
 
 statement ok
 CREATE TABLE f (
-  a INT REFERENCES a (a),
+  a INT REFERENCES a (a) ON UPDATE CASCADE,
   b INT REFERENCES b (b),
   c INT REFERENCES c (c),
   d INT REFERENCES d (d),
@@ -64,3 +64,37 @@ INSERT INTO f VALUES (1, 1, 1, 1, 1, 1)
 
 statement ok
 RESET enable_insert_fast_path
+
+# Test that we do not use parallel FK checks under RC (see #111888).
+subtest no-parallel-fk-checks-from-cascade
+
+statement ok
+CREATE TABLE x (
+  x INT,
+  FOREIGN KEY (x) REFERENCES a (a) ON UPDATE CASCADE,
+  FOREIGN KEY (x) REFERENCES b (b),
+  FOREIGN KEY (x) REFERENCES c (c),
+  FOREIGN KEY (x) REFERENCES d (d),
+  FOREIGN KEY (x) REFERENCES e (e)
+)
+
+statement ok
+INSERT INTO x VALUES (1)
+
+statement error pq: update on table "x" violates foreign key constraint
+UPDATE a SET a = 2 WHERE a = 1
+
+statement ok
+INSERT INTO b VALUES (2)
+
+statement ok
+INSERT INTO c VALUES (2)
+
+statement ok
+INSERT INTO d VALUES (2)
+
+statement ok
+INSERT INTO e VALUES (2)
+
+statement ok
+UPDATE a SET a = 2 WHERE a = 1

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -748,14 +748,14 @@ func mutationOutputColMap(mutation memo.RelExpr) opt.ColMap {
 	return colMap
 }
 
-// checkContainsLocking sets CheckContainsNonDefaultKeyLocking based on whether
-// we found non-default locking while building a check query plan.
+// checkContainsLocking sets PlanFlagCheckContainsLocking based on whether we
+// found locking while building a check query plan.
 func (b *Builder) checkContainsLocking(mainContainsLocking bool) {
-	if b.flags.IsSet(exec.PlanFlagContainsNonDefaultKeyLocking) {
-		b.flags.Set(exec.PlanFlagCheckContainsNonDefaultKeyLocking)
+	if b.flags.IsSet(exec.PlanFlagContainsLocking) {
+		b.flags.Set(exec.PlanFlagCheckContainsLocking)
 	}
 	if mainContainsLocking {
-		b.flags.Set(exec.PlanFlagContainsNonDefaultKeyLocking)
+		b.flags.Set(exec.PlanFlagContainsLocking)
 	}
 }
 
@@ -766,8 +766,8 @@ func (b *Builder) checkContainsLocking(mainContainsLocking bool) {
 // violated. Those queries are each wrapped in an ErrorIfRows operator, which
 // will throw an appropriate error in case the inner query returns any rows.
 func (b *Builder) buildUniqueChecks(checks memo.UniqueChecksExpr) error {
-	defer b.checkContainsLocking(b.flags.IsSet(exec.PlanFlagContainsNonDefaultKeyLocking))
-	b.flags.Unset(exec.PlanFlagContainsNonDefaultKeyLocking)
+	defer b.checkContainsLocking(b.flags.IsSet(exec.PlanFlagContainsLocking))
+	b.flags.Unset(exec.PlanFlagContainsLocking)
 	md := b.mem.Metadata()
 	for i := range checks {
 		c := &checks[i]
@@ -798,8 +798,8 @@ func (b *Builder) buildUniqueChecks(checks memo.UniqueChecksExpr) error {
 }
 
 func (b *Builder) buildFKChecks(checks memo.FKChecksExpr) error {
-	defer b.checkContainsLocking(b.flags.IsSet(exec.PlanFlagContainsNonDefaultKeyLocking))
-	b.flags.Unset(exec.PlanFlagContainsNonDefaultKeyLocking)
+	defer b.checkContainsLocking(b.flags.IsSet(exec.PlanFlagContainsLocking))
+	b.flags.Unset(exec.PlanFlagContainsLocking)
 	md := b.mem.Metadata()
 	for i := range checks {
 		c := &checks[i]

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2951,10 +2951,10 @@ func (b *Builder) buildLocking(locking opt.Locking) (opt.Locking, error) {
 					!b.evalCtx.SessionData().SharedLockingForSerializable) {
 				// Reset locking information as we've determined we're going to be
 				// performing a non-locking read.
-				return opt.Locking{}, nil // early return; do not set PlanFlagContainsNonDefaultKeyLocking
+				return opt.Locking{}, nil // early return; do not set PlanFlagContainsLocking
 			}
 		}
-		b.flags.Set(exec.PlanFlagContainsNonDefaultKeyLocking)
+		b.flags.Set(exec.PlanFlagContainsLocking)
 	}
 	return locking, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -858,6 +858,7 @@ func (b *Builder) buildSubquery(
 			}
 			plan, err := b.factory.ConstructPlan(
 				ePlan.root, nil /* subqueries */, nil /* cascades */, nil /* checks */, inputRowCount,
+				eb.flags,
 			)
 			if err != nil {
 				return err
@@ -947,7 +948,7 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 
 	for _, s := range udf.Def.Body {
 		if s.Relational().CanMutate {
-			b.ContainsMutation = true
+			b.flags.Set(exec.PlanFlagContainsMutation)
 			break
 		}
 	}

--- a/pkg/sql/opt/exec/explain/explain_factory.go
+++ b/pkg/sql/opt/exec/explain/explain_factory.go
@@ -155,6 +155,7 @@ func (f *Factory) ConstructPlan(
 	cascades []exec.Cascade,
 	checks []exec.Node,
 	rootRowCount int64,
+	flags exec.PlanFlags,
 ) (exec.Plan, error) {
 	p := &Plan{
 		Root:       root.(*Node),
@@ -237,7 +238,7 @@ func (f *Factory) ConstructPlan(
 	}
 	var err error
 	p.WrappedPlan, err = f.wrappedFactory.ConstructPlan(
-		p.Root.WrappedNode(), wrappedSubqueries, wrappedCascades, wrappedChecks, rootRowCount,
+		p.Root.WrappedNode(), wrappedSubqueries, wrappedCascades, wrappedChecks, rootRowCount, flags,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/opt/exec/explain/explain_factory_test.go
+++ b/pkg/sql/opt/exec/explain/explain_factory_test.go
@@ -53,7 +53,10 @@ func TestFactory(t *testing.T) {
 		Cost:     1500.0,
 	})
 
-	plan, err := f.ConstructPlan(n, nil /* subqueries */, nil /* cascades */, nil /* checks */, -1 /* rootRowCount */)
+	plan, err := f.ConstructPlan(
+		n, nil /* subqueries */, nil /* cascades */, nil /* checks */, -1, /* rootRowCount */
+		0, /* planFlags */
+	)
 	require.NoError(t, err)
 	p := plan.(*Plan)
 

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -147,8 +147,9 @@ func (f *PlanGistFactory) ConstructPlan(
 	cascades []exec.Cascade,
 	checks []exec.Node,
 	rootRowCount int64,
+	flags exec.PlanFlags,
 ) (exec.Plan, error) {
-	plan, err := f.wrappedFactory.ConstructPlan(root, subqueries, cascades, checks, rootRowCount)
+	plan, err := f.wrappedFactory.ConstructPlan(root, subqueries, cascades, checks, rootRowCount, flags)
 	return plan, err
 }
 

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -67,13 +67,16 @@ const (
 	// PlanFlagContainsMutation is set if the whole plan contains any mutations.
 	PlanFlagContainsMutation
 
-	// PlanFlagContainsNonDefaultKeyLocking is set if at least one node in the
-	// plan uses non-default key locking strength.
-	PlanFlagContainsNonDefaultKeyLocking
+	// PlanFlagContainsLocking is set if at least one node in the plan uses
+	// locking. (Examples of plans using locking include SELECT FOR UPDATE and
+	// SELECT FOR SHARE, UPDATE, UPSERT, and FK checks under read committed
+	// isolation.)
+	PlanFlagContainsLocking
 
-	// PlanFlagCheckContainsNonDefaultKeyLocking is set if at least one node in at
-	// least one check query plan uses non-default key locking strength.
-	PlanFlagCheckContainsNonDefaultKeyLocking
+	// PlanFlagCheckContainsLocking is set if at least one node in at least one
+	// check plan uses locking. Typically this is set for plans with FK checks
+	// under read committed isolation.
+	PlanFlagCheckContainsLocking
 )
 
 func (pf PlanFlags) IsSet(flag PlanFlags) bool {

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -31,11 +31,62 @@ import (
 // (currently maps to sql.planNode).
 type Node interface{}
 
-// Plan represents the plan for a query (currently maps to sql.planTop).
+// Plan represents the plan for a query (currently maps to sql.planComponents).
 // For simple queries, the plan is associated with a single Node tree.
 // For queries containing subqueries, the plan is associated with multiple Node
 // trees (see ConstructPlan).
 type Plan interface{}
+
+// PlanFlags tracks various properties of the built plan.
+type PlanFlags uint32
+
+const (
+	// PlanFlagIsDDL is set if the statement contains DDL.
+	PlanFlagIsDDL = (1 << iota)
+
+	// PlanFlagContainsFullTableScan is set if the statement contains an
+	// unconstrained primary index scan. This could be a full scan of any
+	// cardinality.
+	PlanFlagContainsFullTableScan
+
+	// PlanFlagContainsFullIndexScan is set if the statement contains an
+	// unconstrained non-partial secondary index scan. This could be a full scan
+	// of any cardinality.
+	PlanFlagContainsFullIndexScan
+
+	// PlanFlagContainsLargeFullTableScan is set if the statement contains an
+	// unconstrained primary index scan estimated to read more than
+	// large_full_scan_rows (or without available stats).
+	PlanFlagContainsLargeFullTableScan
+
+	// PlanFlagContainsLargeFullIndexScan is set if the statement contains an
+	// unconstrained non-partial secondary index scan estimated to read more than
+	// large_full_scan_rows (or without without available stats).
+	PlanFlagContainsLargeFullIndexScan
+
+	// PlanFlagContainsMutation is set if the whole plan contains any mutations.
+	PlanFlagContainsMutation
+
+	// PlanFlagContainsNonDefaultKeyLocking is set if at least one node in the
+	// plan uses non-default key locking strength.
+	PlanFlagContainsNonDefaultKeyLocking
+
+	// PlanFlagCheckContainsNonDefaultKeyLocking is set if at least one node in at
+	// least one check query plan uses non-default key locking strength.
+	PlanFlagCheckContainsNonDefaultKeyLocking
+)
+
+func (pf PlanFlags) IsSet(flag PlanFlags) bool {
+	return (pf & flag) != 0
+}
+
+func (pf *PlanFlags) Set(flag PlanFlags) {
+	*pf |= flag
+}
+
+func (pf *PlanFlags) Unset(flag PlanFlags) {
+	*pf &^= flag
+}
 
 // ScanParams contains all the parameters for a table scan.
 type ScanParams struct {

--- a/pkg/sql/opt/optgen/cmd/optgen/exec_factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exec_factory_gen.go
@@ -83,6 +83,7 @@ func (g *execFactoryGen) genExecFactory() {
 	g.w.writeIndent("cascades []Cascade,\n")
 	g.w.writeIndent("checks []Node,\n")
 	g.w.writeIndent("rootRowCount int64,\n")
+	g.w.writeIndent("flags PlanFlags,\n")
 	g.w.unnest(") (Plan, error)\n")
 
 	g.w.write("\n")
@@ -121,6 +122,7 @@ func (g *execFactoryGen) genStubFactory() {
 	g.w.writeIndent("cascades []Cascade,\n")
 	g.w.writeIndent("checks []Node,\n")
 	g.w.writeIndent("rootRowCount int64,\n")
+	g.w.writeIndent("flags PlanFlags,\n")
 	g.w.unnest(") (Plan, error) {\n")
 	g.w.nestIndent("return struct{}{}, nil\n")
 	g.w.unnest("}\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/execfactory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/execfactory
@@ -71,6 +71,7 @@ type Factory interface {
 		cascades []Cascade,
 		checks []Node,
 		rootRowCount int64,
+		flags PlanFlags,
 	) (Plan, error)
 
 	// Ctx returns the ctx of this execution.
@@ -108,6 +109,7 @@ func (StubFactory) ConstructPlan(
 	cascades []Cascade,
 	checks []Node,
 	rootRowCount int64,
+	flags PlanFlags,
 ) (Plan, error) {
 	return struct{}{}, nil
 }

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1178,12 +1178,13 @@ func (ef *execFactory) ConstructPlan(
 	cascades []exec.Cascade,
 	checks []exec.Node,
 	rootRowCount int64,
+	flags exec.PlanFlags,
 ) (exec.Plan, error) {
 	// No need to spool at the root.
 	if spool, ok := root.(*spoolNode); ok {
 		root = spool.source
 	}
-	return constructPlan(ef.planner, root, subqueries, cascades, checks, rootRowCount)
+	return constructPlan(ef.planner, root, subqueries, cascades, checks, rootRowCount, flags)
 }
 
 // urlOutputter handles writing strings into an encoded URL for EXPLAIN (OPT,

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -313,9 +313,6 @@ type planTop struct {
 	// is eligible for auditing (see sql/audit_logging.go)
 	auditEventBuilders []auditlogging.AuditEventBuilder
 
-	// flags is populated during planning and execution.
-	flags planFlags
-
 	// avoidBuffering, when set, causes the execution to avoid buffering
 	// results.
 	avoidBuffering bool
@@ -422,6 +419,9 @@ func (t planComponentType) String() string {
 type planComponents struct {
 	// subqueryPlans contains all the sub-query plans.
 	subqueryPlans []subquery
+
+	// flags is populated during planning and execution.
+	flags planFlags
 
 	// plan for the main query.
 	main planMaybePhysical
@@ -641,7 +641,7 @@ func (pf *planFlags) Set(flag planFlags) {
 }
 
 func (pf *planFlags) Unset(flag planFlags) {
-	*pf &= ^flag
+	*pf &^= flag
 }
 
 // IsDistributed returns true if either the fully or the partially distributed

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -619,13 +619,12 @@ const (
 	// planFlagContainsMutation is set if the plan has any mutations.
 	planFlagContainsMutation
 
-	// planFlagContainsNonDefaultLocking is set if the plan has a node with
-	// non-default key locking strength.
-	planFlagContainsNonDefaultLocking
+	// planFlagContainsLocking is set if the plan has a node with locking.
+	planFlagContainsLocking
 
-	// planFlagCheckContainsNonDefaultLocking is set if at least one check plan
-	// has a node with non-default key locking strength.
-	planFlagCheckContainsNonDefaultLocking
+	// planFlagCheckContainsLocking is set if at least one check plan has a node
+	// with locking.
+	planFlagCheckContainsLocking
 
 	// planFlagSessionMigration is set if the plan is being created during
 	// a session migration.

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -709,10 +709,8 @@ func (opc *optPlanningCtx) runExecBuilder(
 
 	planTop.planComponents = *result
 	planTop.stmt = stmt
-	planTop.flags = opc.flags
-	if bld.IsDDL {
-		planTop.flags.Set(planFlagIsDDL)
-
+	planTop.flags |= opc.flags
+	if planTop.flags.IsSet(planFlagIsDDL) {
 		// The declarative schema changer mode would have already been set here,
 		// since all declarative schema changes are built opaquely. However, some
 		// DDLs (e.g. CREATE TABLE) are built non-opaquely, so we need to set the
@@ -721,27 +719,6 @@ func (opc *optPlanningCtx) runExecBuilder(
 			telemetry.Inc(sqltelemetry.LegacySchemaChangerCounter)
 			planTop.instrumentation.schemaChangerMode = schemaChangerModeLegacy
 		}
-	}
-	if bld.ContainsFullTableScan {
-		planTop.flags.Set(planFlagContainsFullTableScan)
-	}
-	if bld.ContainsFullIndexScan {
-		planTop.flags.Set(planFlagContainsFullIndexScan)
-	}
-	if bld.ContainsLargeFullTableScan {
-		planTop.flags.Set(planFlagContainsLargeFullTableScan)
-	}
-	if bld.ContainsLargeFullIndexScan {
-		planTop.flags.Set(planFlagContainsLargeFullIndexScan)
-	}
-	if bld.ContainsMutation {
-		planTop.flags.Set(planFlagContainsMutation)
-	}
-	if bld.ContainsNonDefaultKeyLocking {
-		planTop.flags.Set(planFlagContainsNonDefaultLocking)
-	}
-	if bld.CheckContainsNonDefaultKeyLocking {
-		planTop.flags.Set(planFlagCheckContainsNonDefaultLocking)
 	}
 	planTop.mem = mem
 	planTop.catalog = opc.catalog


### PR DESCRIPTION
**sql, execbuilder: move plan flags from planTop to planComponents**

Execbuild produces a `sql.planComponents` containing the main query
plan, plus plans for any subqueries, checks, and cascades. In the normal
SQL code path (`sql.(*optPlanningCtx).runExecBuilder`) we copy this
planComponents into a `sql.planTop`, which then is decorated with extra
information gathered from the Builder.

However, there are other users of execbuild that only work with the
planComponents, and don't have a planTop. In the next commit, one such
user, `PlanAndRunCascadesAndChecks`, needs to see some of the plan flags
set when building FK check plans, but doesn't have access to the Builder
which gathered those plans.

To solve this, this commit moves plan flags from the planTop to
planComponents, and then refactors the execbuilder and exec factory to
set some of these flags when creating the planComponents.

Informs: #118720

Epic: None

Release note: None

---

**sql: don't parallelize *any* FK and unique checks containing locking**

In #111896 we disallowed parallel execution of FK and unique checks that
contain locking, to avoid usage of LeafTxns. But #111896 only considered
checks built during planning of the main query, and overlooked checks
built during planning of FK cascades.

This commit also considers checks built during planning of FK cascades.

Fixes: #118720

Epic: None

Release note (bug fix): This commit fixes an internal error with message
like: "LeafTxn ... incompatible with locking request" that occurs when
performing an update under read committed isolation which cascades to a
table with multiple other foreign keys.

---

**sql: rename \*ContainsNonDefaultKeyLocking to \*ContainsLocking**

"Default" locking here simply means no locking. I find this convention
of saying "non-default key locking" a little verbose and confusing.

Epic: None

Release note: None