### PR TITLE
storage: add `MVCCIncrementalIterIntentPolicyIgnore`

### DIFF
--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1993,6 +1993,8 @@ func cmdIterNewIncremental(e *evalCtx) error {
 			opts.IntentPolicy = storage.MVCCIncrementalIterIntentPolicyEmit
 		case "aggregate":
 			opts.IntentPolicy = storage.MVCCIncrementalIterIntentPolicyAggregate
+		case "ignore":
+			opts.IntentPolicy = storage.MVCCIncrementalIterIntentPolicyIgnore
 		default:
 			return errors.Errorf("unknown intent policy %s", arg)
 		}

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -148,6 +148,13 @@ const (
 	// MVCCIncrementalIterIntentPolicyEmit will return intents to
 	// the caller if they are inside or outside the time range.
 	MVCCIncrementalIterIntentPolicyEmit
+	// MVCCIncrementalIterIntentPolicyIgnore will not emit intents at all, by
+	// disabling intent interleaving and filtering out any encountered intents.
+	// This gives a minor performance improvement, but is only safe if the caller
+	// has already checked the lock table prior to using the iterator. Otherwise,
+	// any provisional values will be emitted, as they can't be disambiguated from
+	// committed values.
+	MVCCIncrementalIterIntentPolicyIgnore
 )
 
 // MVCCIncrementalIterOptions bundles options for NewMVCCIncrementalIterator.
@@ -195,13 +202,19 @@ func NewMVCCIncrementalIterator(
 		useTBI = mvccIncrementalIteratorMetamorphicTBI
 	}
 
+	// Disable intent interleaving if requested.
+	iterKind := MVCCKeyAndIntentsIterKind
+	if opts.IntentPolicy == MVCCIncrementalIterIntentPolicyIgnore {
+		iterKind = MVCCKeyIterKind
+	}
+
 	var iter MVCCIterator
 	var err error
 	var timeBoundIter MVCCIterator
 	if useTBI {
 		// An iterator without the timestamp hints is created to ensure that the
 		// iterator visits every required version of every key that has changed.
-		iter, err = reader.NewMVCCIterator(ctx, MVCCKeyAndIntentsIterKind, IterOptions{
+		iter, err = reader.NewMVCCIterator(ctx, iterKind, IterOptions{
 			KeyTypes:             opts.KeyTypes,
 			LowerBound:           opts.StartKey,
 			UpperBound:           opts.EndKey,
@@ -236,7 +249,7 @@ func NewMVCCIncrementalIterator(
 			return nil, err
 		}
 	} else {
-		iter, err = reader.NewMVCCIterator(ctx, MVCCKeyAndIntentsIterKind, IterOptions{
+		iter, err = reader.NewMVCCIterator(ctx, iterKind, IterOptions{
 			KeyTypes:             opts.KeyTypes,
 			LowerBound:           opts.StartKey,
 			UpperBound:           opts.EndKey,
@@ -470,8 +483,15 @@ func (i *MVCCIncrementalIterator) updateMeta() error {
 		case MVCCIncrementalIterIntentPolicyEmit:
 			// We will emit this intent to the caller.
 			return nil
+		case MVCCIncrementalIterIntentPolicyIgnore:
+			// We don't expect to see this since we disabled intent interleaving.
+			i.err = errors.AssertionFailedf("unexpected intent (interleaving disabled): %s", &i.meta)
+			i.valid = false
+			return i.err
 		default:
-			return errors.AssertionFailedf("unknown intent policy: %d", i.intentPolicy)
+			i.err = errors.AssertionFailedf("unknown intent policy: %d", i.intentPolicy)
+			i.valid = false
+			return i.err
 		}
 	}
 	return nil
@@ -570,11 +590,13 @@ func (i *MVCCIncrementalIterator) advance(seeked bool) {
 				// If our policy is emit, we may want this
 				// intent. If it is outside our time bounds, it
 				// will be filtered below.
-			case MVCCIncrementalIterIntentPolicyError, MVCCIncrementalIterIntentPolicyAggregate:
+			case MVCCIncrementalIterIntentPolicyError,
+				MVCCIncrementalIterIntentPolicyAggregate,
+				MVCCIncrementalIterIntentPolicyIgnore:
 				// We have encountered an intent but it must lie outside the timestamp
-				// span (startTime, endTime] or we have aggregated it. In either case,
-				// we want to advance past it, unless we're also on a new range key that
-				// must be emitted.
+				// span (startTime, endTime], or have been aggregated or ignored. In
+				// either case, we want to advance past it, unless we're also on a new
+				// range key that must be emitted.
 				if newRangeKey {
 					i.hasPoint = false
 					return

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
@@ -1086,6 +1086,57 @@ iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
 iter_next_key_ignoring_time: err=conflicting locks on "d"
 error: (*kvpb.LockConflictError:) conflicting locks on "d"
 
+# Ignoring intents will filter them out, but still emit provisional values if
+# the caller hasn't resolved the intents first.
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z intents=ignore
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
+iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
+iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
+iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "o"/7.000000000,0=/BYTES/o7 !
+iter_scan: .
+
+run ok
+iter_new_incremental types=pointsOnly k=a end=z startTs=4 endTs=7 intents=ignore
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/7.000000000,0=/BYTES/a7
+iter_scan: "a"/7.000000000,0=/BYTES/a7
+iter_scan: "f"/6.000000000,0=/BYTES/f6
+iter_scan: "j"/7.000000000,0=/BYTES/j7
+iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "l"/7.000000000,0=/BYTES/l7
+iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: .
+
 # rangesOnly doesn't care about intents.
 run ok
 iter_new_incremental types=rangesOnly k=a end=z intents=error


### PR DESCRIPTION
This allows callers that have already scanned the lock table to disable intent interleaving for a minor performance improvement.

The policy is adopted in `MVCCClearTimeRange` and `MVCCDeleteRangeUsingTombstone`, which already do such lock table scans.

Touches #113116.
Epic: none
Release note: None