### PR TITLE
cli: fix TestUnavailableZip failed

### DIFF
--- a/pkg/cli/zip_per_node.go
+++ b/pkg/cli/zip_per_node.go
@@ -472,18 +472,18 @@ func (zc *debugZipContext) collectPerNodeData(
 				if err := zc.z.createError(sf, name, requestErr); err != nil {
 					return err
 				}
-				// Log out the list of errors that occurred during log entries request.
-				if len(entries.ParseErrors) > 0 {
-					sf.shout("%d parsing errors occurred:", len(entries.ParseErrors))
-					for _, err := range entries.ParseErrors {
-						sf.shout("%s", err)
-					}
-					parseErr := fmt.Errorf("%d errors occurred:\n%s", len(entries.ParseErrors), strings.Join(entries.ParseErrors, "\n"))
-					if err := zc.z.createError(sf, name, parseErr); err != nil {
-						return err
-					}
-				}
 				continue
+			}
+			// Log the list of errors that occurred during log entries request.
+			if len(entries.ParseErrors) > 0 {
+				sf.shout("%d parsing errors occurred:", len(entries.ParseErrors))
+				for _, err := range entries.ParseErrors {
+					sf.shout("%s", err)
+				}
+				parseErr := fmt.Errorf("%d errors occurred:\n%s", len(entries.ParseErrors), strings.Join(entries.ParseErrors, "\n"))
+				if err := zc.z.createError(sf, name, parseErr); err != nil {
+					return err
+				}
 			}
 			sf.progress("writing output: %s", name)
 			warnRedactLeak := false


### PR DESCRIPTION
This patch fixes issue introduced in da0e542b3a0504f84fc092724bfe4631ca748e94 where code (that handles unparsed entries due to errors) was added in "if error" block instead of below it. It was wrong because in case of timeout error, `entries` variable is always nil.
Now logic that handles partially failed entries parsing moved outside and invoked only if no timeout error happens.

Release note: None

Fixes: #117411