### PR TITLE
release: add missing "Release justification"

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -55,6 +55,7 @@ jobs:
 
             Epic: None
             Release note: None
+            Release justification: test-only updates
           commit-message: |
             ${{ matrix.branch }}: Update pkg/testutils/release/cockroach_releases.yaml
 


### PR DESCRIPTION
This PR adds a "Release justification" line to simplify the PR workflow.

Epic: none
Release note: None