### PR TITLE
server: fix bug in initial value of flush throughput metric

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1020,7 +1020,7 @@ func (n *Node) computeMetricsPeriodically(
 		} else {
 			if storeToMetrics[store] == nil {
 				storeToMetrics[store] = &storage.MetricsForInterval{
-					FlushWriteThroughput: newMetrics.LogWriter.WriteThroughput,
+					FlushWriteThroughput: newMetrics.Flush.WriteThroughput,
 				}
 			} else {
 				storeToMetrics[store].FlushWriteThroughput = newMetrics.Flush.WriteThroughput


### PR DESCRIPTION
This bug only affected the first sample, and not later samples against which the delta was computed, so the effect was insignificant.

Epic: none

Release note: None