### PR TITLE
build: ignore nogo rule `loopvarcapture` in external deps

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -268,6 +268,12 @@
             "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
         }
     },
+    "loopvarcapture": {
+        "only_files": {
+            "cockroach/pkg/.*$": "first-party code",
+           "cockroach/bazel-out/.*/bin/pkg/.*$": "first-party code"
+       }
+    },
     "lostcancel": {
         "only_files": {
             "cockroach/pkg/.*$": "first-party code",


### PR DESCRIPTION
This change updates the `loopvarcapture` nogo check to only check first-party code.

Release note: None
Epic: None