### PR TITLE
admission,ui: add graphs for elastic cpu limiter

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
@@ -89,6 +89,60 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Elastic CPU Utilization"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+      tooltip={`CPU utilization by elastic work, compared to the limit set for elastic work.`}
+      showMetricsInTooltip={true}
+    >
+      <Axis units={AxisUnits.Percentage} label="CPU Utilization">
+        {nodeIDs.map(nid => (
+          <>
+            <Metric
+              name="cr.node.admission.elastic_cpu.utilization"
+              title={
+                "Elastic CPU Utilization " +
+                nodeDisplayName(nodeDisplayNameByID, nid)
+              }
+              sources={[nid]}
+            />
+            <Metric
+              name="cr.node.admission.elastic_cpu.utilization_limit"
+              title={
+                "Elastic CPU Utilization Limit " +
+                nodeDisplayName(nodeDisplayNameByID, nid)
+              }
+              sources={[nid]}
+            />
+          </>
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Elastic CPU Exhausted Duration Per Second"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+      tooltip={`Duration of CPU exhaustion by elastic work, in microseconds.`}
+      showMetricsInTooltip={true}
+    >
+      <Axis label="duration (micros/sec)">
+        {nodeIDs.map(nid => (
+          <Metric
+            key={nid}
+            name="cr.node.admission.elastic_cpu.nanos_exhausted_duration"
+            title={
+              "Elastic CPU Exhausted " +
+              nodeDisplayName(nodeDisplayNameByID, nid)
+            }
+            sources={[nid]}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="IO Overload"
       sources={storeSources}
       tenantSource={tenantSource}

--- a/pkg/util/admission/elastic_cpu_granter.go
+++ b/pkg/util/admission/elastic_cpu_granter.go
@@ -324,7 +324,6 @@ var ( // granter-side metrics (some of these have parallels on the requester sid
 		Unit:        metric.Unit_NANOSECONDS,
 	}
 
-	// TODO(irfansharif): Surface this metric in the "Overload" dashboard.
 	elasticCPUGranterUtilization = metric.Metadata{
 		Name:        "admission.elastic_cpu.utilization",
 		Help:        "CPU utilization by elastic work",


### PR DESCRIPTION
This patch adds two new graphs to the Overload page in the metrics dashboard:

* `Elastic CPU Utilization`: graphs `admission.elastic_cpu.utilization` against `admission.elastic_cpu.utilization_limit`.
* `Elastic CPU Exhausted Duration Per Second`: graphs `elastic_cpu.nanos_exhausted_duration`.

Fixes #118493.

Release note (ui change): The Overload Dashboard page now includes two additional graphs:
- Elastic CPU Utilization - This is used the show the CPU utilization by elastic work, compared to the limit set for elastic work.
- Elastic CPU Exhausted Duration Per Second - This is used to show the duration of CPU exhaustion by elastic work, in microseconds.