### PR TITLE
release: confirm yum install

### DIFF
--- a/build/deploy-redhat/Dockerfile.in
+++ b/build/deploy-redhat/Dockerfile.in
@@ -1,6 +1,6 @@
 FROM @repository@:@tag@
 
-RUN microdnf install yum && \
+RUN microdnf install -y yum && \
   yum -v -y update --all && \
   microdnf clean all && \
   rm -rf /var/cache/yum


### PR DESCRIPTION
This adds `-y` flag to install `yum` without user prompt.

Epic: none
Release note: None