### PR TITLE
logictest: skip `distsql_tenant_locality` under duress

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/generated_test.go
@@ -90,6 +90,9 @@ func runCCLLogicTest(t *testing.T, file string) {
 }
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	if file == "distsql_tenant_locality" {
+		skip.UnderDuressWithIssue(t, 118627)
+	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -92,6 +92,9 @@ func runCCLLogicTest(t *testing.T, file string) {
 }
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	if file == "distsql_tenant_locality" {
+		skip.UnderDuressWithIssue(t, 118627)
+	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -72,6 +72,9 @@ func runCCLLogicTest(t *testing.T, file string) {
 {{- if .ExecBuildLogicTest -}}
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	if file == "distsql_tenant_locality" {
+		skip.UnderDuressWithIssue(t, 118627)
+	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,{{ if .ForceProductionValues }}

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
@@ -40,12 +40,12 @@ statement ok
 SELECT * FROM t
 
 # Check sql instance locality in the secondary tenant.
-query ITB retry
-SELECT id, locality, crdb_internal.sql_liveness_is_alive(session_id) FROM system.sql_instances WHERE locality IS NOT NULL ORDER BY id
+query IT
+SELECT id, locality FROM system.sql_instances WHERE locality IS NOT NULL ORDER BY id
 ----
-1  {"Tiers": "region=test"}   true
-2  {"Tiers": "region=test1"}  true
-3  {"Tiers": "region=test2"}  true
+1  {"Tiers": "region=test"}
+2  {"Tiers": "region=test1"}
+3  {"Tiers": "region=test2"}
 
 # Ensure that we plan TableReaders in the regions according to the leaseholder
 # of each range, namely we want

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
@@ -62,6 +62,9 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	if file == "distsql_tenant_locality" {
+		skip.UnderDuressWithIssue(t, 118627)
+	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/generated_test.go
@@ -62,6 +62,9 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	if file == "distsql_tenant_locality" {
+		skip.UnderDuressWithIssue(t, 118627)
+	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/generated_test.go
@@ -62,6 +62,9 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	if file == "distsql_tenant_locality" {
+		skip.UnderDuressWithIssue(t, 118627)
+	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist/generated_test.go
@@ -62,6 +62,9 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	if file == "distsql_tenant_locality" {
+		skip.UnderDuressWithIssue(t, 118627)
+	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/generated_test.go
@@ -62,6 +62,9 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	if file == "distsql_tenant_locality" {
+		skip.UnderDuressWithIssue(t, 118627)
+	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.1/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.1/generated_test.go
@@ -62,6 +62,9 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	if file == "distsql_tenant_locality" {
+		skip.UnderDuressWithIssue(t, 118627)
+	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.2/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.2/generated_test.go
@@ -62,6 +62,9 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	if file == "distsql_tenant_locality" {
+		skip.UnderDuressWithIssue(t, 118627)
+	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/generated_test.go
@@ -62,6 +62,9 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	if file == "distsql_tenant_locality" {
+		skip.UnderDuressWithIssue(t, 118627)
+	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -62,6 +62,9 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
+	if file == "distsql_tenant_locality" {
+		skip.UnderDuressWithIssue(t, 118627)
+	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,


### PR DESCRIPTION
Flaky test: see #118627

Epic: None
Release note: None