### PR TITLE
bincheck: verbose mode

### DIFF
--- a/build/release/bincheck/download_binary.sh
+++ b/build/release/bincheck/download_binary.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -exuo pipefail
 
 download_and_extract() {
   cockroach_version=$1

--- a/build/release/bincheck/test-linux
+++ b/build/release/bincheck/test-linux
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -exuo pipefail
 source ./download_binary.sh
 
 if [[ $# -ne 2 ]]

--- a/build/release/bincheck/test-macos-amd64
+++ b/build/release/bincheck/test-macos-amd64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -exuo pipefail
 source ./download_binary.sh
 
 # Verify arguments.

--- a/build/release/bincheck/test-macos-arm64
+++ b/build/release/bincheck/test-macos-arm64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -exuo pipefail
 source ./download_binary.sh
 
 # Verify arguments.

--- a/build/release/bincheck/test-windows
+++ b/build/release/bincheck/test-windows
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -exuo pipefail
 source ./download_binary.sh
 
 if [[ $# -ne 2 ]]


### PR DESCRIPTION
This PR adds the -x flag to make the preparation steps visible in the logs.

Epic: none
Release note: None