### PR TITLE
changefeedccl: return errors.AssertionFailedf upon CSV encoder error

### DIFF
--- a/pkg/ccl/changefeedccl/encoder_csv.go
+++ b/pkg/ccl/changefeedccl/encoder_csv.go
@@ -49,7 +49,7 @@ func (e *csvEncoder) EncodeValue(
 	ctx context.Context, evCtx eventContext, updatedRow cdcevent.Row, prevRow cdcevent.Row,
 ) ([]byte, error) {
 	if updatedRow.IsDeleted() {
-		return nil, errors.Errorf(`cannot encode deleted rows into CSV format`)
+		return nil, errors.AssertionFailedf(`cannot encode deleted rows into CSV format`)
 	}
 	e.buf.Reset()
 	if err := updatedRow.ForEachColumn().Datum(func(d tree.Datum, col cdcevent.ResultColumn) error {


### PR DESCRIPTION
This patch returns a permanent error instead of a retryable error when CSV encoder encounters deleted message.

Fixes: #118533
Release note: none