### PR TITLE
pkg/ui: add request status code to error messaging

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
@@ -12,12 +12,13 @@ import React from "react";
 import classNames from "classnames/bind";
 import styles from "./sqlActivity.module.scss";
 import moment from "moment-timezone";
+import { isRequestError, RequestError } from "../util";
 
 const cx = classNames.bind(styles);
 
 interface SQLActivityErrorProps {
   statsType: string;
-  error: Error;
+  error: Error | RequestError;
   sourceTables?: string[];
 }
 
@@ -84,6 +85,10 @@ const LoadingError: React.FC<SQLActivityErrorProps> = props => {
       ? `Source Tables: ${props.sourceTables.join(", ")}`
       : "";
 
+  const respCode = isRequestError(props?.error)
+    ? props?.error?.status
+    : undefined;
+
   return (
     <div>
       <div className={cx("row")}>
@@ -105,6 +110,12 @@ const LoadingError: React.FC<SQLActivityErrorProps> = props => {
             .utc()
             .format("YYYY.MM.DD HH:mm:ss")} utc;`}
           <br />
+          {respCode && (
+            <>
+              {`Response code: ${respCode};`}
+              <br />
+            </>
+          )}
           {`Error message: ${props?.error?.message};`}
           <br />
           {`URL: ${url};`}


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/114582

We recently made some nice improvements to our error messaging in DB Console via the changes in https://github.com/cockroachdb/cockroach/pull/105550

However, these changes didn't include the HTTP response status code in the error message, which has created some guess work when interpreting error messages, especially when involving things like timeouts from the load balancer servicing the request.

This patch updates the error messaging to include the HTTP response code if the request being rendered is a RequestError. If it's not, the field is omitted.

Release note (ui change): The error messages surfaced in DB Console now include information about the HTTP response status code, if one is present.

Epic: CRDB-20791

<img width="949" alt="Screenshot 2024-02-05 at 5 04 56 PM" src="https://github.com/cockroachdb/cockroach/assets/8194877/a6c05096-cda7-44aa-bf23-3ddcd2b68a17">



