### PR TITLE
ui: take non-negative derivative of full scan chart

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -196,17 +196,17 @@ export default function (props: GraphDashboardProps) {
       isKvGraph={false}
       sources={nodeSources}
       tenantSource={tenantSource}
-      tooltip={`The total number of full table/index scans ${tooltipSelection}.`}
+      tooltip={`The total number of full table/index scans per second ${tooltipSelection}.`}
       showMetricsInTooltip={true}
     >
-      <Axis label="full scans">
+      <Axis label="full scans per second">
         {_.map(nodeIDs, node => (
           <Metric
             key={node}
             name="cr.node.sql.full.scan.count"
             title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
-            downsampleMax
+            nonNegativeRate
           />
         ))}
       </Axis>


### PR DESCRIPTION
The full scan metric was previously being displayed as a count using a downsampling max aggregation function. This commit changes the full scans graph in the sql dashboard to show the non-negative derivative of the metric since this chart is more useful when displayed as a rate.

Epic: none
Fixes: #118535

Release note (ui change): The `Full Table/Index Scans` chart in the sql metrics dashboard now shows the non-negative derivative of the number of full scans tracked.

Before
<img width="965" alt="image" src="https://github.com/cockroachdb/cockroach/assets/20136951/f4f227c3-20af-4207-907e-38a914fe5c3a">

After
<img width="920" alt="image" src="https://github.com/cockroachdb/cockroach/assets/20136951/49a000ae-e982-4faa-98e7-d8b5770f4707">
