### PR TITLE
sql: reduce allocations in physicalplan.MakeExpression

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2311,9 +2311,11 @@ func (dsp *DistSQLPlanner) addAggregators(
 		}
 		aggregations[i].Arguments = make([]execinfrapb.Expression, len(fholder.arguments))
 		argumentsColumnTypes[i] = make([]*types.T, len(fholder.arguments))
+		var ef physicalplan.ExprFactory
+		ef.Init(ctx, planCtx, nil /* indexVarMap */)
 		for j, argument := range fholder.arguments {
 			var err error
-			aggregations[i].Arguments[j], err = physicalplan.MakeExpression(ctx, argument, planCtx, nil)
+			aggregations[i].Arguments[j], err = ef.Make(argument)
 			if err != nil {
 				return err
 			}
@@ -2822,6 +2824,8 @@ func (dsp *DistSQLPlanner) planAggregators(
 			// keep track of the finalAggs results that correspond
 			// to each aggregation.
 			finalIdx := 0
+			var ef physicalplan.ExprFactory
+			ef.Init(ctx, planCtx, nil /* indexVarMap */)
 			for i, e := range info.aggregations {
 				info := physicalplan.DistAggregationTable[e.Func]
 				if info.FinalRendering == nil {
@@ -2833,9 +2837,7 @@ func (dsp *DistSQLPlanner) planAggregators(
 					// across and within stages.
 					mappedIdx := int(finalIdxMap[finalIdx])
 					var err error
-					renderExprs[i], err = physicalplan.MakeExpression(
-						ctx, h.IndexedVar(mappedIdx), planCtx, nil, /* indexVarMap */
-					)
+					renderExprs[i], err = ef.Make(h.IndexedVar(mappedIdx))
 					if err != nil {
 						return err
 					}
@@ -2854,9 +2856,7 @@ func (dsp *DistSQLPlanner) planAggregators(
 					if err != nil {
 						return err
 					}
-					renderExprs[i], err = physicalplan.MakeExpression(
-						ctx, expr, planCtx, nil, /* indexVarMap */
-					)
+					renderExprs[i], err = ef.Make(expr)
 					if err != nil {
 						return err
 					}
@@ -3174,12 +3174,13 @@ func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 		}
 	}
 
+	var ef physicalplan.ExprFactory
+	ef.Init(ctx, planCtx, nil /* indexVarMap */)
+
 	// Set the lookup condition.
 	if n.lookupExpr != nil {
 		var err error
-		joinReaderSpec.LookupExpr, err = physicalplan.MakeExpression(
-			ctx, n.lookupExpr, planCtx, nil, /* indexVarMap */
-		)
+		joinReaderSpec.LookupExpr, err = ef.Make(n.lookupExpr)
 		if err != nil {
 			return nil, err
 		}
@@ -3189,9 +3190,7 @@ func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 			return nil, errors.AssertionFailedf("remoteLookupExpr is set but lookupExpr is not")
 		}
 		var err error
-		joinReaderSpec.RemoteLookupExpr, err = physicalplan.MakeExpression(
-			ctx, n.remoteLookupExpr, planCtx, nil, /* indexVarMap */
-		)
+		joinReaderSpec.RemoteLookupExpr, err = ef.Make(n.remoteLookupExpr)
 		if err != nil {
 			return nil, err
 		}
@@ -3200,9 +3199,7 @@ func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 	// Set the ON condition.
 	if n.onCond != nil {
 		var err error
-		joinReaderSpec.OnExpr, err = physicalplan.MakeExpression(
-			ctx, n.onCond, planCtx, nil, /* indexVarMap */
-		)
+		joinReaderSpec.OnExpr, err = ef.Make(n.onCond)
 		if err != nil {
 			return nil, err
 		}
@@ -3267,16 +3264,14 @@ func (dsp *DistSQLPlanner) createPlanForInvertedJoin(
 		invertedJoinerSpec.PrefixEqualityColumns[i] = uint32(plan.PlanToStreamColMap[col])
 	}
 
-	if invertedJoinerSpec.InvertedExpr, err = physicalplan.MakeExpression(
-		ctx, n.invertedExpr, planCtx, nil, /* indexVarMap */
-	); err != nil {
+	var ef physicalplan.ExprFactory
+	ef.Init(ctx, planCtx, nil /* indexVarMap */)
+	if invertedJoinerSpec.InvertedExpr, err = ef.Make(n.invertedExpr); err != nil {
 		return nil, err
 	}
 	// Set the ON condition.
 	if n.onExpr != nil {
-		if invertedJoinerSpec.OnExpr, err = physicalplan.MakeExpression(
-			ctx, n.onExpr, planCtx, nil, /* indexVarMap */
-		); err != nil {
+		if invertedJoinerSpec.OnExpr, err = ef.Make(n.onExpr); err != nil {
 			return nil, err
 		}
 	}
@@ -4201,9 +4196,11 @@ func createProjectSetSpec(
 		GeneratedColumnLabels: make([]string, len(n.columns)-n.numColsInSource),
 		NumColsPerGen:         make([]uint32, len(n.exprs)),
 	}
+	var ef physicalplan.ExprFactory
+	ef.Init(ctx, planCtx, indexVarMap)
 	for i, expr := range n.exprs {
 		var err error
-		spec.Exprs[i], err = physicalplan.MakeExpression(ctx, expr, planCtx, indexVarMap)
+		spec.Exprs[i], err = ef.Make(expr)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4198,6 +4198,7 @@ func createProjectSetSpec(
 	}
 	var ef physicalplan.ExprFactory
 	ef.Init(ctx, planCtx, indexVarMap)
+	// TODO(mgartner): Consider using ef.IndexedVarsHint here.
 	for i, expr := range n.exprs {
 		var err error
 		spec.Exprs[i], err = ef.Make(expr)

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -481,9 +481,11 @@ func populateAggFuncSpec(
 	if len(constArgs) > 0 {
 		spec.Arguments = make([]execinfrapb.Expression, len(constArgs))
 		argumentsColumnTypes = make([]*types.T, len(constArgs))
+		var ef physicalplan.ExprFactory
+		ef.Init(ctx, planCtx, nil /* indexVarMap */)
 		for k, argument := range constArgs {
 			var err error
-			spec.Arguments[k], err = physicalplan.MakeExpression(ctx, argument, planCtx, nil)
+			spec.Arguments[k], err = ef.Make(argument)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/physicalplan/physical_plan.go
+++ b/pkg/sql/physicalplan/physical_plan.go
@@ -725,9 +725,11 @@ func (p *PhysicalPlan) AddRendering(
 		compositeMap = reverseProjection(post.OutputColumns, indexVarMap)
 	}
 	post.RenderExprs = make([]execinfrapb.Expression, len(exprs))
+	var ef ExprFactory
+	ef.Init(ctx, exprCtx, compositeMap)
 	for i, e := range exprs {
 		var err error
-		post.RenderExprs[i], err = MakeExpression(ctx, e, exprCtx, compositeMap)
+		post.RenderExprs[i], err = ef.Make(e)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/physicalplan/physical_plan.go
+++ b/pkg/sql/physicalplan/physical_plan.go
@@ -727,6 +727,9 @@ func (p *PhysicalPlan) AddRendering(
 	post.RenderExprs = make([]execinfrapb.Expression, len(exprs))
 	var ef ExprFactory
 	ef.Init(ctx, exprCtx, compositeMap)
+	// The number of expressions to render is a rough estimate for the number of
+	// indexed vars that will be created in all the calls to ef.Make below.
+	ef.IndexedVarsHint(len(exprs))
 	for i, e := range exprs {
 		var err error
 		post.RenderExprs[i], err = ef.Make(e)


### PR DESCRIPTION
#### sql: reduce allocations in physicalplan.MakeExpression

The `physicalplan.MakeExpression` function allocates two visitor structs
on the heap. These structs cannot be stack allocated because they are
passed to the `tree.Walk` function as arguments that implement the
`tree.Visitor` interface. This prevents Go from allocating the structs
on the stack. These allocations can be a significant portion of all
allocations, especially when query plans have many columns flowing
through their operators. Two visitor structs will be allocated for every
expression rendered.

This commit reduces these allocations by introducing the
`physicalplan.ExprFactory` which reuses allocated visitors for each
expression created by the factory.

Release note: None

#### physicalplan: batch allocate indexed vars

`ExprFactory` now batches allocations of indexed vars, reducing the
total number of allocations. In addition, the
`ExprFactory.IndexedVarsHint` method has been added that allows callers
to provide an estimate for the number of indexed vars that will be
created by all calls to `ExprFactory.Make`. This can further reduce
allocations.

Informs #117546

Release note: None
