### PR TITLE
jobs,application_api: replace calls to `skip.Stress` with `skip.Duress`

### DIFF
--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -797,7 +797,7 @@ func TestWaitWithRetryableError(t *testing.T) {
 		registry.WaitForJobs(
 			ctx, []jobspb.JobID{id},
 		))
-	if !skip.Stress() {
+	if !skip.Duress() {
 		require.Equalf(t, int64(targetNumberOfRetries), numberOfTimesDetected.Load(), "jobs query did not retry")
 	} else {
 		// For stress be lenient since we are relying on timing for leasing

--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -47,9 +47,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// additionalTimeoutUnderStress is the additional timeout to use for the http
+// additionalTimeoutUnderDuress is the additional timeout to use for the http
 // client if under stress.
-const additionalTimeoutUnderStress = 30 * time.Second
+const additionalTimeoutUnderDuress = 30 * time.Second
 
 func TestStatusAPICombinedTransactions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -57,8 +57,8 @@ func TestStatusAPICombinedTransactions(t *testing.T) {
 
 	// Increase the timeout for the http client if under stress.
 	additionalTimeout := 0 * time.Second
-	if skip.Stress() {
-		additionalTimeout = additionalTimeoutUnderStress
+	if skip.Duress() {
+		additionalTimeout = additionalTimeoutUnderDuress
 	}
 
 	var params base.TestServerArgs
@@ -393,8 +393,8 @@ func TestStatusAPIStatements(t *testing.T) {
 
 	// Increase the timeout for the http client if under stress.
 	additionalTimeout := 0 * time.Second
-	if skip.Stress() {
-		additionalTimeout = additionalTimeoutUnderStress
+	if skip.Duress() {
+		additionalTimeout = additionalTimeoutUnderDuress
 	}
 
 	// Aug 30 2021 19:50:00 GMT+0000
@@ -520,8 +520,8 @@ func TestStatusAPICombinedStatementsTotalLatency(t *testing.T) {
 	skip.UnderRace(t, "test is too slow to run under race")
 	// Increase the timeout for the http client if under stress.
 	additionalTimeout := 0 * time.Second
-	if skip.Stress() {
-		additionalTimeout = additionalTimeoutUnderStress
+	if skip.Duress() {
+		additionalTimeout = additionalTimeoutUnderDuress
 	}
 
 	sqlStatsKnobs := sqlstats.CreateTestingKnobs()
@@ -676,8 +676,8 @@ func TestStatusAPICombinedStatementsWithFullScans(t *testing.T) {
 
 	// Increase the timeout for the http client if under stress.
 	additionalTimeout := 0 * time.Second
-	if skip.Stress() {
-		additionalTimeout = additionalTimeoutUnderStress
+	if skip.Duress() {
+		additionalTimeout = additionalTimeoutUnderDuress
 	}
 	skip.UnderStressRace(t, "test is too slow to run under stressrace")
 


### PR DESCRIPTION
`skip.Duress()` seems like it should have been used in this case as it gives more time under both `race` and `deadlock`. This will give these tests some extra time if they run in a heavyweight configuration but not "under stress".

Epic: CRDB-8308
Release note: None