### PR TITLE
leaktest: print full stack trace when leaked goroutines detected

### DIFF
--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -158,6 +158,7 @@ func AfterTest(t T) func() {
 					continue
 				}
 				atomic.StoreUint32(&leakDetectorDisabled, 1)
+				err = errors.Wrapf(err, "\nall stacks: \n\n%s\n", allstacks.Get())
 				t.Errorf("%v", err)
 			}
 			break


### PR DESCRIPTION
This commit adds logging to print the entire stack when leaked goroutines are detected in a test. This should help in tracking down leaked resources in issues like #117853, which currently don't have much visibility.

Informs #117853

Release note: None