### PR TITLE
sql,plpgsql: add dispatcher for executing nested PL/pgSQL subroutines

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -86,6 +86,10 @@ type Builder struct {
 	// rather than scans.
 	withExprs []builtWithExpr
 
+	// dispatchers maps from each dispatcher ID to its DispatchChannel, which
+	// allows DispatchExpr instances to communicate with their parent Dispatcher.
+	dispatchers map[memo.DispatcherID]*tree.DispatchChannel
+
 	// allowAutoCommit is passed through to factory methods for mutation
 	// operators. It allows execution to commit the transaction as part of the
 	// mutation itself. See canAutoCommit().

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1210,6 +1210,7 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 		eb := New(ctx, ef, &o, f.Memo(), b.catalog, newRightSide, b.semaCtx, b.evalCtx, false /* allowAutoCommit */, b.IsANSIDML)
 		eb.disableTelemetry = true
 		eb.withExprs = withExprs
+		eb.dispatchers = b.dispatchers
 		plan, err := eb.Build()
 		if err != nil {
 			if errors.IsAssertionFailure(err) {
@@ -3038,7 +3039,8 @@ func (b *Builder) buildRecursiveCTE(rec *memo.RecursiveCTEExpr) (execPlan, error
 		// below will add to withExprs. Cap the slice to force reallocation on any
 		// appends, so that they don't overwrite overwrite later appends by our
 		// original builder.
-		withExprs: b.withExprs[:len(b.withExprs):len(b.withExprs)],
+		withExprs:   b.withExprs[:len(b.withExprs):len(b.withExprs)],
+		dispatchers: b.dispatchers,
 	}
 
 	fn := func(ef exec.Factory, bufferRef exec.Node) (exec.Plan, error) {
@@ -3156,17 +3158,9 @@ func (b *Builder) buildCall(c *memo.CallExpr) (execPlan, error) {
 	}
 
 	// Build the argument expressions.
-	var err error
-	var args tree.TypedExprs
-	ctx := buildScalarCtx{}
-	if len(udf.Args) > 0 {
-		args = make(tree.TypedExprs, len(udf.Args))
-		for i := range udf.Args {
-			args[i], err = b.buildScalar(&ctx, udf.Args[i])
-			if err != nil {
-				return execPlan{}, err
-			}
-		}
+	args, err := b.buildRoutineArgs(&buildScalarCtx{}, udf.Args)
+	if err != nil {
+		return execPlan{}, err
 	}
 
 	for _, s := range udf.Def.Body {

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -81,8 +81,10 @@ func init() {
 		opt.ExistsOp:   (*Builder).buildExistsSubquery,
 		opt.SubqueryOp: (*Builder).buildSubquery,
 
-		// User-defined functions.
-		opt.UDFCallOp: (*Builder).buildUDF,
+		// Routines.
+		opt.UDFCallOp:    (*Builder).buildUDF,
+		opt.DispatcherOp: (*Builder).buildDispatcher,
+		opt.DispatchOp:   (*Builder).buildDispatch,
 	}
 
 	for _, op := range opt.BoolOperators {
@@ -841,6 +843,7 @@ func (b *Builder) buildSubquery(
 			ef := ref.(exec.Factory)
 			eb := New(ctx, ef, b.optimizer, b.mem, b.catalog, input, b.semaCtx, b.evalCtx, false /* allowAutoCommit */, b.IsANSIDML)
 			eb.withExprs = withExprs
+			eb.dispatchers = b.dispatchers
 			eb.disableTelemetry = true
 			eb.planLazySubqueries = true
 			ePlan, err := eb.buildRelational(input)
@@ -933,16 +936,9 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 	}
 
 	// Build the argument expressions.
-	var err error
-	var args tree.TypedExprs
-	if len(udf.Args) > 0 {
-		args = make(tree.TypedExprs, len(udf.Args))
-		for i := range udf.Args {
-			args[i], err = b.buildScalar(ctx, udf.Args[i])
-			if err != nil {
-				return nil, err
-			}
-		}
+	args, err := b.buildRoutineArgs(ctx, udf.Args)
+	if err != nil {
+		return nil, err
 	}
 
 	for _, s := range udf.Def.Body {
@@ -1020,6 +1016,26 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		udf.Def.BlockState,
 		udf.Def.CursorDeclaration,
 	), nil
+}
+
+// buildRoutineArgs handles the common logic for building the arguments of a
+// routine.
+func (b *Builder) buildRoutineArgs(
+	ctx *buildScalarCtx, args memo.ScalarListExpr,
+) (tree.TypedExprs, error) {
+	// Build the argument expressions.
+	var err error
+	var typedArgs tree.TypedExprs
+	if len(args) > 0 {
+		typedArgs = make(tree.TypedExprs, len(args))
+		for i := range args {
+			typedArgs[i], err = b.buildScalar(ctx, args[i])
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return typedArgs, nil
 }
 
 // initRoutineExceptionHandler initializes the exception handler (if any) for
@@ -1198,6 +1214,7 @@ func (b *Builder) buildRoutinePlanGenerator(
 			ef := ref.(exec.Factory)
 			eb := New(ctx, ef, &o, f.Memo(), b.catalog, optimizedExpr, b.semaCtx, b.evalCtx, false /* allowAutoCommit */, b.IsANSIDML)
 			eb.withExprs = withExprs
+			eb.dispatchers = b.dispatchers
 			eb.disableTelemetry = true
 			eb.planLazySubqueries = true
 			plan, err := eb.Build()
@@ -1228,4 +1245,71 @@ func (b *Builder) buildRoutinePlanGenerator(
 
 func expectedLazyRoutineError(typ string) error {
 	return errors.AssertionFailedf("expected %s to be lazily planned as a routine", typ)
+}
+
+// buildDispatcher builds a DispatcherExpr expression into a typed expression
+// that can be evaluated.
+func (b *Builder) buildDispatcher(
+	ctx *buildScalarCtx, scalar opt.ScalarExpr,
+) (tree.TypedExpr, error) {
+	dispatcherExpr := scalar.(*memo.DispatcherExpr)
+	if b.dispatchers == nil {
+		b.dispatchers = make(map[memo.DispatcherID]*tree.DispatchChannel)
+	} else if b.dispatchers[dispatcherExpr.ID] != nil {
+		return nil, errors.AssertionFailedf("conflicting DispatcherID: %d", dispatcherExpr.ID)
+	}
+	dispatchChannel := &tree.DispatchChannel{}
+	b.dispatchers[dispatcherExpr.ID] = dispatchChannel
+	input, err := b.buildScalar(ctx, dispatcherExpr.Input)
+	if err != nil {
+		return nil, err
+	}
+	branches := make([]*tree.RoutineExpr, 0, len(dispatcherExpr.Branches))
+	for _, def := range dispatcherExpr.Branches {
+		if def.BlockState != nil {
+			b.initRoutineExceptionHandler(def.BlockState, def.ExceptionBlock)
+		}
+		actionPlanGen := b.buildRoutinePlanGenerator(
+			def.Params,
+			def.Body,
+			def.BodyProps,
+			false, /* allowOuterWithRefs */
+			nil,   /* wrapRootExpr */
+		)
+		// Build a routine with no arguments for the branch. The actual arguments
+		// will be supplied when (if) the branch is invoked.
+		branches = append(branches, tree.NewTypedRoutineExpr(
+			def.Name,
+			nil, /* args */
+			actionPlanGen,
+			def.Typ,
+			true, /* enableStepping */
+			def.CalledOnNullInput,
+			def.MultiColDataSource,
+			def.SetReturning,
+			false,                 /* tailCall */
+			false,                 /* procedure */
+			def.BlockState,        /* blockState */
+			def.CursorDeclaration, /* cursorDeclaration */
+		))
+	}
+	return tree.NewDispatcherExpr(input, branches, dispatchChannel, dispatcherExpr.Typ), nil
+}
+
+// buildDispatch builds a DispatchExpr expression into a typed expression that
+// can be evaluated.
+func (b *Builder) buildDispatch(
+	ctx *buildScalarCtx, scalar opt.ScalarExpr,
+) (tree.TypedExpr, error) {
+	dispatch := scalar.(*memo.DispatchExpr)
+	dispatchChannel := b.dispatchers[dispatch.Dispatcher]
+	if dispatchChannel == nil {
+		return nil, errors.AssertionFailedf("expected dispatcher for DispatchExpr")
+	}
+
+	args, err := b.buildRoutineArgs(ctx, dispatch.Args)
+	if err != nil {
+		return nil, err
+	}
+	return tree.NewDispatchExpr(args, dispatch.Branch, dispatchChannel, dispatch.Typ), nil
 }

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -752,8 +752,15 @@ type ExceptionBlock struct {
 
 	// Actions contains routine definitions that represent exception handlers for
 	// each code in the Codes slice.
-	Actions []*UDFDefinition
+	Actions RoutineDefList
 }
+
+// RoutineDefList is a list of UDFDefinitions.
+type RoutineDefList []*UDFDefinition
+
+// DispatcherID uniquely identifies a Dispatcher expression within the scope of
+// a query.
+type DispatcherID uint64
 
 // WindowFrame denotes the definition of a window frame for an individual
 // window function, excluding the OFFSET expressions, if present.

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -777,6 +777,16 @@ func (h *hasher) HashUDFDefinition(val *UDFDefinition) {
 	h.HashUint64(uint64(reflect.ValueOf(val).Pointer()))
 }
 
+func (h *hasher) HashDispatcherID(val DispatcherID) {
+	h.HashUint64(uint64(val))
+}
+
+func (h *hasher) HashRoutineDefList(val RoutineDefList) {
+	for _, def := range val {
+		h.HashUDFDefinition(def)
+	}
+}
+
 // ----------------------------------------------------------------------
 //
 // Equality functions
@@ -1309,6 +1319,22 @@ func (h *hasher) IsUDFDefinitionEqual(l, r *UDFDefinition) bool {
 		return false
 	}
 	return h.IsColListEqual(l.Params, r.Params) && l.IsRecursive == r.IsRecursive
+}
+
+func (h *hasher) IsDispatcherIDEqual(l, r DispatcherID) bool {
+	return l == r
+}
+
+func (h *hasher) IsRoutineDefListEqual(l, r RoutineDefList) bool {
+	if len(l) != len(r) {
+		return false
+	}
+	for i := range l {
+		if !h.IsUDFDefinitionEqual(l[i], r[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // encodeDatum turns the given datum into an encoded string of bytes. If two

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -187,6 +187,9 @@ type Memo struct {
 	// curWithID is the highest currently in-use WITH ID.
 	curWithID opt.WithID
 
+	// curDispatcherID is the highest currently in-use Dispatcher ID.
+	curDispatcherID DispatcherID
+
 	newGroupFn func(opt.Expr)
 
 	// disableCheckExpr disables expression validation performed by CheckExpr,
@@ -515,6 +518,12 @@ func (m *Memo) RowsProcessed(expr RelExpr) (_ float64, ok bool) {
 func (m *Memo) NextWithID() opt.WithID {
 	m.curWithID++
 	return m.curWithID
+}
+
+// NextDispatcherID returns a not-yet-assigned identifier for a Dispatcher.
+func (m *Memo) NextDispatcherID() DispatcherID {
+	m.curDispatcherID++
+	return m.curDispatcherID
 }
 
 // Detach is used when we detach a memo that is to be reused later (either for

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -192,6 +192,8 @@ func init() {
 	typingFuncMap[opt.ArrayFlattenOp] = typeArrayFlatten
 	typingFuncMap[opt.IfErrOp] = typeIfErr
 	typingFuncMap[opt.UDFCallOp] = typeUDFCall
+	typingFuncMap[opt.DispatcherOp] = typeDispatcher
+	typingFuncMap[opt.DispatchOp] = typeDispatch
 
 	// Override default typeAsAggregate behavior for aggregate functions with
 	// a large number of possible overloads or where ReturnType depends on
@@ -389,6 +391,16 @@ func typeCast(e opt.ScalarExpr) *types.T {
 // typeUDFCall returns the type of a UDF call operator
 func typeUDFCall(e opt.ScalarExpr) *types.T {
 	return e.(*UDFCallExpr).Def.Typ
+}
+
+// typeDispatcher returns the type of a Dispatcher operator
+func typeDispatcher(e opt.ScalarExpr) *types.T {
+	return e.(*DispatcherExpr).Typ
+}
+
+// typeDispatch returns the type of a Dispatch operator
+func typeDispatch(e opt.ScalarExpr) *types.T {
+	return e.(*DispatchExpr).Typ
 }
 
 // typeSubquery returns the type of a subquery, which is equal to the type of

--- a/pkg/sql/opt/norm/decorrelate_funcs.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs.go
@@ -63,8 +63,8 @@ func (c *CustomFuncs) deriveHasHoistableSubquery(scalar opt.ScalarExpr) bool {
 		// only occurs when the Any is nested, in a projection, etc.
 		return !t.Input.Relational().OuterCols.Empty()
 
-	case *memo.UDFCallExpr:
-		// Do not attempt to hoist UDFs.
+	case *memo.UDFCallExpr, *memo.DispatcherExpr, *memo.DispatchExpr:
+		// Do not attempt to hoist UDFs, dispatchers, or dispatches.
 		return false
 
 	case *memo.EqExpr:

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -1267,6 +1267,40 @@ define UDFCallPrivate {
     TailCall bool
 }
 
+# Dispatcher coordinates the execution of multiple (possibly nested) routine
+# calls. This improves performance for deeply nested calls, and also allows
+# for nested transaction management. See the tree.DispatcherExpr comment for
+# further details.
+[Scalar]
+define Dispatcher {
+    Input ScalarExpr
+    _ DispatcherPrivate
+}
+
+[Private]
+define DispatcherPrivate {
+    ID DispatcherID
+    Branches RoutineDefList
+    Typ Type
+}
+
+# Dispatch is logically equivalent to a routine invocation. In reality, it
+# passes its arguments to a Dispatcher and indicates the routine to execute,
+# so that the Dispatcher can execute the routine in its own (less deeply nested)
+# context. See the tree.DispatcherExpr comment for further details.
+[Scalar]
+define Dispatch {
+    Args ScalarListExpr
+    _ DispatchPrivate
+}
+
+[Private]
+define DispatchPrivate {
+    Dispatcher DispatcherID
+    Branch int
+    Typ Type
+}
+
 # KVOptions is a set of KVOptionItems that specify arbitrary keys and values
 # that are used as modifiers for various statements (see tree.KVOptions). The
 # key is a constant string but the value can be a scalar expression.

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -306,7 +306,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 			plBuilder := newPLpgSQLBuilder(
 				b, cf.Name.Object(), nil /* colRefs */, paramTypes, funcReturnType,
 			)
-			stmtScope = plBuilder.buildBlock(stmt.AST, bodyScope)
+			stmtScope = plBuilder.buildRoutine(stmt.AST, bodyScope)
 		})
 		checkStmtVolatility(targetVolatility, stmtScope, stmt)
 

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -149,7 +149,14 @@ type plpgsqlBuilder struct {
 	// returnType is the return type of the PL/pgSQL function.
 	returnType *types.T
 
-	// continuations is used to model the control flow of a PL/pgSQL function.
+	// dispatcherID is the ID of the (single) Dispatcher expression that will
+	// coordinate execution of the subroutines.
+	dispatcherID memo.DispatcherID
+
+	// branches is the set of subroutines handled by the Dispatcher expression.
+	branches memo.RoutineDefList
+
+	// continuations is used to model the control flow of a PL/pgSQL routine.
 	// The head of the continuations stack is used upon reaching the end of a
 	// statement block to call a function that models the statements that come
 	// next after the block. In the context of a loop, this is used to recursively
@@ -178,10 +185,11 @@ func newPLpgSQLBuilder(
 ) *plpgsqlBuilder {
 	const initialBlocksCap = 2
 	b := &plpgsqlBuilder{
-		ob:         ob,
-		colRefs:    colRefs,
-		returnType: returnType,
-		blocks:     make([]plBlock, 0, initialBlocksCap),
+		ob:           ob,
+		colRefs:      colRefs,
+		returnType:   returnType,
+		blocks:       make([]plBlock, 0, initialBlocksCap),
+		dispatcherID: ob.factory.Memo().NextDispatcherID(),
 	}
 	// Build the initial block for the routine parameters, which are considered
 	// PL/pgSQL variables.
@@ -226,6 +234,26 @@ type plBlock struct {
 	// shared between parent and child or sibling blocks - it is unique within a
 	// given block.
 	state *tree.BlockState
+}
+
+// buildRoutine constructs an expression for the body statements of a PL/pgSQL
+// routine.
+func (b *plpgsqlBuilder) buildRoutine(body *ast.Block, s *scope) *scope {
+	bodyScope := s.push()
+	bodyScope = b.buildBlock(body, bodyScope)
+	input := b.ob.factory.ConstructSubquery(bodyScope.expr, &memo.SubqueryPrivate{})
+	dispatcher := b.ob.factory.ConstructDispatcher(input, &memo.DispatcherPrivate{
+		ID:       b.dispatcherID,
+		Branches: b.branches,
+		Typ:      b.returnType,
+	})
+	b.ensureScopeHasExpr(s)
+	b.addBarrierIfVolatile(s, dispatcher)
+	dispatchColName := scopeColName("").WithMetadataName(b.makeIdentifier("dispatcher"))
+	dispatchScope := s.push()
+	b.ob.synthesizeColumn(dispatchScope, dispatchColName, b.returnType, nil /* expr */, dispatcher)
+	b.ob.constructProjectForScope(s, dispatchScope)
+	return dispatchScope
 }
 
 // buildBlock constructs an expression that returns the result of executing a
@@ -321,7 +349,6 @@ func (b *plpgsqlBuilder) buildBlock(astBlock *ast.Block, s *scope) *scope {
 		b.appendPlpgSQLStmts(&blockCon, astBlock.Body)
 		return b.callContinuation(&blockCon, s)
 	}
-	// Finally, build the body statements for the block.
 	return b.buildPLpgSQLStatements(astBlock.Body, s)
 }
 
@@ -402,17 +429,6 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			// to the continuation that was built above).
 			elseScope := b.buildPLpgSQLStatements(t.ElseBody, s.push())
 			b.popContinuation()
-
-			// If one of the branches does not terminate, return nil to indicate a
-			// non-terminal branch.
-			if thenScope == nil || elseScope == nil {
-				return nil
-			}
-			for j := range elsifScopes {
-				if elsifScopes[j] == nil {
-					return nil
-				}
-			}
 
 			// Build a scalar CASE statement that conditionally executes each branch
 			// of the IF statement as a subquery.
@@ -1172,10 +1188,11 @@ func (b *plpgsqlBuilder) buildExceptions(block *ast.Block) *memo.ExceptionBlock 
 	}
 }
 
-// buildEndOfFunctionRaise builds a RAISE statement that throws an error when
-// control reaches the end of a PLpgSQL routine without reaching a RETURN
-// statement.
-func (b *plpgsqlBuilder) buildEndOfFunctionRaise(inScope *scope) *scope {
+// getEndOfFunctionCon builds a continuation to be called when control reaches
+// the end of a PLpgSQL routine without returning. This is handled by a RAISE
+// statement that throws an appropriate error. Note that the continuation is
+// cached and reused if multiple locations must call it.
+func (b *plpgsqlBuilder) getEndOfFunctionCon() *continuation {
 	makeConstStr := func(str string) opt.ScalarExpr {
 		return b.ob.factory.ConstructConstVal(tree.NewDString(str), types.String)
 	}
@@ -1186,7 +1203,7 @@ func (b *plpgsqlBuilder) buildEndOfFunctionRaise(inScope *scope) *scope {
 		makeConstStr(""), /* hint */
 		makeConstStr(pgcode.RoutineExceptionFunctionExecutedNoReturnStatement.String()), /* code */
 	}
-	con := b.makeContinuation("_end_of_function")
+	con := b.makeContinuation("end_of_function")
 	con.def.Volatility = volatility.Volatile
 	b.appendBodyStmt(&con, b.buildPLpgSQLRaise(con.s, args))
 	// Build a dummy statement that returns NULL. It won't be executed, but
@@ -1195,9 +1212,9 @@ func (b *plpgsqlBuilder) buildEndOfFunctionRaise(inScope *scope) *scope {
 	eofScope := con.s.push()
 	typedNull := b.ob.factory.ConstructNull(b.returnType)
 	b.ob.synthesizeColumn(eofScope, eofColName, b.returnType, nil /* expr */, typedNull)
-	b.ob.constructProjectForScope(inScope, eofScope)
+	b.ob.constructProjectForScope(con.s, eofScope)
 	b.appendBodyStmt(&con, eofScope)
-	return b.callContinuation(&con, inScope)
+	return &con
 }
 
 // buildFetch projects a call to the crdb_internal.plpgsql_fetch builtin
@@ -1306,6 +1323,7 @@ func (b *plpgsqlBuilder) projectRecordVar(s *scope, name ast.Variable) *scope {
 // continuations will have more parameters than those of its parent.
 func (b *plpgsqlBuilder) makeContinuation(conName string) continuation {
 	s := b.ob.allocScope()
+	b.ensureScopeHasExpr(s)
 	params := make(opt.ColList, 0, b.variableCount())
 	addParam := func(name ast.Variable, typ *types.T) {
 		colName := scopeColName(name)
@@ -1325,18 +1343,17 @@ func (b *plpgsqlBuilder) makeContinuation(conName string) continuation {
 			addParam(name, block.varTypes[name])
 		}
 	}
-	b.ensureScopeHasExpr(s)
-	return continuation{
-		def: &memo.UDFDefinition{
-			Params:            params,
-			Name:              b.makeIdentifier(conName),
-			Typ:               b.returnType,
-			CalledOnNullInput: true,
-			BlockState:        b.block().state,
-			RoutineType:       tree.UDFRoutine,
-		},
-		s: s,
+	branchIdx := len(b.branches)
+	def := &memo.UDFDefinition{
+		Params:            params,
+		Name:              b.makeIdentifier(conName),
+		Typ:               b.returnType,
+		CalledOnNullInput: true,
+		BlockState:        b.block().state,
+		RoutineType:       tree.UDFRoutine,
 	}
+	b.branches = append(b.branches, def)
+	return continuation{def: def, branchIdx: branchIdx, s: s}
 }
 
 // makeRecursiveContinuation allocates a new continuation routine that can
@@ -1379,7 +1396,7 @@ func (b *plpgsqlBuilder) appendPlpgSQLStmts(con *continuation, stmts []ast.State
 // given continuation function.
 func (b *plpgsqlBuilder) callContinuation(con *continuation, s *scope) *scope {
 	if con == nil {
-		return b.buildEndOfFunctionRaise(s)
+		return b.callContinuation(b.getEndOfFunctionCon(), s)
 	}
 	args := make(memo.ScalarListExpr, 0, len(con.def.Params))
 	addArg := func(name ast.Variable) {
@@ -1407,13 +1424,16 @@ func (b *plpgsqlBuilder) callContinuation(con *continuation, s *scope) *scope {
 			addArg(name)
 		}
 	}
-	// PLpgSQL continuation routines are always in tail-call position.
-	call := b.ob.factory.ConstructUDFCall(args, &memo.UDFCallPrivate{Def: con.def, TailCall: true})
-	b.addBarrierIfVolatile(s, call)
+	dispatch := b.ob.factory.ConstructDispatch(args, &memo.DispatchPrivate{
+		Dispatcher: b.dispatcherID,
+		Branch:     con.branchIdx,
+		Typ:        b.returnType,
+	})
+	b.addBarrierIfVolatile(s, dispatch)
 
 	returnColName := scopeColName("").WithMetadataName(con.def.Name)
 	returnScope := s.push()
-	b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, call)
+	b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, dispatch)
 	b.ob.constructProjectForScope(s, returnScope)
 	return returnScope
 }
@@ -1508,6 +1528,10 @@ func (b *plpgsqlBuilder) makeIdentifier(id string) string {
 // continuation holds the information necessary to pick up execution from some
 // branching point in the control flow.
 type continuation struct {
+	// branchIdx is the index of this continuation in the routine's dispatcher
+	// branches list.
+	branchIdx int
+
 	// def is used to construct a call into a routine that picks up execution
 	// from a branch in the control flow.
 	def *memo.UDFDefinition

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -1125,7 +1125,7 @@ func (b *plpgsqlBuilder) buildExceptions(block *ast.Block) *memo.ExceptionBlock 
 		return nil
 	}
 	codes := make([]pgcode.Code, 0, len(block.Exceptions))
-	handlers := make([]*memo.UDFDefinition, 0, len(block.Exceptions))
+	handlers := make(memo.RoutineDefList, 0, len(block.Exceptions))
 	addHandler := func(codeStr string, handler *memo.UDFDefinition) {
 		code := pgcode.MakeCode(strings.ToUpper(codeStr))
 		switch code {

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -301,7 +301,7 @@ func (b *Builder) buildRoutine(
 		var expr memo.RelExpr
 		var physProps *physical.Required
 		plBuilder := newPLpgSQLBuilder(b, def.Name, colRefs, o.Types.(tree.ParamTypes), rtyp)
-		stmtScope := plBuilder.buildBlock(stmt.AST, bodyScope)
+		stmtScope := plBuilder.buildRoutine(stmt.AST, bodyScope)
 		rtyp = finishResolveType(stmtScope)
 		expr, physProps, isMultiColDataSource =
 			b.finishBuildLastStmt(stmtScope, bodyScope, isSetReturning, f)

--- a/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
@@ -33,175 +33,180 @@ call
       ├── params: arg_k:1 new_i:2 new_s:3
       └── body
            └── limit
-                ├── columns: "_stmt_exec_1":59
+                ├── columns: dispatcher_8:60
                 ├── project
-                │    ├── columns: "_stmt_exec_1":59
-                │    ├── barrier
-                │    │    ├── columns: c:4
-                │    │    └── project
-                │    │         ├── columns: c:4
-                │    │         ├── values
-                │    │         │    └── tuple
-                │    │         └── projections
-                │    │              └── cast: INT8 [as=c:4]
-                │    │                   └── null
+                │    ├── columns: dispatcher_8:60
+                │    ├── values
+                │    │    └── tuple
                 │    └── projections
-                │         └── udf: _stmt_exec_1 [as="_stmt_exec_1":59]
-                │              ├── args
-                │              │    ├── variable: arg_k:1
-                │              │    ├── variable: new_i:2
-                │              │    ├── variable: new_s:3
-                │              │    └── variable: c:4
-                │              ├── params: arg_k:5 new_i:6 new_s:7 c:8
-                │              └── body
-                │                   └── project
-                │                        ├── columns: "_stmt_exec_ret_2":58
-                │                        ├── barrier
-                │                        │    ├── columns: c:57
-                │                        │    └── project
-                │                        │         ├── columns: c:57
-                │                        │         ├── right-join (cross)
-                │                        │         │    ├── columns: count_rows:14
-                │                        │         │    ├── limit
-                │                        │         │    │    ├── columns: count_rows:14!null
-                │                        │         │    │    ├── scalar-group-by
-                │                        │         │    │    │    ├── columns: count_rows:14!null
-                │                        │         │    │    │    ├── project
-                │                        │         │    │    │    │    └── select
-                │                        │         │    │    │    │         ├── columns: k:9!null i:10 s:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-                │                        │         │    │    │    │         ├── scan t
-                │                        │         │    │    │    │         │    └── columns: k:9!null i:10 s:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-                │                        │         │    │    │    │         └── filters
-                │                        │         │    │    │    │              └── eq
-                │                        │         │    │    │    │                   ├── variable: k:9
-                │                        │         │    │    │    │                   └── variable: arg_k:5
-                │                        │         │    │    │    └── aggregations
-                │                        │         │    │    │         └── count-rows [as=count_rows:14]
-                │                        │         │    │    └── const: 1
-                │                        │         │    ├── values
-                │                        │         │    │    └── tuple
-                │                        │         │    └── filters (true)
-                │                        │         └── projections
-                │                        │              └── variable: count_rows:14 [as=c:57]
-                │                        └── projections
-                │                             └── udf: _stmt_exec_ret_2 [as="_stmt_exec_ret_2":58]
-                │                                  ├── args
-                │                                  │    ├── variable: arg_k:5
-                │                                  │    ├── variable: new_i:6
-                │                                  │    ├── variable: new_s:7
-                │                                  │    └── variable: c:57
-                │                                  ├── params: arg_k:15 new_i:16 new_s:17 c:18
-                │                                  └── body
-                │                                       └── project
-                │                                            ├── columns: stmt_if_7:56
-                │                                            ├── values
-                │                                            │    └── tuple
-                │                                            └── projections
-                │                                                 └── case [as=stmt_if_7:56]
-                │                                                      ├── true
-                │                                                      ├── when
-                │                                                      │    ├── gt
-                │                                                      │    │    ├── variable: c:18
-                │                                                      │    │    └── const: 0
-                │                                                      │    └── subquery
-                │                                                      │         └── project
-                │                                                      │              ├── columns: "_stmt_exec_5":41
-                │                                                      │              ├── values
-                │                                                      │              │    └── tuple
-                │                                                      │              └── projections
-                │                                                      │                   └── udf: _stmt_exec_5 [as="_stmt_exec_5":41]
-                │                                                      │                        ├── args
-                │                                                      │                        │    ├── variable: arg_k:15
-                │                                                      │                        │    ├── variable: new_i:16
-                │                                                      │                        │    ├── variable: new_s:17
-                │                                                      │                        │    └── variable: c:18
-                │                                                      │                        ├── params: arg_k:24 new_i:25 new_s:26 c:27
-                │                                                      │                        └── body
-                │                                                      │                             ├── update t
-                │                                                      │                             │    ├── columns: <none>
-                │                                                      │                             │    ├── fetch columns: k:33 i:34 s:35
-                │                                                      │                             │    ├── update-mapping:
-                │                                                      │                             │    │    ├── i_new:38 => i:29
-                │                                                      │                             │    │    └── s_new:39 => s:30
-                │                                                      │                             │    └── project
-                │                                                      │                             │         ├── columns: i_new:38 s_new:39 k:33!null i:34 s:35 crdb_internal_mvcc_timestamp:36 tableoid:37
-                │                                                      │                             │         ├── select
-                │                                                      │                             │         │    ├── columns: k:33!null i:34 s:35 crdb_internal_mvcc_timestamp:36 tableoid:37
-                │                                                      │                             │         │    ├── scan t
-                │                                                      │                             │         │    │    └── columns: k:33!null i:34 s:35 crdb_internal_mvcc_timestamp:36 tableoid:37
-                │                                                      │                             │         │    └── filters
-                │                                                      │                             │         │         └── eq
-                │                                                      │                             │         │              ├── variable: k:33
-                │                                                      │                             │         │              └── variable: arg_k:24
-                │                                                      │                             │         └── projections
-                │                                                      │                             │              ├── variable: new_i:25 [as=i_new:38]
-                │                                                      │                             │              └── variable: new_s:26 [as=s_new:39]
-                │                                                      │                             └── project
-                │                                                      │                                  ├── columns: stmt_if_3:40
-                │                                                      │                                  ├── values
-                │                                                      │                                  │    └── tuple
-                │                                                      │                                  └── projections
-                │                                                      │                                       └── udf: stmt_if_3 [as=stmt_if_3:40]
-                │                                                      │                                            ├── args
-                │                                                      │                                            │    ├── variable: arg_k:24
-                │                                                      │                                            │    ├── variable: new_i:25
-                │                                                      │                                            │    ├── variable: new_s:26
-                │                                                      │                                            │    └── variable: c:27
-                │                                                      │                                            ├── params: arg_k:19 new_i:20 new_s:21 c:22
-                │                                                      │                                            └── body
-                │                                                      │                                                 └── project
-                │                                                      │                                                      ├── columns: stmt_return_4:23
-                │                                                      │                                                      ├── values
-                │                                                      │                                                      │    └── tuple
-                │                                                      │                                                      └── projections
-                │                                                      │                                                           └── cast: VOID [as=stmt_return_4:23]
-                │                                                      │                                                                └── null
-                │                                                      └── subquery
-                │                                                           └── project
-                │                                                                ├── columns: "_stmt_exec_6":55
-                │                                                                ├── values
-                │                                                                │    └── tuple
-                │                                                                └── projections
-                │                                                                     └── udf: _stmt_exec_6 [as="_stmt_exec_6":55]
-                │                                                                          ├── args
-                │                                                                          │    ├── variable: arg_k:15
-                │                                                                          │    ├── variable: new_i:16
-                │                                                                          │    ├── variable: new_s:17
-                │                                                                          │    └── variable: c:18
-                │                                                                          ├── params: arg_k:42 new_i:43 new_s:44 c:45
-                │                                                                          └── body
-                │                                                                               ├── insert t
-                │                                                                               │    ├── columns: <none>
-                │                                                                               │    ├── insert-mapping:
-                │                                                                               │    │    ├── column1:51 => k:46
-                │                                                                               │    │    ├── column2:52 => i:47
-                │                                                                               │    │    └── column3:53 => s:48
-                │                                                                               │    └── values
-                │                                                                               │         ├── columns: column1:51 column2:52 column3:53
-                │                                                                               │         └── tuple
-                │                                                                               │              ├── variable: arg_k:42
-                │                                                                               │              ├── variable: new_i:43
-                │                                                                               │              └── variable: new_s:44
-                │                                                                               └── project
-                │                                                                                    ├── columns: stmt_if_3:54
-                │                                                                                    ├── values
-                │                                                                                    │    └── tuple
-                │                                                                                    └── projections
-                │                                                                                         └── udf: stmt_if_3 [as=stmt_if_3:54]
-                │                                                                                              ├── args
-                │                                                                                              │    ├── variable: arg_k:42
-                │                                                                                              │    ├── variable: new_i:43
-                │                                                                                              │    ├── variable: new_s:44
-                │                                                                                              │    └── variable: c:45
-                │                                                                                              ├── params: arg_k:19 new_i:20 new_s:21 c:22
-                │                                                                                              └── body
-                │                                                                                                   └── project
-                │                                                                                                        ├── columns: stmt_return_4:23
-                │                                                                                                        ├── values
-                │                                                                                                        │    └── tuple
-                │                                                                                                        └── projections
-                │                                                                                                             └── cast: VOID [as=stmt_return_4:23]
-                │                                                                                                                  └── null
+                │         └── dispatcher
+                │              ├── subquery
+                │              │    └── project
+                │              │         ├── columns: "_stmt_exec_1":59
+                │              │         ├── project
+                │              │         │    ├── columns: c:4
+                │              │         │    ├── values
+                │              │         │    │    └── tuple
+                │              │         │    └── projections
+                │              │         │         └── cast: INT8 [as=c:4]
+                │              │         │              └── null
+                │              │         └── projections
+                │              │              └── dispatch: 1
+                │              │                   ├── branch: 0
+                │              │                   └── args
+                │              │                        ├── variable: arg_k:1
+                │              │                        ├── variable: new_i:2
+                │              │                        ├── variable: new_s:3
+                │              │                        └── variable: c:4
+                │              ├── branch: 0
+                │              │    ├── params: arg_k:5 new_i:6 new_s:7 c:8
+                │              │    └── body
+                │              │         └── project
+                │              │              ├── columns: "_stmt_exec_ret_2":58
+                │              │              ├── project
+                │              │              │    ├── columns: c:57
+                │              │              │    ├── right-join (cross)
+                │              │              │    │    ├── columns: count_rows:14
+                │              │              │    │    ├── limit
+                │              │              │    │    │    ├── columns: count_rows:14!null
+                │              │              │    │    │    ├── scalar-group-by
+                │              │              │    │    │    │    ├── columns: count_rows:14!null
+                │              │              │    │    │    │    ├── project
+                │              │              │    │    │    │    │    └── select
+                │              │              │    │    │    │    │         ├── columns: k:9!null i:10 s:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+                │              │              │    │    │    │    │         ├── scan t
+                │              │              │    │    │    │    │         │    └── columns: k:9!null i:10 s:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+                │              │              │    │    │    │    │         └── filters
+                │              │              │    │    │    │    │              └── eq
+                │              │              │    │    │    │    │                   ├── variable: k:9
+                │              │              │    │    │    │    │                   └── variable: arg_k:5
+                │              │              │    │    │    │    └── aggregations
+                │              │              │    │    │    │         └── count-rows [as=count_rows:14]
+                │              │              │    │    │    └── const: 1
+                │              │              │    │    ├── values
+                │              │              │    │    │    └── tuple
+                │              │              │    │    └── filters (true)
+                │              │              │    └── projections
+                │              │              │         └── variable: count_rows:14 [as=c:57]
+                │              │              └── projections
+                │              │                   └── dispatch: 1
+                │              │                        ├── branch: 1
+                │              │                        └── args
+                │              │                             ├── variable: arg_k:5
+                │              │                             ├── variable: new_i:6
+                │              │                             ├── variable: new_s:7
+                │              │                             └── variable: c:57
+                │              ├── branch: 1
+                │              │    ├── params: arg_k:15 new_i:16 new_s:17 c:18
+                │              │    └── body
+                │              │         └── project
+                │              │              ├── columns: stmt_if_7:56
+                │              │              ├── values
+                │              │              │    └── tuple
+                │              │              └── projections
+                │              │                   └── case [as=stmt_if_7:56]
+                │              │                        ├── true
+                │              │                        ├── when
+                │              │                        │    ├── gt
+                │              │                        │    │    ├── variable: c:18
+                │              │                        │    │    └── const: 0
+                │              │                        │    └── subquery
+                │              │                        │         └── project
+                │              │                        │              ├── columns: "_stmt_exec_5":41
+                │              │                        │              ├── values
+                │              │                        │              │    └── tuple
+                │              │                        │              └── projections
+                │              │                        │                   └── dispatch: 1
+                │              │                        │                        ├── branch: 3
+                │              │                        │                        └── args
+                │              │                        │                             ├── variable: arg_k:15
+                │              │                        │                             ├── variable: new_i:16
+                │              │                        │                             ├── variable: new_s:17
+                │              │                        │                             └── variable: c:18
+                │              │                        └── subquery
+                │              │                             └── project
+                │              │                                  ├── columns: "_stmt_exec_6":55
+                │              │                                  ├── values
+                │              │                                  │    └── tuple
+                │              │                                  └── projections
+                │              │                                       └── dispatch: 1
+                │              │                                            ├── branch: 4
+                │              │                                            └── args
+                │              │                                                 ├── variable: arg_k:15
+                │              │                                                 ├── variable: new_i:16
+                │              │                                                 ├── variable: new_s:17
+                │              │                                                 └── variable: c:18
+                │              ├── branch: 2
+                │              │    ├── params: arg_k:19 new_i:20 new_s:21 c:22
+                │              │    └── body
+                │              │         └── project
+                │              │              ├── columns: stmt_return_4:23
+                │              │              ├── values
+                │              │              │    └── tuple
+                │              │              └── projections
+                │              │                   └── cast: VOID [as=stmt_return_4:23]
+                │              │                        └── null
+                │              ├── branch: 3
+                │              │    ├── params: arg_k:24 new_i:25 new_s:26 c:27
+                │              │    └── body
+                │              │         ├── update t
+                │              │         │    ├── columns: <none>
+                │              │         │    ├── fetch columns: k:33 i:34 s:35
+                │              │         │    ├── update-mapping:
+                │              │         │    │    ├── i_new:38 => i:29
+                │              │         │    │    └── s_new:39 => s:30
+                │              │         │    └── project
+                │              │         │         ├── columns: i_new:38 s_new:39 k:33!null i:34 s:35 crdb_internal_mvcc_timestamp:36 tableoid:37
+                │              │         │         ├── select
+                │              │         │         │    ├── columns: k:33!null i:34 s:35 crdb_internal_mvcc_timestamp:36 tableoid:37
+                │              │         │         │    ├── scan t
+                │              │         │         │    │    └── columns: k:33!null i:34 s:35 crdb_internal_mvcc_timestamp:36 tableoid:37
+                │              │         │         │    └── filters
+                │              │         │         │         └── eq
+                │              │         │         │              ├── variable: k:33
+                │              │         │         │              └── variable: arg_k:24
+                │              │         │         └── projections
+                │              │         │              ├── variable: new_i:25 [as=i_new:38]
+                │              │         │              └── variable: new_s:26 [as=s_new:39]
+                │              │         └── project
+                │              │              ├── columns: stmt_if_3:40
+                │              │              ├── values
+                │              │              │    └── tuple
+                │              │              └── projections
+                │              │                   └── dispatch: 1
+                │              │                        ├── branch: 2
+                │              │                        └── args
+                │              │                             ├── variable: arg_k:24
+                │              │                             ├── variable: new_i:25
+                │              │                             ├── variable: new_s:26
+                │              │                             └── variable: c:27
+                │              └── branch: 4
+                │                   ├── params: arg_k:42 new_i:43 new_s:44 c:45
+                │                   └── body
+                │                        ├── insert t
+                │                        │    ├── columns: <none>
+                │                        │    ├── insert-mapping:
+                │                        │    │    ├── column1:51 => k:46
+                │                        │    │    ├── column2:52 => i:47
+                │                        │    │    └── column3:53 => s:48
+                │                        │    └── values
+                │                        │         ├── columns: column1:51 column2:52 column3:53
+                │                        │         └── tuple
+                │                        │              ├── variable: arg_k:42
+                │                        │              ├── variable: new_i:43
+                │                        │              └── variable: new_s:44
+                │                        └── project
+                │                             ├── columns: stmt_if_3:54
+                │                             ├── values
+                │                             │    └── tuple
+                │                             └── projections
+                │                                  └── dispatch: 1
+                │                                       ├── branch: 2
+                │                                       └── args
+                │                                            ├── variable: arg_k:42
+                │                                            ├── variable: new_i:43
+                │                                            ├── variable: new_s:44
+                │                                            └── variable: c:45
                 └── const: 1
 
 # Case with nested blocks.
@@ -238,197 +243,206 @@ call
       ├── params: x:1
       └── body
            └── limit
-                ├── columns: "_stmt_raise_1":27
+                ├── columns: dispatcher_9:28
                 ├── project
-                │    ├── columns: "_stmt_raise_1":27
-                │    ├── barrier
-                │    │    ├── columns: x:3 y:4!null
-                │    │    └── project
-                │    │         ├── columns: y:4!null x:3
-                │    │         ├── project
-                │    │         │    ├── columns: x:3 y:2!null
-                │    │         │    ├── project
-                │    │         │    │    ├── columns: y:2!null
-                │    │         │    │    ├── values
-                │    │         │    │    │    └── tuple
-                │    │         │    │    └── projections
-                │    │         │    │         └── const: 10 [as=y:2]
-                │    │         │    └── projections
-                │    │         │         └── plus [as=x:3]
-                │    │         │              ├── variable: x:1
-                │    │         │              └── const: 1
-                │    │         └── projections
-                │    │              └── plus [as=y:4]
-                │    │                   ├── variable: y:2
-                │    │                   └── const: 1
+                │    ├── columns: dispatcher_9:28
+                │    ├── values
+                │    │    └── tuple
                 │    └── projections
-                │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":27]
-                │              ├── args
-                │              │    ├── variable: x:3
-                │              │    └── variable: y:4
-                │              ├── params: x:5 y:6
-                │              └── body
-                │                   ├── project
-                │                   │    ├── columns: stmt_raise_2:7
-                │                   │    ├── values
-                │                   │    │    └── tuple
-                │                   │    └── projections
-                │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:7]
-                │                   │              ├── const: 'NOTICE'
-                │                   │              ├── concat
-                │                   │              │    ├── concat
-                │                   │              │    │    ├── concat
-                │                   │              │    │    │    ├── concat
-                │                   │              │    │    │    │    ├── const: ''
-                │                   │              │    │    │    │    └── coalesce
-                │                   │              │    │    │    │         ├── cast: STRING
-                │                   │              │    │    │    │         │    └── variable: x:5
-                │                   │              │    │    │    │         └── const: '<NULL>'
-                │                   │              │    │    │    └── const: ' '
-                │                   │              │    │    └── coalesce
-                │                   │              │    │         ├── cast: STRING
-                │                   │              │    │         │    └── variable: y:6
-                │                   │              │    │         └── const: '<NULL>'
-                │                   │              │    └── const: ''
-                │                   │              ├── const: ''
-                │                   │              ├── const: ''
-                │                   │              └── const: '00000'
-                │                   └── project
-                │                        ├── columns: "_stmt_raise_7":26
-                │                        ├── barrier
-                │                        │    ├── columns: x:18 y:19 z:20!null
-                │                        │    └── project
-                │                        │         ├── columns: z:20!null x:18 y:19
-                │                        │         ├── project
-                │                        │         │    ├── columns: y:19 z:17!null x:18
-                │                        │         │    ├── project
-                │                        │         │    │    ├── columns: x:18 z:17!null
-                │                        │         │    │    ├── project
-                │                        │         │    │    │    ├── columns: z:17!null
-                │                        │         │    │    │    ├── values
-                │                        │         │    │    │    │    └── tuple
-                │                        │         │    │    │    └── projections
-                │                        │         │    │    │         └── const: 100 [as=z:17]
-                │                        │         │    │    └── projections
-                │                        │         │    │         └── plus [as=x:18]
-                │                        │         │    │              ├── variable: x:5
-                │                        │         │    │              └── const: 1
-                │                        │         │    └── projections
-                │                        │         │         └── plus [as=y:19]
-                │                        │         │              ├── variable: y:6
-                │                        │         │              └── const: 1
-                │                        │         └── projections
-                │                        │              └── plus [as=z:20]
-                │                        │                   ├── variable: z:17
-                │                        │                   └── const: 1
-                │                        └── projections
-                │                             └── udf: _stmt_raise_7 [as="_stmt_raise_7":26]
-                │                                  ├── args
-                │                                  │    ├── variable: x:18
-                │                                  │    ├── variable: y:19
-                │                                  │    └── variable: z:20
-                │                                  ├── params: x:21 y:22 z:23
-                │                                  └── body
-                │                                       ├── project
-                │                                       │    ├── columns: stmt_raise_8:24
-                │                                       │    ├── values
-                │                                       │    │    └── tuple
-                │                                       │    └── projections
-                │                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:24]
-                │                                       │              ├── const: 'NOTICE'
-                │                                       │              ├── concat
-                │                                       │              │    ├── concat
-                │                                       │              │    │    ├── concat
-                │                                       │              │    │    │    ├── concat
-                │                                       │              │    │    │    │    ├── concat
-                │                                       │              │    │    │    │    │    ├── concat
-                │                                       │              │    │    │    │    │    │    ├── const: ''
-                │                                       │              │    │    │    │    │    │    └── coalesce
-                │                                       │              │    │    │    │    │    │         ├── cast: STRING
-                │                                       │              │    │    │    │    │    │         │    └── variable: x:21
-                │                                       │              │    │    │    │    │    │         └── const: '<NULL>'
-                │                                       │              │    │    │    │    │    └── const: ' '
-                │                                       │              │    │    │    │    └── coalesce
-                │                                       │              │    │    │    │         ├── cast: STRING
-                │                                       │              │    │    │    │         │    └── variable: y:22
-                │                                       │              │    │    │    │         └── const: '<NULL>'
-                │                                       │              │    │    │    └── const: ' '
-                │                                       │              │    │    └── coalesce
-                │                                       │              │    │         ├── cast: STRING
-                │                                       │              │    │         │    └── variable: z:23
-                │                                       │              │    │         └── const: '<NULL>'
-                │                                       │              │    └── const: ''
-                │                                       │              ├── const: ''
-                │                                       │              ├── const: ''
-                │                                       │              └── const: '00000'
-                │                                       └── project
-                │                                            ├── columns: nested_block_3:25
-                │                                            ├── values
-                │                                            │    └── tuple
-                │                                            └── projections
-                │                                                 └── udf: nested_block_3 [as=nested_block_3:25]
-                │                                                      ├── args
-                │                                                      │    ├── variable: x:21
-                │                                                      │    └── variable: y:22
-                │                                                      ├── params: x:8 y:9
-                │                                                      └── body
-                │                                                           └── project
-                │                                                                ├── columns: "_stmt_raise_4":16
-                │                                                                ├── barrier
-                │                                                                │    ├── columns: x:10 y:11
-                │                                                                │    └── project
-                │                                                                │         ├── columns: y:11 x:10
-                │                                                                │         ├── project
-                │                                                                │         │    ├── columns: x:10
-                │                                                                │         │    ├── values
-                │                                                                │         │    │    └── tuple
-                │                                                                │         │    └── projections
-                │                                                                │         │         └── plus [as=x:10]
-                │                                                                │         │              ├── variable: x:8
-                │                                                                │         │              └── const: 1
-                │                                                                │         └── projections
-                │                                                                │              └── plus [as=y:11]
-                │                                                                │                   ├── variable: y:9
-                │                                                                │                   └── const: 1
-                │                                                                └── projections
-                │                                                                     └── udf: _stmt_raise_4 [as="_stmt_raise_4":16]
-                │                                                                          ├── args
-                │                                                                          │    ├── variable: x:10
-                │                                                                          │    └── variable: y:11
-                │                                                                          ├── params: x:12 y:13
-                │                                                                          └── body
-                │                                                                               ├── project
-                │                                                                               │    ├── columns: stmt_raise_5:14
-                │                                                                               │    ├── values
-                │                                                                               │    │    └── tuple
-                │                                                                               │    └── projections
-                │                                                                               │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_5:14]
-                │                                                                               │              ├── const: 'NOTICE'
-                │                                                                               │              ├── concat
-                │                                                                               │              │    ├── concat
-                │                                                                               │              │    │    ├── concat
-                │                                                                               │              │    │    │    ├── concat
-                │                                                                               │              │    │    │    │    ├── const: ''
-                │                                                                               │              │    │    │    │    └── coalesce
-                │                                                                               │              │    │    │    │         ├── cast: STRING
-                │                                                                               │              │    │    │    │         │    └── variable: x:12
-                │                                                                               │              │    │    │    │         └── const: '<NULL>'
-                │                                                                               │              │    │    │    └── const: ' '
-                │                                                                               │              │    │    └── coalesce
-                │                                                                               │              │    │         ├── cast: STRING
-                │                                                                               │              │    │         │    └── variable: y:13
-                │                                                                               │              │    │         └── const: '<NULL>'
-                │                                                                               │              │    └── const: ''
-                │                                                                               │              ├── const: ''
-                │                                                                               │              ├── const: ''
-                │                                                                               │              └── const: '00000'
-                │                                                                               └── project
-                │                                                                                    ├── columns: stmt_return_6:15
-                │                                                                                    ├── values
-                │                                                                                    │    └── tuple
-                │                                                                                    └── projections
-                │                                                                                         └── cast: VOID [as=stmt_return_6:15]
-                │                                                                                              └── null
+                │         └── dispatcher
+                │              ├── subquery
+                │              │    └── project
+                │              │         ├── columns: "_stmt_raise_1":27
+                │              │         ├── project
+                │              │         │    ├── columns: y:4!null x:3
+                │              │         │    ├── project
+                │              │         │    │    ├── columns: x:3 y:2!null
+                │              │         │    │    ├── project
+                │              │         │    │    │    ├── columns: y:2!null
+                │              │         │    │    │    ├── values
+                │              │         │    │    │    │    └── tuple
+                │              │         │    │    │    └── projections
+                │              │         │    │    │         └── const: 10 [as=y:2]
+                │              │         │    │    └── projections
+                │              │         │    │         └── plus [as=x:3]
+                │              │         │    │              ├── variable: x:1
+                │              │         │    │              └── const: 1
+                │              │         │    └── projections
+                │              │         │         └── plus [as=y:4]
+                │              │         │              ├── variable: y:2
+                │              │         │              └── const: 1
+                │              │         └── projections
+                │              │              └── dispatch: 1
+                │              │                   ├── branch: 0
+                │              │                   └── args
+                │              │                        ├── variable: x:3
+                │              │                        └── variable: y:4
+                │              ├── branch: 0
+                │              │    ├── params: x:5 y:6
+                │              │    └── body
+                │              │         ├── project
+                │              │         │    ├── columns: stmt_raise_2:7
+                │              │         │    ├── values
+                │              │         │    │    └── tuple
+                │              │         │    └── projections
+                │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:7]
+                │              │         │              ├── const: 'NOTICE'
+                │              │         │              ├── concat
+                │              │         │              │    ├── concat
+                │              │         │              │    │    ├── concat
+                │              │         │              │    │    │    ├── concat
+                │              │         │              │    │    │    │    ├── const: ''
+                │              │         │              │    │    │    │    └── coalesce
+                │              │         │              │    │    │    │         ├── cast: STRING
+                │              │         │              │    │    │    │         │    └── variable: x:5
+                │              │         │              │    │    │    │         └── const: '<NULL>'
+                │              │         │              │    │    │    └── const: ' '
+                │              │         │              │    │    └── coalesce
+                │              │         │              │    │         ├── cast: STRING
+                │              │         │              │    │         │    └── variable: y:6
+                │              │         │              │    │         └── const: '<NULL>'
+                │              │         │              │    └── const: ''
+                │              │         │              ├── const: ''
+                │              │         │              ├── const: ''
+                │              │         │              └── const: '00000'
+                │              │         └── project
+                │              │              ├── columns: "_stmt_raise_7":26
+                │              │              ├── project
+                │              │              │    ├── columns: z:20!null x:18 y:19
+                │              │              │    ├── project
+                │              │              │    │    ├── columns: y:19 z:17!null x:18
+                │              │              │    │    ├── project
+                │              │              │    │    │    ├── columns: x:18 z:17!null
+                │              │              │    │    │    ├── project
+                │              │              │    │    │    │    ├── columns: z:17!null
+                │              │              │    │    │    │    ├── values
+                │              │              │    │    │    │    │    └── tuple
+                │              │              │    │    │    │    └── projections
+                │              │              │    │    │    │         └── const: 100 [as=z:17]
+                │              │              │    │    │    └── projections
+                │              │              │    │    │         └── plus [as=x:18]
+                │              │              │    │    │              ├── variable: x:5
+                │              │              │    │    │              └── const: 1
+                │              │              │    │    └── projections
+                │              │              │    │         └── plus [as=y:19]
+                │              │              │    │              ├── variable: y:6
+                │              │              │    │              └── const: 1
+                │              │              │    └── projections
+                │              │              │         └── plus [as=z:20]
+                │              │              │              ├── variable: z:17
+                │              │              │              └── const: 1
+                │              │              └── projections
+                │              │                   └── dispatch: 1
+                │              │                        ├── branch: 3
+                │              │                        └── args
+                │              │                             ├── variable: x:18
+                │              │                             ├── variable: y:19
+                │              │                             └── variable: z:20
+                │              ├── branch: 1
+                │              │    ├── params: x:8 y:9
+                │              │    └── body
+                │              │         └── project
+                │              │              ├── columns: "_stmt_raise_4":16
+                │              │              ├── project
+                │              │              │    ├── columns: y:11 x:10
+                │              │              │    ├── project
+                │              │              │    │    ├── columns: x:10
+                │              │              │    │    ├── values
+                │              │              │    │    │    └── tuple
+                │              │              │    │    └── projections
+                │              │              │    │         └── plus [as=x:10]
+                │              │              │    │              ├── variable: x:8
+                │              │              │    │              └── const: 1
+                │              │              │    └── projections
+                │              │              │         └── plus [as=y:11]
+                │              │              │              ├── variable: y:9
+                │              │              │              └── const: 1
+                │              │              └── projections
+                │              │                   └── dispatch: 1
+                │              │                        ├── branch: 2
+                │              │                        └── args
+                │              │                             ├── variable: x:10
+                │              │                             └── variable: y:11
+                │              ├── branch: 2
+                │              │    ├── params: x:12 y:13
+                │              │    └── body
+                │              │         ├── project
+                │              │         │    ├── columns: stmt_raise_5:14
+                │              │         │    ├── values
+                │              │         │    │    └── tuple
+                │              │         │    └── projections
+                │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_5:14]
+                │              │         │              ├── const: 'NOTICE'
+                │              │         │              ├── concat
+                │              │         │              │    ├── concat
+                │              │         │              │    │    ├── concat
+                │              │         │              │    │    │    ├── concat
+                │              │         │              │    │    │    │    ├── const: ''
+                │              │         │              │    │    │    │    └── coalesce
+                │              │         │              │    │    │    │         ├── cast: STRING
+                │              │         │              │    │    │    │         │    └── variable: x:12
+                │              │         │              │    │    │    │         └── const: '<NULL>'
+                │              │         │              │    │    │    └── const: ' '
+                │              │         │              │    │    └── coalesce
+                │              │         │              │    │         ├── cast: STRING
+                │              │         │              │    │         │    └── variable: y:13
+                │              │         │              │    │         └── const: '<NULL>'
+                │              │         │              │    └── const: ''
+                │              │         │              ├── const: ''
+                │              │         │              ├── const: ''
+                │              │         │              └── const: '00000'
+                │              │         └── project
+                │              │              ├── columns: stmt_return_6:15
+                │              │              ├── values
+                │              │              │    └── tuple
+                │              │              └── projections
+                │              │                   └── cast: VOID [as=stmt_return_6:15]
+                │              │                        └── null
+                │              └── branch: 3
+                │                   ├── params: x:21 y:22 z:23
+                │                   └── body
+                │                        ├── project
+                │                        │    ├── columns: stmt_raise_8:24
+                │                        │    ├── values
+                │                        │    │    └── tuple
+                │                        │    └── projections
+                │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:24]
+                │                        │              ├── const: 'NOTICE'
+                │                        │              ├── concat
+                │                        │              │    ├── concat
+                │                        │              │    │    ├── concat
+                │                        │              │    │    │    ├── concat
+                │                        │              │    │    │    │    ├── concat
+                │                        │              │    │    │    │    │    ├── concat
+                │                        │              │    │    │    │    │    │    ├── const: ''
+                │                        │              │    │    │    │    │    │    └── coalesce
+                │                        │              │    │    │    │    │    │         ├── cast: STRING
+                │                        │              │    │    │    │    │    │         │    └── variable: x:21
+                │                        │              │    │    │    │    │    │         └── const: '<NULL>'
+                │                        │              │    │    │    │    │    └── const: ' '
+                │                        │              │    │    │    │    └── coalesce
+                │                        │              │    │    │    │         ├── cast: STRING
+                │                        │              │    │    │    │         │    └── variable: y:22
+                │                        │              │    │    │    │         └── const: '<NULL>'
+                │                        │              │    │    │    └── const: ' '
+                │                        │              │    │    └── coalesce
+                │                        │              │    │         ├── cast: STRING
+                │                        │              │    │         │    └── variable: z:23
+                │                        │              │    │         └── const: '<NULL>'
+                │                        │              │    └── const: ''
+                │                        │              ├── const: ''
+                │                        │              ├── const: ''
+                │                        │              └── const: '00000'
+                │                        └── project
+                │                             ├── columns: nested_block_3:25
+                │                             ├── values
+                │                             │    └── tuple
+                │                             └── projections
+                │                                  └── dispatch: 1
+                │                                       ├── branch: 1
+                │                                       └── args
+                │                                            ├── variable: x:21
+                │                                            └── variable: y:22
                 └── const: 1
 
 # Nested blocks with an exception handler. Note that the exception handler
@@ -458,165 +472,158 @@ call
  └── procedure: p
       └── body
            └── limit
-                ├── columns: "_stmt_raise_1":18
+                ├── columns: dispatcher_10:19
                 ├── project
-                │    ├── columns: "_stmt_raise_1":18
-                │    ├── barrier
-                │    │    ├── columns: x:1!null
-                │    │    └── project
-                │    │         ├── columns: x:1!null
-                │    │         ├── values
-                │    │         │    └── tuple
-                │    │         └── projections
-                │    │              └── const: 0 [as=x:1]
+                │    ├── columns: dispatcher_10:19
+                │    ├── values
+                │    │    └── tuple
                 │    └── projections
-                │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":18]
-                │              ├── args
-                │              │    └── variable: x:1
-                │              ├── params: x:2
-                │              └── body
-                │                   ├── project
-                │                   │    ├── columns: stmt_raise_2:3
-                │                   │    ├── values
-                │                   │    │    └── tuple
-                │                   │    └── projections
-                │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:3]
-                │                   │              ├── const: 'NOTICE'
-                │                   │              ├── concat
-                │                   │              │    ├── concat
-                │                   │              │    │    ├── const: ''
-                │                   │              │    │    └── coalesce
-                │                   │              │    │         ├── cast: STRING
-                │                   │              │    │         │    └── variable: x:2
-                │                   │              │    │         └── const: '<NULL>'
-                │                   │              │    └── const: ''
-                │                   │              ├── const: ''
-                │                   │              ├── const: ''
-                │                   │              └── const: '00000'
-                │                   └── project
-                │                        ├── columns: exception_block_8:17
-                │                        ├── values
-                │                        │    └── tuple
-                │                        └── projections
-                │                             └── udf: exception_block_8 [as=exception_block_8:17]
-                │                                  ├── args
-                │                                  │    └── variable: x:2
-                │                                  ├── params: x:12
-                │                                  ├── body
-                │                                  │    └── project
-                │                                  │         ├── columns: "_stmt_exec_9":16
-                │                                  │         ├── values
-                │                                  │         │    └── tuple
-                │                                  │         └── projections
-                │                                  │              └── udf: _stmt_exec_9 [as="_stmt_exec_9":16]
-                │                                  │                   ├── args
-                │                                  │                   │    └── variable: x:12
-                │                                  │                   ├── params: x:13
-                │                                  │                   └── body
-                │                                  │                        ├── project
-                │                                  │                        │    ├── columns: "?column?":14!null
-                │                                  │                        │    ├── values
-                │                                  │                        │    │    └── tuple
-                │                                  │                        │    └── projections
-                │                                  │                        │         └── floor-div [as="?column?":14]
-                │                                  │                        │              ├── const: 1
-                │                                  │                        │              └── const: 0
-                │                                  │                        └── project
-                │                                  │                             ├── columns: nested_block_3:15
-                │                                  │                             ├── values
-                │                                  │                             │    └── tuple
-                │                                  │                             └── projections
-                │                                  │                                  └── udf: nested_block_3 [as=nested_block_3:15]
-                │                                  │                                       ├── args
-                │                                  │                                       │    └── variable: x:13
-                │                                  │                                       ├── params: x:4
-                │                                  │                                       └── body
-                │                                  │                                            └── project
-                │                                  │                                                 ├── columns: "_stmt_raise_4":8
-                │                                  │                                                 ├── values
-                │                                  │                                                 │    └── tuple
-                │                                  │                                                 └── projections
-                │                                  │                                                      └── udf: _stmt_raise_4 [as="_stmt_raise_4":8]
-                │                                  │                                                           ├── args
-                │                                  │                                                           │    └── variable: x:4
-                │                                  │                                                           ├── params: x:5
-                │                                  │                                                           └── body
-                │                                  │                                                                ├── project
-                │                                  │                                                                │    ├── columns: stmt_raise_5:6
-                │                                  │                                                                │    ├── values
-                │                                  │                                                                │    │    └── tuple
-                │                                  │                                                                │    └── projections
-                │                                  │                                                                │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_5:6]
-                │                                  │                                                                │              ├── const: 'NOTICE'
-                │                                  │                                                                │              ├── concat
-                │                                  │                                                                │              │    ├── concat
-                │                                  │                                                                │              │    │    ├── const: ''
-                │                                  │                                                                │              │    │    └── coalesce
-                │                                  │                                                                │              │    │         ├── cast: STRING
-                │                                  │                                                                │              │    │         │    └── variable: x:5
-                │                                  │                                                                │              │    │         └── const: '<NULL>'
-                │                                  │                                                                │              │    └── const: ''
-                │                                  │                                                                │              ├── const: ''
-                │                                  │                                                                │              ├── const: ''
-                │                                  │                                                                │              └── const: '00000'
-                │                                  │                                                                └── project
-                │                                  │                                                                     ├── columns: stmt_return_6:7
-                │                                  │                                                                     ├── values
-                │                                  │                                                                     │    └── tuple
-                │                                  │                                                                     └── projections
-                │                                  │                                                                          └── cast: VOID [as=stmt_return_6:7]
-                │                                  │                                                                               └── null
-                │                                  └── exception-handler
-                │                                       └── SQLSTATE '22012'
-                │                                            └── project
-                │                                                 ├── columns: nested_block_3:11
-                │                                                 ├── barrier
-                │                                                 │    ├── columns: x:10!null
-                │                                                 │    └── project
-                │                                                 │         ├── columns: x:10!null
-                │                                                 │         ├── values
-                │                                                 │         │    └── tuple
-                │                                                 │         └── projections
-                │                                                 │              └── const: 100 [as=x:10]
-                │                                                 └── projections
-                │                                                      └── udf: nested_block_3 [as=nested_block_3:11]
-                │                                                           ├── args
-                │                                                           │    └── variable: x:10
-                │                                                           ├── params: x:4
-                │                                                           └── body
-                │                                                                └── project
-                │                                                                     ├── columns: "_stmt_raise_4":8
-                │                                                                     ├── values
-                │                                                                     │    └── tuple
-                │                                                                     └── projections
-                │                                                                          └── udf: _stmt_raise_4 [as="_stmt_raise_4":8]
-                │                                                                               ├── args
-                │                                                                               │    └── variable: x:4
-                │                                                                               ├── params: x:5
-                │                                                                               └── body
-                │                                                                                    ├── project
-                │                                                                                    │    ├── columns: stmt_raise_5:6
-                │                                                                                    │    ├── values
-                │                                                                                    │    │    └── tuple
-                │                                                                                    │    └── projections
-                │                                                                                    │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_5:6]
-                │                                                                                    │              ├── const: 'NOTICE'
-                │                                                                                    │              ├── concat
-                │                                                                                    │              │    ├── concat
-                │                                                                                    │              │    │    ├── const: ''
-                │                                                                                    │              │    │    └── coalesce
-                │                                                                                    │              │    │         ├── cast: STRING
-                │                                                                                    │              │    │         │    └── variable: x:5
-                │                                                                                    │              │    │         └── const: '<NULL>'
-                │                                                                                    │              │    └── const: ''
-                │                                                                                    │              ├── const: ''
-                │                                                                                    │              ├── const: ''
-                │                                                                                    │              └── const: '00000'
-                │                                                                                    └── project
-                │                                                                                         ├── columns: stmt_return_6:7
-                │                                                                                         ├── values
-                │                                                                                         │    └── tuple
-                │                                                                                         └── projections
-                │                                                                                              └── cast: VOID [as=stmt_return_6:7]
-                │                                                                                                   └── null
+                │         └── dispatcher
+                │              ├── subquery
+                │              │    └── project
+                │              │         ├── columns: "_stmt_raise_1":18
+                │              │         ├── project
+                │              │         │    ├── columns: x:1!null
+                │              │         │    ├── values
+                │              │         │    │    └── tuple
+                │              │         │    └── projections
+                │              │         │         └── const: 0 [as=x:1]
+                │              │         └── projections
+                │              │              └── dispatch: 1
+                │              │                   ├── branch: 0
+                │              │                   └── args
+                │              │                        └── variable: x:1
+                │              ├── branch: 0
+                │              │    ├── params: x:2
+                │              │    └── body
+                │              │         ├── project
+                │              │         │    ├── columns: stmt_raise_2:3
+                │              │         │    ├── values
+                │              │         │    │    └── tuple
+                │              │         │    └── projections
+                │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:3]
+                │              │         │              ├── const: 'NOTICE'
+                │              │         │              ├── concat
+                │              │         │              │    ├── concat
+                │              │         │              │    │    ├── const: ''
+                │              │         │              │    │    └── coalesce
+                │              │         │              │    │         ├── cast: STRING
+                │              │         │              │    │         │    └── variable: x:2
+                │              │         │              │    │         └── const: '<NULL>'
+                │              │         │              │    └── const: ''
+                │              │         │              ├── const: ''
+                │              │         │              ├── const: ''
+                │              │         │              └── const: '00000'
+                │              │         └── project
+                │              │              ├── columns: exception_block_8:17
+                │              │              ├── values
+                │              │              │    └── tuple
+                │              │              └── projections
+                │              │                   └── dispatch: 1
+                │              │                        ├── branch: 4
+                │              │                        └── args
+                │              │                             └── variable: x:2
+                │              ├── branch: 1
+                │              │    ├── params: x:4
+                │              │    └── body
+                │              │         └── project
+                │              │              ├── columns: "_stmt_raise_4":8
+                │              │              ├── values
+                │              │              │    └── tuple
+                │              │              └── projections
+                │              │                   └── dispatch: 1
+                │              │                        ├── branch: 2
+                │              │                        └── args
+                │              │                             └── variable: x:4
+                │              ├── branch: 2
+                │              │    ├── params: x:5
+                │              │    └── body
+                │              │         ├── project
+                │              │         │    ├── columns: stmt_raise_5:6
+                │              │         │    ├── values
+                │              │         │    │    └── tuple
+                │              │         │    └── projections
+                │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_5:6]
+                │              │         │              ├── const: 'NOTICE'
+                │              │         │              ├── concat
+                │              │         │              │    ├── concat
+                │              │         │              │    │    ├── const: ''
+                │              │         │              │    │    └── coalesce
+                │              │         │              │    │         ├── cast: STRING
+                │              │         │              │    │         │    └── variable: x:5
+                │              │         │              │    │         └── const: '<NULL>'
+                │              │         │              │    └── const: ''
+                │              │         │              ├── const: ''
+                │              │         │              ├── const: ''
+                │              │         │              └── const: '00000'
+                │              │         └── project
+                │              │              ├── columns: stmt_return_6:7
+                │              │              ├── values
+                │              │              │    └── tuple
+                │              │              └── projections
+                │              │                   └── cast: VOID [as=stmt_return_6:7]
+                │              │                        └── null
+                │              ├── branch: 3
+                │              │    ├── params: x:9
+                │              │    └── body
+                │              │         └── project
+                │              │              ├── columns: nested_block_3:11
+                │              │              ├── project
+                │              │              │    ├── columns: x:10!null
+                │              │              │    ├── values
+                │              │              │    │    └── tuple
+                │              │              │    └── projections
+                │              │              │         └── const: 100 [as=x:10]
+                │              │              └── projections
+                │              │                   └── dispatch: 1
+                │              │                        ├── branch: 1
+                │              │                        └── args
+                │              │                             └── variable: x:10
+                │              ├── branch: 4
+                │              │    ├── params: x:12
+                │              │    ├── body
+                │              │    │    └── project
+                │              │    │         ├── columns: "_stmt_exec_9":16
+                │              │    │         ├── values
+                │              │    │         │    └── tuple
+                │              │    │         └── projections
+                │              │    │              └── dispatch: 1
+                │              │    │                   ├── branch: 5
+                │              │    │                   └── args
+                │              │    │                        └── variable: x:12
+                │              │    └── exception-handler
+                │              │         └── SQLSTATE '22012'
+                │              │              └── project
+                │              │                   ├── columns: nested_block_3:11
+                │              │                   ├── project
+                │              │                   │    ├── columns: x:10!null
+                │              │                   │    ├── values
+                │              │                   │    │    └── tuple
+                │              │                   │    └── projections
+                │              │                   │         └── const: 100 [as=x:10]
+                │              │                   └── projections
+                │              │                        └── dispatch: 1
+                │              │                             ├── branch: 1
+                │              │                             └── args
+                │              │                                  └── variable: x:10
+                │              └── branch: 5
+                │                   ├── params: x:13
+                │                   └── body
+                │                        ├── project
+                │                        │    ├── columns: "?column?":14!null
+                │                        │    ├── values
+                │                        │    │    └── tuple
+                │                        │    └── projections
+                │                        │         └── floor-div [as="?column?":14]
+                │                        │              ├── const: 1
+                │                        │              └── const: 0
+                │                        └── project
+                │                             ├── columns: nested_block_3:15
+                │                             ├── values
+                │                             │    └── tuple
+                │                             └── projections
+                │                                  └── dispatch: 1
+                │                                       ├── branch: 1
+                │                                       └── args
+                │                                            └── variable: x:13
                 └── const: 1

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -1089,11 +1089,11 @@ project
  │    └── tuple
  └── projections
       └── udf: strict_fn [as=strict_fn:5]
-           ├── strict
            ├── args
            │    ├── const: 1
            │    ├── const: 'foo'
            │    └── false
+           ├── strict
            ├── params: i:1 t:2 b:3
            └── body
                 └── limit
@@ -1118,7 +1118,6 @@ project
  │    └── filters
  │         └── eq
  │              ├── udf: strict_fn
- │              │    ├── strict
  │              │    ├── args
  │              │    │    ├── plus
  │              │    │    │    ├── plus
@@ -1128,6 +1127,7 @@ project
  │              │    │    ├── cast: STRING
  │              │    │    │    └── variable: abc.b:2
  │              │    │    └── false
+ │              │    ├── strict
  │              │    ├── params: i:6 t:7 b:8
  │              │    └── body
  │              │         └── limit
@@ -1142,12 +1142,12 @@ project
  │              └── const: 10
  └── projections
       └── udf: strict_fn [as=strict_fn:14]
-           ├── strict
            ├── args
            │    ├── variable: a:1
            │    ├── cast: STRING
            │    │    └── variable: abc.b:2
            │    └── false
+           ├── strict
            ├── params: i:10 t:11 b:12
            └── body
                 └── limit
@@ -1181,7 +1181,6 @@ project
  │    └── columns: t1.i:1
  └── projections
       └── udf: f101516 [as=f101516:16]
-           ├── strict
            ├── args
            │    └── subquery
            │         └── max1-row
@@ -1200,6 +1199,7 @@ project
            │                   │              └── variable: t3.i:9
            │                   └── projections
            │                        └── variable: t1.i:1 [as=i:13]
+           ├── strict
            ├── params: x:14
            └── body
                 └── values
@@ -1220,11 +1220,11 @@ project-set
  │    └── tuple
  └── zip
       └── udf: strict_fn_record
-           ├── strict
            ├── args
            │    ├── const: 1
            │    ├── const: 'foo'
            │    └── false
+           ├── strict
            ├── params: i:1 t:2 b:3
            └── body
                 └── limit
@@ -1248,11 +1248,11 @@ project
  │    └── tuple
  └── projections
       └── udf: strict_fn_record [as=strict_fn_record:8]
-           ├── strict
            ├── args
            │    ├── const: 1
            │    ├── const: 'foo'
            │    └── false
+           ├── strict
            ├── params: i:1 t:2 b:3
            └── body
                 └── project

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -18,24 +18,31 @@ build format=show-scalars
 SELECT f(1, 2);
 ----
 project
- ├── columns: f:4
+ ├── columns: f:5
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:4]
+      └── udf: f [as=f:5]
            ├── args
            │    ├── const: 1
            │    └── const: 2
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_return_1:3
+                     ├── columns: dispatcher_2:4
                      ├── project
-                     │    ├── columns: stmt_return_1:3
+                     │    ├── columns: dispatcher_2:4
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── variable: a:1 [as=stmt_return_1:3]
+                     │         └── dispatcher
+                     │              └── subquery
+                     │                   └── project
+                     │                        ├── columns: stmt_return_1:3
+                     │                        ├── values
+                     │                        │    └── tuple
+                     │                        └── projections
+                     │                             └── variable: a:1 [as=stmt_return_1:3]
                      └── const: 1
 
 exec-ddl
@@ -50,26 +57,33 @@ build format=show-scalars
 SELECT f(1, 2);
 ----
 project
- ├── columns: f:4
+ ├── columns: f:5
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:4]
+      └── udf: f [as=f:5]
            ├── args
            │    ├── const: 1
            │    └── const: 2
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_return_1:3
+                     ├── columns: dispatcher_2:4
                      ├── project
-                     │    ├── columns: stmt_return_1:3
+                     │    ├── columns: dispatcher_2:4
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── plus [as=stmt_return_1:3]
-                     │              ├── variable: a:1
-                     │              └── variable: b:2
+                     │         └── dispatcher
+                     │              └── subquery
+                     │                   └── project
+                     │                        ├── columns: stmt_return_1:3
+                     │                        ├── values
+                     │                        │    └── tuple
+                     │                        └── projections
+                     │                             └── plus [as=stmt_return_1:3]
+                     │                                  ├── variable: a:1
+                     │                                  └── variable: b:2
                      └── const: 1
 
 exec-ddl
@@ -77,84 +91,6 @@ CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
   DECLARE
     c INT;
   BEGIN
-    RETURN c;
-  END
-$$ LANGUAGE PLpgSQL;
-----
-
-build format=show-scalars
-SELECT f(1, 2);
-----
-project
- ├── columns: f:5
- ├── values
- │    └── tuple
- └── projections
-      └── udf: f [as=f:5]
-           ├── args
-           │    ├── const: 1
-           │    └── const: 2
-           ├── params: a:1 b:2
-           └── body
-                └── limit
-                     ├── columns: stmt_return_1:4
-                     ├── project
-                     │    ├── columns: stmt_return_1:4
-                     │    ├── project
-                     │    │    ├── columns: c:3
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         └── cast: INT8 [as=c:3]
-                     │    │              └── null
-                     │    └── projections
-                     │         └── variable: c:3 [as=stmt_return_1:4]
-                     └── const: 1
-
-exec-ddl
-CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
-  DECLARE
-    c INT := 0;
-  BEGIN
-    RETURN c;
-  END
-$$ LANGUAGE PLpgSQL;
-----
-
-build format=show-scalars
-SELECT f(1, 2);
-----
-project
- ├── columns: f:5
- ├── values
- │    └── tuple
- └── projections
-      └── udf: f [as=f:5]
-           ├── args
-           │    ├── const: 1
-           │    └── const: 2
-           ├── params: a:1 b:2
-           └── body
-                └── limit
-                     ├── columns: stmt_return_1:4!null
-                     ├── project
-                     │    ├── columns: stmt_return_1:4!null
-                     │    ├── project
-                     │    │    ├── columns: c:3!null
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         └── const: 0 [as=c:3]
-                     │    └── projections
-                     │         └── variable: c:3 [as=stmt_return_1:4]
-                     └── const: 1
-
-exec-ddl
-CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
-  DECLARE
-    c INT;
-  BEGIN
-    c := 0;
     RETURN c;
   END
 $$ LANGUAGE PLpgSQL;
@@ -175,22 +111,218 @@ project
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_return_1:5!null
+                     ├── columns: dispatcher_2:5
                      ├── project
-                     │    ├── columns: stmt_return_1:5!null
-                     │    ├── project
-                     │    │    ├── columns: c:4!null
-                     │    │    ├── project
-                     │    │    │    ├── columns: c:3
-                     │    │    │    ├── values
-                     │    │    │    │    └── tuple
-                     │    │    │    └── projections
-                     │    │    │         └── cast: INT8 [as=c:3]
-                     │    │    │              └── null
-                     │    │    └── projections
-                     │    │         └── const: 0 [as=c:4]
+                     │    ├── columns: dispatcher_2:5
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── variable: c:4 [as=stmt_return_1:5]
+                     │         └── dispatcher
+                     │              └── subquery
+                     │                   └── project
+                     │                        ├── columns: stmt_return_1:4
+                     │                        ├── project
+                     │                        │    ├── columns: c:3
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── cast: INT8 [as=c:3]
+                     │                        │              └── null
+                     │                        └── projections
+                     │                             └── variable: c:3 [as=stmt_return_1:4]
+                     └── const: 1
+
+exec-ddl
+CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
+  DECLARE
+    c INT := 0;
+  BEGIN
+    RETURN c;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(1, 2);
+----
+project
+ ├── columns: f:6
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:6]
+           ├── args
+           │    ├── const: 1
+           │    └── const: 2
+           ├── params: a:1 b:2
+           └── body
+                └── limit
+                     ├── columns: dispatcher_2:5
+                     ├── project
+                     │    ├── columns: dispatcher_2:5
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── dispatcher
+                     │              └── subquery
+                     │                   └── project
+                     │                        ├── columns: stmt_return_1:4!null
+                     │                        ├── project
+                     │                        │    ├── columns: c:3!null
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── const: 0 [as=c:3]
+                     │                        └── projections
+                     │                             └── variable: c:3 [as=stmt_return_1:4]
+                     └── const: 1
+
+exec-ddl
+CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
+  DECLARE
+    c INT;
+  BEGIN
+    c := 0;
+    RETURN c;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(1, 2);
+----
+project
+ ├── columns: f:7
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:7]
+           ├── args
+           │    ├── const: 1
+           │    └── const: 2
+           ├── params: a:1 b:2
+           └── body
+                └── limit
+                     ├── columns: dispatcher_2:6
+                     ├── project
+                     │    ├── columns: dispatcher_2:6
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── dispatcher
+                     │              └── subquery
+                     │                   └── project
+                     │                        ├── columns: stmt_return_1:5!null
+                     │                        ├── project
+                     │                        │    ├── columns: c:4!null
+                     │                        │    ├── project
+                     │                        │    │    ├── columns: c:3
+                     │                        │    │    ├── values
+                     │                        │    │    │    └── tuple
+                     │                        │    │    └── projections
+                     │                        │    │         └── cast: INT8 [as=c:3]
+                     │                        │    │              └── null
+                     │                        │    └── projections
+                     │                        │         └── const: 0 [as=c:4]
+                     │                        └── projections
+                     │                             └── variable: c:4 [as=stmt_return_1:5]
+                     └── const: 1
+
+exec-ddl
+CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
+  DECLARE
+    c INT;
+  BEGIN
+    IF a < b THEN
+      c := a;
+    ELSE
+      c := b;
+    END IF;
+    RETURN c;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(1, 2);
+----
+project
+ ├── columns: f:14
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:14]
+           ├── args
+           │    ├── const: 1
+           │    └── const: 2
+           ├── params: a:1 b:2
+           └── body
+                └── limit
+                     ├── columns: dispatcher_4:13
+                     ├── project
+                     │    ├── columns: dispatcher_4:13
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_if_3:12
+                     │              │         ├── project
+                     │              │         │    ├── columns: c:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── cast: INT8 [as=c:3]
+                     │              │         │              └── null
+                     │              │         └── projections
+                     │              │              └── case [as=stmt_if_3:12]
+                     │              │                   ├── true
+                     │              │                   ├── when
+                     │              │                   │    ├── lt
+                     │              │                   │    │    ├── variable: a:1
+                     │              │                   │    │    └── variable: b:2
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: stmt_if_1:9
+                     │              │                   │              ├── project
+                     │              │                   │              │    ├── columns: c:8
+                     │              │                   │              │    ├── values
+                     │              │                   │              │    │    └── tuple
+                     │              │                   │              │    └── projections
+                     │              │                   │              │         └── variable: a:1 [as=c:8]
+                     │              │                   │              └── projections
+                     │              │                   │                   └── dispatch: 1
+                     │              │                   │                        ├── branch: 0
+                     │              │                   │                        └── args
+                     │              │                   │                             ├── variable: a:1
+                     │              │                   │                             ├── variable: b:2
+                     │              │                   │                             └── variable: c:8
+                     │              │                   └── subquery
+                     │              │                        └── project
+                     │              │                             ├── columns: stmt_if_1:11
+                     │              │                             ├── project
+                     │              │                             │    ├── columns: c:10
+                     │              │                             │    ├── values
+                     │              │                             │    │    └── tuple
+                     │              │                             │    └── projections
+                     │              │                             │         └── variable: b:2 [as=c:10]
+                     │              │                             └── projections
+                     │              │                                  └── dispatch: 1
+                     │              │                                       ├── branch: 0
+                     │              │                                       └── args
+                     │              │                                            ├── variable: a:1
+                     │              │                                            ├── variable: b:2
+                     │              │                                            └── variable: c:10
+                     │              └── branch: 0
+                     │                   ├── params: a:4 b:5 c:6
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_return_2:7
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── variable: c:6 [as=stmt_return_2:7]
                      └── const: 1
 
 exec-ddl
@@ -210,76 +342,78 @@ build format=show-scalars
 SELECT f(1, 2);
 ----
 project
- ├── columns: f:12
+ ├── columns: f:13
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:12]
+      └── udf: f [as=f:13]
            ├── args
            │    ├── const: 1
            │    └── const: 2
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_if_3:11
+                     ├── columns: dispatcher_4:12
                      ├── project
-                     │    ├── columns: stmt_if_3:11
-                     │    ├── project
-                     │    │    ├── columns: c:3
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         └── cast: INT8 [as=c:3]
-                     │    │              └── null
+                     │    ├── columns: dispatcher_4:12
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── case [as=stmt_if_3:11]
-                     │              ├── true
-                     │              ├── when
-                     │              │    ├── lt
-                     │              │    │    ├── variable: a:1
-                     │              │    │    └── variable: b:2
-                     │              │    └── subquery
-                     │              │         └── project
-                     │              │              ├── columns: stmt_if_1:9
-                     │              │              ├── project
-                     │              │              │    ├── columns: c:8
-                     │              │              │    ├── values
-                     │              │              │    │    └── tuple
-                     │              │              │    └── projections
-                     │              │              │         └── variable: a:1 [as=c:8]
-                     │              │              └── projections
-                     │              │                   └── udf: stmt_if_1 [as=stmt_if_1:9]
-                     │              │                        ├── args
-                     │              │                        │    ├── variable: a:1
-                     │              │                        │    ├── variable: b:2
-                     │              │                        │    └── variable: c:8
-                     │              │                        ├── params: a:4 b:5 c:6
-                     │              │                        └── body
-                     │              │                             └── project
-                     │              │                                  ├── columns: stmt_return_2:7
-                     │              │                                  ├── values
-                     │              │                                  │    └── tuple
-                     │              │                                  └── projections
-                     │              │                                       └── variable: c:6 [as=stmt_return_2:7]
-                     │              └── subquery
-                     │                   └── project
-                     │                        ├── columns: stmt_if_1:10
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── udf: stmt_if_1 [as=stmt_if_1:10]
-                     │                                  ├── args
-                     │                                  │    ├── variable: a:1
-                     │                                  │    ├── variable: b:2
-                     │                                  │    └── variable: c:3
-                     │                                  ├── params: a:4 b:5 c:6
-                     │                                  └── body
-                     │                                       └── project
-                     │                                            ├── columns: stmt_return_2:7
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── variable: c:6 [as=stmt_return_2:7]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_if_3:11
+                     │              │         ├── project
+                     │              │         │    ├── columns: c:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── cast: INT8 [as=c:3]
+                     │              │         │              └── null
+                     │              │         └── projections
+                     │              │              └── case [as=stmt_if_3:11]
+                     │              │                   ├── true
+                     │              │                   ├── when
+                     │              │                   │    ├── lt
+                     │              │                   │    │    ├── variable: a:1
+                     │              │                   │    │    └── variable: b:2
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: stmt_if_1:9
+                     │              │                   │              ├── project
+                     │              │                   │              │    ├── columns: c:8
+                     │              │                   │              │    ├── values
+                     │              │                   │              │    │    └── tuple
+                     │              │                   │              │    └── projections
+                     │              │                   │              │         └── variable: a:1 [as=c:8]
+                     │              │                   │              └── projections
+                     │              │                   │                   └── dispatch: 1
+                     │              │                   │                        ├── branch: 0
+                     │              │                   │                        └── args
+                     │              │                   │                             ├── variable: a:1
+                     │              │                   │                             ├── variable: b:2
+                     │              │                   │                             └── variable: c:8
+                     │              │                   └── subquery
+                     │              │                        └── project
+                     │              │                             ├── columns: stmt_if_1:10
+                     │              │                             ├── values
+                     │              │                             │    └── tuple
+                     │              │                             └── projections
+                     │              │                                  └── dispatch: 1
+                     │              │                                       ├── branch: 0
+                     │              │                                       └── args
+                     │              │                                            ├── variable: a:1
+                     │              │                                            ├── variable: b:2
+                     │              │                                            └── variable: c:3
+                     │              └── branch: 0
+                     │                   ├── params: a:4 b:5 c:6
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_return_2:7
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── variable: c:6 [as=stmt_return_2:7]
                      └── const: 1
 
 exec-ddl
@@ -288,7 +422,7 @@ CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
     c INT;
   BEGIN
     IF a < b THEN
-      c := a;
+      RETURN 100;
     ELSE
       c := b;
     END IF;
@@ -312,69 +446,159 @@ project
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_if_3:12
+                     ├── columns: dispatcher_5:12
                      ├── project
-                     │    ├── columns: stmt_if_3:12
-                     │    ├── project
-                     │    │    ├── columns: c:3
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         └── cast: INT8 [as=c:3]
-                     │    │              └── null
+                     │    ├── columns: dispatcher_5:12
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── case [as=stmt_if_3:12]
-                     │              ├── true
-                     │              ├── when
-                     │              │    ├── lt
-                     │              │    │    ├── variable: a:1
-                     │              │    │    └── variable: b:2
-                     │              │    └── subquery
-                     │              │         └── project
-                     │              │              ├── columns: stmt_if_1:9
-                     │              │              ├── project
-                     │              │              │    ├── columns: c:8
-                     │              │              │    ├── values
-                     │              │              │    │    └── tuple
-                     │              │              │    └── projections
-                     │              │              │         └── variable: a:1 [as=c:8]
-                     │              │              └── projections
-                     │              │                   └── udf: stmt_if_1 [as=stmt_if_1:9]
-                     │              │                        ├── args
-                     │              │                        │    ├── variable: a:1
-                     │              │                        │    ├── variable: b:2
-                     │              │                        │    └── variable: c:8
-                     │              │                        ├── params: a:4 b:5 c:6
-                     │              │                        └── body
-                     │              │                             └── project
-                     │              │                                  ├── columns: stmt_return_2:7
-                     │              │                                  ├── values
-                     │              │                                  │    └── tuple
-                     │              │                                  └── projections
-                     │              │                                       └── variable: c:6 [as=stmt_return_2:7]
-                     │              └── subquery
-                     │                   └── project
-                     │                        ├── columns: stmt_if_1:11
-                     │                        ├── project
-                     │                        │    ├── columns: c:10
-                     │                        │    ├── values
-                     │                        │    │    └── tuple
-                     │                        │    └── projections
-                     │                        │         └── variable: b:2 [as=c:10]
-                     │                        └── projections
-                     │                             └── udf: stmt_if_1 [as=stmt_if_1:11]
-                     │                                  ├── args
-                     │                                  │    ├── variable: a:1
-                     │                                  │    ├── variable: b:2
-                     │                                  │    └── variable: c:10
-                     │                                  ├── params: a:4 b:5 c:6
-                     │                                  └── body
-                     │                                       └── project
-                     │                                            ├── columns: stmt_return_2:7
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── variable: c:6 [as=stmt_return_2:7]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_if_4:11
+                     │              │         ├── project
+                     │              │         │    ├── columns: c:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── cast: INT8 [as=c:3]
+                     │              │         │              └── null
+                     │              │         └── projections
+                     │              │              └── case [as=stmt_if_4:11]
+                     │              │                   ├── true
+                     │              │                   ├── when
+                     │              │                   │    ├── lt
+                     │              │                   │    │    ├── variable: a:1
+                     │              │                   │    │    └── variable: b:2
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: stmt_return_3:8!null
+                     │              │                   │              ├── values
+                     │              │                   │              │    └── tuple
+                     │              │                   │              └── projections
+                     │              │                   │                   └── const: 100 [as=stmt_return_3:8]
+                     │              │                   └── subquery
+                     │              │                        └── project
+                     │              │                             ├── columns: stmt_if_1:10
+                     │              │                             ├── project
+                     │              │                             │    ├── columns: c:9
+                     │              │                             │    ├── values
+                     │              │                             │    │    └── tuple
+                     │              │                             │    └── projections
+                     │              │                             │         └── variable: b:2 [as=c:9]
+                     │              │                             └── projections
+                     │              │                                  └── dispatch: 1
+                     │              │                                       ├── branch: 0
+                     │              │                                       └── args
+                     │              │                                            ├── variable: a:1
+                     │              │                                            ├── variable: b:2
+                     │              │                                            └── variable: c:9
+                     │              └── branch: 0
+                     │                   ├── params: a:4 b:5 c:6
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_return_2:7
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── variable: c:6 [as=stmt_return_2:7]
+                     └── const: 1
+
+exec-ddl
+CREATE OR REPLACE FUNCTION f(a INT, b INT) RETURNS INT AS $$
+  DECLARE
+    c INT;
+  BEGIN
+    IF a < b THEN
+      c := a;
+    ELSE
+      c := b;
+    END IF;
+    RETURN c;
+  END
+$$ LANGUAGE PLpgSQL;
+----
+
+build format=show-scalars
+SELECT f(1, 2);
+----
+project
+ ├── columns: f:14
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: f [as=f:14]
+           ├── args
+           │    ├── const: 1
+           │    └── const: 2
+           ├── params: a:1 b:2
+           └── body
+                └── limit
+                     ├── columns: dispatcher_4:13
+                     ├── project
+                     │    ├── columns: dispatcher_4:13
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_if_3:12
+                     │              │         ├── project
+                     │              │         │    ├── columns: c:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── cast: INT8 [as=c:3]
+                     │              │         │              └── null
+                     │              │         └── projections
+                     │              │              └── case [as=stmt_if_3:12]
+                     │              │                   ├── true
+                     │              │                   ├── when
+                     │              │                   │    ├── lt
+                     │              │                   │    │    ├── variable: a:1
+                     │              │                   │    │    └── variable: b:2
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: stmt_if_1:9
+                     │              │                   │              ├── project
+                     │              │                   │              │    ├── columns: c:8
+                     │              │                   │              │    ├── values
+                     │              │                   │              │    │    └── tuple
+                     │              │                   │              │    └── projections
+                     │              │                   │              │         └── variable: a:1 [as=c:8]
+                     │              │                   │              └── projections
+                     │              │                   │                   └── dispatch: 1
+                     │              │                   │                        ├── branch: 0
+                     │              │                   │                        └── args
+                     │              │                   │                             ├── variable: a:1
+                     │              │                   │                             ├── variable: b:2
+                     │              │                   │                             └── variable: c:8
+                     │              │                   └── subquery
+                     │              │                        └── project
+                     │              │                             ├── columns: stmt_if_1:11
+                     │              │                             ├── project
+                     │              │                             │    ├── columns: c:10
+                     │              │                             │    ├── values
+                     │              │                             │    │    └── tuple
+                     │              │                             │    └── projections
+                     │              │                             │         └── variable: b:2 [as=c:10]
+                     │              │                             └── projections
+                     │              │                                  └── dispatch: 1
+                     │              │                                       ├── branch: 0
+                     │              │                                       └── args
+                     │              │                                            ├── variable: a:1
+                     │              │                                            ├── variable: b:2
+                     │              │                                            └── variable: c:10
+                     │              └── branch: 0
+                     │                   ├── params: a:4 b:5 c:6
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_return_2:7
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── variable: c:6 [as=stmt_return_2:7]
                      └── const: 1
 
 exec-ddl
@@ -396,64 +620,73 @@ build format=show-scalars
 SELECT f(1, 2);
 ----
 project
- ├── columns: f:12
+ ├── columns: f:13
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:12]
+      └── udf: f [as=f:13]
            ├── args
            │    ├── const: 1
            │    └── const: 2
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_if_4:11
+                     ├── columns: dispatcher_5:12
                      ├── project
-                     │    ├── columns: stmt_if_4:11
-                     │    ├── project
-                     │    │    ├── columns: c:3
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         └── cast: INT8 [as=c:3]
-                     │    │              └── null
+                     │    ├── columns: dispatcher_5:12
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── case [as=stmt_if_4:11]
-                     │              ├── true
-                     │              ├── when
-                     │              │    ├── lt
-                     │              │    │    ├── variable: a:1
-                     │              │    │    └── variable: b:2
-                     │              │    └── subquery
-                     │              │         └── project
-                     │              │              ├── columns: stmt_if_1:9
-                     │              │              ├── project
-                     │              │              │    ├── columns: c:8
-                     │              │              │    ├── values
-                     │              │              │    │    └── tuple
-                     │              │              │    └── projections
-                     │              │              │         └── variable: a:1 [as=c:8]
-                     │              │              └── projections
-                     │              │                   └── udf: stmt_if_1 [as=stmt_if_1:9]
-                     │              │                        ├── args
-                     │              │                        │    ├── variable: a:1
-                     │              │                        │    ├── variable: b:2
-                     │              │                        │    └── variable: c:8
-                     │              │                        ├── params: a:4 b:5 c:6
-                     │              │                        └── body
-                     │              │                             └── project
-                     │              │                                  ├── columns: stmt_return_2:7
-                     │              │                                  ├── values
-                     │              │                                  │    └── tuple
-                     │              │                                  └── projections
-                     │              │                                       └── variable: c:6 [as=stmt_return_2:7]
-                     │              └── subquery
-                     │                   └── project
-                     │                        ├── columns: stmt_return_3:10!null
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── const: 100 [as=stmt_return_3:10]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_if_4:11
+                     │              │         ├── project
+                     │              │         │    ├── columns: c:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── cast: INT8 [as=c:3]
+                     │              │         │              └── null
+                     │              │         └── projections
+                     │              │              └── case [as=stmt_if_4:11]
+                     │              │                   ├── true
+                     │              │                   ├── when
+                     │              │                   │    ├── lt
+                     │              │                   │    │    ├── variable: a:1
+                     │              │                   │    │    └── variable: b:2
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: stmt_if_1:9
+                     │              │                   │              ├── project
+                     │              │                   │              │    ├── columns: c:8
+                     │              │                   │              │    ├── values
+                     │              │                   │              │    │    └── tuple
+                     │              │                   │              │    └── projections
+                     │              │                   │              │         └── variable: a:1 [as=c:8]
+                     │              │                   │              └── projections
+                     │              │                   │                   └── dispatch: 1
+                     │              │                   │                        ├── branch: 0
+                     │              │                   │                        └── args
+                     │              │                   │                             ├── variable: a:1
+                     │              │                   │                             ├── variable: b:2
+                     │              │                   │                             └── variable: c:8
+                     │              │                   └── subquery
+                     │              │                        └── project
+                     │              │                             ├── columns: stmt_return_3:10!null
+                     │              │                             ├── values
+                     │              │                             │    └── tuple
+                     │              │                             └── projections
+                     │              │                                  └── const: 100 [as=stmt_return_3:10]
+                     │              └── branch: 0
+                     │                   ├── params: a:4 b:5 c:6
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_return_2:7
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── variable: c:6 [as=stmt_return_2:7]
                      └── const: 1
 
 exec-ddl
@@ -475,64 +708,73 @@ build format=show-scalars
 SELECT f(1, 2);
 ----
 project
- ├── columns: f:12
+ ├── columns: f:13
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:12]
+      └── udf: f [as=f:13]
            ├── args
            │    ├── const: 1
            │    └── const: 2
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_if_4:11
+                     ├── columns: dispatcher_5:12
                      ├── project
-                     │    ├── columns: stmt_if_4:11
-                     │    ├── project
-                     │    │    ├── columns: c:3
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         └── cast: INT8 [as=c:3]
-                     │    │              └── null
+                     │    ├── columns: dispatcher_5:12
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── case [as=stmt_if_4:11]
-                     │              ├── true
-                     │              ├── when
-                     │              │    ├── lt
-                     │              │    │    ├── variable: a:1
-                     │              │    │    └── variable: b:2
-                     │              │    └── subquery
-                     │              │         └── project
-                     │              │              ├── columns: stmt_return_3:8!null
-                     │              │              ├── values
-                     │              │              │    └── tuple
-                     │              │              └── projections
-                     │              │                   └── const: 100 [as=stmt_return_3:8]
-                     │              └── subquery
-                     │                   └── project
-                     │                        ├── columns: stmt_if_1:10
-                     │                        ├── project
-                     │                        │    ├── columns: c:9
-                     │                        │    ├── values
-                     │                        │    │    └── tuple
-                     │                        │    └── projections
-                     │                        │         └── variable: b:2 [as=c:9]
-                     │                        └── projections
-                     │                             └── udf: stmt_if_1 [as=stmt_if_1:10]
-                     │                                  ├── args
-                     │                                  │    ├── variable: a:1
-                     │                                  │    ├── variable: b:2
-                     │                                  │    └── variable: c:9
-                     │                                  ├── params: a:4 b:5 c:6
-                     │                                  └── body
-                     │                                       └── project
-                     │                                            ├── columns: stmt_return_2:7
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── variable: c:6 [as=stmt_return_2:7]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_if_4:11
+                     │              │         ├── project
+                     │              │         │    ├── columns: c:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── cast: INT8 [as=c:3]
+                     │              │         │              └── null
+                     │              │         └── projections
+                     │              │              └── case [as=stmt_if_4:11]
+                     │              │                   ├── true
+                     │              │                   ├── when
+                     │              │                   │    ├── lt
+                     │              │                   │    │    ├── variable: a:1
+                     │              │                   │    │    └── variable: b:2
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: stmt_return_3:8!null
+                     │              │                   │              ├── values
+                     │              │                   │              │    └── tuple
+                     │              │                   │              └── projections
+                     │              │                   │                   └── const: 100 [as=stmt_return_3:8]
+                     │              │                   └── subquery
+                     │              │                        └── project
+                     │              │                             ├── columns: stmt_if_1:10
+                     │              │                             ├── project
+                     │              │                             │    ├── columns: c:9
+                     │              │                             │    ├── values
+                     │              │                             │    │    └── tuple
+                     │              │                             │    └── projections
+                     │              │                             │         └── variable: b:2 [as=c:9]
+                     │              │                             └── projections
+                     │              │                                  └── dispatch: 1
+                     │              │                                       ├── branch: 0
+                     │              │                                       └── args
+                     │              │                                            ├── variable: a:1
+                     │              │                                            ├── variable: b:2
+                     │              │                                            └── variable: c:9
+                     │              └── branch: 0
+                     │                   ├── params: a:4 b:5 c:6
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_return_2:7
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── variable: c:6 [as=stmt_return_2:7]
                      └── const: 1
 
 exec-ddl
@@ -553,48 +795,89 @@ build format=show-scalars
 SELECT f(1, 2);
 ----
 project
- ├── columns: f:16
+ ├── columns: f:17
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:16]
+      └── udf: f [as=f:17]
            ├── args
            │    ├── const: 1
            │    └── const: 2
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_if_7:15
+                     ├── columns: dispatcher_8:16
                      ├── project
-                     │    ├── columns: stmt_if_7:15
-                     │    ├── project
-                     │    │    ├── columns: c:3
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         └── cast: INT8 [as=c:3]
-                     │    │              └── null
+                     │    ├── columns: dispatcher_8:16
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── case [as=stmt_if_7:15]
-                     │              ├── true
-                     │              ├── when
-                     │              │    ├── lt
-                     │              │    │    ├── variable: a:1
-                     │              │    │    └── variable: b:2
-                     │              │    └── subquery
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_if_7:15
+                     │              │         ├── project
+                     │              │         │    ├── columns: c:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── cast: INT8 [as=c:3]
+                     │              │         │              └── null
+                     │              │         └── projections
+                     │              │              └── case [as=stmt_if_7:15]
+                     │              │                   ├── true
+                     │              │                   ├── when
+                     │              │                   │    ├── lt
+                     │              │                   │    │    ├── variable: a:1
+                     │              │                   │    │    └── variable: b:2
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: stmt_return_5:13!null
+                     │              │                   │              ├── values
+                     │              │                   │              │    └── tuple
+                     │              │                   │              └── projections
+                     │              │                   │                   └── const: 100 [as=stmt_return_5:13]
+                     │              │                   └── subquery
+                     │              │                        └── project
+                     │              │                             ├── columns: stmt_return_6:14!null
+                     │              │                             ├── values
+                     │              │                             │    └── tuple
+                     │              │                             └── projections
+                     │              │                                  └── const: 0 [as=stmt_return_6:14]
+                     │              ├── branch: 0
+                     │              │    ├── params: a:4 b:5 c:6
+                     │              │    └── body
                      │              │         └── project
-                     │              │              ├── columns: stmt_return_5:13!null
+                     │              │              ├── columns: end_of_function_2:12
                      │              │              ├── values
                      │              │              │    └── tuple
                      │              │              └── projections
-                     │              │                   └── const: 100 [as=stmt_return_5:13]
-                     │              └── subquery
-                     │                   └── project
-                     │                        ├── columns: stmt_return_6:14!null
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── const: 0 [as=stmt_return_6:14]
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             ├── variable: a:4
+                     │              │                             ├── variable: b:5
+                     │              │                             └── variable: c:6
+                     │              └── branch: 1
+                     │                   ├── params: a:7 b:8 c:9
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_3:10
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_3:10]
+                     │                        │              ├── const: 'ERROR'
+                     │                        │              ├── const: 'control reached end of function without RETURN'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: '2F005'
+                     │                        └── project
+                     │                             ├── columns: end_of_function_4:11
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── null [as=end_of_function_4:11]
                      └── const: 1
 
 exec-ddl
@@ -613,40 +896,83 @@ build format=show-scalars
 SELECT f(1, 2);
 ----
 project
- ├── columns: f:18
+ ├── columns: f:19
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:18]
+      └── udf: f [as=f:19]
            ├── args
            │    ├── const: 1
            │    └── const: 2
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_loop_5:17
+                     ├── columns: dispatcher_7:18
                      ├── project
-                     │    ├── columns: stmt_loop_5:17
-                     │    ├── project
-                     │    │    ├── columns: i:3
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         └── variable: a:1 [as=i:3]
+                     │    ├── columns: dispatcher_7:18
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: stmt_loop_5 [as=stmt_loop_5:17]
-                     │              ├── args
-                     │              │    ├── variable: a:1
-                     │              │    ├── variable: b:2
-                     │              │    └── variable: i:3
-                     │              ├── params: a:13 b:14 i:15
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: stmt_return_6:16!null
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── const: 100 [as=stmt_return_6:16]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_loop_5:17
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── variable: a:1 [as=i:3]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 2
+                     │              │                   └── args
+                     │              │                        ├── variable: a:1
+                     │              │                        ├── variable: b:2
+                     │              │                        └── variable: i:3
+                     │              ├── branch: 0
+                     │              │    ├── params: a:4 b:5 i:6
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: end_of_function_2:12
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             ├── variable: a:4
+                     │              │                             ├── variable: b:5
+                     │              │                             └── variable: i:6
+                     │              ├── branch: 1
+                     │              │    ├── params: a:7 b:8 i:9
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_3:10
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_3:10]
+                     │              │         │              ├── const: 'ERROR'
+                     │              │         │              ├── const: 'control reached end of function without RETURN'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '2F005'
+                     │              │         └── project
+                     │              │              ├── columns: end_of_function_4:11
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── null [as=end_of_function_4:11]
+                     │              └── branch: 2
+                     │                   ├── params: a:13 b:14 i:15
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_return_6:16!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 100 [as=stmt_return_6:16]
                      └── const: 1
 
 exec-ddl
@@ -668,71 +994,116 @@ build format=show-scalars
 SELECT f(1, 2);
 ----
 project
- ├── columns: f:24
+ ├── columns: f:25
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:24]
+      └── udf: f [as=f:25]
            ├── args
            │    ├── const: 1
            │    └── const: 2
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_loop_5:23
+                     ├── columns: dispatcher_10:24
                      ├── project
-                     │    ├── columns: stmt_loop_5:23
-                     │    ├── project
-                     │    │    ├── columns: i:3
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         └── variable: a:1 [as=i:3]
+                     │    ├── columns: dispatcher_10:24
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: stmt_loop_5 [as=stmt_loop_5:23]
-                     │              ├── args
-                     │              │    ├── variable: a:1
-                     │              │    ├── variable: b:2
-                     │              │    └── variable: i:3
-                     │              ├── params: a:13 b:14 i:15
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: stmt_if_9:22
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── case [as=stmt_if_9:22]
-                     │                                  ├── true
-                     │                                  ├── when
-                     │                                  │    ├── lt
-                     │                                  │    │    ├── variable: a:13
-                     │                                  │    │    └── variable: b:14
-                     │                                  │    └── subquery
-                     │                                  │         └── project
-                     │                                  │              ├── columns: stmt_return_8:20!null
-                     │                                  │              ├── values
-                     │                                  │              │    └── tuple
-                     │                                  │              └── projections
-                     │                                  │                   └── const: 0 [as=stmt_return_8:20]
-                     │                                  └── subquery
-                     │                                       └── project
-                     │                                            ├── columns: stmt_if_6:21
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: stmt_if_6 [as=stmt_if_6:21]
-                     │                                                      ├── args
-                     │                                                      │    ├── variable: a:13
-                     │                                                      │    ├── variable: b:14
-                     │                                                      │    └── variable: i:15
-                     │                                                      ├── params: a:16 b:17 i:18
-                     │                                                      └── body
-                     │                                                           └── project
-                     │                                                                ├── columns: stmt_return_7:19!null
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── const: 100 [as=stmt_return_7:19]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_loop_5:23
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── variable: a:1 [as=i:3]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 2
+                     │              │                   └── args
+                     │              │                        ├── variable: a:1
+                     │              │                        ├── variable: b:2
+                     │              │                        └── variable: i:3
+                     │              ├── branch: 0
+                     │              │    ├── params: a:4 b:5 i:6
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: end_of_function_2:12
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             ├── variable: a:4
+                     │              │                             ├── variable: b:5
+                     │              │                             └── variable: i:6
+                     │              ├── branch: 1
+                     │              │    ├── params: a:7 b:8 i:9
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_3:10
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_3:10]
+                     │              │         │              ├── const: 'ERROR'
+                     │              │         │              ├── const: 'control reached end of function without RETURN'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '2F005'
+                     │              │         └── project
+                     │              │              ├── columns: end_of_function_4:11
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── null [as=end_of_function_4:11]
+                     │              ├── branch: 2
+                     │              │    ├── params: a:13 b:14 i:15
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_9:22
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_9:22]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── lt
+                     │              │                        │    │    ├── variable: a:13
+                     │              │                        │    │    └── variable: b:14
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: stmt_return_8:20!null
+                     │              │                        │              ├── values
+                     │              │                        │              │    └── tuple
+                     │              │                        │              └── projections
+                     │              │                        │                   └── const: 0 [as=stmt_return_8:20]
+                     │              │                        └── subquery
+                     │              │                             └── project
+                     │              │                                  ├── columns: stmt_if_6:21
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 3
+                     │              │                                            └── args
+                     │              │                                                 ├── variable: a:13
+                     │              │                                                 ├── variable: b:14
+                     │              │                                                 └── variable: i:15
+                     │              └── branch: 3
+                     │                   ├── params: a:16 b:17 i:18
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_return_7:19!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 100 [as=stmt_return_7:19]
                      └── const: 1
 
 exec-ddl
@@ -754,125 +1125,140 @@ build format=show-scalars
 SELECT f(1, 2);
 ----
 project
- ├── columns: f:26
+ ├── columns: f:27
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:26]
+      └── udf: f [as=f:27]
            ├── args
            │    ├── const: 1
            │    └── const: 2
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_loop_3:25
+                     ├── columns: dispatcher_9:26
                      ├── project
-                     │    ├── columns: stmt_loop_3:25
-                     │    ├── project
-                     │    │    ├── columns: i:3
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         └── variable: a:1 [as=i:3]
+                     │    ├── columns: dispatcher_9:26
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: stmt_loop_3 [as=stmt_loop_3:25]
-                     │              ├── args
-                     │              │    ├── variable: a:1
-                     │              │    ├── variable: b:2
-                     │              │    └── variable: i:3
-                     │              ├── params: a:8 b:9 i:10
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: stmt_if_8:24
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── case [as=stmt_if_8:24]
-                     │                                  ├── true
-                     │                                  ├── when
-                     │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:10
-                     │                                  │    │    └── variable: b:9
-                     │                                  │    └── subquery
-                     │                                  │         └── project
-                     │                                  │              ├── columns: loop_exit_1:22
-                     │                                  │              ├── values
-                     │                                  │              │    └── tuple
-                     │                                  │              └── projections
-                     │                                  │                   └── udf: loop_exit_1 [as=loop_exit_1:22]
-                     │                                  │                        ├── args
-                     │                                  │                        │    ├── variable: a:8
-                     │                                  │                        │    ├── variable: b:9
-                     │                                  │                        │    └── variable: i:10
-                     │                                  │                        ├── params: a:4 b:5 i:6
-                     │                                  │                        └── body
-                     │                                  │                             └── project
-                     │                                  │                                  ├── columns: stmt_return_2:7
-                     │                                  │                                  ├── values
-                     │                                  │                                  │    └── tuple
-                     │                                  │                                  └── projections
-                     │                                  │                                       └── variable: i:6 [as=stmt_return_2:7]
-                     │                                  └── subquery
-                     │                                       └── project
-                     │                                            ├── columns: stmt_if_4:23
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: stmt_if_4 [as=stmt_if_4:23]
-                     │                                                      ├── args
-                     │                                                      │    ├── variable: a:8
-                     │                                                      │    ├── variable: b:9
-                     │                                                      │    └── variable: i:10
-                     │                                                      ├── params: a:11 b:12 i:13
-                     │                                                      └── body
-                     │                                                           └── project
-                     │                                                                ├── columns: stmt_if_7:21
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── case [as=stmt_if_7:21]
-                     │                                                                          ├── true
-                     │                                                                          ├── when
-                     │                                                                          │    ├── eq
-                     │                                                                          │    │    ├── variable: i:13
-                     │                                                                          │    │    └── const: 8
-                     │                                                                          │    └── subquery
-                     │                                                                          │         └── project
-                     │                                                                          │              ├── columns: stmt_return_6:19!null
-                     │                                                                          │              ├── values
-                     │                                                                          │              │    └── tuple
-                     │                                                                          │              └── projections
-                     │                                                                          │                   └── const: 100 [as=stmt_return_6:19]
-                     │                                                                          └── subquery
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: stmt_if_5:20
-                     │                                                                                    ├── values
-                     │                                                                                    │    └── tuple
-                     │                                                                                    └── projections
-                     │                                                                                         └── udf: stmt_if_5 [as=stmt_if_5:20]
-                     │                                                                                              ├── args
-                     │                                                                                              │    ├── variable: a:11
-                     │                                                                                              │    ├── variable: b:12
-                     │                                                                                              │    └── variable: i:13
-                     │                                                                                              ├── params: a:14 b:15 i:16
-                     │                                                                                              └── body
-                     │                                                                                                   └── project
-                     │                                                                                                        ├── columns: stmt_loop_3:18
-                     │                                                                                                        ├── project
-                     │                                                                                                        │    ├── columns: i:17
-                     │                                                                                                        │    ├── values
-                     │                                                                                                        │    │    └── tuple
-                     │                                                                                                        │    └── projections
-                     │                                                                                                        │         └── plus [as=i:17]
-                     │                                                                                                        │              ├── variable: i:16
-                     │                                                                                                        │              └── const: 1
-                     │                                                                                                        └── projections
-                     │                                                                                                             └── udf: stmt_loop_3 [as=stmt_loop_3:18]
-                     │                                                                                                                  ├── args
-                     │                                                                                                                  │    ├── variable: a:14
-                     │                                                                                                                  │    ├── variable: b:15
-                     │                                                                                                                  │    └── variable: i:17
-                     │                                                                                                                  └── recursive-call
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_loop_3:25
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── variable: a:1 [as=i:3]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 1
+                     │              │                   └── args
+                     │              │                        ├── variable: a:1
+                     │              │                        ├── variable: b:2
+                     │              │                        └── variable: i:3
+                     │              ├── branch: 0
+                     │              │    ├── params: a:4 b:5 i:6
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:7
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── variable: i:6 [as=stmt_return_2:7]
+                     │              ├── branch: 1
+                     │              │    ├── params: a:8 b:9 i:10
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_8:24
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_8:24]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── ge
+                     │              │                        │    │    ├── variable: i:10
+                     │              │                        │    │    └── variable: b:9
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: loop_exit_1:22
+                     │              │                        │              ├── values
+                     │              │                        │              │    └── tuple
+                     │              │                        │              └── projections
+                     │              │                        │                   └── dispatch: 1
+                     │              │                        │                        ├── branch: 0
+                     │              │                        │                        └── args
+                     │              │                        │                             ├── variable: a:8
+                     │              │                        │                             ├── variable: b:9
+                     │              │                        │                             └── variable: i:10
+                     │              │                        └── subquery
+                     │              │                             └── project
+                     │              │                                  ├── columns: stmt_if_4:23
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 2
+                     │              │                                            └── args
+                     │              │                                                 ├── variable: a:8
+                     │              │                                                 ├── variable: b:9
+                     │              │                                                 └── variable: i:10
+                     │              ├── branch: 2
+                     │              │    ├── params: a:11 b:12 i:13
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_7:21
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_7:21]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── eq
+                     │              │                        │    │    ├── variable: i:13
+                     │              │                        │    │    └── const: 8
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: stmt_return_6:19!null
+                     │              │                        │              ├── values
+                     │              │                        │              │    └── tuple
+                     │              │                        │              └── projections
+                     │              │                        │                   └── const: 100 [as=stmt_return_6:19]
+                     │              │                        └── subquery
+                     │              │                             └── project
+                     │              │                                  ├── columns: stmt_if_5:20
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 3
+                     │              │                                            └── args
+                     │              │                                                 ├── variable: a:11
+                     │              │                                                 ├── variable: b:12
+                     │              │                                                 └── variable: i:13
+                     │              └── branch: 3
+                     │                   ├── params: a:14 b:15 i:16
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_loop_3:18
+                     │                             ├── project
+                     │                             │    ├── columns: i:17
+                     │                             │    ├── values
+                     │                             │    │    └── tuple
+                     │                             │    └── projections
+                     │                             │         └── plus [as=i:17]
+                     │                             │              ├── variable: i:16
+                     │                             │              └── const: 1
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 1
+                     │                                       └── args
+                     │                                            ├── variable: a:14
+                     │                                            ├── variable: b:15
+                     │                                            └── variable: i:17
                      └── const: 1
 
 exec-ddl
@@ -893,94 +1279,107 @@ build format=show-scalars
 SELECT f(1, 5);
 ----
 project
- ├── columns: f:20
+ ├── columns: f:21
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:20]
+      └── udf: f [as=f:21]
            ├── args
            │    ├── const: 1
            │    └── const: 5
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_loop_3:19
+                     ├── columns: dispatcher_6:20
                      ├── project
-                     │    ├── columns: stmt_loop_3:19
-                     │    ├── project
-                     │    │    ├── columns: i:3
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         └── variable: a:1 [as=i:3]
+                     │    ├── columns: dispatcher_6:20
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: stmt_loop_3 [as=stmt_loop_3:19]
-                     │              ├── args
-                     │              │    ├── variable: a:1
-                     │              │    ├── variable: b:2
-                     │              │    └── variable: i:3
-                     │              ├── params: a:8 b:9 i:10
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: stmt_if_5:18
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── case [as=stmt_if_5:18]
-                     │                                  ├── true
-                     │                                  ├── when
-                     │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:10
-                     │                                  │    │    └── variable: b:9
-                     │                                  │    └── subquery
-                     │                                  │         └── project
-                     │                                  │              ├── columns: loop_exit_1:16
-                     │                                  │              ├── values
-                     │                                  │              │    └── tuple
-                     │                                  │              └── projections
-                     │                                  │                   └── udf: loop_exit_1 [as=loop_exit_1:16]
-                     │                                  │                        ├── args
-                     │                                  │                        │    ├── variable: a:8
-                     │                                  │                        │    ├── variable: b:9
-                     │                                  │                        │    └── variable: i:10
-                     │                                  │                        ├── params: a:4 b:5 i:6
-                     │                                  │                        └── body
-                     │                                  │                             └── project
-                     │                                  │                                  ├── columns: stmt_return_2:7
-                     │                                  │                                  ├── values
-                     │                                  │                                  │    └── tuple
-                     │                                  │                                  └── projections
-                     │                                  │                                       └── variable: i:6 [as=stmt_return_2:7]
-                     │                                  └── subquery
-                     │                                       └── project
-                     │                                            ├── columns: stmt_if_4:17
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: stmt_if_4 [as=stmt_if_4:17]
-                     │                                                      ├── args
-                     │                                                      │    ├── variable: a:8
-                     │                                                      │    ├── variable: b:9
-                     │                                                      │    └── variable: i:10
-                     │                                                      ├── params: a:11 b:12 i:13
-                     │                                                      └── body
-                     │                                                           └── project
-                     │                                                                ├── columns: stmt_loop_3:15
-                     │                                                                ├── project
-                     │                                                                │    ├── columns: i:14
-                     │                                                                │    ├── values
-                     │                                                                │    │    └── tuple
-                     │                                                                │    └── projections
-                     │                                                                │         └── plus [as=i:14]
-                     │                                                                │              ├── variable: i:13
-                     │                                                                │              └── const: 1
-                     │                                                                └── projections
-                     │                                                                     └── udf: stmt_loop_3 [as=stmt_loop_3:15]
-                     │                                                                          ├── args
-                     │                                                                          │    ├── variable: a:11
-                     │                                                                          │    ├── variable: b:12
-                     │                                                                          │    └── variable: i:14
-                     │                                                                          └── recursive-call
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_loop_3:19
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── variable: a:1 [as=i:3]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 1
+                     │              │                   └── args
+                     │              │                        ├── variable: a:1
+                     │              │                        ├── variable: b:2
+                     │              │                        └── variable: i:3
+                     │              ├── branch: 0
+                     │              │    ├── params: a:4 b:5 i:6
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:7
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── variable: i:6 [as=stmt_return_2:7]
+                     │              ├── branch: 1
+                     │              │    ├── params: a:8 b:9 i:10
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_5:18
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_5:18]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── ge
+                     │              │                        │    │    ├── variable: i:10
+                     │              │                        │    │    └── variable: b:9
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: loop_exit_1:16
+                     │              │                        │              ├── values
+                     │              │                        │              │    └── tuple
+                     │              │                        │              └── projections
+                     │              │                        │                   └── dispatch: 1
+                     │              │                        │                        ├── branch: 0
+                     │              │                        │                        └── args
+                     │              │                        │                             ├── variable: a:8
+                     │              │                        │                             ├── variable: b:9
+                     │              │                        │                             └── variable: i:10
+                     │              │                        └── subquery
+                     │              │                             └── project
+                     │              │                                  ├── columns: stmt_if_4:17
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 2
+                     │              │                                            └── args
+                     │              │                                                 ├── variable: a:8
+                     │              │                                                 ├── variable: b:9
+                     │              │                                                 └── variable: i:10
+                     │              └── branch: 2
+                     │                   ├── params: a:11 b:12 i:13
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_loop_3:15
+                     │                             ├── project
+                     │                             │    ├── columns: i:14
+                     │                             │    ├── values
+                     │                             │    │    └── tuple
+                     │                             │    └── projections
+                     │                             │         └── plus [as=i:14]
+                     │                             │              ├── variable: i:13
+                     │                             │              └── const: 1
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 1
+                     │                                       └── args
+                     │                                            ├── variable: a:11
+                     │                                            ├── variable: b:12
+                     │                                            └── variable: i:14
                      └── const: 1
 
 exec-ddl
@@ -1005,157 +1404,165 @@ build format=show-scalars
 SELECT f(0, 0);
 ----
 project
- ├── columns: f:32
+ ├── columns: f:33
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:32]
+      └── udf: f [as=f:33]
            ├── args
            │    ├── const: 0
            │    └── const: 0
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_if_7:31
+                     ├── columns: dispatcher_8:32
                      ├── project
-                     │    ├── columns: stmt_if_7:31
-                     │    ├── project
-                     │    │    ├── columns: i:4 sum:3!null
-                     │    │    ├── project
-                     │    │    │    ├── columns: sum:3!null
-                     │    │    │    ├── values
-                     │    │    │    │    └── tuple
-                     │    │    │    └── projections
-                     │    │    │         └── const: 0 [as=sum:3]
-                     │    │    └── projections
-                     │    │         └── variable: a:1 [as=i:4]
+                     │    ├── columns: dispatcher_8:32
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── case [as=stmt_if_7:31]
-                     │              ├── true
-                     │              ├── when
-                     │              │    ├── and
-                     │              │    │    ├── is-not
-                     │              │    │    │    ├── variable: a:1
-                     │              │    │    │    └── null
-                     │              │    │    └── is-not
-                     │              │    │         ├── variable: b:2
-                     │              │    │         └── null
-                     │              │    └── subquery
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_if_7:31
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:4 sum:3!null
+                     │              │         │    ├── project
+                     │              │         │    │    ├── columns: sum:3!null
+                     │              │         │    │    ├── values
+                     │              │         │    │    │    └── tuple
+                     │              │         │    │    └── projections
+                     │              │         │    │         └── const: 0 [as=sum:3]
+                     │              │         │    └── projections
+                     │              │         │         └── variable: a:1 [as=i:4]
+                     │              │         └── projections
+                     │              │              └── case [as=stmt_if_7:31]
+                     │              │                   ├── true
+                     │              │                   ├── when
+                     │              │                   │    ├── and
+                     │              │                   │    │    ├── is-not
+                     │              │                   │    │    │    ├── variable: a:1
+                     │              │                   │    │    │    └── null
+                     │              │                   │    │    └── is-not
+                     │              │                   │    │         ├── variable: b:2
+                     │              │                   │    │         └── null
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: stmt_loop_4:29
+                     │              │                   │              ├── values
+                     │              │                   │              │    └── tuple
+                     │              │                   │              └── projections
+                     │              │                   │                   └── dispatch: 1
+                     │              │                   │                        ├── branch: 2
+                     │              │                   │                        └── args
+                     │              │                   │                             ├── variable: a:1
+                     │              │                   │                             ├── variable: b:2
+                     │              │                   │                             ├── variable: sum:3
+                     │              │                   │                             └── variable: i:4
+                     │              │                   └── subquery
+                     │              │                        └── project
+                     │              │                             ├── columns: stmt_if_1:30
+                     │              │                             ├── values
+                     │              │                             │    └── tuple
+                     │              │                             └── projections
+                     │              │                                  └── dispatch: 1
+                     │              │                                       ├── branch: 0
+                     │              │                                       └── args
+                     │              │                                            ├── variable: a:1
+                     │              │                                            ├── variable: b:2
+                     │              │                                            ├── variable: sum:3
+                     │              │                                            └── variable: i:4
+                     │              ├── branch: 0
+                     │              │    ├── params: a:5 b:6 sum:7 i:8
+                     │              │    └── body
                      │              │         └── project
-                     │              │              ├── columns: stmt_loop_4:29
+                     │              │              ├── columns: stmt_return_2:9
                      │              │              ├── values
                      │              │              │    └── tuple
                      │              │              └── projections
-                     │              │                   └── udf: stmt_loop_4 [as=stmt_loop_4:29]
-                     │              │                        ├── args
-                     │              │                        │    ├── variable: a:1
-                     │              │                        │    ├── variable: b:2
-                     │              │                        │    ├── variable: sum:3
-                     │              │                        │    └── variable: i:4
-                     │              │                        ├── params: a:15 b:16 sum:17 i:18
-                     │              │                        └── body
+                     │              │                   └── variable: sum:7 [as=stmt_return_2:9]
+                     │              ├── branch: 1
+                     │              │    ├── params: a:10 b:11 sum:12 i:13
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_1:14
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 0
+                     │              │                        └── args
+                     │              │                             ├── variable: a:10
+                     │              │                             ├── variable: b:11
+                     │              │                             ├── variable: sum:12
+                     │              │                             └── variable: i:13
+                     │              ├── branch: 2
+                     │              │    ├── params: a:15 b:16 sum:17 i:18
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_6:28
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_6:28]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── ge
+                     │              │                        │    │    ├── variable: i:18
+                     │              │                        │    │    └── variable: b:16
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: loop_exit_3:26
+                     │              │                        │              ├── values
+                     │              │                        │              │    └── tuple
+                     │              │                        │              └── projections
+                     │              │                        │                   └── dispatch: 1
+                     │              │                        │                        ├── branch: 1
+                     │              │                        │                        └── args
+                     │              │                        │                             ├── variable: a:15
+                     │              │                        │                             ├── variable: b:16
+                     │              │                        │                             ├── variable: sum:17
+                     │              │                        │                             └── variable: i:18
+                     │              │                        └── subquery
                      │              │                             └── project
-                     │              │                                  ├── columns: stmt_if_6:28
+                     │              │                                  ├── columns: stmt_if_5:27
                      │              │                                  ├── values
                      │              │                                  │    └── tuple
                      │              │                                  └── projections
-                     │              │                                       └── case [as=stmt_if_6:28]
-                     │              │                                            ├── true
-                     │              │                                            ├── when
-                     │              │                                            │    ├── ge
-                     │              │                                            │    │    ├── variable: i:18
-                     │              │                                            │    │    └── variable: b:16
-                     │              │                                            │    └── subquery
-                     │              │                                            │         └── project
-                     │              │                                            │              ├── columns: loop_exit_3:26
-                     │              │                                            │              ├── values
-                     │              │                                            │              │    └── tuple
-                     │              │                                            │              └── projections
-                     │              │                                            │                   └── udf: loop_exit_3 [as=loop_exit_3:26]
-                     │              │                                            │                        ├── args
-                     │              │                                            │                        │    ├── variable: a:15
-                     │              │                                            │                        │    ├── variable: b:16
-                     │              │                                            │                        │    ├── variable: sum:17
-                     │              │                                            │                        │    └── variable: i:18
-                     │              │                                            │                        ├── params: a:10 b:11 sum:12 i:13
-                     │              │                                            │                        └── body
-                     │              │                                            │                             └── project
-                     │              │                                            │                                  ├── columns: stmt_if_1:14
-                     │              │                                            │                                  ├── values
-                     │              │                                            │                                  │    └── tuple
-                     │              │                                            │                                  └── projections
-                     │              │                                            │                                       └── udf: stmt_if_1 [as=stmt_if_1:14]
-                     │              │                                            │                                            ├── args
-                     │              │                                            │                                            │    ├── variable: a:10
-                     │              │                                            │                                            │    ├── variable: b:11
-                     │              │                                            │                                            │    ├── variable: sum:12
-                     │              │                                            │                                            │    └── variable: i:13
-                     │              │                                            │                                            ├── params: a:5 b:6 sum:7 i:8
-                     │              │                                            │                                            └── body
-                     │              │                                            │                                                 └── project
-                     │              │                                            │                                                      ├── columns: stmt_return_2:9
-                     │              │                                            │                                                      ├── values
-                     │              │                                            │                                                      │    └── tuple
-                     │              │                                            │                                                      └── projections
-                     │              │                                            │                                                           └── variable: sum:7 [as=stmt_return_2:9]
-                     │              │                                            └── subquery
-                     │              │                                                 └── project
-                     │              │                                                      ├── columns: stmt_if_5:27
-                     │              │                                                      ├── values
-                     │              │                                                      │    └── tuple
-                     │              │                                                      └── projections
-                     │              │                                                           └── udf: stmt_if_5 [as=stmt_if_5:27]
-                     │              │                                                                ├── args
-                     │              │                                                                │    ├── variable: a:15
-                     │              │                                                                │    ├── variable: b:16
-                     │              │                                                                │    ├── variable: sum:17
-                     │              │                                                                │    └── variable: i:18
-                     │              │                                                                ├── params: a:19 b:20 sum:21 i:22
-                     │              │                                                                └── body
-                     │              │                                                                     └── project
-                     │              │                                                                          ├── columns: stmt_loop_4:25
-                     │              │                                                                          ├── project
-                     │              │                                                                          │    ├── columns: i:24 sum:23
-                     │              │                                                                          │    ├── project
-                     │              │                                                                          │    │    ├── columns: sum:23
-                     │              │                                                                          │    │    ├── values
-                     │              │                                                                          │    │    │    └── tuple
-                     │              │                                                                          │    │    └── projections
-                     │              │                                                                          │    │         └── plus [as=sum:23]
-                     │              │                                                                          │    │              ├── variable: sum:21
-                     │              │                                                                          │    │              └── variable: i:22
-                     │              │                                                                          │    └── projections
-                     │              │                                                                          │         └── plus [as=i:24]
-                     │              │                                                                          │              ├── variable: i:22
-                     │              │                                                                          │              └── const: 1
-                     │              │                                                                          └── projections
-                     │              │                                                                               └── udf: stmt_loop_4 [as=stmt_loop_4:25]
-                     │              │                                                                                    ├── args
-                     │              │                                                                                    │    ├── variable: a:19
-                     │              │                                                                                    │    ├── variable: b:20
-                     │              │                                                                                    │    ├── variable: sum:23
-                     │              │                                                                                    │    └── variable: i:24
-                     │              │                                                                                    └── recursive-call
-                     │              └── subquery
-                     │                   └── project
-                     │                        ├── columns: stmt_if_1:30
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── udf: stmt_if_1 [as=stmt_if_1:30]
-                     │                                  ├── args
-                     │                                  │    ├── variable: a:1
-                     │                                  │    ├── variable: b:2
-                     │                                  │    ├── variable: sum:3
-                     │                                  │    └── variable: i:4
-                     │                                  ├── params: a:5 b:6 sum:7 i:8
-                     │                                  └── body
-                     │                                       └── project
-                     │                                            ├── columns: stmt_return_2:9
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── variable: sum:7 [as=stmt_return_2:9]
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 3
+                     │              │                                            └── args
+                     │              │                                                 ├── variable: a:15
+                     │              │                                                 ├── variable: b:16
+                     │              │                                                 ├── variable: sum:17
+                     │              │                                                 └── variable: i:18
+                     │              └── branch: 3
+                     │                   ├── params: a:19 b:20 sum:21 i:22
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_loop_4:25
+                     │                             ├── project
+                     │                             │    ├── columns: i:24 sum:23
+                     │                             │    ├── project
+                     │                             │    │    ├── columns: sum:23
+                     │                             │    │    ├── values
+                     │                             │    │    │    └── tuple
+                     │                             │    │    └── projections
+                     │                             │    │         └── plus [as=sum:23]
+                     │                             │    │              ├── variable: sum:21
+                     │                             │    │              └── variable: i:22
+                     │                             │    └── projections
+                     │                             │         └── plus [as=i:24]
+                     │                             │              ├── variable: i:22
+                     │                             │              └── const: 1
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 2
+                     │                                       └── args
+                     │                                            ├── variable: a:19
+                     │                                            ├── variable: b:20
+                     │                                            ├── variable: sum:23
+                     │                                            └── variable: i:24
                      └── const: 1
 
 exec-ddl
@@ -1182,152 +1589,167 @@ build format=show-scalars
 SELECT f(5, -5);
 ----
 project
- ├── columns: f:33
+ ├── columns: f:34
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:33]
+      └── udf: f [as=f:34]
            ├── args
            │    ├── const: 5
            │    └── const: -5
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_loop_3:32
+                     ├── columns: dispatcher_8:33
                      ├── project
-                     │    ├── columns: stmt_loop_3:32
-                     │    ├── project
-                     │    │    ├── columns: i:4 sum:3!null
-                     │    │    ├── project
-                     │    │    │    ├── columns: sum:3!null
-                     │    │    │    ├── values
-                     │    │    │    │    └── tuple
-                     │    │    │    └── projections
-                     │    │    │         └── const: 0 [as=sum:3]
-                     │    │    └── projections
-                     │    │         └── variable: a:1 [as=i:4]
+                     │    ├── columns: dispatcher_8:33
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: stmt_loop_3 [as=stmt_loop_3:32]
-                     │              ├── args
-                     │              │    ├── variable: a:1
-                     │              │    ├── variable: b:2
-                     │              │    ├── variable: sum:3
-                     │              │    └── variable: i:4
-                     │              ├── params: a:10 b:11 sum:12 i:13
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: stmt_if_7:31
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── case [as=stmt_if_7:31]
-                     │                                  ├── true
-                     │                                  ├── when
-                     │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:13
-                     │                                  │    │    └── variable: b:11
-                     │                                  │    └── subquery
-                     │                                  │         └── project
-                     │                                  │              ├── columns: loop_exit_1:29
-                     │                                  │              ├── values
-                     │                                  │              │    └── tuple
-                     │                                  │              └── projections
-                     │                                  │                   └── udf: loop_exit_1 [as=loop_exit_1:29]
-                     │                                  │                        ├── args
-                     │                                  │                        │    ├── variable: a:10
-                     │                                  │                        │    ├── variable: b:11
-                     │                                  │                        │    ├── variable: sum:12
-                     │                                  │                        │    └── variable: i:13
-                     │                                  │                        ├── params: a:5 b:6 sum:7 i:8
-                     │                                  │                        └── body
-                     │                                  │                             └── project
-                     │                                  │                                  ├── columns: stmt_return_2:9
-                     │                                  │                                  ├── values
-                     │                                  │                                  │    └── tuple
-                     │                                  │                                  └── projections
-                     │                                  │                                       └── variable: sum:7 [as=stmt_return_2:9]
-                     │                                  └── subquery
-                     │                                       └── project
-                     │                                            ├── columns: stmt_if_4:30
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: stmt_if_4 [as=stmt_if_4:30]
-                     │                                                      ├── args
-                     │                                                      │    ├── variable: a:10
-                     │                                                      │    ├── variable: b:11
-                     │                                                      │    ├── variable: sum:12
-                     │                                                      │    └── variable: i:13
-                     │                                                      ├── params: a:14 b:15 sum:16 i:17
-                     │                                                      └── body
-                     │                                                           └── project
-                     │                                                                ├── columns: stmt_if_6:28
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── case [as=stmt_if_6:28]
-                     │                                                                          ├── true
-                     │                                                                          ├── when
-                     │                                                                          │    ├── eq
-                     │                                                                          │    │    ├── variable: i:17
-                     │                                                                          │    │    └── const: 2
-                     │                                                                          │    └── subquery
-                     │                                                                          │         └── project
-                     │                                                                          │              ├── columns: stmt_loop_3:26
-                     │                                                                          │              ├── project
-                     │                                                                          │              │    ├── columns: i:25
-                     │                                                                          │              │    ├── values
-                     │                                                                          │              │    │    └── tuple
-                     │                                                                          │              │    └── projections
-                     │                                                                          │              │         └── plus [as=i:25]
-                     │                                                                          │              │              ├── variable: i:17
-                     │                                                                          │              │              └── const: 1
-                     │                                                                          │              └── projections
-                     │                                                                          │                   └── udf: stmt_loop_3 [as=stmt_loop_3:26]
-                     │                                                                          │                        ├── args
-                     │                                                                          │                        │    ├── variable: a:14
-                     │                                                                          │                        │    ├── variable: b:15
-                     │                                                                          │                        │    ├── variable: sum:16
-                     │                                                                          │                        │    └── variable: i:25
-                     │                                                                          │                        └── recursive-call
-                     │                                                                          └── subquery
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: stmt_if_5:27
-                     │                                                                                    ├── values
-                     │                                                                                    │    └── tuple
-                     │                                                                                    └── projections
-                     │                                                                                         └── udf: stmt_if_5 [as=stmt_if_5:27]
-                     │                                                                                              ├── args
-                     │                                                                                              │    ├── variable: a:14
-                     │                                                                                              │    ├── variable: b:15
-                     │                                                                                              │    ├── variable: sum:16
-                     │                                                                                              │    └── variable: i:17
-                     │                                                                                              ├── params: a:18 b:19 sum:20 i:21
-                     │                                                                                              └── body
-                     │                                                                                                   └── project
-                     │                                                                                                        ├── columns: stmt_loop_3:24
-                     │                                                                                                        ├── project
-                     │                                                                                                        │    ├── columns: i:23 sum:22
-                     │                                                                                                        │    ├── project
-                     │                                                                                                        │    │    ├── columns: sum:22
-                     │                                                                                                        │    │    ├── values
-                     │                                                                                                        │    │    │    └── tuple
-                     │                                                                                                        │    │    └── projections
-                     │                                                                                                        │    │         └── plus [as=sum:22]
-                     │                                                                                                        │    │              ├── variable: sum:20
-                     │                                                                                                        │    │              └── variable: i:21
-                     │                                                                                                        │    └── projections
-                     │                                                                                                        │         └── plus [as=i:23]
-                     │                                                                                                        │              ├── variable: i:21
-                     │                                                                                                        │              └── const: 1
-                     │                                                                                                        └── projections
-                     │                                                                                                             └── udf: stmt_loop_3 [as=stmt_loop_3:24]
-                     │                                                                                                                  ├── args
-                     │                                                                                                                  │    ├── variable: a:18
-                     │                                                                                                                  │    ├── variable: b:19
-                     │                                                                                                                  │    ├── variable: sum:22
-                     │                                                                                                                  │    └── variable: i:23
-                     │                                                                                                                  └── recursive-call
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_loop_3:32
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:4 sum:3!null
+                     │              │         │    ├── project
+                     │              │         │    │    ├── columns: sum:3!null
+                     │              │         │    │    ├── values
+                     │              │         │    │    │    └── tuple
+                     │              │         │    │    └── projections
+                     │              │         │    │         └── const: 0 [as=sum:3]
+                     │              │         │    └── projections
+                     │              │         │         └── variable: a:1 [as=i:4]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 1
+                     │              │                   └── args
+                     │              │                        ├── variable: a:1
+                     │              │                        ├── variable: b:2
+                     │              │                        ├── variable: sum:3
+                     │              │                        └── variable: i:4
+                     │              ├── branch: 0
+                     │              │    ├── params: a:5 b:6 sum:7 i:8
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:9
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── variable: sum:7 [as=stmt_return_2:9]
+                     │              ├── branch: 1
+                     │              │    ├── params: a:10 b:11 sum:12 i:13
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_7:31
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_7:31]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── ge
+                     │              │                        │    │    ├── variable: i:13
+                     │              │                        │    │    └── variable: b:11
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: loop_exit_1:29
+                     │              │                        │              ├── values
+                     │              │                        │              │    └── tuple
+                     │              │                        │              └── projections
+                     │              │                        │                   └── dispatch: 1
+                     │              │                        │                        ├── branch: 0
+                     │              │                        │                        └── args
+                     │              │                        │                             ├── variable: a:10
+                     │              │                        │                             ├── variable: b:11
+                     │              │                        │                             ├── variable: sum:12
+                     │              │                        │                             └── variable: i:13
+                     │              │                        └── subquery
+                     │              │                             └── project
+                     │              │                                  ├── columns: stmt_if_4:30
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 2
+                     │              │                                            └── args
+                     │              │                                                 ├── variable: a:10
+                     │              │                                                 ├── variable: b:11
+                     │              │                                                 ├── variable: sum:12
+                     │              │                                                 └── variable: i:13
+                     │              ├── branch: 2
+                     │              │    ├── params: a:14 b:15 sum:16 i:17
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_6:28
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_6:28]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── eq
+                     │              │                        │    │    ├── variable: i:17
+                     │              │                        │    │    └── const: 2
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: stmt_loop_3:26
+                     │              │                        │              ├── project
+                     │              │                        │              │    ├── columns: i:25
+                     │              │                        │              │    ├── values
+                     │              │                        │              │    │    └── tuple
+                     │              │                        │              │    └── projections
+                     │              │                        │              │         └── plus [as=i:25]
+                     │              │                        │              │              ├── variable: i:17
+                     │              │                        │              │              └── const: 1
+                     │              │                        │              └── projections
+                     │              │                        │                   └── dispatch: 1
+                     │              │                        │                        ├── branch: 1
+                     │              │                        │                        └── args
+                     │              │                        │                             ├── variable: a:14
+                     │              │                        │                             ├── variable: b:15
+                     │              │                        │                             ├── variable: sum:16
+                     │              │                        │                             └── variable: i:25
+                     │              │                        └── subquery
+                     │              │                             └── project
+                     │              │                                  ├── columns: stmt_if_5:27
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 3
+                     │              │                                            └── args
+                     │              │                                                 ├── variable: a:14
+                     │              │                                                 ├── variable: b:15
+                     │              │                                                 ├── variable: sum:16
+                     │              │                                                 └── variable: i:17
+                     │              └── branch: 3
+                     │                   ├── params: a:18 b:19 sum:20 i:21
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_loop_3:24
+                     │                             ├── project
+                     │                             │    ├── columns: i:23 sum:22
+                     │                             │    ├── project
+                     │                             │    │    ├── columns: sum:22
+                     │                             │    │    ├── values
+                     │                             │    │    │    └── tuple
+                     │                             │    │    └── projections
+                     │                             │    │         └── plus [as=sum:22]
+                     │                             │    │              ├── variable: sum:20
+                     │                             │    │              └── variable: i:21
+                     │                             │    └── projections
+                     │                             │         └── plus [as=i:23]
+                     │                             │              ├── variable: i:21
+                     │                             │              └── const: 1
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 1
+                     │                                       └── args
+                     │                                            ├── variable: a:18
+                     │                                            ├── variable: b:19
+                     │                                            ├── variable: sum:22
+                     │                                            └── variable: i:23
                      └── const: 1
 
 exec-ddl
@@ -1356,195 +1778,214 @@ build format=show-scalars
 SELECT f(1, 5)
 ----
 project
- ├── columns: f:51
+ ├── columns: f:52
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:51]
+      └── udf: f [as=f:52]
            ├── args
            │    ├── const: 1
            │    └── const: 5
            ├── params: a:1 b:2
            └── body
                 └── limit
-                     ├── columns: stmt_loop_3:50
+                     ├── columns: dispatcher_10:51
                      ├── project
-                     │    ├── columns: stmt_loop_3:50
-                     │    ├── project
-                     │    │    ├── columns: j:5 sum:3!null i:4
-                     │    │    ├── project
-                     │    │    │    ├── columns: i:4 sum:3!null
-                     │    │    │    ├── project
-                     │    │    │    │    ├── columns: sum:3!null
-                     │    │    │    │    ├── values
-                     │    │    │    │    │    └── tuple
-                     │    │    │    │    └── projections
-                     │    │    │    │         └── const: 0 [as=sum:3]
-                     │    │    │    └── projections
-                     │    │    │         └── variable: a:1 [as=i:4]
-                     │    │    └── projections
-                     │    │         └── cast: INT8 [as=j:5]
-                     │    │              └── null
+                     │    ├── columns: dispatcher_10:51
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: stmt_loop_3 [as=stmt_loop_3:50]
-                     │              ├── args
-                     │              │    ├── variable: a:1
-                     │              │    ├── variable: b:2
-                     │              │    ├── variable: sum:3
-                     │              │    ├── variable: i:4
-                     │              │    └── variable: j:5
-                     │              ├── params: a:12 b:13 sum:14 i:15 j:16
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: stmt_if_9:49
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── case [as=stmt_if_9:49]
-                     │                                  ├── true
-                     │                                  ├── when
-                     │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:15
-                     │                                  │    │    └── variable: b:13
-                     │                                  │    └── subquery
-                     │                                  │         └── project
-                     │                                  │              ├── columns: loop_exit_1:47
-                     │                                  │              ├── values
-                     │                                  │              │    └── tuple
-                     │                                  │              └── projections
-                     │                                  │                   └── udf: loop_exit_1 [as=loop_exit_1:47]
-                     │                                  │                        ├── args
-                     │                                  │                        │    ├── variable: a:12
-                     │                                  │                        │    ├── variable: b:13
-                     │                                  │                        │    ├── variable: sum:14
-                     │                                  │                        │    ├── variable: i:15
-                     │                                  │                        │    └── variable: j:16
-                     │                                  │                        ├── params: a:6 b:7 sum:8 i:9 j:10
-                     │                                  │                        └── body
-                     │                                  │                             └── project
-                     │                                  │                                  ├── columns: stmt_return_2:11
-                     │                                  │                                  ├── values
-                     │                                  │                                  │    └── tuple
-                     │                                  │                                  └── projections
-                     │                                  │                                       └── variable: sum:8 [as=stmt_return_2:11]
-                     │                                  └── subquery
-                     │                                       └── project
-                     │                                            ├── columns: stmt_if_4:48
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: stmt_if_4 [as=stmt_if_4:48]
-                     │                                                      ├── args
-                     │                                                      │    ├── variable: a:12
-                     │                                                      │    ├── variable: b:13
-                     │                                                      │    ├── variable: sum:14
-                     │                                                      │    ├── variable: i:15
-                     │                                                      │    └── variable: j:16
-                     │                                                      ├── params: a:17 b:18 sum:19 i:20 j:21
-                     │                                                      └── body
-                     │                                                           └── project
-                     │                                                                ├── columns: stmt_loop_6:46
-                     │                                                                ├── project
-                     │                                                                │    ├── columns: j:22!null
-                     │                                                                │    ├── values
-                     │                                                                │    │    └── tuple
-                     │                                                                │    └── projections
-                     │                                                                │         └── const: 0 [as=j:22]
-                     │                                                                └── projections
-                     │                                                                     └── udf: stmt_loop_6 [as=stmt_loop_6:46]
-                     │                                                                          ├── args
-                     │                                                                          │    ├── variable: a:17
-                     │                                                                          │    ├── variable: b:18
-                     │                                                                          │    ├── variable: sum:19
-                     │                                                                          │    ├── variable: i:20
-                     │                                                                          │    └── variable: j:22
-                     │                                                                          ├── params: a:30 b:31 sum:32 i:33 j:34
-                     │                                                                          └── body
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: stmt_if_8:45
-                     │                                                                                    ├── values
-                     │                                                                                    │    └── tuple
-                     │                                                                                    └── projections
-                     │                                                                                         └── case [as=stmt_if_8:45]
-                     │                                                                                              ├── true
-                     │                                                                                              ├── when
-                     │                                                                                              │    ├── ge
-                     │                                                                                              │    │    ├── variable: j:34
-                     │                                                                                              │    │    └── variable: i:33
-                     │                                                                                              │    └── subquery
-                     │                                                                                              │         └── project
-                     │                                                                                              │              ├── columns: loop_exit_5:43
-                     │                                                                                              │              ├── values
-                     │                                                                                              │              │    └── tuple
-                     │                                                                                              │              └── projections
-                     │                                                                                              │                   └── udf: loop_exit_5 [as=loop_exit_5:43]
-                     │                                                                                              │                        ├── args
-                     │                                                                                              │                        │    ├── variable: a:30
-                     │                                                                                              │                        │    ├── variable: b:31
-                     │                                                                                              │                        │    ├── variable: sum:32
-                     │                                                                                              │                        │    ├── variable: i:33
-                     │                                                                                              │                        │    └── variable: j:34
-                     │                                                                                              │                        ├── params: a:23 b:24 sum:25 i:26 j:27
-                     │                                                                                              │                        └── body
-                     │                                                                                              │                             └── project
-                     │                                                                                              │                                  ├── columns: stmt_loop_3:29
-                     │                                                                                              │                                  ├── project
-                     │                                                                                              │                                  │    ├── columns: i:28
-                     │                                                                                              │                                  │    ├── values
-                     │                                                                                              │                                  │    │    └── tuple
-                     │                                                                                              │                                  │    └── projections
-                     │                                                                                              │                                  │         └── plus [as=i:28]
-                     │                                                                                              │                                  │              ├── variable: i:26
-                     │                                                                                              │                                  │              └── const: 1
-                     │                                                                                              │                                  └── projections
-                     │                                                                                              │                                       └── udf: stmt_loop_3 [as=stmt_loop_3:29]
-                     │                                                                                              │                                            ├── args
-                     │                                                                                              │                                            │    ├── variable: a:23
-                     │                                                                                              │                                            │    ├── variable: b:24
-                     │                                                                                              │                                            │    ├── variable: sum:25
-                     │                                                                                              │                                            │    ├── variable: i:28
-                     │                                                                                              │                                            │    └── variable: j:27
-                     │                                                                                              │                                            └── recursive-call
-                     │                                                                                              └── subquery
-                     │                                                                                                   └── project
-                     │                                                                                                        ├── columns: stmt_if_7:44
-                     │                                                                                                        ├── values
-                     │                                                                                                        │    └── tuple
-                     │                                                                                                        └── projections
-                     │                                                                                                             └── udf: stmt_if_7 [as=stmt_if_7:44]
-                     │                                                                                                                  ├── args
-                     │                                                                                                                  │    ├── variable: a:30
-                     │                                                                                                                  │    ├── variable: b:31
-                     │                                                                                                                  │    ├── variable: sum:32
-                     │                                                                                                                  │    ├── variable: i:33
-                     │                                                                                                                  │    └── variable: j:34
-                     │                                                                                                                  ├── params: a:35 b:36 sum:37 i:38 j:39
-                     │                                                                                                                  └── body
-                     │                                                                                                                       └── project
-                     │                                                                                                                            ├── columns: stmt_loop_6:42
-                     │                                                                                                                            ├── project
-                     │                                                                                                                            │    ├── columns: j:41 sum:40
-                     │                                                                                                                            │    ├── project
-                     │                                                                                                                            │    │    ├── columns: sum:40
-                     │                                                                                                                            │    │    ├── values
-                     │                                                                                                                            │    │    │    └── tuple
-                     │                                                                                                                            │    │    └── projections
-                     │                                                                                                                            │    │         └── plus [as=sum:40]
-                     │                                                                                                                            │    │              ├── variable: sum:37
-                     │                                                                                                                            │    │              └── variable: j:39
-                     │                                                                                                                            │    └── projections
-                     │                                                                                                                            │         └── plus [as=j:41]
-                     │                                                                                                                            │              ├── variable: j:39
-                     │                                                                                                                            │              └── const: 1
-                     │                                                                                                                            └── projections
-                     │                                                                                                                                 └── udf: stmt_loop_6 [as=stmt_loop_6:42]
-                     │                                                                                                                                      ├── args
-                     │                                                                                                                                      │    ├── variable: a:35
-                     │                                                                                                                                      │    ├── variable: b:36
-                     │                                                                                                                                      │    ├── variable: sum:40
-                     │                                                                                                                                      │    ├── variable: i:38
-                     │                                                                                                                                      │    └── variable: j:41
-                     │                                                                                                                                      └── recursive-call
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_loop_3:50
+                     │              │         ├── project
+                     │              │         │    ├── columns: j:5 sum:3!null i:4
+                     │              │         │    ├── project
+                     │              │         │    │    ├── columns: i:4 sum:3!null
+                     │              │         │    │    ├── project
+                     │              │         │    │    │    ├── columns: sum:3!null
+                     │              │         │    │    │    ├── values
+                     │              │         │    │    │    │    └── tuple
+                     │              │         │    │    │    └── projections
+                     │              │         │    │    │         └── const: 0 [as=sum:3]
+                     │              │         │    │    └── projections
+                     │              │         │    │         └── variable: a:1 [as=i:4]
+                     │              │         │    └── projections
+                     │              │         │         └── cast: INT8 [as=j:5]
+                     │              │         │              └── null
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 1
+                     │              │                   └── args
+                     │              │                        ├── variable: a:1
+                     │              │                        ├── variable: b:2
+                     │              │                        ├── variable: sum:3
+                     │              │                        ├── variable: i:4
+                     │              │                        └── variable: j:5
+                     │              ├── branch: 0
+                     │              │    ├── params: a:6 b:7 sum:8 i:9 j:10
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:11
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── variable: sum:8 [as=stmt_return_2:11]
+                     │              ├── branch: 1
+                     │              │    ├── params: a:12 b:13 sum:14 i:15 j:16
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_9:49
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_9:49]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── ge
+                     │              │                        │    │    ├── variable: i:15
+                     │              │                        │    │    └── variable: b:13
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: loop_exit_1:47
+                     │              │                        │              ├── values
+                     │              │                        │              │    └── tuple
+                     │              │                        │              └── projections
+                     │              │                        │                   └── dispatch: 1
+                     │              │                        │                        ├── branch: 0
+                     │              │                        │                        └── args
+                     │              │                        │                             ├── variable: a:12
+                     │              │                        │                             ├── variable: b:13
+                     │              │                        │                             ├── variable: sum:14
+                     │              │                        │                             ├── variable: i:15
+                     │              │                        │                             └── variable: j:16
+                     │              │                        └── subquery
+                     │              │                             └── project
+                     │              │                                  ├── columns: stmt_if_4:48
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 2
+                     │              │                                            └── args
+                     │              │                                                 ├── variable: a:12
+                     │              │                                                 ├── variable: b:13
+                     │              │                                                 ├── variable: sum:14
+                     │              │                                                 ├── variable: i:15
+                     │              │                                                 └── variable: j:16
+                     │              ├── branch: 2
+                     │              │    ├── params: a:17 b:18 sum:19 i:20 j:21
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_loop_6:46
+                     │              │              ├── project
+                     │              │              │    ├── columns: j:22!null
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── const: 0 [as=j:22]
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 4
+                     │              │                        └── args
+                     │              │                             ├── variable: a:17
+                     │              │                             ├── variable: b:18
+                     │              │                             ├── variable: sum:19
+                     │              │                             ├── variable: i:20
+                     │              │                             └── variable: j:22
+                     │              ├── branch: 3
+                     │              │    ├── params: a:23 b:24 sum:25 i:26 j:27
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_loop_3:29
+                     │              │              ├── project
+                     │              │              │    ├── columns: i:28
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── plus [as=i:28]
+                     │              │              │              ├── variable: i:26
+                     │              │              │              └── const: 1
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             ├── variable: a:23
+                     │              │                             ├── variable: b:24
+                     │              │                             ├── variable: sum:25
+                     │              │                             ├── variable: i:28
+                     │              │                             └── variable: j:27
+                     │              ├── branch: 4
+                     │              │    ├── params: a:30 b:31 sum:32 i:33 j:34
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_8:45
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_8:45]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── ge
+                     │              │                        │    │    ├── variable: j:34
+                     │              │                        │    │    └── variable: i:33
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: loop_exit_5:43
+                     │              │                        │              ├── values
+                     │              │                        │              │    └── tuple
+                     │              │                        │              └── projections
+                     │              │                        │                   └── dispatch: 1
+                     │              │                        │                        ├── branch: 3
+                     │              │                        │                        └── args
+                     │              │                        │                             ├── variable: a:30
+                     │              │                        │                             ├── variable: b:31
+                     │              │                        │                             ├── variable: sum:32
+                     │              │                        │                             ├── variable: i:33
+                     │              │                        │                             └── variable: j:34
+                     │              │                        └── subquery
+                     │              │                             └── project
+                     │              │                                  ├── columns: stmt_if_7:44
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 5
+                     │              │                                            └── args
+                     │              │                                                 ├── variable: a:30
+                     │              │                                                 ├── variable: b:31
+                     │              │                                                 ├── variable: sum:32
+                     │              │                                                 ├── variable: i:33
+                     │              │                                                 └── variable: j:34
+                     │              └── branch: 5
+                     │                   ├── params: a:35 b:36 sum:37 i:38 j:39
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_loop_6:42
+                     │                             ├── project
+                     │                             │    ├── columns: j:41 sum:40
+                     │                             │    ├── project
+                     │                             │    │    ├── columns: sum:40
+                     │                             │    │    ├── values
+                     │                             │    │    │    └── tuple
+                     │                             │    │    └── projections
+                     │                             │    │         └── plus [as=sum:40]
+                     │                             │    │              ├── variable: sum:37
+                     │                             │    │              └── variable: j:39
+                     │                             │    └── projections
+                     │                             │         └── plus [as=j:41]
+                     │                             │              ├── variable: j:39
+                     │                             │              └── const: 1
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 4
+                     │                                       └── args
+                     │                                            ├── variable: a:35
+                     │                                            ├── variable: b:36
+                     │                                            ├── variable: sum:40
+                     │                                            ├── variable: i:38
+                     │                                            └── variable: j:41
                      └── const: 1
 
 exec-ddl
@@ -1566,103 +2007,116 @@ build format=show-scalars
 SELECT f(5)
 ----
 project
- ├── columns: f:21
+ ├── columns: f:22
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:21]
+      └── udf: f [as=f:22]
            ├── args
            │    └── const: 5
            ├── params: n:1
            └── body
                 └── limit
-                     ├── columns: stmt_loop_3:20
+                     ├── columns: dispatcher_6:21
                      ├── project
-                     │    ├── columns: stmt_loop_3:20
-                     │    ├── project
-                     │    │    ├── columns: i:3!null sum:2!null
-                     │    │    ├── project
-                     │    │    │    ├── columns: sum:2!null
-                     │    │    │    ├── values
-                     │    │    │    │    └── tuple
-                     │    │    │    └── projections
-                     │    │    │         └── const: 0 [as=sum:2]
-                     │    │    └── projections
-                     │    │         └── const: 0 [as=i:3]
+                     │    ├── columns: dispatcher_6:21
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: stmt_loop_3 [as=stmt_loop_3:20]
-                     │              ├── args
-                     │              │    ├── variable: n:1
-                     │              │    ├── variable: sum:2
-                     │              │    └── variable: i:3
-                     │              ├── params: n:8 sum:9 i:10
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: stmt_if_5:19
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── case [as=stmt_if_5:19]
-                     │                                  ├── true
-                     │                                  ├── when
-                     │                                  │    ├── lt
-                     │                                  │    │    ├── variable: i:10
-                     │                                  │    │    └── variable: n:8
-                     │                                  │    └── subquery
-                     │                                  │         └── project
-                     │                                  │              ├── columns: stmt_if_4:17
-                     │                                  │              ├── project
-                     │                                  │              │    ├── columns: i:16 sum:15
-                     │                                  │              │    ├── project
-                     │                                  │              │    │    ├── columns: sum:15
-                     │                                  │              │    │    ├── values
-                     │                                  │              │    │    │    └── tuple
-                     │                                  │              │    │    └── projections
-                     │                                  │              │    │         └── plus [as=sum:15]
-                     │                                  │              │    │              ├── variable: sum:9
-                     │                                  │              │    │              └── variable: i:10
-                     │                                  │              │    └── projections
-                     │                                  │              │         └── plus [as=i:16]
-                     │                                  │              │              ├── variable: i:10
-                     │                                  │              │              └── const: 1
-                     │                                  │              └── projections
-                     │                                  │                   └── udf: stmt_if_4 [as=stmt_if_4:17]
-                     │                                  │                        ├── args
-                     │                                  │                        │    ├── variable: n:8
-                     │                                  │                        │    ├── variable: sum:15
-                     │                                  │                        │    └── variable: i:16
-                     │                                  │                        ├── params: n:11 sum:12 i:13
-                     │                                  │                        └── body
-                     │                                  │                             └── project
-                     │                                  │                                  ├── columns: stmt_loop_3:14
-                     │                                  │                                  ├── values
-                     │                                  │                                  │    └── tuple
-                     │                                  │                                  └── projections
-                     │                                  │                                       └── udf: stmt_loop_3 [as=stmt_loop_3:14]
-                     │                                  │                                            ├── args
-                     │                                  │                                            │    ├── variable: n:11
-                     │                                  │                                            │    ├── variable: sum:12
-                     │                                  │                                            │    └── variable: i:13
-                     │                                  │                                            └── recursive-call
-                     │                                  └── subquery
-                     │                                       └── project
-                     │                                            ├── columns: loop_exit_1:18
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: loop_exit_1 [as=loop_exit_1:18]
-                     │                                                      ├── args
-                     │                                                      │    ├── variable: n:8
-                     │                                                      │    ├── variable: sum:9
-                     │                                                      │    └── variable: i:10
-                     │                                                      ├── params: n:4 sum:5 i:6
-                     │                                                      └── body
-                     │                                                           └── project
-                     │                                                                ├── columns: stmt_return_2:7
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── variable: sum:5 [as=stmt_return_2:7]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_loop_3:20
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:3!null sum:2!null
+                     │              │         │    ├── project
+                     │              │         │    │    ├── columns: sum:2!null
+                     │              │         │    │    ├── values
+                     │              │         │    │    │    └── tuple
+                     │              │         │    │    └── projections
+                     │              │         │    │         └── const: 0 [as=sum:2]
+                     │              │         │    └── projections
+                     │              │         │         └── const: 0 [as=i:3]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 1
+                     │              │                   └── args
+                     │              │                        ├── variable: n:1
+                     │              │                        ├── variable: sum:2
+                     │              │                        └── variable: i:3
+                     │              ├── branch: 0
+                     │              │    ├── params: n:4 sum:5 i:6
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:7
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── variable: sum:5 [as=stmt_return_2:7]
+                     │              ├── branch: 1
+                     │              │    ├── params: n:8 sum:9 i:10
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_5:19
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_5:19]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── lt
+                     │              │                        │    │    ├── variable: i:10
+                     │              │                        │    │    └── variable: n:8
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: stmt_if_4:17
+                     │              │                        │              ├── project
+                     │              │                        │              │    ├── columns: i:16 sum:15
+                     │              │                        │              │    ├── project
+                     │              │                        │              │    │    ├── columns: sum:15
+                     │              │                        │              │    │    ├── values
+                     │              │                        │              │    │    │    └── tuple
+                     │              │                        │              │    │    └── projections
+                     │              │                        │              │    │         └── plus [as=sum:15]
+                     │              │                        │              │    │              ├── variable: sum:9
+                     │              │                        │              │    │              └── variable: i:10
+                     │              │                        │              │    └── projections
+                     │              │                        │              │         └── plus [as=i:16]
+                     │              │                        │              │              ├── variable: i:10
+                     │              │                        │              │              └── const: 1
+                     │              │                        │              └── projections
+                     │              │                        │                   └── dispatch: 1
+                     │              │                        │                        ├── branch: 2
+                     │              │                        │                        └── args
+                     │              │                        │                             ├── variable: n:8
+                     │              │                        │                             ├── variable: sum:15
+                     │              │                        │                             └── variable: i:16
+                     │              │                        └── subquery
+                     │              │                             └── project
+                     │              │                                  ├── columns: loop_exit_1:18
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 0
+                     │              │                                            └── args
+                     │              │                                                 ├── variable: n:8
+                     │              │                                                 ├── variable: sum:9
+                     │              │                                                 └── variable: i:10
+                     │              └── branch: 2
+                     │                   ├── params: n:11 sum:12 i:13
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_loop_3:14
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 1
+                     │                                       └── args
+                     │                                            ├── variable: n:11
+                     │                                            ├── variable: sum:12
+                     │                                            └── variable: i:13
                      └── const: 1
 
 exec-ddl
@@ -1725,110 +2179,127 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:12
+ ├── columns: f:13
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:12]
+      └── udf: f [as=f:13]
            └── body
                 └── limit
-                     ├── columns: "_stmt_raise_1":11
+                     ├── columns: dispatcher_12:12
                      ├── project
-                     │    ├── columns: "_stmt_raise_1":11
+                     │    ├── columns: dispatcher_12:12
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":11]
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:1
-                     │                   │    ├── values
-                     │                   │    │    └── tuple
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
-                     │                   │              ├── const: 'DEBUG1'
-                     │                   │              ├── const: 'foo'
-                     │                   │              ├── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              └── const: '00000'
-                     │                   └── project
-                     │                        ├── columns: "_stmt_raise_3":10
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── udf: _stmt_raise_3 [as="_stmt_raise_3":10]
-                     │                                  └── body
-                     │                                       ├── project
-                     │                                       │    ├── columns: stmt_raise_4:2
-                     │                                       │    ├── values
-                     │                                       │    │    └── tuple
-                     │                                       │    └── projections
-                     │                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_4:2]
-                     │                                       │              ├── const: 'LOG'
-                     │                                       │              ├── const: 'foo'
-                     │                                       │              ├── const: ''
-                     │                                       │              ├── const: ''
-                     │                                       │              └── const: '00000'
-                     │                                       └── project
-                     │                                            ├── columns: "_stmt_raise_5":9
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: _stmt_raise_5 [as="_stmt_raise_5":9]
-                     │                                                      └── body
-                     │                                                           ├── project
-                     │                                                           │    ├── columns: stmt_raise_6:3
-                     │                                                           │    ├── values
-                     │                                                           │    │    └── tuple
-                     │                                                           │    └── projections
-                     │                                                           │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_6:3]
-                     │                                                           │              ├── const: 'INFO'
-                     │                                                           │              ├── const: 'foo'
-                     │                                                           │              ├── const: ''
-                     │                                                           │              ├── const: ''
-                     │                                                           │              └── const: '00000'
-                     │                                                           └── project
-                     │                                                                ├── columns: "_stmt_raise_7":8
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── udf: _stmt_raise_7 [as="_stmt_raise_7":8]
-                     │                                                                          └── body
-                     │                                                                               ├── project
-                     │                                                                               │    ├── columns: stmt_raise_8:4
-                     │                                                                               │    ├── values
-                     │                                                                               │    │    └── tuple
-                     │                                                                               │    └── projections
-                     │                                                                               │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:4]
-                     │                                                                               │              ├── const: 'NOTICE'
-                     │                                                                               │              ├── const: 'foo'
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              └── const: '00000'
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: "_stmt_raise_9":7
-                     │                                                                                    ├── values
-                     │                                                                                    │    └── tuple
-                     │                                                                                    └── projections
-                     │                                                                                         └── udf: _stmt_raise_9 [as="_stmt_raise_9":7]
-                     │                                                                                              └── body
-                     │                                                                                                   ├── project
-                     │                                                                                                   │    ├── columns: stmt_raise_10:5
-                     │                                                                                                   │    ├── values
-                     │                                                                                                   │    │    └── tuple
-                     │                                                                                                   │    └── projections
-                     │                                                                                                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_10:5]
-                     │                                                                                                   │              ├── const: 'WARNING'
-                     │                                                                                                   │              ├── const: 'foo'
-                     │                                                                                                   │              ├── const: ''
-                     │                                                                                                   │              ├── const: ''
-                     │                                                                                                   │              └── const: '00000'
-                     │                                                                                                   └── project
-                     │                                                                                                        ├── columns: stmt_return_11:6!null
-                     │                                                                                                        ├── values
-                     │                                                                                                        │    └── tuple
-                     │                                                                                                        └── projections
-                     │                                                                                                             └── const: 0 [as=stmt_return_11:6]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_1":11
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 0
+                     │              ├── branch: 0
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_2:1
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
+                     │              │         │              ├── const: 'DEBUG1'
+                     │              │         │              ├── const: 'foo'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_3":10
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 1
+                     │              ├── branch: 1
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_4:2
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_4:2]
+                     │              │         │              ├── const: 'LOG'
+                     │              │         │              ├── const: 'foo'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_5":9
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 2
+                     │              ├── branch: 2
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_6:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_6:3]
+                     │              │         │              ├── const: 'INFO'
+                     │              │         │              ├── const: 'foo'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_7":8
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 3
+                     │              ├── branch: 3
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_8:4
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:4]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: 'foo'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_9":7
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 4
+                     │              └── branch: 4
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_10:5
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_10:5]
+                     │                        │              ├── const: 'WARNING'
+                     │                        │              ├── const: 'foo'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: '00000'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_11:6!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 0 [as=stmt_return_11:6]
                      └── const: 1
 
 exec-ddl
@@ -1848,202 +2319,219 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:12
+ ├── columns: f:13
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:12]
+      └── udf: f [as=f:13]
            └── body
                 └── limit
-                     ├── columns: "_stmt_raise_1":11
+                     ├── columns: dispatcher_12:12
                      ├── project
-                     │    ├── columns: "_stmt_raise_1":11
+                     │    ├── columns: dispatcher_12:12
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":11]
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:1
-                     │                   │    ├── values
-                     │                   │    │    └── tuple
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
-                     │                   │              ├── const: 'NOTICE'
-                     │                   │              ├── concat
-                     │                   │              │    ├── concat
-                     │                   │              │    │    ├── const: ''
-                     │                   │              │    │    └── coalesce
-                     │                   │              │    │         ├── cast: STRING
-                     │                   │              │    │         │    └── const: 1
-                     │                   │              │    │         └── const: '<NULL>'
-                     │                   │              │    └── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              └── const: '00000'
-                     │                   └── project
-                     │                        ├── columns: "_stmt_raise_3":10
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── udf: _stmt_raise_3 [as="_stmt_raise_3":10]
-                     │                                  └── body
-                     │                                       ├── project
-                     │                                       │    ├── columns: stmt_raise_4:2
-                     │                                       │    ├── values
-                     │                                       │    │    └── tuple
-                     │                                       │    └── projections
-                     │                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_4:2]
-                     │                                       │              ├── const: 'NOTICE'
-                     │                                       │              ├── concat
-                     │                                       │              │    ├── concat
-                     │                                       │              │    │    ├── concat
-                     │                                       │              │    │    │    ├── concat
-                     │                                       │              │    │    │    │    ├── concat
-                     │                                       │              │    │    │    │    │    ├── concat
-                     │                                       │              │    │    │    │    │    │    ├── const: 'foo: '
-                     │                                       │              │    │    │    │    │    │    └── coalesce
-                     │                                       │              │    │    │    │    │    │         ├── cast: STRING
-                     │                                       │              │    │    │    │    │    │         │    └── const: 1
-                     │                                       │              │    │    │    │    │    │         └── const: '<NULL>'
-                     │                                       │              │    │    │    │    │    └── const: ', '
-                     │                                       │              │    │    │    │    └── coalesce
-                     │                                       │              │    │    │    │         ├── cast: STRING
-                     │                                       │              │    │    │    │         │    └── const: 2
-                     │                                       │              │    │    │    │         └── const: '<NULL>'
-                     │                                       │              │    │    │    └── const: ', '
-                     │                                       │              │    │    └── coalesce
-                     │                                       │              │    │         ├── cast: STRING
-                     │                                       │              │    │         │    └── const: 3
-                     │                                       │              │    │         └── const: '<NULL>'
-                     │                                       │              │    └── const: ''
-                     │                                       │              ├── const: ''
-                     │                                       │              ├── const: ''
-                     │                                       │              └── const: '00000'
-                     │                                       └── project
-                     │                                            ├── columns: "_stmt_raise_5":9
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: _stmt_raise_5 [as="_stmt_raise_5":9]
-                     │                                                      └── body
-                     │                                                           ├── project
-                     │                                                           │    ├── columns: stmt_raise_6:3
-                     │                                                           │    ├── values
-                     │                                                           │    │    └── tuple
-                     │                                                           │    └── projections
-                     │                                                           │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_6:3]
-                     │                                                           │              ├── const: 'NOTICE'
-                     │                                                           │              ├── concat
-                     │                                                           │              │    ├── concat
-                     │                                                           │              │    │    ├── const: ''
-                     │                                                           │              │    │    └── const: '%'
-                     │                                                           │              │    └── const: ''
-                     │                                                           │              ├── const: ''
-                     │                                                           │              ├── const: ''
-                     │                                                           │              └── const: '00000'
-                     │                                                           └── project
-                     │                                                                ├── columns: "_stmt_raise_7":8
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── udf: _stmt_raise_7 [as="_stmt_raise_7":8]
-                     │                                                                          └── body
-                     │                                                                               ├── project
-                     │                                                                               │    ├── columns: stmt_raise_8:4
-                     │                                                                               │    ├── values
-                     │                                                                               │    │    └── tuple
-                     │                                                                               │    └── projections
-                     │                                                                               │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:4]
-                     │                                                                               │              ├── const: 'NOTICE'
-                     │                                                                               │              ├── concat
-                     │                                                                               │              │    ├── concat
-                     │                                                                               │              │    │    ├── concat
-                     │                                                                               │              │    │    │    ├── concat
-                     │                                                                               │              │    │    │    │    ├── const: ''
-                     │                                                                               │              │    │    │    │    └── const: '%'
-                     │                                                                               │              │    │    │    └── const: ''
-                     │                                                                               │              │    │    └── coalesce
-                     │                                                                               │              │    │         ├── cast: STRING
-                     │                                                                               │              │    │         │    └── const: 1
-                     │                                                                               │              │    │         └── const: '<NULL>'
-                     │                                                                               │              │    └── const: ''
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              └── const: '00000'
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: "_stmt_raise_9":7
-                     │                                                                                    ├── values
-                     │                                                                                    │    └── tuple
-                     │                                                                                    └── projections
-                     │                                                                                         └── udf: _stmt_raise_9 [as="_stmt_raise_9":7]
-                     │                                                                                              └── body
-                     │                                                                                                   ├── project
-                     │                                                                                                   │    ├── columns: stmt_raise_10:5
-                     │                                                                                                   │    ├── values
-                     │                                                                                                   │    │    └── tuple
-                     │                                                                                                   │    └── projections
-                     │                                                                                                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_10:5]
-                     │                                                                                                   │              ├── const: 'NOTICE'
-                     │                                                                                                   │              ├── concat
-                     │                                                                                                   │              │    ├── concat
-                     │                                                                                                   │              │    │    ├── concat
-                     │                                                                                                   │              │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── const: ''
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: '%'
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: ''
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── coalesce
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │         ├── cast: STRING
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │         │    └── const: 1
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │         └── const: '<NULL>'
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: 'foo'
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: '%'
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: ' bar'
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: '%'
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: ''
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    │    └── const: '%'
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    │    └── const: ' '
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    │    └── const: '%'
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    │    └── const: ' '
-                     │                                                                                                   │              │    │    │    │    │    │    │    │    └── const: '%'
-                     │                                                                                                   │              │    │    │    │    │    │    │    └── const: ''
-                     │                                                                                                   │              │    │    │    │    │    │    └── const: '%'
-                     │                                                                                                   │              │    │    │    │    │    └── const: ' ba'
-                     │                                                                                                   │              │    │    │    │    └── coalesce
-                     │                                                                                                   │              │    │    │    │         ├── cast: STRING
-                     │                                                                                                   │              │    │    │    │         │    └── const: 2
-                     │                                                                                                   │              │    │    │    │         └── const: '<NULL>'
-                     │                                                                                                   │              │    │    │    └── const: 'z'
-                     │                                                                                                   │              │    │    └── coalesce
-                     │                                                                                                   │              │    │         ├── cast: STRING
-                     │                                                                                                   │              │    │         │    └── const: 3
-                     │                                                                                                   │              │    │         └── const: '<NULL>'
-                     │                                                                                                   │              │    └── const: ''
-                     │                                                                                                   │              ├── const: ''
-                     │                                                                                                   │              ├── const: ''
-                     │                                                                                                   │              └── const: '00000'
-                     │                                                                                                   └── project
-                     │                                                                                                        ├── columns: stmt_return_11:6!null
-                     │                                                                                                        ├── values
-                     │                                                                                                        │    └── tuple
-                     │                                                                                                        └── projections
-                     │                                                                                                             └── const: 0 [as=stmt_return_11:6]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_1":11
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 0
+                     │              ├── branch: 0
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_2:1
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── concat
+                     │              │         │              │    ├── concat
+                     │              │         │              │    │    ├── const: ''
+                     │              │         │              │    │    └── coalesce
+                     │              │         │              │    │         ├── cast: STRING
+                     │              │         │              │    │         │    └── const: 1
+                     │              │         │              │    │         └── const: '<NULL>'
+                     │              │         │              │    └── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_3":10
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 1
+                     │              ├── branch: 1
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_4:2
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_4:2]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── concat
+                     │              │         │              │    ├── concat
+                     │              │         │              │    │    ├── concat
+                     │              │         │              │    │    │    ├── concat
+                     │              │         │              │    │    │    │    ├── concat
+                     │              │         │              │    │    │    │    │    ├── concat
+                     │              │         │              │    │    │    │    │    │    ├── const: 'foo: '
+                     │              │         │              │    │    │    │    │    │    └── coalesce
+                     │              │         │              │    │    │    │    │    │         ├── cast: STRING
+                     │              │         │              │    │    │    │    │    │         │    └── const: 1
+                     │              │         │              │    │    │    │    │    │         └── const: '<NULL>'
+                     │              │         │              │    │    │    │    │    └── const: ', '
+                     │              │         │              │    │    │    │    └── coalesce
+                     │              │         │              │    │    │    │         ├── cast: STRING
+                     │              │         │              │    │    │    │         │    └── const: 2
+                     │              │         │              │    │    │    │         └── const: '<NULL>'
+                     │              │         │              │    │    │    └── const: ', '
+                     │              │         │              │    │    └── coalesce
+                     │              │         │              │    │         ├── cast: STRING
+                     │              │         │              │    │         │    └── const: 3
+                     │              │         │              │    │         └── const: '<NULL>'
+                     │              │         │              │    └── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_5":9
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 2
+                     │              ├── branch: 2
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_6:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_6:3]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── concat
+                     │              │         │              │    ├── concat
+                     │              │         │              │    │    ├── const: ''
+                     │              │         │              │    │    └── const: '%'
+                     │              │         │              │    └── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_7":8
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 3
+                     │              ├── branch: 3
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_8:4
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:4]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── concat
+                     │              │         │              │    ├── concat
+                     │              │         │              │    │    ├── concat
+                     │              │         │              │    │    │    ├── concat
+                     │              │         │              │    │    │    │    ├── const: ''
+                     │              │         │              │    │    │    │    └── const: '%'
+                     │              │         │              │    │    │    └── const: ''
+                     │              │         │              │    │    └── coalesce
+                     │              │         │              │    │         ├── cast: STRING
+                     │              │         │              │    │         │    └── const: 1
+                     │              │         │              │    │         └── const: '<NULL>'
+                     │              │         │              │    └── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_9":7
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 4
+                     │              └── branch: 4
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_10:5
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_10:5]
+                     │                        │              ├── const: 'NOTICE'
+                     │                        │              ├── concat
+                     │                        │              │    ├── concat
+                     │                        │              │    │    ├── concat
+                     │                        │              │    │    │    ├── concat
+                     │                        │              │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── concat
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    ├── const: ''
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: '%'
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: ''
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── coalesce
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │         ├── cast: STRING
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │         │    └── const: 1
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │         └── const: '<NULL>'
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: 'foo'
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: '%'
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: ' bar'
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: '%'
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    │    └── const: ''
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    │    └── const: '%'
+                     │                        │              │    │    │    │    │    │    │    │    │    │    │    └── const: ' '
+                     │                        │              │    │    │    │    │    │    │    │    │    │    └── const: '%'
+                     │                        │              │    │    │    │    │    │    │    │    │    └── const: ' '
+                     │                        │              │    │    │    │    │    │    │    │    └── const: '%'
+                     │                        │              │    │    │    │    │    │    │    └── const: ''
+                     │                        │              │    │    │    │    │    │    └── const: '%'
+                     │                        │              │    │    │    │    │    └── const: ' ba'
+                     │                        │              │    │    │    │    └── coalesce
+                     │                        │              │    │    │    │         ├── cast: STRING
+                     │                        │              │    │    │    │         │    └── const: 2
+                     │                        │              │    │    │    │         └── const: '<NULL>'
+                     │                        │              │    │    │    └── const: 'z'
+                     │                        │              │    │    └── coalesce
+                     │                        │              │    │         ├── cast: STRING
+                     │                        │              │    │         │    └── const: 3
+                     │                        │              │    │         └── const: '<NULL>'
+                     │                        │              │    └── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: '00000'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_11:6!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 0 [as=stmt_return_11:6]
                      └── const: 1
 
 exec-ddl
@@ -2066,164 +2554,187 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:18
+ ├── columns: f:19
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:18]
+      └── udf: f [as=f:19]
            └── body
                 └── limit
-                     ├── columns: "_stmt_raise_1":17
+                     ├── columns: dispatcher_18:18
                      ├── project
-                     │    ├── columns: "_stmt_raise_1":17
+                     │    ├── columns: dispatcher_18:18
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":17]
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:1
-                     │                   │    ├── values
-                     │                   │    │    └── tuple
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
-                     │                   │              ├── const: 'NOTICE'
-                     │                   │              ├── const: 'division_by_zero'
-                     │                   │              ├── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              └── const: 'division_by_zero'
-                     │                   └── project
-                     │                        ├── columns: "_stmt_raise_3":16
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── udf: _stmt_raise_3 [as="_stmt_raise_3":16]
-                     │                                  └── body
-                     │                                       ├── project
-                     │                                       │    ├── columns: stmt_raise_4:2
-                     │                                       │    ├── values
-                     │                                       │    │    └── tuple
-                     │                                       │    └── projections
-                     │                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_4:2]
-                     │                                       │              ├── const: 'NOTICE'
-                     │                                       │              ├── const: 'null_value_not_allowed'
-                     │                                       │              ├── const: ''
-                     │                                       │              ├── const: ''
-                     │                                       │              └── const: 'null_value_not_allowed'
-                     │                                       └── project
-                     │                                            ├── columns: "_stmt_raise_5":15
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: _stmt_raise_5 [as="_stmt_raise_5":15]
-                     │                                                      └── body
-                     │                                                           ├── project
-                     │                                                           │    ├── columns: stmt_raise_6:3
-                     │                                                           │    ├── values
-                     │                                                           │    │    └── tuple
-                     │                                                           │    └── projections
-                     │                                                           │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_6:3]
-                     │                                                           │              ├── const: 'NOTICE'
-                     │                                                           │              ├── const: 'reading_sql_data_not_permitted'
-                     │                                                           │              ├── const: ''
-                     │                                                           │              ├── const: ''
-                     │                                                           │              └── const: 'reading_sql_data_not_permitted'
-                     │                                                           └── project
-                     │                                                                ├── columns: "_stmt_raise_7":14
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── udf: _stmt_raise_7 [as="_stmt_raise_7":14]
-                     │                                                                          └── body
-                     │                                                                               ├── project
-                     │                                                                               │    ├── columns: stmt_raise_8:4
-                     │                                                                               │    ├── values
-                     │                                                                               │    │    └── tuple
-                     │                                                                               │    └── projections
-                     │                                                                               │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:4]
-                     │                                                                               │              ├── const: 'NOTICE'
-                     │                                                                               │              ├── const: '22012'
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              └── const: '22012'
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: "_stmt_raise_9":13
-                     │                                                                                    ├── values
-                     │                                                                                    │    └── tuple
-                     │                                                                                    └── projections
-                     │                                                                                         └── udf: _stmt_raise_9 [as="_stmt_raise_9":13]
-                     │                                                                                              └── body
-                     │                                                                                                   ├── project
-                     │                                                                                                   │    ├── columns: stmt_raise_10:5
-                     │                                                                                                   │    ├── values
-                     │                                                                                                   │    │    └── tuple
-                     │                                                                                                   │    └── projections
-                     │                                                                                                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_10:5]
-                     │                                                                                                   │              ├── const: 'NOTICE'
-                     │                                                                                                   │              ├── const: '22004'
-                     │                                                                                                   │              ├── const: ''
-                     │                                                                                                   │              ├── const: ''
-                     │                                                                                                   │              └── const: '22004'
-                     │                                                                                                   └── project
-                     │                                                                                                        ├── columns: "_stmt_raise_11":12
-                     │                                                                                                        ├── values
-                     │                                                                                                        │    └── tuple
-                     │                                                                                                        └── projections
-                     │                                                                                                             └── udf: _stmt_raise_11 [as="_stmt_raise_11":12]
-                     │                                                                                                                  └── body
-                     │                                                                                                                       ├── project
-                     │                                                                                                                       │    ├── columns: stmt_raise_12:6
-                     │                                                                                                                       │    ├── values
-                     │                                                                                                                       │    │    └── tuple
-                     │                                                                                                                       │    └── projections
-                     │                                                                                                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_12:6]
-                     │                                                                                                                       │              ├── const: 'NOTICE'
-                     │                                                                                                                       │              ├── const: '39004'
-                     │                                                                                                                       │              ├── const: ''
-                     │                                                                                                                       │              ├── const: ''
-                     │                                                                                                                       │              └── const: '39004'
-                     │                                                                                                                       └── project
-                     │                                                                                                                            ├── columns: "_stmt_raise_13":11
-                     │                                                                                                                            ├── values
-                     │                                                                                                                            │    └── tuple
-                     │                                                                                                                            └── projections
-                     │                                                                                                                                 └── udf: _stmt_raise_13 [as="_stmt_raise_13":11]
-                     │                                                                                                                                      └── body
-                     │                                                                                                                                           ├── project
-                     │                                                                                                                                           │    ├── columns: stmt_raise_14:7
-                     │                                                                                                                                           │    ├── values
-                     │                                                                                                                                           │    │    └── tuple
-                     │                                                                                                                                           │    └── projections
-                     │                                                                                                                                           │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_14:7]
-                     │                                                                                                                                           │              ├── const: 'NOTICE'
-                     │                                                                                                                                           │              ├── const: '2F004'
-                     │                                                                                                                                           │              ├── const: ''
-                     │                                                                                                                                           │              ├── const: ''
-                     │                                                                                                                                           │              └── const: '2F004'
-                     │                                                                                                                                           └── project
-                     │                                                                                                                                                ├── columns: "_stmt_raise_15":10
-                     │                                                                                                                                                ├── values
-                     │                                                                                                                                                │    └── tuple
-                     │                                                                                                                                                └── projections
-                     │                                                                                                                                                     └── udf: _stmt_raise_15 [as="_stmt_raise_15":10]
-                     │                                                                                                                                                          └── body
-                     │                                                                                                                                                               ├── project
-                     │                                                                                                                                                               │    ├── columns: stmt_raise_16:8
-                     │                                                                                                                                                               │    ├── values
-                     │                                                                                                                                                               │    │    └── tuple
-                     │                                                                                                                                                               │    └── projections
-                     │                                                                                                                                                               │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_16:8]
-                     │                                                                                                                                                               │              ├── const: 'NOTICE'
-                     │                                                                                                                                                               │              ├── const: '38004'
-                     │                                                                                                                                                               │              ├── const: ''
-                     │                                                                                                                                                               │              ├── const: ''
-                     │                                                                                                                                                               │              └── const: '38004'
-                     │                                                                                                                                                               └── project
-                     │                                                                                                                                                                    ├── columns: stmt_return_17:9!null
-                     │                                                                                                                                                                    ├── values
-                     │                                                                                                                                                                    │    └── tuple
-                     │                                                                                                                                                                    └── projections
-                     │                                                                                                                                                                         └── const: 0 [as=stmt_return_17:9]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_1":17
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 0
+                     │              ├── branch: 0
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_2:1
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: 'division_by_zero'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: 'division_by_zero'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_3":16
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 1
+                     │              ├── branch: 1
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_4:2
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_4:2]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: 'null_value_not_allowed'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: 'null_value_not_allowed'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_5":15
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 2
+                     │              ├── branch: 2
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_6:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_6:3]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: 'reading_sql_data_not_permitted'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: 'reading_sql_data_not_permitted'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_7":14
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 3
+                     │              ├── branch: 3
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_8:4
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:4]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: '22012'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '22012'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_9":13
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 4
+                     │              ├── branch: 4
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_10:5
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_10:5]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: '22004'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '22004'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_11":12
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 5
+                     │              ├── branch: 5
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_12:6
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_12:6]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: '39004'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '39004'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_13":11
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 6
+                     │              ├── branch: 6
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_14:7
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_14:7]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: '2F004'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '2F004'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_15":10
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 7
+                     │              └── branch: 7
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_16:8
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_16:8]
+                     │                        │              ├── const: 'NOTICE'
+                     │                        │              ├── const: '38004'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: '38004'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_17:9!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 0 [as=stmt_return_17:9]
                      └── const: 1
 
 exec-ddl
@@ -2245,131 +2756,150 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:14
+ ├── columns: f:15
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:14]
+      └── udf: f [as=f:15]
            └── body
                 └── limit
-                     ├── columns: "_stmt_raise_1":13
+                     ├── columns: dispatcher_14:14
                      ├── project
-                     │    ├── columns: "_stmt_raise_1":13
+                     │    ├── columns: dispatcher_14:14
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":13]
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:1
-                     │                   │    ├── values
-                     │                   │    │    └── tuple
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
-                     │                   │              ├── const: 'NOTICE'
-                     │                   │              ├── const: 'foo'
-                     │                   │              ├── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              └── const: '00000'
-                     │                   └── project
-                     │                        ├── columns: "_stmt_raise_3":12
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── udf: _stmt_raise_3 [as="_stmt_raise_3":12]
-                     │                                  └── body
-                     │                                       ├── project
-                     │                                       │    ├── columns: stmt_raise_4:2
-                     │                                       │    ├── values
-                     │                                       │    │    └── tuple
-                     │                                       │    └── projections
-                     │                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_4:2]
-                     │                                       │              ├── const: 'NOTICE'
-                     │                                       │              ├── function: format
-                     │                                       │              │    ├── const: '%s %s!'
-                     │                                       │              │    ├── const: 'Hello'
-                     │                                       │              │    └── const: 'World'
-                     │                                       │              ├── const: ''
-                     │                                       │              ├── const: ''
-                     │                                       │              └── const: '00000'
-                     │                                       └── project
-                     │                                            ├── columns: "_stmt_raise_5":11
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: _stmt_raise_5 [as="_stmt_raise_5":11]
-                     │                                                      └── body
-                     │                                                           ├── project
-                     │                                                           │    ├── columns: stmt_raise_6:3
-                     │                                                           │    ├── values
-                     │                                                           │    │    └── tuple
-                     │                                                           │    └── projections
-                     │                                                           │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_6:3]
-                     │                                                           │              ├── const: 'NOTICE'
-                     │                                                           │              ├── const: 'foo'
-                     │                                                           │              ├── const: 'bar'
-                     │                                                           │              ├── const: 'baz'
-                     │                                                           │              └── const: '00000'
-                     │                                                           └── project
-                     │                                                                ├── columns: "_stmt_raise_7":10
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── udf: _stmt_raise_7 [as="_stmt_raise_7":10]
-                     │                                                                          └── body
-                     │                                                                               ├── project
-                     │                                                                               │    ├── columns: stmt_raise_8:4
-                     │                                                                               │    ├── values
-                     │                                                                               │    │    └── tuple
-                     │                                                                               │    └── projections
-                     │                                                                               │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:4]
-                     │                                                                               │              ├── const: 'NOTICE'
-                     │                                                                               │              ├── const: 'foo'
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              └── const: 'division_by_zero'
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: "_stmt_raise_9":9
-                     │                                                                                    ├── values
-                     │                                                                                    │    └── tuple
-                     │                                                                                    └── projections
-                     │                                                                                         └── udf: _stmt_raise_9 [as="_stmt_raise_9":9]
-                     │                                                                                              └── body
-                     │                                                                                                   ├── project
-                     │                                                                                                   │    ├── columns: stmt_raise_10:5
-                     │                                                                                                   │    ├── values
-                     │                                                                                                   │    │    └── tuple
-                     │                                                                                                   │    └── projections
-                     │                                                                                                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_10:5]
-                     │                                                                                                   │              ├── const: 'NOTICE'
-                     │                                                                                                   │              ├── const: 'foo'
-                     │                                                                                                   │              ├── const: ''
-                     │                                                                                                   │              ├── const: ''
-                     │                                                                                                   │              └── const: '22012'
-                     │                                                                                                   └── project
-                     │                                                                                                        ├── columns: "_stmt_raise_11":8
-                     │                                                                                                        ├── values
-                     │                                                                                                        │    └── tuple
-                     │                                                                                                        └── projections
-                     │                                                                                                             └── udf: _stmt_raise_11 [as="_stmt_raise_11":8]
-                     │                                                                                                                  └── body
-                     │                                                                                                                       ├── project
-                     │                                                                                                                       │    ├── columns: stmt_raise_12:6
-                     │                                                                                                                       │    ├── values
-                     │                                                                                                                       │    │    └── tuple
-                     │                                                                                                                       │    └── projections
-                     │                                                                                                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_12:6]
-                     │                                                                                                                       │              ├── const: 'NOTICE'
-                     │                                                                                                                       │              ├── const: 'division_by_zero'
-                     │                                                                                                                       │              ├── const: ''
-                     │                                                                                                                       │              ├── const: ''
-                     │                                                                                                                       │              └── const: 'division_by_zero'
-                     │                                                                                                                       └── project
-                     │                                                                                                                            ├── columns: stmt_return_13:7!null
-                     │                                                                                                                            ├── values
-                     │                                                                                                                            │    └── tuple
-                     │                                                                                                                            └── projections
-                     │                                                                                                                                 └── const: 0 [as=stmt_return_13:7]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_1":13
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 0
+                     │              ├── branch: 0
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_2:1
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: 'foo'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_3":12
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 1
+                     │              ├── branch: 1
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_4:2
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_4:2]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── function: format
+                     │              │         │              │    ├── const: '%s %s!'
+                     │              │         │              │    ├── const: 'Hello'
+                     │              │         │              │    └── const: 'World'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_5":11
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 2
+                     │              ├── branch: 2
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_6:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_6:3]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: 'foo'
+                     │              │         │              ├── const: 'bar'
+                     │              │         │              ├── const: 'baz'
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_7":10
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 3
+                     │              ├── branch: 3
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_8:4
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:4]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: 'foo'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: 'division_by_zero'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_9":9
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 4
+                     │              ├── branch: 4
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_10:5
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_10:5]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: 'foo'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '22012'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_11":8
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 5
+                     │              └── branch: 5
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_12:6
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_12:6]
+                     │                        │              ├── const: 'NOTICE'
+                     │                        │              ├── const: 'division_by_zero'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: 'division_by_zero'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_13:7!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 0 [as=stmt_return_13:7]
                      └── const: 1
 
 exec-ddl
@@ -2392,170 +2922,179 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:29
+ ├── columns: f:30
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:29]
+      └── udf: f [as=f:30]
            └── body
                 └── limit
-                     ├── columns: "_stmt_raise_1":28
+                     ├── columns: dispatcher_10:29
                      ├── project
-                     │    ├── columns: "_stmt_raise_1":28
-                     │    ├── barrier
-                     │    │    ├── columns: i:1!null
-                     │    │    └── project
-                     │    │         ├── columns: i:1!null
-                     │    │         ├── values
-                     │    │         │    └── tuple
-                     │    │         └── projections
-                     │    │              └── const: 0 [as=i:1]
+                     │    ├── columns: dispatcher_10:29
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":28]
-                     │              ├── args
-                     │              │    └── variable: i:1
-                     │              ├── params: i:2
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:3
-                     │                   │    ├── values
-                     │                   │    │    └── tuple
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:3]
-                     │                   │              ├── const: 'NOTICE'
-                     │                   │              ├── concat
-                     │                   │              │    ├── concat
-                     │                   │              │    │    ├── const: '1: i = '
-                     │                   │              │    │    └── coalesce
-                     │                   │              │    │         ├── cast: STRING
-                     │                   │              │    │         │    └── variable: i:2
-                     │                   │              │    │         └── const: '<NULL>'
-                     │                   │              │    └── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              └── const: '00000'
-                     │                   └── project
-                     │                        ├── columns: "_stmt_raise_3":27
-                     │                        ├── barrier
-                     │                        │    ├── columns: i:4!null
-                     │                        │    └── project
-                     │                        │         ├── columns: i:4!null
-                     │                        │         ├── values
-                     │                        │         │    └── tuple
-                     │                        │         └── projections
-                     │                        │              └── const: 100 [as=i:4]
-                     │                        └── projections
-                     │                             └── udf: _stmt_raise_3 [as="_stmt_raise_3":27]
-                     │                                  ├── args
-                     │                                  │    └── variable: i:4
-                     │                                  ├── params: i:5
-                     │                                  └── body
-                     │                                       ├── project
-                     │                                       │    ├── columns: stmt_raise_4:6
-                     │                                       │    ├── values
-                     │                                       │    │    └── tuple
-                     │                                       │    └── projections
-                     │                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_4:6]
-                     │                                       │              ├── const: 'NOTICE'
-                     │                                       │              ├── concat
-                     │                                       │              │    ├── concat
-                     │                                       │              │    │    ├── const: '2: i = '
-                     │                                       │              │    │    └── coalesce
-                     │                                       │              │    │         ├── cast: STRING
-                     │                                       │              │    │         │    └── variable: i:5
-                     │                                       │              │    │         └── const: '<NULL>'
-                     │                                       │              │    └── const: ''
-                     │                                       │              ├── const: ''
-                     │                                       │              ├── const: ''
-                     │                                       │              └── const: '00000'
-                     │                                       └── project
-                     │                                            ├── columns: "_stmt_raise_5":26
-                     │                                            ├── barrier
-                     │                                            │    ├── columns: i:13
-                     │                                            │    └── project
-                     │                                            │         ├── columns: i:13
-                     │                                            │         ├── values
-                     │                                            │         │    └── tuple
-                     │                                            │         └── projections
-                     │                                            │              └── subquery [as=i:13]
-                     │                                            │                   └── max1-row
-                     │                                            │                        ├── columns: count_rows:12!null
-                     │                                            │                        └── scalar-group-by
-                     │                                            │                             ├── columns: count_rows:12!null
-                     │                                            │                             ├── project
-                     │                                            │                             │    └── scan xy
-                     │                                            │                             │         └── columns: x:7 y:8 rowid:9!null crdb_internal_mvcc_timestamp:10 tableoid:11
-                     │                                            │                             └── aggregations
-                     │                                            │                                  └── count-rows [as=count_rows:12]
-                     │                                            └── projections
-                     │                                                 └── udf: _stmt_raise_5 [as="_stmt_raise_5":26]
-                     │                                                      ├── args
-                     │                                                      │    └── variable: i:13
-                     │                                                      ├── params: i:14
-                     │                                                      └── body
-                     │                                                           ├── project
-                     │                                                           │    ├── columns: stmt_raise_6:15
-                     │                                                           │    ├── values
-                     │                                                           │    │    └── tuple
-                     │                                                           │    └── projections
-                     │                                                           │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_6:15]
-                     │                                                           │              ├── const: 'NOTICE'
-                     │                                                           │              ├── concat
-                     │                                                           │              │    ├── concat
-                     │                                                           │              │    │    ├── const: '3: i = '
-                     │                                                           │              │    │    └── coalesce
-                     │                                                           │              │    │         ├── cast: STRING
-                     │                                                           │              │    │         │    └── variable: i:14
-                     │                                                           │              │    │         └── const: '<NULL>'
-                     │                                                           │              │    └── const: ''
-                     │                                                           │              ├── const: ''
-                     │                                                           │              ├── const: ''
-                     │                                                           │              └── const: '00000'
-                     │                                                           └── project
-                     │                                                                ├── columns: "_stmt_raise_7":25
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── udf: _stmt_raise_7 [as="_stmt_raise_7":25]
-                     │                                                                          ├── args
-                     │                                                                          │    └── variable: i:14
-                     │                                                                          ├── params: i:16
-                     │                                                                          └── body
-                     │                                                                               ├── project
-                     │                                                                               │    ├── columns: stmt_raise_8:23
-                     │                                                                               │    ├── values
-                     │                                                                               │    │    └── tuple
-                     │                                                                               │    └── projections
-                     │                                                                               │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:23]
-                     │                                                                               │              ├── const: 'NOTICE'
-                     │                                                                               │              ├── concat
-                     │                                                                               │              │    ├── concat
-                     │                                                                               │              │    │    ├── const: 'max_x: '
-                     │                                                                               │              │    │    └── coalesce
-                     │                                                                               │              │    │         ├── cast: STRING
-                     │                                                                               │              │    │         │    └── subquery
-                     │                                                                               │              │    │         │         └── max1-row
-                     │                                                                               │              │    │         │              ├── columns: max:22
-                     │                                                                               │              │    │         │              └── scalar-group-by
-                     │                                                                               │              │    │         │                   ├── columns: max:22
-                     │                                                                               │              │    │         │                   ├── project
-                     │                                                                               │              │    │         │                   │    ├── columns: x:17
-                     │                                                                               │              │    │         │                   │    └── scan xy
-                     │                                                                               │              │    │         │                   │         └── columns: x:17 y:18 rowid:19!null crdb_internal_mvcc_timestamp:20 tableoid:21
-                     │                                                                               │              │    │         │                   └── aggregations
-                     │                                                                               │              │    │         │                        └── max [as=max:22]
-                     │                                                                               │              │    │         │                             └── variable: x:17
-                     │                                                                               │              │    │         └── const: '<NULL>'
-                     │                                                                               │              │    └── const: ''
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              └── const: '00000'
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: stmt_return_9:24
-                     │                                                                                    ├── values
-                     │                                                                                    │    └── tuple
-                     │                                                                                    └── projections
-                     │                                                                                         └── variable: i:16 [as=stmt_return_9:24]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_1":28
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:1!null
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── const: 0 [as=i:1]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 0
+                     │              │                   └── args
+                     │              │                        └── variable: i:1
+                     │              ├── branch: 0
+                     │              │    ├── params: i:2
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_2:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:3]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── concat
+                     │              │         │              │    ├── concat
+                     │              │         │              │    │    ├── const: '1: i = '
+                     │              │         │              │    │    └── coalesce
+                     │              │         │              │    │         ├── cast: STRING
+                     │              │         │              │    │         │    └── variable: i:2
+                     │              │         │              │    │         └── const: '<NULL>'
+                     │              │         │              │    └── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_3":27
+                     │              │              ├── project
+                     │              │              │    ├── columns: i:4!null
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── const: 100 [as=i:4]
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             └── variable: i:4
+                     │              ├── branch: 1
+                     │              │    ├── params: i:5
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_4:6
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_4:6]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── concat
+                     │              │         │              │    ├── concat
+                     │              │         │              │    │    ├── const: '2: i = '
+                     │              │         │              │    │    └── coalesce
+                     │              │         │              │    │         ├── cast: STRING
+                     │              │         │              │    │         │    └── variable: i:5
+                     │              │         │              │    │         └── const: '<NULL>'
+                     │              │         │              │    └── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_5":26
+                     │              │              ├── project
+                     │              │              │    ├── columns: i:13
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── subquery [as=i:13]
+                     │              │              │              └── max1-row
+                     │              │              │                   ├── columns: count_rows:12!null
+                     │              │              │                   └── scalar-group-by
+                     │              │              │                        ├── columns: count_rows:12!null
+                     │              │              │                        ├── project
+                     │              │              │                        │    └── scan xy
+                     │              │              │                        │         └── columns: x:7 y:8 rowid:9!null crdb_internal_mvcc_timestamp:10 tableoid:11
+                     │              │              │                        └── aggregations
+                     │              │              │                             └── count-rows [as=count_rows:12]
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 2
+                     │              │                        └── args
+                     │              │                             └── variable: i:13
+                     │              ├── branch: 2
+                     │              │    ├── params: i:14
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_6:15
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_6:15]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── concat
+                     │              │         │              │    ├── concat
+                     │              │         │              │    │    ├── const: '3: i = '
+                     │              │         │              │    │    └── coalesce
+                     │              │         │              │    │         ├── cast: STRING
+                     │              │         │              │    │         │    └── variable: i:14
+                     │              │         │              │    │         └── const: '<NULL>'
+                     │              │         │              │    └── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_7":25
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 3
+                     │              │                        └── args
+                     │              │                             └── variable: i:14
+                     │              └── branch: 3
+                     │                   ├── params: i:16
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_8:23
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:23]
+                     │                        │              ├── const: 'NOTICE'
+                     │                        │              ├── concat
+                     │                        │              │    ├── concat
+                     │                        │              │    │    ├── const: 'max_x: '
+                     │                        │              │    │    └── coalesce
+                     │                        │              │    │         ├── cast: STRING
+                     │                        │              │    │         │    └── subquery
+                     │                        │              │    │         │         └── max1-row
+                     │                        │              │    │         │              ├── columns: max:22
+                     │                        │              │    │         │              └── scalar-group-by
+                     │                        │              │    │         │                   ├── columns: max:22
+                     │                        │              │    │         │                   ├── project
+                     │                        │              │    │         │                   │    ├── columns: x:17
+                     │                        │              │    │         │                   │    └── scan xy
+                     │                        │              │    │         │                   │         └── columns: x:17 y:18 rowid:19!null crdb_internal_mvcc_timestamp:20 tableoid:21
+                     │                        │              │    │         │                   └── aggregations
+                     │                        │              │    │         │                        └── max [as=max:22]
+                     │                        │              │    │         │                             └── variable: x:17
+                     │                        │              │    │         └── const: '<NULL>'
+                     │                        │              │    └── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: '00000'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_9:24
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── variable: i:16 [as=stmt_return_9:24]
                      └── const: 1
 
 exec-ddl
@@ -2578,140 +3117,155 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:18
+ ├── columns: f:19
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:18]
+      └── udf: f [as=f:19]
            └── body
                 └── limit
-                     ├── columns: stmt_loop_5:17
+                     ├── columns: dispatcher_10:18
                      ├── project
-                     │    ├── columns: stmt_loop_5:17
-                     │    ├── barrier
-                     │    │    ├── columns: i:1!null
-                     │    │    └── project
-                     │    │         ├── columns: i:1!null
-                     │    │         ├── values
-                     │    │         │    └── tuple
-                     │    │         └── projections
-                     │    │              └── const: 0 [as=i:1]
+                     │    ├── columns: dispatcher_10:18
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: stmt_loop_5 [as=stmt_loop_5:17]
-                     │              ├── args
-                     │              │    └── variable: i:1
-                     │              ├── params: i:7
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: stmt_if_9:16
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── case [as=stmt_if_9:16]
-                     │                                  ├── true
-                     │                                  ├── when
-                     │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:7
-                     │                                  │    │    └── const: 5
-                     │                                  │    └── subquery
-                     │                                  │         └── project
-                     │                                  │              ├── columns: loop_exit_1:14
-                     │                                  │              ├── values
-                     │                                  │              │    └── tuple
-                     │                                  │              └── projections
-                     │                                  │                   └── udf: loop_exit_1 [as=loop_exit_1:14]
-                     │                                  │                        ├── args
-                     │                                  │                        │    └── variable: i:7
-                     │                                  │                        ├── params: i:2
-                     │                                  │                        └── body
-                     │                                  │                             └── project
-                     │                                  │                                  ├── columns: "_stmt_raise_2":6
-                     │                                  │                                  ├── values
-                     │                                  │                                  │    └── tuple
-                     │                                  │                                  └── projections
-                     │                                  │                                       └── udf: _stmt_raise_2 [as="_stmt_raise_2":6]
-                     │                                  │                                            ├── args
-                     │                                  │                                            │    └── variable: i:2
-                     │                                  │                                            ├── params: i:3
-                     │                                  │                                            └── body
-                     │                                  │                                                 ├── project
-                     │                                  │                                                 │    ├── columns: stmt_raise_3:4
-                     │                                  │                                                 │    ├── values
-                     │                                  │                                                 │    │    └── tuple
-                     │                                  │                                                 │    └── projections
-                     │                                  │                                                 │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_3:4]
-                     │                                  │                                                 │              ├── const: 'NOTICE'
-                     │                                  │                                                 │              ├── concat
-                     │                                  │                                                 │              │    ├── concat
-                     │                                  │                                                 │              │    │    ├── const: 'finished with i = '
-                     │                                  │                                                 │              │    │    └── coalesce
-                     │                                  │                                                 │              │    │         ├── cast: STRING
-                     │                                  │                                                 │              │    │         │    └── variable: i:3
-                     │                                  │                                                 │              │    │         └── const: '<NULL>'
-                     │                                  │                                                 │              │    └── const: ''
-                     │                                  │                                                 │              ├── const: ''
-                     │                                  │                                                 │              ├── const: ''
-                     │                                  │                                                 │              └── const: '00000'
-                     │                                  │                                                 └── project
-                     │                                  │                                                      ├── columns: stmt_return_4:5!null
-                     │                                  │                                                      ├── values
-                     │                                  │                                                      │    └── tuple
-                     │                                  │                                                      └── projections
-                     │                                  │                                                           └── const: 0 [as=stmt_return_4:5]
-                     │                                  └── subquery
-                     │                                       └── project
-                     │                                            ├── columns: stmt_if_6:15
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: stmt_if_6 [as=stmt_if_6:15]
-                     │                                                      ├── args
-                     │                                                      │    └── variable: i:7
-                     │                                                      ├── params: i:8
-                     │                                                      └── body
-                     │                                                           └── project
-                     │                                                                ├── columns: "_stmt_raise_7":13
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── udf: _stmt_raise_7 [as="_stmt_raise_7":13]
-                     │                                                                          ├── args
-                     │                                                                          │    └── variable: i:8
-                     │                                                                          ├── params: i:9
-                     │                                                                          └── body
-                     │                                                                               ├── project
-                     │                                                                               │    ├── columns: stmt_raise_8:10
-                     │                                                                               │    ├── values
-                     │                                                                               │    │    └── tuple
-                     │                                                                               │    └── projections
-                     │                                                                               │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:10]
-                     │                                                                               │              ├── const: 'NOTICE'
-                     │                                                                               │              ├── concat
-                     │                                                                               │              │    ├── concat
-                     │                                                                               │              │    │    ├── const: 'i = '
-                     │                                                                               │              │    │    └── coalesce
-                     │                                                                               │              │    │         ├── cast: STRING
-                     │                                                                               │              │    │         │    └── variable: i:9
-                     │                                                                               │              │    │         └── const: '<NULL>'
-                     │                                                                               │              │    └── const: ''
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              └── const: '00000'
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: stmt_loop_5:12
-                     │                                                                                    ├── project
-                     │                                                                                    │    ├── columns: i:11
-                     │                                                                                    │    ├── values
-                     │                                                                                    │    │    └── tuple
-                     │                                                                                    │    └── projections
-                     │                                                                                    │         └── plus [as=i:11]
-                     │                                                                                    │              ├── variable: i:9
-                     │                                                                                    │              └── const: 1
-                     │                                                                                    └── projections
-                     │                                                                                         └── udf: stmt_loop_5 [as=stmt_loop_5:12]
-                     │                                                                                              ├── args
-                     │                                                                                              │    └── variable: i:11
-                     │                                                                                              └── recursive-call
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_loop_5:17
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:1!null
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── const: 0 [as=i:1]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 2
+                     │              │                   └── args
+                     │              │                        └── variable: i:1
+                     │              ├── branch: 0
+                     │              │    ├── params: i:2
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_2":6
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             └── variable: i:2
+                     │              ├── branch: 1
+                     │              │    ├── params: i:3
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_3:4
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_3:4]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── concat
+                     │              │         │              │    ├── concat
+                     │              │         │              │    │    ├── const: 'finished with i = '
+                     │              │         │              │    │    └── coalesce
+                     │              │         │              │    │         ├── cast: STRING
+                     │              │         │              │    │         │    └── variable: i:3
+                     │              │         │              │    │         └── const: '<NULL>'
+                     │              │         │              │    └── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_4:5!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 0 [as=stmt_return_4:5]
+                     │              ├── branch: 2
+                     │              │    ├── params: i:7
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_9:16
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_9:16]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── ge
+                     │              │                        │    │    ├── variable: i:7
+                     │              │                        │    │    └── const: 5
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: loop_exit_1:14
+                     │              │                        │              ├── values
+                     │              │                        │              │    └── tuple
+                     │              │                        │              └── projections
+                     │              │                        │                   └── dispatch: 1
+                     │              │                        │                        ├── branch: 0
+                     │              │                        │                        └── args
+                     │              │                        │                             └── variable: i:7
+                     │              │                        └── subquery
+                     │              │                             └── project
+                     │              │                                  ├── columns: stmt_if_6:15
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 3
+                     │              │                                            └── args
+                     │              │                                                 └── variable: i:7
+                     │              ├── branch: 3
+                     │              │    ├── params: i:8
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_7":13
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 4
+                     │              │                        └── args
+                     │              │                             └── variable: i:8
+                     │              └── branch: 4
+                     │                   ├── params: i:9
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_8:10
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:10]
+                     │                        │              ├── const: 'NOTICE'
+                     │                        │              ├── concat
+                     │                        │              │    ├── concat
+                     │                        │              │    │    ├── const: 'i = '
+                     │                        │              │    │    └── coalesce
+                     │                        │              │    │         ├── cast: STRING
+                     │                        │              │    │         │    └── variable: i:9
+                     │                        │              │    │         └── const: '<NULL>'
+                     │                        │              │    └── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: '00000'
+                     │                        └── project
+                     │                             ├── columns: stmt_loop_5:12
+                     │                             ├── project
+                     │                             │    ├── columns: i:11
+                     │                             │    ├── values
+                     │                             │    │    └── tuple
+                     │                             │    └── projections
+                     │                             │         └── plus [as=i:11]
+                     │                             │              ├── variable: i:9
+                     │                             │              └── const: 1
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 2
+                     │                                       └── args
+                     │                                            └── variable: i:11
                      └── const: 1
 
 # Testing RAISE statement with EXCEPTION log level.
@@ -2728,38 +3282,47 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:4
+ ├── columns: f:5
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:4]
+      └── udf: f [as=f:5]
            └── body
                 └── limit
-                     ├── columns: "_stmt_raise_1":3
+                     ├── columns: dispatcher_4:4
                      ├── project
-                     │    ├── columns: "_stmt_raise_1":3
+                     │    ├── columns: dispatcher_4:4
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":3]
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:1
-                     │                   │    ├── values
-                     │                   │    │    └── tuple
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
-                     │                   │              ├── const: 'ERROR'
-                     │                   │              ├── const: 'foo'
-                     │                   │              ├── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              └── const: 'P0001'
-                     │                   └── project
-                     │                        ├── columns: stmt_return_3:2!null
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── const: 0 [as=stmt_return_3:2]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_1":3
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 0
+                     │              └── branch: 0
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_2:1
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
+                     │                        │              ├── const: 'ERROR'
+                     │                        │              ├── const: 'foo'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: 'P0001'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_3:2!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 0 [as=stmt_return_3:2]
                      └── const: 1
 
 exec-ddl
@@ -2775,38 +3338,47 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:4
+ ├── columns: f:5
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:4]
+      └── udf: f [as=f:5]
            └── body
                 └── limit
-                     ├── columns: "_stmt_raise_1":3
+                     ├── columns: dispatcher_4:4
                      ├── project
-                     │    ├── columns: "_stmt_raise_1":3
+                     │    ├── columns: dispatcher_4:4
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":3]
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:1
-                     │                   │    ├── values
-                     │                   │    │    └── tuple
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
-                     │                   │              ├── const: 'ERROR'
-                     │                   │              ├── const: 'division_by_zero'
-                     │                   │              ├── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              └── const: 'division_by_zero'
-                     │                   └── project
-                     │                        ├── columns: stmt_return_3:2!null
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── const: 0 [as=stmt_return_3:2]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_1":3
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 0
+                     │              └── branch: 0
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_2:1
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
+                     │                        │              ├── const: 'ERROR'
+                     │                        │              ├── const: 'division_by_zero'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: 'division_by_zero'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_3:2!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 0 [as=stmt_return_3:2]
                      └── const: 1
 
 exec-ddl
@@ -2822,38 +3394,47 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:4
+ ├── columns: f:5
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:4]
+      └── udf: f [as=f:5]
            └── body
                 └── limit
-                     ├── columns: "_stmt_raise_1":3
+                     ├── columns: dispatcher_4:4
                      ├── project
-                     │    ├── columns: "_stmt_raise_1":3
+                     │    ├── columns: dispatcher_4:4
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":3]
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:1
-                     │                   │    ├── values
-                     │                   │    │    └── tuple
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
-                     │                   │              ├── const: 'ERROR'
-                     │                   │              ├── const: '22012'
-                     │                   │              ├── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              └── const: '22012'
-                     │                   └── project
-                     │                        ├── columns: stmt_return_3:2!null
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── const: 0 [as=stmt_return_3:2]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_1":3
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 0
+                     │              └── branch: 0
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_2:1
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
+                     │                        │              ├── const: 'ERROR'
+                     │                        │              ├── const: '22012'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: '22012'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_3:2!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 0 [as=stmt_return_3:2]
                      └── const: 1
 
 exec-ddl
@@ -2879,244 +3460,219 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:25
+ ├── columns: f:26
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:25]
+      └── udf: f [as=f:26]
            └── body
                 └── limit
-                     ├── columns: stmt_loop_5:24
+                     ├── columns: dispatcher_14:25
                      ├── project
-                     │    ├── columns: stmt_loop_5:24
-                     │    ├── barrier
-                     │    │    ├── columns: i:1!null
-                     │    │    └── project
-                     │    │         ├── columns: i:1!null
-                     │    │         ├── values
-                     │    │         │    └── tuple
-                     │    │         └── projections
-                     │    │              └── const: 0 [as=i:1]
+                     │    ├── columns: dispatcher_14:25
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: stmt_loop_5 [as=stmt_loop_5:24]
-                     │              ├── args
-                     │              │    └── variable: i:1
-                     │              ├── params: i:7
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: stmt_if_13:23
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── case [as=stmt_if_13:23]
-                     │                                  ├── true
-                     │                                  ├── when
-                     │                                  │    ├── ge
-                     │                                  │    │    ├── variable: i:7
-                     │                                  │    │    └── const: 5
-                     │                                  │    └── subquery
-                     │                                  │         └── project
-                     │                                  │              ├── columns: loop_exit_1:21
-                     │                                  │              ├── values
-                     │                                  │              │    └── tuple
-                     │                                  │              └── projections
-                     │                                  │                   └── udf: loop_exit_1 [as=loop_exit_1:21]
-                     │                                  │                        ├── args
-                     │                                  │                        │    └── variable: i:7
-                     │                                  │                        ├── params: i:2
-                     │                                  │                        └── body
-                     │                                  │                             └── project
-                     │                                  │                                  ├── columns: "_stmt_raise_2":6
-                     │                                  │                                  ├── values
-                     │                                  │                                  │    └── tuple
-                     │                                  │                                  └── projections
-                     │                                  │                                       └── udf: _stmt_raise_2 [as="_stmt_raise_2":6]
-                     │                                  │                                            ├── args
-                     │                                  │                                            │    └── variable: i:2
-                     │                                  │                                            ├── params: i:3
-                     │                                  │                                            └── body
-                     │                                  │                                                 ├── project
-                     │                                  │                                                 │    ├── columns: stmt_raise_3:4
-                     │                                  │                                                 │    ├── values
-                     │                                  │                                                 │    │    └── tuple
-                     │                                  │                                                 │    └── projections
-                     │                                  │                                                 │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_3:4]
-                     │                                  │                                                 │              ├── const: 'NOTICE'
-                     │                                  │                                                 │              ├── concat
-                     │                                  │                                                 │              │    ├── concat
-                     │                                  │                                                 │              │    │    ├── const: 'finished with i = '
-                     │                                  │                                                 │              │    │    └── coalesce
-                     │                                  │                                                 │              │    │         ├── cast: STRING
-                     │                                  │                                                 │              │    │         │    └── variable: i:3
-                     │                                  │                                                 │              │    │         └── const: '<NULL>'
-                     │                                  │                                                 │              │    └── const: ''
-                     │                                  │                                                 │              ├── const: ''
-                     │                                  │                                                 │              ├── const: ''
-                     │                                  │                                                 │              └── const: '00000'
-                     │                                  │                                                 └── project
-                     │                                  │                                                      ├── columns: stmt_return_4:5!null
-                     │                                  │                                                      ├── values
-                     │                                  │                                                      │    └── tuple
-                     │                                  │                                                      └── projections
-                     │                                  │                                                           └── const: 0 [as=stmt_return_4:5]
-                     │                                  └── subquery
-                     │                                       └── project
-                     │                                            ├── columns: stmt_if_6:22
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: stmt_if_6 [as=stmt_if_6:22]
-                     │                                                      ├── args
-                     │                                                      │    └── variable: i:7
-                     │                                                      ├── params: i:8
-                     │                                                      └── body
-                     │                                                           └── project
-                     │                                                                ├── columns: stmt_if_12:20
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── case [as=stmt_if_12:20]
-                     │                                                                          ├── true
-                     │                                                                          ├── when
-                     │                                                                          │    ├── eq
-                     │                                                                          │    │    ├── variable: i:8
-                     │                                                                          │    │    └── const: 3
-                     │                                                                          │    └── subquery
-                     │                                                                          │         └── project
-                     │                                                                          │              ├── columns: "_stmt_raise_10":18
-                     │                                                                          │              ├── values
-                     │                                                                          │              │    └── tuple
-                     │                                                                          │              └── projections
-                     │                                                                          │                   └── udf: _stmt_raise_10 [as="_stmt_raise_10":18]
-                     │                                                                          │                        ├── args
-                     │                                                                          │                        │    └── variable: i:8
-                     │                                                                          │                        ├── params: i:15
-                     │                                                                          │                        └── body
-                     │                                                                          │                             ├── project
-                     │                                                                          │                             │    ├── columns: stmt_raise_11:16
-                     │                                                                          │                             │    ├── values
-                     │                                                                          │                             │    │    └── tuple
-                     │                                                                          │                             │    └── projections
-                     │                                                                          │                             │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_11:16]
-                     │                                                                          │                             │              ├── const: 'ERROR'
-                     │                                                                          │                             │              ├── concat
-                     │                                                                          │                             │              │    ├── concat
-                     │                                                                          │                             │              │    │    ├── const: 'i = '
-                     │                                                                          │                             │              │    │    └── coalesce
-                     │                                                                          │                             │              │    │         ├── cast: STRING
-                     │                                                                          │                             │              │    │         │    └── variable: i:15
-                     │                                                                          │                             │              │    │         └── const: '<NULL>'
-                     │                                                                          │                             │              │    └── const: ''
-                     │                                                                          │                             │              ├── const: ''
-                     │                                                                          │                             │              ├── const: ''
-                     │                                                                          │                             │              └── const: 'P0001'
-                     │                                                                          │                             └── project
-                     │                                                                          │                                  ├── columns: stmt_if_7:17
-                     │                                                                          │                                  ├── values
-                     │                                                                          │                                  │    └── tuple
-                     │                                                                          │                                  └── projections
-                     │                                                                          │                                       └── udf: stmt_if_7 [as=stmt_if_7:17]
-                     │                                                                          │                                            ├── args
-                     │                                                                          │                                            │    └── variable: i:15
-                     │                                                                          │                                            ├── params: i:9
-                     │                                                                          │                                            └── body
-                     │                                                                          │                                                 └── project
-                     │                                                                          │                                                      ├── columns: "_stmt_raise_8":14
-                     │                                                                          │                                                      ├── values
-                     │                                                                          │                                                      │    └── tuple
-                     │                                                                          │                                                      └── projections
-                     │                                                                          │                                                           └── udf: _stmt_raise_8 [as="_stmt_raise_8":14]
-                     │                                                                          │                                                                ├── args
-                     │                                                                          │                                                                │    └── variable: i:9
-                     │                                                                          │                                                                ├── params: i:10
-                     │                                                                          │                                                                └── body
-                     │                                                                          │                                                                     ├── project
-                     │                                                                          │                                                                     │    ├── columns: stmt_raise_9:11
-                     │                                                                          │                                                                     │    ├── values
-                     │                                                                          │                                                                     │    │    └── tuple
-                     │                                                                          │                                                                     │    └── projections
-                     │                                                                          │                                                                     │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_9:11]
-                     │                                                                          │                                                                     │              ├── const: 'NOTICE'
-                     │                                                                          │                                                                     │              ├── concat
-                     │                                                                          │                                                                     │              │    ├── concat
-                     │                                                                          │                                                                     │              │    │    ├── const: 'i = '
-                     │                                                                          │                                                                     │              │    │    └── coalesce
-                     │                                                                          │                                                                     │              │    │         ├── cast: STRING
-                     │                                                                          │                                                                     │              │    │         │    └── variable: i:10
-                     │                                                                          │                                                                     │              │    │         └── const: '<NULL>'
-                     │                                                                          │                                                                     │              │    └── const: ''
-                     │                                                                          │                                                                     │              ├── const: ''
-                     │                                                                          │                                                                     │              ├── const: ''
-                     │                                                                          │                                                                     │              └── const: '00000'
-                     │                                                                          │                                                                     └── project
-                     │                                                                          │                                                                          ├── columns: stmt_loop_5:13
-                     │                                                                          │                                                                          ├── project
-                     │                                                                          │                                                                          │    ├── columns: i:12
-                     │                                                                          │                                                                          │    ├── values
-                     │                                                                          │                                                                          │    │    └── tuple
-                     │                                                                          │                                                                          │    └── projections
-                     │                                                                          │                                                                          │         └── plus [as=i:12]
-                     │                                                                          │                                                                          │              ├── variable: i:10
-                     │                                                                          │                                                                          │              └── const: 1
-                     │                                                                          │                                                                          └── projections
-                     │                                                                          │                                                                               └── udf: stmt_loop_5 [as=stmt_loop_5:13]
-                     │                                                                          │                                                                                    ├── args
-                     │                                                                          │                                                                                    │    └── variable: i:12
-                     │                                                                          │                                                                                    └── recursive-call
-                     │                                                                          └── subquery
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: stmt_if_7:19
-                     │                                                                                    ├── values
-                     │                                                                                    │    └── tuple
-                     │                                                                                    └── projections
-                     │                                                                                         └── udf: stmt_if_7 [as=stmt_if_7:19]
-                     │                                                                                              ├── args
-                     │                                                                                              │    └── variable: i:8
-                     │                                                                                              ├── params: i:9
-                     │                                                                                              └── body
-                     │                                                                                                   └── project
-                     │                                                                                                        ├── columns: "_stmt_raise_8":14
-                     │                                                                                                        ├── values
-                     │                                                                                                        │    └── tuple
-                     │                                                                                                        └── projections
-                     │                                                                                                             └── udf: _stmt_raise_8 [as="_stmt_raise_8":14]
-                     │                                                                                                                  ├── args
-                     │                                                                                                                  │    └── variable: i:9
-                     │                                                                                                                  ├── params: i:10
-                     │                                                                                                                  └── body
-                     │                                                                                                                       ├── project
-                     │                                                                                                                       │    ├── columns: stmt_raise_9:11
-                     │                                                                                                                       │    ├── values
-                     │                                                                                                                       │    │    └── tuple
-                     │                                                                                                                       │    └── projections
-                     │                                                                                                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_9:11]
-                     │                                                                                                                       │              ├── const: 'NOTICE'
-                     │                                                                                                                       │              ├── concat
-                     │                                                                                                                       │              │    ├── concat
-                     │                                                                                                                       │              │    │    ├── const: 'i = '
-                     │                                                                                                                       │              │    │    └── coalesce
-                     │                                                                                                                       │              │    │         ├── cast: STRING
-                     │                                                                                                                       │              │    │         │    └── variable: i:10
-                     │                                                                                                                       │              │    │         └── const: '<NULL>'
-                     │                                                                                                                       │              │    └── const: ''
-                     │                                                                                                                       │              ├── const: ''
-                     │                                                                                                                       │              ├── const: ''
-                     │                                                                                                                       │              └── const: '00000'
-                     │                                                                                                                       └── project
-                     │                                                                                                                            ├── columns: stmt_loop_5:13
-                     │                                                                                                                            ├── project
-                     │                                                                                                                            │    ├── columns: i:12
-                     │                                                                                                                            │    ├── values
-                     │                                                                                                                            │    │    └── tuple
-                     │                                                                                                                            │    └── projections
-                     │                                                                                                                            │         └── plus [as=i:12]
-                     │                                                                                                                            │              ├── variable: i:10
-                     │                                                                                                                            │              └── const: 1
-                     │                                                                                                                            └── projections
-                     │                                                                                                                                 └── udf: stmt_loop_5 [as=stmt_loop_5:13]
-                     │                                                                                                                                      ├── args
-                     │                                                                                                                                      │    └── variable: i:12
-                     │                                                                                                                                      └── recursive-call
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_loop_5:24
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:1!null
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── const: 0 [as=i:1]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 2
+                     │              │                   └── args
+                     │              │                        └── variable: i:1
+                     │              ├── branch: 0
+                     │              │    ├── params: i:2
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_2":6
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             └── variable: i:2
+                     │              ├── branch: 1
+                     │              │    ├── params: i:3
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_3:4
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_3:4]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── concat
+                     │              │         │              │    ├── concat
+                     │              │         │              │    │    ├── const: 'finished with i = '
+                     │              │         │              │    │    └── coalesce
+                     │              │         │              │    │         ├── cast: STRING
+                     │              │         │              │    │         │    └── variable: i:3
+                     │              │         │              │    │         └── const: '<NULL>'
+                     │              │         │              │    └── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_4:5!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 0 [as=stmt_return_4:5]
+                     │              ├── branch: 2
+                     │              │    ├── params: i:7
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_13:23
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_13:23]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── ge
+                     │              │                        │    │    ├── variable: i:7
+                     │              │                        │    │    └── const: 5
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: loop_exit_1:21
+                     │              │                        │              ├── values
+                     │              │                        │              │    └── tuple
+                     │              │                        │              └── projections
+                     │              │                        │                   └── dispatch: 1
+                     │              │                        │                        ├── branch: 0
+                     │              │                        │                        └── args
+                     │              │                        │                             └── variable: i:7
+                     │              │                        └── subquery
+                     │              │                             └── project
+                     │              │                                  ├── columns: stmt_if_6:22
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 3
+                     │              │                                            └── args
+                     │              │                                                 └── variable: i:7
+                     │              ├── branch: 3
+                     │              │    ├── params: i:8
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_12:20
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_12:20]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── eq
+                     │              │                        │    │    ├── variable: i:8
+                     │              │                        │    │    └── const: 3
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: "_stmt_raise_10":18
+                     │              │                        │              ├── values
+                     │              │                        │              │    └── tuple
+                     │              │                        │              └── projections
+                     │              │                        │                   └── dispatch: 1
+                     │              │                        │                        ├── branch: 6
+                     │              │                        │                        └── args
+                     │              │                        │                             └── variable: i:8
+                     │              │                        └── subquery
+                     │              │                             └── project
+                     │              │                                  ├── columns: stmt_if_7:19
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 4
+                     │              │                                            └── args
+                     │              │                                                 └── variable: i:8
+                     │              ├── branch: 4
+                     │              │    ├── params: i:9
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_8":14
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 5
+                     │              │                        └── args
+                     │              │                             └── variable: i:9
+                     │              ├── branch: 5
+                     │              │    ├── params: i:10
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_9:11
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_9:11]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── concat
+                     │              │         │              │    ├── concat
+                     │              │         │              │    │    ├── const: 'i = '
+                     │              │         │              │    │    └── coalesce
+                     │              │         │              │    │         ├── cast: STRING
+                     │              │         │              │    │         │    └── variable: i:10
+                     │              │         │              │    │         └── const: '<NULL>'
+                     │              │         │              │    └── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: stmt_loop_5:13
+                     │              │              ├── project
+                     │              │              │    ├── columns: i:12
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── plus [as=i:12]
+                     │              │              │              ├── variable: i:10
+                     │              │              │              └── const: 1
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 2
+                     │              │                        └── args
+                     │              │                             └── variable: i:12
+                     │              └── branch: 6
+                     │                   ├── params: i:15
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_11:16
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_11:16]
+                     │                        │              ├── const: 'ERROR'
+                     │                        │              ├── concat
+                     │                        │              │    ├── concat
+                     │                        │              │    │    ├── const: 'i = '
+                     │                        │              │    │    └── coalesce
+                     │                        │              │    │         ├── cast: STRING
+                     │                        │              │    │         │    └── variable: i:15
+                     │                        │              │    │         └── const: '<NULL>'
+                     │                        │              │    └── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: 'P0001'
+                     │                        └── project
+                     │                             ├── columns: stmt_if_7:17
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 4
+                     │                                       └── args
+                     │                                            └── variable: i:15
                      └── const: 1
 
 exec-ddl
@@ -3132,38 +3688,47 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:4
+ ├── columns: f:5
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:4]
+      └── udf: f [as=f:5]
            └── body
                 └── limit
-                     ├── columns: "_stmt_raise_1":3
+                     ├── columns: dispatcher_4:4
                      ├── project
-                     │    ├── columns: "_stmt_raise_1":3
+                     │    ├── columns: dispatcher_4:4
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":3]
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:1
-                     │                   │    ├── values
-                     │                   │    │    └── tuple
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
-                     │                   │              ├── const: 'ERROR'
-                     │                   │              ├── const: 'division_by_zero'
-                     │                   │              ├── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              └── const: 'division_by_zero'
-                     │                   └── project
-                     │                        ├── columns: stmt_return_3:2!null
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── const: 0 [as=stmt_return_3:2]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_1":3
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 0
+                     │              └── branch: 0
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_2:1
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
+                     │                        │              ├── const: 'ERROR'
+                     │                        │              ├── const: 'division_by_zero'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: 'division_by_zero'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_3:2!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 0 [as=stmt_return_3:2]
                      └── const: 1
 
 exec-ddl
@@ -3179,38 +3744,47 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:4
+ ├── columns: f:5
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:4]
+      └── udf: f [as=f:5]
            └── body
                 └── limit
-                     ├── columns: "_stmt_raise_1":3
+                     ├── columns: dispatcher_4:4
                      ├── project
-                     │    ├── columns: "_stmt_raise_1":3
+                     │    ├── columns: dispatcher_4:4
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":3]
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:1
-                     │                   │    ├── values
-                     │                   │    │    └── tuple
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
-                     │                   │              ├── const: 'ERROR'
-                     │                   │              ├── const: '22012'
-                     │                   │              ├── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              └── const: '22012'
-                     │                   └── project
-                     │                        ├── columns: stmt_return_3:2!null
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── const: 0 [as=stmt_return_3:2]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_1":3
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 0
+                     │              └── branch: 0
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_2:1
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
+                     │                        │              ├── const: 'ERROR'
+                     │                        │              ├── const: '22012'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: '22012'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_3:2!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 0 [as=stmt_return_3:2]
                      └── const: 1
 
 exec-ddl
@@ -3226,38 +3800,47 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:4
+ ├── columns: f:5
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:4]
+      └── udf: f [as=f:5]
            └── body
                 └── limit
-                     ├── columns: "_stmt_raise_1":3
+                     ├── columns: dispatcher_4:4
                      ├── project
-                     │    ├── columns: "_stmt_raise_1":3
+                     │    ├── columns: dispatcher_4:4
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":3]
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:1
-                     │                   │    ├── values
-                     │                   │    │    └── tuple
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
-                     │                   │              ├── const: 'ERROR'
-                     │                   │              ├── const: 'P0001'
-                     │                   │              ├── const: 'use default errcode for the code and message'
-                     │                   │              ├── const: ''
-                     │                   │              └── const: 'P0001'
-                     │                   └── project
-                     │                        ├── columns: stmt_return_3:2!null
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── const: 0 [as=stmt_return_3:2]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_1":3
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 0
+                     │              └── branch: 0
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_2:1
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
+                     │                        │              ├── const: 'ERROR'
+                     │                        │              ├── const: 'P0001'
+                     │                        │              ├── const: 'use default errcode for the code and message'
+                     │                        │              ├── const: ''
+                     │                        │              └── const: 'P0001'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_3:2!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 0 [as=stmt_return_3:2]
                      └── const: 1
 
 exec-ddl
@@ -3273,38 +3856,47 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:4
+ ├── columns: f:5
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:4]
+      └── udf: f [as=f:5]
            └── body
                 └── limit
-                     ├── columns: "_stmt_raise_1":3
+                     ├── columns: dispatcher_4:4
                      ├── project
-                     │    ├── columns: "_stmt_raise_1":3
+                     │    ├── columns: dispatcher_4:4
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":3]
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:1
-                     │                   │    ├── values
-                     │                   │    │    └── tuple
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
-                     │                   │              ├── const: 'ERROR'
-                     │                   │              ├── const: 'foo'
-                     │                   │              ├── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              └── const: 'P0001'
-                     │                   └── project
-                     │                        ├── columns: stmt_return_3:2!null
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── const: 0 [as=stmt_return_3:2]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_1":3
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 0
+                     │              └── branch: 0
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_2:1
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1]
+                     │                        │              ├── const: 'ERROR'
+                     │                        │              ├── const: 'foo'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: 'P0001'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_3:2!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 0 [as=stmt_return_3:2]
                      └── const: 1
 
 # Testing IF statements with ELSIF branches.
@@ -3330,98 +3922,100 @@ build format=show-scalars
 SELECT f(0);
 ----
 project
- ├── columns: f:13
+ ├── columns: f:14
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:13]
+      └── udf: f [as=f:14]
            ├── args
            │    └── const: 0
            ├── params: n:1
            └── body
                 └── limit
-                     ├── columns: stmt_if_5:12
+                     ├── columns: dispatcher_6:13
                      ├── project
-                     │    ├── columns: stmt_if_5:12
-                     │    ├── project
-                     │    │    ├── columns: i:2!null
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         └── const: -1 [as=i:2]
+                     │    ├── columns: dispatcher_6:13
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── case [as=stmt_if_5:12]
-                     │              ├── true
-                     │              ├── when
-                     │              │    ├── eq
-                     │              │    │    ├── variable: n:1
-                     │              │    │    └── const: 0
-                     │              │    └── subquery
-                     │              │         └── project
-                     │              │              ├── columns: stmt_return_3:6!null
-                     │              │              ├── values
-                     │              │              │    └── tuple
-                     │              │              └── projections
-                     │              │                   └── const: 0 [as=stmt_return_3:6]
-                     │              ├── when
-                     │              │    ├── eq
-                     │              │    │    ├── variable: n:1
-                     │              │    │    └── const: 1
-                     │              │    └── subquery
-                     │              │         └── project
-                     │              │              ├── columns: stmt_if_1:8
-                     │              │              ├── project
-                     │              │              │    ├── columns: i:7!null
-                     │              │              │    ├── values
-                     │              │              │    │    └── tuple
-                     │              │              │    └── projections
-                     │              │              │         └── const: 100 [as=i:7]
-                     │              │              └── projections
-                     │              │                   └── udf: stmt_if_1 [as=stmt_if_1:8]
-                     │              │                        ├── args
-                     │              │                        │    ├── variable: n:1
-                     │              │                        │    └── variable: i:7
-                     │              │                        ├── params: n:3 i:4
-                     │              │                        └── body
-                     │              │                             └── project
-                     │              │                                  ├── columns: stmt_return_2:5
-                     │              │                                  ├── values
-                     │              │                                  │    └── tuple
-                     │              │                                  └── projections
-                     │              │                                       └── variable: i:4 [as=stmt_return_2:5]
-                     │              ├── when
-                     │              │    ├── eq
-                     │              │    │    ├── variable: n:1
-                     │              │    │    └── const: 2
-                     │              │    └── subquery
-                     │              │         └── project
-                     │              │              ├── columns: stmt_return_4:10!null
-                     │              │              ├── project
-                     │              │              │    ├── columns: i:9!null
-                     │              │              │    ├── values
-                     │              │              │    │    └── tuple
-                     │              │              │    └── projections
-                     │              │              │         └── const: 200 [as=i:9]
-                     │              │              └── projections
-                     │              │                   └── variable: i:9 [as=stmt_return_4:10]
-                     │              └── subquery
-                     │                   └── project
-                     │                        ├── columns: stmt_if_1:11
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── udf: stmt_if_1 [as=stmt_if_1:11]
-                     │                                  ├── args
-                     │                                  │    ├── variable: n:1
-                     │                                  │    └── variable: i:2
-                     │                                  ├── params: n:3 i:4
-                     │                                  └── body
-                     │                                       └── project
-                     │                                            ├── columns: stmt_return_2:5
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── variable: i:4 [as=stmt_return_2:5]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: stmt_if_5:12
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:2!null
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── const: -1 [as=i:2]
+                     │              │         └── projections
+                     │              │              └── case [as=stmt_if_5:12]
+                     │              │                   ├── true
+                     │              │                   ├── when
+                     │              │                   │    ├── eq
+                     │              │                   │    │    ├── variable: n:1
+                     │              │                   │    │    └── const: 0
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: stmt_return_3:6!null
+                     │              │                   │              ├── values
+                     │              │                   │              │    └── tuple
+                     │              │                   │              └── projections
+                     │              │                   │                   └── const: 0 [as=stmt_return_3:6]
+                     │              │                   ├── when
+                     │              │                   │    ├── eq
+                     │              │                   │    │    ├── variable: n:1
+                     │              │                   │    │    └── const: 1
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: stmt_if_1:8
+                     │              │                   │              ├── project
+                     │              │                   │              │    ├── columns: i:7!null
+                     │              │                   │              │    ├── values
+                     │              │                   │              │    │    └── tuple
+                     │              │                   │              │    └── projections
+                     │              │                   │              │         └── const: 100 [as=i:7]
+                     │              │                   │              └── projections
+                     │              │                   │                   └── dispatch: 1
+                     │              │                   │                        ├── branch: 0
+                     │              │                   │                        └── args
+                     │              │                   │                             ├── variable: n:1
+                     │              │                   │                             └── variable: i:7
+                     │              │                   ├── when
+                     │              │                   │    ├── eq
+                     │              │                   │    │    ├── variable: n:1
+                     │              │                   │    │    └── const: 2
+                     │              │                   │    └── subquery
+                     │              │                   │         └── project
+                     │              │                   │              ├── columns: stmt_return_4:10!null
+                     │              │                   │              ├── project
+                     │              │                   │              │    ├── columns: i:9!null
+                     │              │                   │              │    ├── values
+                     │              │                   │              │    │    └── tuple
+                     │              │                   │              │    └── projections
+                     │              │                   │              │         └── const: 200 [as=i:9]
+                     │              │                   │              └── projections
+                     │              │                   │                   └── variable: i:9 [as=stmt_return_4:10]
+                     │              │                   └── subquery
+                     │              │                        └── project
+                     │              │                             ├── columns: stmt_if_1:11
+                     │              │                             ├── values
+                     │              │                             │    └── tuple
+                     │              │                             └── projections
+                     │              │                                  └── dispatch: 1
+                     │              │                                       ├── branch: 0
+                     │              │                                       └── args
+                     │              │                                            ├── variable: n:1
+                     │              │                                            └── variable: i:2
+                     │              └── branch: 0
+                     │                   ├── params: n:3 i:4
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_return_2:5
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── variable: i:4 [as=stmt_return_2:5]
                      └── const: 1
 
 # Testing EXCEPTION blocks.
@@ -3444,51 +4038,84 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:6
+ ├── columns: f:7
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:6]
+      └── udf: f [as=f:7]
            └── body
                 └── limit
-                     ├── columns: exception_block_7:5
+                     ├── columns: dispatcher_9:6
                      ├── project
-                     │    ├── columns: exception_block_7:5
+                     │    ├── columns: dispatcher_9:6
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: exception_block_7 [as=exception_block_7:5]
-                     │              ├── body
+                     │         └── dispatcher
+                     │              ├── subquery
                      │              │    └── project
-                     │              │         ├── columns: stmt_return_8:4!null
+                     │              │         ├── columns: exception_block_7:5
                      │              │         ├── values
                      │              │         │    └── tuple
                      │              │         └── projections
-                     │              │              └── floor-div [as=stmt_return_8:4]
-                     │              │                   ├── const: 1
-                     │              │                   └── const: 0
-                     │              └── exception-handler
-                     │                   ├── SQLSTATE '22012'
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 3
+                     │              ├── branch: 0
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:1!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 100 [as=stmt_return_2:1]
+                     │              ├── branch: 1
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_4:2!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 200 [as=stmt_return_4:2]
+                     │              ├── branch: 2
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_6:3!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 300 [as=stmt_return_6:3]
+                     │              └── branch: 3
+                     │                   ├── body
                      │                   │    └── project
-                     │                   │         ├── columns: stmt_return_2:1!null
+                     │                   │         ├── columns: stmt_return_8:4!null
                      │                   │         ├── values
                      │                   │         │    └── tuple
                      │                   │         └── projections
-                     │                   │              └── const: 100 [as=stmt_return_2:1]
-                     │                   ├── SQLSTATE '2201B'
-                     │                   │    └── project
-                     │                   │         ├── columns: stmt_return_4:2!null
-                     │                   │         ├── values
-                     │                   │         │    └── tuple
-                     │                   │         └── projections
-                     │                   │              └── const: 200 [as=stmt_return_4:2]
-                     │                   └── SQLSTATE '2200C'
-                     │                        └── project
-                     │                             ├── columns: stmt_return_6:3!null
-                     │                             ├── values
-                     │                             │    └── tuple
-                     │                             └── projections
-                     │                                  └── const: 300 [as=stmt_return_6:3]
+                     │                   │              └── floor-div [as=stmt_return_8:4]
+                     │                   │                   ├── const: 1
+                     │                   │                   └── const: 0
+                     │                   └── exception-handler
+                     │                        ├── SQLSTATE '22012'
+                     │                        │    └── project
+                     │                        │         ├── columns: stmt_return_2:1!null
+                     │                        │         ├── values
+                     │                        │         │    └── tuple
+                     │                        │         └── projections
+                     │                        │              └── const: 100 [as=stmt_return_2:1]
+                     │                        ├── SQLSTATE '2201B'
+                     │                        │    └── project
+                     │                        │         ├── columns: stmt_return_4:2!null
+                     │                        │         ├── values
+                     │                        │         │    └── tuple
+                     │                        │         └── projections
+                     │                        │              └── const: 200 [as=stmt_return_4:2]
+                     │                        └── SQLSTATE '2200C'
+                     │                             └── project
+                     │                                  ├── columns: stmt_return_6:3!null
+                     │                                  ├── values
+                     │                                  │    └── tuple
+                     │                                  └── projections
+                     │                                       └── const: 300 [as=stmt_return_6:3]
                      └── const: 1
 
 exec-ddl
@@ -3510,72 +4137,122 @@ build format=show-scalars
 SELECT f(0);
 ----
 project
- ├── columns: f:14
+ ├── columns: f:15
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:14]
+      └── udf: f [as=f:15]
            ├── args
            │    └── const: 0
            ├── params: i:1
            └── body
                 └── limit
-                     ├── columns: exception_block_3:13
+                     ├── columns: dispatcher_11:14
                      ├── project
-                     │    ├── columns: exception_block_3:13
+                     │    ├── columns: dispatcher_11:14
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: exception_block_3 [as=exception_block_3:13]
-                     │              ├── args
-                     │              │    └── variable: i:1
-                     │              ├── params: i:4
-                     │              ├── body
+                     │         └── dispatcher
+                     │              ├── subquery
                      │              │    └── project
-                     │              │         ├── columns: stmt_if_10:12
+                     │              │         ├── columns: exception_block_3:13
                      │              │         ├── values
                      │              │         │    └── tuple
                      │              │         └── projections
-                     │              │              └── case [as=stmt_if_10:12]
-                     │              │                   ├── true
-                     │              │                   ├── when
-                     │              │                   │    ├── gt
-                     │              │                   │    │    ├── variable: i:4
-                     │              │                   │    │    └── const: 0
-                     │              │                   │    └── subquery
-                     │              │                   │         └── project
-                     │              │                   │              ├── columns: stmt_return_8:10!null
-                     │              │                   │              ├── values
-                     │              │                   │              │    └── tuple
-                     │              │                   │              └── projections
-                     │              │                   │                   └── floor-div [as=stmt_return_8:10]
-                     │              │                   │                        ├── const: 1
-                     │              │                   │                        └── const: 0
-                     │              │                   └── subquery
-                     │              │                        └── project
-                     │              │                             ├── columns: stmt_return_9:11
-                     │              │                             ├── values
-                     │              │                             │    └── tuple
-                     │              │                             └── projections
-                     │              │                                  └── cast: INT8 [as=stmt_return_9:11]
-                     │              │                                       └── function: sqrt
-                     │              │                                            └── cast: FLOAT8
-                     │              │                                                 └── variable: i:4
-                     │              └── exception-handler
-                     │                   ├── SQLSTATE '22012'
-                     │                   │    └── project
-                     │                   │         ├── columns: stmt_return_2:3!null
-                     │                   │         ├── values
-                     │                   │         │    └── tuple
-                     │                   │         └── projections
-                     │                   │              └── const: 100 [as=stmt_return_2:3]
-                     │                   └── SQLSTATE '22022'
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 1
+                     │              │                   └── args
+                     │              │                        └── variable: i:1
+                     │              ├── branch: 0
+                     │              │    ├── params: i:2
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:3!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 100 [as=stmt_return_2:3]
+                     │              ├── branch: 1
+                     │              │    ├── params: i:4
+                     │              │    ├── body
+                     │              │    │    └── project
+                     │              │    │         ├── columns: stmt_if_10:12
+                     │              │    │         ├── values
+                     │              │    │         │    └── tuple
+                     │              │    │         └── projections
+                     │              │    │              └── case [as=stmt_if_10:12]
+                     │              │    │                   ├── true
+                     │              │    │                   ├── when
+                     │              │    │                   │    ├── gt
+                     │              │    │                   │    │    ├── variable: i:4
+                     │              │    │                   │    │    └── const: 0
+                     │              │    │                   │    └── subquery
+                     │              │    │                   │         └── project
+                     │              │    │                   │              ├── columns: stmt_return_8:10!null
+                     │              │    │                   │              ├── values
+                     │              │    │                   │              │    └── tuple
+                     │              │    │                   │              └── projections
+                     │              │    │                   │                   └── floor-div [as=stmt_return_8:10]
+                     │              │    │                   │                        ├── const: 1
+                     │              │    │                   │                        └── const: 0
+                     │              │    │                   └── subquery
+                     │              │    │                        └── project
+                     │              │    │                             ├── columns: stmt_return_9:11
+                     │              │    │                             ├── values
+                     │              │    │                             │    └── tuple
+                     │              │    │                             └── projections
+                     │              │    │                                  └── cast: INT8 [as=stmt_return_9:11]
+                     │              │    │                                       └── function: sqrt
+                     │              │    │                                            └── cast: FLOAT8
+                     │              │    │                                                 └── variable: i:4
+                     │              │    └── exception-handler
+                     │              │         ├── SQLSTATE '22012'
+                     │              │         │    └── project
+                     │              │         │         ├── columns: stmt_return_2:3!null
+                     │              │         │         ├── values
+                     │              │         │         │    └── tuple
+                     │              │         │         └── projections
+                     │              │         │              └── const: 100 [as=stmt_return_2:3]
+                     │              │         └── SQLSTATE '22022'
+                     │              │              └── project
+                     │              │                   ├── columns: stmt_return_2:3!null
+                     │              │                   ├── values
+                     │              │                   │    └── tuple
+                     │              │                   └── projections
+                     │              │                        └── const: 100 [as=stmt_return_2:3]
+                     │              ├── branch: 2
+                     │              │    ├── params: i:5
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: end_of_function_5:9
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 3
+                     │              │                        └── args
+                     │              │                             └── variable: i:5
+                     │              └── branch: 3
+                     │                   ├── params: i:6
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_6:7
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_6:7]
+                     │                        │              ├── const: 'ERROR'
+                     │                        │              ├── const: 'control reached end of function without RETURN'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: '2F005'
                      │                        └── project
-                     │                             ├── columns: stmt_return_2:3!null
+                     │                             ├── columns: end_of_function_7:8
                      │                             ├── values
                      │                             │    └── tuple
                      │                             └── projections
-                     │                                  └── const: 100 [as=stmt_return_2:3]
+                     │                                  └── null [as=end_of_function_7:8]
                      └── const: 1
 
 exec-ddl
@@ -3599,72 +4276,131 @@ build format=show-scalars
 SELECT f(0);
 ----
 project
- ├── columns: f:16
+ ├── columns: f:17
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:16]
+      └── udf: f [as=f:17]
            ├── args
            │    └── const: 0
            ├── params: i:1
            └── body
                 └── limit
-                     ├── columns: exception_block_5:15
+                     ├── columns: dispatcher_13:16
                      ├── project
-                     │    ├── columns: exception_block_5:15
+                     │    ├── columns: dispatcher_13:16
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: exception_block_5 [as=exception_block_5:15]
-                     │              ├── args
-                     │              │    └── variable: i:1
-                     │              ├── params: i:6
-                     │              ├── body
+                     │         └── dispatcher
+                     │              ├── subquery
                      │              │    └── project
-                     │              │         ├── columns: stmt_if_12:14
+                     │              │         ├── columns: exception_block_5:15
                      │              │         ├── values
                      │              │         │    └── tuple
                      │              │         └── projections
-                     │              │              └── case [as=stmt_if_12:14]
-                     │              │                   ├── true
-                     │              │                   ├── when
-                     │              │                   │    ├── gt
-                     │              │                   │    │    ├── variable: i:6
-                     │              │                   │    │    └── const: 0
-                     │              │                   │    └── subquery
-                     │              │                   │         └── project
-                     │              │                   │              ├── columns: stmt_return_10:12!null
-                     │              │                   │              ├── values
-                     │              │                   │              │    └── tuple
-                     │              │                   │              └── projections
-                     │              │                   │                   └── floor-div [as=stmt_return_10:12]
-                     │              │                   │                        ├── const: 1
-                     │              │                   │                        └── const: 0
-                     │              │                   └── subquery
-                     │              │                        └── project
-                     │              │                             ├── columns: stmt_return_11:13
-                     │              │                             ├── values
-                     │              │                             │    └── tuple
-                     │              │                             └── projections
-                     │              │                                  └── cast: INT8 [as=stmt_return_11:13]
-                     │              │                                       └── function: sqrt
-                     │              │                                            └── cast: FLOAT8
-                     │              │                                                 └── variable: i:6
-                     │              └── exception-handler
-                     │                   ├── SQLSTATE '22012'
-                     │                   │    └── project
-                     │                   │         ├── columns: stmt_return_2:3!null
-                     │                   │         ├── values
-                     │                   │         │    └── tuple
-                     │                   │         └── projections
-                     │                   │              └── const: 100 [as=stmt_return_2:3]
-                     │                   └── SQLSTATE '22022'
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 2
+                     │              │                   └── args
+                     │              │                        └── variable: i:1
+                     │              ├── branch: 0
+                     │              │    ├── params: i:2
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:3!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 100 [as=stmt_return_2:3]
+                     │              ├── branch: 1
+                     │              │    ├── params: i:4
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_4:5!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: -1 [as=stmt_return_4:5]
+                     │              ├── branch: 2
+                     │              │    ├── params: i:6
+                     │              │    ├── body
+                     │              │    │    └── project
+                     │              │    │         ├── columns: stmt_if_12:14
+                     │              │    │         ├── values
+                     │              │    │         │    └── tuple
+                     │              │    │         └── projections
+                     │              │    │              └── case [as=stmt_if_12:14]
+                     │              │    │                   ├── true
+                     │              │    │                   ├── when
+                     │              │    │                   │    ├── gt
+                     │              │    │                   │    │    ├── variable: i:6
+                     │              │    │                   │    │    └── const: 0
+                     │              │    │                   │    └── subquery
+                     │              │    │                   │         └── project
+                     │              │    │                   │              ├── columns: stmt_return_10:12!null
+                     │              │    │                   │              ├── values
+                     │              │    │                   │              │    └── tuple
+                     │              │    │                   │              └── projections
+                     │              │    │                   │                   └── floor-div [as=stmt_return_10:12]
+                     │              │    │                   │                        ├── const: 1
+                     │              │    │                   │                        └── const: 0
+                     │              │    │                   └── subquery
+                     │              │    │                        └── project
+                     │              │    │                             ├── columns: stmt_return_11:13
+                     │              │    │                             ├── values
+                     │              │    │                             │    └── tuple
+                     │              │    │                             └── projections
+                     │              │    │                                  └── cast: INT8 [as=stmt_return_11:13]
+                     │              │    │                                       └── function: sqrt
+                     │              │    │                                            └── cast: FLOAT8
+                     │              │    │                                                 └── variable: i:6
+                     │              │    └── exception-handler
+                     │              │         ├── SQLSTATE '22012'
+                     │              │         │    └── project
+                     │              │         │         ├── columns: stmt_return_2:3!null
+                     │              │         │         ├── values
+                     │              │         │         │    └── tuple
+                     │              │         │         └── projections
+                     │              │         │              └── const: 100 [as=stmt_return_2:3]
+                     │              │         └── SQLSTATE '22022'
+                     │              │              └── project
+                     │              │                   ├── columns: stmt_return_4:5!null
+                     │              │                   ├── values
+                     │              │                   │    └── tuple
+                     │              │                   └── projections
+                     │              │                        └── const: -1 [as=stmt_return_4:5]
+                     │              ├── branch: 3
+                     │              │    ├── params: i:7
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: end_of_function_7:11
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 4
+                     │              │                        └── args
+                     │              │                             └── variable: i:7
+                     │              └── branch: 4
+                     │                   ├── params: i:8
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_8:9
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:9]
+                     │                        │              ├── const: 'ERROR'
+                     │                        │              ├── const: 'control reached end of function without RETURN'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: '2F005'
                      │                        └── project
-                     │                             ├── columns: stmt_return_4:5!null
+                     │                             ├── columns: end_of_function_9:10
                      │                             ├── values
                      │                             │    └── tuple
                      │                             └── projections
-                     │                                  └── const: -1 [as=stmt_return_4:5]
+                     │                                  └── null [as=end_of_function_9:10]
                      └── const: 1
 
 exec-ddl
@@ -3687,67 +4423,102 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:8
+ ├── columns: f:9
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:8]
+      └── udf: f [as=f:9]
            └── body
                 └── limit
-                     ├── columns: exception_block_7:7
+                     ├── columns: dispatcher_11:8
                      ├── project
-                     │    ├── columns: exception_block_7:7
+                     │    ├── columns: dispatcher_11:8
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: exception_block_7 [as=exception_block_7:7]
-                     │              ├── body
+                     │         └── dispatcher
+                     │              ├── subquery
                      │              │    └── project
-                     │              │         ├── columns: "_stmt_raise_8":6
+                     │              │         ├── columns: exception_block_7:7
                      │              │         ├── values
                      │              │         │    └── tuple
                      │              │         └── projections
-                     │              │              └── udf: _stmt_raise_8 [as="_stmt_raise_8":6]
-                     │              │                   └── body
-                     │              │                        ├── project
-                     │              │                        │    ├── columns: stmt_raise_9:4
-                     │              │                        │    ├── values
-                     │              │                        │    │    └── tuple
-                     │              │                        │    └── projections
-                     │              │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_9:4]
-                     │              │                        │              ├── const: 'ERROR'
-                     │              │                        │              ├── const: 'division_by_zero'
-                     │              │                        │              ├── const: ''
-                     │              │                        │              ├── const: ''
-                     │              │                        │              └── const: 'division_by_zero'
-                     │              │                        └── project
-                     │              │                             ├── columns: stmt_return_10:5!null
-                     │              │                             ├── values
-                     │              │                             │    └── tuple
-                     │              │                             └── projections
-                     │              │                                  └── const: 0 [as=stmt_return_10:5]
-                     │              └── exception-handler
-                     │                   ├── SQLSTATE '22012'
-                     │                   │    └── project
-                     │                   │         ├── columns: stmt_return_2:1!null
-                     │                   │         ├── values
-                     │                   │         │    └── tuple
-                     │                   │         └── projections
-                     │                   │              └── const: 101 [as=stmt_return_2:1]
-                     │                   ├── SQLSTATE '22P02'
-                     │                   │    └── project
-                     │                   │         ├── columns: stmt_return_4:2!null
-                     │                   │         ├── values
-                     │                   │         │    └── tuple
-                     │                   │         └── projections
-                     │                   │              └── const: 102 [as=stmt_return_4:2]
-                     │                   └── SQLSTATE '22P03'
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 3
+                     │              ├── branch: 0
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:1!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 101 [as=stmt_return_2:1]
+                     │              ├── branch: 1
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_4:2!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 102 [as=stmt_return_4:2]
+                     │              ├── branch: 2
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_6:3!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 103 [as=stmt_return_6:3]
+                     │              ├── branch: 3
+                     │              │    ├── body
+                     │              │    │    └── project
+                     │              │    │         ├── columns: "_stmt_raise_8":6
+                     │              │    │         ├── values
+                     │              │    │         │    └── tuple
+                     │              │    │         └── projections
+                     │              │    │              └── dispatch: 1
+                     │              │    │                   └── branch: 4
+                     │              │    └── exception-handler
+                     │              │         ├── SQLSTATE '22012'
+                     │              │         │    └── project
+                     │              │         │         ├── columns: stmt_return_2:1!null
+                     │              │         │         ├── values
+                     │              │         │         │    └── tuple
+                     │              │         │         └── projections
+                     │              │         │              └── const: 101 [as=stmt_return_2:1]
+                     │              │         ├── SQLSTATE '22P02'
+                     │              │         │    └── project
+                     │              │         │         ├── columns: stmt_return_4:2!null
+                     │              │         │         ├── values
+                     │              │         │         │    └── tuple
+                     │              │         │         └── projections
+                     │              │         │              └── const: 102 [as=stmt_return_4:2]
+                     │              │         └── SQLSTATE '22P03'
+                     │              │              └── project
+                     │              │                   ├── columns: stmt_return_6:3!null
+                     │              │                   ├── values
+                     │              │                   │    └── tuple
+                     │              │                   └── projections
+                     │              │                        └── const: 103 [as=stmt_return_6:3]
+                     │              └── branch: 4
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_9:4
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_9:4]
+                     │                        │              ├── const: 'ERROR'
+                     │                        │              ├── const: 'division_by_zero'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: 'division_by_zero'
                      │                        └── project
-                     │                             ├── columns: stmt_return_6:3!null
+                     │                             ├── columns: stmt_return_10:5!null
                      │                             ├── values
                      │                             │    └── tuple
                      │                             └── projections
-                     │                                  └── const: 103 [as=stmt_return_6:3]
+                     │                                  └── const: 0 [as=stmt_return_10:5]
                      └── const: 1
 
 # The exception block does not catch errors thrown during variable declaration.
@@ -3768,50 +4539,66 @@ build format=show-scalars
 SELECT f(0);
 ----
 project
- ├── columns: f:10
+ ├── columns: f:11
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:10]
+      └── udf: f [as=f:11]
            ├── args
            │    └── const: 0
            ├── params: n:1
            └── body
                 └── limit
-                     ├── columns: exception_block_3:9
+                     ├── columns: dispatcher_5:10
                      ├── project
-                     │    ├── columns: exception_block_3:9
-                     │    ├── barrier
-                     │    │    ├── columns: i:2
-                     │    │    └── project
-                     │    │         ├── columns: i:2
-                     │    │         ├── values
-                     │    │         │    └── tuple
-                     │    │         └── projections
-                     │    │              └── floor-div [as=i:2]
-                     │    │                   ├── const: 100
-                     │    │                   └── variable: n:1
+                     │    ├── columns: dispatcher_5:10
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: exception_block_3 [as=exception_block_3:9]
-                     │              ├── args
-                     │              │    ├── variable: n:1
-                     │              │    └── variable: i:2
-                     │              ├── params: n:6 i:7
-                     │              ├── body
+                     │         └── dispatcher
+                     │              ├── subquery
                      │              │    └── project
-                     │              │         ├── columns: stmt_return_4:8
-                     │              │         ├── values
-                     │              │         │    └── tuple
+                     │              │         ├── columns: exception_block_3:9
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:2
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── floor-div [as=i:2]
+                     │              │         │              ├── const: 100
+                     │              │         │              └── variable: n:1
                      │              │         └── projections
-                     │              │              └── variable: i:7 [as=stmt_return_4:8]
-                     │              └── exception-handler
-                     │                   └── SQLSTATE '22012'
-                     │                        └── project
-                     │                             ├── columns: stmt_return_2:5!null
-                     │                             ├── values
-                     │                             │    └── tuple
-                     │                             └── projections
-                     │                                  └── const: 101 [as=stmt_return_2:5]
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 1
+                     │              │                   └── args
+                     │              │                        ├── variable: n:1
+                     │              │                        └── variable: i:2
+                     │              ├── branch: 0
+                     │              │    ├── params: n:3 i:4
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:5!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 101 [as=stmt_return_2:5]
+                     │              └── branch: 1
+                     │                   ├── params: n:6 i:7
+                     │                   ├── body
+                     │                   │    └── project
+                     │                   │         ├── columns: stmt_return_4:8
+                     │                   │         ├── values
+                     │                   │         │    └── tuple
+                     │                   │         └── projections
+                     │                   │              └── variable: i:7 [as=stmt_return_4:8]
+                     │                   └── exception-handler
+                     │                        └── SQLSTATE '22012'
+                     │                             └── project
+                     │                                  ├── columns: stmt_return_2:5!null
+                     │                                  ├── values
+                     │                                  │    └── tuple
+                     │                                  └── projections
+                     │                                       └── const: 101 [as=stmt_return_2:5]
                      └── const: 1
 
 # Each variable assignment is wrapped in an exception handler.
@@ -3835,11 +4622,11 @@ build format=show-scalars
 SELECT f(0, 0, 0);
 ----
 project
- ├── columns: f:34
+ ├── columns: f:35
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:34]
+      └── udf: f [as=f:35]
            ├── args
            │    ├── const: 0
            │    ├── const: 0
@@ -3847,103 +4634,119 @@ project
            ├── params: i:1 j:2 k:3
            └── body
                 └── limit
-                     ├── columns: exception_block_3:33
+                     ├── columns: dispatcher_8:34
                      ├── project
-                     │    ├── columns: exception_block_3:33
-                     │    ├── barrier
-                     │    │    ├── columns: x:4!null
-                     │    │    └── project
-                     │    │         ├── columns: x:4!null
-                     │    │         ├── values
-                     │    │         │    └── tuple
-                     │    │         └── projections
-                     │    │              └── const: 0 [as=x:4]
+                     │    ├── columns: dispatcher_8:34
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: exception_block_3 [as=exception_block_3:33]
-                     │              ├── args
-                     │              │    ├── variable: i:1
-                     │              │    ├── variable: j:2
-                     │              │    ├── variable: k:3
-                     │              │    └── variable: x:4
-                     │              ├── params: i:10 j:11 k:12 x:13
-                     │              ├── body
+                     │         └── dispatcher
+                     │              ├── subquery
                      │              │    └── project
-                     │              │         ├── columns: assign_exception_block_4:32
-                     │              │         ├── barrier
-                     │              │         │    ├── columns: x:14
-                     │              │         │    └── project
-                     │              │         │         ├── columns: x:14
-                     │              │         │         ├── values
-                     │              │         │         │    └── tuple
-                     │              │         │         └── projections
-                     │              │         │              └── floor-div [as=x:14]
-                     │              │         │                   ├── const: 1
-                     │              │         │                   └── variable: i:10
+                     │              │         ├── columns: exception_block_3:33
+                     │              │         ├── project
+                     │              │         │    ├── columns: x:4!null
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── const: 0 [as=x:4]
                      │              │         └── projections
-                     │              │              └── udf: assign_exception_block_4 [as=assign_exception_block_4:32]
-                     │              │                   ├── args
-                     │              │                   │    ├── variable: i:10
-                     │              │                   │    ├── variable: j:11
-                     │              │                   │    ├── variable: k:12
-                     │              │                   │    └── variable: x:14
-                     │              │                   ├── params: i:15 j:16 k:17 x:18
-                     │              │                   └── body
-                     │              │                        └── project
-                     │              │                             ├── columns: assign_exception_block_5:31
-                     │              │                             ├── barrier
-                     │              │                             │    ├── columns: x:19
-                     │              │                             │    └── project
-                     │              │                             │         ├── columns: x:19
-                     │              │                             │         ├── values
-                     │              │                             │         │    └── tuple
-                     │              │                             │         └── projections
-                     │              │                             │              └── floor-div [as=x:19]
-                     │              │                             │                   ├── const: 2
-                     │              │                             │                   └── variable: j:16
-                     │              │                             └── projections
-                     │              │                                  └── udf: assign_exception_block_5 [as=assign_exception_block_5:31]
-                     │              │                                       ├── args
-                     │              │                                       │    ├── variable: i:15
-                     │              │                                       │    ├── variable: j:16
-                     │              │                                       │    ├── variable: k:17
-                     │              │                                       │    └── variable: x:19
-                     │              │                                       ├── params: i:20 j:21 k:22 x:23
-                     │              │                                       └── body
-                     │              │                                            └── project
-                     │              │                                                 ├── columns: assign_exception_block_6:30
-                     │              │                                                 ├── barrier
-                     │              │                                                 │    ├── columns: x:24
-                     │              │                                                 │    └── project
-                     │              │                                                 │         ├── columns: x:24
-                     │              │                                                 │         ├── values
-                     │              │                                                 │         │    └── tuple
-                     │              │                                                 │         └── projections
-                     │              │                                                 │              └── floor-div [as=x:24]
-                     │              │                                                 │                   ├── const: 3
-                     │              │                                                 │                   └── variable: k:22
-                     │              │                                                 └── projections
-                     │              │                                                      └── udf: assign_exception_block_6 [as=assign_exception_block_6:30]
-                     │              │                                                           ├── args
-                     │              │                                                           │    ├── variable: i:20
-                     │              │                                                           │    ├── variable: j:21
-                     │              │                                                           │    ├── variable: k:22
-                     │              │                                                           │    └── variable: x:24
-                     │              │                                                           ├── params: i:25 j:26 k:27 x:28
-                     │              │                                                           └── body
-                     │              │                                                                └── project
-                     │              │                                                                     ├── columns: stmt_return_7:29
-                     │              │                                                                     ├── values
-                     │              │                                                                     │    └── tuple
-                     │              │                                                                     └── projections
-                     │              │                                                                          └── variable: x:28 [as=stmt_return_7:29]
-                     │              └── exception-handler
-                     │                   └── SQLSTATE '22012'
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 1
+                     │              │                   └── args
+                     │              │                        ├── variable: i:1
+                     │              │                        ├── variable: j:2
+                     │              │                        ├── variable: k:3
+                     │              │                        └── variable: x:4
+                     │              ├── branch: 0
+                     │              │    ├── params: i:5 j:6 k:7 x:8
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:9
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── variable: x:8 [as=stmt_return_2:9]
+                     │              ├── branch: 1
+                     │              │    ├── params: i:10 j:11 k:12 x:13
+                     │              │    ├── body
+                     │              │    │    └── project
+                     │              │    │         ├── columns: assign_exception_block_4:32
+                     │              │    │         ├── project
+                     │              │    │         │    ├── columns: x:14
+                     │              │    │         │    ├── values
+                     │              │    │         │    │    └── tuple
+                     │              │    │         │    └── projections
+                     │              │    │         │         └── floor-div [as=x:14]
+                     │              │    │         │              ├── const: 1
+                     │              │    │         │              └── variable: i:10
+                     │              │    │         └── projections
+                     │              │    │              └── dispatch: 1
+                     │              │    │                   ├── branch: 2
+                     │              │    │                   └── args
+                     │              │    │                        ├── variable: i:10
+                     │              │    │                        ├── variable: j:11
+                     │              │    │                        ├── variable: k:12
+                     │              │    │                        └── variable: x:14
+                     │              │    └── exception-handler
+                     │              │         └── SQLSTATE '22012'
+                     │              │              └── project
+                     │              │                   ├── columns: stmt_return_2:9
+                     │              │                   ├── values
+                     │              │                   │    └── tuple
+                     │              │                   └── projections
+                     │              │                        └── variable: x:8 [as=stmt_return_2:9]
+                     │              ├── branch: 2
+                     │              │    ├── params: i:15 j:16 k:17 x:18
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: assign_exception_block_5:31
+                     │              │              ├── project
+                     │              │              │    ├── columns: x:19
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── floor-div [as=x:19]
+                     │              │              │              ├── const: 2
+                     │              │              │              └── variable: j:16
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 3
+                     │              │                        └── args
+                     │              │                             ├── variable: i:15
+                     │              │                             ├── variable: j:16
+                     │              │                             ├── variable: k:17
+                     │              │                             └── variable: x:19
+                     │              ├── branch: 3
+                     │              │    ├── params: i:20 j:21 k:22 x:23
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: assign_exception_block_6:30
+                     │              │              ├── project
+                     │              │              │    ├── columns: x:24
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── floor-div [as=x:24]
+                     │              │              │              ├── const: 3
+                     │              │              │              └── variable: k:22
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 4
+                     │              │                        └── args
+                     │              │                             ├── variable: i:20
+                     │              │                             ├── variable: j:21
+                     │              │                             ├── variable: k:22
+                     │              │                             └── variable: x:24
+                     │              └── branch: 4
+                     │                   ├── params: i:25 j:26 k:27 x:28
+                     │                   └── body
                      │                        └── project
-                     │                             ├── columns: stmt_return_2:9
+                     │                             ├── columns: stmt_return_7:29
                      │                             ├── values
                      │                             │    └── tuple
                      │                             └── projections
-                     │                                  └── variable: x:8 [as=stmt_return_2:9]
+                     │                                  └── variable: x:28 [as=stmt_return_7:29]
                      └── const: 1
 
 exec-ddl
@@ -3970,168 +4773,183 @@ build format=show-scalars
 SELECT f(0);
 ----
 project
- ├── columns: f:31
+ ├── columns: f:32
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:31]
+      └── udf: f [as=f:32]
            ├── args
            │    └── const: 0
            ├── params: i:1
            └── body
                 └── limit
-                     ├── columns: exception_block_3:30
+                     ├── columns: dispatcher_13:31
                      ├── project
-                     │    ├── columns: exception_block_3:30
-                     │    ├── barrier
-                     │    │    ├── columns: x:2
-                     │    │    └── project
-                     │    │         ├── columns: x:2
-                     │    │         ├── values
-                     │    │         │    └── tuple
-                     │    │         └── projections
-                     │    │              └── cast: INT8 [as=x:2]
-                     │    │                   └── null
+                     │    ├── columns: dispatcher_13:31
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: exception_block_3 [as=exception_block_3:30]
-                     │              ├── args
-                     │              │    ├── variable: i:1
-                     │              │    └── variable: x:2
-                     │              ├── params: i:6 x:7
-                     │              ├── body
+                     │         └── dispatcher
+                     │              ├── subquery
                      │              │    └── project
-                     │              │         ├── columns: stmt_if_12:29
-                     │              │         ├── values
-                     │              │         │    └── tuple
+                     │              │         ├── columns: exception_block_3:30
+                     │              │         ├── project
+                     │              │         │    ├── columns: x:2
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── cast: INT8 [as=x:2]
+                     │              │         │              └── null
                      │              │         └── projections
-                     │              │              └── case [as=stmt_if_12:29]
-                     │              │                   ├── true
-                     │              │                   ├── when
-                     │              │                   │    ├── eq
-                     │              │                   │    │    ├── variable: i:6
-                     │              │                   │    │    └── const: 0
-                     │              │                   │    └── subquery
-                     │              │                   │         └── project
-                     │              │                   │              ├── columns: assign_exception_block_6:19
-                     │              │                   │              ├── barrier
-                     │              │                   │              │    ├── columns: x:11!null
-                     │              │                   │              │    └── project
-                     │              │                   │              │         ├── columns: x:11!null
-                     │              │                   │              │         ├── values
-                     │              │                   │              │         │    └── tuple
-                     │              │                   │              │         └── projections
-                     │              │                   │              │              └── const: 100 [as=x:11]
-                     │              │                   │              └── projections
-                     │              │                   │                   └── udf: assign_exception_block_6 [as=assign_exception_block_6:19]
-                     │              │                   │                        ├── args
-                     │              │                   │                        │    ├── variable: i:6
-                     │              │                   │                        │    └── variable: x:11
-                     │              │                   │                        ├── params: i:12 x:13
-                     │              │                   │                        └── body
-                     │              │                   │                             └── project
-                     │              │                   │                                  ├── columns: "_stmt_raise_7":18
-                     │              │                   │                                  ├── values
-                     │              │                   │                                  │    └── tuple
-                     │              │                   │                                  └── projections
-                     │              │                   │                                       └── udf: _stmt_raise_7 [as="_stmt_raise_7":18]
-                     │              │                   │                                            ├── args
-                     │              │                   │                                            │    ├── variable: i:12
-                     │              │                   │                                            │    └── variable: x:13
-                     │              │                   │                                            ├── params: i:14 x:15
-                     │              │                   │                                            └── body
-                     │              │                   │                                                 ├── project
-                     │              │                   │                                                 │    ├── columns: stmt_raise_8:16
-                     │              │                   │                                                 │    ├── values
-                     │              │                   │                                                 │    │    └── tuple
-                     │              │                   │                                                 │    └── projections
-                     │              │                   │                                                 │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:16]
-                     │              │                   │                                                 │              ├── const: 'ERROR'
-                     │              │                   │                                                 │              ├── const: 'division_by_zero'
-                     │              │                   │                                                 │              ├── const: ''
-                     │              │                   │                                                 │              ├── const: ''
-                     │              │                   │                                                 │              └── const: 'division_by_zero'
-                     │              │                   │                                                 └── project
-                     │              │                   │                                                      ├── columns: stmt_if_4:17
-                     │              │                   │                                                      ├── values
-                     │              │                   │                                                      │    └── tuple
-                     │              │                   │                                                      └── projections
-                     │              │                   │                                                           └── udf: stmt_if_4 [as=stmt_if_4:17]
-                     │              │                   │                                                                ├── args
-                     │              │                   │                                                                │    ├── variable: i:14
-                     │              │                   │                                                                │    └── variable: x:15
-                     │              │                   │                                                                ├── params: i:8 x:9
-                     │              │                   │                                                                └── body
-                     │              │                   │                                                                     └── project
-                     │              │                   │                                                                          ├── columns: stmt_return_5:10!null
-                     │              │                   │                                                                          ├── values
-                     │              │                   │                                                                          │    └── tuple
-                     │              │                   │                                                                          └── projections
-                     │              │                   │                                                                               └── const: 0 [as=stmt_return_5:10]
-                     │              │                   └── subquery
-                     │              │                        └── project
-                     │              │                             ├── columns: assign_exception_block_9:28
-                     │              │                             ├── barrier
-                     │              │                             │    ├── columns: x:20!null
-                     │              │                             │    └── project
-                     │              │                             │         ├── columns: x:20!null
-                     │              │                             │         ├── values
-                     │              │                             │         │    └── tuple
-                     │              │                             │         └── projections
-                     │              │                             │              └── const: 200 [as=x:20]
-                     │              │                             └── projections
-                     │              │                                  └── udf: assign_exception_block_9 [as=assign_exception_block_9:28]
-                     │              │                                       ├── args
-                     │              │                                       │    ├── variable: i:6
-                     │              │                                       │    └── variable: x:20
-                     │              │                                       ├── params: i:21 x:22
-                     │              │                                       └── body
-                     │              │                                            └── project
-                     │              │                                                 ├── columns: "_stmt_raise_10":27
-                     │              │                                                 ├── values
-                     │              │                                                 │    └── tuple
-                     │              │                                                 └── projections
-                     │              │                                                      └── udf: _stmt_raise_10 [as="_stmt_raise_10":27]
-                     │              │                                                           ├── args
-                     │              │                                                           │    ├── variable: i:21
-                     │              │                                                           │    └── variable: x:22
-                     │              │                                                           ├── params: i:23 x:24
-                     │              │                                                           └── body
-                     │              │                                                                ├── project
-                     │              │                                                                │    ├── columns: stmt_raise_11:25
-                     │              │                                                                │    ├── values
-                     │              │                                                                │    │    └── tuple
-                     │              │                                                                │    └── projections
-                     │              │                                                                │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_11:25]
-                     │              │                                                                │              ├── const: 'ERROR'
-                     │              │                                                                │              ├── const: 'division_by_zero'
-                     │              │                                                                │              ├── const: ''
-                     │              │                                                                │              ├── const: ''
-                     │              │                                                                │              └── const: 'division_by_zero'
-                     │              │                                                                └── project
-                     │              │                                                                     ├── columns: stmt_if_4:26
-                     │              │                                                                     ├── values
-                     │              │                                                                     │    └── tuple
-                     │              │                                                                     └── projections
-                     │              │                                                                          └── udf: stmt_if_4 [as=stmt_if_4:26]
-                     │              │                                                                               ├── args
-                     │              │                                                                               │    ├── variable: i:23
-                     │              │                                                                               │    └── variable: x:24
-                     │              │                                                                               ├── params: i:8 x:9
-                     │              │                                                                               └── body
-                     │              │                                                                                    └── project
-                     │              │                                                                                         ├── columns: stmt_return_5:10!null
-                     │              │                                                                                         ├── values
-                     │              │                                                                                         │    └── tuple
-                     │              │                                                                                         └── projections
-                     │              │                                                                                              └── const: 0 [as=stmt_return_5:10]
-                     │              └── exception-handler
-                     │                   └── SQLSTATE '22012'
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 1
+                     │              │                   └── args
+                     │              │                        ├── variable: i:1
+                     │              │                        └── variable: x:2
+                     │              ├── branch: 0
+                     │              │    ├── params: i:3 x:4
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:5
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── variable: x:4 [as=stmt_return_2:5]
+                     │              ├── branch: 1
+                     │              │    ├── params: i:6 x:7
+                     │              │    ├── body
+                     │              │    │    └── project
+                     │              │    │         ├── columns: stmt_if_12:29
+                     │              │    │         ├── values
+                     │              │    │         │    └── tuple
+                     │              │    │         └── projections
+                     │              │    │              └── case [as=stmt_if_12:29]
+                     │              │    │                   ├── true
+                     │              │    │                   ├── when
+                     │              │    │                   │    ├── eq
+                     │              │    │                   │    │    ├── variable: i:6
+                     │              │    │                   │    │    └── const: 0
+                     │              │    │                   │    └── subquery
+                     │              │    │                   │         └── project
+                     │              │    │                   │              ├── columns: assign_exception_block_6:19
+                     │              │    │                   │              ├── project
+                     │              │    │                   │              │    ├── columns: x:11!null
+                     │              │    │                   │              │    ├── values
+                     │              │    │                   │              │    │    └── tuple
+                     │              │    │                   │              │    └── projections
+                     │              │    │                   │              │         └── const: 100 [as=x:11]
+                     │              │    │                   │              └── projections
+                     │              │    │                   │                   └── dispatch: 1
+                     │              │    │                   │                        ├── branch: 3
+                     │              │    │                   │                        └── args
+                     │              │    │                   │                             ├── variable: i:6
+                     │              │    │                   │                             └── variable: x:11
+                     │              │    │                   └── subquery
+                     │              │    │                        └── project
+                     │              │    │                             ├── columns: assign_exception_block_9:28
+                     │              │    │                             ├── project
+                     │              │    │                             │    ├── columns: x:20!null
+                     │              │    │                             │    ├── values
+                     │              │    │                             │    │    └── tuple
+                     │              │    │                             │    └── projections
+                     │              │    │                             │         └── const: 200 [as=x:20]
+                     │              │    │                             └── projections
+                     │              │    │                                  └── dispatch: 1
+                     │              │    │                                       ├── branch: 5
+                     │              │    │                                       └── args
+                     │              │    │                                            ├── variable: i:6
+                     │              │    │                                            └── variable: x:20
+                     │              │    └── exception-handler
+                     │              │         └── SQLSTATE '22012'
+                     │              │              └── project
+                     │              │                   ├── columns: stmt_return_2:5
+                     │              │                   ├── values
+                     │              │                   │    └── tuple
+                     │              │                   └── projections
+                     │              │                        └── variable: x:4 [as=stmt_return_2:5]
+                     │              ├── branch: 2
+                     │              │    ├── params: i:8 x:9
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_5:10!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 0 [as=stmt_return_5:10]
+                     │              ├── branch: 3
+                     │              │    ├── params: i:12 x:13
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_7":18
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 4
+                     │              │                        └── args
+                     │              │                             ├── variable: i:12
+                     │              │                             └── variable: x:13
+                     │              ├── branch: 4
+                     │              │    ├── params: i:14 x:15
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_8:16
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:16]
+                     │              │         │              ├── const: 'ERROR'
+                     │              │         │              ├── const: 'division_by_zero'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: 'division_by_zero'
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_4:17
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 2
+                     │              │                        └── args
+                     │              │                             ├── variable: i:14
+                     │              │                             └── variable: x:15
+                     │              ├── branch: 5
+                     │              │    ├── params: i:21 x:22
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_10":27
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 6
+                     │              │                        └── args
+                     │              │                             ├── variable: i:21
+                     │              │                             └── variable: x:22
+                     │              └── branch: 6
+                     │                   ├── params: i:23 x:24
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_11:25
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_11:25]
+                     │                        │              ├── const: 'ERROR'
+                     │                        │              ├── const: 'division_by_zero'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: 'division_by_zero'
                      │                        └── project
-                     │                             ├── columns: stmt_return_2:5
+                     │                             ├── columns: stmt_if_4:26
                      │                             ├── values
                      │                             │    └── tuple
                      │                             └── projections
-                     │                                  └── variable: x:4 [as=stmt_return_2:5]
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 2
+                     │                                       └── args
+                     │                                            ├── variable: i:23
+                     │                                            └── variable: x:24
                      └── const: 1
 
 exec-ddl
@@ -4156,164 +4974,186 @@ build format=show-scalars
 SELECT f(0, 0);
 ----
 project
- ├── columns: f:45
+ ├── columns: f:46
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:45]
+      └── udf: f [as=f:46]
            ├── args
            │    ├── const: 0
            │    └── const: 0
            ├── params: n:1 a:2
            └── body
                 └── limit
-                     ├── columns: exception_block_3:44
+                     ├── columns: dispatcher_11:45
                      ├── project
-                     │    ├── columns: exception_block_3:44
-                     │    ├── barrier
-                     │    │    ├── columns: x:3 i:4!null
-                     │    │    └── project
-                     │    │         ├── columns: i:4!null x:3
-                     │    │         ├── project
-                     │    │         │    ├── columns: x:3
-                     │    │         │    ├── values
-                     │    │         │    │    └── tuple
-                     │    │         │    └── projections
-                     │    │         │         └── cast: INT8 [as=x:3]
-                     │    │         │              └── null
-                     │    │         └── projections
-                     │    │              └── const: 0 [as=i:4]
+                     │    ├── columns: dispatcher_11:45
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: exception_block_3 [as=exception_block_3:44]
-                     │              ├── args
-                     │              │    ├── variable: n:1
-                     │              │    ├── variable: a:2
-                     │              │    ├── variable: x:3
-                     │              │    └── variable: i:4
-                     │              ├── params: n:10 a:11 x:12 i:13
-                     │              ├── body
+                     │         └── dispatcher
+                     │              ├── subquery
                      │              │    └── project
-                     │              │         ├── columns: stmt_loop_6:43
-                     │              │         ├── values
-                     │              │         │    └── tuple
+                     │              │         ├── columns: exception_block_3:44
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:4!null x:3
+                     │              │         │    ├── project
+                     │              │         │    │    ├── columns: x:3
+                     │              │         │    │    ├── values
+                     │              │         │    │    │    └── tuple
+                     │              │         │    │    └── projections
+                     │              │         │    │         └── cast: INT8 [as=x:3]
+                     │              │         │    │              └── null
+                     │              │         │    └── projections
+                     │              │         │         └── const: 0 [as=i:4]
                      │              │         └── projections
-                     │              │              └── udf: stmt_loop_6 [as=stmt_loop_6:43]
-                     │              │                   ├── args
-                     │              │                   │    ├── variable: n:10
-                     │              │                   │    ├── variable: a:11
-                     │              │                   │    ├── variable: x:12
-                     │              │                   │    └── variable: i:13
-                     │              │                   ├── params: n:19 a:20 x:21 i:22
-                     │              │                   └── body
-                     │              │                        └── project
-                     │              │                             ├── columns: stmt_if_10:42
-                     │              │                             ├── values
-                     │              │                             │    └── tuple
-                     │              │                             └── projections
-                     │              │                                  └── case [as=stmt_if_10:42]
-                     │              │                                       ├── true
-                     │              │                                       ├── when
-                     │              │                                       │    ├── ge
-                     │              │                                       │    │    ├── variable: i:22
-                     │              │                                       │    │    └── variable: n:19
-                     │              │                                       │    └── subquery
-                     │              │                                       │         └── project
-                     │              │                                       │              ├── columns: loop_exit_4:40
-                     │              │                                       │              ├── values
-                     │              │                                       │              │    └── tuple
-                     │              │                                       │              └── projections
-                     │              │                                       │                   └── udf: loop_exit_4 [as=loop_exit_4:40]
-                     │              │                                       │                        ├── args
-                     │              │                                       │                        │    ├── variable: n:19
-                     │              │                                       │                        │    ├── variable: a:20
-                     │              │                                       │                        │    ├── variable: x:21
-                     │              │                                       │                        │    └── variable: i:22
-                     │              │                                       │                        ├── params: n:14 a:15 x:16 i:17
-                     │              │                                       │                        └── body
-                     │              │                                       │                             └── project
-                     │              │                                       │                                  ├── columns: stmt_return_5:18!null
-                     │              │                                       │                                  ├── values
-                     │              │                                       │                                  │    └── tuple
-                     │              │                                       │                                  └── projections
-                     │              │                                       │                                       └── const: -1 [as=stmt_return_5:18]
-                     │              │                                       └── subquery
-                     │              │                                            └── project
-                     │              │                                                 ├── columns: stmt_if_7:41
-                     │              │                                                 ├── values
-                     │              │                                                 │    └── tuple
-                     │              │                                                 └── projections
-                     │              │                                                      └── udf: stmt_if_7 [as=stmt_if_7:41]
-                     │              │                                                           ├── args
-                     │              │                                                           │    ├── variable: n:19
-                     │              │                                                           │    ├── variable: a:20
-                     │              │                                                           │    ├── variable: x:21
-                     │              │                                                           │    └── variable: i:22
-                     │              │                                                           ├── params: n:23 a:24 x:25 i:26
-                     │              │                                                           └── body
-                     │              │                                                                └── project
-                     │              │                                                                     ├── columns: assign_exception_block_8:39
-                     │              │                                                                     ├── barrier
-                     │              │                                                                     │    ├── columns: x:27
-                     │              │                                                                     │    └── project
-                     │              │                                                                     │         ├── columns: x:27
-                     │              │                                                                     │         ├── values
-                     │              │                                                                     │         │    └── tuple
-                     │              │                                                                     │         └── projections
-                     │              │                                                                     │              └── floor-div [as=x:27]
-                     │              │                                                                     │                   ├── const: 1
-                     │              │                                                                     │                   └── minus
-                     │              │                                                                     │                        ├── variable: i:26
-                     │              │                                                                     │                        └── variable: a:24
-                     │              │                                                                     └── projections
-                     │              │                                                                          └── udf: assign_exception_block_8 [as=assign_exception_block_8:39]
-                     │              │                                                                               ├── args
-                     │              │                                                                               │    ├── variable: n:23
-                     │              │                                                                               │    ├── variable: a:24
-                     │              │                                                                               │    ├── variable: x:27
-                     │              │                                                                               │    └── variable: i:26
-                     │              │                                                                               ├── params: n:28 a:29 x:30 i:31
-                     │              │                                                                               └── body
-                     │              │                                                                                    └── project
-                     │              │                                                                                         ├── columns: assign_exception_block_9:38
-                     │              │                                                                                         ├── barrier
-                     │              │                                                                                         │    ├── columns: i:32
-                     │              │                                                                                         │    └── project
-                     │              │                                                                                         │         ├── columns: i:32
-                     │              │                                                                                         │         ├── values
-                     │              │                                                                                         │         │    └── tuple
-                     │              │                                                                                         │         └── projections
-                     │              │                                                                                         │              └── plus [as=i:32]
-                     │              │                                                                                         │                   ├── variable: i:31
-                     │              │                                                                                         │                   └── const: 1
-                     │              │                                                                                         └── projections
-                     │              │                                                                                              └── udf: assign_exception_block_9 [as=assign_exception_block_9:38]
-                     │              │                                                                                                   ├── args
-                     │              │                                                                                                   │    ├── variable: n:28
-                     │              │                                                                                                   │    ├── variable: a:29
-                     │              │                                                                                                   │    ├── variable: x:30
-                     │              │                                                                                                   │    └── variable: i:32
-                     │              │                                                                                                   ├── params: n:33 a:34 x:35 i:36
-                     │              │                                                                                                   └── body
-                     │              │                                                                                                        └── project
-                     │              │                                                                                                             ├── columns: stmt_loop_6:37
-                     │              │                                                                                                             ├── values
-                     │              │                                                                                                             │    └── tuple
-                     │              │                                                                                                             └── projections
-                     │              │                                                                                                                  └── udf: stmt_loop_6 [as=stmt_loop_6:37]
-                     │              │                                                                                                                       ├── args
-                     │              │                                                                                                                       │    ├── variable: n:33
-                     │              │                                                                                                                       │    ├── variable: a:34
-                     │              │                                                                                                                       │    ├── variable: x:35
-                     │              │                                                                                                                       │    └── variable: i:36
-                     │              │                                                                                                                       └── recursive-call
-                     │              └── exception-handler
-                     │                   └── SQLSTATE '22012'
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 1
+                     │              │                   └── args
+                     │              │                        ├── variable: n:1
+                     │              │                        ├── variable: a:2
+                     │              │                        ├── variable: x:3
+                     │              │                        └── variable: i:4
+                     │              ├── branch: 0
+                     │              │    ├── params: n:5 a:6 x:7 i:8
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:9
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── variable: i:8 [as=stmt_return_2:9]
+                     │              ├── branch: 1
+                     │              │    ├── params: n:10 a:11 x:12 i:13
+                     │              │    ├── body
+                     │              │    │    └── project
+                     │              │    │         ├── columns: stmt_loop_6:43
+                     │              │    │         ├── values
+                     │              │    │         │    └── tuple
+                     │              │    │         └── projections
+                     │              │    │              └── dispatch: 1
+                     │              │    │                   ├── branch: 3
+                     │              │    │                   └── args
+                     │              │    │                        ├── variable: n:10
+                     │              │    │                        ├── variable: a:11
+                     │              │    │                        ├── variable: x:12
+                     │              │    │                        └── variable: i:13
+                     │              │    └── exception-handler
+                     │              │         └── SQLSTATE '22012'
+                     │              │              └── project
+                     │              │                   ├── columns: stmt_return_2:9
+                     │              │                   ├── values
+                     │              │                   │    └── tuple
+                     │              │                   └── projections
+                     │              │                        └── variable: i:8 [as=stmt_return_2:9]
+                     │              ├── branch: 2
+                     │              │    ├── params: n:14 a:15 x:16 i:17
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_5:18!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: -1 [as=stmt_return_5:18]
+                     │              ├── branch: 3
+                     │              │    ├── params: n:19 a:20 x:21 i:22
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_10:42
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_10:42]
+                     │              │                        ├── true
+                     │              │                        ├── when
+                     │              │                        │    ├── ge
+                     │              │                        │    │    ├── variable: i:22
+                     │              │                        │    │    └── variable: n:19
+                     │              │                        │    └── subquery
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: loop_exit_4:40
+                     │              │                        │              ├── values
+                     │              │                        │              │    └── tuple
+                     │              │                        │              └── projections
+                     │              │                        │                   └── dispatch: 1
+                     │              │                        │                        ├── branch: 2
+                     │              │                        │                        └── args
+                     │              │                        │                             ├── variable: n:19
+                     │              │                        │                             ├── variable: a:20
+                     │              │                        │                             ├── variable: x:21
+                     │              │                        │                             └── variable: i:22
+                     │              │                        └── subquery
+                     │              │                             └── project
+                     │              │                                  ├── columns: stmt_if_7:41
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 4
+                     │              │                                            └── args
+                     │              │                                                 ├── variable: n:19
+                     │              │                                                 ├── variable: a:20
+                     │              │                                                 ├── variable: x:21
+                     │              │                                                 └── variable: i:22
+                     │              ├── branch: 4
+                     │              │    ├── params: n:23 a:24 x:25 i:26
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: assign_exception_block_8:39
+                     │              │              ├── project
+                     │              │              │    ├── columns: x:27
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── floor-div [as=x:27]
+                     │              │              │              ├── const: 1
+                     │              │              │              └── minus
+                     │              │              │                   ├── variable: i:26
+                     │              │              │                   └── variable: a:24
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 5
+                     │              │                        └── args
+                     │              │                             ├── variable: n:23
+                     │              │                             ├── variable: a:24
+                     │              │                             ├── variable: x:27
+                     │              │                             └── variable: i:26
+                     │              ├── branch: 5
+                     │              │    ├── params: n:28 a:29 x:30 i:31
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: assign_exception_block_9:38
+                     │              │              ├── project
+                     │              │              │    ├── columns: i:32
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── plus [as=i:32]
+                     │              │              │              ├── variable: i:31
+                     │              │              │              └── const: 1
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 6
+                     │              │                        └── args
+                     │              │                             ├── variable: n:28
+                     │              │                             ├── variable: a:29
+                     │              │                             ├── variable: x:30
+                     │              │                             └── variable: i:32
+                     │              └── branch: 6
+                     │                   ├── params: n:33 a:34 x:35 i:36
+                     │                   └── body
                      │                        └── project
-                     │                             ├── columns: stmt_return_2:9
+                     │                             ├── columns: stmt_loop_6:37
                      │                             ├── values
                      │                             │    └── tuple
                      │                             └── projections
-                     │                                  └── variable: i:8 [as=stmt_return_2:9]
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 3
+                     │                                       └── args
+                     │                                            ├── variable: n:33
+                     │                                            ├── variable: a:34
+                     │                                            ├── variable: x:35
+                     │                                            └── variable: i:36
                      └── const: 1
 
 # Testing SQL statement execution.
@@ -4334,84 +5174,97 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:29
+ ├── columns: f:30
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:29]
+      └── udf: f [as=f:30]
            └── body
                 └── limit
-                     ├── columns: "_stmt_exec_1":28
+                     ├── columns: dispatcher_5:29
                      ├── project
-                     │    ├── columns: "_stmt_exec_1":28
+                     │    ├── columns: dispatcher_5:29
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_exec_1 [as="_stmt_exec_1":28]
-                     │              └── body
-                     │                   ├── insert kv
-                     │                   │    ├── columns: <none>
-                     │                   │    ├── insert-mapping:
-                     │                   │    │    ├── column1:5 => k:1
-                     │                   │    │    └── column2:6 => v:2
-                     │                   │    └── values
-                     │                   │         ├── columns: column1:5!null column2:6!null
-                     │                   │         └── tuple
-                     │                   │              ├── const: 100
-                     │                   │              └── const: 100
-                     │                   └── project
-                     │                        ├── columns: "_stmt_exec_2":27
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── udf: _stmt_exec_2 [as="_stmt_exec_2":27]
-                     │                                  └── body
-                     │                                       ├── delete kv
-                     │                                       │    ├── columns: <none>
-                     │                                       │    ├── fetch columns: k:11 v:12
-                     │                                       │    └── select
-                     │                                       │         ├── columns: k:11!null v:12 crdb_internal_mvcc_timestamp:13 tableoid:14
-                     │                                       │         ├── scan kv
-                     │                                       │         │    └── columns: k:11!null v:12 crdb_internal_mvcc_timestamp:13 tableoid:14
-                     │                                       │         └── filters
-                     │                                       │              └── eq
-                     │                                       │                   ├── variable: k:11
-                     │                                       │                   └── const: 100
-                     │                                       └── project
-                     │                                            ├── columns: "_stmt_exec_3":26
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: _stmt_exec_3 [as="_stmt_exec_3":26]
-                     │                                                      └── body
-                     │                                                           ├── insert kv
-                     │                                                           │    ├── columns: <none>
-                     │                                                           │    ├── insert-mapping:
-                     │                                                           │    │    ├── column1:19 => k:15
-                     │                                                           │    │    └── column2:20 => v:16
-                     │                                                           │    └── values
-                     │                                                           │         ├── columns: column1:19!null column2:20!null
-                     │                                                           │         └── tuple
-                     │                                                           │              ├── const: 100
-                     │                                                           │              └── const: 100
-                     │                                                           └── project
-                     │                                                                ├── columns: stmt_return_4:25
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── subquery [as=stmt_return_4:25]
-                     │                                                                          └── max1-row
-                     │                                                                               ├── columns: v:22
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: v:22
-                     │                                                                                    └── select
-                     │                                                                                         ├── columns: k:21!null v:22 crdb_internal_mvcc_timestamp:23 tableoid:24
-                     │                                                                                         ├── scan kv
-                     │                                                                                         │    └── columns: k:21!null v:22 crdb_internal_mvcc_timestamp:23 tableoid:24
-                     │                                                                                         └── filters
-                     │                                                                                              └── eq
-                     │                                                                                                   ├── variable: k:21
-                     │                                                                                                   └── const: 100
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_exec_1":28
+                     │              │         ├── values
+                     │              │         │    └── tuple
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 0
+                     │              ├── branch: 0
+                     │              │    └── body
+                     │              │         ├── insert kv
+                     │              │         │    ├── columns: <none>
+                     │              │         │    ├── insert-mapping:
+                     │              │         │    │    ├── column1:5 => k:1
+                     │              │         │    │    └── column2:6 => v:2
+                     │              │         │    └── values
+                     │              │         │         ├── columns: column1:5!null column2:6!null
+                     │              │         │         └── tuple
+                     │              │         │              ├── const: 100
+                     │              │         │              └── const: 100
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_exec_2":27
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 1
+                     │              ├── branch: 1
+                     │              │    └── body
+                     │              │         ├── delete kv
+                     │              │         │    ├── columns: <none>
+                     │              │         │    ├── fetch columns: k:11 v:12
+                     │              │         │    └── select
+                     │              │         │         ├── columns: k:11!null v:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                     │              │         │         ├── scan kv
+                     │              │         │         │    └── columns: k:11!null v:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                     │              │         │         └── filters
+                     │              │         │              └── eq
+                     │              │         │                   ├── variable: k:11
+                     │              │         │                   └── const: 100
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_exec_3":26
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        └── branch: 2
+                     │              └── branch: 2
+                     │                   └── body
+                     │                        ├── insert kv
+                     │                        │    ├── columns: <none>
+                     │                        │    ├── insert-mapping:
+                     │                        │    │    ├── column1:19 => k:15
+                     │                        │    │    └── column2:20 => v:16
+                     │                        │    └── values
+                     │                        │         ├── columns: column1:19!null column2:20!null
+                     │                        │         └── tuple
+                     │                        │              ├── const: 100
+                     │                        │              └── const: 100
+                     │                        └── project
+                     │                             ├── columns: stmt_return_4:25
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── subquery [as=stmt_return_4:25]
+                     │                                       └── max1-row
+                     │                                            ├── columns: v:22
+                     │                                            └── project
+                     │                                                 ├── columns: v:22
+                     │                                                 └── select
+                     │                                                      ├── columns: k:21!null v:22 crdb_internal_mvcc_timestamp:23 tableoid:24
+                     │                                                      ├── scan kv
+                     │                                                      │    └── columns: k:21!null v:22 crdb_internal_mvcc_timestamp:23 tableoid:24
+                     │                                                      └── filters
+                     │                                                           └── eq
+                     │                                                                ├── variable: k:21
+                     │                                                                └── const: 100
                      └── const: 1
 
 # Testing SELECT INTO.
@@ -4431,70 +5284,81 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:17
+ ├── columns: f:18
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:17]
+      └── udf: f [as=f:18]
            └── body
                 └── limit
-                     ├── columns: "_stmt_exec_1":16
+                     ├── columns: dispatcher_4:17
                      ├── project
-                     │    ├── columns: "_stmt_exec_1":16
-                     │    ├── project
-                     │    │    ├── columns: j:2 i:1
-                     │    │    ├── project
-                     │    │    │    ├── columns: i:1
-                     │    │    │    ├── values
-                     │    │    │    │    └── tuple
-                     │    │    │    └── projections
-                     │    │    │         └── cast: INT8 [as=i:1]
-                     │    │    │              └── null
-                     │    │    └── projections
-                     │    │         └── cast: INT8 [as=j:2]
-                     │    │              └── null
+                     │    ├── columns: dispatcher_4:17
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_exec_1 [as="_stmt_exec_1":16]
-                     │              ├── args
-                     │              │    ├── variable: i:1
-                     │              │    └── variable: j:2
-                     │              ├── params: i:3 j:4
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: "_stmt_exec_ret_2":15
-                     │                        ├── project
-                     │                        │    ├── columns: i:13 j:14
-                     │                        │    ├── right-join (cross)
-                     │                        │    │    ├── columns: x:5 y:6
-                     │                        │    │    ├── limit
-                     │                        │    │    │    ├── columns: x:5 y:6
-                     │                        │    │    │    ├── internal-ordering: -5
-                     │                        │    │    │    ├── project
-                     │                        │    │    │    │    ├── columns: x:5 y:6
-                     │                        │    │    │    │    └── scan xy
-                     │                        │    │    │    │         └── columns: x:5 y:6 rowid:7!null crdb_internal_mvcc_timestamp:8 tableoid:9
-                     │                        │    │    │    └── const: 1
-                     │                        │    │    ├── values
-                     │                        │    │    │    └── tuple
-                     │                        │    │    └── filters (true)
-                     │                        │    └── projections
-                     │                        │         ├── variable: x:5 [as=i:13]
-                     │                        │         └── variable: y:6 [as=j:14]
-                     │                        └── projections
-                     │                             └── udf: _stmt_exec_ret_2 [as="_stmt_exec_ret_2":15]
-                     │                                  ├── args
-                     │                                  │    ├── variable: i:13
-                     │                                  │    └── variable: j:14
-                     │                                  ├── params: i:10 j:11
-                     │                                  └── body
-                     │                                       └── project
-                     │                                            ├── columns: stmt_return_3:12
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── plus [as=stmt_return_3:12]
-                     │                                                      ├── variable: i:10
-                     │                                                      └── variable: j:11
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_exec_1":16
+                     │              │         ├── project
+                     │              │         │    ├── columns: j:2 i:1
+                     │              │         │    ├── project
+                     │              │         │    │    ├── columns: i:1
+                     │              │         │    │    ├── values
+                     │              │         │    │    │    └── tuple
+                     │              │         │    │    └── projections
+                     │              │         │    │         └── cast: INT8 [as=i:1]
+                     │              │         │    │              └── null
+                     │              │         │    └── projections
+                     │              │         │         └── cast: INT8 [as=j:2]
+                     │              │         │              └── null
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 0
+                     │              │                   └── args
+                     │              │                        ├── variable: i:1
+                     │              │                        └── variable: j:2
+                     │              ├── branch: 0
+                     │              │    ├── params: i:3 j:4
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_exec_ret_2":15
+                     │              │              ├── project
+                     │              │              │    ├── columns: i:13 j:14
+                     │              │              │    ├── right-join (cross)
+                     │              │              │    │    ├── columns: x:5 y:6
+                     │              │              │    │    ├── limit
+                     │              │              │    │    │    ├── columns: x:5 y:6
+                     │              │              │    │    │    ├── internal-ordering: -5
+                     │              │              │    │    │    ├── project
+                     │              │              │    │    │    │    ├── columns: x:5 y:6
+                     │              │              │    │    │    │    └── scan xy
+                     │              │              │    │    │    │         └── columns: x:5 y:6 rowid:7!null crdb_internal_mvcc_timestamp:8 tableoid:9
+                     │              │              │    │    │    └── const: 1
+                     │              │              │    │    ├── values
+                     │              │              │    │    │    └── tuple
+                     │              │              │    │    └── filters (true)
+                     │              │              │    └── projections
+                     │              │              │         ├── variable: x:5 [as=i:13]
+                     │              │              │         └── variable: y:6 [as=j:14]
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             ├── variable: i:13
+                     │              │                             └── variable: j:14
+                     │              └── branch: 1
+                     │                   ├── params: i:10 j:11
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_return_3:12
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── plus [as=stmt_return_3:12]
+                     │                                       ├── variable: i:10
+                     │                                       └── variable: j:11
                      └── const: 1
 
 # It is possible to reference a previous value of a target variable in a
@@ -4517,163 +5381,176 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:29
+ ├── columns: f:30
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:29]
+      └── udf: f [as=f:30]
            └── body
                 └── limit
-                     ├── columns: "_stmt_exec_1":28
+                     ├── columns: dispatcher_10:29
                      ├── project
-                     │    ├── columns: "_stmt_exec_1":28
-                     │    ├── barrier
-                     │    │    ├── columns: i:1
-                     │    │    └── project
-                     │    │         ├── columns: i:1
-                     │    │         ├── values
-                     │    │         │    └── tuple
-                     │    │         └── projections
-                     │    │              └── cast: INT8 [as=i:1]
-                     │    │                   └── null
+                     │    ├── columns: dispatcher_10:29
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_exec_1 [as="_stmt_exec_1":28]
-                     │              ├── args
-                     │              │    └── variable: i:1
-                     │              ├── params: i:2
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: "_stmt_exec_ret_2":27
-                     │                        ├── barrier
-                     │                        │    ├── columns: i:26
-                     │                        │    └── project
-                     │                        │         ├── columns: i:26
-                     │                        │         ├── right-join (cross)
-                     │                        │         │    ├── columns: x:3
-                     │                        │         │    ├── limit
-                     │                        │         │    │    ├── columns: x:3
-                     │                        │         │    │    ├── internal-ordering: -3
-                     │                        │         │    │    ├── project
-                     │                        │         │    │    │    ├── columns: x:3
-                     │                        │         │    │    │    └── scan xy
-                     │                        │         │    │    │         └── columns: x:3 y:4 rowid:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
-                     │                        │         │    │    └── const: 1
-                     │                        │         │    ├── values
-                     │                        │         │    │    └── tuple
-                     │                        │         │    └── filters (true)
-                     │                        │         └── projections
-                     │                        │              └── variable: x:3 [as=i:26]
-                     │                        └── projections
-                     │                             └── udf: _stmt_exec_ret_2 [as="_stmt_exec_ret_2":27]
-                     │                                  ├── args
-                     │                                  │    └── variable: i:26
-                     │                                  ├── params: i:8
-                     │                                  └── body
-                     │                                       └── project
-                     │                                            ├── columns: "_stmt_raise_3":25
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: _stmt_raise_3 [as="_stmt_raise_3":25]
-                     │                                                      ├── args
-                     │                                                      │    └── variable: i:8
-                     │                                                      ├── params: i:9
-                     │                                                      └── body
-                     │                                                           ├── project
-                     │                                                           │    ├── columns: stmt_raise_4:10
-                     │                                                           │    ├── values
-                     │                                                           │    │    └── tuple
-                     │                                                           │    └── projections
-                     │                                                           │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_4:10]
-                     │                                                           │              ├── const: 'NOTICE'
-                     │                                                           │              ├── concat
-                     │                                                           │              │    ├── concat
-                     │                                                           │              │    │    ├── const: 'i = '
-                     │                                                           │              │    │    └── coalesce
-                     │                                                           │              │    │         ├── cast: STRING
-                     │                                                           │              │    │         │    └── variable: i:9
-                     │                                                           │              │    │         └── const: '<NULL>'
-                     │                                                           │              │    └── const: ''
-                     │                                                           │              ├── const: ''
-                     │                                                           │              ├── const: ''
-                     │                                                           │              └── const: '00000'
-                     │                                                           └── project
-                     │                                                                ├── columns: "_stmt_exec_5":24
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── udf: _stmt_exec_5 [as="_stmt_exec_5":24]
-                     │                                                                          ├── args
-                     │                                                                          │    └── variable: i:9
-                     │                                                                          ├── params: i:11
-                     │                                                                          └── body
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: "_stmt_exec_ret_6":23
-                     │                                                                                    ├── barrier
-                     │                                                                                    │    ├── columns: i:22
-                     │                                                                                    │    └── project
-                     │                                                                                    │         ├── columns: i:22
-                     │                                                                                    │         ├── right-join (cross)
-                     │                                                                                    │         │    ├── columns: x:12
-                     │                                                                                    │         │    ├── limit
-                     │                                                                                    │         │    │    ├── columns: x:12!null
-                     │                                                                                    │         │    │    ├── internal-ordering: -12
-                     │                                                                                    │         │    │    ├── project
-                     │                                                                                    │         │    │    │    ├── columns: x:12!null
-                     │                                                                                    │         │    │    │    └── select
-                     │                                                                                    │         │    │    │         ├── columns: x:12!null y:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-                     │                                                                                    │         │    │    │         ├── scan xy
-                     │                                                                                    │         │    │    │         │    └── columns: x:12 y:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-                     │                                                                                    │         │    │    │         └── filters
-                     │                                                                                    │         │    │    │              └── lt
-                     │                                                                                    │         │    │    │                   ├── variable: x:12
-                     │                                                                                    │         │    │    │                   └── variable: i:11
-                     │                                                                                    │         │    │    └── const: 1
-                     │                                                                                    │         │    ├── values
-                     │                                                                                    │         │    │    └── tuple
-                     │                                                                                    │         │    └── filters (true)
-                     │                                                                                    │         └── projections
-                     │                                                                                    │              └── variable: x:12 [as=i:22]
-                     │                                                                                    └── projections
-                     │                                                                                         └── udf: _stmt_exec_ret_6 [as="_stmt_exec_ret_6":23]
-                     │                                                                                              ├── args
-                     │                                                                                              │    └── variable: i:22
-                     │                                                                                              ├── params: i:17
-                     │                                                                                              └── body
-                     │                                                                                                   └── project
-                     │                                                                                                        ├── columns: "_stmt_raise_7":21
-                     │                                                                                                        ├── values
-                     │                                                                                                        │    └── tuple
-                     │                                                                                                        └── projections
-                     │                                                                                                             └── udf: _stmt_raise_7 [as="_stmt_raise_7":21]
-                     │                                                                                                                  ├── args
-                     │                                                                                                                  │    └── variable: i:17
-                     │                                                                                                                  ├── params: i:18
-                     │                                                                                                                  └── body
-                     │                                                                                                                       ├── project
-                     │                                                                                                                       │    ├── columns: stmt_raise_8:19
-                     │                                                                                                                       │    ├── values
-                     │                                                                                                                       │    │    └── tuple
-                     │                                                                                                                       │    └── projections
-                     │                                                                                                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:19]
-                     │                                                                                                                       │              ├── const: 'NOTICE'
-                     │                                                                                                                       │              ├── concat
-                     │                                                                                                                       │              │    ├── concat
-                     │                                                                                                                       │              │    │    ├── const: 'i = '
-                     │                                                                                                                       │              │    │    └── coalesce
-                     │                                                                                                                       │              │    │         ├── cast: STRING
-                     │                                                                                                                       │              │    │         │    └── variable: i:18
-                     │                                                                                                                       │              │    │         └── const: '<NULL>'
-                     │                                                                                                                       │              │    └── const: ''
-                     │                                                                                                                       │              ├── const: ''
-                     │                                                                                                                       │              ├── const: ''
-                     │                                                                                                                       │              └── const: '00000'
-                     │                                                                                                                       └── project
-                     │                                                                                                                            ├── columns: stmt_return_9:20!null
-                     │                                                                                                                            ├── values
-                     │                                                                                                                            │    └── tuple
-                     │                                                                                                                            └── projections
-                     │                                                                                                                                 └── const: 0 [as=stmt_return_9:20]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_exec_1":28
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:1
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── cast: INT8 [as=i:1]
+                     │              │         │              └── null
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 0
+                     │              │                   └── args
+                     │              │                        └── variable: i:1
+                     │              ├── branch: 0
+                     │              │    ├── params: i:2
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_exec_ret_2":27
+                     │              │              ├── project
+                     │              │              │    ├── columns: i:26
+                     │              │              │    ├── right-join (cross)
+                     │              │              │    │    ├── columns: x:3
+                     │              │              │    │    ├── limit
+                     │              │              │    │    │    ├── columns: x:3
+                     │              │              │    │    │    ├── internal-ordering: -3
+                     │              │              │    │    │    ├── project
+                     │              │              │    │    │    │    ├── columns: x:3
+                     │              │              │    │    │    │    └── scan xy
+                     │              │              │    │    │    │         └── columns: x:3 y:4 rowid:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+                     │              │              │    │    │    └── const: 1
+                     │              │              │    │    ├── values
+                     │              │              │    │    │    └── tuple
+                     │              │              │    │    └── filters (true)
+                     │              │              │    └── projections
+                     │              │              │         └── variable: x:3 [as=i:26]
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             └── variable: i:26
+                     │              ├── branch: 1
+                     │              │    ├── params: i:8
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_3":25
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 2
+                     │              │                        └── args
+                     │              │                             └── variable: i:8
+                     │              ├── branch: 2
+                     │              │    ├── params: i:9
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_4:10
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_4:10]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── concat
+                     │              │         │              │    ├── concat
+                     │              │         │              │    │    ├── const: 'i = '
+                     │              │         │              │    │    └── coalesce
+                     │              │         │              │    │         ├── cast: STRING
+                     │              │         │              │    │         │    └── variable: i:9
+                     │              │         │              │    │         └── const: '<NULL>'
+                     │              │         │              │    └── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_exec_5":24
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 3
+                     │              │                        └── args
+                     │              │                             └── variable: i:9
+                     │              ├── branch: 3
+                     │              │    ├── params: i:11
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_exec_ret_6":23
+                     │              │              ├── project
+                     │              │              │    ├── columns: i:22
+                     │              │              │    ├── right-join (cross)
+                     │              │              │    │    ├── columns: x:12
+                     │              │              │    │    ├── limit
+                     │              │              │    │    │    ├── columns: x:12!null
+                     │              │              │    │    │    ├── internal-ordering: -12
+                     │              │              │    │    │    ├── project
+                     │              │              │    │    │    │    ├── columns: x:12!null
+                     │              │              │    │    │    │    └── select
+                     │              │              │    │    │    │         ├── columns: x:12!null y:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+                     │              │              │    │    │    │         ├── scan xy
+                     │              │              │    │    │    │         │    └── columns: x:12 y:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
+                     │              │              │    │    │    │         └── filters
+                     │              │              │    │    │    │              └── lt
+                     │              │              │    │    │    │                   ├── variable: x:12
+                     │              │              │    │    │    │                   └── variable: i:11
+                     │              │              │    │    │    └── const: 1
+                     │              │              │    │    ├── values
+                     │              │              │    │    │    └── tuple
+                     │              │              │    │    └── filters (true)
+                     │              │              │    └── projections
+                     │              │              │         └── variable: x:12 [as=i:22]
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 4
+                     │              │                        └── args
+                     │              │                             └── variable: i:22
+                     │              ├── branch: 4
+                     │              │    ├── params: i:17
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_7":21
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 5
+                     │              │                        └── args
+                     │              │                             └── variable: i:17
+                     │              └── branch: 5
+                     │                   ├── params: i:18
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_8:19
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:19]
+                     │                        │              ├── const: 'NOTICE'
+                     │                        │              ├── concat
+                     │                        │              │    ├── concat
+                     │                        │              │    │    ├── const: 'i = '
+                     │                        │              │    │    └── coalesce
+                     │                        │              │    │         ├── cast: STRING
+                     │                        │              │    │         │    └── variable: i:18
+                     │                        │              │    │         └── const: '<NULL>'
+                     │                        │              │    └── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: '00000'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_9:20!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 0 [as=stmt_return_9:20]
                      └── const: 1
 
 # Testing OPEN statement.
@@ -4692,60 +5569,67 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:9
+ ├── columns: f:10
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:9]
+      └── udf: f [as=f:10]
            └── body
                 └── limit
-                     ├── columns: "_gen_cursor_name_3":8
+                     ├── columns: dispatcher_4:9
                      ├── project
-                     │    ├── columns: "_gen_cursor_name_3":8
-                     │    ├── barrier
-                     │    │    ├── columns: curs:1!null
-                     │    │    └── project
-                     │    │         ├── columns: curs:1!null
-                     │    │         ├── values
-                     │    │         │    └── tuple
-                     │    │         └── projections
-                     │    │              └── const: 'foo' [as=curs:1]
+                     │    ├── columns: dispatcher_4:9
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _gen_cursor_name_3 [as="_gen_cursor_name_3":8]
-                     │              ├── args
-                     │              │    └── variable: curs:1
-                     │              ├── params: curs:5
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: "_stmt_open_1":7
-                     │                        ├── barrier
-                     │                        │    ├── columns: curs:6
-                     │                        │    └── project
-                     │                        │         ├── columns: curs:6
-                     │                        │         ├── values
-                     │                        │         │    └── tuple
-                     │                        │         └── projections
-                     │                        │              └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:6]
-                     │                        │                   └── variable: curs:5
-                     │                        └── projections
-                     │                             └── udf: _stmt_open_1 [as="_stmt_open_1":7]
-                     │                                  ├── args
-                     │                                  │    └── variable: curs:6
-                     │                                  ├── params: curs:2
-                     │                                  └── body
-                     │                                       ├── open-cursor
-                     │                                       │    └── project
-                     │                                       │         ├── columns: "?column?":3!null
-                     │                                       │         ├── values
-                     │                                       │         │    └── tuple
-                     │                                       │         └── projections
-                     │                                       │              └── const: 1 [as="?column?":3]
-                     │                                       └── project
-                     │                                            ├── columns: stmt_return_2:4!null
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── const: 0 [as=stmt_return_2:4]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_gen_cursor_name_3":8
+                     │              │         ├── project
+                     │              │         │    ├── columns: curs:1!null
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── const: 'foo' [as=curs:1]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 1
+                     │              │                   └── args
+                     │              │                        └── variable: curs:1
+                     │              ├── branch: 0
+                     │              │    ├── params: curs:2
+                     │              │    └── body
+                     │              │         ├── open-cursor
+                     │              │         │    └── project
+                     │              │         │         ├── columns: "?column?":3!null
+                     │              │         │         ├── values
+                     │              │         │         │    └── tuple
+                     │              │         │         └── projections
+                     │              │         │              └── const: 1 [as="?column?":3]
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:4!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 0 [as=stmt_return_2:4]
+                     │              └── branch: 1
+                     │                   ├── params: curs:5
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: "_stmt_open_1":7
+                     │                             ├── project
+                     │                             │    ├── columns: curs:6
+                     │                             │    ├── values
+                     │                             │    │    └── tuple
+                     │                             │    └── projections
+                     │                             │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:6]
+                     │                             │              └── variable: curs:5
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 0
+                     │                                       └── args
+                     │                                            └── variable: curs:6
                      └── const: 1
 
 exec-ddl
@@ -4764,70 +5648,77 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:16
+ ├── columns: f:17
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:16]
+      └── udf: f [as=f:17]
            └── body
                 └── limit
-                     ├── columns: "_gen_cursor_name_3":15
+                     ├── columns: dispatcher_4:16
                      ├── project
-                     │    ├── columns: "_gen_cursor_name_3":15
-                     │    ├── barrier
-                     │    │    ├── columns: i:1!null curs:2!null
-                     │    │    └── project
-                     │    │         ├── columns: curs:2!null i:1!null
-                     │    │         ├── project
-                     │    │         │    ├── columns: i:1!null
-                     │    │         │    ├── values
-                     │    │         │    │    └── tuple
-                     │    │         │    └── projections
-                     │    │         │         └── const: 3 [as=i:1]
-                     │    │         └── projections
-                     │    │              └── const: 'foo' [as=curs:2]
+                     │    ├── columns: dispatcher_4:16
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _gen_cursor_name_3 [as="_gen_cursor_name_3":15]
-                     │              ├── args
-                     │              │    ├── variable: i:1
-                     │              │    └── variable: curs:2
-                     │              ├── params: i:11 curs:12
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: "_stmt_open_1":14
-                     │                        ├── barrier
-                     │                        │    ├── columns: curs:13
-                     │                        │    └── project
-                     │                        │         ├── columns: curs:13
-                     │                        │         ├── values
-                     │                        │         │    └── tuple
-                     │                        │         └── projections
-                     │                        │              └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:13]
-                     │                        │                   └── variable: curs:12
-                     │                        └── projections
-                     │                             └── udf: _stmt_open_1 [as="_stmt_open_1":14]
-                     │                                  ├── args
-                     │                                  │    ├── variable: i:11
-                     │                                  │    └── variable: curs:13
-                     │                                  ├── params: i:3 curs:4
-                     │                                  └── body
-                     │                                       ├── open-cursor
-                     │                                       │    └── project
-                     │                                       │         ├── columns: x:5!null y:6
-                     │                                       │         └── select
-                     │                                       │              ├── columns: x:5!null y:6 rowid:7!null crdb_internal_mvcc_timestamp:8 tableoid:9
-                     │                                       │              ├── scan xy
-                     │                                       │              │    └── columns: x:5 y:6 rowid:7!null crdb_internal_mvcc_timestamp:8 tableoid:9
-                     │                                       │              └── filters
-                     │                                       │                   └── eq
-                     │                                       │                        ├── variable: x:5
-                     │                                       │                        └── variable: i:3
-                     │                                       └── project
-                     │                                            ├── columns: stmt_return_2:10!null
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── const: 0 [as=stmt_return_2:10]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_gen_cursor_name_3":15
+                     │              │         ├── project
+                     │              │         │    ├── columns: curs:2!null i:1!null
+                     │              │         │    ├── project
+                     │              │         │    │    ├── columns: i:1!null
+                     │              │         │    │    ├── values
+                     │              │         │    │    │    └── tuple
+                     │              │         │    │    └── projections
+                     │              │         │    │         └── const: 3 [as=i:1]
+                     │              │         │    └── projections
+                     │              │         │         └── const: 'foo' [as=curs:2]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 1
+                     │              │                   └── args
+                     │              │                        ├── variable: i:1
+                     │              │                        └── variable: curs:2
+                     │              ├── branch: 0
+                     │              │    ├── params: i:3 curs:4
+                     │              │    └── body
+                     │              │         ├── open-cursor
+                     │              │         │    └── project
+                     │              │         │         ├── columns: x:5!null y:6
+                     │              │         │         └── select
+                     │              │         │              ├── columns: x:5!null y:6 rowid:7!null crdb_internal_mvcc_timestamp:8 tableoid:9
+                     │              │         │              ├── scan xy
+                     │              │         │              │    └── columns: x:5 y:6 rowid:7!null crdb_internal_mvcc_timestamp:8 tableoid:9
+                     │              │         │              └── filters
+                     │              │         │                   └── eq
+                     │              │         │                        ├── variable: x:5
+                     │              │         │                        └── variable: i:3
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:10!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 0 [as=stmt_return_2:10]
+                     │              └── branch: 1
+                     │                   ├── params: i:11 curs:12
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: "_stmt_open_1":14
+                     │                             ├── project
+                     │                             │    ├── columns: curs:13
+                     │                             │    ├── values
+                     │                             │    │    └── tuple
+                     │                             │    └── projections
+                     │                             │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:13]
+                     │                             │              └── variable: curs:12
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 0
+                     │                                       └── args
+                     │                                            ├── variable: i:11
+                     │                                            └── variable: curs:13
                      └── const: 1
 
 exec-ddl
@@ -4849,148 +5740,159 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:35
+ ├── columns: f:36
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:35]
+      └── udf: f [as=f:36]
            └── body
                 └── limit
-                     ├── columns: "_gen_cursor_name_7":34
+                     ├── columns: dispatcher_8:35
                      ├── project
-                     │    ├── columns: "_gen_cursor_name_7":34
-                     │    ├── barrier
-                     │    │    ├── columns: curs:1!null curs2:2!null curs3:3!null
-                     │    │    └── project
-                     │    │         ├── columns: curs3:3!null curs:1!null curs2:2!null
-                     │    │         ├── project
-                     │    │         │    ├── columns: curs2:2!null curs:1!null
-                     │    │         │    ├── project
-                     │    │         │    │    ├── columns: curs:1!null
-                     │    │         │    │    ├── values
-                     │    │         │    │    │    └── tuple
-                     │    │         │    │    └── projections
-                     │    │         │    │         └── const: 'foo' [as=curs:1]
-                     │    │         │    └── projections
-                     │    │         │         └── const: 'bar' [as=curs2:2]
-                     │    │         └── projections
-                     │    │              └── const: 'baz' [as=curs3:3]
+                     │    ├── columns: dispatcher_8:35
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _gen_cursor_name_7 [as="_gen_cursor_name_7":34]
-                     │              ├── args
-                     │              │    ├── variable: curs:1
-                     │              │    ├── variable: curs2:2
-                     │              │    └── variable: curs3:3
-                     │              ├── params: curs:29 curs2:30 curs3:31
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: "_stmt_open_1":33
-                     │                        ├── barrier
-                     │                        │    ├── columns: curs:32
-                     │                        │    └── project
-                     │                        │         ├── columns: curs:32
-                     │                        │         ├── values
-                     │                        │         │    └── tuple
-                     │                        │         └── projections
-                     │                        │              └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:32]
-                     │                        │                   └── variable: curs:29
-                     │                        └── projections
-                     │                             └── udf: _stmt_open_1 [as="_stmt_open_1":33]
-                     │                                  ├── args
-                     │                                  │    ├── variable: curs:32
-                     │                                  │    ├── variable: curs2:30
-                     │                                  │    └── variable: curs3:31
-                     │                                  ├── params: curs:4 curs2:5 curs3:6
-                     │                                  └── body
-                     │                                       ├── open-cursor
-                     │                                       │    └── project
-                     │                                       │         ├── columns: "?column?":7!null
-                     │                                       │         ├── values
-                     │                                       │         │    └── tuple
-                     │                                       │         └── projections
-                     │                                       │              └── const: 1 [as="?column?":7]
-                     │                                       └── project
-                     │                                            ├── columns: "_gen_cursor_name_6":28
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: _gen_cursor_name_6 [as="_gen_cursor_name_6":28]
-                     │                                                      ├── args
-                     │                                                      │    ├── variable: curs:4
-                     │                                                      │    ├── variable: curs2:5
-                     │                                                      │    └── variable: curs3:6
-                     │                                                      ├── params: curs:23 curs2:24 curs3:25
-                     │                                                      └── body
-                     │                                                           └── project
-                     │                                                                ├── columns: "_stmt_open_2":27
-                     │                                                                ├── barrier
-                     │                                                                │    ├── columns: curs2:26
-                     │                                                                │    └── project
-                     │                                                                │         ├── columns: curs2:26
-                     │                                                                │         ├── values
-                     │                                                                │         │    └── tuple
-                     │                                                                │         └── projections
-                     │                                                                │              └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs2:26]
-                     │                                                                │                   └── variable: curs2:24
-                     │                                                                └── projections
-                     │                                                                     └── udf: _stmt_open_2 [as="_stmt_open_2":27]
-                     │                                                                          ├── args
-                     │                                                                          │    ├── variable: curs:23
-                     │                                                                          │    ├── variable: curs2:26
-                     │                                                                          │    └── variable: curs3:25
-                     │                                                                          ├── params: curs:8 curs2:9 curs3:10
-                     │                                                                          └── body
-                     │                                                                               ├── open-cursor
-                     │                                                                               │    └── project
-                     │                                                                               │         ├── columns: "?column?":11!null
-                     │                                                                               │         ├── values
-                     │                                                                               │         │    └── tuple
-                     │                                                                               │         └── projections
-                     │                                                                               │              └── const: 2 [as="?column?":11]
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: "_gen_cursor_name_5":22
-                     │                                                                                    ├── values
-                     │                                                                                    │    └── tuple
-                     │                                                                                    └── projections
-                     │                                                                                         └── udf: _gen_cursor_name_5 [as="_gen_cursor_name_5":22]
-                     │                                                                                              ├── args
-                     │                                                                                              │    ├── variable: curs:8
-                     │                                                                                              │    ├── variable: curs2:9
-                     │                                                                                              │    └── variable: curs3:10
-                     │                                                                                              ├── params: curs:17 curs2:18 curs3:19
-                     │                                                                                              └── body
-                     │                                                                                                   └── project
-                     │                                                                                                        ├── columns: "_stmt_open_3":21
-                     │                                                                                                        ├── barrier
-                     │                                                                                                        │    ├── columns: curs3:20
-                     │                                                                                                        │    └── project
-                     │                                                                                                        │         ├── columns: curs3:20
-                     │                                                                                                        │         ├── values
-                     │                                                                                                        │         │    └── tuple
-                     │                                                                                                        │         └── projections
-                     │                                                                                                        │              └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs3:20]
-                     │                                                                                                        │                   └── variable: curs3:19
-                     │                                                                                                        └── projections
-                     │                                                                                                             └── udf: _stmt_open_3 [as="_stmt_open_3":21]
-                     │                                                                                                                  ├── args
-                     │                                                                                                                  │    ├── variable: curs:17
-                     │                                                                                                                  │    ├── variable: curs2:18
-                     │                                                                                                                  │    └── variable: curs3:20
-                     │                                                                                                                  ├── params: curs:12 curs2:13 curs3:14
-                     │                                                                                                                  └── body
-                     │                                                                                                                       ├── open-cursor
-                     │                                                                                                                       │    └── project
-                     │                                                                                                                       │         ├── columns: "?column?":15!null
-                     │                                                                                                                       │         ├── values
-                     │                                                                                                                       │         │    └── tuple
-                     │                                                                                                                       │         └── projections
-                     │                                                                                                                       │              └── const: 3 [as="?column?":15]
-                     │                                                                                                                       └── project
-                     │                                                                                                                            ├── columns: stmt_return_4:16!null
-                     │                                                                                                                            ├── values
-                     │                                                                                                                            │    └── tuple
-                     │                                                                                                                            └── projections
-                     │                                                                                                                                 └── const: 0 [as=stmt_return_4:16]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_gen_cursor_name_7":34
+                     │              │         ├── project
+                     │              │         │    ├── columns: curs3:3!null curs:1!null curs2:2!null
+                     │              │         │    ├── project
+                     │              │         │    │    ├── columns: curs2:2!null curs:1!null
+                     │              │         │    │    ├── project
+                     │              │         │    │    │    ├── columns: curs:1!null
+                     │              │         │    │    │    ├── values
+                     │              │         │    │    │    │    └── tuple
+                     │              │         │    │    │    └── projections
+                     │              │         │    │    │         └── const: 'foo' [as=curs:1]
+                     │              │         │    │    └── projections
+                     │              │         │    │         └── const: 'bar' [as=curs2:2]
+                     │              │         │    └── projections
+                     │              │         │         └── const: 'baz' [as=curs3:3]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 5
+                     │              │                   └── args
+                     │              │                        ├── variable: curs:1
+                     │              │                        ├── variable: curs2:2
+                     │              │                        └── variable: curs3:3
+                     │              ├── branch: 0
+                     │              │    ├── params: curs:4 curs2:5 curs3:6
+                     │              │    └── body
+                     │              │         ├── open-cursor
+                     │              │         │    └── project
+                     │              │         │         ├── columns: "?column?":7!null
+                     │              │         │         ├── values
+                     │              │         │         │    └── tuple
+                     │              │         │         └── projections
+                     │              │         │              └── const: 1 [as="?column?":7]
+                     │              │         └── project
+                     │              │              ├── columns: "_gen_cursor_name_6":28
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 4
+                     │              │                        └── args
+                     │              │                             ├── variable: curs:4
+                     │              │                             ├── variable: curs2:5
+                     │              │                             └── variable: curs3:6
+                     │              ├── branch: 1
+                     │              │    ├── params: curs:8 curs2:9 curs3:10
+                     │              │    └── body
+                     │              │         ├── open-cursor
+                     │              │         │    └── project
+                     │              │         │         ├── columns: "?column?":11!null
+                     │              │         │         ├── values
+                     │              │         │         │    └── tuple
+                     │              │         │         └── projections
+                     │              │         │              └── const: 2 [as="?column?":11]
+                     │              │         └── project
+                     │              │              ├── columns: "_gen_cursor_name_5":22
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 3
+                     │              │                        └── args
+                     │              │                             ├── variable: curs:8
+                     │              │                             ├── variable: curs2:9
+                     │              │                             └── variable: curs3:10
+                     │              ├── branch: 2
+                     │              │    ├── params: curs:12 curs2:13 curs3:14
+                     │              │    └── body
+                     │              │         ├── open-cursor
+                     │              │         │    └── project
+                     │              │         │         ├── columns: "?column?":15!null
+                     │              │         │         ├── values
+                     │              │         │         │    └── tuple
+                     │              │         │         └── projections
+                     │              │         │              └── const: 3 [as="?column?":15]
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_4:16!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 0 [as=stmt_return_4:16]
+                     │              ├── branch: 3
+                     │              │    ├── params: curs:17 curs2:18 curs3:19
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_open_3":21
+                     │              │              ├── project
+                     │              │              │    ├── columns: curs3:20
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs3:20]
+                     │              │              │              └── variable: curs3:19
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 2
+                     │              │                        └── args
+                     │              │                             ├── variable: curs:17
+                     │              │                             ├── variable: curs2:18
+                     │              │                             └── variable: curs3:20
+                     │              ├── branch: 4
+                     │              │    ├── params: curs:23 curs2:24 curs3:25
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_open_2":27
+                     │              │              ├── project
+                     │              │              │    ├── columns: curs2:26
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs2:26]
+                     │              │              │              └── variable: curs2:24
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             ├── variable: curs:23
+                     │              │                             ├── variable: curs2:26
+                     │              │                             └── variable: curs3:25
+                     │              └── branch: 5
+                     │                   ├── params: curs:29 curs2:30 curs3:31
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: "_stmt_open_1":33
+                     │                             ├── project
+                     │                             │    ├── columns: curs:32
+                     │                             │    ├── values
+                     │                             │    │    └── tuple
+                     │                             │    └── projections
+                     │                             │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:32]
+                     │                             │              └── variable: curs:29
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 0
+                     │                                       └── args
+                     │                                            ├── variable: curs:32
+                     │                                            ├── variable: curs2:30
+                     │                                            └── variable: curs3:31
                      └── const: 1
 
 # Testing CLOSE statement.
@@ -5010,14 +5912,14 @@ build format=show-all
 SELECT f();
 ----
 project
- ├── columns: f:12(int)
+ ├── columns: f:13(int)
  ├── cardinality: [1 - 1]
  ├── volatile
  ├── stats: [rows=1]
  ├── cost: 0.05
  ├── key: ()
- ├── fd: ()-->(12)
- ├── prune: (12)
+ ├── fd: ()-->(13)
+ ├── prune: (13)
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── stats: [rows=1]
@@ -5025,147 +5927,152 @@ project
  │    ├── key: ()
  │    └── tuple [type=tuple]
  └── projections
-      └── udf: f [as=f:12, type=int, volatile, udf]
+      └── udf: f [as=f:13, type=int, volatile, udf]
            └── body
                 └── limit
-                     ├── columns: "_gen_cursor_name_5":11(int)
+                     ├── columns: dispatcher_6:12(int)
                      ├── cardinality: [1 - 1]
-                     ├── volatile
                      ├── stats: [rows=1]
                      ├── key: ()
-                     ├── fd: ()-->(11)
+                     ├── fd: ()-->(12)
                      ├── project
-                     │    ├── columns: "_gen_cursor_name_5":11(int)
+                     │    ├── columns: dispatcher_6:12(int)
                      │    ├── cardinality: [1 - 1]
-                     │    ├── volatile
                      │    ├── stats: [rows=1]
                      │    ├── key: ()
-                     │    ├── fd: ()-->(11)
-                     │    ├── barrier
-                     │    │    ├── columns: curs:1(refcursor!null)
+                     │    ├── fd: ()-->(12)
+                     │    ├── values
                      │    │    ├── cardinality: [1 - 1]
                      │    │    ├── stats: [rows=1]
                      │    │    ├── key: ()
-                     │    │    ├── fd: ()-->(1)
-                     │    │    └── project
-                     │    │         ├── columns: curs:1(refcursor!null)
-                     │    │         ├── cardinality: [1 - 1]
-                     │    │         ├── stats: [rows=1]
-                     │    │         ├── key: ()
-                     │    │         ├── fd: ()-->(1)
-                     │    │         ├── values
-                     │    │         │    ├── cardinality: [1 - 1]
-                     │    │         │    ├── stats: [rows=1]
-                     │    │         │    ├── key: ()
-                     │    │         │    └── tuple [type=tuple]
-                     │    │         └── projections
-                     │    │              └── const: 'foo' [as=curs:1, type=refcursor]
+                     │    │    └── tuple [type=tuple]
                      │    └── projections
-                     │         └── udf: _gen_cursor_name_5 [as="_gen_cursor_name_5":11, type=int, outer=(1), volatile, udf]
-                     │              ├── args
-                     │              │    └── variable: curs:1 [type=refcursor]
-                     │              ├── params: curs:8(refcursor)
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: "_stmt_open_1":10(int)
-                     │                        ├── outer: (8)
-                     │                        ├── cardinality: [1 - 1]
-                     │                        ├── volatile
-                     │                        ├── stats: [rows=1]
-                     │                        ├── key: ()
-                     │                        ├── fd: ()-->(10)
-                     │                        ├── barrier
-                     │                        │    ├── columns: curs:9(refcursor)
-                     │                        │    ├── outer: (8)
-                     │                        │    ├── cardinality: [1 - 1]
-                     │                        │    ├── volatile
-                     │                        │    ├── stats: [rows=1]
-                     │                        │    ├── key: ()
-                     │                        │    ├── fd: ()-->(9)
-                     │                        │    └── project
-                     │                        │         ├── columns: curs:9(refcursor)
-                     │                        │         ├── outer: (8)
-                     │                        │         ├── cardinality: [1 - 1]
-                     │                        │         ├── volatile
-                     │                        │         ├── stats: [rows=1]
-                     │                        │         ├── key: ()
-                     │                        │         ├── fd: ()-->(9)
-                     │                        │         ├── values
-                     │                        │         │    ├── cardinality: [1 - 1]
-                     │                        │         │    ├── stats: [rows=1]
-                     │                        │         │    ├── key: ()
-                     │                        │         │    └── tuple [type=tuple]
-                     │                        │         └── projections
-                     │                        │              └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:9, type=refcursor, outer=(8), volatile]
-                     │                        │                   └── variable: curs:8 [type=refcursor]
-                     │                        └── projections
-                     │                             └── udf: _stmt_open_1 [as="_stmt_open_1":10, type=int, outer=(9), volatile, udf]
-                     │                                  ├── args
-                     │                                  │    └── variable: curs:9 [type=refcursor]
-                     │                                  ├── params: curs:2(refcursor)
-                     │                                  └── body
-                     │                                       ├── open-cursor
-                     │                                       │    └── project
-                     │                                       │         ├── columns: "?column?":3(int!null)
-                     │                                       │         ├── cardinality: [1 - 1]
-                     │                                       │         ├── stats: [rows=1]
-                     │                                       │         ├── key: ()
-                     │                                       │         ├── fd: ()-->(3)
-                     │                                       │         ├── values
-                     │                                       │         │    ├── cardinality: [1 - 1]
-                     │                                       │         │    ├── stats: [rows=1]
-                     │                                       │         │    ├── key: ()
-                     │                                       │         │    └── tuple [type=tuple]
-                     │                                       │         └── projections
-                     │                                       │              └── const: 1 [as="?column?":3, type=int]
-                     │                                       └── project
-                     │                                            ├── columns: "_stmt_close_2":7(int)
-                     │                                            ├── outer: (2)
-                     │                                            ├── cardinality: [1 - 1]
-                     │                                            ├── volatile
-                     │                                            ├── stats: [rows=1]
-                     │                                            ├── key: ()
-                     │                                            ├── fd: ()-->(7)
-                     │                                            ├── values
-                     │                                            │    ├── cardinality: [1 - 1]
-                     │                                            │    ├── stats: [rows=1]
-                     │                                            │    ├── key: ()
-                     │                                            │    └── tuple [type=tuple]
-                     │                                            └── projections
-                     │                                                 └── udf: _stmt_close_2 [as="_stmt_close_2":7, type=int, outer=(2), volatile, udf]
-                     │                                                      ├── args
-                     │                                                      │    └── variable: curs:2 [type=refcursor]
-                     │                                                      ├── params: curs:4(refcursor)
-                     │                                                      └── body
-                     │                                                           ├── project
-                     │                                                           │    ├── columns: stmt_close_3:5(int)
-                     │                                                           │    ├── outer: (4)
-                     │                                                           │    ├── cardinality: [1 - 1]
-                     │                                                           │    ├── volatile
-                     │                                                           │    ├── stats: [rows=1]
-                     │                                                           │    ├── key: ()
-                     │                                                           │    ├── fd: ()-->(5)
-                     │                                                           │    ├── values
-                     │                                                           │    │    ├── cardinality: [1 - 1]
-                     │                                                           │    │    ├── stats: [rows=1]
-                     │                                                           │    │    ├── key: ()
-                     │                                                           │    │    └── tuple [type=tuple]
-                     │                                                           │    └── projections
-                     │                                                           │         └── function: crdb_internal.plpgsql_close [as=stmt_close_3:5, type=int, outer=(4), volatile]
-                     │                                                           │              └── variable: curs:4 [type=refcursor]
-                     │                                                           └── project
-                     │                                                                ├── columns: stmt_return_4:6(int!null)
-                     │                                                                ├── cardinality: [1 - 1]
-                     │                                                                ├── stats: [rows=1]
-                     │                                                                ├── key: ()
-                     │                                                                ├── fd: ()-->(6)
-                     │                                                                ├── values
-                     │                                                                │    ├── cardinality: [1 - 1]
-                     │                                                                │    ├── stats: [rows=1]
-                     │                                                                │    ├── key: ()
-                     │                                                                │    └── tuple [type=tuple]
-                     │                                                                └── projections
-                     │                                                                     └── const: 0 [as=stmt_return_4:6, type=int]
+                     │         └── dispatcher
+                     │              ├── subquery [type=int]
+                     │              │    └── project
+                     │              │         ├── columns: "_gen_cursor_name_5":11(int)
+                     │              │         ├── cardinality: [1 - 1]
+                     │              │         ├── stats: [rows=1]
+                     │              │         ├── key: ()
+                     │              │         ├── fd: ()-->(11)
+                     │              │         ├── project
+                     │              │         │    ├── columns: curs:1(refcursor!null)
+                     │              │         │    ├── cardinality: [1 - 1]
+                     │              │         │    ├── stats: [rows=1]
+                     │              │         │    ├── key: ()
+                     │              │         │    ├── fd: ()-->(1)
+                     │              │         │    ├── prune: (1)
+                     │              │         │    ├── values
+                     │              │         │    │    ├── cardinality: [1 - 1]
+                     │              │         │    │    ├── stats: [rows=1]
+                     │              │         │    │    ├── key: ()
+                     │              │         │    │    └── tuple [type=tuple]
+                     │              │         │    └── projections
+                     │              │         │         └── const: 'foo' [as=curs:1, type=refcursor]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 2
+                     │              │                   └── args
+                     │              │                        └── variable: curs:1 [type=refcursor]
+                     │              ├── branch: 0
+                     │              │    ├── params: curs:2(refcursor)
+                     │              │    └── body
+                     │              │         ├── open-cursor
+                     │              │         │    └── project
+                     │              │         │         ├── columns: "?column?":3(int!null)
+                     │              │         │         ├── cardinality: [1 - 1]
+                     │              │         │         ├── stats: [rows=1]
+                     │              │         │         ├── key: ()
+                     │              │         │         ├── fd: ()-->(3)
+                     │              │         │         ├── values
+                     │              │         │         │    ├── cardinality: [1 - 1]
+                     │              │         │         │    ├── stats: [rows=1]
+                     │              │         │         │    ├── key: ()
+                     │              │         │         │    └── tuple [type=tuple]
+                     │              │         │         └── projections
+                     │              │         │              └── const: 1 [as="?column?":3, type=int]
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_close_2":7(int)
+                     │              │              ├── outer: (2)
+                     │              │              ├── cardinality: [1 - 1]
+                     │              │              ├── stats: [rows=1]
+                     │              │              ├── key: ()
+                     │              │              ├── fd: ()-->(7)
+                     │              │              ├── values
+                     │              │              │    ├── cardinality: [1 - 1]
+                     │              │              │    ├── stats: [rows=1]
+                     │              │              │    ├── key: ()
+                     │              │              │    └── tuple [type=tuple]
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             └── variable: curs:2 [type=refcursor]
+                     │              ├── branch: 1
+                     │              │    ├── params: curs:4(refcursor)
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_close_3:5(int)
+                     │              │         │    ├── outer: (4)
+                     │              │         │    ├── cardinality: [1 - 1]
+                     │              │         │    ├── volatile
+                     │              │         │    ├── stats: [rows=1]
+                     │              │         │    ├── key: ()
+                     │              │         │    ├── fd: ()-->(5)
+                     │              │         │    ├── values
+                     │              │         │    │    ├── cardinality: [1 - 1]
+                     │              │         │    │    ├── stats: [rows=1]
+                     │              │         │    │    ├── key: ()
+                     │              │         │    │    └── tuple [type=tuple]
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_close [as=stmt_close_3:5, type=int, outer=(4), volatile]
+                     │              │         │              └── variable: curs:4 [type=refcursor]
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_4:6(int!null)
+                     │              │              ├── cardinality: [1 - 1]
+                     │              │              ├── stats: [rows=1]
+                     │              │              ├── key: ()
+                     │              │              ├── fd: ()-->(6)
+                     │              │              ├── values
+                     │              │              │    ├── cardinality: [1 - 1]
+                     │              │              │    ├── stats: [rows=1]
+                     │              │              │    ├── key: ()
+                     │              │              │    └── tuple [type=tuple]
+                     │              │              └── projections
+                     │              │                   └── const: 0 [as=stmt_return_4:6, type=int]
+                     │              └── branch: 2
+                     │                   ├── params: curs:8(refcursor)
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: "_stmt_open_1":10(int)
+                     │                             ├── outer: (8)
+                     │                             ├── cardinality: [1 - 1]
+                     │                             ├── volatile
+                     │                             ├── stats: [rows=1]
+                     │                             ├── key: ()
+                     │                             ├── fd: ()-->(10)
+                     │                             ├── project
+                     │                             │    ├── columns: curs:9(refcursor)
+                     │                             │    ├── outer: (8)
+                     │                             │    ├── cardinality: [1 - 1]
+                     │                             │    ├── volatile
+                     │                             │    ├── stats: [rows=1]
+                     │                             │    ├── key: ()
+                     │                             │    ├── fd: ()-->(9)
+                     │                             │    ├── prune: (9)
+                     │                             │    ├── values
+                     │                             │    │    ├── cardinality: [1 - 1]
+                     │                             │    │    ├── stats: [rows=1]
+                     │                             │    │    ├── key: ()
+                     │                             │    │    └── tuple [type=tuple]
+                     │                             │    └── projections
+                     │                             │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:9, type=refcursor, outer=(8), volatile]
+                     │                             │              └── variable: curs:8 [type=refcursor]
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 0
+                     │                                       └── args
+                     │                                            └── variable: curs:9 [type=refcursor]
                      └── const: 1 [type=int]
 
 # Combined exception block and cursors.
@@ -5188,114 +6095,137 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:19
+ ├── columns: f:20
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:19]
+      └── udf: f [as=f:20]
            └── body
                 └── limit
-                     ├── columns: exception_block_5:18
+                     ├── columns: dispatcher_9:19
                      ├── project
-                     │    ├── columns: exception_block_5:18
-                     │    ├── barrier
-                     │    │    ├── columns: curs:1!null
-                     │    │    └── project
-                     │    │         ├── columns: curs:1!null
-                     │    │         ├── values
-                     │    │         │    └── tuple
-                     │    │         └── projections
-                     │    │              └── const: 'foo' [as=curs:1]
+                     │    ├── columns: dispatcher_9:19
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: exception_block_5 [as=exception_block_5:18]
-                     │              ├── args
-                     │              │    └── variable: curs:1
-                     │              ├── params: curs:10
-                     │              ├── body
+                     │         └── dispatcher
+                     │              ├── subquery
                      │              │    └── project
-                     │              │         ├── columns: "_gen_cursor_name_8":17
-                     │              │         ├── values
-                     │              │         │    └── tuple
+                     │              │         ├── columns: exception_block_5:18
+                     │              │         ├── project
+                     │              │         │    ├── columns: curs:1!null
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── const: 'foo' [as=curs:1]
                      │              │         └── projections
-                     │              │              └── udf: _gen_cursor_name_8 [as="_gen_cursor_name_8":17]
-                     │              │                   ├── args
-                     │              │                   │    └── variable: curs:10
-                     │              │                   ├── params: curs:14
-                     │              │                   └── body
-                     │              │                        └── project
-                     │              │                             ├── columns: "_stmt_open_6":16
-                     │              │                             ├── barrier
-                     │              │                             │    ├── columns: curs:15
-                     │              │                             │    └── project
-                     │              │                             │         ├── columns: curs:15
-                     │              │                             │         ├── values
-                     │              │                             │         │    └── tuple
-                     │              │                             │         └── projections
-                     │              │                             │              └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:15]
-                     │              │                             │                   └── variable: curs:14
-                     │              │                             └── projections
-                     │              │                                  └── udf: _stmt_open_6 [as="_stmt_open_6":16]
-                     │              │                                       ├── args
-                     │              │                                       │    └── variable: curs:15
-                     │              │                                       ├── params: curs:11
-                     │              │                                       └── body
-                     │              │                                            ├── open-cursor
-                     │              │                                            │    └── project
-                     │              │                                            │         ├── columns: "?column?":12!null
-                     │              │                                            │         ├── values
-                     │              │                                            │         │    └── tuple
-                     │              │                                            │         └── projections
-                     │              │                                            │              └── const: 1 [as="?column?":12]
-                     │              │                                            └── project
-                     │              │                                                 ├── columns: stmt_return_7:13!null
-                     │              │                                                 ├── values
-                     │              │                                                 │    └── tuple
-                     │              │                                                 └── projections
-                     │              │                                                      └── floor-div [as=stmt_return_7:13]
-                     │              │                                                           ├── const: 1
-                     │              │                                                           └── const: 0
-                     │              └── exception-handler
-                     │                   └── SQLSTATE '22012'
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 3
+                     │              │                   └── args
+                     │              │                        └── variable: curs:1
+                     │              ├── branch: 0
+                     │              │    ├── params: curs:2
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_gen_cursor_name_4":9
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 2
+                     │              │                        └── args
+                     │              │                             └── variable: curs:2
+                     │              ├── branch: 1
+                     │              │    ├── params: curs:3
+                     │              │    └── body
+                     │              │         ├── open-cursor
+                     │              │         │    └── project
+                     │              │         │         ├── columns: "?column?":4!null
+                     │              │         │         ├── values
+                     │              │         │         │    └── tuple
+                     │              │         │         └── projections
+                     │              │         │              └── const: 2 [as="?column?":4]
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_3:5!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: -1 [as=stmt_return_3:5]
+                     │              ├── branch: 2
+                     │              │    ├── params: curs:6
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_open_2":8
+                     │              │              ├── project
+                     │              │              │    ├── columns: curs:7
+                     │              │              │    ├── values
+                     │              │              │    │    └── tuple
+                     │              │              │    └── projections
+                     │              │              │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:7]
+                     │              │              │              └── variable: curs:6
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             └── variable: curs:7
+                     │              ├── branch: 3
+                     │              │    ├── params: curs:10
+                     │              │    ├── body
+                     │              │    │    └── project
+                     │              │    │         ├── columns: "_gen_cursor_name_8":17
+                     │              │    │         ├── values
+                     │              │    │         │    └── tuple
+                     │              │    │         └── projections
+                     │              │    │              └── dispatch: 1
+                     │              │    │                   ├── branch: 5
+                     │              │    │                   └── args
+                     │              │    │                        └── variable: curs:10
+                     │              │    └── exception-handler
+                     │              │         └── SQLSTATE '22012'
+                     │              │              └── project
+                     │              │                   ├── columns: "_gen_cursor_name_4":9
+                     │              │                   ├── values
+                     │              │                   │    └── tuple
+                     │              │                   └── projections
+                     │              │                        └── dispatch: 1
+                     │              │                             ├── branch: 2
+                     │              │                             └── args
+                     │              │                                  └── variable: curs:2
+                     │              ├── branch: 4
+                     │              │    ├── params: curs:11
+                     │              │    └── body
+                     │              │         ├── open-cursor
+                     │              │         │    └── project
+                     │              │         │         ├── columns: "?column?":12!null
+                     │              │         │         ├── values
+                     │              │         │         │    └── tuple
+                     │              │         │         └── projections
+                     │              │         │              └── const: 1 [as="?column?":12]
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_7:13!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── floor-div [as=stmt_return_7:13]
+                     │              │                        ├── const: 1
+                     │              │                        └── const: 0
+                     │              └── branch: 5
+                     │                   ├── params: curs:14
+                     │                   └── body
                      │                        └── project
-                     │                             ├── columns: "_gen_cursor_name_4":9
-                     │                             ├── values
-                     │                             │    └── tuple
+                     │                             ├── columns: "_stmt_open_6":16
+                     │                             ├── project
+                     │                             │    ├── columns: curs:15
+                     │                             │    ├── values
+                     │                             │    │    └── tuple
+                     │                             │    └── projections
+                     │                             │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:15]
+                     │                             │              └── variable: curs:14
                      │                             └── projections
-                     │                                  └── udf: _gen_cursor_name_4 [as="_gen_cursor_name_4":9]
-                     │                                       ├── args
-                     │                                       │    └── variable: curs:2
-                     │                                       ├── params: curs:6
-                     │                                       └── body
-                     │                                            └── project
-                     │                                                 ├── columns: "_stmt_open_2":8
-                     │                                                 ├── barrier
-                     │                                                 │    ├── columns: curs:7
-                     │                                                 │    └── project
-                     │                                                 │         ├── columns: curs:7
-                     │                                                 │         ├── values
-                     │                                                 │         │    └── tuple
-                     │                                                 │         └── projections
-                     │                                                 │              └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:7]
-                     │                                                 │                   └── variable: curs:6
-                     │                                                 └── projections
-                     │                                                      └── udf: _stmt_open_2 [as="_stmt_open_2":8]
-                     │                                                           ├── args
-                     │                                                           │    └── variable: curs:7
-                     │                                                           ├── params: curs:3
-                     │                                                           └── body
-                     │                                                                ├── open-cursor
-                     │                                                                │    └── project
-                     │                                                                │         ├── columns: "?column?":4!null
-                     │                                                                │         ├── values
-                     │                                                                │         │    └── tuple
-                     │                                                                │         └── projections
-                     │                                                                │              └── const: 2 [as="?column?":4]
-                     │                                                                └── project
-                     │                                                                     ├── columns: stmt_return_3:5!null
-                     │                                                                     ├── values
-                     │                                                                     │    └── tuple
-                     │                                                                     └── projections
-                     │                                                                          └── const: -1 [as=stmt_return_3:5]
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 4
+                     │                                       └── args
+                     │                                            └── variable: curs:15
                      └── const: 1
 
 # Testing FETCH/MOVE.
@@ -5316,14 +6246,14 @@ build format=show-all
 SELECT f();
 ----
 project
- ├── columns: f:24(int)
+ ├── columns: f:25(int)
  ├── cardinality: [1 - 1]
  ├── volatile
  ├── stats: [rows=1]
  ├── cost: 0.05
  ├── key: ()
- ├── fd: ()-->(24)
- ├── prune: (24)
+ ├── fd: ()-->(25)
+ ├── prune: (25)
  ├── values
  │    ├── cardinality: [1 - 1]
  │    ├── stats: [rows=1]
@@ -5331,191 +6261,200 @@ project
  │    ├── key: ()
  │    └── tuple [type=tuple]
  └── projections
-      └── udf: f [as=f:24, type=int, volatile, udf]
+      └── udf: f [as=f:25, type=int, volatile, udf]
            └── body
                 └── limit
-                     ├── columns: "_gen_cursor_name_6":23(int)
+                     ├── columns: dispatcher_7:24(int)
                      ├── cardinality: [1 - 1]
-                     ├── volatile
+                     ├── immutable
                      ├── stats: [rows=1]
                      ├── key: ()
-                     ├── fd: ()-->(23)
+                     ├── fd: ()-->(24)
                      ├── project
-                     │    ├── columns: "_gen_cursor_name_6":23(int)
+                     │    ├── columns: dispatcher_7:24(int)
                      │    ├── cardinality: [1 - 1]
-                     │    ├── volatile
+                     │    ├── immutable
                      │    ├── stats: [rows=1]
                      │    ├── key: ()
-                     │    ├── fd: ()-->(23)
-                     │    ├── barrier
-                     │    │    ├── columns: curs:1(refcursor!null) x:2(int)
+                     │    ├── fd: ()-->(24)
+                     │    ├── values
                      │    │    ├── cardinality: [1 - 1]
-                     │    │    ├── immutable
                      │    │    ├── stats: [rows=1]
                      │    │    ├── key: ()
-                     │    │    ├── fd: ()-->(1,2)
-                     │    │    └── project
-                     │    │         ├── columns: x:2(int) curs:1(refcursor!null)
-                     │    │         ├── cardinality: [1 - 1]
-                     │    │         ├── immutable
-                     │    │         ├── stats: [rows=1]
-                     │    │         ├── key: ()
-                     │    │         ├── fd: ()-->(1,2)
-                     │    │         ├── project
-                     │    │         │    ├── columns: curs:1(refcursor!null)
-                     │    │         │    ├── cardinality: [1 - 1]
-                     │    │         │    ├── stats: [rows=1]
-                     │    │         │    ├── key: ()
-                     │    │         │    ├── fd: ()-->(1)
-                     │    │         │    ├── prune: (1)
-                     │    │         │    ├── values
-                     │    │         │    │    ├── cardinality: [1 - 1]
-                     │    │         │    │    ├── stats: [rows=1]
-                     │    │         │    │    ├── key: ()
-                     │    │         │    │    └── tuple [type=tuple]
-                     │    │         │    └── projections
-                     │    │         │         └── const: 'foo' [as=curs:1, type=refcursor]
-                     │    │         └── projections
-                     │    │              └── cast: INT8 [as=x:2, type=int, immutable]
-                     │    │                   └── null [type=unknown]
+                     │    │    └── tuple [type=tuple]
                      │    └── projections
-                     │         └── udf: _gen_cursor_name_6 [as="_gen_cursor_name_6":23, type=int, outer=(1,2), volatile, udf]
-                     │              ├── args
-                     │              │    ├── variable: curs:1 [type=refcursor]
-                     │              │    └── variable: x:2 [type=int]
-                     │              ├── params: curs:19(refcursor) x:20(int)
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: "_stmt_open_1":22(int)
-                     │                        ├── outer: (19,20)
-                     │                        ├── cardinality: [1 - 1]
-                     │                        ├── volatile
-                     │                        ├── stats: [rows=1]
-                     │                        ├── key: ()
-                     │                        ├── fd: ()-->(22)
-                     │                        ├── barrier
-                     │                        │    ├── columns: curs:21(refcursor)
-                     │                        │    ├── outer: (19)
-                     │                        │    ├── cardinality: [1 - 1]
-                     │                        │    ├── volatile
-                     │                        │    ├── stats: [rows=1]
-                     │                        │    ├── key: ()
-                     │                        │    ├── fd: ()-->(21)
-                     │                        │    └── project
-                     │                        │         ├── columns: curs:21(refcursor)
-                     │                        │         ├── outer: (19)
-                     │                        │         ├── cardinality: [1 - 1]
-                     │                        │         ├── volatile
-                     │                        │         ├── stats: [rows=1]
-                     │                        │         ├── key: ()
-                     │                        │         ├── fd: ()-->(21)
-                     │                        │         ├── values
-                     │                        │         │    ├── cardinality: [1 - 1]
-                     │                        │         │    ├── stats: [rows=1]
-                     │                        │         │    ├── key: ()
-                     │                        │         │    └── tuple [type=tuple]
-                     │                        │         └── projections
-                     │                        │              └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:21, type=refcursor, outer=(19), volatile]
-                     │                        │                   └── variable: curs:19 [type=refcursor]
-                     │                        └── projections
-                     │                             └── udf: _stmt_open_1 [as="_stmt_open_1":22, type=int, outer=(20,21), volatile, udf]
-                     │                                  ├── args
-                     │                                  │    ├── variable: curs:21 [type=refcursor]
-                     │                                  │    └── variable: x:20 [type=int]
-                     │                                  ├── params: curs:3(refcursor) x:4(int)
-                     │                                  └── body
-                     │                                       ├── open-cursor
-                     │                                       │    └── project
-                     │                                       │         ├── columns: t.public.xy.x:5(int) t.public.xy.y:6(int)
-                     │                                       │         ├── stats: [rows=1000]
-                     │                                       │         └── scan t.public.xy
-                     │                                       │              ├── columns: t.public.xy.x:5(int) t.public.xy.y:6(int) t.public.xy.rowid:7(int!null) t.public.xy.crdb_internal_mvcc_timestamp:8(decimal) t.public.xy.tableoid:9(oid)
-                     │                                       │              ├── stats: [rows=1000]
-                     │                                       │              ├── key: (7)
-                     │                                       │              ├── fd: (7)-->(5,6,8,9)
-                     │                                       │              └── prune: (5-9)
-                     │                                       └── project
-                     │                                            ├── columns: "_stmt_fetch_2":18(int)
-                     │                                            ├── outer: (3,4)
-                     │                                            ├── cardinality: [1 - 1]
-                     │                                            ├── volatile
-                     │                                            ├── stats: [rows=1]
-                     │                                            ├── key: ()
-                     │                                            ├── fd: ()-->(18)
-                     │                                            ├── values
-                     │                                            │    ├── cardinality: [1 - 1]
-                     │                                            │    ├── stats: [rows=1]
-                     │                                            │    ├── key: ()
-                     │                                            │    └── tuple [type=tuple]
-                     │                                            └── projections
-                     │                                                 └── udf: _stmt_fetch_2 [as="_stmt_fetch_2":18, type=int, outer=(3,4), volatile, udf]
-                     │                                                      ├── args
-                     │                                                      │    ├── variable: curs:3 [type=refcursor]
-                     │                                                      │    └── variable: x:4 [type=int]
-                     │                                                      ├── params: curs:10(refcursor) x:11(int)
-                     │                                                      └── body
-                     │                                                           └── project
-                     │                                                                ├── columns: "_stmt_exec_ret_4":17(int)
-                     │                                                                ├── outer: (10)
-                     │                                                                ├── cardinality: [1 - 1]
-                     │                                                                ├── volatile
-                     │                                                                ├── stats: [rows=1]
-                     │                                                                ├── key: ()
-                     │                                                                ├── fd: ()-->(17)
-                     │                                                                ├── project
-                     │                                                                │    ├── columns: x:13(int)
-                     │                                                                │    ├── outer: (10)
-                     │                                                                │    ├── cardinality: [1 - 1]
-                     │                                                                │    ├── volatile
-                     │                                                                │    ├── stats: [rows=1]
-                     │                                                                │    ├── key: ()
-                     │                                                                │    ├── fd: ()-->(13)
-                     │                                                                │    ├── prune: (13)
-                     │                                                                │    ├── project
-                     │                                                                │    │    ├── columns: stmt_fetch_3:12(tuple{int})
-                     │                                                                │    │    ├── outer: (10)
-                     │                                                                │    │    ├── cardinality: [1 - 1]
-                     │                                                                │    │    ├── volatile
-                     │                                                                │    │    ├── stats: [rows=1]
-                     │                                                                │    │    ├── key: ()
-                     │                                                                │    │    ├── fd: ()-->(12)
-                     │                                                                │    │    ├── prune: (12)
-                     │                                                                │    │    ├── values
-                     │                                                                │    │    │    ├── cardinality: [1 - 1]
-                     │                                                                │    │    │    ├── stats: [rows=1]
-                     │                                                                │    │    │    ├── key: ()
-                     │                                                                │    │    │    └── tuple [type=tuple]
-                     │                                                                │    │    └── projections
-                     │                                                                │    │         └── function: crdb_internal.plpgsql_fetch [as=stmt_fetch_3:12, type=tuple{int}, outer=(10), volatile]
-                     │                                                                │    │              ├── variable: curs:10 [type=refcursor]
-                     │                                                                │    │              ├── const: 0 [type=int]
-                     │                                                                │    │              ├── const: 1 [type=int]
-                     │                                                                │    │              └── tuple [type=tuple{int}]
-                     │                                                                │    │                   └── null [type=int]
-                     │                                                                │    └── projections
-                     │                                                                │         └── column-access: 0 [as=x:13, type=int, outer=(12)]
-                     │                                                                │              └── variable: stmt_fetch_3:12 [type=tuple{int}]
-                     │                                                                └── projections
-                     │                                                                     └── udf: _stmt_exec_ret_4 [as="_stmt_exec_ret_4":17, type=int, outer=(10,13), udf]
-                     │                                                                          ├── args
-                     │                                                                          │    ├── variable: curs:10 [type=refcursor]
-                     │                                                                          │    └── variable: x:13 [type=int]
-                     │                                                                          ├── params: curs:14(refcursor) x:15(int)
-                     │                                                                          └── body
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: stmt_return_5:16(int)
-                     │                                                                                    ├── outer: (15)
-                     │                                                                                    ├── cardinality: [1 - 1]
-                     │                                                                                    ├── stats: [rows=1]
-                     │                                                                                    ├── key: ()
-                     │                                                                                    ├── fd: ()-->(16)
-                     │                                                                                    ├── values
-                     │                                                                                    │    ├── cardinality: [1 - 1]
-                     │                                                                                    │    ├── stats: [rows=1]
-                     │                                                                                    │    ├── key: ()
-                     │                                                                                    │    └── tuple [type=tuple]
-                     │                                                                                    └── projections
-                     │                                                                                         └── variable: x:15 [as=stmt_return_5:16, type=int, outer=(15)]
+                     │         └── dispatcher
+                     │              ├── subquery [type=int]
+                     │              │    └── project
+                     │              │         ├── columns: "_gen_cursor_name_6":23(int)
+                     │              │         ├── cardinality: [1 - 1]
+                     │              │         ├── immutable
+                     │              │         ├── stats: [rows=1]
+                     │              │         ├── key: ()
+                     │              │         ├── fd: ()-->(23)
+                     │              │         ├── project
+                     │              │         │    ├── columns: x:2(int) curs:1(refcursor!null)
+                     │              │         │    ├── cardinality: [1 - 1]
+                     │              │         │    ├── immutable
+                     │              │         │    ├── stats: [rows=1]
+                     │              │         │    ├── key: ()
+                     │              │         │    ├── fd: ()-->(1,2)
+                     │              │         │    ├── prune: (1,2)
+                     │              │         │    ├── project
+                     │              │         │    │    ├── columns: curs:1(refcursor!null)
+                     │              │         │    │    ├── cardinality: [1 - 1]
+                     │              │         │    │    ├── stats: [rows=1]
+                     │              │         │    │    ├── key: ()
+                     │              │         │    │    ├── fd: ()-->(1)
+                     │              │         │    │    ├── prune: (1)
+                     │              │         │    │    ├── values
+                     │              │         │    │    │    ├── cardinality: [1 - 1]
+                     │              │         │    │    │    ├── stats: [rows=1]
+                     │              │         │    │    │    ├── key: ()
+                     │              │         │    │    │    └── tuple [type=tuple]
+                     │              │         │    │    └── projections
+                     │              │         │    │         └── const: 'foo' [as=curs:1, type=refcursor]
+                     │              │         │    └── projections
+                     │              │         │         └── cast: INT8 [as=x:2, type=int, immutable]
+                     │              │         │              └── null [type=unknown]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 3
+                     │              │                   └── args
+                     │              │                        ├── variable: curs:1 [type=refcursor]
+                     │              │                        └── variable: x:2 [type=int]
+                     │              ├── branch: 0
+                     │              │    ├── params: curs:3(refcursor) x:4(int)
+                     │              │    └── body
+                     │              │         ├── open-cursor
+                     │              │         │    └── project
+                     │              │         │         ├── columns: t.public.xy.x:5(int) t.public.xy.y:6(int)
+                     │              │         │         ├── stats: [rows=1000]
+                     │              │         │         └── scan t.public.xy
+                     │              │         │              ├── columns: t.public.xy.x:5(int) t.public.xy.y:6(int) t.public.xy.rowid:7(int!null) t.public.xy.crdb_internal_mvcc_timestamp:8(decimal) t.public.xy.tableoid:9(oid)
+                     │              │         │              ├── stats: [rows=1000]
+                     │              │         │              ├── key: (7)
+                     │              │         │              ├── fd: (7)-->(5,6,8,9)
+                     │              │         │              └── prune: (5-9)
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_fetch_2":18(int)
+                     │              │              ├── outer: (3,4)
+                     │              │              ├── cardinality: [1 - 1]
+                     │              │              ├── stats: [rows=1]
+                     │              │              ├── key: ()
+                     │              │              ├── fd: ()-->(18)
+                     │              │              ├── values
+                     │              │              │    ├── cardinality: [1 - 1]
+                     │              │              │    ├── stats: [rows=1]
+                     │              │              │    ├── key: ()
+                     │              │              │    └── tuple [type=tuple]
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             ├── variable: curs:3 [type=refcursor]
+                     │              │                             └── variable: x:4 [type=int]
+                     │              ├── branch: 1
+                     │              │    ├── params: curs:10(refcursor) x:11(int)
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_exec_ret_4":17(int)
+                     │              │              ├── outer: (10)
+                     │              │              ├── cardinality: [1 - 1]
+                     │              │              ├── volatile
+                     │              │              ├── stats: [rows=1]
+                     │              │              ├── key: ()
+                     │              │              ├── fd: ()-->(17)
+                     │              │              ├── project
+                     │              │              │    ├── columns: x:13(int)
+                     │              │              │    ├── outer: (10)
+                     │              │              │    ├── cardinality: [1 - 1]
+                     │              │              │    ├── volatile
+                     │              │              │    ├── stats: [rows=1]
+                     │              │              │    ├── key: ()
+                     │              │              │    ├── fd: ()-->(13)
+                     │              │              │    ├── prune: (13)
+                     │              │              │    ├── project
+                     │              │              │    │    ├── columns: stmt_fetch_3:12(tuple{int})
+                     │              │              │    │    ├── outer: (10)
+                     │              │              │    │    ├── cardinality: [1 - 1]
+                     │              │              │    │    ├── volatile
+                     │              │              │    │    ├── stats: [rows=1]
+                     │              │              │    │    ├── key: ()
+                     │              │              │    │    ├── fd: ()-->(12)
+                     │              │              │    │    ├── prune: (12)
+                     │              │              │    │    ├── values
+                     │              │              │    │    │    ├── cardinality: [1 - 1]
+                     │              │              │    │    │    ├── stats: [rows=1]
+                     │              │              │    │    │    ├── key: ()
+                     │              │              │    │    │    └── tuple [type=tuple]
+                     │              │              │    │    └── projections
+                     │              │              │    │         └── function: crdb_internal.plpgsql_fetch [as=stmt_fetch_3:12, type=tuple{int}, outer=(10), volatile]
+                     │              │              │    │              ├── variable: curs:10 [type=refcursor]
+                     │              │              │    │              ├── const: 0 [type=int]
+                     │              │              │    │              ├── const: 1 [type=int]
+                     │              │              │    │              └── tuple [type=tuple{int}]
+                     │              │              │    │                   └── null [type=int]
+                     │              │              │    └── projections
+                     │              │              │         └── column-access: 0 [as=x:13, type=int, outer=(12)]
+                     │              │              │              └── variable: stmt_fetch_3:12 [type=tuple{int}]
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 2
+                     │              │                        └── args
+                     │              │                             ├── variable: curs:10 [type=refcursor]
+                     │              │                             └── variable: x:13 [type=int]
+                     │              ├── branch: 2
+                     │              │    ├── params: curs:14(refcursor) x:15(int)
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_5:16(int)
+                     │              │              ├── outer: (15)
+                     │              │              ├── cardinality: [1 - 1]
+                     │              │              ├── stats: [rows=1]
+                     │              │              ├── key: ()
+                     │              │              ├── fd: ()-->(16)
+                     │              │              ├── values
+                     │              │              │    ├── cardinality: [1 - 1]
+                     │              │              │    ├── stats: [rows=1]
+                     │              │              │    ├── key: ()
+                     │              │              │    └── tuple [type=tuple]
+                     │              │              └── projections
+                     │              │                   └── variable: x:15 [as=stmt_return_5:16, type=int, outer=(15)]
+                     │              └── branch: 3
+                     │                   ├── params: curs:19(refcursor) x:20(int)
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: "_stmt_open_1":22(int)
+                     │                             ├── outer: (19,20)
+                     │                             ├── cardinality: [1 - 1]
+                     │                             ├── volatile
+                     │                             ├── stats: [rows=1]
+                     │                             ├── key: ()
+                     │                             ├── fd: ()-->(22)
+                     │                             ├── project
+                     │                             │    ├── columns: curs:21(refcursor)
+                     │                             │    ├── outer: (19)
+                     │                             │    ├── cardinality: [1 - 1]
+                     │                             │    ├── volatile
+                     │                             │    ├── stats: [rows=1]
+                     │                             │    ├── key: ()
+                     │                             │    ├── fd: ()-->(21)
+                     │                             │    ├── prune: (21)
+                     │                             │    ├── values
+                     │                             │    │    ├── cardinality: [1 - 1]
+                     │                             │    │    ├── stats: [rows=1]
+                     │                             │    │    ├── key: ()
+                     │                             │    │    └── tuple [type=tuple]
+                     │                             │    └── projections
+                     │                             │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:21, type=refcursor, outer=(19), volatile]
+                     │                             │              └── variable: curs:19 [type=refcursor]
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 0
+                     │                                       └── args
+                     │                                            ├── variable: curs:21 [type=refcursor]
+                     │                                            └── variable: x:20 [type=int]
                      └── const: 1 [type=int]
 
 exec-ddl
@@ -5534,78 +6473,87 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:16
+ ├── columns: f:17
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:16]
+      └── udf: f [as=f:17]
            └── body
                 └── limit
-                     ├── columns: "_gen_cursor_name_5":15
+                     ├── columns: dispatcher_6:16
                      ├── project
-                     │    ├── columns: "_gen_cursor_name_5":15
-                     │    ├── barrier
-                     │    │    ├── columns: curs:1!null
-                     │    │    └── project
-                     │    │         ├── columns: curs:1!null
-                     │    │         ├── values
-                     │    │         │    └── tuple
-                     │    │         └── projections
-                     │    │              └── const: 'foo' [as=curs:1]
+                     │    ├── columns: dispatcher_6:16
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _gen_cursor_name_5 [as="_gen_cursor_name_5":15]
-                     │              ├── args
-                     │              │    └── variable: curs:1
-                     │              ├── params: curs:12
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: "_stmt_open_1":14
-                     │                        ├── barrier
-                     │                        │    ├── columns: curs:13
-                     │                        │    └── project
-                     │                        │         ├── columns: curs:13
-                     │                        │         ├── values
-                     │                        │         │    └── tuple
-                     │                        │         └── projections
-                     │                        │              └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:13]
-                     │                        │                   └── variable: curs:12
-                     │                        └── projections
-                     │                             └── udf: _stmt_open_1 [as="_stmt_open_1":14]
-                     │                                  ├── args
-                     │                                  │    └── variable: curs:13
-                     │                                  ├── params: curs:2
-                     │                                  └── body
-                     │                                       ├── open-cursor
-                     │                                       │    └── project
-                     │                                       │         ├── columns: x:3 y:4
-                     │                                       │         └── scan xy
-                     │                                       │              └── columns: x:3 y:4 rowid:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
-                     │                                       └── project
-                     │                                            ├── columns: "_stmt_fetch_2":11
-                     │                                            ├── values
-                     │                                            │    └── tuple
-                     │                                            └── projections
-                     │                                                 └── udf: _stmt_fetch_2 [as="_stmt_fetch_2":11]
-                     │                                                      ├── args
-                     │                                                      │    └── variable: curs:2
-                     │                                                      ├── params: curs:8
-                     │                                                      └── body
-                     │                                                           ├── project
-                     │                                                           │    ├── columns: stmt_fetch_3:9
-                     │                                                           │    ├── values
-                     │                                                           │    │    └── tuple
-                     │                                                           │    └── projections
-                     │                                                           │         └── function: crdb_internal.plpgsql_fetch [as=stmt_fetch_3:9]
-                     │                                                           │              ├── variable: curs:8
-                     │                                                           │              ├── const: 0
-                     │                                                           │              ├── const: 1
-                     │                                                           │              └── tuple
-                     │                                                           └── project
-                     │                                                                ├── columns: stmt_return_4:10!null
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── const: 0 [as=stmt_return_4:10]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_gen_cursor_name_5":15
+                     │              │         ├── project
+                     │              │         │    ├── columns: curs:1!null
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── const: 'foo' [as=curs:1]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 2
+                     │              │                   └── args
+                     │              │                        └── variable: curs:1
+                     │              ├── branch: 0
+                     │              │    ├── params: curs:2
+                     │              │    └── body
+                     │              │         ├── open-cursor
+                     │              │         │    └── project
+                     │              │         │         ├── columns: x:3 y:4
+                     │              │         │         └── scan xy
+                     │              │         │              └── columns: x:3 y:4 rowid:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_fetch_2":11
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             └── variable: curs:2
+                     │              ├── branch: 1
+                     │              │    ├── params: curs:8
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_fetch_3:9
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_fetch [as=stmt_fetch_3:9]
+                     │              │         │              ├── variable: curs:8
+                     │              │         │              ├── const: 0
+                     │              │         │              ├── const: 1
+                     │              │         │              └── tuple
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_4:10!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: 0 [as=stmt_return_4:10]
+                     │              └── branch: 2
+                     │                   ├── params: curs:12
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: "_stmt_open_1":14
+                     │                             ├── project
+                     │                             │    ├── columns: curs:13
+                     │                             │    ├── values
+                     │                             │    │    └── tuple
+                     │                             │    └── projections
+                     │                             │         └── function: crdb_internal.plpgsql_gen_cursor_name [as=curs:13]
+                     │                             │              └── variable: curs:12
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 0
+                     │                                       └── args
+                     │                                            └── variable: curs:13
                      └── const: 1
 
 # Correctly display the OTHERS branch.
@@ -5628,51 +6576,84 @@ build format=show-scalars
 SELECT f();
 ----
 project
- ├── columns: f:6
+ ├── columns: f:7
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f [as=f:6]
+      └── udf: f [as=f:7]
            └── body
                 └── limit
-                     ├── columns: exception_block_7:5
+                     ├── columns: dispatcher_9:6
                      ├── project
-                     │    ├── columns: exception_block_7:5
+                     │    ├── columns: dispatcher_9:6
                      │    ├── values
                      │    │    └── tuple
                      │    └── projections
-                     │         └── udf: exception_block_7 [as=exception_block_7:5]
-                     │              ├── body
+                     │         └── dispatcher
+                     │              ├── subquery
                      │              │    └── project
-                     │              │         ├── columns: stmt_return_8:4!null
+                     │              │         ├── columns: exception_block_7:5
                      │              │         ├── values
                      │              │         │    └── tuple
                      │              │         └── projections
-                     │              │              └── floor-div [as=stmt_return_8:4]
-                     │              │                   ├── const: 1
-                     │              │                   └── const: 0
-                     │              └── exception-handler
-                     │                   ├── SQLSTATE 'P0004'
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 3
+                     │              ├── branch: 0
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_2:1!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: -1 [as=stmt_return_2:1]
+                     │              ├── branch: 1
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_4:2!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: -2 [as=stmt_return_4:2]
+                     │              ├── branch: 2
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_return_6:3!null
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── const: -3 [as=stmt_return_6:3]
+                     │              └── branch: 3
+                     │                   ├── body
                      │                   │    └── project
-                     │                   │         ├── columns: stmt_return_2:1!null
+                     │                   │         ├── columns: stmt_return_8:4!null
                      │                   │         ├── values
                      │                   │         │    └── tuple
                      │                   │         └── projections
-                     │                   │              └── const: -1 [as=stmt_return_2:1]
-                     │                   ├── OTHERS
-                     │                   │    └── project
-                     │                   │         ├── columns: stmt_return_4:2!null
-                     │                   │         ├── values
-                     │                   │         │    └── tuple
-                     │                   │         └── projections
-                     │                   │              └── const: -2 [as=stmt_return_4:2]
-                     │                   └── SQLSTATE '57014'
-                     │                        └── project
-                     │                             ├── columns: stmt_return_6:3!null
-                     │                             ├── values
-                     │                             │    └── tuple
-                     │                             └── projections
-                     │                                  └── const: -3 [as=stmt_return_6:3]
+                     │                   │              └── floor-div [as=stmt_return_8:4]
+                     │                   │                   ├── const: 1
+                     │                   │                   └── const: 0
+                     │                   └── exception-handler
+                     │                        ├── SQLSTATE 'P0004'
+                     │                        │    └── project
+                     │                        │         ├── columns: stmt_return_2:1!null
+                     │                        │         ├── values
+                     │                        │         │    └── tuple
+                     │                        │         └── projections
+                     │                        │              └── const: -1 [as=stmt_return_2:1]
+                     │                        ├── OTHERS
+                     │                        │    └── project
+                     │                        │         ├── columns: stmt_return_4:2!null
+                     │                        │         ├── values
+                     │                        │         │    └── tuple
+                     │                        │         └── projections
+                     │                        │              └── const: -2 [as=stmt_return_4:2]
+                     │                        └── SQLSTATE '57014'
+                     │                             └── project
+                     │                                  ├── columns: stmt_return_6:3!null
+                     │                                  ├── values
+                     │                                  │    └── tuple
+                     │                                  └── projections
+                     │                                       └── const: -3 [as=stmt_return_6:3]
                      └── const: 1
 
 # Project a typed NULL for the end-of-function RAISE statement.
@@ -5687,38 +6668,47 @@ build format=(show-scalars,show-types)
 SELECT f();
 ----
 project
- ├── columns: f:4(int)
+ ├── columns: f:5(int)
  ├── values
  │    └── tuple [type=tuple]
  └── projections
-      └── udf: f [as=f:4, type=int]
+      └── udf: f [as=f:5, type=int]
            └── body
                 └── limit
-                     ├── columns: "_end_of_function_1":3(int)
+                     ├── columns: dispatcher_4:4(int)
                      ├── project
-                     │    ├── columns: "_end_of_function_1":3(int)
+                     │    ├── columns: dispatcher_4:4(int)
                      │    ├── values
                      │    │    └── tuple [type=tuple]
                      │    └── projections
-                     │         └── udf: _end_of_function_1 [as="_end_of_function_1":3, type=int]
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:1(int)
-                     │                   │    ├── values
-                     │                   │    │    └── tuple [type=tuple]
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1, type=int]
-                     │                   │              ├── const: 'ERROR' [type=string]
-                     │                   │              ├── const: 'control reached end of function without RETURN' [type=string]
-                     │                   │              ├── const: '' [type=string]
-                     │                   │              ├── const: '' [type=string]
-                     │                   │              └── const: '2F005' [type=string]
-                     │                   └── project
-                     │                        ├── columns: end_of_function_3:2(int)
-                     │                        ├── values
-                     │                        │    └── tuple [type=tuple]
-                     │                        └── projections
-                     │                             └── null [as=end_of_function_3:2, type=int]
+                     │         └── dispatcher
+                     │              ├── subquery [type=int]
+                     │              │    └── project
+                     │              │         ├── columns: end_of_function_1:3(int)
+                     │              │         ├── values
+                     │              │         │    └── tuple [type=tuple]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   └── branch: 0
+                     │              └── branch: 0
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_2:1(int)
+                     │                        │    ├── values
+                     │                        │    │    └── tuple [type=tuple]
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:1, type=int]
+                     │                        │              ├── const: 'ERROR' [type=string]
+                     │                        │              ├── const: 'control reached end of function without RETURN' [type=string]
+                     │                        │              ├── const: '' [type=string]
+                     │                        │              ├── const: '' [type=string]
+                     │                        │              └── const: '2F005' [type=string]
+                     │                        └── project
+                     │                             ├── columns: end_of_function_3:2(int)
+                     │                             ├── values
+                     │                             │    └── tuple [type=tuple]
+                     │                             └── projections
+                     │                                  └── null [as=end_of_function_3:2, type=int]
                      └── const: 1 [type=int]
 
 exec-ddl
@@ -5737,105 +6727,118 @@ build format=(show-scalars,show-types)
 SELECT f();
 ----
 project
- ├── columns: f:15(int)
+ ├── columns: f:16(int)
  ├── values
  │    └── tuple [type=tuple]
  └── projections
-      └── udf: f [as=f:15, type=int]
+      └── udf: f [as=f:16, type=int]
            └── body
                 └── limit
-                     ├── columns: stmt_loop_5:14(int)
+                     ├── columns: dispatcher_8:15(int)
                      ├── project
-                     │    ├── columns: stmt_loop_5:14(int)
-                     │    ├── barrier
-                     │    │    ├── columns: i:1(int!null)
-                     │    │    └── project
-                     │    │         ├── columns: i:1(int!null)
-                     │    │         ├── values
-                     │    │         │    └── tuple [type=tuple]
-                     │    │         └── projections
-                     │    │              └── const: 0 [as=i:1, type=int]
+                     │    ├── columns: dispatcher_8:15(int)
+                     │    ├── values
+                     │    │    └── tuple [type=tuple]
                      │    └── projections
-                     │         └── udf: stmt_loop_5 [as=stmt_loop_5:14, type=int]
-                     │              ├── args
-                     │              │    └── variable: i:1 [type=int]
-                     │              ├── params: i:7(int)
-                     │              └── body
-                     │                   └── project
-                     │                        ├── columns: stmt_if_7:13(int)
-                     │                        ├── values
-                     │                        │    └── tuple [type=tuple]
-                     │                        └── projections
-                     │                             └── case [as=stmt_if_7:13, type=int]
-                     │                                  ├── true [type=bool]
-                     │                                  ├── when [type=int]
-                     │                                  │    ├── lt [type=bool]
-                     │                                  │    │    ├── variable: i:7 [type=int]
-                     │                                  │    │    └── const: 10 [type=int]
-                     │                                  │    └── subquery [type=int]
-                     │                                  │         └── project
-                     │                                  │              ├── columns: stmt_if_6:11(int)
-                     │                                  │              ├── project
-                     │                                  │              │    ├── columns: i:10(int)
-                     │                                  │              │    ├── values
-                     │                                  │              │    │    └── tuple [type=tuple]
-                     │                                  │              │    └── projections
-                     │                                  │              │         └── plus [as=i:10, type=int]
-                     │                                  │              │              ├── variable: i:7 [type=int]
-                     │                                  │              │              └── const: 1 [type=int]
-                     │                                  │              └── projections
-                     │                                  │                   └── udf: stmt_if_6 [as=stmt_if_6:11, type=int]
-                     │                                  │                        ├── args
-                     │                                  │                        │    └── variable: i:10 [type=int]
-                     │                                  │                        ├── params: i:8(int)
-                     │                                  │                        └── body
-                     │                                  │                             └── project
-                     │                                  │                                  ├── columns: stmt_loop_5:9(int)
-                     │                                  │                                  ├── values
-                     │                                  │                                  │    └── tuple [type=tuple]
-                     │                                  │                                  └── projections
-                     │                                  │                                       └── udf: stmt_loop_5 [as=stmt_loop_5:9, type=int]
-                     │                                  │                                            ├── args
-                     │                                  │                                            │    └── variable: i:8 [type=int]
-                     │                                  │                                            └── recursive-call
-                     │                                  └── subquery [type=int]
-                     │                                       └── project
-                     │                                            ├── columns: loop_exit_1:12(int)
-                     │                                            ├── values
-                     │                                            │    └── tuple [type=tuple]
-                     │                                            └── projections
-                     │                                                 └── udf: loop_exit_1 [as=loop_exit_1:12, type=int]
-                     │                                                      ├── args
-                     │                                                      │    └── variable: i:7 [type=int]
-                     │                                                      ├── params: i:2(int)
-                     │                                                      └── body
-                     │                                                           └── project
-                     │                                                                ├── columns: "_end_of_function_2":6(int)
-                     │                                                                ├── values
-                     │                                                                │    └── tuple [type=tuple]
-                     │                                                                └── projections
-                     │                                                                     └── udf: _end_of_function_2 [as="_end_of_function_2":6, type=int]
-                     │                                                                          ├── args
-                     │                                                                          │    └── variable: i:2 [type=int]
-                     │                                                                          ├── params: i:3(int)
-                     │                                                                          └── body
-                     │                                                                               ├── project
-                     │                                                                               │    ├── columns: stmt_raise_3:4(int)
-                     │                                                                               │    ├── values
-                     │                                                                               │    │    └── tuple [type=tuple]
-                     │                                                                               │    └── projections
-                     │                                                                               │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_3:4, type=int]
-                     │                                                                               │              ├── const: 'ERROR' [type=string]
-                     │                                                                               │              ├── const: 'control reached end of function without RETURN' [type=string]
-                     │                                                                               │              ├── const: '' [type=string]
-                     │                                                                               │              ├── const: '' [type=string]
-                     │                                                                               │              └── const: '2F005' [type=string]
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: end_of_function_4:5(int)
-                     │                                                                                    ├── values
-                     │                                                                                    │    └── tuple [type=tuple]
-                     │                                                                                    └── projections
-                     │                                                                                         └── null [as=end_of_function_4:5, type=int]
+                     │         └── dispatcher
+                     │              ├── subquery [type=int]
+                     │              │    └── project
+                     │              │         ├── columns: stmt_loop_5:14(int)
+                     │              │         ├── project
+                     │              │         │    ├── columns: i:1(int!null)
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple [type=tuple]
+                     │              │         │    └── projections
+                     │              │         │         └── const: 0 [as=i:1, type=int]
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 2
+                     │              │                   └── args
+                     │              │                        └── variable: i:1 [type=int]
+                     │              ├── branch: 0
+                     │              │    ├── params: i:2(int)
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: end_of_function_2:6(int)
+                     │              │              ├── values
+                     │              │              │    └── tuple [type=tuple]
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             └── variable: i:2 [type=int]
+                     │              ├── branch: 1
+                     │              │    ├── params: i:3(int)
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_3:4(int)
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple [type=tuple]
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_3:4, type=int]
+                     │              │         │              ├── const: 'ERROR' [type=string]
+                     │              │         │              ├── const: 'control reached end of function without RETURN' [type=string]
+                     │              │         │              ├── const: '' [type=string]
+                     │              │         │              ├── const: '' [type=string]
+                     │              │         │              └── const: '2F005' [type=string]
+                     │              │         └── project
+                     │              │              ├── columns: end_of_function_4:5(int)
+                     │              │              ├── values
+                     │              │              │    └── tuple [type=tuple]
+                     │              │              └── projections
+                     │              │                   └── null [as=end_of_function_4:5, type=int]
+                     │              ├── branch: 2
+                     │              │    ├── params: i:7(int)
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: stmt_if_7:13(int)
+                     │              │              ├── values
+                     │              │              │    └── tuple [type=tuple]
+                     │              │              └── projections
+                     │              │                   └── case [as=stmt_if_7:13, type=int]
+                     │              │                        ├── true [type=bool]
+                     │              │                        ├── when [type=int]
+                     │              │                        │    ├── lt [type=bool]
+                     │              │                        │    │    ├── variable: i:7 [type=int]
+                     │              │                        │    │    └── const: 10 [type=int]
+                     │              │                        │    └── subquery [type=int]
+                     │              │                        │         └── project
+                     │              │                        │              ├── columns: stmt_if_6:11(int)
+                     │              │                        │              ├── project
+                     │              │                        │              │    ├── columns: i:10(int)
+                     │              │                        │              │    ├── values
+                     │              │                        │              │    │    └── tuple [type=tuple]
+                     │              │                        │              │    └── projections
+                     │              │                        │              │         └── plus [as=i:10, type=int]
+                     │              │                        │              │              ├── variable: i:7 [type=int]
+                     │              │                        │              │              └── const: 1 [type=int]
+                     │              │                        │              └── projections
+                     │              │                        │                   └── dispatch: 1
+                     │              │                        │                        ├── branch: 3
+                     │              │                        │                        └── args
+                     │              │                        │                             └── variable: i:10 [type=int]
+                     │              │                        └── subquery [type=int]
+                     │              │                             └── project
+                     │              │                                  ├── columns: loop_exit_1:12(int)
+                     │              │                                  ├── values
+                     │              │                                  │    └── tuple [type=tuple]
+                     │              │                                  └── projections
+                     │              │                                       └── dispatch: 1
+                     │              │                                            ├── branch: 0
+                     │              │                                            └── args
+                     │              │                                                 └── variable: i:7 [type=int]
+                     │              └── branch: 3
+                     │                   ├── params: i:8(int)
+                     │                   └── body
+                     │                        └── project
+                     │                             ├── columns: stmt_loop_5:9(int)
+                     │                             ├── values
+                     │                             │    └── tuple [type=tuple]
+                     │                             └── projections
+                     │                                  └── dispatch: 1
+                     │                                       ├── branch: 2
+                     │                                       └── args
+                     │                                            └── variable: i:8 [type=int]
                      └── const: 1 [type=int]
 
 # Infer return type for a RECORD-returning routine.
@@ -5851,21 +6854,28 @@ build format=(show-scalars,show-types)
 SELECT f();
 ----
 project
- ├── columns: f:2(tuple{bool})
+ ├── columns: f:3(tuple{bool})
  ├── values
  │    └── tuple [type=tuple]
  └── projections
-      └── udf: f [as=f:2, type=tuple{bool}]
+      └── udf: f [as=f:3, type=tuple{bool}]
            └── body
                 └── limit
-                     ├── columns: stmt_return_1:1(tuple{bool}!null)
+                     ├── columns: dispatcher_2:2(tuple{bool})
                      ├── project
-                     │    ├── columns: stmt_return_1:1(tuple{bool}!null)
+                     │    ├── columns: dispatcher_2:2(tuple{bool})
                      │    ├── values
                      │    │    └── tuple [type=tuple]
                      │    └── projections
-                     │         └── tuple [as=stmt_return_1:1, type=tuple{bool}]
-                     │              └── false [type=bool]
+                     │         └── dispatcher
+                     │              └── subquery [type=tuple{bool}]
+                     │                   └── project
+                     │                        ├── columns: stmt_return_1:1(tuple{bool}!null)
+                     │                        ├── values
+                     │                        │    └── tuple [type=tuple]
+                     │                        └── projections
+                     │                             └── tuple [as=stmt_return_1:1, type=tuple{bool}]
+                     │                                  └── false [type=bool]
                      └── const: 1 [type=int]
 
 # Regression test for #114826 - ensure that SQL statements return at least one
@@ -5893,180 +6903,195 @@ build format=show-scalars
 SELECT f114826();
 ----
 project
- ├── columns: f114826:35
+ ├── columns: f114826:36
  ├── values
  │    └── tuple
  └── projections
-      └── udf: f114826 [as=f114826:35]
+      └── udf: f114826 [as=f114826:36]
            └── body
                 └── limit
-                     ├── columns: "_stmt_raise_1":34
+                     ├── columns: dispatcher_12:35
                      ├── project
-                     │    ├── columns: "_stmt_raise_1":34
-                     │    ├── barrier
-                     │    │    ├── columns: found:1
-                     │    │    └── project
-                     │    │         ├── columns: found:1
-                     │    │         ├── values
-                     │    │         │    └── tuple
-                     │    │         └── projections
-                     │    │              └── cast: INT8 [as=found:1]
-                     │    │                   └── null
+                     │    ├── columns: dispatcher_12:35
+                     │    ├── values
+                     │    │    └── tuple
                      │    └── projections
-                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":34]
-                     │              ├── args
-                     │              │    └── variable: found:1
-                     │              ├── params: found:2
-                     │              └── body
-                     │                   ├── project
-                     │                   │    ├── columns: stmt_raise_2:3
-                     │                   │    ├── values
-                     │                   │    │    └── tuple
-                     │                   │    └── projections
-                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:3]
-                     │                   │              ├── const: 'NOTICE'
-                     │                   │              ├── const: 'HERE 1'
-                     │                   │              ├── const: ''
-                     │                   │              ├── const: ''
-                     │                   │              └── const: '00000'
-                     │                   └── project
-                     │                        ├── columns: "_stmt_exec_3":33
-                     │                        ├── values
-                     │                        │    └── tuple
-                     │                        └── projections
-                     │                             └── udf: _stmt_exec_3 [as="_stmt_exec_3":33]
-                     │                                  ├── args
-                     │                                  │    └── variable: found:2
-                     │                                  ├── params: found:4
-                     │                                  └── body
-                     │                                       └── project
-                     │                                            ├── columns: "_stmt_exec_ret_4":32
-                     │                                            ├── barrier
-                     │                                            │    ├── columns: found:31
-                     │                                            │    └── project
-                     │                                            │         ├── columns: found:31
-                     │                                            │         ├── right-join (cross)
-                     │                                            │         │    ├── columns: a:5
-                     │                                            │         │    ├── limit
-                     │                                            │         │    │    ├── columns: a:5!null
-                     │                                            │         │    │    ├── project
-                     │                                            │         │    │    │    ├── columns: a:5!null
-                     │                                            │         │    │    │    └── select
-                     │                                            │         │    │    │         ├── columns: a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
-                     │                                            │         │    │    │         ├── scan t114826
-                     │                                            │         │    │    │         │    └── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
-                     │                                            │         │    │    │         └── filters
-                     │                                            │         │    │    │              └── eq
-                     │                                            │         │    │    │                   ├── variable: a:5
-                     │                                            │         │    │    │                   └── const: 3
-                     │                                            │         │    │    └── const: 1
-                     │                                            │         │    ├── values
-                     │                                            │         │    │    └── tuple
-                     │                                            │         │    └── filters (true)
-                     │                                            │         └── projections
-                     │                                            │              └── variable: a:5 [as=found:31]
-                     │                                            └── projections
-                     │                                                 └── udf: _stmt_exec_ret_4 [as="_stmt_exec_ret_4":32]
-                     │                                                      ├── args
-                     │                                                      │    └── variable: found:31
-                     │                                                      ├── params: found:9
-                     │                                                      └── body
-                     │                                                           └── project
-                     │                                                                ├── columns: "_stmt_raise_5":30
-                     │                                                                ├── values
-                     │                                                                │    └── tuple
-                     │                                                                └── projections
-                     │                                                                     └── udf: _stmt_raise_5 [as="_stmt_raise_5":30]
-                     │                                                                          ├── args
-                     │                                                                          │    └── variable: found:9
-                     │                                                                          ├── params: found:10
-                     │                                                                          └── body
-                     │                                                                               ├── project
-                     │                                                                               │    ├── columns: stmt_raise_6:11
-                     │                                                                               │    ├── values
-                     │                                                                               │    │    └── tuple
-                     │                                                                               │    └── projections
-                     │                                                                               │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_6:11]
-                     │                                                                               │              ├── const: 'NOTICE'
-                     │                                                                               │              ├── const: 'HERE 2'
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              ├── const: ''
-                     │                                                                               │              └── const: '00000'
-                     │                                                                               └── project
-                     │                                                                                    ├── columns: "_stmt_exec_7":29
-                     │                                                                                    ├── values
-                     │                                                                                    │    └── tuple
-                     │                                                                                    └── projections
-                     │                                                                                         └── udf: _stmt_exec_7 [as="_stmt_exec_7":29]
-                     │                                                                                              ├── args
-                     │                                                                                              │    └── variable: found:10
-                     │                                                                                              ├── params: found:12
-                     │                                                                                              └── body
-                     │                                                                                                   └── project
-                     │                                                                                                        ├── columns: "_stmt_exec_ret_8":28
-                     │                                                                                                        ├── barrier
-                     │                                                                                                        │    ├── columns: found:27
-                     │                                                                                                        │    └── project
-                     │                                                                                                        │         ├── columns: found:27
-                     │                                                                                                        │         ├── right-join (cross)
-                     │                                                                                                        │         │    ├── columns: a:13
-                     │                                                                                                        │         │    ├── limit
-                     │                                                                                                        │         │    │    ├── columns: a:13
-                     │                                                                                                        │         │    │    ├── project
-                     │                                                                                                        │         │    │    │    ├── columns: a:13
-                     │                                                                                                        │         │    │    │    └── insert t114826
-                     │                                                                                                        │         │    │    │         ├── columns: a:13 rowid:14!null
-                     │                                                                                                        │         │    │    │         ├── insert-mapping:
-                     │                                                                                                        │         │    │    │         │    ├── a:17 => a:13
-                     │                                                                                                        │         │    │    │         │    └── rowid_default:21 => rowid:14
-                     │                                                                                                        │         │    │    │         ├── return-mapping:
-                     │                                                                                                        │         │    │    │         │    ├── a:17 => a:13
-                     │                                                                                                        │         │    │    │         │    └── rowid_default:21 => rowid:14
-                     │                                                                                                        │         │    │    │         └── project
-                     │                                                                                                        │         │    │    │              ├── columns: rowid_default:21 a:17
-                     │                                                                                                        │         │    │    │              ├── project
-                     │                                                                                                        │         │    │    │              │    ├── columns: a:17
-                     │                                                                                                        │         │    │    │              │    └── scan t114826
-                     │                                                                                                        │         │    │    │              │         └── columns: a:17 rowid:18!null crdb_internal_mvcc_timestamp:19 tableoid:20
-                     │                                                                                                        │         │    │    │              └── projections
-                     │                                                                                                        │         │    │    │                   └── function: unique_rowid [as=rowid_default:21]
-                     │                                                                                                        │         │    │    └── const: 1
-                     │                                                                                                        │         │    ├── values
-                     │                                                                                                        │         │    │    └── tuple
-                     │                                                                                                        │         │    └── filters (true)
-                     │                                                                                                        │         └── projections
-                     │                                                                                                        │              └── variable: a:13 [as=found:27]
-                     │                                                                                                        └── projections
-                     │                                                                                                             └── udf: _stmt_exec_ret_8 [as="_stmt_exec_ret_8":28]
-                     │                                                                                                                  ├── args
-                     │                                                                                                                  │    └── variable: found:27
-                     │                                                                                                                  ├── params: found:22
-                     │                                                                                                                  └── body
-                     │                                                                                                                       └── project
-                     │                                                                                                                            ├── columns: "_stmt_raise_9":26
-                     │                                                                                                                            ├── values
-                     │                                                                                                                            │    └── tuple
-                     │                                                                                                                            └── projections
-                     │                                                                                                                                 └── udf: _stmt_raise_9 [as="_stmt_raise_9":26]
-                     │                                                                                                                                      ├── args
-                     │                                                                                                                                      │    └── variable: found:22
-                     │                                                                                                                                      ├── params: found:23
-                     │                                                                                                                                      └── body
-                     │                                                                                                                                           ├── project
-                     │                                                                                                                                           │    ├── columns: stmt_raise_10:24
-                     │                                                                                                                                           │    ├── values
-                     │                                                                                                                                           │    │    └── tuple
-                     │                                                                                                                                           │    └── projections
-                     │                                                                                                                                           │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_10:24]
-                     │                                                                                                                                           │              ├── const: 'NOTICE'
-                     │                                                                                                                                           │              ├── const: 'HERE 3'
-                     │                                                                                                                                           │              ├── const: ''
-                     │                                                                                                                                           │              ├── const: ''
-                     │                                                                                                                                           │              └── const: '00000'
-                     │                                                                                                                                           └── project
-                     │                                                                                                                                                ├── columns: stmt_return_11:25!null
-                     │                                                                                                                                                ├── values
-                     │                                                                                                                                                │    └── tuple
-                     │                                                                                                                                                └── projections
-                     │                                                                                                                                                     └── const: 10 [as=stmt_return_11:25]
+                     │         └── dispatcher
+                     │              ├── subquery
+                     │              │    └── project
+                     │              │         ├── columns: "_stmt_raise_1":34
+                     │              │         ├── project
+                     │              │         │    ├── columns: found:1
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── cast: INT8 [as=found:1]
+                     │              │         │              └── null
+                     │              │         └── projections
+                     │              │              └── dispatch: 1
+                     │              │                   ├── branch: 0
+                     │              │                   └── args
+                     │              │                        └── variable: found:1
+                     │              ├── branch: 0
+                     │              │    ├── params: found:2
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_2:3
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:3]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: 'HERE 1'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_exec_3":33
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 1
+                     │              │                        └── args
+                     │              │                             └── variable: found:2
+                     │              ├── branch: 1
+                     │              │    ├── params: found:4
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_exec_ret_4":32
+                     │              │              ├── project
+                     │              │              │    ├── columns: found:31
+                     │              │              │    ├── right-join (cross)
+                     │              │              │    │    ├── columns: a:5
+                     │              │              │    │    ├── limit
+                     │              │              │    │    │    ├── columns: a:5!null
+                     │              │              │    │    │    ├── project
+                     │              │              │    │    │    │    ├── columns: a:5!null
+                     │              │              │    │    │    │    └── select
+                     │              │              │    │    │    │         ├── columns: a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+                     │              │              │    │    │    │         ├── scan t114826
+                     │              │              │    │    │    │         │    └── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+                     │              │              │    │    │    │         └── filters
+                     │              │              │    │    │    │              └── eq
+                     │              │              │    │    │    │                   ├── variable: a:5
+                     │              │              │    │    │    │                   └── const: 3
+                     │              │              │    │    │    └── const: 1
+                     │              │              │    │    ├── values
+                     │              │              │    │    │    └── tuple
+                     │              │              │    │    └── filters (true)
+                     │              │              │    └── projections
+                     │              │              │         └── variable: a:5 [as=found:31]
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 2
+                     │              │                        └── args
+                     │              │                             └── variable: found:31
+                     │              ├── branch: 2
+                     │              │    ├── params: found:9
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_5":30
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 3
+                     │              │                        └── args
+                     │              │                             └── variable: found:9
+                     │              ├── branch: 3
+                     │              │    ├── params: found:10
+                     │              │    └── body
+                     │              │         ├── project
+                     │              │         │    ├── columns: stmt_raise_6:11
+                     │              │         │    ├── values
+                     │              │         │    │    └── tuple
+                     │              │         │    └── projections
+                     │              │         │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_6:11]
+                     │              │         │              ├── const: 'NOTICE'
+                     │              │         │              ├── const: 'HERE 2'
+                     │              │         │              ├── const: ''
+                     │              │         │              ├── const: ''
+                     │              │         │              └── const: '00000'
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_exec_7":29
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 4
+                     │              │                        └── args
+                     │              │                             └── variable: found:10
+                     │              ├── branch: 4
+                     │              │    ├── params: found:12
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_exec_ret_8":28
+                     │              │              ├── project
+                     │              │              │    ├── columns: found:27
+                     │              │              │    ├── right-join (cross)
+                     │              │              │    │    ├── columns: a:13
+                     │              │              │    │    ├── limit
+                     │              │              │    │    │    ├── columns: a:13
+                     │              │              │    │    │    ├── project
+                     │              │              │    │    │    │    ├── columns: a:13
+                     │              │              │    │    │    │    └── insert t114826
+                     │              │              │    │    │    │         ├── columns: a:13 rowid:14!null
+                     │              │              │    │    │    │         ├── insert-mapping:
+                     │              │              │    │    │    │         │    ├── a:17 => a:13
+                     │              │              │    │    │    │         │    └── rowid_default:21 => rowid:14
+                     │              │              │    │    │    │         ├── return-mapping:
+                     │              │              │    │    │    │         │    ├── a:17 => a:13
+                     │              │              │    │    │    │         │    └── rowid_default:21 => rowid:14
+                     │              │              │    │    │    │         └── project
+                     │              │              │    │    │    │              ├── columns: rowid_default:21 a:17
+                     │              │              │    │    │    │              ├── project
+                     │              │              │    │    │    │              │    ├── columns: a:17
+                     │              │              │    │    │    │              │    └── scan t114826
+                     │              │              │    │    │    │              │         └── columns: a:17 rowid:18!null crdb_internal_mvcc_timestamp:19 tableoid:20
+                     │              │              │    │    │    │              └── projections
+                     │              │              │    │    │    │                   └── function: unique_rowid [as=rowid_default:21]
+                     │              │              │    │    │    └── const: 1
+                     │              │              │    │    ├── values
+                     │              │              │    │    │    └── tuple
+                     │              │              │    │    └── filters (true)
+                     │              │              │    └── projections
+                     │              │              │         └── variable: a:13 [as=found:27]
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 5
+                     │              │                        └── args
+                     │              │                             └── variable: found:27
+                     │              ├── branch: 5
+                     │              │    ├── params: found:22
+                     │              │    └── body
+                     │              │         └── project
+                     │              │              ├── columns: "_stmt_raise_9":26
+                     │              │              ├── values
+                     │              │              │    └── tuple
+                     │              │              └── projections
+                     │              │                   └── dispatch: 1
+                     │              │                        ├── branch: 6
+                     │              │                        └── args
+                     │              │                             └── variable: found:22
+                     │              └── branch: 6
+                     │                   ├── params: found:23
+                     │                   └── body
+                     │                        ├── project
+                     │                        │    ├── columns: stmt_raise_10:24
+                     │                        │    ├── values
+                     │                        │    │    └── tuple
+                     │                        │    └── projections
+                     │                        │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_10:24]
+                     │                        │              ├── const: 'NOTICE'
+                     │                        │              ├── const: 'HERE 3'
+                     │                        │              ├── const: ''
+                     │                        │              ├── const: ''
+                     │                        │              └── const: '00000'
+                     │                        └── project
+                     │                             ├── columns: stmt_return_11:25!null
+                     │                             ├── values
+                     │                             │    └── tuple
+                     │                             └── projections
+                     │                                  └── const: 10 [as=stmt_return_11:25]
                      └── const: 1

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -196,6 +196,8 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"UniqueID":             {fullName: "opt.UniqueID", passByVal: true},
 		"WithID":               {fullName: "opt.WithID", passByVal: true},
 		"UDFDefinition":        {fullName: "memo.UDFDefinition", isPointer: true},
+		"RoutineDefList":       {fullName: "memo.RoutineDefList", passByVal: true},
+		"DispatcherID":         {fullName: "memo.DispatcherID", passByVal: true},
 		"Ordering":             {fullName: "opt.Ordering", passByVal: true},
 		"OrderingChoice":       {fullName: "props.OrderingChoice", passByVal: true},
 		"GroupingOrder":        {fullName: "memo.GroupingOrder", passByVal: true},

--- a/pkg/sql/sem/eval/expr.go
+++ b/pkg/sql/sem/eval/expr.go
@@ -622,7 +622,7 @@ func (e *evaluator) EvalSubquery(ctx context.Context, subquery *tree.Subquery) (
 func (e *evaluator) EvalRoutineExpr(
 	ctx context.Context, routine *tree.RoutineExpr,
 ) (tree.Datum, error) {
-	args, err := e.evalRoutineArgs(ctx, routine)
+	args, err := e.evalRoutineArgs(ctx, routine.Args)
 	if err != nil {
 		return nil, err
 	}
@@ -630,21 +630,52 @@ func (e *evaluator) EvalRoutineExpr(
 }
 
 func (e *evaluator) evalRoutineArgs(
-	ctx context.Context, expr *tree.RoutineExpr,
+	ctx context.Context, routineArgs tree.TypedExprs,
 ) (args tree.Datums, err error) {
-	if len(expr.Args) > 0 {
+	if len(routineArgs) > 0 {
 		// Evaluate each argument expression.
 		// TODO(mgartner): Use a scratch tree.Datums to avoid allocation on
 		// every invocation.
-		args = make(tree.Datums, len(expr.Args))
-		for i := range expr.Args {
-			args[i], err = expr.Args[i].Eval(ctx, e)
+		args = make(tree.Datums, len(routineArgs))
+		for i := range routineArgs {
+			args[i], err = routineArgs[i].Eval(ctx, e)
 			if err != nil {
 				return nil, err
 			}
 		}
 	}
 	return args, nil
+}
+
+func (e *evaluator) EvalDispatchExpr(
+	ctx context.Context, dispatch *tree.DispatchExpr,
+) (tree.Datum, error) {
+	args, err := e.evalRoutineArgs(ctx, dispatch.Args)
+	if err != nil {
+		return nil, err
+	}
+	dispatch.Sender.Send(dispatch.BranchIdx, args)
+	return tree.DNull, nil
+}
+
+func (e *evaluator) EvalDispatcherExpr(
+	ctx context.Context, dispatcher *tree.DispatcherExpr,
+) (tree.Datum, error) {
+	res, err := dispatcher.Input.Eval(ctx, e)
+	if err != nil {
+		return nil, err
+	}
+	for dispatcher.Receiver.HasNext() {
+		branchOrd, args := dispatcher.Receiver.Next()
+		if branchOrd >= len(dispatcher.Branches) {
+			return nil, errors.AssertionFailedf("branch ordinal out of range: %d", branchOrd)
+		}
+		res, err = e.Planner.EvalRoutineExpr(ctx, dispatcher.Branches[branchOrd], args)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
 func (e *evaluator) EvalTuple(ctx context.Context, t *tree.Tuple) (tree.Datum, error) {

--- a/pkg/sql/sem/eval/generators.go
+++ b/pkg/sql/sem/eval/generators.go
@@ -44,7 +44,7 @@ func GetFuncGenerator(
 func GetRoutineGenerator(
 	ctx context.Context, evalCtx *Context, expr *tree.RoutineExpr,
 ) (ValueGenerator, error) {
-	args, err := (*evaluator)(evalCtx).evalRoutineArgs(ctx, expr)
+	args, err := (*evaluator)(evalCtx).evalRoutineArgs(ctx, expr.Args)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "decimal.go",
         "delete.go",
         "discard.go",
+        "dispatch.go",
         "drop.go",
         "drop_owned_by.go",
         "eval.go",

--- a/pkg/sql/sem/tree/dispatch.go
+++ b/pkg/sql/sem/tree/dispatch.go
@@ -1,0 +1,190 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+)
+
+// DispatcherExpr is used to execute logically nested routine calls without
+// having to nest the execution context. Whenever a nested routine would be
+// evaluated as specified by the logical plan, control instead returns to the
+// dispatcher, which executes the routine in its own top-level context.
+// This is useful for two reasons:
+//
+//  1. Execution of deeply nested routines only consumes the resources for
+//     one routine at a time, since the previous routine is cleaned up whenever
+//     control returns to the DispatcherExpr.
+//  2. This will provide a single location to implement explicit transaction
+//     control for PL/pgSQL routines (tracked in #115294).
+//
+// A DispatcherExpr is evaluated according to the following steps:
+//
+//  1. If this is the first iteration, the Input expression is evaluated.
+//     Otherwise, the branch indicated by the last iteration is evaluated.
+//  2. If a DispatchExpr was evaluated in the last step, it will have passed the
+//     next branch to execute, and its arguments. Return to step (1).
+//  3. If evaluation never reached a DispatchExpr, execution has finished. The
+//     result of evaluating the expression in step (1) is the final result.
+//
+// These steps are implemented in eval/expr.go.
+type DispatcherExpr struct {
+	// Input is the initial expression to be evaluated. It may refer to the
+	// dispatcher's branches, but is not itself a branch. Generally, it will
+	// contain a DispatchExpr that will indicate a branch to be executed after
+	// execution of the Input expressions finishes to obtain the final result.
+	Input TypedExpr
+
+	// Branches is an ordered set of routines that may be invoked by DispatchExprs
+	// within Input and the branches themselves.
+	Branches []*RoutineExpr
+
+	// Receiver allows the DispatcherExpr to receive the next branch to execute
+	// and its arguments from a descendant DispatchExpr.
+	Receiver *DispatchChannel
+
+	// Typ is the return type of the DispatcherExpr.
+	Typ *types.T
+}
+
+var _ TypedExpr = &DispatcherExpr{}
+
+// NewDispatcherExpr returns a new DispatcherExpr with all fields initialized.
+func NewDispatcherExpr(
+	input TypedExpr, branches []*RoutineExpr, dispatchChannel *DispatchChannel, typ *types.T,
+) *DispatcherExpr {
+	return &DispatcherExpr{
+		Input:    input,
+		Branches: branches,
+		Receiver: dispatchChannel,
+		Typ:      typ,
+	}
+}
+
+// TypeCheck is part of the Expr interface.
+func (node *DispatcherExpr) TypeCheck(
+	ctx context.Context, semaCtx *SemaContext, desired *types.T,
+) (TypedExpr, error) {
+	return node, nil
+}
+
+// ResolvedType is part of the TypedExpr interface.
+func (node *DispatcherExpr) ResolvedType() *types.T {
+	return node.Typ
+}
+
+// Format is part of the Expr interface.
+func (node *DispatcherExpr) Format(ctx *FmtCtx) {
+	ctx.Printf("dispatcher")
+}
+
+// Walk is part of the Expr interface.
+func (node *DispatcherExpr) Walk(v Visitor) Expr {
+	// Cannot walk into a DispatcherExpr, so this is a no-op.
+	return node
+}
+
+// DispatchExpr represents a nested routine call. It avoids nesting *execution*
+// of the nested call by deferring the execution until control reaches the
+// top-level DispatcherExpr. See the DispatcherExpr comment for further details.
+type DispatchExpr struct {
+	// Args is the set of arguments with which the nested routine must be
+	// evaluated.
+	Args TypedExprs
+
+	// Branch is the index of the next branch of the parent DispatcherExpr that
+	// should be executed with the Args.
+	BranchIdx int
+
+	// Sender is used to directly pass the index of the next branch to be
+	// evaluated and its arguments to the parent DispatcherExpr.
+	Sender *DispatchChannel
+
+	// Type is the return type of the DispatchExpr.
+	Typ *types.T
+}
+
+// NewDispatchExpr returns a new DispatchExpr with all fields initialized.
+func NewDispatchExpr(
+	args TypedExprs, branchIdx int, dispatcherChannel *DispatchChannel, typ *types.T,
+) *DispatchExpr {
+	return &DispatchExpr{
+		Args:      args,
+		BranchIdx: branchIdx,
+		Sender:    dispatcherChannel,
+		Typ:       typ,
+	}
+}
+
+var _ TypedExpr = &DispatchExpr{}
+
+// TypeCheck is part of the Expr interface.
+func (node *DispatchExpr) TypeCheck(
+	ctx context.Context, semaCtx *SemaContext, desired *types.T,
+) (TypedExpr, error) {
+	return node, nil
+}
+
+// ResolvedType is part of the TypedExpr interface.
+func (node *DispatchExpr) ResolvedType() *types.T {
+	return node.Typ
+}
+
+// Format is part of the Expr interface.
+func (node *DispatchExpr) Format(ctx *FmtCtx) {
+	ctx.Printf("dispatch: %d(", node.BranchIdx)
+	ctx.FormatNode(&node.Args)
+	ctx.WriteByte(')')
+}
+
+// Walk is part of the Expr interface.
+func (node *DispatchExpr) Walk(v Visitor) Expr {
+	// Cannot walk into a DispatchExpr, so this is a no-op.
+	return node
+}
+
+// DispatchChannel provides a method for DispatchExpr instances to communicate
+// with their parent DispatcherExpr.
+type DispatchChannel struct {
+	branchIdx int
+	args      Datums
+	hasNext   bool
+}
+
+// Send is called by a DispatchExpr to invoke a branch of a DispatcherExpr.
+func (ch *DispatchChannel) Send(branchIdx int, args Datums) {
+	if ch.hasNext {
+		panic(errors.AssertionFailedf("invoked Send twice"))
+	}
+	ch.branchIdx = branchIdx
+	ch.args = args
+	ch.hasNext = true
+}
+
+// HasNext indicates the presence of a request to execute a dispatcher branch.
+func (ch *DispatchChannel) HasNext() bool {
+	return ch.hasNext
+}
+
+// Next retrieves the index of the next dispatcher branch that should execute,
+// as well as arguments to invoke it with. It can only be called is HasNext()
+// returns true.
+func (ch *DispatchChannel) Next() (branch int, args Datums) {
+	if !ch.hasNext {
+		panic(errors.AssertionFailedf("cannot call Next without a previous call to Send"))
+	}
+	branch, args = ch.branchIdx, ch.args
+	ch.hasNext = false
+	return branch, args
+}

--- a/pkg/sql/sem/tree/eval_expr_generated.go
+++ b/pkg/sql/sem/tree/eval_expr_generated.go
@@ -36,6 +36,8 @@ type ExprEvaluator interface {
 	EvalColumnItem(context.Context, *ColumnItem) (Datum, error)
 	EvalComparisonExpr(context.Context, *ComparisonExpr) (Datum, error)
 	EvalDefaultVal(context.Context, *DefaultVal) (Datum, error)
+	EvalDispatchExpr(context.Context, *DispatchExpr) (Datum, error)
+	EvalDispatcherExpr(context.Context, *DispatcherExpr) (Datum, error)
 	EvalFuncExpr(context.Context, *FuncExpr) (Datum, error)
 	EvalIfErrExpr(context.Context, *IfErrExpr) (Datum, error)
 	EvalIfExpr(context.Context, *IfExpr) (Datum, error)
@@ -274,6 +276,16 @@ func (node *DVoid) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 // Eval is part of the TypedExpr interface.
 func (node *DefaultVal) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return v.EvalDefaultVal(ctx, node)
+}
+
+// Eval is part of the TypedExpr interface.
+func (node *DispatchExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalDispatchExpr(ctx, node)
+}
+
+// Eval is part of the TypedExpr interface.
+func (node *DispatcherExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalDispatcherExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1782,6 +1782,8 @@ func (node *RangeCond) String() string        { return AsString(node) }
 func (node *StrVal) String() string           { return AsString(node) }
 func (node *Subquery) String() string         { return AsString(node) }
 func (node *RoutineExpr) String() string      { return AsString(node) }
+func (node *DispatchExpr) String() string     { return AsString(node) }
+func (node *DispatcherExpr) String() string   { return AsString(node) }
 func (node *Tuple) String() string            { return AsString(node) }
 func (node *TupleStar) String() string        { return AsString(node) }
 func (node *AnnotateTypeExpr) String() string { return AsString(node) }


### PR DESCRIPTION
#### sql/sem: add routine dispatch and dispatcher expressions

This commit adds two expressions, `Dispatch` and `Dispatcher`, which
evaluate a series of (mutually nested) routines. While it is possible
to evaluate nested routines directly, this has a drawback - the resources
for the entire call stack have to be maintained when a given routine is
executing. The new expressions are used to "flatten" this execution so
that routines are always executed in a top-level context, which avoids
the unnecessary overhead. See the `tree.DispatcherExpr` comment for
more details.

Note that `Dispatch` can only be used in tail-call position, where the
last thing a routine does is to call into another routine. Also note
that PL/pgSQL subroutines already have tail-call optimization - this
will be made explicit in following commits through use of the new
expressions.

There is an additional, and important, benefit of this change: it will
enable an implementation of nested transaction control. It is not
(currently) possible to arbitrarily commit and start a new transaction
within SQL execution. However, the Dispatcher expression will be able
to execute its branches through the internal executor, with a "delegate"
txn it is free to commit and replace. These changes will take place in
a future PR.

#### opt: add optimizer representations for Dispatcher and Dispatch

This commit adds support in the optimizer for analogues of the
execution-time expressions `DispatcherExpr` and `DispatchExpr` added in
the previous commit.

#### execbuilder: build Dispatcher and Dispatch expressions

This patch extends the execbuilder with the logic needed to build
the optimizer representations of `DispatcherExpr` and `DispatchExpr`
into their implementations (defined in `tree/dispatch.go`).

#### plpgsql: use Dispatcher and Dispatch expressions for PL/pgSQL subroutines

This commit updates the PL/pgSQL optbuilder logic to construct `Dispatch`
expressions to invoke subroutines through a `Dispatcher`, rather than
direct `UDFCall` expressions. The reasoning for this change is given in
the commit that introduced `tree.DispatcherExpr`.

Informs #115294

Release note: None