### PR TITLE
kvfollowerreadsccl: skip test under `race` not `stressrace`

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -940,7 +940,7 @@ func TestSecondaryTenantFollowerReadsRouting(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	defer utilccl.TestingEnableEnterprise()()
 
-	skip.UnderStressRace(t, "times out")
+	skip.UnderRace(t, "times out")
 	skip.UnderDeadlock(t)
 
 	for _, testCase := range []struct {


### PR DESCRIPTION
Epic: CRDB-8308
Release note: None