### PR TITLE
bincheck: do not run geos tests on Windows

### DIFF
--- a/build/release/bincheck/bincheck
+++ b/build/release/bincheck/bincheck
@@ -57,7 +57,7 @@ EOF
 diff -u expected actual
 
 # Verify libgeos functionality on all platforms except MacOS ARM64 and Windows
-if [[ $(uname -om) == "Darwin arm64" ]]; then
+if [[ $(uname -om) == "Darwin arm64" || $(uname -o) == "Msys" ]]; then
   echo "Skipping libgeos tests"
 else
   echo "Testing libgeos functionality"

--- a/build/release/bincheck/download_binary.sh
+++ b/build/release/bincheck/download_binary.sh
@@ -17,8 +17,6 @@ download_and_extract() {
   else
     curl -sSfL "${binary_url}" > cockroach.zip
     7z e -omnt cockroach.zip
-    mkdir -p mnt/lib
-    mv mnt/*.dll mnt/lib/
   fi
 
   echo "Downloaded ${binary_url}"


### PR DESCRIPTION
In #106642 we stopped shipping libgeos on Windows, but didn't update the bincheck test to reflect the change.

Epic: none
Release note: None