### PR TITLE
sql: some fixes around routines and types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -789,4 +789,27 @@ FROM purchase
 
 subtest end
 
+# Regression test for missing a cast on top of the generator function to match
+# the expected return type (#113186, #114846).
+statement ok
+CREATE FUNCTION f113186() RETURNS RECORD LANGUAGE SQL AS $$ SELECT 1.99; $$;
 
+query I
+SELECT * FROM f113186() AS foo(x INT);
+----
+2
+
+statement error invalid cast: decimal -> timestamp
+SELECT * FROM f113186() AS foo(x TIMESTAMP);
+
+statement ok
+CREATE FUNCTION array_to_set(anyarray) RETURNS SETOF RECORD AS $$
+   SELECT i AS "index", $1[i] AS "value" FROM generate_subscripts($1, 1) i
+$$ LANGUAGE SQL STRICT IMMUTABLE;
+
+query RT colnames,rowsort
+SELECT * FROM array_to_set(array['one', 'two']) AS t(f1 numeric(4,2), f2 text);
+----
+f1    f2
+1.00  one
+2.00  two

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -362,3 +362,23 @@ vectorized: true
   columns: (f88259)
   size: 1 column, 1 row
   row 0, expr 0: f88259(333, 444)
+
+# Regression test for not using actual parameter types (#114846).
+statement ok
+CREATE FUNCTION array_to_set(anyarray) RETURNS SETOF RECORD AS $$
+   SELECT i AS "index", $1[i] AS "value" FROM generate_subscripts($1, 1) i
+$$ LANGUAGE SQL STRICT IMMUTABLE;
+
+query T
+EXPLAIN (VERBOSE, TYPES) SELECT * FROM array_to_set(array['one', 'two']) AS t(f1 numeric(4,2), f2 text);
+----
+distribution: local
+vectorized: true
+·
+• project set
+│ columns: (f1 decimal, f2 string)
+│ estimated row count: 1
+│ render 0: (array_to_set((ARRAY[('one')[string],('two')[string]])[string[]]))[tuple{int AS index, string AS value}]
+│
+└── • emptyrow
+      columns: ()

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -222,11 +222,22 @@ func (b *Builder) buildRoutine(
 			panic(unimplemented.NewWithIssue(88947,
 				"variadiac user-defined functions are not yet supported"))
 		}
+		if len(paramTypes) != len(args) {
+			panic(errors.AssertionFailedf(
+				"different number of static parameters %d and actual arguments %d", len(paramTypes), len(args),
+			))
+		}
 		params = make(opt.ColList, len(paramTypes))
 		for i := range paramTypes {
 			paramType := &paramTypes[i]
 			argColName := funcParamColName(tree.Name(paramType.Name), i)
-			col := b.synthesizeColumn(bodyScope, argColName, paramType.Typ, nil /* expr */, nil /* scalar */)
+			// Use statically defined argument type (unless it is a wildcard in
+			// which case we use the actual parameter type).
+			argType := paramType.Typ
+			if argType.IsWildcardType() {
+				argType = args[i].DataType()
+			}
+			col := b.synthesizeColumn(bodyScope, argColName, argType, nil /* expr */, nil /* scalar */)
 			col.setParamOrd(i)
 			params[i] = col.id
 		}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1833,7 +1833,7 @@ func (expr *Array) TypeCheck(
 	}
 
 	if len(expr.Exprs) == 0 {
-		if desiredParam == types.Any {
+		if desiredParam.Identical(types.Any) {
 			return nil, errAmbiguousArrayType
 		}
 		expr.typ = types.MakeArray(desiredParam)

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2139,9 +2139,12 @@ func (t *T) Equal(other *T) bool {
 // IsWildcardType returns true if the type is only used as a wildcard during
 // static analysis, and cannot be used during execution.
 func (t *T) IsWildcardType() bool {
-	switch t {
-	case Any, AnyArray, AnyCollatedString, AnyEnum, AnyEnumArray, AnyTuple, AnyTupleArray:
-		return true
+	for _, wildcard := range []*T{Any, AnyArray, AnyCollatedString, AnyEnum, AnyEnumArray, AnyTuple, AnyTupleArray} {
+		// Note that pointer comparison is insufficient since we might have
+		// deserialized t from disk.
+		if t.Identical(wildcard) {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
See each commit for details.

Fixes: #113186
Fixes: #114846

Release note (bug fix): CockroachDB could previously encounter an internal error of the form `invalid datum type given: ..., expected ...` when executing some UDFs and this is now fixed. The bug has been present since 23.1.0 release.