### PR TITLE
*: use new slice to array conversion syntax

### DIFF
--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -946,11 +946,8 @@ func (sm SpanMeta) ToProto() *tracingpb.TraceInfo {
 func SpanMetaFromProto(info tracingpb.TraceInfo) SpanMeta {
 	var otelCtx oteltrace.SpanContext
 	if info.Otel != nil {
-		// NOTE: The ugly starry expressions below can be simplified once/if direct
-		// conversions from slices to arrays gets adopted:
-		// https://github.com/golang/go/issues/46505
-		traceID := *(*[16]byte)(info.Otel.TraceID)
-		spanID := *(*[8]byte)(info.Otel.SpanID)
+		traceID := [16]byte(info.Otel.TraceID)
+		spanID := [8]byte(info.Otel.SpanID)
 		otelCtx = otelCtx.WithRemote(true).WithTraceID(traceID).WithSpanID(spanID)
 	}
 


### PR DESCRIPTION
Closes #110261.

This commit adopts the new slice to array conversion syntax introduced in go 1.20. The new syntax is only applicable in one small part of the codebase, so it's a small change.

From https://tip.golang.org/doc/go1.20:

> Go 1.20 extends this to allow conversions from a slice to an array: given a slice x, [4]byte(x) can now be written instead of *(*[4]byte)(x).

Release note: None