### PR TITLE
release-23.2: sql: allow usage of table stats on system.jobs

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -1,7 +1,4 @@
-# LogicTest: 5node
-
-# Tests that verify we retrieve the stats correctly. Note that we can't create
-# statistics if distsql mode is OFF.
+# LogicTest: local
 
 statement ok
 CREATE TABLE uv (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
@@ -373,3 +370,42 @@ limit
  │    └── filters
  │         └── j:1 IS NULL [outer=(1), immutable, constraints=(/1: [/NULL - /NULL]; tight), fd=()-->(1)]
  └── 1
+
+# Ensure we can run ALTER statements on the system.jobs table.
+statement ok
+INSERT INTO system.users VALUES ('node', NULL, true, 3);
+
+statement ok
+GRANT node TO root;
+
+# Ensure that stats on the system.jobs table are being used.
+statement ok
+ALTER TABLE system.jobs INJECT STATISTICS '[
+    {
+        "avg_size": 7,
+        "columns": [
+            "id"
+        ],
+        "created_at": "2024-02-02 22:56:02.854028",
+        "distinct_count": 19,
+        "histo_col_type": "INT8",
+        "histo_version": 3,
+        "null_count": 0,
+        "row_count": 19
+    }
+]';
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT * FROM system.jobs;
+----
+scan jobs
+ ├── columns: id:1 status:2 created:3 payload:4 progress:5 created_by_type:6 created_by_id:7 claim_session_id:8 claim_instance_id:9 num_runs:10 last_run:11 job_type:12
+ ├── partial index predicates
+ │    └── jobs_run_stats_idx: filters
+ │         └── status:2 IN ('cancel-requested', 'pause-requested', 'pending', 'reverting', 'running') [outer=(2), constraints=(/2: [/'cancel-requested' - /'cancel-requested'] [/'pause-requested' - /'pause-requested'] [/'pending' - /'pending'] [/'reverting' - /'reverting'] [/'running' - /'running']; tight)]
+ ├── stats: [rows=19]
+ ├── cost: 61.81
+ ├── key: (1)
+ ├── fd: (1)-->(2-12)
+ ├── distribution: test
+ └── prune: (1-12)

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
@@ -13,7 +13,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
     exec_properties = {"Pool": "large"},
-    shard_count = 29,
+    shard_count = 28,
     tags = [
         "cpu:3",
     ],

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
@@ -285,10 +285,3 @@ func TestExecBuild_scan_parallel(
 	defer leaktest.AfterTest(t)()
 	runExecBuildLogicTest(t, "scan_parallel")
 }
-
-func TestExecBuild_stats(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runExecBuildLogicTest(t, "stats")
-}

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -580,6 +580,13 @@ func TestExecBuild_srfs(
 	runExecBuildLogicTest(t, "srfs")
 }
 
+func TestExecBuild_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "stats")
+}
+
 func TestExecBuild_subquery(
 	t *testing.T,
 ) {

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -234,9 +234,25 @@ func (sc *TableStatisticsCache) GetTableStats(
 	return sc.getTableStatsFromCache(ctx, table.GetID(), &forecast)
 }
 
-func statsDisallowedSystemTable(tableID descpb.ID) bool {
+// DisallowedOnSystemTable returns true if this tableID belongs to a special
+// system table on which we want to disallow stats collection and stats usage.
+func DisallowedOnSystemTable(tableID descpb.ID) bool {
 	switch tableID {
-	case keys.TableStatisticsTableID, keys.LeaseTableID, keys.JobsTableID, keys.ScheduledJobsTableID:
+	// Disable stats on system.table_statistics because it can lead to deadlocks
+	// around the stats cache (which issues an internal query in
+	// getTableStatsFromDB to fetch statistics for a single table, and that
+	// query in turn will want table stats on system.table_statistics to come up
+	// with a plan).
+	//
+	// Disable stats on system.lease since it's known to cause hangs.
+	// TODO(yuzefovich): check whether it's still a problem.
+	//
+	// Disable stats on system.scheduled_jobs because the table is mutated too
+	// frequently and would trigger too many stats collections. The potential
+	// benefit is not worth the potential performance hit.
+	// TODO(yuzefovich): re-evaluate this assumption. Perhaps we could at
+	// least enable manual collection on this table.
+	case keys.TableStatisticsTableID, keys.LeaseTableID, keys.ScheduledJobsTableID:
 		return true
 	}
 	return false
@@ -246,12 +262,7 @@ func statsDisallowedSystemTable(tableID descpb.ID) bool {
 // used by the query optimizer.
 func statsUsageAllowed(table catalog.TableDescriptor, clusterSettings *cluster.Settings) bool {
 	if catalog.IsSystemDescriptor(table) {
-		// Disable stats usage on system.table_statistics and system.lease. Looking
-		// up stats on system.lease is known to cause hangs, and the same could
-		// happen with system.table_statistics. Stats on system.jobs and
-		// system.scheduled_jobs are also disallowed because autostats are disabled
-		// on them.
-		if statsDisallowedSystemTable(table.GetID()) {
+		if DisallowedOnSystemTable(table.GetID()) {
 			return false
 		}
 		// Return whether the optimizer is allowed to use stats on system tables.
@@ -266,14 +277,7 @@ func autostatsCollectionAllowed(
 	table catalog.TableDescriptor, clusterSettings *cluster.Settings,
 ) bool {
 	if catalog.IsSystemDescriptor(table) {
-		// Disable autostats on system.table_statistics and system.lease. Looking
-		// up stats on system.lease is known to cause hangs, and the same could
-		// happen with system.table_statistics. No need to collect stats if we
-		// cannot use them. Stats on system.jobs and system.scheduled_jobs
-		// are also disallowed because they are mutated too frequently and would
-		// trigger too many stats collections. The potential benefit is not worth
-		// the potential performance hit.
-		if statsDisallowedSystemTable(table.GetID()) {
+		if DisallowedOnSystemTable(table.GetID()) {
 			return false
 		}
 		// Return whether autostats collection is allowed on system tables,


### PR DESCRIPTION
Backport 1/1 commits from #118693.

/cc @cockroachdb/release

---

In 23.1 (in a6e2818085a8c9097a2a1251d88f0d80533106b6, also fixed in fe2e2508ab6f34d82a53cc3ad599538c3a9b5a62) we allowed stats collection on `system.jobs` table. However, we forgot to update another place where the jobs table ID was mentioned - whether auto collection on the jobs table is allowed and whether usage (by the optimizer) of the table stats on jobs table is allowed. This is now fixed.

Additionally, this commit performs a minor cleanup of tests around this. In particular, `stats` execbuilder test now runs in the local mode (previously it was using 5node due to some peculiar historical reasons).

Epic: None

Release note: None

Release justification: bug fix.