### PR TITLE
logictest: add ability to call skip.UnderStress from Test-script

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/generated_test.go
@@ -90,9 +90,6 @@ func runCCLLogicTest(t *testing.T, file string) {
 }
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	if file == "distsql_tenant_locality" {
-		skip.UnderDuressWithIssue(t, 118627)
-	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -92,9 +92,6 @@ func runCCLLogicTest(t *testing.T, file string) {
 }
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	if file == "distsql_tenant_locality" {
-		skip.UnderDuressWithIssue(t, 118627)
-	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -72,9 +72,6 @@ func runCCLLogicTest(t *testing.T, file string) {
 {{- if .ExecBuildLogicTest -}}
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	if file == "distsql_tenant_locality" {
-		skip.UnderDuressWithIssue(t, 118627)
-	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,{{ if .ForceProductionValues }}

--- a/pkg/sql/logictest/testdata/logic_test/udf_schema_change
+++ b/pkg/sql/logictest/testdata/logic_test/udf_schema_change
@@ -329,7 +329,7 @@ $$
 statement ok
 ALTER FUNCTION f_test_sc(INT) SET SCHEMA test_alter_sc;
 
-skip config local-mixed-23.1
+skipif config local-mixed-23.1
 query TT
   WITH fns AS (
             SELECT crdb_internal.pb_to_json(
@@ -376,7 +376,7 @@ SELECT fn->>'id' AS id, fn->'parentSchemaId'
   ORDER BY id;
 ----
 112  105
-113  115
+113  114
 115  114
 
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
@@ -1,4 +1,5 @@
 # LogicTest: 3node-tenant-multiregion
+skip under duress 118627
 
 # Create a table on the secondary tenant.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
@@ -62,9 +62,6 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	if file == "distsql_tenant_locality" {
-		skip.UnderDuressWithIssue(t, 118627)
-	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/generated_test.go
@@ -62,9 +62,6 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	if file == "distsql_tenant_locality" {
-		skip.UnderDuressWithIssue(t, 118627)
-	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/generated_test.go
@@ -62,9 +62,6 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	if file == "distsql_tenant_locality" {
-		skip.UnderDuressWithIssue(t, 118627)
-	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist/generated_test.go
@@ -62,9 +62,6 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	if file == "distsql_tenant_locality" {
-		skip.UnderDuressWithIssue(t, 118627)
-	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-legacy-schema-changer/generated_test.go
@@ -62,9 +62,6 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	if file == "distsql_tenant_locality" {
-		skip.UnderDuressWithIssue(t, 118627)
-	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.1/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.1/generated_test.go
@@ -62,9 +62,6 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	if file == "distsql_tenant_locality" {
-		skip.UnderDuressWithIssue(t, 118627)
-	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.2/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-23.2/generated_test.go
@@ -62,9 +62,6 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	if file == "distsql_tenant_locality" {
-		skip.UnderDuressWithIssue(t, 118627)
-	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/generated_test.go
@@ -62,9 +62,6 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	if file == "distsql_tenant_locality" {
-		skip.UnderDuressWithIssue(t, 118627)
-	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -62,9 +62,6 @@ func TestMain(m *testing.M) {
 
 func runExecBuildLogicTest(t *testing.T, file string) {
 	defer sql.TestingOverrideExplainEnvVersion("CockroachDB execbuilder test version")()
-	if file == "distsql_tenant_locality" {
-		skip.UnderDuressWithIssue(t, 118627)
-	}
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	serverArgs := logictest.TestServerArgs{
 		DisableWorkmemRandomization: true,

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -136,12 +136,22 @@ func UnderStressWithIssue(t SkippableTest, githubIssueID int, args ...interface{
 	}
 }
 
-// UnderStressRace skips this test during stressrace runs, which are tests
-// run under stress with the -race flag.
+// UnderStressRace skips this test during stressrace runs, which are tests run
+// under stress with the -race flag.
 func UnderStressRace(t SkippableTest, args ...interface{}) {
 	t.Helper()
 	if Stress() && util.RaceEnabled {
 		maybeSkip(t, "disabled under stressrace", args...)
+	}
+}
+
+// UnderStressRaceWithIssue skips this test during stressrace runs, which are
+// tests run under stress with the -race flag, logging the given issue ID as the
+// reason.
+func UnderStressRaceWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
+	t.Helper()
+	if Stress() && util.RaceEnabled {
+		maybeSkip(t, withIssue("disabled under stressrace", githubIssueID), args...)
 	}
 }
 


### PR DESCRIPTION
**logictest: add ability to call skip.UnderStress from Test-script**

We already had a `skip` command in our fork of Test-script. Flesh it out
a bit with options for `skip.UnderStress` and family. The new syntax
comes in three forms:

```
skip <ISSUE> [args...]
skip ignorelint [args...]
skip under <deadlock/race/stress/stressrace/metamorphic/duress> [ISSUE] [args...]
```

The first form calls `skip.WithIssue`, the second form calls
`skip.IgnoreLint`, and the third form calls `skip.UnderStress` and
family.

Before this change, the only supported form was `skip [ISSUE]` which
called `skip.IgnoreLint`. With this cange, commands in this original
form will instead call `skip.WithIssue`. AFAIK there are no existing
skip commands currently, so this should be a moot point.

Also fix one mistaken use of `skip` which should have been `skipif`.

Informs: #118627

Epic: None

Release note: None

---

**exec: skip distsql_tenant_locality under duress**

In #118769 we added a skip under duress for the distsql_tenant_locality
logic test due to #118627.

Now that the `skip` command supports calling `skip.UnderDuress()`, move
the skip for distsql_tenant_locality from the logictest template to the
test script itself.

Informs: #118627

Epic: None

Release note: None