### PR TITLE
engineccl: Add feature flag for encryption at rest v2

### DIFF
--- a/pkg/ccl/baseccl/encryption_options.proto
+++ b/pkg/ccl/baseccl/encryption_options.proto
@@ -31,4 +31,15 @@ message EncryptionOptions {
 
   // Default data key rotation in seconds.
   int64 data_key_rotation_period = 3;
+
+  // The implementation version is used to select between implementations
+  // that do not change the on-disk data. This allows for low-risk rollouts
+  // of optimized implementations. Options which affect the on-disk data
+  // (such as different encrpytion algorithms) would be managed elsewhere
+  // to allow for migrations.
+  //
+  // There are currently two versions, 1 and 2, defined in
+  // storageccl/engineccl/ctr_stream.go.
+  // A value of zero will use the default, currently 1.
+  int64 version = 4;
 }

--- a/pkg/ccl/baseccl/encryption_options.proto
+++ b/pkg/ccl/baseccl/encryption_options.proto
@@ -41,5 +41,5 @@ message EncryptionOptions {
   // There are currently two versions, 1 and 2, defined in
   // storageccl/engineccl/ctr_stream.go.
   // A value of zero will use the default, currently 1.
-  int64 version = 4;
+  int64 impl_version = 4;
 }

--- a/pkg/ccl/baseccl/encryption_spec.go
+++ b/pkg/ccl/baseccl/encryption_spec.go
@@ -36,7 +36,7 @@ type StoreEncryptionSpec struct {
 	KeyPath        string
 	OldKeyPath     string
 	RotationPeriod time.Duration
-	Version        int64
+	ImplVersion    int64
 }
 
 // ToEncryptionOptions convert to a serialized EncryptionOptions protobuf.
@@ -48,7 +48,7 @@ func (es StoreEncryptionSpec) ToEncryptionOptions() ([]byte, error) {
 			OldKey:     es.OldKeyPath,
 		},
 		DataKeyRotationPeriod: int64(es.RotationPeriod / time.Second),
-		Version:               es.Version,
+		ImplVersion:           es.ImplVersion,
 	}
 
 	return protoutil.Marshal(&opts)
@@ -57,8 +57,8 @@ func (es StoreEncryptionSpec) ToEncryptionOptions() ([]byte, error) {
 // String returns a fully parsable version of the encryption spec.
 func (es StoreEncryptionSpec) String() string {
 	// All fields are set.
-	return fmt.Sprintf("path=%s,key=%s,old-key=%s,rotation-period=%s,version=%d",
-		es.Path, es.KeyPath, es.OldKeyPath, es.RotationPeriod, es.Version)
+	return fmt.Sprintf("path=%s,key=%s,old-key=%s,rotation-period=%s,impl_version=%d",
+		es.Path, es.KeyPath, es.OldKeyPath, es.RotationPeriod, es.ImplVersion)
 }
 
 // NewStoreEncryptionSpec parses the string passed in and returns a new
@@ -125,11 +125,11 @@ func NewStoreEncryptionSpec(value string) (StoreEncryptionSpec, error) {
 			if err != nil {
 				return StoreEncryptionSpec{}, errors.Wrapf(err, "could not parse rotation-duration value: %s", value)
 			}
-		case "version":
+		case "impl_version":
 			var err error
-			es.Version, err = strconv.ParseInt(value, 10, 64)
+			es.ImplVersion, err = strconv.ParseInt(value, 10, 64)
 			if err != nil {
-				return StoreEncryptionSpec{}, errors.Wrapf(err, "could not parse version: %s", value)
+				return StoreEncryptionSpec{}, errors.Wrapf(err, "could not parse impl_version: %s", value)
 			}
 		default:
 			return StoreEncryptionSpec{}, fmt.Errorf("%s is not a valid enterprise-encryption field", field)

--- a/pkg/ccl/baseccl/encryption_spec_test.go
+++ b/pkg/ccl/baseccl/encryption_spec_test.go
@@ -45,6 +45,10 @@ func TestNewStoreEncryptionSpec(t *testing.T) {
 		{"path=data,key=new.key,old-key=old.key,rotation-period=1", `could not parse rotation-duration value: 1: time: missing unit in duration "1"`, StoreEncryptionSpec{}},
 		{"path=data,key=new.key,old-key=old.key,rotation-period=1d", `could not parse rotation-duration value: 1d: time: unknown unit "d" in duration "1d"`, StoreEncryptionSpec{}},
 
+		// Version.
+		{"path=/data,key=/new.key,old-key=plain,version=x", `could not parse version: x: strconv.ParseInt: parsing "x": invalid syntax`, StoreEncryptionSpec{}},
+		{"path=/data,key=/new.key,old-key=plain,version=2", "", StoreEncryptionSpec{Path: "/data", KeyPath: "/new.key", OldKeyPath: "plain", RotationPeriod: DefaultRotationPeriod, Version: 2}},
+
 		// Good values.
 		{"path=/data,key=/new.key,old-key=/old.key", "", StoreEncryptionSpec{Path: "/data", KeyPath: "/new.key", OldKeyPath: "/old.key", RotationPeriod: DefaultRotationPeriod}},
 		{"path=/data,key=/new.key,old-key=/old.key,rotation-period=1h", "", StoreEncryptionSpec{Path: "/data", KeyPath: "/new.key", OldKeyPath: "/old.key", RotationPeriod: time.Hour}},

--- a/pkg/ccl/baseccl/encryption_spec_test.go
+++ b/pkg/ccl/baseccl/encryption_spec_test.go
@@ -46,8 +46,8 @@ func TestNewStoreEncryptionSpec(t *testing.T) {
 		{"path=data,key=new.key,old-key=old.key,rotation-period=1d", `could not parse rotation-duration value: 1d: time: unknown unit "d" in duration "1d"`, StoreEncryptionSpec{}},
 
 		// Version.
-		{"path=/data,key=/new.key,old-key=plain,version=x", `could not parse version: x: strconv.ParseInt: parsing "x": invalid syntax`, StoreEncryptionSpec{}},
-		{"path=/data,key=/new.key,old-key=plain,version=2", "", StoreEncryptionSpec{Path: "/data", KeyPath: "/new.key", OldKeyPath: "plain", RotationPeriod: DefaultRotationPeriod, Version: 2}},
+		{"path=/data,key=/new.key,old-key=plain,impl_version=x", `could not parse impl_version: x: strconv.ParseInt: parsing "x": invalid syntax`, StoreEncryptionSpec{}},
+		{"path=/data,key=/new.key,old-key=plain,impl_version=2", "", StoreEncryptionSpec{Path: "/data", KeyPath: "/new.key", OldKeyPath: "plain", RotationPeriod: DefaultRotationPeriod, ImplVersion: 2}},
 
 		// Good values.
 		{"path=/data,key=/new.key,old-key=/old.key", "", StoreEncryptionSpec{Path: "/data", KeyPath: "/new.key", OldKeyPath: "/old.key", RotationPeriod: DefaultRotationPeriod}},

--- a/pkg/ccl/storageccl/engineccl/ctr_stream.go
+++ b/pkg/ccl/storageccl/engineccl/ctr_stream.go
@@ -28,9 +28,9 @@ import (
 // FileStream for either a new file (using the active key provided by the KeyManager) or an
 // existing file (by looking up the key in the KeyManager).
 type FileCipherStreamCreator struct {
-	envType    enginepb.EnvType
-	keyManager PebbleKeyManager
-	version    int64
+	envType     enginepb.EnvType
+	keyManager  PebbleKeyManager
+	implVersion int64
 }
 
 const (
@@ -73,7 +73,7 @@ func (c *FileCipherStreamCreator) CreateNew(
 	}
 	// Does not matter how we convert 4 random bytes into uint32
 	settings.Counter = binary.LittleEndian.Uint32(counterBytes)
-	switch c.version {
+	switch c.implVersion {
 	case 0 /* default */, 1:
 		ctrCS, err := newCTRBlockCipherStream(key, settings.Nonce, settings.Counter)
 		if err != nil {
@@ -89,7 +89,7 @@ func (c *FileCipherStreamCreator) CreateNew(
 		}
 		return settings, fcs2, nil
 	default:
-		return settings, nil, errors.Newf("unsupported version %d", c.version)
+		return settings, nil, errors.Newf("unsupported version %d", c.implVersion)
 	}
 }
 

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs.go
@@ -323,9 +323,9 @@ func newEncryptedEnv(
 		FS:           fs,
 		fileRegistry: fr,
 		streamCreator: &FileCipherStreamCreator{
-			envType:    enginepb.EnvType_Store,
-			keyManager: storeKeyManager,
-			version:    options.Version,
+			envType:     enginepb.EnvType_Store,
+			keyManager:  storeKeyManager,
+			implVersion: options.ImplVersion,
 		},
 	}
 	dataKeyManager := &DataKeyManager{
@@ -341,9 +341,9 @@ func newEncryptedEnv(
 		FS:           fs,
 		fileRegistry: fr,
 		streamCreator: &FileCipherStreamCreator{
-			envType:    enginepb.EnvType_Data,
-			keyManager: dataKeyManager,
-			version:    options.Version,
+			envType:     enginepb.EnvType_Data,
+			keyManager:  dataKeyManager,
+			implVersion: options.ImplVersion,
 		},
 	}
 

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs.go
@@ -325,6 +325,7 @@ func newEncryptedEnv(
 		streamCreator: &FileCipherStreamCreator{
 			envType:    enginepb.EnvType_Store,
 			keyManager: storeKeyManager,
+			version:    options.Version,
 		},
 	}
 	dataKeyManager := &DataKeyManager{
@@ -342,6 +343,7 @@ func newEncryptedEnv(
 		streamCreator: &FileCipherStreamCreator{
 			envType:    enginepb.EnvType_Data,
 			keyManager: dataKeyManager,
+			version:    options.Version,
 		},
 	}
 

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -106,11 +106,11 @@ func TestEncryptedFS(t *testing.T) {
 
 	for idx, tc := range testCases {
 		// Alternate between versions 1 and 2 to verify that we can upgrade and downgrade freely.
-		version := 1
+		implVersion := 1
 		if idx%2 == 1 {
-			version = 2
+			implVersion = 2
 		}
-		streamCreator := &FileCipherStreamCreator{keyManager: keyManager, envType: enginepb.EnvType_Store, version: int64(version)}
+		streamCreator := &FileCipherStreamCreator{keyManager: keyManager, envType: enginepb.EnvType_Store, implVersion: int64(implVersion)}
 
 		fs := &encryptedFS{FS: memFS, fileRegistry: fileRegistry, streamCreator: streamCreator}
 

--- a/pkg/ccl/storageccl/engineccl/testdata/ctr_stream
+++ b/pkg/ccl/storageccl/engineccl/testdata/ctr_stream
@@ -6,7 +6,7 @@
 # order to minimize maintenance burden we use the datadriven package with
 # its "rewrite" option. To produce random inputs, you can use something like
 #   head -c 16 /dev/random | od -An -tx1 -v
-# (note that macOS `od` uses more whitespacae than linux `od`, so this file
+# (note that macOS `od` uses more whitespace than linux `od`, so this file
 # uses the linux `od` format).
 
 # 128 bytes of random data. In this file we'll verify the entire contents
@@ -80,7 +80,9 @@ e7 f7 3f 8b d8 22 34 d9 fb ef b0 9f d8 e2 7a ad
 0d 0e 42 46 09 29 a2 21 82 42 95 35 1c f7 2a 6e
 
 # And so does the offset. Note that the way this parameter works is to
-# logically shift the static test input data into the given offset.
+# logically shift the static test input data into the given offset,
+# so the output of offset=1 is not the same as the output of
+# offset=0 with the first byte chopped off.
 encrypt offset=1
 ----
 4b 41 65 df 7c 2a 96 0d 07 34 93 4c da fd 88 4a
@@ -138,3 +140,30 @@ e4 dc aa 44 1f f0 a5 e6 b4 53 a3 5d 72 ca 94 b7
 5e 90 a3 4b 85 5e 77 32 62 0c 63 46 5c 63 23 10
 42 bc 8e 63 df ca b4 d7 b7 05 60 96 3d 08 5e 0d
 0f 0e 97 bf 1f 0c 92 3b 87 62 fc 0b f5 c9 bc e4
+
+create-iv name=max
+ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
+----
+ok
+
+encrypt offset=0 iv=max skip-v1=true
+----
+97 f0 99 31 fd a9 6e 96 57 b9 f3 b6 66 41 24 a1
+ed 2f 5b d0 36 7b 42 8b 48 2d 86 ae aa ad 28 65
+d6 34 64 4b f6 b9 ac 9c 5a af 35 be 2d 19 00 21
+61 22 5d 5a 2c 29 84 da 05 66 7c 4f d2 de 89 08
+c1 c8 df 90 01 59 4c 1c b6 fe 01 a0 0e 25 9f 70
+1c fb 8e 2b 46 b1 eb 19 5c 06 1b 2f 47 68 a7 ce
+d5 f4 12 81 cb aa 93 21 30 db 52 9c 6f 99 3d 1b
+64 67 27 a2 f7 2f ad db 5c b7 90 0c 08 1a f8 51
+
+encrypt offset=1 iv=max skip-v1=true
+----
+ef db d5 f1 25 a1 f2 f1 96 c4 70 da c8 7a 4a 0f
+b9 5c 32 c7 2a bf cd f0 8e 3e 5d f2 66 63 fb 3c
+fd 0d 0d 5d e2 da 1a 33 94 09 5e a0 2c ed 2a 50
+f3 6f 21 4b 82 3c a4 d6 7c 96 97 57 51 f7 1f 7f
+98 21 32 54 30 0d 15 9f 05 b9 8b bf c0 8a ed 76
+12 1b 7f e8 1b 96 0d cc 8d 2e 5b c5 51 eb 50 7c
+9e 2e 2e 49 b4 37 b8 79 82 39 50 8b 4e 51 4f f3
+1e 42 40 d0 be a3 5a e2 89 9d b1 26 56 b9 fb 15

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -193,6 +193,7 @@ go_library(
         "//pkg/ccl/changefeedccl",
         "//pkg/ccl/changefeedccl/cdctest",
         "//pkg/ccl/changefeedccl/changefeedbase",
+        "//pkg/ccl/storageccl/engineccl/enginepbccl",
         "//pkg/ccl/streamingccl/replicationutils",
         "//pkg/cli",
         "//pkg/cli/clisqlclient",

--- a/pkg/cmd/roachtest/tests/encryption.go
+++ b/pkg/cmd/roachtest/tests/encryption.go
@@ -44,9 +44,9 @@ func registerEncryption(r registry.Registry) {
 
 		keys := []string{"plain", "plain", "aes-128.key", "aes-256.key"}
 		for keyIdx := 1; keyIdx < len(keys); keyIdx++ {
-			for _, version := range []int{1, 2} {
+			for _, implVersion := range []int{1, 2} {
 				opts := option.DefaultStartOpts()
-				opts.RoachprodOpts.ExtraArgs = []string{fmt.Sprintf("--enterprise-encryption=path=data,key=%s,old-key=%s,version=%d", keys[keyIdx], keys[keyIdx-1], version)}
+				opts.RoachprodOpts.ExtraArgs = []string{fmt.Sprintf("--enterprise-encryption=path=data,key=%s,old-key=%s,impl_version=%d", keys[keyIdx], keys[keyIdx-1], implVersion)}
 				c.Start(ctx, t.L(), opts, install.MakeClusterSettings(), c.Range(1, nodes))
 				WaitForReady(ctx, t, c, c.Range(1, nodes))
 


### PR DESCRIPTION
The v2 implementation of encryption at rest improves performance in most cases, but it slows down small random reads (see #115549 for benchmarks). We don't believe we do small random reads, but out of an abundance of caution (and a desire to make this change backportable), I've put it behind a feature flag. We should be able to move pretty quickly to flip the default and then remove the flag but we need a little real-world testing first.

Note that one expected benefit of this change is to reduce the impact that splits have on tail latency, since it makes the stats recomputation faster.

Release note (performance improvement): "version=2" may be added to the --enterprise-encryption flag to use a new faster implementation.

Epic: None