### PR TITLE
roachpb: stop reading `Lease.DeprecatedStartStasis`

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -1942,9 +1942,6 @@ func TestAcquireLease(t *testing.T) {
 					t.Errorf("unexpected lease start: %s; expected %s", lease.Start, expStart)
 				}
 
-				if *lease.DeprecatedStartStasis != *lease.Expiration {
-					t.Errorf("%s already in stasis (or beyond): %+v", ts, lease)
-				}
 				if lease.Expiration.LessEq(ts) {
 					t.Errorf("%s already expired: %+v", ts, lease)
 				}

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1981,8 +1981,8 @@ func equivalentTimestamps(a, b *hlc.Timestamp) bool {
 
 // Equal implements the gogoproto Equal interface. This implementation is
 // forked from the gogoproto generated code to allow l.Expiration == nil and
-// l.Expiration == &hlc.Timestamp{} to compare equal. Ditto for
-// DeprecatedStartStasis.
+// l.Expiration == &hlc.Timestamp{} to compare equal. It also ignores
+// DeprecatedStartStasis entirely to allow for its removal in a later release.
 func (l *Lease) Equal(that interface{}) bool {
 	if that == nil {
 		return l == nil
@@ -2010,9 +2010,6 @@ func (l *Lease) Equal(that interface{}) bool {
 		return false
 	}
 	if !l.Replica.Equal(&that1.Replica) {
-		return false
-	}
-	if !equivalentTimestamps(l.DeprecatedStartStasis, that1.DeprecatedStartStasis) {
 		return false
 	}
 	if !l.ProposedTS.Equal(that1.ProposedTS) {

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -664,6 +664,16 @@ message Lease {
   ReplicaDescriptor replica = 3 [(gogoproto.nullable) = false];
 
   // The start of the lease stasis period. This field is deprecated.
+  //
+  // TODO(erikgrinaker): remove this. Migration:
+  //
+  // - 2016: the field was deprecated (#10305).
+  //
+  // - 24.1: stop reading the field. 23.2 nodes compare the field below Raft in
+  //   Lease.Equal(), so we must populate the field for backwards compatibility.
+  //
+  // - 24.2 or later: remove the field when backwards compatibility with 23.2
+  //   is no longer needed.
   util.hlc.Timestamp deprecated_start_stasis = 4;
 
   // The current timestamp when this lease has been proposed. Used after a

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -1146,6 +1146,14 @@ func TestLeaseEqual(t *testing.T) {
 		t.Fatalf("unexpectedly did not compare equal: %s", pretty.Diff(a, b))
 	}
 
+	// Verify that DeprecatedStartStasis is ignored entirely.
+	a = Lease{DeprecatedStartStasis: &hlc.Timestamp{WallTime: 1}}
+	b = Lease{DeprecatedStartStasis: &hlc.Timestamp{WallTime: 2}}
+	c := Lease{}
+	require.True(t, a.Equal(b))
+	require.True(t, a.Equal(c))
+	require.True(t, b.Equal(c))
+
 	if !(*Lease)(nil).Equal(nil) {
 		t.Fatalf("unexpectedly did not compare equal")
 	}
@@ -1171,7 +1179,6 @@ func TestLeaseEqual(t *testing.T) {
 		{Start: clockTS},
 		{Expiration: &ts},
 		{Replica: ReplicaDescriptor{NodeID: 1}},
-		{DeprecatedStartStasis: &ts},
 		{ProposedTS: &clockTS},
 		{Epoch: 1},
 		{Sequence: 1},


### PR DESCRIPTION
This will allow removing the field in a later version. We still have to populate the field for backwards compatibility with 23.2.

Epic: none
Release note: None