### PR TITLE
kvclient: dont' evict down leaseholder

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2534,22 +2534,6 @@ func (ds *DistSender) sendToReplicas(
 			if withCommit && !grpcutil.RequestDidNotStart(err) {
 				ambiguousError = err
 			}
-
-			// If the error wasn't just a context cancellation and the down replica
-			// is cached as the lease holder, evict it. The only other eviction
-			// happens below on NotLeaseHolderError, but if the next replica is the
-			// actual lease holder, we're never going to receive one of those and
-			// will thus pay the price of trying the down node first forever.
-			//
-			// NB: we should consider instead adding a successful reply from the next
-			// replica into the cache, but without a leaseholder (and taking into
-			// account that the local node can't be down) it won't take long until we
-			// talk to a replica that tells us who the leaseholder is.
-			if ctx.Err() == nil {
-				if lh := routing.Leaseholder(); lh != nil && lh.IsSame(curReplica) {
-					routing.EvictLease(ctx)
-				}
-			}
 		} else {
 			// If the reply contains a timestamp, update the local HLC with it.
 			if br.Error != nil {

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -1427,9 +1427,9 @@ func TestDistSenderRetryOnTransportErrors(t *testing.T) {
 	}
 }
 
-// This test verifies that when we have a cached leaseholder that is down
-// it is ejected from the cache.
-func TestDistSenderDownNodeEvictLeaseholder(t *testing.T) {
+// TestDistSenderLeaseholderDown verifies that when we have a cached leaseholder
+// that is down it remains in the cache.
+func TestDistSenderLeaseholderDown(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -1478,10 +1478,9 @@ func TestDistSenderDownNodeEvictLeaseholder(t *testing.T) {
 			contacted1 = true
 			return nil, errors.New("mock RPC error")
 		case 2:
-			// The client has cleared the lease in the cache after the failure of the
-			// first RPC.
+			// The client keeps the lease entry but moves onto the other replicas.
 			assert.Equal(t, desc.Generation, ba.ClientRangeInfo.DescriptorGeneration)
-			assert.Equal(t, roachpb.LeaseSequence(0), ba.ClientRangeInfo.LeaseSequence)
+			assert.Equal(t, lease1.Sequence, ba.ClientRangeInfo.LeaseSequence)
 			assert.Equal(t, roachpb.LEAD_FOR_GLOBAL_READS, ba.ClientRangeInfo.ClosedTimestampPolicy)
 			contacted2 = true
 			br := ba.CreateReply()


### PR DESCRIPTION
We should not change routing information based on whether a leaseholder is up or down. This causes churn in the updating of lease information. Instead we reply on circuit breakers to fast-ignore down leaseholders

Epic: none

Release note: None