### PR TITLE
multitenant: upgrade min supported version for 24.1

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -79,7 +79,7 @@ func runMultiTenantUpgrade(
 	// Update this map with every new release.
 	versionToMinSupportedVersion := map[string]string{
 		"23.2": "23.1",
-		"24.1": "23.1",
+		"24.1": "23.2",
 	}
 	curBinaryMajorAndMinorVersion := getMajorAndMinorVersionOnly(v)
 	currentBinaryMinSupportedVersion, ok := versionToMinSupportedVersion[curBinaryMajorAndMinorVersion]


### PR DESCRIPTION
Fix the multitenant-upgrade roachtest by upgrading the min supported version for 24.1 to 23.1. We could probably do something smarter to ensure that we don't need to update this in every release, but making this quick change now to prevent the test from continually failing.

Release note: None

Fixes: #118213