### PR TITLE
kvenemesis: move test to `large` worker pool

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -60,7 +60,7 @@ go_library(
 
 go_test(
     name = "kvnemesis_test",
-    size = "large",
+    size = "medium",
     srcs = [
         "applier_test.go",
         "engine_test.go",
@@ -74,7 +74,7 @@ go_test(
     embed = [":kvnemesis"],
     exec_properties = select({
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "default"},
+        "//conditions:default": {"test.Pool": "large"},
     }),
     deps = [
         "//pkg/base",


### PR DESCRIPTION
This test is prone to timing out.

Closes #118740

Epic: CRDB-8308
Release note: None