### PR TITLE
release-23.1: cluster-ui: bump cluster-ui npm version

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "23.1.13",
+  "version": "23.1.14",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
It's been a moment since our last version bump of cluster-ui for release-23.1 (last bump here:
https://github.com/cockroachdb/cockroach/pull/115667)

This patch bumps the version on `release-23.1` from `23.1.13` to `23.1.14`.

**NOTE:** This PR is slated to be merged to `release-23.1` directly, not `master`. A separate, similar PR will be filed for `release-23.2`.

Release note: none

Epic: none

Release justification: cluster-ui version upgrade