### PR TITLE
release 23.2: changefeedccl: migrate deprecated pts records to new scheme

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -242,6 +242,7 @@ go_test(
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/protectedts",
+        "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/roachpb",
         "//pkg/scheduledjobs",
         "//pkg/scheduledjobs/schedulebase",

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1626,20 +1626,43 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 		highWater = cf.highWaterAtStart
 	}
 
-	recordID := progress.ProtectedTimestampRecord
-	if recordID == uuid.Nil {
+	if progress.ProtectedTimestampRecord == uuid.Nil {
 		ptr := createProtectedTimestampRecord(
 			ctx, cf.flowCtx.Codec(), cf.spec.JobID, AllTargets(cf.spec.Feed), highWater,
 		)
 		progress.ProtectedTimestampRecord = ptr.ID.GetUUID()
+		return pts.Protect(ctx, ptr)
+	}
+
+	log.VEventf(ctx, 2, "updating protected timestamp %v at %v", progress.ProtectedTimestampRecord, highWater)
+
+	rec, err := pts.GetRecord(ctx, progress.ProtectedTimestampRecord)
+	if err != nil {
+		return err
+	}
+
+	if rec.Target != nil {
+		return pts.UpdateTimestamp(ctx, progress.ProtectedTimestampRecord, highWater)
+	}
+
+	// If this changefeed was created in 22.1 or earlier, it may be using a deprecated pts record in which
+	// the target field is nil. If so, we "migrate" it to use the new style of pts records and delete the old one.
+	preserveDeprecatedPts := cf.knobs.PreserveDeprecatedPts != nil && cf.knobs.PreserveDeprecatedPts()
+	if !preserveDeprecatedPts {
+		prevRecordId := progress.ProtectedTimestampRecord
+		ptr := createProtectedTimestampRecord(
+			ctx, cf.flowCtx.Codec(), cf.spec.JobID, AllTargets(cf.spec.Feed), highWater,
+		)
 		if err := pts.Protect(ctx, ptr); err != nil {
 			return err
 		}
-	} else {
-		log.VEventf(ctx, 2, "updating protected timestamp %v at %v", recordID, highWater)
-		if err := pts.UpdateTimestamp(ctx, recordID, highWater); err != nil {
+		progress.ProtectedTimestampRecord = ptr.ID.GetUUID()
+		if err := pts.Release(ctx, prevRecordId); err != nil {
 			return err
 		}
+
+		log.Eventf(ctx, "created new pts record %v to replace old pts record %v at %v",
+			progress.ProtectedTimestampRecord, prevRecordId, highWater)
 	}
 
 	return nil

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -77,6 +77,10 @@ type TestingKnobs struct {
 
 	// OnDrain returns the channel to select on to detect node drain
 	OnDrain func() <-chan struct{}
+
+	// PreserveDeprecatedPts is used to prevent a changefeed from upgrading
+	// its PTS record from the deprecated style to the new style.
+	PreserveDeprecatedPts func() bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/117945

---

This change adds logic in changefeeds to "migrate" pts records which use the old style (ie. protect spans instead of targets / desc ids). With this change, when a changefeed manages its pts record (once every 10 minutes by default), it will check to see if the record is deprecated. If so, it will create a new record with the non-deprecated style and remove the old one.

This change helps accomplish #82888 by effectively removing changefeed jobs relying on the old PTS subsystem, allowing the old subsystem to be removed.

Informs: https://github.com/cockroachdb/cockroach/issues/82888
Release note: None
Epic: CRDB-34798

Release justification: This is a small change which will fix old-style PTS records automatically without version gates or complicated mechanisms. It will reduce the footprint of changes such as https://github.com/cockroachdb/cockroach/pull/118772 and https://github.com/cockroachdb/cockroach/pull/112093 by reducing the number of records affected. Thus, this reduces the risk of bugs and failures in the future.