### PR TITLE
schemachanger: address index validation errors during pk swap

### DIFF
--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -759,6 +759,10 @@ type TableDescriptor interface {
 	// IsSchemaLocked returns true if we don't allow performing schema changes
 	// on this table descriptor.
 	IsSchemaLocked() bool
+	// IsPrimaryKeySwapMutation returns true if the mutation is a primary key
+	// swap mutation or a secondary index used by the declarative schema changer
+	// for a primary index swap.
+	IsPrimaryKeySwapMutation(m *descpb.DescriptorMutation) bool
 }
 
 // MutableTableDescriptor is both a MutableDescriptor and a TableDescriptor.

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -1452,8 +1452,17 @@ func (desc *Mutable) MakeMutationComplete(m descpb.DescriptorMutation) error {
 			desc.AddColumn(t.Column)
 
 		case *descpb.DescriptorMutation_Index:
-			if err := desc.AddSecondaryIndex(*t.Index); err != nil {
-				return err
+			// If a primary index is being made public, then we only need set the
+			// index inside the descriptor directly. Only the declarative schema
+			// changer will use index mutations like this.
+			isPrimaryIndexToPublic := desc.IsPrimaryKeySwapMutation(&m)
+			if isPrimaryIndexToPublic {
+				desc.SetPrimaryIndex(*t.Index)
+			} else {
+				// Otherwise, we need to add this index as a secondary index.
+				if err := desc.AddSecondaryIndex(*t.Index); err != nil {
+					return err
+				}
 			}
 
 		case *descpb.DescriptorMutation_Constraint:
@@ -2065,9 +2074,9 @@ func (desc *wrapper) MakeFirstMutationPublic(
 		}
 		i++
 		switch {
-		case policy.shouldSkip(&mutation):
+		case policy.shouldSkip(desc, &mutation):
 			// Don't add to clone.
-		case policy.shouldRetain(&mutation):
+		case policy.shouldRetain(desc, &mutation):
 			mutation.Direction = descpb.DescriptorMutation_ADD
 			fallthrough
 		default:
@@ -2099,9 +2108,11 @@ func (p mutationPublicationPolicy) includes(f catalog.MutationPublicationFilter)
 	return p.policy.Contains(int(f))
 }
 
-func (p mutationPublicationPolicy) shouldSkip(m *descpb.DescriptorMutation) bool {
+func (p mutationPublicationPolicy) shouldSkip(
+	desc catalog.TableDescriptor, m *descpb.DescriptorMutation,
+) bool {
 	switch {
-	case m.GetPrimaryKeySwap() != nil:
+	case desc.IsPrimaryKeySwapMutation(m):
 		return p.includes(catalog.IgnorePKSwaps)
 	case m.GetConstraint() != nil:
 		return p.includes(catalog.IgnoreConstraints)
@@ -2110,7 +2121,9 @@ func (p mutationPublicationPolicy) shouldSkip(m *descpb.DescriptorMutation) bool
 	}
 }
 
-func (p mutationPublicationPolicy) shouldRetain(m *descpb.DescriptorMutation) bool {
+func (p mutationPublicationPolicy) shouldRetain(
+	desc catalog.TableDescriptor, m *descpb.DescriptorMutation,
+) bool {
 	switch {
 	case m.GetColumn() != nil && m.Direction == descpb.DescriptorMutation_DROP:
 		return p.includes(catalog.RetainDroppingColumns)

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3397,7 +3397,7 @@ ALTER TABLE t_99281 ADD COLUMN p INT DEFAULT unique_rowid(), ADD FOREIGN KEY (j)
 # The following statement is not supported using the legacy schema changer.
 skipif config local-legacy-schema-changer
 skipif config local-mixed-23.1
-statement error pq: foreign key violation: "t_99281" row j=0, i=[0-1] has no match in "t_99281_other"
+statement error pq: foreign key violation: "t_99281" row j=0, k=[0-1] has no match in "t_99281_other"
 ALTER TABLE t_99281 ALTER PRIMARY KEY USING COLUMNS (k), ADD FOREIGN KEY (j) REFERENCES t_99281_other;
 
 query TT
@@ -3535,3 +3535,21 @@ CREATE TABLE public.t_118246 (
 )
 
 subtest end
+
+
+# When the new primary key does not have the same columns as the original primary
+# key schema changes recreating secondary indexes could fail incorrectly during validation,
+# if the secondary had some references to the old primary index key (for example
+# partial expressions). This was because an scan of the new secondary index would
+# not return the old primary key, which query execution was expecting.
+subtest 118626
+
+statement ok
+CREATE TABLE public.t_118626(n int primary key, b int NOT NULL, c int NOT NULL);
+INSERT INTO public.t_118626 VALUES(1, 2, 3);
+
+statement ok
+CREATE UNIQUE INDEX ON public.t_118626(c) WHERE n>= 1;
+
+statement ok
+ALTER TABLE public.t_118626 ALTER PRIMARY KEY USING COLUMNS(b);

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.definition
@@ -1,6 +1,9 @@
 setup
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 ----
 
 # Note: Unlike other tests, we intentionally avoid

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 EXPLAIN (DDL) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -8,223 +11,470 @@ EXPLAIN (DDL) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 4 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-)}
- │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey+)}
- │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey+)}
- │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey+)}
- │         ├── 3 elements transitioning toward TRANSIENT_ABSENT
- │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
- │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
- │         └── 6 Mutation operations
- │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":4,"IndexID":4,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":5}}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":4,"TableID":104}
- │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":5,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
- │              └── AddColumnToIndex {"ColumnID":2,"IndexID":5,"TableID":104}
+ │         ├── 16 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx+)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx+)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx+)}
+ │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx+)}
+ │         ├── 12 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+ │         └── 28 Mutation operations
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":10,"IndexID":16,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":17}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":11,"IndexID":17,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── SetAddedIndexPartialPredicate {"Expr":"i \u003c= 0:::INT8","IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── SetAddedIndexPartialPredicate {"Expr":"i \u003c= 0:::INT8","IndexID":9,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── SetAddedIndexPartialPredicate {"Expr":"j \u003c= 0:::INT8","IndexID":10,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── SetAddedIndexPartialPredicate {"Expr":"j \u003c= 0:::INT8","IndexID":11,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 4 elements transitioning toward PUBLIC
- │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-)}
- │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey+)}
- │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey+)}
- │    │    │    └── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey+)}
- │    │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
- │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
- │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
+ │    │    ├── 16 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey+)}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx+)}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx+)}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx+)}
+ │    │    │    └── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx+)}
+ │    │    ├── 12 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+ │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+ │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+ │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+ │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 4 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-)}
- │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey+)}
- │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey+)}
- │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey+)}
- │         ├── 3 elements transitioning toward TRANSIENT_ABSENT
- │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
- │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
- │         └── 10 Mutation operations
- │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":4,"IndexID":4,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":5}}
- │              ├── MaybeAddSplitForIndex {"IndexID":4,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":4,"TableID":104}
- │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":5,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
- │              ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"TableID":104}
+ │         ├── 16 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx+)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx+)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx+)}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx+)}
+ │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx+)}
+ │         ├── 12 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+ │         └── 38 Mutation operations
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":10,"IndexID":16,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":17}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":16,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":11,"IndexID":17,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":17,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── MaybeAddSplitForIndex {"IndexID":8,"TableID":104}
+ │              ├── SetAddedIndexPartialPredicate {"Expr":"i \u003c= 0:::INT8","IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── SetAddedIndexPartialPredicate {"Expr":"i \u003c= 0:::INT8","IndexID":9,"TableID":104}
+ │              ├── MaybeAddSplitForIndex {"IndexID":9,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── MaybeAddSplitForIndex {"IndexID":10,"TableID":104}
+ │              ├── SetAddedIndexPartialPredicate {"Expr":"j \u003c= 0:::INT8","IndexID":10,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── SetAddedIndexPartialPredicate {"Expr":"j \u003c= 0:::INT8","IndexID":11,"TableID":104}
+ │              ├── MaybeAddSplitForIndex {"IndexID":11,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │              ├── MaybeAddSplitForIndex {"IndexID":12,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │              ├── MaybeAddSplitForIndex {"IndexID":13,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
  │    ├── Stage 1 of 15 in PostCommitPhase
- │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
- │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 5}
- │    │    └── 3 Mutation operations
- │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":5,"TableID":104}
+ │    │    ├── 8 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 17}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 9}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 11}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 13}
+ │    │    └── 6 Mutation operations
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":17,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":9,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":11,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":13,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 2 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-)}
- │    │    └── 1 Backfill operation
- │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":1,"TableID":104}
+ │    │    ├── 4 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2}
+ │    │    │    ├── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6}
+ │    │    └── 4 Backfill operations
+ │    │         ├── BackfillIndex {"IndexID":16,"SourceIndexID":1,"TableID":104}
+ │    │         ├── BackfillIndex {"IndexID":8,"SourceIndexID":1,"TableID":104}
+ │    │         ├── BackfillIndex {"IndexID":10,"SourceIndexID":1,"TableID":104}
+ │    │         └── BackfillIndex {"IndexID":12,"SourceIndexID":1,"TableID":104}
  │    ├── Stage 3 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-)}
- │    │    └── 3 Mutation operations
- │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":4,"TableID":104}
+ │    │    ├── 4 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2}
+ │    │    │    ├── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6}
+ │    │    └── 6 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":16,"TableID":104}
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":8,"TableID":104}
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":10,"TableID":104}
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":12,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 4 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-)}
- │    │    └── 3 Mutation operations
- │    │         ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":104}
+ │    │    ├── 4 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2}
+ │    │    │    ├── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6}
+ │    │    └── 6 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":16,"TableID":104}
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":8,"TableID":104}
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":10,"TableID":104}
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":12,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 5 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-)}
- │    │    └── 1 Backfill operation
- │    │         └── MergeIndex {"BackfilledIndexID":4,"TableID":104,"TemporaryIndexID":5}
+ │    │    ├── 4 elements transitioning toward PUBLIC
+ │    │    │    ├── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2}
+ │    │    │    ├── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6}
+ │    │    └── 4 Backfill operations
+ │    │         ├── MergeIndex {"BackfilledIndexID":16,"TableID":104,"TemporaryIndexID":17}
+ │    │         ├── MergeIndex {"BackfilledIndexID":8,"TableID":104,"TemporaryIndexID":9}
+ │    │         ├── MergeIndex {"BackfilledIndexID":10,"TableID":104,"TemporaryIndexID":11}
+ │    │         └── MergeIndex {"BackfilledIndexID":12,"TableID":104,"TemporaryIndexID":13}
  │    ├── Stage 6 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-)}
- │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
- │    │    └── 4 Mutation operations
- │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
- │    │         ├── MakeMergedIndexWriteOnly {"IndexID":4,"TableID":104}
+ │    │    ├── 4 elements transitioning toward PUBLIC
+ │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2}
+ │    │    │    ├── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4}
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6}
+ │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 10 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":17,"TableID":104}
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":13,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":16,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":8,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":10,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":12,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 7 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-)}
- │    │    └── 1 Validation operation
- │    │         └── ValidateIndex {"IndexID":4,"TableID":104}
+ │    │    ├── 4 elements transitioning toward PUBLIC
+ │    │    │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2}
+ │    │    │    ├── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4}
+ │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6}
+ │    │    └── 4 Validation operations
+ │    │         ├── ValidateIndex {"IndexID":16,"TableID":104}
+ │    │         ├── ValidateIndex {"IndexID":8,"TableID":104}
+ │    │         ├── ValidateIndex {"IndexID":10,"TableID":104}
+ │    │         └── ValidateIndex {"IndexID":12,"TableID":104}
  │    ├── Stage 8 of 15 in PostCommitPhase
- │    │    ├── 7 elements transitioning toward PUBLIC
- │    │    │    ├── VALIDATED → PUBLIC        PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey+)}
- │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey+), RecreateSourceIndexID: 0}
- │    │    │    ├── ABSENT    → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key+)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_i_key+)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key+)}
- │    │    │    └── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key+)}
+ │    │    ├── 13 elements transitioning toward PUBLIC
+ │    │    │    ├── VALIDATED → PUBLIC        PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey+)}
+ │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx+)}
+ │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx+)}
+ │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx+), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 6}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_k_idx", IndexID: 12 (t_k_idx+)}
+ │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key+), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key+)}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 14 (t_i_key+)}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 14 (t_i_key+)}
+ │    │    │    └── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key+)}
  │    │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey+)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
- │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
- │    │    ├── 2 elements transitioning toward ABSENT
+ │    │    │    ├── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey+)}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 15}
+ │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
+ │    │    ├── 5 elements transitioning toward ABSENT
  │    │    │    ├── PUBLIC    → VALIDATED     PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
- │    │    │    └── PUBLIC    → ABSENT        IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
- │    │    └── 15 Mutation operations
+ │    │    │    ├── PUBLIC    → ABSENT        IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC    → VALIDATED     SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx-), RecreateSourceIndexID: 0}
+ │    │    │    ├── PUBLIC    → VALIDATED     SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx-), RecreateSourceIndexID: 0}
+ │    │    │    └── PUBLIC    → VALIDATED     SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx-), RecreateSourceIndexID: 0}
+ │    │    └── 27 Mutation operations
  │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
- │    │         ├── SetIndexName {"IndexID":4,"Name":"t_pkey","TableID":104}
- │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":4,"TableID":104}
+ │    │         ├── SetIndexName {"IndexID":16,"Name":"t_pkey","TableID":104}
+ │    │         ├── SetIndexName {"IndexID":8,"Name":"t_i_idx","TableID":104}
+ │    │         ├── SetIndexName {"IndexID":10,"Name":"t_j_idx","TableID":104}
+ │    │         ├── SetIndexName {"IndexID":12,"Name":"t_k_idx","TableID":104}
+ │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":16,"TableID":104}
+ │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":8,"TableID":104}
+ │    │         ├── RefreshStats {"TableID":104}
+ │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":10,"TableID":104}
+ │    │         ├── RefreshStats {"TableID":104}
+ │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":12,"TableID":104}
+ │    │         ├── RefreshStats {"TableID":104}
  │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
- │    │         ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":104}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":14,"TableID":104}
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
- │    │         ├── MaybeAddSplitForIndex {"IndexID":3,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
- │    │         ├── SetIndexName {"IndexID":2,"Name":"t_i_key","TableID":104}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":15,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":14,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":15,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
+ │    │         ├── SetIndexName {"IndexID":14,"Name":"t_i_key","TableID":104}
+ │    │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
+ │    │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":6,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 15 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey+)}
- │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 3}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey+)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 15}
  │    │    └── 3 Mutation operations
- │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":3,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":15,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 10 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key+), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey+), RecreateSourceIndexID: 0}
  │    │    └── 1 Backfill operation
- │    │         └── BackfillIndex {"IndexID":2,"SourceIndexID":4,"TableID":104}
+ │    │         └── BackfillIndex {"IndexID":14,"SourceIndexID":16,"TableID":104}
  │    ├── Stage 11 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key+), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey+), RecreateSourceIndexID: 0}
  │    │    └── 3 Mutation operations
- │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":14,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 12 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key+), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey+), RecreateSourceIndexID: 0}
  │    │    └── 3 Mutation operations
- │    │         ├── MakeBackfilledIndexMerging {"IndexID":2,"TableID":104}
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":14,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 13 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key+), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey+), RecreateSourceIndexID: 0}
  │    │    └── 1 Backfill operation
- │    │         └── MergeIndex {"BackfilledIndexID":2,"TableID":104,"TemporaryIndexID":3}
+ │    │         └── MergeIndex {"BackfilledIndexID":14,"TableID":104,"TemporaryIndexID":15}
  │    ├── Stage 14 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key+), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey+), RecreateSourceIndexID: 0}
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey+)}
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey+)}
  │    │    └── 4 Mutation operations
- │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
- │    │         ├── MakeMergedIndexWriteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":15,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":14,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    └── Stage 15 of 15 in PostCommitPhase
  │         ├── 1 element transitioning toward PUBLIC
- │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey+), RecreateSourceIndexID: 0}
+ │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key+), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey+), RecreateSourceIndexID: 0}
  │         └── 1 Validation operation
- │              └── ValidateIndex {"IndexID":2,"TableID":104}
+ │              └── ValidateIndex {"IndexID":14,"TableID":104}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey+), RecreateSourceIndexID: 0}
-      │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey+)}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
-      │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
-      │    ├── 3 elements transitioning toward ABSENT
+      │    │    └── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key+), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey+), RecreateSourceIndexID: 0}
+      │    ├── 15 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey+)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 15}
+      │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
+      │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 1 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 1 (t_pkey-)}
-      │    │    └── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
-      │    └── 13 Mutation operations
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 1 (t_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_i_idx-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT           IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 2 (t_i_idx-)}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_j_idx-)}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_j_idx-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT           IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 4 (t_j_idx-)}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 6 (t_k_idx-)}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 6 (t_k_idx-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx-), RecreateSourceIndexID: 0}
+      │    │    └── PUBLIC                → ABSENT           IndexName:{DescID: 104 (t), Name: "t_k_idx", IndexID: 6 (t_k_idx-)}
+      │    └── 36 Mutation operations
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":14,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":15,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":4,"TableID":104}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
-           ├── 2 elements transitioning toward TRANSIENT_ABSENT
-           │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           │    └── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           ├── 2 elements transitioning toward ABSENT
+           ├── 5 elements transitioning toward TRANSIENT_ABSENT
+           │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           │    └── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
+           ├── 8 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT           PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
-           │    └── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 1 (t_pkey-)}
-           └── 6 Mutation operations
+           │    ├── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 1 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT           SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx-), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 2 (t_i_idx-)}
+           │    ├── DELETE_ONLY → ABSENT           SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx-), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 4 (t_j_idx-)}
+           │    ├── DELETE_ONLY → ABSENT           SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx-), RecreateSourceIndexID: 0}
+           │    └── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 6 (t_k_idx-)}
+           └── 15 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":1,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":15,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.explain_shape
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 EXPLAIN (DDL, SHAPE) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -8,18 +11,27 @@ EXPLAIN (DDL, SHAPE) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  ├── execute 2 system table mutations transactions
  ├── backfill using primary index t_pkey- in relation t
- │    └── into t_pkey+ (j; i)
+ │    ├── into t_i_idx+ (i: j)
+ │    ├── into t_j_idx+ (j)
+ │    ├── into t_k_idx+ (k: j)
+ │    └── into t_pkey+ (j; i, k)
  ├── execute 2 system table mutations transactions
  ├── merge temporary indexes into backfilled indexes in relation t
- │    └── from t@[5] into t_pkey+
+ │    ├── from t@[9] into t_i_idx+
+ │    ├── from t@[11] into t_j_idx+
+ │    ├── from t@[13] into t_k_idx+
+ │    └── from t@[17] into t_pkey+
  ├── execute 1 system table mutations transaction
  ├── validate UNIQUE constraint backed by index t_pkey+ in relation t
+ ├── validate UNIQUE constraint backed by index t_i_idx+ in relation t
+ ├── validate UNIQUE constraint backed by index t_j_idx+ in relation t
+ ├── validate UNIQUE constraint backed by index t_k_idx+ in relation t
  ├── execute 2 system table mutations transactions
  ├── backfill using primary index t_pkey+ in relation t
  │    └── into t_i_key+ (i: j)
  ├── execute 2 system table mutations transactions
  ├── merge temporary indexes into backfilled indexes in relation t
- │    └── from t@[3] into t_i_key+
+ │    └── from t@[15] into t_i_key+
  ├── execute 1 system table mutations transaction
  ├── validate UNIQUE constraint backed by index t_i_key+ in relation t
  └── execute 2 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.side_effects
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 ----
 ...
 +object {100 101 t} -> 104
@@ -21,20 +24,20 @@ write *eventpb.AlterTable to event log:
     tag: ALTER TABLE
     user: root
   tableName: defaultdb.public.t
-## StatementPhase stage 1 of 1 with 6 MutationType ops
+## StatementPhase stage 1 of 1 with 28 MutationType ops
 upsert descriptor #104
   ...
-     id: 104
+       version: 4
      modificationTime: {}
   +  mutations:
   +  - direction: ADD
   +    index:
-  +      constraintId: 4
+  +      constraintId: 10
   +      createdExplicitly: true
   +      encodingType: 1
   +      foreignKey: {}
   +      geoConfig: {}
-  +      id: 4
+  +      id: 16
   +      interleave: {}
   +      keyColumnDirections:
   +      - ASC
@@ -42,14 +45,118 @@ upsert descriptor #104
   +      - 2
   +      keyColumnNames:
   +      - j
-  +      name: crdb_internal_index_4_name_placeholder
+  +      name: crdb_internal_index_16_name_placeholder
   +      partitioning: {}
   +      sharded: {}
   +      storeColumnIds:
   +      - 1
+  +      - 3
   +      storeColumnNames:
   +      - i
+  +      - k
   +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 11
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 17
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - j
+  +      name: crdb_internal_index_17_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 3
+  +      storeColumnNames:
+  +      - i
+  +      - k
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 2
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 8
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - i
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_8_name_placeholder
+  +      partitioning: {}
+  +      predicate: i <= 0:::INT8
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 3
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 9
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - i
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_9_name_placeholder
+  +      partitioning: {}
+  +      predicate: i <= 0:::INT8
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 4
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 10
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - j
+  +      name: crdb_internal_index_10_name_placeholder
+  +      partitioning: {}
+  +      predicate: j <= 0:::INT8
+  +      sharded: {}
+  +      storeColumnNames: []
   +      version: 4
   +    mutationId: 1
   +    state: BACKFILLING
@@ -57,10 +164,9 @@ upsert descriptor #104
   +    index:
   +      constraintId: 5
   +      createdExplicitly: true
-  +      encodingType: 1
   +      foreignKey: {}
   +      geoConfig: {}
-  +      id: 5
+  +      id: 11
   +      interleave: {}
   +      keyColumnDirections:
   +      - ASC
@@ -68,38 +174,83 @@ upsert descriptor #104
   +      - 2
   +      keyColumnNames:
   +      - j
-  +      name: crdb_internal_index_5_name_placeholder
+  +      name: crdb_internal_index_11_name_placeholder
+  +      partitioning: {}
+  +      predicate: j <= 0:::INT8
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 6
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 12
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - k
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_12_name_placeholder
   +      partitioning: {}
   +      sharded: {}
-  +      storeColumnIds:
-  +      - 1
-  +      storeColumnNames:
-  +      - i
-  +      unique: true
+  +      storeColumnNames: []
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 7
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 13
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - k
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_13_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
   +      useDeletePreservingEncoding: true
   +      version: 4
   +    mutationId: 1
   +    state: DELETE_ONLY
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   -  nextConstraintId: 2
-  +  nextConstraintId: 6
+  +  nextConstraintId: 12
      nextFamilyId: 1
-  -  nextIndexId: 2
-  +  nextIndexId: 6
+  -  nextIndexId: 8
+  +  nextIndexId: 18
      nextMutationId: 1
      parentId: 100
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "1"
-  +  version: "2"
+  -  version: "19"
+  +  version: "20"
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 10 MutationType ops
+## PreCommitPhase stage 2 of 2 with 38 MutationType ops
 upsert descriptor #104
   ...
      createAsOfTime:
@@ -113,14 +264,18 @@ upsert descriptor #104
   +      columns:
   +        "1": i
   +        "2": j
+  +        "3": k
   +        "4294967294": tableoid
   +        "4294967295": crdb_internal_mvcc_timestamp
   +      families:
   +        "0": primary
   +      id: 104
   +      indexes:
-  +        "2": t_i_key
-  +        "4": t_pkey
+  +        "8": t_i_idx
+  +        "10": t_j_idx
+  +        "12": t_k_idx
+  +        "14": t_i_key
+  +        "16": t_pkey
   +      name: t
   +    relevantStatements:
   +    - statement:
@@ -133,17 +288,17 @@ upsert descriptor #104
      families:
      - columnIds:
   ...
-     id: 104
+       version: 4
      modificationTime: {}
   +  mutations:
   +  - direction: ADD
   +    index:
-  +      constraintId: 4
+  +      constraintId: 10
   +      createdExplicitly: true
   +      encodingType: 1
   +      foreignKey: {}
   +      geoConfig: {}
-  +      id: 4
+  +      id: 16
   +      interleave: {}
   +      keyColumnDirections:
   +      - ASC
@@ -151,14 +306,118 @@ upsert descriptor #104
   +      - 2
   +      keyColumnNames:
   +      - j
-  +      name: crdb_internal_index_4_name_placeholder
+  +      name: crdb_internal_index_16_name_placeholder
   +      partitioning: {}
   +      sharded: {}
   +      storeColumnIds:
   +      - 1
+  +      - 3
   +      storeColumnNames:
   +      - i
+  +      - k
   +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 11
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 17
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - j
+  +      name: crdb_internal_index_17_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 3
+  +      storeColumnNames:
+  +      - i
+  +      - k
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 2
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 8
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - i
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_8_name_placeholder
+  +      partitioning: {}
+  +      predicate: i <= 0:::INT8
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 3
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 9
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - i
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_9_name_placeholder
+  +      partitioning: {}
+  +      predicate: i <= 0:::INT8
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 4
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 10
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - j
+  +      name: crdb_internal_index_10_name_placeholder
+  +      partitioning: {}
+  +      predicate: j <= 0:::INT8
+  +      sharded: {}
+  +      storeColumnNames: []
   +      version: 4
   +    mutationId: 1
   +    state: BACKFILLING
@@ -166,10 +425,9 @@ upsert descriptor #104
   +    index:
   +      constraintId: 5
   +      createdExplicitly: true
-  +      encodingType: 1
   +      foreignKey: {}
   +      geoConfig: {}
-  +      id: 5
+  +      id: 11
   +      interleave: {}
   +      keyColumnDirections:
   +      - ASC
@@ -177,32 +435,77 @@ upsert descriptor #104
   +      - 2
   +      keyColumnNames:
   +      - j
-  +      name: crdb_internal_index_5_name_placeholder
+  +      name: crdb_internal_index_11_name_placeholder
+  +      partitioning: {}
+  +      predicate: j <= 0:::INT8
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 6
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 12
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - k
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_12_name_placeholder
   +      partitioning: {}
   +      sharded: {}
-  +      storeColumnIds:
-  +      - 1
-  +      storeColumnNames:
-  +      - i
-  +      unique: true
+  +      storeColumnNames: []
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 7
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 13
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - k
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_13_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
   +      useDeletePreservingEncoding: true
   +      version: 4
   +    mutationId: 1
   +    state: DELETE_ONLY
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   -  nextConstraintId: 2
-  +  nextConstraintId: 6
+  +  nextConstraintId: 12
      nextFamilyId: 1
-  -  nextIndexId: 2
-  +  nextIndexId: 6
+  -  nextIndexId: 8
+  +  nextIndexId: 18
      nextMutationId: 1
      parentId: 100
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "1"
-  +  version: "2"
+  -  version: "19"
+  +  version: "20"
 persist all catalog changes to storage
 create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)"
   descriptor IDs: [104]
@@ -213,30 +516,72 @@ notified job registry to adopt jobs: [1]
 begin transaction #2
 commit transaction #2
 begin transaction #3
-## PostCommitPhase stage 1 of 15 with 3 MutationType ops
+## PostCommitPhase stage 1 of 15 with 6 MutationType ops
 upsert descriptor #104
   ...
          version: 4
        mutationId: 1
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "2"
-  +  version: "3"
+  -  version: "20"
+  +  version: "21"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 2 of 15 with 1 BackfillType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 2 of 15 with 4 BackfillType ops pending"
 commit transaction #3
 begin transaction #4
-## PostCommitPhase stage 2 of 15 with 1 BackfillType op
-backfill indexes [4] from index #1 in table #104
+## PostCommitPhase stage 2 of 15 with 4 BackfillType ops
+backfill indexes [8 10 12 16] from index #1 in table #104
 commit transaction #4
 begin transaction #5
-## PostCommitPhase stage 3 of 15 with 3 MutationType ops
+## PostCommitPhase stage 3 of 15 with 6 MutationType ops
 upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
   ...
          version: 4
        mutationId: 1
@@ -247,14 +592,35 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "3"
-  +  version: "4"
+  -  version: "21"
+  +  version: "22"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 4 of 15 with 1 MutationType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 4 of 15 with 4 MutationType ops pending"
 commit transaction #5
 begin transaction #6
-## PostCommitPhase stage 4 of 15 with 3 MutationType ops
+## PostCommitPhase stage 4 of 15 with 6 MutationType ops
 upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
   ...
          version: 4
        mutationId: 1
@@ -265,18 +631,50 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "4"
-  +  version: "5"
+  -  version: "22"
+  +  version: "23"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 5 of 15 with 1 BackfillType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 5 of 15 with 4 BackfillType ops pending"
 commit transaction #6
 begin transaction #7
-## PostCommitPhase stage 5 of 15 with 1 BackfillType op
-merge temporary indexes [5] into backfilled indexes [4] in table #104
+## PostCommitPhase stage 5 of 15 with 4 BackfillType ops
+merge temporary indexes [9 11 13 17] into backfilled indexes [8 10 12 16] in table #104
 commit transaction #7
 begin transaction #8
-## PostCommitPhase stage 6 of 15 with 4 MutationType ops
+## PostCommitPhase stage 6 of 15 with 10 MutationType ops
 upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 11
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 3
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
   ...
          version: 4
        mutationId: 1
@@ -291,48 +689,131 @@ upsert descriptor #104
        mutationId: 1
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 7
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "5"
-  +  version: "6"
+  -  version: "23"
+  +  version: "24"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 7 of 15 with 1 ValidationType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 7 of 15 with 4 ValidationType ops pending"
 commit transaction #8
 begin transaction #9
-## PostCommitPhase stage 7 of 15 with 1 ValidationType op
-validate forward indexes [4] in table #104
+## PostCommitPhase stage 7 of 15 with 4 ValidationType ops
+validate forward indexes [16] in table #104
+validate forward indexes [8] in table #104
+validate forward indexes [10] in table #104
+validate forward indexes [12] in table #104
 commit transaction #9
 begin transaction #10
-## PostCommitPhase stage 8 of 15 with 15 MutationType ops
+## PostCommitPhase stage 8 of 15 with 27 MutationType ops
 upsert descriptor #104
   ...
+     id: 104
+     indexes:
+  -  - createdAtNanos: "1640995200000000000"
+  +  - constraintId: 2
+  +    createdAtNanos: "1640998800000000000"
+       createdExplicitly: true
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 2
+  +    id: 8
+       interleave: {}
+       keyColumnDirections:
+  ...
+       keyColumnNames:
+       - i
+  +    keySuffixColumnIds:
+  +    - 2
+       name: t_i_idx
+       partitioning: {}
+       predicate: i <= 0:::INT8
+       sharded: {}
+  +    storeColumnNames: []
+       version: 4
+  -  - createdAtNanos: "1640995200000000000"
+  +  - constraintId: 4
+  +    createdAtNanos: "1640998800000000000"
+       createdExplicitly: true
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 4
+  +    id: 10
+       interleave: {}
+       keyColumnDirections:
+  ...
+       keyColumnNames:
+       - j
+  -    keySuffixColumnIds:
+  -    - 1
+       name: t_j_idx
+       partitioning: {}
+       predicate: j <= 0:::INT8
+       sharded: {}
+  +    storeColumnNames: []
+       version: 4
+  -  - createdAtNanos: "1640995200000000000"
+  +  - constraintId: 6
+  +    createdAtNanos: "1640998800000000000"
+       createdExplicitly: true
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 6
+  +    id: 12
+       interleave: {}
+       keyColumnDirections:
+  ...
+       - k
+       keySuffixColumnIds:
+  -    - 1
+  +    - 2
+       name: t_k_idx
+       partitioning: {}
+       sharded: {}
+  +    storeColumnNames: []
+       version: 4
      modificationTime: {}
      mutations:
   -  - direction: ADD
   +  - direction: DROP
        index:
-  -      constraintId: 4
-  +      constraintId: 5
+  -      constraintId: 10
+  +      constraintId: 11
          createdExplicitly: true
          encodingType: 1
          foreignKey: {}
          geoConfig: {}
-  -      id: 4
-  +      id: 5
+  -      id: 16
+  +      id: 17
          interleave: {}
          keyColumnDirections:
   ...
          keyColumnNames:
          - j
-  -      name: crdb_internal_index_4_name_placeholder
-  +      name: crdb_internal_index_5_name_placeholder
+  -      name: crdb_internal_index_16_name_placeholder
+  +      name: crdb_internal_index_17_name_placeholder
          partitioning: {}
          sharded: {}
   ...
-         - i
+         - k
          unique: true
   +      useDeletePreservingEncoding: true
          version: 4
@@ -341,15 +822,161 @@ upsert descriptor #104
   +    state: DELETE_ONLY
      - direction: DROP
        index:
-  -      constraintId: 5
-  -      createdExplicitly: true
-  +      constraintId: 1
-  +      createdAtNanos: "1640995200000000000"
-         encodingType: 1
+  -      constraintId: 11
+  +      constraintId: 3
+         createdExplicitly: true
+  -      encodingType: 1
          foreignKey: {}
          geoConfig: {}
-  -      id: 5
+  -      id: 17
+  +      id: 9
+         interleave: {}
+         keyColumnDirections:
+         - ASC
+         keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - i
+  +      keySuffixColumnIds:
+         - 2
+  +      name: crdb_internal_index_9_name_placeholder
+  +      partitioning: {}
+  +      predicate: i <= 0:::INT8
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+  +    index:
+  +      constraintId: 5
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 11
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+         keyColumnNames:
+         - j
+  -      name: crdb_internal_index_17_name_placeholder
+  +      name: crdb_internal_index_11_name_placeholder
+         partitioning: {}
+  +      predicate: j <= 0:::INT8
+         sharded: {}
+  -      storeColumnIds:
+  -      - 1
+  -      - 3
+  -      storeColumnNames:
+  -      - i
+  -      - k
+  -      unique: true
+  +      storeColumnNames: []
+         useDeletePreservingEncoding: true
+         version: 4
+       mutationId: 1
+       state: DELETE_ONLY
+  -  - direction: ADD
+  +  - direction: DROP
+       index:
+  -      constraintId: 2
+  -      createdAtNanos: "1640998800000000000"
+  +      constraintId: 7
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 8
+  +      id: 13
+         interleave: {}
+         keyColumnDirections:
+         - ASC
+         keyColumnIds:
+  -      - 1
+  +      - 3
+         keyColumnNames:
+  -      - i
+  +      - k
+         keySuffixColumnIds:
+         - 2
+  -      name: crdb_internal_index_8_name_placeholder
+  +      name: crdb_internal_index_13_name_placeholder
+         partitioning: {}
+  -      predicate: i <= 0:::INT8
+         sharded: {}
+         storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 3
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
   +      id: 1
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - i
+  +      name: crdb_internal_index_1_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 2
+  +      - 3
+  +      storeColumnNames:
+  +      - j
+  +      - k
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 8
+  +      createdAtNanos: "1640998800000000000"
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 9
+  +      id: 14
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keySuffixColumnIds:
+         - 2
+  -      name: crdb_internal_index_9_name_placeholder
+  +      name: t_i_key
+         partitioning: {}
+  -      predicate: i <= 0:::INT8
+         sharded: {}
+         storeColumnNames: []
+  -      useDeletePreservingEncoding: true
+  +      unique: true
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: BACKFILLING
+     - direction: ADD
+       index:
+  -      constraintId: 4
+  -      createdAtNanos: "1640998800000000000"
+  +      constraintId: 9
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 10
+  +      id: 15
          interleave: {}
          keyColumnDirections:
          - ASC
@@ -358,80 +985,123 @@ upsert descriptor #104
   +      - 1
          keyColumnNames:
   -      - j
-  -      name: crdb_internal_index_5_name_placeholder
+  -      name: crdb_internal_index_10_name_placeholder
   +      - i
-  +      name: crdb_internal_index_1_name_placeholder
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_15_name_placeholder
+         partitioning: {}
+  -      predicate: j <= 0:::INT8
+         sharded: {}
+         storeColumnNames: []
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 5
+  +      createdAtNanos: "1640995200000000000"
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 11
+  +      id: 2
+         interleave: {}
+         keyColumnDirections:
+         - ASC
+         keyColumnIds:
+  -      - 2
+  +      - 1
+         keyColumnNames:
+  -      - j
+  -      name: crdb_internal_index_11_name_placeholder
+  +      - i
+  +      name: t_i_idx
+         partitioning: {}
+  -      predicate: j <= 0:::INT8
+  +      predicate: i <= 0:::INT8
+         sharded: {}
+  -      storeColumnNames: []
+  -      useDeletePreservingEncoding: true
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+  -      constraintId: 6
+  -      createdAtNanos: "1640998800000000000"
+  +      createdAtNanos: "1640995200000000000"
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 12
+  +      id: 4
+         interleave: {}
+         keyColumnDirections:
+         - ASC
+         keyColumnIds:
+  -      - 3
+  +      - 2
+         keyColumnNames:
+  -      - k
+  +      - j
+         keySuffixColumnIds:
+  -      - 2
+  -      name: crdb_internal_index_12_name_placeholder
+  +      - 1
+  +      name: t_j_idx
+         partitioning: {}
+  +      predicate: j <= 0:::INT8
+         sharded: {}
+  -      storeColumnNames: []
+         version: 4
+       mutationId: 1
+  ...
+     - direction: DROP
+       index:
+  -      constraintId: 7
+  +      createdAtNanos: "1640995200000000000"
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 13
+  +      id: 6
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - k
+         keySuffixColumnIds:
+  -      - 2
+  -      name: crdb_internal_index_13_name_placeholder
+  +      - 1
+  +      name: t_k_idx
          partitioning: {}
          sharded: {}
-         storeColumnIds:
-  -      - 1
-  +      - 2
-         storeColumnNames:
-  +      - j
-  +      unique: true
-  +      version: 4
-  +    mutationId: 1
-  +    state: WRITE_ONLY
-  +  - direction: ADD
-  +    index:
-  +      constraintId: 2
-  +      createdAtNanos: "1640998800000000000"
-  +      createdExplicitly: true
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 2
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      keyColumnIds:
-  +      - 1
-  +      keyColumnNames:
-         - i
-  +      keySuffixColumnIds:
-  +      - 2
-  +      name: t_i_key
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnNames: []
-         unique: true
-  +      version: 4
-  +    mutationId: 1
-  +    state: BACKFILLING
-  +  - direction: ADD
-  +    index:
-  +      constraintId: 3
-  +      createdExplicitly: true
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 3
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      keyColumnIds:
-  +      - 1
-  +      keyColumnNames:
-  +      - i
-  +      keySuffixColumnIds:
-  +      - 2
-  +      name: crdb_internal_index_3_name_placeholder
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnNames: []
-  +      unique: true
-         useDeletePreservingEncoding: true
+  -      storeColumnNames: []
+  -      useDeletePreservingEncoding: true
          version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 4
   ...
      parentId: 100
      primaryIndex:
   -    constraintId: 1
   -    createdAtNanos: "1640995200000000000"
-  +    constraintId: 4
+  +    constraintId: 10
   +    createdExplicitly: true
        encodingType: 1
        foreignKey: {}
        geoConfig: {}
   -    id: 1
-  +    id: 4
+  +    id: 16
        interleave: {}
        keyColumnDirections:
        - ASC
@@ -447,17 +1117,19 @@ upsert descriptor #104
        storeColumnIds:
   -    - 2
   +    - 1
+       - 3
        storeColumnNames:
   -    - j
   +    - i
+       - k
        unique: true
-       version: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "6"
-  +  version: "7"
+  -  version: "24"
+  +  version: "25"
 persist all catalog changes to storage
+adding table for stats refresh: 104
 update progress of schema change job #1: "PostCommitPhase stage 9 of 15 with 1 MutationType op pending"
 commit transaction #10
 begin transaction #11
@@ -468,19 +1140,19 @@ upsert descriptor #104
        mutationId: 1
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
-     name: t
-     nextColumnId: 3
+     - direction: DROP
+       index:
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "7"
-  +  version: "8"
+  -  version: "25"
+  +  version: "26"
 persist all catalog changes to storage
 update progress of schema change job #1: "PostCommitPhase stage 10 of 15 with 1 BackfillType op pending"
 commit transaction #11
 begin transaction #12
 ## PostCommitPhase stage 10 of 15 with 1 BackfillType op
-backfill indexes [2] from index #4 in table #104
+backfill indexes [14] from index #16 in table #104
 commit transaction #12
 begin transaction #13
 ## PostCommitPhase stage 11 of 15 with 3 MutationType ops
@@ -495,8 +1167,8 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "8"
-  +  version: "9"
+  -  version: "26"
+  +  version: "27"
 persist all catalog changes to storage
 update progress of schema change job #1: "PostCommitPhase stage 12 of 15 with 1 MutationType op pending"
 commit transaction #13
@@ -513,14 +1185,14 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "9"
-  +  version: "10"
+  -  version: "27"
+  +  version: "28"
 persist all catalog changes to storage
 update progress of schema change job #1: "PostCommitPhase stage 13 of 15 with 1 BackfillType op pending"
 commit transaction #14
 begin transaction #15
 ## PostCommitPhase stage 13 of 15 with 1 BackfillType op
-merge temporary indexes [3] into backfilled indexes [2] in table #104
+merge temporary indexes [15] into backfilled indexes [14] in table #104
 commit transaction #15
 begin transaction #16
 ## PostCommitPhase stage 14 of 15 with 4 MutationType ops
@@ -533,28 +1205,28 @@ upsert descriptor #104
   +    state: WRITE_ONLY
   +  - direction: DROP
        index:
-         constraintId: 3
+         constraintId: 9
   ...
          version: 4
        mutationId: 1
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
-     name: t
-     nextColumnId: 3
+     - direction: DROP
+       index:
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "10"
-  +  version: "11"
+  -  version: "28"
+  +  version: "29"
 persist all catalog changes to storage
 update progress of schema change job #1: "PostCommitPhase stage 15 of 15 with 1 ValidationType op pending"
 commit transaction #16
 begin transaction #17
 ## PostCommitPhase stage 15 of 15 with 1 ValidationType op
-validate forward indexes [2] in table #104
+validate forward indexes [14] in table #104
 commit transaction #17
 begin transaction #18
-## PostCommitNonRevertiblePhase stage 1 of 2 with 13 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 2 with 36 MutationType ops
 upsert descriptor #104
   ...
            statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)
@@ -563,15 +1235,14 @@ upsert descriptor #104
        targetRanks: <redacted>
        targets: <redacted>
   ...
-     formatVersion: 3
-     id: 104
-  +  indexes:
-  +  - constraintId: 2
+       storeColumnNames: []
+       version: 4
+  +  - constraintId: 8
   +    createdAtNanos: "1640998800000000000"
   +    createdExplicitly: true
   +    foreignKey: {}
   +    geoConfig: {}
-  +    id: 2
+  +    id: 14
   +    interleave: {}
   +    keyColumnDirections:
   +    - ASC
@@ -591,12 +1262,12 @@ upsert descriptor #104
      mutations:
      - direction: DROP
        index:
-  -      constraintId: 5
+  -      constraintId: 11
   -      createdExplicitly: true
   -      encodingType: 1
   -      foreignKey: {}
   -      geoConfig: {}
-  -      id: 5
+  -      id: 17
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
@@ -604,14 +1275,88 @@ upsert descriptor #104
   -      - 2
   -      keyColumnNames:
   -      - j
-  -      name: crdb_internal_index_5_name_placeholder
+  -      name: crdb_internal_index_17_name_placeholder
   -      partitioning: {}
   -      sharded: {}
   -      storeColumnIds:
   -      - 1
+  -      - 3
   -      storeColumnNames:
   -      - i
+  -      - k
   -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 3
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 9
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - i
+  -      keySuffixColumnIds:
+  -      - 2
+  -      name: crdb_internal_index_9_name_placeholder
+  -      partitioning: {}
+  -      predicate: i <= 0:::INT8
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      useDeletePreservingEncoding: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 5
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 11
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - j
+  -      name: crdb_internal_index_11_name_placeholder
+  -      partitioning: {}
+  -      predicate: j <= 0:::INT8
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      useDeletePreservingEncoding: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 7
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 13
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      keyColumnNames:
+  -      - k
+  -      keySuffixColumnIds:
+  -      - 2
+  -      name: crdb_internal_index_13_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnNames: []
   -      useDeletePreservingEncoding: true
   -      version: 4
   -    mutationId: 1
@@ -626,12 +1371,12 @@ upsert descriptor #104
   -    state: WRITE_ONLY
   -  - direction: ADD
   -    index:
-  -      constraintId: 2
+  -      constraintId: 8
   -      createdAtNanos: "1640998800000000000"
   -      createdExplicitly: true
   -      foreignKey: {}
   -      geoConfig: {}
-  -      id: 2
+  -      id: 14
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
@@ -651,11 +1396,11 @@ upsert descriptor #104
   -    state: WRITE_ONLY
   -  - direction: DROP
   -    index:
-  -      constraintId: 3
+  -      constraintId: 9
   -      createdExplicitly: true
   -      foreignKey: {}
   -      geoConfig: {}
-  -      id: 3
+  -      id: 15
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
@@ -665,7 +1410,7 @@ upsert descriptor #104
   -      - i
   -      keySuffixColumnIds:
   -      - 2
-  -      name: crdb_internal_index_3_name_placeholder
+  -      name: crdb_internal_index_15_name_placeholder
   -      partitioning: {}
   -      sharded: {}
   -      storeColumnNames: []
@@ -674,19 +1419,60 @@ upsert descriptor #104
   -      version: 4
   -    mutationId: 1
        state: DELETE_ONLY
+     - direction: DROP
+  ...
+         keyColumnNames:
+         - i
+  -      name: t_i_idx
+  +      name: crdb_internal_index_2_name_placeholder
+         partitioning: {}
+  -      predicate: i <= 0:::INT8
+         sharded: {}
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  ...
+         keySuffixColumnIds:
+         - 1
+  -      name: t_j_idx
+  +      name: crdb_internal_index_4_name_placeholder
+         partitioning: {}
+  -      predicate: j <= 0:::INT8
+         sharded: {}
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  ...
+         keySuffixColumnIds:
+         - 1
+  -      name: t_k_idx
+  +      name: crdb_internal_index_6_name_placeholder
+         partitioning: {}
+         sharded: {}
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
      name: t
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "11"
-  +  version: "12"
+  -  version: "29"
+  +  version: "30"
 persist all catalog changes to storage
 adding table for stats refresh: 104
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops pending"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 2 with 13 MutationType ops pending"
 set schema change job #1 to non-cancellable
 commit transaction #18
 begin transaction #19
-## PostCommitNonRevertiblePhase stage 2 of 2 with 6 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 2 with 15 MutationType ops
 upsert descriptor #104
   ...
      createAsOfTime:
@@ -700,14 +1486,18 @@ upsert descriptor #104
   -      columns:
   -        "1": i
   -        "2": j
+  -        "3": k
   -        "4294967294": tableoid
   -        "4294967295": crdb_internal_mvcc_timestamp
   -      families:
   -        "0": primary
   -      id: 104
   -      indexes:
-  -        "2": t_i_key
-  -        "4": t_pkey
+  -        "8": t_i_idx
+  -        "10": t_j_idx
+  -        "12": t_k_idx
+  -        "14": t_i_key
+  -        "16": t_pkey
   -      name: t
   -    relevantStatements:
   -    - statement:
@@ -742,20 +1532,86 @@ upsert descriptor #104
   -      sharded: {}
   -      storeColumnIds:
   -      - 2
+  -      - 3
   -      storeColumnNames:
   -      - j
+  -      - k
   -      unique: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - i
+  -      name: crdb_internal_index_2_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 4
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - j
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_4_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 6
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      keyColumnNames:
+  -      - k
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_6_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
   -      version: 4
   -    mutationId: 1
   -    state: DELETE_ONLY
   +  mutations: []
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "12"
-  +  version: "13"
+  -  version: "30"
+  +  version: "31"
 persist all catalog changes to storage
 create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)"
   descriptor IDs: [104]

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_10_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,64 +12,141 @@ EXPLAIN (DDL) rollback at post-commit stage 10 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
+      │    ├── 5 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 12 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
-      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 16 Mutation operations
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 15}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
+      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
+      │    └── 34 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
+      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":15,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":14,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":15,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":14,"Name":"crdb_internal_in...","TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":14,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey-)}
-      │    └── 6 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │    ├── 16 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_k_idx", IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
+      │    └── 20 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── SetIndexName {"IndexID":12,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 5 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           └── 7 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 14 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
+           └── 16 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":14,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":15,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_11_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,64 +12,141 @@ EXPLAIN (DDL) rollback at post-commit stage 11 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
+      │    ├── 5 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 12 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
-      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 16 Mutation operations
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 15}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
+      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
+      │    └── 34 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
+      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":15,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":14,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":15,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":14,"Name":"crdb_internal_in...","TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":14,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey-)}
-      │    └── 6 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │    ├── 16 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_k_idx", IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
+      │    └── 20 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── SetIndexName {"IndexID":12,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 5 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           └── 7 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 14 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
+           └── 16 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":14,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":15,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_12_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,64 +12,141 @@ EXPLAIN (DDL) rollback at post-commit stage 12 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
+      │    ├── 5 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 12 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
-      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 16 Mutation operations
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 15}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
+      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
+      │    └── 34 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
+      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":15,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":14,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":15,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":14,"Name":"crdb_internal_in...","TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":14,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey-)}
-      │    └── 6 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │    ├── 16 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_k_idx", IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
+      │    └── 20 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── SetIndexName {"IndexID":12,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 5 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           └── 7 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 14 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
+           └── 16 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":14,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":15,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_13_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,66 +12,143 @@ EXPLAIN (DDL) rollback at post-commit stage 13 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
+      │    ├── 5 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 12 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
-      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 16 Mutation operations
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 15}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
+      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
+      │    └── 34 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
+      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":15,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":15,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":14,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":14,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":14,"Name":"crdb_internal_in...","TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey-)}
-      │    └── 7 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_k_idx", IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
+      │    └── 21 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":14,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── SetIndexName {"IndexID":12,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 5 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           └── 7 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 14 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
+           └── 16 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":14,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":15,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_14_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,66 +12,143 @@ EXPLAIN (DDL) rollback at post-commit stage 14 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
+      │    ├── 5 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 12 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
-      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 16 Mutation operations
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 15}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
+      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
+      │    └── 34 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
+      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":15,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":15,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":14,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":14,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":14,"Name":"crdb_internal_in...","TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey-)}
-      │    └── 7 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_k_idx", IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
+      │    └── 21 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":14,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── SetIndexName {"IndexID":12,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 5 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           └── 7 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 14 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
+           └── 16 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":14,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":15,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_15_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,64 +12,141 @@ EXPLAIN (DDL) rollback at post-commit stage 15 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
+      │    ├── 5 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 12 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
-      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 16 Mutation operations
+      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 15}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
+      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
+      │    └── 34 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
+      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":14,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":14,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":15,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":14,"Name":"crdb_internal_in...","TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    └── 6 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │    ├── 16 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_k_idx", IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
+      │    └── 20 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":14,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── SetIndexName {"IndexID":12,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 5 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           └── 7 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 14 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
+           └── 16 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":14,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":15,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_1_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_1_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,21 +12,63 @@ EXPLAIN (DDL) rollback at post-commit stage 1 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
-           ├── 7 elements transitioning toward ABSENT
-           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-           └── 9 Mutation operations
-                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
-                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+           ├── 28 elements transitioning toward ABSENT
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+           │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+           │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+           │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+           └── 30 Mutation operations
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_2_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_2_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,30 +12,84 @@ EXPLAIN (DDL) rollback at post-commit stage 2 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    └── 8 Mutation operations
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    └── 26 Mutation operations
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
-           ├── 3 elements transitioning toward ABSENT
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           └── 5 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           └── 14 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_3_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_3_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,30 +12,84 @@ EXPLAIN (DDL) rollback at post-commit stage 3 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    └── 8 Mutation operations
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    └── 26 Mutation operations
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
-           ├── 3 elements transitioning toward ABSENT
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           └── 5 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           └── 14 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_4_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_4_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,30 +12,84 @@ EXPLAIN (DDL) rollback at post-commit stage 4 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    └── 8 Mutation operations
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    └── 26 Mutation operations
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
-           ├── 3 elements transitioning toward ABSENT
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           └── 5 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           └── 14 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_5_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_5_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,32 +12,94 @@ EXPLAIN (DDL) rollback at post-commit stage 5 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    └── 8 Mutation operations
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    └── 28 Mutation operations
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
-           ├── 4 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           └── 6 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 16 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           └── 18 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_6_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_6_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,32 +12,94 @@ EXPLAIN (DDL) rollback at post-commit stage 6 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    └── 8 Mutation operations
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    └── 28 Mutation operations
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
-           ├── 4 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           └── 6 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 16 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           └── 18 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_7_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_7_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,30 +12,86 @@ EXPLAIN (DDL) rollback at post-commit stage 7 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    └── 8 Mutation operations
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    └── 28 Mutation operations
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
-           ├── 3 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           └── 5 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           └── 14 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_8_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_8_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,30 +12,86 @@ EXPLAIN (DDL) rollback at post-commit stage 8 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    └── 8 Mutation operations
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    └── 28 Mutation operations
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
-           ├── 3 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           └── 5 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           └── 14 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_9_of_15.explain
@@ -1,6 +1,9 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, k INT DEFAULT 54);
 INSERT INTO t(i, j) VALUES (-4, -4), (-2, -2), (-3, -3);
+CREATE INDEX ON t(i) WHERE i<=0;
+CREATE INDEX ON t(j) WHERE j<= 0;
+CREATE INDEX ON t(k);
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
@@ -9,60 +12,137 @@ EXPLAIN (DDL) rollback at post-commit stage 9 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹j›);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
+      │    ├── 5 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC    PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 12 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
-      │    │    ├── BACKFILL_ONLY         → ABSENT    SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    │    ├── DELETE_ONLY           → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 2 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
-      │    │    └── PUBLIC                → ABSENT    IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
-      │    └── 16 Mutation operations
+      │    │    ├── ABSENT                → PUBLIC    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC    SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC    SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC    SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
+      │    ├── 24 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── PUBLIC                → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── PUBLIC                → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    │    ├── BACKFILL_ONLY         → ABSENT    SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── DELETE_ONLY           → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 15}
+      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
+      │    │    └── PUBLIC                → ABSENT    IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
+      │    └── 34 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
+      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":13,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":13,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":14,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":15,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":14,"Name":"crdb_internal_in...","TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":14,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    └── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    └── 5 Mutation operations
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │    ├── 15 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── VALIDATED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC    → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── VALIDATED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC    → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── VALIDATED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC    → ABSENT      IndexName:{DescID: 104 (t), Name: "t_k_idx", IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    └── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    └── 19 Mutation operations
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── SetIndexName {"IndexID":12,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":12,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":12,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 4 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
-           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
-           └── 6 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+           ├── 13 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_i_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_j_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
+           └── 15 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":13,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":14,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":16,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":17,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}


### PR DESCRIPTION
Previously, when mutations were made public for validation queries, the declarative schema changer primary key swaps were not appropriately handled. This could lead to scenarios where queries would be unable to find columns in recreated secondary indexes that should ideally exist (i.e. columns from the old primary key). This would cause validation to fail on these newly created indexes. To address, this patch adds logic for making declarative primary key swaps mutations properly by detecting them.

Fixes: #118626

Release note (bug fix): ALTER PRIMARY KEY could fail with a "non-nullable column <x> with no value! Index scanned .." when validating recreated secondary indexes.