### PR TITLE
kvclient: remove unnecessary return value

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2600,9 +2600,8 @@ func (ds *DistSender) sendToReplicas(
 					// happen when the next RPC comes back, but we don't want to wait out
 					// the additional RPC latency.
 
-					var updatedLeaseholder bool
 					if tErr.Lease != nil {
-						updatedLeaseholder = routing.SyncTokenAndMaybeUpdateCache(ctx, tErr.Lease, &tErr.RangeDesc)
+						routing.SyncTokenAndMaybeUpdateCache(ctx, tErr.Lease, &tErr.RangeDesc)
 					}
 					// Move the new leaseholder to the head of the queue for the next
 					// retry. Note that the leaseholder might not be the one indicated by

--- a/pkg/kv/kvclient/rangecache/range_cache_test.go
+++ b/pkg/kv/kvclient/rangecache/range_cache_test.go
@@ -1664,8 +1664,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 					Sequence: 1,
 				}
 				oldTok := tok
-				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCache(ctx, l, &desc1)
-				require.True(t, updatedLeaseholder)
+				tok.SyncTokenAndMaybeUpdateCache(ctx, l, &desc1)
 				require.Equal(t, oldTok.Desc(), tok.Desc())
 				require.Equal(t, &l.Replica, tok.Leaseholder())
 				require.Equal(t, oldTok.ClosedTimestampPolicy(lag), tok.ClosedTimestampPolicy(lag))
@@ -1710,10 +1709,9 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 					Lease:                 roachpb.Lease{},
 					ClosedTimestampPolicy: lead,
 				})
-				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCache(
+				tok.SyncTokenAndMaybeUpdateCache(
 					ctx, &roachpb.Lease{Replica: rep2, Sequence: 3}, &staleRangeDescriptor,
 				)
-				require.True(t, updatedLeaseholder)
 				require.NotNil(t, tok)
 				require.Equal(t, &desc2, tok.Desc())
 				require.Equal(t, &rep2, tok.Leaseholder())
@@ -1747,8 +1745,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 					Lease:                 l,
 					ClosedTimestampPolicy: lead,
 				})
-				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCache(ctx, &l, &desc2)
-				require.False(t, updatedLeaseholder)
+				tok.SyncTokenAndMaybeUpdateCache(ctx, &l, &desc2)
 				require.NotNil(t, tok)
 				require.Equal(t, &desc3, tok.Desc())
 				require.Equal(t, &rep2, tok.Leaseholder())
@@ -1774,10 +1771,9 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCache(
+				tok.SyncTokenAndMaybeUpdateCache(
 					ctx, &roachpb.Lease{Replica: rep2, Sequence: 3}, &desc2,
 				)
-				require.False(t, updatedLeaseholder)
 				require.NotNil(t, tok)
 				require.Equal(t, &desc2, tok.Desc())
 				require.Equal(t, &rep3, tok.Leaseholder())
@@ -1803,10 +1799,9 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCache(
+				tok.SyncTokenAndMaybeUpdateCache(
 					ctx, &roachpb.Lease{Replica: rep2, Sequence: 3}, &desc1,
 				)
-				require.False(t, updatedLeaseholder)
 				require.NotNil(t, tok)
 				require.Equal(t, &desc2, tok.Desc())
 				require.Equal(t, &rep3, tok.Leaseholder())
@@ -1833,10 +1828,9 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCache(
+				tok.SyncTokenAndMaybeUpdateCache(
 					ctx, &roachpb.Lease{Replica: rep2, Sequence: 3}, &desc3,
 				)
-				require.False(t, updatedLeaseholder)
 				require.NotNil(t, tok)
 				require.Equal(t, &desc3, tok.Desc())
 				require.Nil(t, tok.Leaseholder())
@@ -1869,8 +1863,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 					Sequence: 2,
 				}
 				incompatibleDescriptor.Generation = desc2.Generation + 1
-				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCache(ctx, &l, &incompatibleDescriptor)
-				require.False(t, updatedLeaseholder)
+				tok.SyncTokenAndMaybeUpdateCache(ctx, &l, &incompatibleDescriptor)
 				require.False(t, tok.Valid())
 
 				entries := cache.GetCachedOverlapping(
@@ -1901,10 +1894,9 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				require.NoError(t, err)
 
 				incompatibleDescriptor.Generation = desc2.Generation - 1
-				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCache(
+				tok.SyncTokenAndMaybeUpdateCache(
 					ctx, &roachpb.Lease{Replica: rep2, Sequence: 4}, &incompatibleDescriptor,
 				)
-				require.False(t, updatedLeaseholder)
 				require.True(t, tok.Valid())
 
 				entries := cache.GetCachedOverlapping(
@@ -1933,10 +1925,9 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCache(
+				tok.SyncTokenAndMaybeUpdateCache(
 					ctx, &roachpb.Lease{Replica: rep2}, &desc2,
 				)
-				require.True(t, updatedLeaseholder)
 				require.Equal(t, &desc2, tok.Desc())
 				require.Equal(t, &rep2, tok.Leaseholder())
 				require.Equal(t, roachpb.LeaseSequence(0), tok.Lease().Sequence)
@@ -2020,9 +2011,7 @@ func TestRangeCacheEntryMaybeUpdate(t *testing.T) {
 		Replica:  rep1,
 		Sequence: 1,
 	}
-	updated, updatedLease, e := e.maybeUpdate(ctx, &l, &desc)
-	require.True(t, updated)
-	require.True(t, updatedLease)
+	updated, e := e.maybeUpdate(ctx, &l, &desc)
 	require.True(t, l.Equal(e.lease))
 	require.True(t, desc.Equal(e.desc))
 
@@ -2033,8 +2022,8 @@ func TestRangeCacheEntryMaybeUpdate(t *testing.T) {
 		Sequence: 0,
 	}
 	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc)
+	updated, e = e.maybeUpdate(ctx, &l, &desc)
 	require.True(t, updated)
-	require.True(t, updatedLease)
 	require.Equal(t, l.Replica, e.lease.Replica)
 	require.Equal(t, desc, e.desc)
 	// Check that the lease is Speculative.
@@ -2046,9 +2035,8 @@ func TestRangeCacheEntryMaybeUpdate(t *testing.T) {
 		Replica:  rep1,
 		Sequence: 0,
 	}
-	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc)
+	updated, e = e.maybeUpdate(ctx, &l, &desc)
 	require.True(t, updated)
-	require.True(t, updatedLease)
 	require.Equal(t, l.Replica, e.lease.Replica)
 	require.Equal(t, desc, e.desc)
 	// Check that the lease is Speculative.
@@ -2061,7 +2049,7 @@ func TestRangeCacheEntryMaybeUpdate(t *testing.T) {
 	}
 	// Ensure that a speculative lease is not overwritten when accompanied by a
 	// stale range descriptor.
-	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &staleDesc)
+	updated, e = e.maybeUpdate(ctx, &l, &staleDesc)
 	require.False(t, updated)
 	require.False(t, updatedLease)
 	require.Equal(t, oldL.Replica, e.lease.Replica)
@@ -2075,18 +2063,16 @@ func TestRangeCacheEntryMaybeUpdate(t *testing.T) {
 		Replica:  rep1,
 		Sequence: 1,
 	}
-	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &staleDesc)
+	updated, e = e.maybeUpdate(ctx, &l, &staleDesc)
 	require.False(t, updated)
-	require.False(t, updatedLease)
 	require.Equal(t, oldL.Replica, e.lease.Replica)
 	require.Equal(t, desc, e.desc)
 
 	// Empty out the lease and ensure that it is overwritten by a lease even if
 	// the accompanying range descriptor is stale.
 	e.lease = roachpb.Lease{}
-	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &staleDesc)
+	updated, e = e.maybeUpdate(ctx, &l, &staleDesc)
 	require.True(t, updated)
-	require.True(t, updatedLease)
 	require.Equal(t, oldL.Replica, e.lease.Replica)
 	require.Equal(t, l, e.lease)
 	// The range descriptor shouldn't be updated because the one supplied was
@@ -2098,7 +2084,7 @@ func TestRangeCacheEntryMaybeUpdate(t *testing.T) {
 		Replica:  rep2,
 		Sequence: 2,
 	}
-	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc)
+	updated, e = e.maybeUpdate(ctx, &l, &desc)
 	require.True(t, updated)
 	require.True(t, updatedLease)
 	require.Equal(t, l, e.lease)
@@ -2109,15 +2095,13 @@ func TestRangeCacheEntryMaybeUpdate(t *testing.T) {
 		Replica:  rep1,
 		Sequence: 1,
 	}
-	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc)
+	updated, e = e.maybeUpdate(ctx, &l, &desc)
 	require.False(t, updated)
-	require.False(t, updatedLease)
 	require.NotEqual(t, l, e.lease)
 
 	// Check that updating to an older descriptor doesn't work.
-	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &staleDesc)
+	updated, e = e.maybeUpdate(ctx, &l, &staleDesc)
 	require.False(t, updated)
-	require.False(t, updatedLease)
 	require.Equal(t, desc, e.desc)
 
 	// Check that updating to the same lease returns false.
@@ -2126,17 +2110,15 @@ func TestRangeCacheEntryMaybeUpdate(t *testing.T) {
 		Sequence: 2,
 	}
 	require.Equal(t, l, e.lease)
-	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc)
+	updated, e = e.maybeUpdate(ctx, &l, &desc)
 	require.False(t, updated)
-	require.False(t, updatedLease)
 	require.Equal(t, l, e.lease)
 	require.Equal(t, desc, e.desc)
 
 	// Check that updating just the descriptor to a newer descriptor returns the
 	// correct values for updated and updatedLease.
-	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc2)
+	updated, e = e.maybeUpdate(ctx, &l, &desc2)
 	require.True(t, updated)
-	require.False(t, updatedLease)
 	require.Equal(t, l, e.lease)
 	require.Equal(t, desc2, e.desc)
 
@@ -2148,9 +2130,8 @@ func TestRangeCacheEntryMaybeUpdate(t *testing.T) {
 		Sequence: 1,
 	}
 	require.Equal(t, roachpb.LeaseSequence(2), e.lease.Sequence)
-	updated, updatedLease, e = e.maybeUpdate(ctx, &l, &desc3)
+	updated, e = e.maybeUpdate(ctx, &l, &desc3)
 	require.True(t, updated)
-	require.False(t, updatedLease)
 	require.True(t, e.lease.Empty())
 	require.Equal(t, desc3, e.desc)
 }


### PR DESCRIPTION
We no longer need to return whether we updated the leaseholder from the SyncTokenAndMaybeUpdateCache method as we don't change behavior based on whether the leaeseholder was updated.

Epic: none

Release note: None