### PR TITLE
engflow: tag some builds appropriately

### DIFF
--- a/.github/workflows/experimental-github-actions-testing.yml
+++ b/.github/workflows/experimental-github-actions-testing.yml
@@ -17,7 +17,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: ./build/github/get-engflow-keys.sh
       - name: run tests
-        run: bazel test //pkg:all_tests //pkg/ui:lint //pkg/ui:test --config crosslinux --jobs 300 --remote_download_minimal --bes_keywords=github_pr_number=${{ github.event.pull_request.number }} --config=use_ci_timeouts --build_event_binary_file=bes.bin $(./build/github/engflow-args.sh)
+        run: bazel test //pkg:all_tests //pkg/ui:lint //pkg/ui:test --config crosslinux --jobs 300 --remote_download_minimal --bes_keywords=github_pr_number=${{ github.event.pull_request.number }} --config=use_ci_timeouts --build_event_binary_file=bes.bin $(./build/github/engflow-args.sh) --bes_keywords ci-unit-test
       - name: upload test results
         run: ./build/github/upload-test-results.sh bes.bin
         if: always()

--- a/build/github/upload-test-results.sh
+++ b/build/github/upload-test-results.sh
@@ -10,7 +10,7 @@ fi
 
 THIS_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 
-bazel build //pkg/cmd/bazci/extract-test-results --config crosslinux --jobs 300 $($THIS_DIR/engflow-args.sh)
+bazel build //pkg/cmd/bazci/extract-test-results --config crosslinux --jobs 300 $($THIS_DIR/engflow-args.sh) --bes_keywords helper-binary
 _bazel/bin/pkg/cmd/bazci/extract-test-results/extract-test-results_/extract-test-results -eventsfile $1 -servername mesolite -cert /home/agent/engflow.crt -key /home/agent/engflow.key -jsonout test-results.json
 gcloud storage cp test-results.json gs://engflow-data/$(date +%F)/$(python3 -c "import json, sys; print(json.load(sys.stdin)['invocation_id'])" < test-results.json).json
 rm test-results.json

--- a/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
@@ -30,7 +30,7 @@ bazel test //pkg:all_tests $ENGFLOW_FLAGS --remote_download_minimal \
     || status=$?
 
 # Upload results to GitHub.
-bazel build //pkg/cmd/bazci/process-bep-file $ENGFLOW_FLAGS
+bazel build //pkg/cmd/bazci/process-bep-file $ENGFLOW_FLAGS --bes_keywords helper-binary
 _bazel/bin/pkg/cmd/bazci/process-bep-file/process-bep-file_/process-bep-file \
     -branch $TC_BUILD_BRANCH -eventsfile artifacts/eventstream \
     -cert /home/agent/engflow/engflow.crt -key /home/agent/engflow/engflow.key \


### PR DESCRIPTION
We tag builds of helper binaries to help distinguish them from other builds. Also, unit test runs get a `ci-unit-test` tag.

Epic: CRDB-83083
Release note: None