### PR TITLE
release-23.2: cluster-ui: bump cluster-ui npm version

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "23.2.4",
+  "version": "23.2.5",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
It's been a moment since our last version bump of cluster-ui for
release-23.2 (last bump here: https://github.com/cockroachdb/cockroach/pull/118561)

This patch bumps the version on `release-23.2` from `23.2.4` to
`23.2.5`.

Release note: none

Epic: none

Release justification: routinely scheduled cluster-ui version upgrade