### PR TITLE
server: enable continuous CPU profiler

### DIFF
--- a/pkg/server/profiler/cpuprofiler.go
+++ b/pkg/server/profiler/cpuprofiler.go
@@ -12,7 +12,6 @@ package profiler
 
 import (
 	"context"
-	"math"
 	"os"
 	"runtime/pprof"
 	"time"
@@ -41,7 +40,8 @@ var cpuUsageCombined = settings.RegisterIntSetting(
 		"the profiler will never take a profile and conversely, if a value"+
 		"of 0 is set, a profile will be taken every time the cpu profile"+
 		"interval has passed or the provided usage is increasing",
-	math.MaxInt64,
+	65,
+	settings.PositiveInt,
 )
 
 var cpuProfileInterval = settings.RegisterDurationSetting(
@@ -51,14 +51,16 @@ var cpuProfileInterval = settings.RegisterDurationSetting(
 	// account the high water mark seen. Without this, if CPU ever reaches 100%,
 	// we'll never take another profile.
 	"duration after which the high water mark resets and a new cpu profile can be taken",
-	5*time.Minute, settings.PositiveDuration,
+	20*time.Minute,
+	settings.PositiveDuration,
 )
 
 var cpuProfileDuration = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"server.cpu_profile.duration",
 	"the duration for how long a cpu profile is taken",
-	10*time.Second, settings.PositiveDuration,
+	10*time.Second,
+	settings.PositiveDuration,
 )
 
 const cpuProfFileNamePrefix = "cpuprof"


### PR DESCRIPTION
This patch enables the CPU profile with a threshold of 75% and a max frequency of 20min.

The motivation for this change is that recently, I have noticed a few cases during investigations where CPU utilization spikes but we lack profiles after the fact. This hinders our ability to dig deeper into the source of high CPU usage. Having profiles can help inform us of future AC integrations that we may need, or other performance improvements we can do elsewhere.

Informs #97699.

Release note (ops change): CRDB will now automatically generate CPU profiles if there is an increase in CPU utilization. This can help investigate possible issues after the fact.