### PR TITLE
sql: fix bug with type name conflict, allow resolving any object

### DIFF
--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -207,6 +207,8 @@ func ResolveExistingObject(
 				return nil, prefix, sqlerrors.NewUndefinedRelationError(un)
 			case tree.TypeObject:
 				return nil, prefix, sqlerrors.NewUndefinedTypeError(un)
+			case tree.AnyObject:
+				return nil, prefix, sqlerrors.NewUndefinedObjectError(un)
 			default:
 				return nil, prefix, errors.AssertionFailedf("unknown object kind %d", lookupFlags.DesiredObjectKind)
 			}
@@ -254,6 +256,8 @@ func ResolveExistingObject(
 		}
 
 		return obj.(catalog.TableDescriptor), prefix, nil
+	case tree.AnyObject:
+		return obj, prefix, nil
 	default:
 		return nil, prefix, errors.AssertionFailedf(
 			"unknown desired object kind %d", lookupFlags.DesiredObjectKind)

--- a/pkg/sql/catalog/resolver/resolver_bench_test.go
+++ b/pkg/sql/catalog/resolver/resolver_bench_test.go
@@ -71,6 +71,7 @@ func BenchmarkResolveExistingObject(b *testing.B) {
 		},
 	} {
 		b.Run(tc.testName, func(b *testing.B) {
+			tc.flags.DesiredObjectKind = tree.TableObject
 			ctx := context.Background()
 			s, sqlDB, kvDB := serverutils.StartServer(b, base.TestServerArgs{})
 			defer s.Stopper().Stop(ctx)

--- a/pkg/sql/comment_on_column.go
+++ b/pkg/sql/comment_on_column.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -36,11 +38,10 @@ func (p *planner) CommentOnColumn(ctx context.Context, n *tree.CommentOnColumn) 
 		return nil, err
 	}
 
-	var tableName tree.TableName
-	if n.ColumnItem.TableName != nil {
-		tableName = n.ColumnItem.TableName.ToTableName()
+	if n.ColumnItem.TableName == nil {
+		return nil, pgerror.New(pgcode.Syntax, "column name must be qualified")
 	}
-	tableDesc, err := p.resolveUncachedTableDescriptor(ctx, &tableName, true, tree.ResolveRequireTableDesc)
+	tableDesc, err := p.ResolveUncachedTableDescriptorEx(ctx, n.ColumnItem.TableName, true, tree.ResolveRequireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/comment_on
+++ b/pkg/sql/logictest/testdata/logic_test/comment_on
@@ -134,6 +134,9 @@ COMMENT ON COLUMN public.t.b IS 'column b'
 statement ok
 COMMENT ON COLUMN t.b IS 'column b AGAIN';
 
+statement error column name must be qualified
+COMMENT ON COLUMN b IS 'unqualified column b';
+
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t];
 ----

--- a/pkg/sql/logictest/testdata/logic_test/event_log_legacy
+++ b/pkg/sql/logictest/testdata/logic_test/event_log_legacy
@@ -980,7 +980,7 @@ SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
 FROM system.eventlog
 WHERE "eventType" = 'comment_on_column'
 ----
-1  {"ColumnName": "id", "Comment": "This is a column.", "EventType": "comment_on_column", "Statement": "COMMENT ON COLUMN a.id IS 'This is a column.'", "TableName": "defaultdb.public.a", "Tag": "COMMENT ON COLUMN", "User": "root"}
+1  {"ColumnName": "id", "Comment": "This is a column.", "EventType": "comment_on_column", "Statement": "COMMENT ON COLUMN defaultdb.public.a.id IS 'This is a column.'", "TableName": "defaultdb.public.a", "Tag": "COMMENT ON COLUMN", "User": "root"}
 
 statement ok
 CREATE INDEX b_index ON a (b)

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2410,3 +2410,29 @@ subtest regression_106838
 
 statement error pgcode 42601 pq: invalid OWNED BY option
 CREATE SEQUENCE s_106838 OWNED BY col;
+
+subtest serial_normalization_type_name_conflict
+
+statement ok
+SET serial_normalization = 'sql_sequence';
+SET default_int_size=8;
+
+statement ok
+CREATE TYPE t72820_i_seq AS enum ('a')
+
+statement ok
+CREATE TABLE t72820 (i SERIAL PRIMARY KEY)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t72820]
+----
+CREATE TABLE public.t72820 (
+   i INT8 NOT NULL DEFAULT nextval('public.t72820_i_seq1'::REGCLASS),
+   CONSTRAINT t72820_pkey PRIMARY KEY (i ASC)
+)
+
+statement ok
+RESET serial_normalization;
+RESET default_int_size;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2411,7 +2411,7 @@ subtest regression_106838
 statement error pgcode 42601 pq: invalid OWNED BY option
 CREATE SEQUENCE s_106838 OWNED BY col;
 
-subtest serial_normalization_type_name_conflict
+subtest sequence_type_name_conflict
 
 statement ok
 SET serial_normalization = 'sql_sequence';
@@ -2430,6 +2430,19 @@ CREATE TABLE public.t72820 (
    i INT8 NOT NULL DEFAULT nextval('public.t72820_i_seq1'::REGCLASS),
    CONSTRAINT t72820_pkey PRIMARY KEY (i ASC)
 )
+
+# Also make sure that creating a sequence directly handles the name conflict.
+skipif config local-legacy-schema-changer
+skipif config local-mixed-23.1
+skipif config local-mixed-23.2
+statement error relation "test.public.t72820_i_seq" already exists
+CREATE SEQUENCE t72820_i_seq
+
+onlyif config local-legacy-schema-changer
+onlyif config local-mixed-23.1
+onlyif config local-mixed-23.2
+statement error type "test.public.t72820_i_seq" already exists
+CREATE SEQUENCE t72820_i_seq
 
 statement ok
 RESET serial_normalization;

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4453,6 +4453,10 @@ comment_stmt:
       sqllex.Error(fmt.Sprintf("invalid column name: %q", tree.ErrString($4.unresolvedName())))
             return 1
     }
+    if columnItem != nil && columnItem.TableName != nil {
+      aIdx := sqllex.(*lexer).NewAnnotation()
+      columnItem.TableName.AnnotatedNode = tree.AnnotatedNode{AnnIdx: aIdx}
+    }
     $$.val = &tree.CommentOnColumn{ColumnItem: columnItem, Comment: $6.strPtr()}
   }
 | COMMENT ON INDEX table_index_name IS comment_text

--- a/pkg/sql/parser/testdata/comment
+++ b/pkg/sql/parser/testdata/comment
@@ -1,3 +1,12 @@
+# Using an unqualified column name should still parse, even though it can't be
+# executed.
+parse
+COMMENT ON COLUMN a IS 'a'
+----
+COMMENT ON COLUMN a IS 'a'
+(COMMENT ON COLUMN (a) IS 'a') -- fully parenthesized
+COMMENT ON COLUMN a IS '_' -- literals removed
+COMMENT ON COLUMN _ IS 'a' -- identifiers removed
 
 parse
 COMMENT ON COLUMN a.b IS 'a'

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -173,6 +174,13 @@ func (sr *schemaResolver) LookupObject(
 		prefix, desc, err = descs.PrefixAndTable(ctx, g, &tn)
 	case tree.TypeObject:
 		prefix, desc, err = descs.PrefixAndType(ctx, g, &tn)
+	case tree.AnyObject:
+		prefix, desc, err = descs.PrefixAndTable(ctx, g, &tn)
+		if err != nil {
+			if sqlerrors.IsUndefinedRelationError(err) || errors.Is(err, catalog.ErrDescriptorWrongType) {
+				prefix, desc, err = descs.PrefixAndType(ctx, g, &tn)
+			}
+		}
 	default:
 		return false, prefix, nil, errors.AssertionFailedf(
 			"unknown desired object kind %v", flags.DesiredObjectKind,
@@ -187,6 +195,8 @@ func (sr *schemaResolver) LookupObject(
 			desc, err = sr.descCollection.MutableByID(sr.txn).Table(ctx, desc.GetID())
 		case tree.TypeObject:
 			desc, err = sr.descCollection.MutableByID(sr.txn).Type(ctx, desc.GetID())
+		case tree.AnyObject:
+			desc, err = sr.descCollection.MutableByID(sr.txn).Desc(ctx, desc.GetID())
 		}
 	}
 	return desc != nil, prefix, desc, err

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_sequence.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_sequence.go
@@ -41,11 +41,12 @@ func CreateSequence(b BuildCtx, n *tree.CreateSequence) {
 	owner := b.CurrentUser()
 
 	// Detect duplicate sequence names.
-	ers := b.ResolveSequence(n.Name.ToUnresolvedObjectName(),
+	ers := b.ResolveRelation(n.Name.ToUnresolvedObjectName(),
 		ResolveParams{
 			IsExistenceOptional: true,
 			RequiredPrivilege:   privilege.USAGE,
 			WithOffline:         true, // We search sequence with provided name, including offline ones.
+			ResolveTypes:        true, // Check for collisions with type names.
 		})
 	if ers != nil && !ers.IsEmpty() {
 		if n.IfNotExists {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -344,6 +344,10 @@ type ResolveParams struct {
 	// WithOffline, if set, instructs the catalog reader to include offline
 	// descriptors.
 	WithOffline bool
+
+	// ResolveTypes if set, instructs the catalog reader to resolve types
+	// and not just tables, sequences, and views.
+	ResolveTypes bool
 }
 
 // NameResolver looks up elements in the catalog by name, and vice-versa.

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -322,6 +322,11 @@ func (s *TestState) MayResolveTable(
 	}
 	table, err := catalog.AsTableDescriptor(desc)
 	if err != nil {
+		// Finding a descriptor of a different type is not an error; it is
+		// equivalent to "not found".
+		if errors.Is(err, catalog.ErrDescriptorWrongType) {
+			return prefix, nil
+		}
 		panic(err)
 	}
 	return prefix, table
@@ -340,6 +345,11 @@ func (s *TestState) MayResolveType(
 	}
 	typ, err := catalog.AsTypeDescriptor(desc)
 	if err != nil {
+		// Finding a descriptor of a different type is not an error; it is
+		// equivalent to "not found".
+		if errors.Is(err, catalog.ErrDescriptorWrongType) {
+			return prefix, nil
+		}
 		panic(err)
 	}
 	return prefix, typ

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -152,10 +152,14 @@ func newInvTableNameError(n fmt.Stringer) error {
 type DesiredObjectKind byte
 
 const (
+	_ DesiredObjectKind = iota
 	// TableObject is used when a table-like object is desired from resolution.
-	TableObject DesiredObjectKind = iota
+	TableObject
 	// TypeObject is used when a type-like object is desired from resolution.
 	TypeObject
+	// AnyObject is used when any object is acceptable. This is primary used when
+	// looking for name conflicts.
+	AnyObject
 )
 
 // RequiredTableKind controls what kind of TableDescriptor backed object is

--- a/pkg/sql/sem/tree/object_name.go
+++ b/pkg/sql/sem/tree/object_name.go
@@ -10,6 +10,8 @@
 
 package tree
 
+import "github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
+
 // ObjectName is a common interface for qualified object names.
 type ObjectName interface {
 	NodeFormatter
@@ -23,6 +25,7 @@ type ObjectName interface {
 var _ ObjectName = &TableName{}
 var _ ObjectName = &TypeName{}
 var _ ObjectName = &RoutineName{}
+var _ ObjectName = &UnspecifiedObjectName{}
 
 // objName is the internal type for a qualified object.
 type objName struct {
@@ -33,6 +36,22 @@ type objName struct {
 	// ObjectNamePrefix is the path to the object.  This can be modified
 	// further by name resolution, see name_resolution.go.
 	ObjectNamePrefix
+}
+
+func makeQualifiedObjName(db, schema, object Name) objName {
+	return makeObjNameWithPrefix(ObjectNamePrefix{
+		CatalogName:     db,
+		SchemaName:      schema,
+		ExplicitSchema:  true,
+		ExplicitCatalog: true,
+	}, object)
+}
+
+func makeObjNameWithPrefix(prefix ObjectNamePrefix, object Name) objName {
+	return objName{
+		ObjectName:       object,
+		ObjectNamePrefix: prefix,
+	}
 }
 
 func (o *objName) Object() string {
@@ -57,6 +76,41 @@ func (o *objName) ToUnresolvedObjectName() *UnresolvedObjectName {
 	}
 	return u
 }
+
+func (o *objName) String() string { return AsString(o) }
+
+// FQString renders the table name in full, not omitting the prefix
+// schema and catalog names. Suitable for logging, etc.
+func (o *objName) FQString() string {
+	ctx := NewFmtCtx(FmtSimple)
+	schemaName := o.SchemaName.String()
+	// The pg_catalog and pg_extension schemas cannot be referenced from inside
+	// an anonymous ("") database. This makes their FQ string always relative.
+	if schemaName != catconstants.PgCatalogName && schemaName != catconstants.PgExtensionSchemaName {
+		ctx.FormatNode(&o.CatalogName)
+		ctx.WriteByte('.')
+	}
+	ctx.FormatNode(&o.SchemaName)
+	ctx.WriteByte('.')
+	ctx.FormatNode(&o.ObjectName)
+	return ctx.CloseAndGetString()
+}
+
+// Format implements the NodeFormatter interface.
+func (o *objName) Format(ctx *FmtCtx) {
+	ctx.FormatNode(&o.ObjectNamePrefix)
+	if o.ExplicitSchema || ctx.alwaysFormatTablePrefix() {
+		ctx.WriteByte('.')
+	}
+	ctx.FormatNode(&o.ObjectName)
+}
+
+// UnspecifiedObjectName is an object name correspond to any object type.
+type UnspecifiedObjectName struct {
+	objName
+}
+
+func (u UnspecifiedObjectName) objectName() {}
 
 // ObjectNamePrefix corresponds to the path prefix of an object name.
 type ObjectNamePrefix struct {

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -10,8 +10,6 @@
 
 package tree
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
-
 // TableName corresponds to the name of a table in a FROM clause,
 // INSERT or UPDATE statement, etc.
 //
@@ -34,32 +32,10 @@ func (t *TableName) Format(ctx *FmtCtx) {
 		ctx.tableNameFormatter(ctx, t)
 		return
 	}
-	t.ObjectNamePrefix.Format(ctx)
-	if t.ExplicitSchema || ctx.alwaysFormatTablePrefix() {
-		ctx.WriteByte('.')
-	}
-	ctx.FormatNode(&t.ObjectName)
+	t.objName.Format(ctx)
 }
-func (t *TableName) String() string { return AsString(t) }
 
 func (t *TableName) objectName() {}
-
-// FQString renders the table name in full, not omitting the prefix
-// schema and catalog names. Suitable for logging, etc.
-func (t *TableName) FQString() string {
-	ctx := NewFmtCtx(FmtSimple)
-	schemaName := t.SchemaName.String()
-	// The pg_catalog and pg_extension schemas cannot be referenced from inside
-	// an anonymous ("") database. This makes their FQ string always relative.
-	if schemaName != catconstants.PgCatalogName && schemaName != catconstants.PgExtensionSchemaName {
-		ctx.FormatNode(&t.CatalogName)
-		ctx.WriteByte('.')
-	}
-	ctx.FormatNode(&t.SchemaName)
-	ctx.WriteByte('.')
-	ctx.FormatNode(&t.ObjectName)
-	return ctx.CloseAndGetString()
-}
 
 // Table retrieves the unqualified table name.
 func (t *TableName) Table() string {
@@ -84,31 +60,22 @@ func NewTableNameWithSchema(db, sc, tbl Name) *TableName {
 
 // MakeTableNameWithSchema creates a new fully qualified table name.
 func MakeTableNameWithSchema(db, schema, tbl Name) TableName {
-	return TableName{objName{
-		ObjectName: tbl,
-		ObjectNamePrefix: ObjectNamePrefix{
-			CatalogName:     db,
-			SchemaName:      schema,
-			ExplicitSchema:  true,
-			ExplicitCatalog: true,
-		},
-	}}
+	return TableName{
+		objName: makeQualifiedObjName(db, schema, tbl),
+	}
 }
 
 // MakeTableNameFromPrefix creates a table name from an unqualified name
 // and a resolved prefix.
 func MakeTableNameFromPrefix(prefix ObjectNamePrefix, object Name) TableName {
-	return TableName{objName{
-		ObjectName:       object,
-		ObjectNamePrefix: prefix,
-	}}
+	return TableName{
+		objName: makeObjNameWithPrefix(prefix, object),
+	}
 }
 
 // MakeUnqualifiedTableName creates a new base table name.
 func MakeUnqualifiedTableName(tbl Name) TableName {
-	return TableName{objName{
-		ObjectName: tbl,
-	}}
+	return MakeTableNameFromPrefix(ObjectNamePrefix{}, tbl)
 }
 
 // NewUnqualifiedTableName creates a new base table name.
@@ -118,10 +85,10 @@ func NewUnqualifiedTableName(tbl Name) *TableName {
 }
 
 func makeTableNameFromUnresolvedName(n *UnresolvedName) TableName {
-	return TableName{objName{
-		ObjectName:       Name(n.Parts[0]),
-		ObjectNamePrefix: makeObjectNamePrefixFromUnresolvedName(n),
-	}}
+	return MakeTableNameFromPrefix(
+		makeObjectNamePrefixFromUnresolvedName(n),
+		Name(n.Parts[0]),
+	)
 }
 
 func makeObjectNamePrefixFromUnresolvedName(n *UnresolvedName) ObjectNamePrefix {

--- a/pkg/sql/sem/tree/type_name.go
+++ b/pkg/sql/sem/tree/type_name.go
@@ -42,34 +42,13 @@ func (t *TypeName) Type() string {
 
 // Format implements the NodeFormatter interface.
 func (t *TypeName) Format(ctx *FmtCtx) {
-	ctx.FormatNode(&t.ObjectNamePrefix)
-	if t.ExplicitSchema || ctx.alwaysFormatTablePrefix() {
-		ctx.WriteByte('.')
-	}
-	ctx.FormatNode(&t.ObjectName)
-}
-
-// String implements the Stringer interface.
-func (t *TypeName) String() string {
-	return AsString(t)
+	t.objName.Format(ctx)
 }
 
 // SQLString implements the ResolvableTypeReference interface.
 func (t *TypeName) SQLString() string {
 	// FmtBareIdentifiers prevents the TypeName string from being wrapped in quotations.
 	return AsStringWithFlags(t, FmtBareIdentifiers)
-}
-
-// FQString renders the type name in full, not omitting the prefix
-// schema and catalog names. Suitable for logging, etc.
-func (t *TypeName) FQString() string {
-	ctx := NewFmtCtx(FmtSimple)
-	ctx.FormatNode(&t.CatalogName)
-	ctx.WriteByte('.')
-	ctx.FormatNode(&t.SchemaName)
-	ctx.WriteByte('.')
-	ctx.FormatNode(&t.ObjectName)
-	return ctx.CloseAndGetString()
 }
 
 func (t *TypeName) objectName() {}
@@ -103,12 +82,9 @@ func MakeTypeNameWithPrefix(prefix ObjectNamePrefix, typ string) TypeName {
 
 // MakeQualifiedTypeName creates a fully qualified type name.
 func MakeQualifiedTypeName(db, schema, typ string) TypeName {
-	return MakeTypeNameWithPrefix(ObjectNamePrefix{
-		ExplicitCatalog: true,
-		CatalogName:     Name(db),
-		ExplicitSchema:  true,
-		SchemaName:      Name(schema),
-	}, typ)
+	return TypeName{
+		objName: makeQualifiedObjName(Name(db), Name(schema), Name(typ)),
+	}
 }
 
 // NewQualifiedTypeName returns a fully qualified type name.

--- a/pkg/sql/serial.go
+++ b/pkg/sql/serial.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
@@ -88,11 +89,17 @@ func (p *planner) generateSequenceForSerial(
 
 	// Now skip over all names that are already taken.
 	nameBase := seqName.ObjectName
+	flags := tree.ObjectLookupFlags{
+		Required:          false,
+		RequireMutable:    false,
+		IncludeOffline:    true,
+		DesiredObjectKind: tree.AnyObject,
+	}
 	for i := 0; ; i++ {
 		if i > 0 {
 			seqName.ObjectName = tree.Name(fmt.Sprintf("%s%d", nameBase, i))
 		}
-		res, err := p.resolveUncachedTableDescriptor(ctx, seqName, false /*required*/, tree.ResolveAnyTableKind)
+		res, _, err := resolver.ResolveExistingObject(ctx, p, seqName.ToUnresolvedObjectName(), flags)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -158,6 +158,11 @@ func NewInvalidWildcardError(name string) error {
 		"%q does not match any valid database or schema", name)
 }
 
+// NewUndefinedObjectError creates an error that represents a missing object.
+func NewUndefinedObjectError(name tree.NodeFormatter) error {
+	return pgerror.Newf(pgcode.UndefinedObject, "object %q does not exist", tree.ErrString(name))
+}
+
 // NewUndefinedTypeError creates an error that represents a missing type.
 func NewUndefinedTypeError(name tree.NodeFormatter) error {
 	return pgerror.Newf(pgcode.UndefinedObject, "type %q does not exist", tree.ErrString(name))

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -279,7 +279,7 @@ var opWeights = []int{
 	alterTableSetColumnDefault:        1,
 	alterTableSetColumnNotNull:        1,
 	alterTypeDropValue:                0, // Disabled and tracked with #114844, #113859, and #115612.
-	commentOn:                         0, // Disabled and tracked with #116795.
+	commentOn:                         1,
 	createFunction:                    1,
 	createIndex:                       1,
 	createSchema:                      1,


### PR DESCRIPTION
Prior to this change there was a bug when a type name conflicted with a sequence name (#72820). This resolves that problem by adding logic to resolve any sort of object with a given name.

It also removes a bad method from sql/resolver.go

replaces #72824
fixes #72820
fixes https://github.com/cockroachdb/cockroach/issues/118753
fixes https://github.com/cockroachdb/cockroach/issues/116795

Release note (bug fix): Fixed a bug which caused an inscrutable error when a sequence name allocated by `SERIAL` conflicted with an existing type name.