### PR TITLE
release 23.1: jobs: break up transaction in pts management poller

### DIFF
--- a/pkg/jobs/metricspoller/BUILD.bazel
+++ b/pkg/jobs/metricspoller/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/sql/isql",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/util/contextutil",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/metric",

--- a/pkg/jobs/metricspoller/job_statistics.go
+++ b/pkg/jobs/metricspoller/job_statistics.go
@@ -12,6 +12,7 @@ package metricspoller
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -24,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -92,6 +94,8 @@ type schedulePTSStat struct {
 	m *jobs.ExecutorPTSMetrics
 }
 
+const cancelJobTimeout = 60 * time.Second
+
 // manageProtectedTimestamps manages protected timestamp records owned by
 // various jobs or schedules.. This function mostly concerns itself with
 // collecting statistics related to job PTS records. It also detects PTS records
@@ -100,37 +104,51 @@ type schedulePTSStat struct {
 func manageProtectedTimestamps(ctx context.Context, execCtx sql.JobExecContext) error {
 	var ptsStats map[jobspb.Type]*ptsStat
 	var schedulePtsStats map[string]*schedulePTSStat
-
+	var ptsState ptpb.State
 	execCfg := execCtx.ExecCfg()
+
 	if err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		ptsStats = make(map[jobspb.Type]*ptsStat)
 		schedulePtsStats = make(map[string]*schedulePTSStat)
+		var err error
+		ptsState, err = execCfg.ProtectedTimestampProvider.WithTxn(txn).GetState(ctx)
+		return err
+	}); err != nil {
+		return err
+	}
 
-		ptsState, err := execCfg.ProtectedTimestampProvider.WithTxn(txn).GetState(ctx)
+	// Iterate over each job with a fresh transaction, to avoid reading and
+	// updating too many jobs in a single transaction.
+	for _, scannedRec := range ptsState.Records {
+		id, err := jobsprotectedts.DecodeID(scannedRec.Meta)
 		if err != nil {
 			return err
 		}
-		for _, rec := range ptsState.Records {
-			id, err := jobsprotectedts.DecodeID(rec.Meta)
-			if err != nil {
-				return err
-			}
-			switch rec.MetaType {
-			case jobsprotectedts.GetMetaType(jobsprotectedts.Jobs):
-				if err := processJobPTSRecord(ctx, execCfg, id, rec, ptsStats, txn); err != nil {
+		if err := contextutil.RunWithTimeout(ctx, "cancel-old-job-pts", cancelJobTimeout, func(ctx context.Context) error {
+			return execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+				// Grab the pts within the transaction to ensure we have an up to date view of it.
+				rec, err := execCfg.ProtectedTimestampProvider.WithTxn(txn).GetRecord(ctx, scannedRec.ID.GetUUID())
+				if err != nil {
 					return err
 				}
-			case jobsprotectedts.GetMetaType(jobsprotectedts.Schedules):
-				if err := processSchedulePTSRecord(ctx, id, rec, schedulePtsStats, txn); err != nil {
-					return err
+				switch rec.MetaType {
+				case jobsprotectedts.GetMetaType(jobsprotectedts.Jobs):
+					if err := processJobPTSRecord(ctx, execCfg, id, rec, ptsStats, txn); err != nil {
+						return err
+					}
+				case jobsprotectedts.GetMetaType(jobsprotectedts.Schedules):
+					if err := processSchedulePTSRecord(ctx, id, rec, schedulePtsStats, txn); err != nil {
+						return err
+					}
 				}
-			default:
-				continue
-			}
+				return nil
+			})
+		}); err != nil {
+			// If we fail to process one record, we should still try to process
+			// subsequent records, therefore, just log the error instead of returning
+			// early.
+			log.Infof(ctx, "could not process pts record id %d: %s", scannedRec.ID, err.Error())
 		}
-		return nil
-	}); err != nil {
-		return err
 	}
 
 	updateJobPTSMetrics(execCfg.JobRegistry.MetricsStruct(), execCfg.Clock, ptsStats)
@@ -143,7 +161,7 @@ func processJobPTSRecord(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
 	jobID int64,
-	rec ptpb.Record,
+	rec *ptpb.Record,
 	ptsStats map[jobspb.Type]*ptsStat,
 	txn isql.Txn,
 ) error {
@@ -218,7 +236,7 @@ func updateJobPTSMetrics(
 func processSchedulePTSRecord(
 	ctx context.Context,
 	scheduleID int64,
-	rec ptpb.Record,
+	rec *ptpb.Record,
 	ptsStats map[string]*schedulePTSStat,
 	txn isql.Txn,
 ) error {


### PR DESCRIPTION
Previously the pts management poller would grab all pts records and scan (and potentially modify) over the associated job records in a single txn. To prevent contention with other job queries, this patch breaks this transaction up, such that the pts records are fetched with one txn, and each job is processed with its own txn.

Informs #118512

Release note: none

Release justification: low risk, high impact bug fix