### PR TITLE
sql: avoid direct pointer comparisons for *types.T

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/functions.go
+++ b/pkg/ccl/changefeedccl/cdceval/functions.go
@@ -168,7 +168,7 @@ func cdcTimestampBuiltin(
 				},
 				Info:              doc + " as HLC timestamp",
 				Volatility:        v,
-				PreferredOverload: preferredOverloadReturnType == types.Decimal,
+				PreferredOverload: preferredOverloadReturnType.Identical(types.Decimal),
 			},
 			{
 				Types:      tree.ParamTypes{},
@@ -179,7 +179,7 @@ func cdcTimestampBuiltin(
 				},
 				Info:              doc + " as TIMESTAMPTZ",
 				Volatility:        v,
-				PreferredOverload: preferredOverloadReturnType == types.TimestampTZ,
+				PreferredOverload: preferredOverloadReturnType.Identical(types.TimestampTZ),
 			},
 			{
 				Types:      tree.ParamTypes{},
@@ -190,7 +190,7 @@ func cdcTimestampBuiltin(
 				},
 				Info:              doc + " as TIMESTAMP",
 				Volatility:        v,
-				PreferredOverload: preferredOverloadReturnType == types.Timestamp,
+				PreferredOverload: preferredOverloadReturnType.Identical(types.Timestamp),
 			},
 		},
 	)

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -1121,7 +1121,7 @@ func TestJsonRountrip(t *testing.T) {
 	rng, _ := randutil.NewTestRand()
 
 	isFloatOrDecimal := func(typ *types.T) bool {
-		return typ == types.Float4 || typ == types.Float || typ == types.Decimal
+		return typ.Identical(types.Float4) || typ.Identical(types.Float) || typ.Identical(types.Decimal)
 	}
 
 	type test struct {

--- a/pkg/col/coldata/vec_test.go
+++ b/pkg/col/coldata/vec_test.go
@@ -432,7 +432,7 @@ func BenchmarkAppend(b *testing.B) {
 		for _, nullProbability := range []float64{0, 0.2} {
 			for _, bc := range benchCases {
 				// Only test the AppendNoInline case for bytes.
-				if typ != types.Bytes && bc.bytesLen == longBytesLen {
+				if !typ.Identical(types.Bytes) && bc.bytesLen == longBytesLen {
 					continue
 				}
 				src := coldata.NewMemColumn(typ, coldata.BatchSize(), coldata.StandardColumnFactory)

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -177,12 +177,12 @@ func runConversionBenchmarks(
 			b.Fatalf("unexpected batch width: %d", batch.Width())
 		}
 		var typNameSuffix string
-		if typ == types.Bytes {
+		if typ.Identical(types.Bytes) {
 			tc.numBytes = int64(tc.bytesFixedLength * coldata.BatchSize())
 			if tc.bytesFixedLength == bytesInlinedLen {
 				typNameSuffix = "_inlined"
 			}
-		} else if typ == types.Decimal {
+		} else if typ.Identical(types.Decimal) {
 			// Decimal is variable length type, so we want to calculate precisely the
 			// total size of all decimals in the vector.
 			decimals := batch.ColVec(0).Decimal()

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -1042,7 +1042,7 @@ func (s *Smither) makeCreateFunc() (cf *tree.CreateRoutine, ok bool) {
 				stmt = expr.(*tree.StatementSource).Statement
 				// If the rtype isn't a RECORD, change it to rrefs or RECORD depending
 				// how many columns there are to avoid return type mismatch errors.
-				if rtyp != types.AnyTuple {
+				if !rtyp.Identical(types.AnyTuple) {
 					if len(rrefs) == 1 && s.coin() && rrefs[0].typ.Family() != types.CollatedStringFamily {
 						rtyp = rrefs[0].typ
 					} else {

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -781,7 +781,7 @@ func (v *replaceDatumPlaceholderVisitor) VisitPre(
 ) (recurse bool, newExpr tree.Expr) {
 	switch t := expr.(type) {
 	case tree.Datum:
-		if t.ResolvedType().IsNumeric() || t.ResolvedType() == types.Bool {
+		if t.ResolvedType().IsNumeric() || t.ResolvedType().Identical(types.Bool) {
 			v.Args = append(v.Args, expr)
 			placeholder, _ := tree.NewPlaceholder(strconv.Itoa(len(v.Args)))
 			return false, placeholder

--- a/pkg/internal/sqlsmith/scope.go
+++ b/pkg/internal/sqlsmith/scope.go
@@ -60,7 +60,7 @@ func (s *Smither) canRecurseScalar(isPredicate bool, typ *types.T) bool {
 // Smither option is `true`, the desired expression type is boolean, and the
 // expression is being generated for use in a query predicate.
 func (s *Smither) avoidConstantBooleanExpressions(isPredicate bool, typ *types.T) bool {
-	if isPredicate && s.unlikelyConstantPredicate && typ == types.Bool {
+	if isPredicate && s.unlikelyConstantPredicate && typ.Identical(types.Bool) {
 		return true
 	}
 	return false

--- a/pkg/internal/sqlsmith/type.go
+++ b/pkg/internal/sqlsmith/type.go
@@ -105,7 +105,7 @@ func (s *Smither) randType() *types.T {
 			(s.disableOIDs && typ.Family() == types.OidFamily) {
 			continue
 		}
-		if s.postgres && typ == types.Name {
+		if s.postgres && typ.Identical(types.Name) {
 			// Name type in CRDB doesn't match Postgres behavior. Exclude for tests
 			// which compare CRDB behavior to Postgres.
 			continue

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -2293,7 +2293,7 @@ func planProjectionOperators(
 			// anything extra for them, but we do need to handle the string
 			// case.
 			leftType, rightType := leftExpr.ResolvedType(), rightExpr.ResolvedType()
-			if t.Op.ReturnType == types.String && leftType.Family() != rightType.Family() {
+			if t.Op.ReturnType.Identical(types.String) && leftType.Family() != rightType.Family() {
 				// This is a special case of the STRING concatenation - we have
 				// to plan a cast of the non-string type to a STRING.
 				if leftType.Family() == types.StringFamily {

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -491,9 +491,9 @@ func runDistinctBenchmarks(
 	}
 	bytesValueScratch := make([]byte, bytesValueLength)
 	setFirstValue := func(vec coldata.Vec) {
-		if typ := vec.Type(); typ == types.Int {
+		if typ := vec.Type(); typ.Identical(types.Int) {
 			vec.Int64()[0] = 0
-		} else if typ == types.Bytes {
+		} else if typ.Identical(types.Bytes) {
 			vec.Bytes().Set(0, bytesValueScratch)
 		} else {
 			colexecerror.InternalError(errors.AssertionFailedf("unsupported type %s", typ))
@@ -503,13 +503,13 @@ func runDistinctBenchmarks(
 		if i == 0 {
 			colexecerror.InternalError(errors.New("setIthValue called with i == 0"))
 		}
-		if typ := vec.Type(); typ == types.Int {
+		if typ := vec.Type(); typ.Identical(types.Int) {
 			col := vec.Int64()
 			col[i] = col[i-1]
 			if rng.Float64() < newValueProbability {
 				col[i]++
 			}
-		} else if typ == types.Bytes {
+		} else if typ.Identical(types.Bytes) {
 			if rng.Float64() < newValueProbability {
 				copy(bytesValueScratch, vec.Bytes().Get(i-1))
 				for pos := 0; pos < bytesValueLength; pos++ {
@@ -569,13 +569,13 @@ func runDistinctBenchmarks(
 						})
 						for colIdx, oldCol := range cols {
 							cols[colIdx] = testAllocator.NewMemColumn(typs[colIdx], nRows)
-							if typs[colIdx] == types.Int {
+							if typs[colIdx].Identical(types.Int) {
 								oldInt64s := oldCol.Int64()
 								newInt64s := cols[colIdx].Int64()
 								for i := 0; i < nRows; i++ {
 									newInt64s[i] = oldInt64s[order[i]]
 								}
-							} else if typs[colIdx] == types.Bytes {
+							} else if typs[colIdx].Identical(types.Bytes) {
 								oldBytes := oldCol.Bytes()
 								newBytes := cols[colIdx].Bytes()
 								for i := 0; i < nRows; i++ {

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -239,7 +239,7 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 					continue
 				}
 				var cols []coldata.Vec
-				if typ == types.Int {
+				if typ.Identical(types.Int) {
 					cols = newIntColumns(nCols, nRows, 1 /* dupCount */)
 				} else {
 					cols = newBytesColumns(nCols, nRows, 1 /* dupCount */)

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1062,7 +1062,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 			// will have 15 duplicates.
 			dupCount = 16
 		}
-		if typ == types.Int {
+		if typ.Identical(types.Int) {
 			cols = newIntColumns(nCols, length, dupCount)
 		} else {
 			cols = newBytesColumns(nCols, length, dupCount)

--- a/pkg/sql/create_as_test.go
+++ b/pkg/sql/create_as_test.go
@@ -64,7 +64,8 @@ func TestCreateAsVTable(t *testing.T) {
 						}
 						// Filter out vector columns to prevent error in CTAS:
 						// "VECTOR column types are unsupported".
-						if colDef.Type == types.Int2Vector || colDef.Type == types.OidVector {
+						if colDef.Type.(*types.T).Identical(types.Int2Vector) ||
+							colDef.Type.(*types.T).Identical(types.OidVector) {
 							continue
 						}
 						ctasColumns = append(ctasColumns, colDef.Name.String())

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -346,12 +346,12 @@ func (v *distSQLExprCheckVisitor) VisitPre(expr tree.Expr) (recurse bool, newExp
 		// We need to check for arrays of untyped tuples here since constant-folding
 		// on builtin functions sometimes produces this. DecodeUntaggedDatum
 		// requires that all the types of the tuple contents are known.
-		if t.ResolvedType().ArrayContents() == types.AnyTuple {
+		if t.ResolvedType().ArrayContents().Identical(types.AnyTuple) {
 			v.err = newQueryNotSupportedErrorf("array %s cannot be executed with distsql", t)
 			return false, expr
 		}
 	case *tree.DTuple:
-		if t.ResolvedType() == types.AnyTuple {
+		if t.ResolvedType().Identical(types.AnyTuple) {
 			v.err = newQueryNotSupportedErrorf("tuple %s cannot be executed with distsql", t)
 			return false, expr
 		}

--- a/pkg/sql/evalcatalog/encode_table_index_key.go
+++ b/pkg/sql/evalcatalog/encode_table_index_key.go
@@ -104,7 +104,7 @@ func (ec *Builtins) EncodeTableIndexKey(
 		if err != nil {
 			return nil, err
 		}
-		if d.ResolvedType() == types.Unknown {
+		if d.ResolvedType().Family() == types.UnknownFamily {
 			if !col.IsNullable() {
 				return nil, pgerror.Newf(pgcode.NotNullViolation, "NULL provided as a value for a nonnullable column")
 			}

--- a/pkg/sql/importer/read_import_avro_logical_test.go
+++ b/pkg/sql/importer/read_import_avro_logical_test.go
@@ -70,7 +70,7 @@ type avroLogicalInfo struct {
 }
 
 func logicalEncoder(datum tree.Datum, avroType string) (ans interface{}, err error) {
-	if datum.ResolvedType() == types.Unknown {
+	if datum.ResolvedType().Family() == types.UnknownFamily {
 		return nil, nil
 	}
 	switch datum.ResolvedType().Family() {

--- a/pkg/sql/opt/invertedidx/tsearch.go
+++ b/pkg/sql/opt/invertedidx/tsearch.go
@@ -59,7 +59,7 @@ func (t *tsqueryFilterPlanner) extractInvertedFilterConditionFromLeaf(
 		return inverted.NonInvertedColExpression{}, expr, nil
 	}
 	d := memo.ExtractConstDatum(constantVal)
-	if d.ResolvedType() != types.TSQuery {
+	if !d.ResolvedType().Identical(types.TSQuery) {
 		panic(errors.AssertionFailedf(
 			"trying to apply tsvector inverted index to unsupported type %s", d.ResolvedType().SQLStringForError(),
 		))

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -497,7 +497,7 @@ func (b *Builder) trackReferencedColumnForViews(col *scopeColumn) {
 
 func (b *Builder) maybeTrackRegclassDependenciesForViews(texpr tree.TypedExpr) {
 	if b.trackSchemaDeps {
-		if texpr.ResolvedType() == types.RegClass {
+		if texpr.ResolvedType().Identical(types.RegClass) {
 			// We do not add a dependency if the RegClass Expr contains variables,
 			// we cannot resolve the variables in this context. This matches Postgres
 			// behavior.

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -1649,7 +1649,7 @@ func (r *recordTypeVisitor) Visit(stmt ast.Statement) (newStmt ast.Statement, re
 		}
 	case *ast.Return:
 		desired := types.Any
-		if r.typ != types.Unknown {
+		if r.typ.Family() != types.UnknownFamily {
 			desired = r.typ
 		}
 		expr, _ := tree.WalkExpr(r.s, t.Expr)
@@ -1658,13 +1658,13 @@ func (r *recordTypeVisitor) Visit(stmt ast.Statement) (newStmt ast.Statement, re
 			panic(err)
 		}
 		typ := typedExpr.ResolvedType()
-		if typ == types.Unknown {
+		if typ.Family() == types.UnknownFamily {
 			return stmt, false
 		}
 		if typ.Family() != types.TupleFamily {
 			panic(nonCompositeErr)
 		}
-		if r.typ == types.Unknown {
+		if r.typ.Family() == types.UnknownFamily {
 			r.typ = typ
 			return stmt, false
 		}

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -221,11 +221,11 @@ func (b *Builder) buildScalar(
 		// arguments with a CastExpr that preserves the static type.
 
 		left := t.TypedLeft()
-		if left.ResolvedType() == types.Unknown {
+		if left.ResolvedType().Family() == types.UnknownFamily {
 			left = reType(left, t.ResolvedBinOp().LeftType)
 		}
 		right := t.TypedRight()
-		if right.ResolvedType() == types.Unknown {
+		if right.ResolvedType().Family() == types.UnknownFamily {
 			right = reType(right, t.ResolvedBinOp().RightType)
 		}
 		out = b.constructBinary(

--- a/pkg/sql/opt/optbuilder/union_test.go
+++ b/pkg/sql/opt/optbuilder/union_test.go
@@ -67,15 +67,14 @@ func TestUnionType(t *testing.T) {
 			expected: types.Decimal,
 		},
 		{
-			// Error.
-			left:     types.Float,
-			right:    types.String,
-			expected: nil,
+			left:     types.MakeArray(types.MakeTuple([]*types.T{types.Any})),
+			right:    types.MakeArray(types.MakeTuple([]*types.T{types.Bool})),
+			expected: types.MakeArray(types.MakeTuple([]*types.T{types.Bool})),
 		},
 		{
 			// Error.
-			left:     types.MakeArray(types.MakeTuple([]*types.T{types.Any})),
-			right:    types.MakeArray(types.MakeTuple([]*types.T{types.Bool})),
+			left:     types.Float,
+			right:    types.String,
 			expected: nil,
 		},
 	}

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -246,7 +246,7 @@ func (b *Builder) projectColumn(dst *scopeColumn, src *scopeColumn) {
 // default label for a function expression. Returns true if the function's
 // return type is not an empty tuple and doesn't declare any tuple labels.
 func (b *Builder) shouldCreateDefaultColumn(texpr tree.TypedExpr) bool {
-	if texpr.ResolvedType() == types.EmptyTuple {
+	if texpr.ResolvedType().Identical(types.EmptyTuple) {
 		// This is only to support crdb_internal.unary_table().
 		return false
 	}

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -155,9 +155,9 @@ func rightHasMoreSpecificTuple(left, right *types.T) (isMoreSpecific bool, isEqu
 		return rightHasMoreSpecificTuple(left.ArrayContents(), right.ArrayContents())
 	}
 	if left.Family() == types.TupleFamily && right.Family() == types.TupleFamily {
-		if right == types.AnyTuple {
+		if right.Identical(types.AnyTuple) {
 			return false, true
-		} else if left == types.AnyTuple {
+		} else if left.Identical(types.AnyTuple) {
 			return true, true
 		} else if len(left.TupleContents()) != len(right.TupleContents()) {
 			return false, false

--- a/pkg/sql/randgen/expr.go
+++ b/pkg/sql/randgen/expr.go
@@ -283,8 +283,9 @@ func typeToStringCastHasIncorrectVolatility(t *types.T) bool {
 		types.IntervalFamily, types.TupleFamily:
 		return true
 	case types.OidFamily:
-		return t == types.RegClass || t == types.RegNamespace || t == types.RegProc ||
-			t == types.RegProcedure || t == types.RegRole || t == types.RegType
+		return t.Identical(types.RegClass) || t.Identical(types.RegNamespace) ||
+			t.Identical(types.RegProc) || t.Identical(types.RegProcedure) ||
+			t.Identical(types.RegRole) || t.Identical(types.RegType)
 	default:
 		return false
 	}

--- a/pkg/sql/randgen/type.go
+++ b/pkg/sql/randgen/type.go
@@ -203,7 +203,7 @@ func RandColumnTypes(rng *rand.Rand, numCols int) []*types.T {
 // RandSortingType returns a column type which can be key-encoded.
 func RandSortingType(rng *rand.Rand) *types.T {
 	typ := RandType(rng)
-	for colinfo.MustBeValueEncoded(typ) || typ == types.Void {
+	for colinfo.MustBeValueEncoded(typ) || typ.Family() == types.VoidFamily {
 		typ = RandType(rng)
 	}
 	return typ

--- a/pkg/sql/rowenc/roundtrip_format_test.go
+++ b/pkg/sql/rowenc/roundtrip_format_test.go
@@ -53,7 +53,7 @@ func TestRandParseDatumStringAs(t *testing.T) {
 	},
 		types.Scalar...)
 	for _, ty := range types.Scalar {
-		if ty != types.Jsonb {
+		if !ty.Identical(types.Jsonb) {
 			tests = append(tests, types.MakeArray(ty))
 		}
 	}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -10786,7 +10786,7 @@ func makeEnumTypeFunc(impl func(t *types.T) (tree.Datum, error)) tree.FnWithExpr
 		ctx context.Context, evalCtx *eval.Context, args tree.Exprs,
 	) (tree.Datum, error) {
 		enumType := args[0].(tree.TypedExpr).ResolvedType()
-		if enumType == types.Unknown || enumType == types.AnyEnum {
+		if enumType.Family() == types.UnknownFamily || enumType.Identical(types.AnyEnum) {
 			return nil, errors.WithHint(pgerror.New(pgcode.InvalidParameterValue, "input expression must always resolve to the same enum type"),
 				"Try NULL::yourenumtype")
 		}

--- a/pkg/sql/sem/cast/cast.go
+++ b/pkg/sql/sem/cast/cast.go
@@ -164,7 +164,8 @@ func ValidCast(src, tgt *types.T, ctx Context) bool {
 	// Casts from a tuple type to AnyTuple are a no-op so they are always valid.
 	// If tgt is AnyTuple, we continue to LookupCast below which contains a
 	// special case for these casts.
-	if srcFamily == types.TupleFamily && tgtFamily == types.TupleFamily && tgt != types.AnyTuple {
+	if srcFamily == types.TupleFamily && tgtFamily == types.TupleFamily &&
+		!tgt.Identical(types.AnyTuple) {
 		srcTypes := src.TupleContents()
 		tgtTypes := tgt.TupleContents()
 		// The tuple types must have the same number of elements.
@@ -265,7 +266,7 @@ func LookupCast(src, tgt *types.T) (Cast, bool) {
 
 	// Casts from any tuple type to AnyTuple are no-ops, so they are implicit
 	// and immutable.
-	if srcFamily == types.TupleFamily && tgt == types.AnyTuple {
+	if srcFamily == types.TupleFamily && tgt.Identical(types.AnyTuple) {
 		return Cast{
 			MaxContext: ContextImplicit,
 			Volatility: volatility.Immutable,

--- a/pkg/sql/sem/eval/binary_op.go
+++ b/pkg/sql/sem/eval/binary_op.go
@@ -229,7 +229,7 @@ func (e *evaluator) EvalConcatArraysOp(
 func (e *evaluator) EvalConcatOp(
 	ctx context.Context, op *tree.ConcatOp, left, right tree.Datum,
 ) (tree.Datum, error) {
-	if op.Left == types.String {
+	if op.Left.Identical(types.String) {
 		casted, err := PerformCast(ctx, e.ctx(), right, types.String)
 		if err != nil {
 			return nil, err
@@ -238,7 +238,7 @@ func (e *evaluator) EvalConcatOp(
 			string(tree.MustBeDString(left)) + string(tree.MustBeDString(casted)),
 		), nil
 	}
-	if op.Right == types.String {
+	if op.Right.Identical(types.String) {
 		casted, err := PerformCast(ctx, e.ctx(), left, types.String)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -961,7 +961,7 @@ func performCastWithoutPrecisionTruncation(
 	case types.TupleFamily:
 		switch v := d.(type) {
 		case *tree.DTuple:
-			if t == types.AnyTuple {
+			if t.Identical(types.AnyTuple) {
 				// If AnyTuple is the target type, we can just use the input tuple.
 				return v, nil
 			}

--- a/pkg/sql/sem/eval/window_funcs.go
+++ b/pkg/sql/sem/eval/window_funcs.go
@@ -686,7 +686,7 @@ func (wfr *WindowFrameRun) IsRowSkipped(ctx context.Context, idx int) (bool, err
 // performed up front. This allows us to return an expected error in the event
 // of an invalid comparison, rather than panicking.
 func compareForWindow(evalCtx *Context, left, right tree.Datum) (int, error) {
-	if types.IsDateTimeType(left.ResolvedType()) && left.ResolvedType() != types.Interval {
+	if types.IsDateTimeType(left.ResolvedType()) && !left.ResolvedType().Identical(types.Interval) {
 		// Datetime values (other than Intervals) are converted to timestamps for
 		// comparison. Note that the right side never needs to be casted.
 		ts, err := tree.TimeFromDatumForComparison(evalCtx, left)

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -5964,7 +5964,7 @@ func NewDRefCursor(d string) Datum {
 // initialized from an existing *DArray, with the special oid for IntVector.
 func NewDIntVectorFromDArray(d *DArray) Datum {
 	// Sanity: Validate the type of the array, since it should be int2.
-	if d.ParamTyp != types.Int2 {
+	if !d.ParamTyp.Identical(types.Int2) {
 		panic(errors.AssertionFailedf("int2vector can only be made from int2 not %s", d.ParamTyp.SQLStringForError()))
 	}
 	ret := new(DArray)

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -449,7 +449,7 @@ func initNonArrayToNonArrayConcatenation() {
 	for _, t := range append([]*types.T{types.AnyTuple}, types.Scalar...) {
 		// Do not re-add String+String or String+Bytes, as they already exist
 		// and have predefined correct behavior.
-		if t != types.String && t != types.Bytes {
+		if !t.Identical(types.String) && !t.Identical(types.Bytes) {
 			addConcat(t, types.String, fromTypeToVolatility[t.Oid()])
 			addConcat(types.String, t, fromTypeToVolatility[t.Oid()])
 		}

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -85,7 +85,7 @@ func TestStringConcat(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	for _, typ := range append([]*types.T{types.AnyTuple}, types.Scalar...) {
 		// Strings and Bytes are handled specially.
-		if typ == types.String || typ == types.Bytes {
+		if typ.Identical(types.String) || typ.Identical(types.Bytes) {
 			continue
 		}
 		d := randgen.RandDatum(rng, typ, false /* nullOk */)

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -891,7 +891,7 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 			return err
 		}
 		s.typedExprs[i] = typ
-		if typ.ResolvedType() == types.AnyCollatedString {
+		if typ.ResolvedType().Identical(types.AnyCollatedString) {
 			ambiguousCollatedTypes = true
 		}
 		rt := typ.ResolvedType()
@@ -910,14 +910,14 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 		var concreteType *types.T
 		for i, ok := typeableIdxs.Next(0); ok; i, ok = typeableIdxs.Next(i + 1) {
 			typ := s.typedExprs[i].ResolvedType()
-			if typ != types.AnyCollatedString {
+			if !typ.Identical(types.AnyCollatedString) {
 				concreteType = typ
 				break
 			}
 		}
 		if concreteType != nil {
 			for i, ok := typeableIdxs.Next(0); ok; i, ok = typeableIdxs.Next(i + 1) {
-				if s.typedExprs[i].ResolvedType() == types.AnyCollatedString {
+				if s.typedExprs[i].ResolvedType().Identical(types.AnyCollatedString) {
 					typ, err := s.exprs[i].TypeCheck(ctx, semaCtx, concreteType)
 					if err != nil {
 						return err

--- a/pkg/sql/sem/tree/parse_tuple.go
+++ b/pkg/sql/sem/tree/parse_tuple.go
@@ -196,7 +196,7 @@ func doParseDTupleFromString(
 	if t.TupleContents() == nil {
 		return nil, false, errors.AssertionFailedf("not a tuple type %s", t.SQLStringForError())
 	}
-	if t == types.AnyTuple {
+	if t.Identical(types.AnyTuple) {
 		return nil, false, unsupportedRecordError
 	}
 	parser := tupleParseState{

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2159,9 +2159,14 @@ func (t *T) Equal(other *T) bool {
 // IsWildcardType returns true if the type is only used as a wildcard during
 // static analysis, and cannot be used during execution.
 func (t *T) IsWildcardType() bool {
-	switch t {
-	case Any, AnyArray, AnyCollatedString, AnyEnum, AnyEnumArray, AnyTuple, AnyTupleArray:
-		return true
+	for _, wildcard := range []*T{
+		Any, AnyArray, AnyCollatedString, AnyEnum, AnyEnumArray, AnyTuple, AnyTupleArray,
+	} {
+		// Note that pointer comparison is insufficient since we might have
+		// deserialized t from disk.
+		if t.Identical(wildcard) {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
This commit replaces various `*types.T` pointer comparisons with type family comparisons or calls to the `type.Identical()` method. This is necessary because deserialization from disk may result in identical types other than the global singletons (e.g. `types.Any`).

There is no release note, since these bugs have not resulted in any known issues.

Informs #114846

Release note: None