### PR TITLE
release-23.1: rangefeed: deflake `TestDBClientScan`

### DIFF
--- a/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -57,6 +58,7 @@ func TestDBClientScan(t *testing.T) {
 	db := tc.Server(0).DB()
 	beforeAny := db.Clock().Now()
 	scratchKey := tc.ScratchRange(t)
+
 	mkKey := func(k string) roachpb.Key {
 		return encoding.EncodeStringAscending(scratchKey, k)
 	}
@@ -137,7 +139,36 @@ func TestDBClientScan(t *testing.T) {
 			db, keys.SystemSQLCodec, "defaultdb", "foo")
 		fooSpan := fooDesc.PrimaryIndexSpan(keys.SystemSQLCodec)
 
-		// We expect 4 splits -- we'll start the scan with parallelism set to 3.
+		// Ensure the splits make it into the meta ranges and range cache. Simply
+		// running a DistSender scan does not appear sufficient in rare cases.
+		//
+		// ScanWithOptions will split the scan requests itself based on the range
+		// cache and assert on that split, before sending them to the DistSender.
+		ds := tc.Server(0).DistSenderI().(*kvcoord.DistSender)
+		testutils.SucceedsSoon(t, func() error {
+			// Flush the cache, and repopulate it via a scan. This looks at the
+			// canonical range descriptors rather than the possibly stale meta ranges.
+			ds.RangeDescriptorCache().Clear()
+			_, err := db.Scan(ctx, fooSpan.Key, fooSpan.EndKey, 0)
+			require.NoError(t, err)
+
+			var descs []roachpb.RangeDescriptor
+			iter := kvcoord.MakeRangeIterator(ds)
+			for iter.Seek(ctx, roachpb.RKey(fooSpan.Key), kvcoord.Ascending); iter.Valid(); iter.Next(ctx) {
+				desc := iter.Desc()
+				if !fooSpan.Overlaps(desc.KeySpan().AsRawSpanWithNoLocals()) {
+					break
+				}
+				descs = append(descs, *desc)
+			}
+			if len(descs) == 4 {
+				t.Logf("range cache has 4 ranges: %v", descs)
+				return nil
+			}
+			return errors.Errorf("range cache has %d ranges: %v", len(descs), descs)
+		})
+
+		// We have 4 ranges -- we'll start the scan with parallelism set to 3.
 		// We will block these scans from completion until we know that we have 3
 		// concurrently running scan requests.
 		var parallelism = 3


### PR DESCRIPTION
Backport 1/1 commits from #118635.

/cc @cockroachdb/release

Release justification: test fix.

---

This flaked because of a stale DistSender range cache, which hasn't picked up recent splits. Explicitly flush the cache, and wait for it to be fully repopulated via scans -- these look at the canonical range descriptors, rather than the also possibly stale meta ranges.

Resolves #113750.
Epic: none
Release note: None
