### PR TITLE
sql: make privilege order deterministic in error message

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -789,19 +789,19 @@ user testuser
 statement error user testuser does not have REPAIRCLUSTERMETADATA system privilege
 ALTER RANGE default CONFIGURE ZONE USING num_replicas = 3
 
-statement error pq: user testuser does not have ZONECONFIG or CREATE privilege on database auth
+statement error pq: user testuser does not have CREATE or ZONECONFIG privilege on database auth
 ALTER DATABASE auth CONFIGURE ZONE USING num_replicas = 3
 
 statement error user testuser does not have REPAIRCLUSTERMETADATA system privilege
 ALTER TABLE system.jobs CONFIGURE ZONE USING num_replicas = 3
 
-statement error pq: user testuser does not have ZONECONFIG or CREATE privilege on relation t
+statement error pq: user testuser does not have CREATE or ZONECONFIG privilege on relation t
 ALTER TABLE auth.t CONFIGURE ZONE USING num_replicas = 3
 
-statement error pq: user testuser does not have ZONECONFIG or CREATE privilege on relation t
+statement error pq: user testuser does not have CREATE or ZONECONFIG privilege on relation t
 ALTER PARTITION p OF TABLE auth.t CONFIGURE ZONE USING num_replicas = 3
 
-statement error pq: user testuser does not have ZONECONFIG or CREATE privilege on relation t
+statement error pq: user testuser does not have CREATE or ZONECONFIG privilege on relation t
 ALTER PARTITION p OF INDEX auth.t@x CONFIGURE ZONE USING num_replicas = 3
 
 # Granting CREATE on databases and tables should allow CONFIGURE ZONE on those
@@ -827,10 +827,10 @@ REVOKE CREATE ON TABLE auth.t FROM testuser;
 
 user testuser
 
-statement error pq: user testuser does not have ZONECONFIG or CREATE privilege on database auth
+statement error pq: user testuser does not have CREATE or ZONECONFIG privilege on database auth
 ALTER DATABASE auth CONFIGURE ZONE USING num_replicas = 3
 
-statement error pq: user testuser does not have ZONECONFIG or CREATE privilege on relation t
+statement error pq: user testuser does not have CREATE or ZONECONFIG privilege on relation t
 ALTER TABLE auth.t CONFIGURE ZONE USING num_replicas = 3
 
 
@@ -860,7 +860,7 @@ statement ok
 ALTER DATABASE auth CONFIGURE ZONE USING num_replicas = 3
 
 # Existing tables should not inherit ZONECONFIG privilege
-statement error pq: user testuser does not have ZONECONFIG or CREATE privilege on relation t
+statement error pq: user testuser does not have CREATE or ZONECONFIG privilege on relation t
 ALTER TABLE auth.t CONFIGURE ZONE USING num_replicas = 3
 
 # New tables should inherit ZONECONFIG privilege

--- a/pkg/sql/logictest/testdata/logic_test/grant_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/grant_sequence
@@ -12,7 +12,7 @@ SET ROLE readwrite
 statement error pq: user readwrite does not have SELECT privilege on relation a
 SELECT * FROM a;
 
-statement error pq: nextval\(\): user readwrite does not have USAGE or UPDATE privilege on relation a
+statement error pq: nextval\(\): user readwrite does not have UPDATE or USAGE privilege on relation a
 SELECT nextval('a')
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -932,7 +932,7 @@ user testuser
 statement error pq: user testuser does not have SELECT privilege on relation priv_test
 SELECT * FROM priv_test
 
-statement error pq: nextval\(\): user testuser does not have USAGE or UPDATE privilege on relation priv_test
+statement error pq: nextval\(\): user testuser does not have UPDATE or USAGE privilege on relation priv_test
 SELECT nextval('priv_test')
 
 statement error pq: setval\(\): user testuser does not have UPDATE privilege on relation priv_test

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -295,10 +295,10 @@ CREATE VIEW v (x, y) AS SELECT a, b FROM zc; ALTER TABLE v CONFIGURE ZONE USING 
 
 user root
 
-statement error pq: user root does not have ZONECONFIG or CREATE privilege on relation pg_type
+statement error pq: user root does not have CREATE or ZONECONFIG privilege on relation pg_type
 ALTER TABLE pg_catalog.pg_type CONFIGURE ZONE USING gc.ttlseconds = 100000
 
-statement error pq: user root does not have ZONECONFIG or CREATE privilege on relation columns
+statement error pq: user root does not have CREATE or ZONECONFIG privilege on relation columns
 ALTER TABLE information_schema.columns CONFIGURE ZONE USING gc.ttlseconds = 100000
 
 # Test tables in different schemas do not show the zone configs

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -12,6 +12,7 @@
 package sqlerrors
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -379,6 +380,7 @@ func NewInsufficientPrivilegeOnDescriptorError(
 	for _, priv := range orPrivs {
 		orPrivsInStr = append(orPrivsInStr, string(priv.DisplayName()))
 	}
+	sort.Strings(orPrivsInStr)
 	privsStr := strings.Join(orPrivsInStr, " or ")
 	return pgerror.Newf(pgcode.InsufficientPrivilege,
 		"user %s does not have %s privilege on %s %s",


### PR DESCRIPTION
Before this change, if a user did not have correct privileges to run a command, the error message could print the missing privileges in any order. This commit makes this order deterministic to reduce test flakiness.

Epic: none
Fixes: #118586

Release note: None