### PR TITLE
ui: improve db page nodes/regions query

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
@@ -73,8 +73,7 @@ function newDatabaseDetailsResponse(): DatabaseDetailsResponse {
     },
     stats: {
       replicaData: {
-        replicas: [],
-        regions: [],
+        storeIDs: [],
       },
       indexStats: { num_index_recommendations: 0 },
     },
@@ -309,7 +308,10 @@ const getDatabaseZoneConfig: DatabaseDetailsQuery<DatabaseZoneConfigRow> = {
 
 // Database Stats
 type DatabaseDetailsStats = {
-  replicaData: SqlApiQueryResponse<DatabaseReplicasRegionsRow>;
+  replicaData: {
+    storeIDs: number[];
+    error?: Error;
+  };
   indexStats: SqlApiQueryResponse<DatabaseIndexUsageStatsResponse>;
 };
 
@@ -354,44 +356,31 @@ function formatSpanStatsExecutionResult(
 }
 
 type DatabaseReplicasRegionsRow = {
-  replicas: number[];
-  regions: string[];
+  store_ids: number[];
 };
 
 const getDatabaseReplicasAndRegions: DatabaseDetailsQuery<DatabaseReplicasRegionsRow> =
   {
     createStmt: dbName => {
+      // This query is meant to retrieve the per-database set of store ids.
       return {
         sql: Format(
-          `WITH replicasAndRegionsPerDbRange AS (
-            SELECT
-              r.replicas,
-              ARRAY(SELECT DISTINCT split_part(split_part(unnest(replica_localities), ',', 1), '=', 2)) AS regions
-            FROM crdb_internal.tables AS t
-                   JOIN %1.crdb_internal.table_spans AS s ON s.descriptor_id = t.table_id
-                   JOIN crdb_internal.ranges_no_leases AS r ON s.start_key < r.end_key AND s.end_key > r.start_key
-            WHERE t.database_name = $1
-          )
-           SELECT
-             array_agg(DISTINCT replica_val) AS replicas,
-             array_agg(DISTINCT region_val) AS regions
-           FROM replicasAndRegionsPerDbRange, unnest(replicas) AS replica_val, unnest(regions) AS region_val`,
+          `
+            SELECT array_agg(DISTINCT unnested_store_ids) AS store_ids
+            FROM [SHOW RANGES FROM DATABASE %1], unnest(replicas) AS unnested_store_ids
+`,
           [new Identifier(dbName)],
         ),
-        arguments: [dbName],
       };
     },
     addToDatabaseDetail: (
       txn_result: SqlTxnResult<DatabaseReplicasRegionsRow>,
       resp: DatabaseDetailsResponse,
     ) => {
-      if (!txnResultIsEmpty(txn_result)) {
-        resp.stats.replicaData.regions = txn_result.rows[0].regions;
-        resp.stats.replicaData.replicas = txn_result.rows[0].replicas;
-      }
       if (txn_result.error) {
         resp.stats.replicaData.error = txn_result.error;
       }
+      resp.stats.replicaData.storeIDs = txn_result?.rows[0]?.store_ids ?? [];
     },
     handleMaxSizeError: (_dbName, _response, _dbDetail) => {
       return Promise.resolve(false);

--- a/pkg/ui/workspaces/cluster-ui/src/databases/combiners.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databases/combiners.ts
@@ -78,9 +78,10 @@ const deriveDatabaseDetails = (
   isTenant: boolean,
 ): DatabasesPageDataDatabase => {
   const dbStats = dbDetails?.data?.results.stats;
-  const nodes = dbStats?.replicaData.replicas || [];
+  // TODO #118957 (xinhaoz) Use store id to regions mapping.
+  const stores = dbStats?.replicaData.storeIDs || [];
   const nodesByRegionString = getNodesByRegionString(
-    nodes,
+    stores,
     nodeRegionsByID,
     isTenant,
   );
@@ -99,7 +100,7 @@ const deriveDatabaseDetails = (
     name: database,
     spanStats: spanStats?.data?.results.spanStats,
     tables: dbDetails?.data?.results.tablesResp,
-    nodes: nodes,
+    nodes: stores,
     nodesByRegionString,
     numIndexRecommendations,
   };

--- a/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetails.saga.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetails.saga.spec.ts
@@ -69,8 +69,7 @@ describe("DatabaseDetails sagas", () => {
       },
       stats: {
         replicaData: {
-          replicas: [1, 2, 3],
-          regions: ["this", "is", "a", "region"],
+          storeIDs: [1, 2, 3],
         },
         indexStats: { num_index_recommendations: 4 },
       },

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -189,8 +189,7 @@ describe("rest api", function () {
           {
             rows: [
               {
-                replicas: [1, 2, 3],
-                regions: ["gcp-europe-west1", "gcp-europe-west2"],
+                store_ids: [1, 2, 3],
               },
             ],
           },

--- a/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
+++ b/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
@@ -101,25 +101,6 @@ function stubGet(path: string, writer: $protobuf.Writer, prefix: string) {
   fetchMock.get(`${prefix}${path}`, writer.finish());
 }
 
-export function createMockDatabaseRangesForTable(
-  numRangesCreate: number,
-  numNodes: number,
-): clusterUiApi.DatabaseDetailsRow[] {
-  const res = [];
-  const replicas = [];
-  for (let i = 1; i <= numNodes; i++) {
-    replicas.push(i);
-  }
-  for (let i = 0; i < numRangesCreate; i++) {
-    res.push({
-      replicas: replicas,
-      regions: ["gcp-europe-west1", "gcp-europe-west2"],
-      range_size: 10,
-    });
-  }
-  return res;
-}
-
 export function stubSqlApiCall<T>(
   req: clusterUiApi.SqlExecutionRequest,
   mockTxnResults: mockSqlTxnResult<T>[],

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
@@ -254,16 +254,13 @@ describe("Databases Page", function () {
         {
           rows: [
             {
-              replicas: [1, 2, 3],
-              regions: ["gcp-europe-west1", "gcp-europe-west2"],
+              store_ids: [1, 2, 3],
             },
             {
-              replicas: [1, 2, 3],
-              regions: ["gcp-europe-west1", "gcp-europe-west2"],
+              store_ids: [1, 2, 3],
             },
             {
-              replicas: [1, 2, 3],
-              regions: ["gcp-europe-west1", "gcp-europe-west2"],
+              store_ids: [1, 2, 3],
             },
           ],
         },


### PR DESCRIPTION
This commit rewrites the query to fetch node and region information for a db
in the databases page in db-console. The runtime of the query is improved
by removing the expressions used to extract the region information in the
`replica_locality` column of the ranges table since this field was not used
in the client.

The function `createMockDatabaseRangesForTable` in `fakeApi.ts` is also
deleted as it has no callers.

Part of: #114690

Release note: None

-----------------------------------
https://www.loom.com/share/cec82ea6c26849e28cfea31d66fdc719