### PR TITLE
release-22.2: admission,ui: add graphs for elastic cpu limiter

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
@@ -79,6 +79,56 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Elastic CPU Utilization"
+      sources={nodeSources}
+      tooltip={`CPU utilization by elastic work, compared to the limit set for elastic work.`}
+    >
+      <Axis units={AxisUnits.Percentage} label="CPU Utilization">
+        {nodeIDs.map(nid => (
+          <>
+            <Metric
+              name="cr.node.admission.elastic_cpu.utilization"
+              title={
+                "Elastic CPU Utilization " +
+                nodeDisplayName(nodeDisplayNameByID, nid)
+              }
+              sources={[nid]}
+            />
+            <Metric
+              name="cr.node.admission.elastic_cpu.utilization_limit"
+              title={
+                "Elastic CPU Utilization Limit " +
+                nodeDisplayName(nodeDisplayNameByID, nid)
+              }
+              sources={[nid]}
+            />
+          </>
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Elastic CPU Exhausted Duration Per Second"
+      sources={nodeSources}
+      tooltip={`Duration of CPU exhaustion by elastic work, in microseconds.`}
+    >
+      <Axis label="duration (micros/sec)">
+        {nodeIDs.map(nid => (
+          <Metric
+            key={nid}
+            name="cr.node.admission.elastic_cpu.nanos_exhausted_duration"
+            title={
+              "Elastic CPU Exhausted " +
+              nodeDisplayName(nodeDisplayNameByID, nid)
+            }
+            sources={[nid]}
+            nonNegativeRate
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="LSM L0 Health"
       sources={storeSources}
       tooltip={`The number of files and sublevels within Level 0.`}

--- a/pkg/util/admission/elastic_cpu_granter.go
+++ b/pkg/util/admission/elastic_cpu_granter.go
@@ -325,7 +325,6 @@ var ( // granter-side metrics (some of these have parallels on the requester sid
 		Unit:        metric.Unit_NANOSECONDS,
 	}
 
-	// TODO(irfansharif): Surface this metric in the "Overload" dashboard.
 	elasticCPUGranterUtilization = metric.Metadata{
 		Name:        "admission.elastic_cpu.utilization",
 		Help:        "CPU utilization by elastic work",


### PR DESCRIPTION
Backport 1/1 commits from #118763.

/cc @cockroachdb/release

---

This patch adds two new graphs to the Overload page in the metrics dashboard:

* `Elastic CPU Utilization`: graphs `admission.elastic_cpu.utilization` against `admission.elastic_cpu.utilization_limit`.
* `Elastic CPU Exhausted Duration Per Second`: graphs `elastic_cpu.nanos_exhausted_duration`.

Fixes #118493.

Release note (ui change): The Overload Dashboard page now includes two additional graphs:
- Elastic CPU Utilization - This is used the show the CPU utilization by elastic work, compared to the limit set for elastic work.
- Elastic CPU Exhausted Duration Per Second - This is used to show the duration of CPU exhaustion by elastic work, in microseconds.

---

Release justification: We were missing these graphs and it was pointed out in a recent [internal thread](https://cockroachlabs.slack.com/archives/C063CP41TG9/p1706631871768479) that this could be useful for customers.
