### PR TITLE
opt/execbuilder: fix buggy allocation of result columns

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1051,8 +1051,9 @@ func (b *Builder) buildProject(prj *memo.ProjectExpr) (execPlan, error) {
 	}
 
 	var res execPlan
-	exprs := make(tree.TypedExprs, 0, len(projections)+prj.Passthrough.Len())
-	cols := make(colinfo.ResultColumns, 0, len(exprs))
+	numExprs := len(projections) + prj.Passthrough.Len()
+	exprs := make(tree.TypedExprs, 0, numExprs)
+	cols := make(colinfo.ResultColumns, 0, numExprs)
 	ctx := input.makeBuildScalarCtx()
 	for i := range projections {
 		item := &projections[i]


### PR DESCRIPTION
This commit fixes a subtle bug where a slice was always allocated
with zero capacity, rather than the known required capacity. This bug
caused no user facing issues, but did cause extra allocations when
appending to the slice.

Informs #117546 

Release note: None
