### PR TITLE
roachprod: add Grow command

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -138,6 +138,28 @@ Local Clusters
 	}),
 }
 
+var growCmd = &cobra.Command{
+	Use:   `grow <cluster> <num-nodes>`,
+	Short: `grow a cluster by adding nodes`,
+	Long: `grow a cluster by adding the specified number of nodes to it.
+
+The cluster has to be a managed cluster (i.e., a cluster created with the
+gce-managed flag). Only Google Cloud clusters currently support adding nodes.
+The new nodes will use the instance template that was used to create the cluster
+originally (Nodes will be created in the same zone as the existing nodes, or if
+the cluster is geographically distributed, the nodes will be fairly distributed
+across the zones of the cluster).
+`,
+	Args: cobra.ExactArgs(2),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		count, err := strconv.ParseInt(args[1], 10, 8)
+		if err != nil || count < 1 {
+			return errors.Wrapf(err, "invalid num-nodes argument")
+		}
+		return roachprod.Grow(context.Background(), config.Logger, args[0], int(count))
+	}),
+}
+
 var setupSSHCmd = &cobra.Command{
 	Use:   "setup-ssh <cluster>",
 	Short: "set up ssh for a cluster",
@@ -1437,6 +1459,7 @@ func main() {
 	cobra.EnableCommandSorting = false
 	rootCmd.AddCommand(
 		createCmd,
+		growCmd,
 		resetCmd,
 		destroyCmd,
 		extendCmd,

--- a/pkg/roachprod/cloud/BUILD.bazel
+++ b/pkg/roachprod/cloud/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/roachprod/config",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
+        "//pkg/roachprod/vm/gce",
         "//pkg/util/timeutil",
         "@com_github_aws_aws_sdk_go_v2_config//:config",
         "@com_github_aws_aws_sdk_go_v2_service_ec2//:ec2",

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1499,6 +1499,27 @@ func Create(
 	return SetupSSH(ctx, l, clusterName)
 }
 
+func Grow(ctx context.Context, l *logger.Logger, clusterName string, numNodes int) error {
+	if numNodes <= 0 || numNodes >= 1000 {
+		// Upper limit is just for safety.
+		return fmt.Errorf("number of nodes must be in [1..999]")
+	}
+
+	if err := LoadClusters(); err != nil {
+		return err
+	}
+	c, err := newCluster(l, clusterName)
+	if err != nil {
+		return err
+	}
+
+	err = cloud.GrowCluster(l, &c.Cluster, numNodes)
+	if err != nil {
+		return err
+	}
+	return SetupSSH(ctx, l, clusterName)
+}
+
 // GC garbage-collects expired clusters, unused SSH key pairs in AWS, and unused
 // DNS records.
 func GC(l *logger.Logger, dryrun bool) error {

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -596,6 +596,10 @@ func (p *Provider) Create(
 	return p.waitForIPs(l, names, regions, providerOpts)
 }
 
+func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) error {
+	panic("unimplemented")
+}
+
 // waitForIPs waits until AWS reports both internal and external IP addresses
 // for all newly created VMs. If we did not wait for these IPs then attempts to
 // list the new VMs after the creation might find VMs without an external IP.

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -138,6 +138,10 @@ func (p *Provider) AttachVolume(*logger.Logger, vm.Volume, *vm.VM) (string, erro
 	panic("unimplemented")
 }
 
+func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) error {
+	panic("unimplemented")
+}
+
 // New constructs a new Provider instance.
 func New() *Provider {
 	p := &Provider{}

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -99,6 +99,11 @@ func (p *provider) Create(
 	return errors.Newf("%s", p.unimplemented)
 }
 
+// Grow implements vm.Provider and returns Unimplemented.
+func (p *provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names []string) error {
+	return errors.Newf("%s", p.unimplemented)
+}
+
 // Delete implements vm.Provider and returns Unimplemented.
 func (p *provider) Delete(l *logger.Logger, vms vm.List) error {
 	return errors.Newf("%s", p.unimplemented)

--- a/pkg/roachprod/vm/gce/BUILD.bazel
+++ b/pkg/roachprod/vm/gce/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
     }),
     deps = [
         "//pkg/roachprod/vm",
+        "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//assert",

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -242,6 +242,10 @@ func (p *Provider) Create(
 	return nil
 }
 
+func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names []string) error {
+	return errors.New("unimplemented")
+}
+
 // Delete is part of the vm.Provider interface.
 func (p *Provider) Delete(l *logger.Logger, vms vm.List) error {
 	panic("DeleteCluster should be used")

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -433,6 +433,7 @@ type Provider interface {
 	// zones for the given provider.
 	ConfigSSH(l *logger.Logger, zones []string) error
 	Create(l *logger.Logger, names []string, opts CreateOpts, providerOpts ProviderOpts) error
+	Grow(l *logger.Logger, vms List, clusterName string, names []string) error
 	Reset(l *logger.Logger, vms List) error
 	Delete(l *logger.Logger, vms List) error
 	Extend(l *logger.Logger, vms List, lifetime time.Duration) error


### PR DESCRIPTION
Previously, after creating a managed (MIG) cluster in GCE it was not possible to add nodes. This change introduces a new `Grow` method on the gcloud Provider, and as part of the Provider interface.

New nodes are distributed among the zones, the groups are currently in, to balance out the nodes.

Epic: CRDB-33832
See: #117802

Release Note: None