### PR TITLE
roachtest: print issue number after test failure

### DIFF
--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -104,7 +104,8 @@ func DefaultIssueFilerFromFormatter(
 			}
 			req.ExtraParams["stress"] = "true"
 		}
-		return issues.Post(ctx, log.Default(), fmter, req, opts)
+		_, err := issues.Post(ctx, log.Default(), fmter, req, opts)
+		return err
 	}
 
 }

--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -337,7 +337,34 @@ func buildIssueQueries(
 	return existingIssueQuery, relatedIssuesQuery
 }
 
-func (p *poster) post(origCtx context.Context, formatter IssueFormatter, req PostRequest) error {
+type TestFailureType string
+
+const (
+	TestFailureNewIssue     = TestFailureType("new_issue")
+	TestFailureIssueComment = TestFailureType("comment")
+)
+
+// TestFailureIssue encapsulates data about an issue created or
+// changed in order to report a test failure.
+type TestFailureIssue struct {
+	Type TestFailureType
+	ID   int
+}
+
+func (tfi TestFailureIssue) String() string {
+	switch tfi.Type {
+	case TestFailureNewIssue:
+		return fmt.Sprintf("created new GitHub issue #%d", tfi.ID)
+	case TestFailureIssueComment:
+		return fmt.Sprintf("commented on existing GitHub issue #%d", tfi.ID)
+	default:
+		return fmt.Sprintf("[unrecognized test failure type %q, ID=%d]", tfi.Type, tfi.ID)
+	}
+}
+
+func (p *poster) post(
+	origCtx context.Context, formatter IssueFormatter, req PostRequest,
+) (*TestFailureIssue, error) {
 	ctx := &postCtx{Context: origCtx}
 	data := p.templateData(
 		ctx,
@@ -402,6 +429,7 @@ func (p *poster) post(origCtx context.Context, formatter IssueFormatter, req Pos
 	createLabels := []string{RobotLabel}
 	createLabels = append(createLabels, req.labels()...)
 	createLabels = append(createLabels, releaseLabel(p.Branch))
+	var result TestFailureIssue
 	if foundIssue == nil {
 		issueRequest := github.IssueRequest{
 			Title:     &title,
@@ -411,11 +439,13 @@ func (p *poster) post(origCtx context.Context, formatter IssueFormatter, req Pos
 		}
 		issue, _, err := p.createIssue(ctx, p.Org, p.Repo, &issueRequest)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create GitHub issue %s",
+			return nil, errors.Wrapf(err, "failed to create GitHub issue %s",
 				github.Stringify(issueRequest))
 		}
 
-		p.l.Printf("created GitHub issue #%d", *issue.Number)
+		result.Type = TestFailureNewIssue
+		result.ID = *issue.Number
+		p.l.Printf("%s", result)
 		if req.ProjectColumnID != 0 {
 			_, _, err := p.createProjectCard(ctx, int64(req.ProjectColumnID), &github.ProjectCardOptions{
 				ContentID:   *issue.ID,
@@ -433,14 +463,16 @@ func (p *poster) post(origCtx context.Context, formatter IssueFormatter, req Pos
 		comment := github.IssueComment{Body: github.String(body)}
 		if _, _, err := p.createComment(
 			ctx, p.Org, p.Repo, *foundIssue, &comment); err != nil {
-			return errors.Wrapf(err, "failed to update issue #%d with %s",
+			return nil, errors.Wrapf(err, "failed to update issue #%d with %s",
 				*foundIssue, github.Stringify(comment))
 		} else {
-			p.l.Printf("created comment on existing GitHub issue (#%d)", *foundIssue)
+			result.Type = TestFailureIssueComment
+			result.ID = *foundIssue
+			p.l.Printf("%s", result)
 		}
 	}
 
-	return nil
+	return &result, nil
 }
 
 func (p *poster) teamcityURL(tab, fragment string) *url.URL {
@@ -559,9 +591,9 @@ type Logger interface {
 // will be returned.
 func Post(
 	ctx context.Context, l Logger, formatter IssueFormatter, req PostRequest, opts *Options,
-) error {
+) (*TestFailureIssue, error) {
 	if !opts.CanPost() {
-		return errors.Newf("GITHUB_API_TOKEN env variable is not set; cannot post issue")
+		return nil, errors.Newf("GITHUB_API_TOKEN env variable is not set; cannot post issue")
 	}
 
 	client := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(

--- a/pkg/cmd/internal/issues/issues_test.go
+++ b/pkg/cmd/internal/issues/issues_test.go
@@ -404,15 +404,19 @@ test logs left over in: /go/src/github.com/cockroachdb/cockroach/artifacts/logTe
 				// Override the default.
 				req.Labels = []string{}
 			}
-			require.NoError(t, p.post(context.Background(), UnitTestFormatter, req))
+			issue, err := p.post(context.Background(), UnitTestFormatter, req)
+			require.NoError(t, err)
+			require.Equal(t, issueNumber, issue.ID)
 
 			switch foundIssue {
 			case foundNoIssue, foundOnlyRelatedIssue:
 				require.True(t, createdIssue)
 				require.False(t, createdComment)
+				require.Equal(t, TestFailureNewIssue, issue.Type)
 			case foundOnlyMatchingIssue, foundMatchingAndRelatedIssue:
 				require.False(t, createdIssue)
 				require.True(t, createdComment)
+				require.Equal(t, TestFailureIssueComment, issue.Type)
 			default:
 				t.Errorf("unhandled: %s", foundIssue)
 			}
@@ -460,7 +464,8 @@ func TestPostEndToEnd(t *testing.T) {
 		HelpCommand: UnitTestHelpCommand(""),
 	}
 
-	require.NoError(t, Post(context.Background(), log.Default(), UnitTestFormatter, req, opts))
+	_, err := Post(context.Background(), log.Default(), UnitTestFormatter, req, opts)
+	require.NoError(t, err)
 }
 
 // setEnv overrides the env variables corresponding to the input map. The

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -750,7 +750,7 @@ func (r *testRunner) runWorker(
 		handleClusterCreationFailure := func(err error) {
 			t.Error(errClusterProvisioningFailed(err))
 
-			if err := github.MaybePost(t, l, t.failureMsg()); err != nil {
+			if _, err := github.MaybePost(t, l, t.failureMsg()); err != nil {
 				shout(ctx, l, stdout, "failed to post issue: %s", err)
 			}
 		}
@@ -1016,6 +1016,17 @@ func (r *testRunner) runTest(
 				}
 				output := fmt.Sprintf("%s\ntest artifacts and logs in: %s", failureMsg, t.ArtifactsDir())
 
+				issue, err := github.MaybePost(t, l, output)
+				if err != nil {
+					shout(ctx, l, stdout, "failed to post issue: %s", err)
+				}
+
+				// If an issue was created (or comment added) on GitHub,
+				// include that information in the output so that it can be
+				// easily inspected on the TeamCity overview page.
+				if issue != nil {
+					output += "\n" + issue.String()
+				}
 				if roachtestflags.TeamCity {
 					// If `##teamcity[testFailed ...]` is not present before `##teamCity[testFinished ...]`,
 					// TeamCity regards the test as successful.
@@ -1024,10 +1035,6 @@ func (r *testRunner) runTest(
 				}
 
 				shout(ctx, l, stdout, "--- FAIL: %s (%s)\n%s", testRunID, durationStr, output)
-
-				if err := github.MaybePost(t, l, output); err != nil {
-					shout(ctx, l, stdout, "failed to post issue: %s", err)
-				}
 			} else {
 				shout(ctx, l, stdout, "--- PASS: %s (%s)", testRunID, durationStr)
 			}


### PR DESCRIPTION
This commit updates the GitHub issue poster so that information about
the issue is returned when an issue is created or a comment
added. The roachtest test runner uses this information in the TeamCity
output so that we can easily see the issue corresponding to a test
failure directly in the TC overview page.

Epic: none

Release note: None