### PR TITLE
roachtest: add weak isolation transactions to follower-reads test suite

### DIFF
--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -168,6 +168,10 @@ func registerYCSB(r registry.Registry) {
 
 func enableIsolationLevels(ctx context.Context, t test.Test, db *gosql.DB) error {
 	for _, cmd := range []string{
+		// NOTE: even as we switch the default value of these setting to true on
+		// master, we should keep these to ensure that the settings are configured
+		// properly in mixed-version roachtests.
+		`SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = 'true';`,
 		`SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = 'true';`,
 	} {
 		if _, err := db.ExecContext(ctx, cmd); err != nil {


### PR DESCRIPTION
Fixes #108671.

Now that #100154 is fixed (Aug 12, 2023), follower reads will work in Read Committed transactions. To test this, this commit extends the `follower-reads` roachtest suite to use weak isolation transactions (Read Committed and Snapshot) to verify and catch regressions.

Release note: None