### PR TITLE
kvserver,roachpb: remove max L0-sublevels

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -211,7 +211,6 @@ go_library(
         "//pkg/util/quotapool",
         "//pkg/util/retry",
         "//pkg/util/shuffle",
-        "//pkg/util/slidingwindow",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/syncutil/singleflight",

--- a/pkg/kv/kvserver/asim/state/load.go
+++ b/pkg/kv/kvserver/asim/state/load.go
@@ -137,7 +137,6 @@ func NewCapacityOverride() CapacityOverride {
 		QueriesPerSecond: capacityOverrideSentinel,
 		WritesPerSecond:  capacityOverrideSentinel,
 		CPUPerSecond:     capacityOverrideSentinel,
-		L0Sublevels:      capacityOverrideSentinel,
 		IOThreshold: admissionpb.IOThreshold{
 			L0NumSubLevels:           capacityOverrideSentinel,
 			L0NumSubLevelsThreshold:  capacityOverrideSentinel,
@@ -152,7 +151,7 @@ func NewCapacityOverride() CapacityOverride {
 func (co CapacityOverride) String() string {
 	return fmt.Sprintf(
 		"capacity=%d, available=%d, used=%d, logical_bytes=%d, range_count=%d, lease_count=%d, "+
-			"queries_per_sec=%.2f, writes_per_sec=%.2f, cpu_per_sec=%.2f, l0_sublevels=%d, io_threhold=%v",
+			"queries_per_sec=%.2f, writes_per_sec=%.2f, cpu_per_sec=%.2f, io_threhold=%v",
 		co.Capacity,
 		co.Available,
 		co.Used,
@@ -162,7 +161,6 @@ func (co CapacityOverride) String() string {
 		co.QueriesPerSecond,
 		co.WritesPerSecond,
 		co.CPUPerSecond,
-		co.L0Sublevels,
 		co.IOThreshold,
 	)
 }
@@ -197,9 +195,6 @@ func mergeOverride(
 	}
 	if override.CPUPerSecond != capacityOverrideSentinel {
 		ret.CPUPerSecond = override.CPUPerSecond
-	}
-	if override.L0Sublevels != capacityOverrideSentinel {
-		ret.L0Sublevels = override.L0Sublevels
 	}
 	if override.IOThreshold.L0NumFiles != capacityOverrideSentinel {
 		ret.IOThreshold.L0NumFiles = override.IOThreshold.L0NumFiles

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -20,7 +20,6 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvbase"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocatorimpl"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
@@ -32,9 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
-	"github.com/cockroachdb/cockroach/pkg/util/slidingwindow"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/sstable"
 	"go.etcd.io/raft/v3/raftpb"
@@ -2366,13 +2363,6 @@ type StoreMetrics struct {
 	// This includes all replicas, including quiesced ones.
 	RecentReplicaCPUNanosPerSecond *metric.ManualWindowHistogram
 	RecentReplicaQueriesPerSecond  *metric.ManualWindowHistogram
-	// l0SublevelsWindowedMax doesn't get recorded to metrics itself, it maintains
-	// an ad-hoc history for gosipping information for allocator use.
-	l0SublevelsWindowedMax syncutil.AtomicFloat64
-	l0SublevelsTracker     struct {
-		syncutil.Mutex
-		swag *slidingwindow.Swag
-	}
 
 	// Follower read metrics.
 	FollowerReadsCount *metric.Counter
@@ -3422,19 +3412,6 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		ReplicaReadBatchWithoutInterleavingIter:  metric.NewCounter(metaReplicaReadBatchWithoutInterleavingIter),
 	}
 
-	{
-		// Track the maximum L0 sublevels seen in the last 10 minutes. backed
-		// by a sliding window, which we  record and query indirectly in
-		// L0SublevelsMax. this is not exported to as metric.
-		sm.l0SublevelsTracker.swag = slidingwindow.NewMaxSwag(
-			timeutil.Now(),
-			// Use 5 sliding windows, so the retention period is divided by 5 to
-			// calculate the interval of the sliding window buckets.
-			allocatorimpl.L0SublevelTrackerRetention/5,
-			5,
-		)
-	}
-
 	storeRegistry.AddMetricStruct(sm)
 	storeRegistry.AddMetricStruct(sm.LoadSplitterMetrics)
 	return sm
@@ -3552,13 +3529,6 @@ func (sm *StoreMetrics) updateEngineMetrics(m storage.Metrics) {
 	sm.BatchCommitWALRotWaitDuration.Update(int64(m.BatchCommitStats.WALRotationDuration))
 	sm.BatchCommitCommitWaitDuration.Update(int64(m.BatchCommitStats.CommitWaitDuration))
 	sm.categoryIterMetrics.update(m.CategoryStats)
-
-	// Update the maximum number of L0 sub-levels seen.
-	sm.l0SublevelsTracker.Lock()
-	sm.l0SublevelsTracker.swag.Record(timeutil.Now(), float64(m.Levels[0].Sublevels))
-	curMax, _ := sm.l0SublevelsTracker.swag.Query(timeutil.Now())
-	sm.l0SublevelsTracker.Unlock()
-	syncutil.StoreFloat64(&sm.l0SublevelsWindowedMax, curMax)
 
 	for level, stats := range m.Levels {
 		sm.RdbBytesIngested[level].Update(int64(stats.BytesIngested))

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2860,7 +2860,6 @@ func (s *Store) Capacity(ctx context.Context, useCached bool) (roachpb.StoreCapa
 	var leaseCount int32
 	var rangeCount int32
 	var logicalBytes int64
-	var l0SublevelsMax int64
 	var totalQueriesPerSecond float64
 	var totalWritesPerSecond float64
 	var totalStoreCPUTimePerSecond float64
@@ -2875,8 +2874,6 @@ func (s *Store) Capacity(ctx context.Context, useCached bool) (roachpb.StoreCapa
 	// used in Db Console only.
 	rankingsByTenantAccumulator := NewTenantReplicaAccumulator(load.Queries)
 
-	// Query the current L0 sublevels and record the updated maximum to metrics.
-	l0SublevelsMax = int64(syncutil.LoadFloat64(&s.metrics.l0SublevelsWindowedMax))
 	newStoreReplicaVisitor(s).Visit(func(r *Replica) bool {
 		rangeCount++
 		if r.OwnsValidLease(ctx, now) {
@@ -2921,7 +2918,6 @@ func (s *Store) Capacity(ctx context.Context, useCached bool) (roachpb.StoreCapa
 	capacity.CPUPerSecond = totalStoreCPUTimePerSecond
 	capacity.QueriesPerSecond = totalQueriesPerSecond
 	capacity.WritesPerSecond = totalWritesPerSecond
-	capacity.L0Sublevels = l0SublevelsMax
 	{
 		s.ioThreshold.Lock()
 		capacity.IOThreshold = *s.ioThreshold.t

--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -322,10 +322,6 @@ message StoreCapacity {
   // This is the sum of all the replica's cpu time on this store, which is
   // tracked in replica stats.
   optional double cpu_per_second = 14 [(gogoproto.nullable) = false, (gogoproto.customname) = "CPUPerSecond"];
-  // l0_sublevels tracks the current number of l0 sublevels in the store.
-  // TODO(kvoli): Remove this field in 23.2. The field is no longer consulted
-  // in 23.1
-  optional int64 l0_sublevels = 12 [(gogoproto.nullable) = false];
   optional cockroach.util.admission.admissionpb.IOThreshold io_threshold = 13 [(gogoproto.nullable) = false, (gogoproto.customname) = "IOThreshold" ];
   // bytes_per_replica and writes_per_replica contain percentiles for the
   // number of bytes and writes-per-second to each replica in the store.
@@ -333,6 +329,7 @@ message StoreCapacity {
   optional Percentiles bytes_per_replica = 6 [(gogoproto.nullable) = false];
   optional Percentiles writes_per_replica = 7 [(gogoproto.nullable) = false];
   reserved 11;
+  reserved 12;
 }
 
 // StoreProperties contains configuration and OS-level details for a storage device.


### PR DESCRIPTION
The max L0-sublevels in the store capacity hasn't been used since 22.2.
Stop populating the field and remove related tracking infrastructure.

---

The L0 sublevels field in store capacity hasn't been used since 22.2. It
is now also no longer populated. Remove the field from the store
capacity proto.

Epic: none
Release note: None