### PR TITLE
sql: reduce allocations in rowContainerIterator

### DIFF
--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -191,15 +191,7 @@ func (i *rowContainerIterator) Next() (tree.Datums, error) {
 		// All rows have been exhausted.
 		return nil, nil
 	}
-	origRow, err := i.iter.Row()
-	if err != nil {
-		return nil, err
-	}
-	// Shallow-copy the row to ensure that it is safe to hold on to after Next()
-	// and Close() calls - see the RowIterator interface.
-	row := make(tree.Datums, len(origRow))
-	copy(row, origRow)
-	return row, nil
+	return i.iter.Row()
 }
 
 func (i *rowContainerIterator) Close() {

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -540,15 +540,16 @@ var _ isql.Rows = &plpgsqlCursorHelper{}
 
 // Next implements the isql.Rows interface.
 func (h *plpgsqlCursorHelper) Next(_ context.Context) (bool, error) {
-	var err error
-	h.lastRow, err = h.iter.Next()
-	if err != nil {
+	row, err := h.iter.Next()
+	if err != nil || row == nil {
 		return false, err
 	}
-	if h.lastRow != nil {
-		h.rowsAffected++
-	}
-	return h.lastRow != nil, nil
+	// Shallow-copy the row to ensure that it is safe to hold on to after Next()
+	// and Close() calls - see the isql.Rows interface.
+	h.lastRow = make(tree.Datums, len(row))
+	copy(h.lastRow, row)
+	h.rowsAffected++
+	return true, nil
 }
 
 // Cur implements the isql.Rows interface.


### PR DESCRIPTION
In #111318 a shallow copy of rows was added to
`rowContainerIterator.Next`. This copy is only necessary for one usage
of the iterator within `plpgsqlCursorHelper`. This commit moves the copy
to the cursor helper which reduces allocations for all other usages of
the iterator.

Informs #117546

Release note: None
