### PR TITLE
toolchains: make macOS toolchain remote-friendly

### DIFF
--- a/build/toolchains/darwin/BUILD.tmpl
+++ b/build/toolchains/darwin/BUILD.tmpl
@@ -33,7 +33,9 @@ filegroup(
     srcs = [
         "bin/%{target}-apple-darwin21.2-cc",
         "bin/%{target}-apple-darwin21.2-c++",
-    ],
+    ] + glob(
+        ["SDK/**"], exclude=["SDK/MacOSX12.1.sdk/usr/share/**"]
+    ) + glob(["lib/**"]),
 )
 
 filegroup(
@@ -47,6 +49,7 @@ filegroup(
     name = "linker_files",
     srcs = [
         "bin/%{target}-apple-darwin21.2-cc",
+        "bin/%{target}-apple-darwin21.2-ld",
         "bin/xcrun",
     ],
 )

--- a/build/toolchains/darwin/cc_toolchain_config.bzl.tmpl
+++ b/build/toolchains/darwin/cc_toolchain_config.bzl.tmpl
@@ -112,7 +112,6 @@ def _impl(ctx):
                         flags = [
                             "-g1",
                             "-Wall",
-                            "-I%{repo_path}/SDK/MacOSX12.1.sdk/usr/include/c++/v1",
                         ],
                     ),
                 ]),
@@ -122,7 +121,7 @@ def _impl(ctx):
 
     linker_flags = [
         "-lstdc++",
-        "-L%{repo_path}/lib",
+        "-Lexternal/%{repo_name}/lib",
     ]
 
     default_linker_flags = feature(
@@ -138,7 +137,7 @@ def _impl(ctx):
             env_set(
                 actions = all_link_actions,
                 env_entries = [
-                    env_entry(key = "LD_LIBRARY_PATH", value = "%{repo_path}/lib"),
+                    env_entry(key = "LD_LIBRARY_PATH", value = "external/%{repo_name}/lib"),
                 ],
             ),
 	]
@@ -204,7 +203,7 @@ def _impl(ctx):
             "%sysroot%/usr/include",
             "/usr/lib/llvm-10/lib/clang/10.0.0/include",
         ],
-        builtin_sysroot = "%{repo_path}/SDK/MacOSX12.1.sdk",
+        builtin_sysroot = "external/%{repo_name}/SDK/MacOSX12.1.sdk",
     )
 
 cc_toolchain_config = rule(

--- a/build/toolchains/darwin/toolchain.bzl
+++ b/build/toolchains/darwin/toolchain.bzl
@@ -11,8 +11,6 @@ def _impl(rctx):
         stripPrefix = "x-tools/x86_64-apple-darwin21.2/",
     )
 
-    repo_path = str(rctx.path(""))
-
     rctx.template(
         "BUILD",
         Label("@com_github_cockroachdb_cockroach//build:toolchains/darwin/BUILD.tmpl"),
@@ -27,7 +25,7 @@ def _impl(rctx):
         Label("@com_github_cockroachdb_cockroach//build:toolchains/darwin/cc_toolchain_config.bzl.tmpl"),
         substitutions = {
             "%{host}": rctx.attr.host,
-            "%{repo_path}": repo_path,
+            "%{repo_name}": rctx.name,
             "%{target}": rctx.attr.target,
         },
         executable = False,


### PR DESCRIPTION
Some bits and pieces were missing here that prevent builds from succeeding remotely.

Epic: CRDB-8308
Release note: None