### PR TITLE
backupccl: skip TestDataDriven_multiregion under duress

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -512,6 +512,10 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 			skip.WithIssue(t, issue)
 			return ""
 
+		case "skip-under-duress":
+			skip.UnderDuress(t)
+			return ""
+
 		case "reset":
 			ds.cleanup(ctx, t)
 			ds = newDatadrivenTestState()

--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -1,5 +1,8 @@
 # disabled to run within tenant because multiregion primitives are not supported within tenant
 
+skip-under-duress
+----
+
 new-cluster name=s1 allow-implicit-access disable-tenant localities=us-east-1,us-west-1,eu-central-1
 ----
 


### PR DESCRIPTION
Fixes #118567

Release note: none