### PR TITLE
release-23.2: jobs: add DeleteTerminalJobByID function

### DIFF
--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -149,10 +149,7 @@ func (n *createStatsNode) runJob(ctx context.Context) error {
 	if err = job.AwaitCompletion(ctx); err != nil {
 		if errors.Is(err, stats.ConcurrentCreateStatsError) {
 			// Delete the job so users don't see it and get confused by the error.
-			const stmt = `DELETE FROM system.jobs WHERE id = $1`
-			if _ /* cols */, delErr := n.p.ExecCfg().InternalDB.Executor().Exec(
-				ctx, "delete-job", nil /* txn */, stmt, jobID,
-			); delErr != nil {
+			if delErr := n.p.ExecCfg().JobRegistry.DeleteTerminalJobByID(ctx, job.ID()); delErr != nil {
 				log.Warningf(ctx, "failed to delete job: %v", delErr)
 			}
 		}


### PR DESCRIPTION
Backport 1/1 commits from #118589.

/cc @cockroachdb/release

Release justification: Bug fix for a bug that can lead to job system unavailability.

---

The CREATE AUTO STATS code was manually modifying the system.jobs table in a way that left the job_info table with abandoned rows.

Fixes #118582

Release note (bug fix): AUTO CREATE STATS jobs could previously lead to growth in an internal system table resulting in slower job-system related queries.
