### PR TITLE
workflows: shut down bazel server if we're asked to cancel the build

### DIFF
--- a/.github/workflows/experimental-github-actions-testing.yml
+++ b/.github/workflows/experimental-github-actions-testing.yml
@@ -17,7 +17,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - run: ./build/github/get-engflow-keys.sh
       - name: run tests
-        run: bazel test //pkg:all_tests //pkg/ui:lint //pkg/ui:test --config crosslinux --jobs 300 --remote_download_minimal --bes_keywords=github_pr_number=${{ github.event.pull_request.number }} --config=use_ci_timeouts --build_event_binary_file=bes.bin $(./build/github/engflow-args.sh) --bes_keywords ci-unit-test
+        run: ./build/github/run-bazel.sh test //pkg:all_tests //pkg/ui:lint //pkg/ui:test --config crosslinux --jobs 300 --remote_download_minimal --bes_keywords=github_pr_number=${{ github.event.pull_request.number }} --config=use_ci_timeouts --build_event_binary_file=bes.bin $(./build/github/engflow-args.sh) --bes_keywords ci-unit-test
       - name: upload test results
         run: ./build/github/upload-test-results.sh bes.bin
         if: always()

--- a/build/github/run-bazel.sh
+++ b/build/github/run-bazel.sh
@@ -1,0 +1,11 @@
+# Any arguments passed to this script will be directly passed to Bazel. In
+# addition to just calling Bazel, this script has the property that the Bazel
+# server will be killed if we receive an interrupt.
+
+bazel_shutdown() {
+    bazel shutdown
+}
+
+trap bazel_shutdown EXIT
+
+bazel "$@"


### PR DESCRIPTION
This is implemented as a [SIGINT](https://docs.github.com/en/actions/managing-workflow-runs/canceling-a-workflow#steps-github-takes-to-cancel-a-workflow-run). However, the build is likely to just continue running in the background because this may not be enough to tear Bazel down. This could cause steps that need to happen later to stall indefinitely. We just shut down the server directly in this case.

Epic: CRDB-8308
Release note: None