### PR TITLE
changefeedccl: revert Dial() to fetch metadata for specific topics

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1596,7 +1596,6 @@ func registerCDC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "cdc/kafka-topics",
 		Owner:            `cdc`,
-		Skip:             "#116872",
 		Cluster:          r.MakeClusterSpec(4, spec.Arch(vm.ArchAMD64)),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,


### PR DESCRIPTION
Now that we have fixed kafka auth setup in roachtests, we can change Dial() to
fetch metadata for specific topics only.

Part of: https://github.com/cockroachdb/cockroach/pull/119077
Epic: none
Release note: none
