### PR TITLE
cli: update docs url for sql shell

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -276,7 +276,7 @@ func (c *cliState) printCliHelp() {
 	fmt.Fprintf(c.iCtx.stdout, helpMessageFmt,
 		demoHelpStr,
 		docs.URL("sql-statements.html"),
-		docs.URL("use-the-built-in-sql-client.html"),
+		docs.URL("cockroach-sql.html"),
 	)
 	fmt.Fprintln(c.iCtx.stdout)
 }


### PR DESCRIPTION
The SQL shell help function redirects the user to
use-the-built-in-sql-client.html this page no longer exists. Instead the SQL shell should point to cockroach-sql.html.

Epic: None

Release note (cli change): Change the SQL shell help URL to point to cockroach-sql.html.