### PR TITLE
Revert "workload/schemachange: re-enable COMMENT in workload"

### DIFF
--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -279,7 +279,7 @@ var opWeights = []int{
 	alterTableSetColumnDefault:        1,
 	alterTableSetColumnNotNull:        1,
 	alterTypeDropValue:                0, // Disabled and tracked with #114844, #113859, and #115612.
-	commentOn:                         1,
+	commentOn:                         0, // Disabled and tracked with #116795.
 	createFunction:                    1,
 	createIndex:                       1,
 	createSchema:                      1,


### PR DESCRIPTION
This reverts commit 60171b42af73b28e23bb89898a6758d4b09ca7ea. There are a few flakes should should be resolved first.

informs https://github.com/cockroachdb/cockroach/issues/116795
fixes https://github.com/cockroachdb/cockroach/issues/118941
Release note: None