### PR TITLE
explain: fix overflow when printing estimated row count

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -2393,3 +2393,36 @@ inner-join (hash)
  │    └── unfiltered-cols: (6-9)
  └── filters
       └── k:6 = a:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+
+# Regression test for overflow when printing out the estimated row count.
+statement ok
+CREATE TABLE very_large_table (k INT PRIMARY KEY);
+
+statement ok
+ALTER TABLE very_large_table INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2024-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000000000,
+    "distinct_count": 1000000000000
+  }
+]'
+
+query T
+EXPLAIN SELECT t1.k FROM very_large_table AS t1, very_large_table AS t2;
+----
+distribution: local
+vectorized: true
+·
+• cross join
+│ estimated row count: 9,223,372,036,854,775,807
+│
+├── • scan
+│     estimated row count: 1,000,000,000,000 (100% of the table; stats collected <hidden> ago)
+│     table: very_large_table@very_large_table_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      estimated row count: 1,000,000,000,000 (100% of the table; stats collected <hidden> ago)
+      table: very_large_table@very_large_table_pkey
+      spans: FULL SCAN

--- a/pkg/util/humanizeutil/count.go
+++ b/pkg/util/humanizeutil/count.go
@@ -11,6 +11,8 @@
 package humanizeutil
 
 import (
+	"math"
+
 	"github.com/cockroachdb/redact"
 	"github.com/dustin/go-humanize"
 )
@@ -18,9 +20,15 @@ import (
 // Count formats a unitless integer value like a row count. It uses separating
 // commas for large values (e.g. "1,000,000").
 func Count(val uint64) redact.SafeString {
+	if val > math.MaxInt64 {
+		val = math.MaxInt64
+	}
 	return redact.SafeString(humanize.Comma(int64(val)))
 }
 
 func Countf(val float64) redact.SafeString {
+	if val > math.MaxInt64 {
+		val = math.MaxInt64
+	}
 	return redact.SafeString(humanize.Commaf(val))
 }


### PR DESCRIPTION
Previously, when the optimizer estimated a very large row count (which is float64), we would first cast it to uint64 (which would work ok in case the count is large - we'd get `max int64 + 1`), and then we would cast it to int64 which can result in a negative number. This is now fixed by adding a check before casting to int64 to cap the value at max int64.

Epic: None

Release note: None