### PR TITLE
release-23.2: roachtest: introduce `registry.ErrorWithOwner`

### DIFF
--- a/pkg/cmd/roachtest/registry/BUILD.bazel
+++ b/pkg/cmd/roachtest/registry/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "registry",
     srcs = [
         "encryption.go",
+        "errors.go",
         "filter.go",
         "owners.go",
         "registry_interface.go",

--- a/pkg/cmd/roachtest/registry/errors.go
+++ b/pkg/cmd/roachtest/registry/errors.go
@@ -1,0 +1,56 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package registry
+
+import "fmt"
+
+type (
+	ErrorWithOwnership struct {
+		// TitleOverride allows errors to overwrite the "{testName}
+		// failed" title used in issues. This allows issues to be grouped
+		// even if they happen in different tests.
+		TitleOverride string
+		// InfraFlake indicates that this error is an infrastructure
+		// flake, and the issue will be labeled accordingly.
+		InfraFlake bool
+		Owner      Owner
+		Err        error
+	}
+
+	errorOption func(*ErrorWithOwnership)
+)
+
+func (ewo ErrorWithOwnership) Error() string {
+	return fmt.Sprintf("%s [owner=%s]", ewo.Err.Error(), ewo.Owner)
+}
+
+func WithTitleOverride(title string) errorOption {
+	return func(ewo *ErrorWithOwnership) {
+		ewo.TitleOverride = title
+	}
+}
+
+func InfraFlake(ewo *ErrorWithOwnership) {
+	ewo.InfraFlake = true
+}
+
+// ErrorWithOwner allows the caller to associate `err` with
+// `owner`. When `t.Fatal` is called with an error of this type, the
+// resulting GitHub issue is created and assigned to the team
+// corresponding to `owner`.
+func ErrorWithOwner(owner Owner, err error, opts ...errorOption) ErrorWithOwnership {
+	result := ErrorWithOwnership{Owner: owner, Err: err}
+	for _, opt := range opts {
+		opt(&result)
+	}
+
+	return result
+}

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -473,13 +473,10 @@ func (t *testImpl) failedRLocked() bool {
 	return t.mu.numFailures > 0
 }
 
-func (t *testImpl) firstFailure() failure {
+func (t *testImpl) failures() []failure {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	if len(t.mu.failures) == 0 {
-		return failure{}
-	}
-	return t.mu.failures[0]
+	return t.mu.failures
 }
 
 func (t *testImpl) failureMsg() string {
@@ -490,15 +487,42 @@ func (t *testImpl) failureMsg() string {
 	return b.String()
 }
 
-// failureContainsError returns true if any of the errors in a given failure
-// matches the reference error
-func failureContainsError(f failure, refError error) bool {
-	for _, err := range f.errors {
-		if errors.Is(err, refError) {
+// failuresContainError returns true if any of the errors in any of
+// the given failures matches the reference error.
+func failuresContainsError(failures []failure, refError error) bool {
+	for _, f := range failures {
+		for _, err := range f.errors {
+			if errors.Is(err, refError) {
+				return true
+			}
+		}
+
+		if errors.Is(f.squashedErr, refError) {
 			return true
 		}
 	}
-	return errors.Is(f.squashedErr, refError)
+
+	return false
+}
+
+// failuresSpecifyOwner checks if any of the errors in any of the
+// given failures is a failure that is associated with an owner. If
+// such an error is found, it is returned; otherwise, nil is returned.
+func failuresSpecifyOwner(failures []failure) *registry.ErrorWithOwnership {
+	var ref registry.ErrorWithOwnership
+	for _, f := range failures {
+		for _, err := range f.errors {
+			if errors.As(err, &ref) {
+				return &ref
+			}
+		}
+
+		if errors.As(f.squashedErr, &ref) {
+			return &ref
+		}
+	}
+
+	return nil
 }
 
 func (t *testImpl) ArtifactsDir() string {

--- a/pkg/cmd/roachtest/test_impl_test.go
+++ b/pkg/cmd/roachtest/test_impl_test.go
@@ -13,6 +13,8 @@ package main
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,4 +41,15 @@ func TestTeamCityEscape(t *testing.T) {
 	require.Equal(t, "|0x00bf", TeamCityEscape("\u00bf"))
 	require.Equal(t, "|0x00bfaaa", TeamCityEscape("\u00bfaaa"))
 	require.Equal(t, "bb|0x00bfaaa", TeamCityEscape("bb\u00bfaaa"))
+}
+
+func Test_failureSpecifyOwnerAndAddFailureCombination(t *testing.T) {
+	ti := testImpl{
+		l: nilLogger(),
+	}
+	ti.addFailure(0, "", errClusterProvisioningFailed(errors.New("oops")))
+	errWithOwnership := failuresSpecifyOwner(ti.failures())
+
+	require.NotNil(t, errWithOwnership)
+	require.Equal(t, registry.OwnerTestEng, errWithOwnership.Owner)
 }


### PR DESCRIPTION
Backport 1/1 commits from #118324.

/cc @cockroachdb/release

---

This function allows the caller to assign ownership directly when creating an error, which is very useful when we know that a failure during a certain part of the test should always be investigated by a certain team (for instance, if a test fails during setup, Test Eng should investigate, as the owners of the test infrastructure).

Epic: none

Release note: None

Release justification: test only changes.
