### PR TITLE
release-23.1.15-rc: jobs: add DeleteTerminalJobByID function

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1319,6 +1319,38 @@ func (r *Registry) cleanupOldJobsPage(
 	return !morePages, maxID, nil
 }
 
+// DeleteTerminalJobByID deletes the given job ID if it is in a
+// terminal state. If it is is in a non-terminal state, an error is
+// returned.
+func (r *Registry) DeleteTerminalJobByID(ctx context.Context, id jobspb.JobID) error {
+	return r.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		row, err := txn.QueryRow(ctx, "get-job-status", txn.KV(),
+			"SELECT status FROM system.jobs WHERE id = $1", id)
+		if err != nil {
+			return err
+		}
+		if row == nil {
+			return nil
+		}
+		status := Status(*row[0].(*tree.DString))
+		switch status {
+		case StatusSucceeded, StatusCanceled, StatusFailed:
+			_, err := txn.Exec(
+				ctx, "delete-job", txn.KV(), "DELETE FROM system.jobs WHERE id = $1", id,
+			)
+			if err != nil {
+				return err
+			}
+			_, err = txn.Exec(
+				ctx, "delete-job-info", txn.KV(), "DELETE FROM system.job_info WHERE job_id = $1", id,
+			)
+			return err
+		default:
+			return errors.Newf("job %d has non-terminal status: %q", id, status)
+		}
+	})
+}
+
 // getJobFn attempts to get a resumer from the given job id. If the job id
 // does not have a resumer then it returns an error message suitable for users.
 func (r *Registry) getJobFn(

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -1159,6 +1159,111 @@ func TestJitterCalculation(t *testing.T) {
 	}
 }
 
+func TestDeleteTerminalJobByID(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer ResetConstructors()
+
+	errCh := make(chan error)
+	RegisterConstructor(jobspb.TypeImport, func(job *Job, cs *cluster.Settings) Resumer {
+		return FakeResumer{
+			OnResume: func(ctx context.Context) error {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case err := <-errCh:
+					return err
+				}
+			},
+			FailOrCancel: func(ctx context.Context) error {
+				return nil
+			},
+		}
+	}, UsesTenantCostControl)
+
+	ctx := context.Background()
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	var (
+		r   = s.JobRegistry().(*Registry)
+		idb = s.InternalDB().(isql.DB)
+	)
+
+	createStartableJob := func() *StartableJob {
+		jobID := r.MakeJobID()
+		var j *StartableJob
+		err := idb.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return r.CreateStartableJobWithTxn(ctx, &j, jobID, txn, Record{
+				JobID:       jobID,
+				Description: "testing",
+				Username:    username.RootUserName(),
+				Details:     jobspb.ImportDetails{},
+				Progress:    jobspb.ImportProgress{},
+			})
+		})
+		require.NoError(t, err)
+		return j
+	}
+
+	assertValidDeletion := func(id jobspb.JobID) {
+		var count int
+		require.NoError(t, sqlDB.QueryRow("SELECT count(*) FROM system.jobs WHERE id = $1", id).Scan(&count))
+		require.Equal(t, 0, count, "expected no job rows")
+		sqlDB.QueryRow("SELECT count(*) FROM system.job_info WHERE job_id = $1", id)
+		require.Equal(t, 0, count, "expected no job_info rows")
+	}
+
+	t.Run("running job is not deleted", func(t *testing.T) {
+		j := createStartableJob()
+		require.NoError(t, j.Start(ctx))
+		require.Error(t, r.DeleteTerminalJobByID(ctx, j.ID()))
+		errCh <- nil
+		require.NoError(t, j.AwaitCompletion(ctx))
+	})
+	t.Run("paused job is not deleted", func(t *testing.T) {
+		j := createStartableJob()
+		require.NoError(t, j.Start(ctx))
+		require.NoError(t, idb.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return r.PauseRequested(ctx, txn, j.ID(), "test paused")
+		}))
+		require.Error(t, j.AwaitCompletion(ctx))
+		_ = r.WaitForJobs(ctx, []jobspb.JobID{j.ID()})
+		require.Error(t, r.DeleteTerminalJobByID(ctx, j.ID()))
+	})
+	t.Run("successful job is deleted", func(t *testing.T) {
+		j := createStartableJob()
+		require.NoError(t, j.Start(ctx))
+		errCh <- nil
+		require.NoError(t, j.AwaitCompletion(ctx))
+		_ = r.WaitForJobs(ctx, []jobspb.JobID{j.ID()})
+		require.NoError(t, r.DeleteTerminalJobByID(ctx, j.ID()))
+		assertValidDeletion(j.ID())
+	})
+	t.Run("failed job is deleted", func(t *testing.T) {
+		j := createStartableJob()
+		require.NoError(t, j.Start(ctx))
+		errCh <- errors.New("test error")
+		require.Error(t, j.AwaitCompletion(ctx))
+		_ = r.WaitForJobs(ctx, []jobspb.JobID{j.ID()})
+		require.NoError(t, r.DeleteTerminalJobByID(ctx, j.ID()))
+		assertValidDeletion(j.ID())
+	})
+	t.Run("canceled job is deleted", func(t *testing.T) {
+		j := createStartableJob()
+		require.NoError(t, j.Start(ctx))
+		require.NoError(t, j.Cancel(ctx))
+		require.Error(t, j.AwaitCompletion(ctx))
+		_ = r.WaitForJobs(ctx, []jobspb.JobID{j.ID()})
+		require.NoError(t, r.DeleteTerminalJobByID(ctx, j.ID()))
+		assertValidDeletion(j.ID())
+	})
+}
+
 // TestRunWithoutLoop tests that Run calls will trigger the execution of a
 // job even when the adoption loop is set to infinitely slow and that the
 // observation of the completion of the job using the notification channel

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -149,10 +149,7 @@ func (n *createStatsNode) runJob(ctx context.Context) error {
 	if err = job.AwaitCompletion(ctx); err != nil {
 		if errors.Is(err, stats.ConcurrentCreateStatsError) {
 			// Delete the job so users don't see it and get confused by the error.
-			const stmt = `DELETE FROM system.jobs WHERE id = $1`
-			if _ /* cols */, delErr := n.p.ExecCfg().InternalDB.Executor().Exec(
-				ctx, "delete-job", nil /* txn */, stmt, jobID,
-			); delErr != nil {
+			if delErr := n.p.ExecCfg().JobRegistry.DeleteTerminalJobByID(ctx, job.ID()); delErr != nil {
 				log.Warningf(ctx, "failed to delete job: %v", delErr)
 			}
 		}


### PR DESCRIPTION
Backport 1/1 commits from #118589.

/cc @cockroachdb/release

Release justification: Bug fix for bug that led to job system unavailability. 

---

The CREATE AUTO STATS code was manually modifying the system.jobs table in a way that left the job_info table with abandoned rows.

Fixes #118582

Release note (bug fix): AUTO CREATE STATS jobs could previously lead to growth in an internal system table resulting in slower job-system related queries.
