### PR TITLE
release-23.2: increase resilience of restore jobs

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1744,6 +1745,78 @@ func TestRestoreCheckpointing(t *testing.T) {
 	// Ensure that no persisted work was repeated on resume and that all work was persisted.
 	checkPersistedSpanLength(1)
 	require.Equal(t, totalEntries-entriesBeforePause, postResumeCount)
+}
+
+// TestRestoreJobRetryReset tests that the job level retry counter
+// resets after the frontier progresses. To do so, the test does the following:
+// 1. Intercept the restore job before the flow begins and send a retryable error
+// 2. After we send MaxRetries-1, allow the job to complete the flow and send a progress update
+// 3. After progress has been recorded, intercept the restore job again and send retryable errors until the job pauses.
+// 4. Assert that more than max retries have been sent, implying that the retry counter reset after progress was made.
+func TestRestoreJobRetryReset(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	mu := struct {
+		syncutil.Mutex
+		initialScanComplete bool
+		retryCount          int
+	}{}
+	waitForProgress := make(chan struct{})
+
+	maxRetries := 4
+
+	params := base.TestClusterArgs{}
+	knobs := base.TestingKnobs{
+		BackupRestore: &sql.BackupRestoreTestingKnobs{
+			RestoreDistSQLRetryPolicy: &retry.Options{
+				InitialBackoff: time.Microsecond,
+				Multiplier:     2,
+				MaxBackoff:     2 * time.Microsecond,
+				MaxRetries:     maxRetries,
+			},
+			RunBeforeRestoreFlow: func() error {
+				mu.Lock()
+				defer mu.Unlock()
+				if mu.retryCount >= maxRetries-1 {
+					return nil
+				}
+				mu.retryCount++
+				// Send a retryable error
+				return syscall.ECONNRESET
+			},
+			RunAfterRestoreFlow: func() error {
+				mu.Lock()
+				defer mu.Unlock()
+				// Wait for progress to persist, then continue sending retryable errors
+				<-waitForProgress
+				mu.retryCount++
+				// Send a retryable error
+				return syscall.ECONNRESET
+			},
+		},
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+	}
+	params.ServerArgs = base.TestServerArgs{Knobs: knobs}
+
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, 10, InitManualReplication, params)
+	defer cleanupFn()
+
+	sqlDB.Exec(t, `BACKUP DATABASE data INTO $1`, localFoo)
+	var restoreJobId jobspb.JobID
+	sqlDB.QueryRow(t, `RESTORE DATABASE DATA FROM LATEST IN $1 with new_db_name=d2, detached`, localFoo).Scan(&restoreJobId)
+	testutils.SucceedsSoon(t, func() error {
+		jobProgress := jobutils.GetJobProgress(t, sqlDB, restoreJobId)
+		if len(jobProgress.GetRestore().Checkpoint) == 0 {
+			return errors.Newf("frontier has not advanced yet")
+		}
+		return nil
+	})
+	close(waitForProgress)
+
+	jobutils.WaitForJobToPause(t, sqlDB, restoreJobId)
+
+	require.Greater(t, mu.retryCount, maxRetries+2)
 }
 
 func createAndWaitForJob(

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1667,7 +1667,7 @@ func TestRestoreCheckpointing(t *testing.T) {
 	knobs := base.TestingKnobs{
 		DistSQL: &execinfra.TestingKnobs{
 			BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
-				RunAfterProcessingRestoreSpanEntry: func(_ context.Context, _ *execinfrapb.RestoreSpanEntry) {
+				RunAfterProcessingRestoreSpanEntry: func(_ context.Context, _ *execinfrapb.RestoreSpanEntry) error {
 					//  Because the restore processor has several workers that
 					//  concurrently send addsstable requests and because all workers will
 					//  wait on the lock below, when one flush gets blocked on the
@@ -1689,6 +1689,7 @@ func TestRestoreCheckpointing(t *testing.T) {
 					if wasPausedBeforeWaiting {
 						postResumeCount++
 					}
+					return nil
 				},
 			},
 		},
@@ -1817,6 +1818,75 @@ func TestRestoreJobRetryReset(t *testing.T) {
 	jobutils.WaitForJobToPause(t, sqlDB, restoreJobId)
 
 	require.Greater(t, mu.retryCount, maxRetries+2)
+}
+
+// TestRestoreRetryProcErr tests that the restore data processor will mark
+// errors as retryable if and only if it has made progress.
+func TestRestoreRetryProcErr(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testutils.RunTrueAndFalse(t, "restore processor progress", func(t *testing.T, makeProgress bool) {
+		mu := struct {
+			syncutil.Mutex
+			flowCount int
+			spanCount int
+		}{}
+		params := base.TestClusterArgs{}
+		knobs := base.TestingKnobs{
+			DistSQL: &execinfra.TestingKnobs{
+				BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
+					RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, _ *execinfrapb.RestoreSpanEntry) error {
+						mu.Lock()
+						defer mu.Unlock()
+						if makeProgress && mu.spanCount == 0 {
+							// Allow a span entry to progress to test that the restore processor
+							// sends a retryable error after progress was sent.
+							mu.spanCount++
+							return nil
+						}
+						// This error will only get retried if a span entry has already been processed.
+						return errors.New("gross external storage error")
+					}}},
+			BackupRestore: &sql.BackupRestoreTestingKnobs{
+				RestoreDistSQLRetryPolicy: &retry.Options{
+					InitialBackoff: time.Microsecond,
+					Multiplier:     2,
+					MaxBackoff:     2 * time.Microsecond,
+					MaxRetries:     4,
+				},
+				RunBeforeRestoreFlow: func() error {
+					mu.Lock()
+					defer mu.Unlock()
+					mu.flowCount++
+					return nil
+				},
+			},
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		}
+		params.ServerArgs = base.TestServerArgs{Knobs: knobs}
+
+		_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, 10, InitManualReplication, params)
+		defer cleanupFn()
+
+		sqlDB.Exec(t, `CREATE DATABASE d`)
+		for i := 1; i <= 4; i++ {
+			tableName := fmt.Sprintf("d.t%d", i)
+			sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE %s (id INT PRIMARY KEY, s STRING)`, tableName))
+			sqlDB.Exec(t, fmt.Sprintf(`INSERT INTO %s VALUES (1, 'x'),(2,'y')`, tableName))
+		}
+
+		sqlDB.Exec(t, `BACKUP DATABASE d INTO $1`, localFoo)
+		var restoreJobId jobspb.JobID
+		sqlDB.QueryRow(t, `RESTORE DATABASE d FROM LATEST IN $1 with new_db_name=d2, detached`, localFoo).Scan(&restoreJobId)
+		jobutils.WaitForJobToPause(t, sqlDB, restoreJobId)
+
+		expectedFlowCount := 1
+		if makeProgress {
+			expectedFlowCount = 2
+		}
+		require.Equal(t, mu.flowCount, expectedFlowCount)
+	})
 }
 
 func createAndWaitForJob(
@@ -7650,8 +7720,9 @@ func TestClientDisconnect(t *testing.T) {
 
 			args := base.TestClusterArgs{}
 			knobs := base.TestingKnobs{
-				DistSQL: &execinfra.TestingKnobs{BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, _ *execinfrapb.RestoreSpanEntry) {
+				DistSQL: &execinfra.TestingKnobs{BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, _ *execinfrapb.RestoreSpanEntry) error {
 					blockBackupOrRestore(ctx)
+					return nil
 				}}},
 				Store: &kvserver.StoreTestingKnobs{
 					TestingResponseFilter: func(ctx context.Context, ba *kvpb.BatchRequest, br *kvpb.BatchResponse) *kvpb.Error {
@@ -11455,8 +11526,9 @@ func TestRestoreMemoryMonitoringWithShadowing(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			DistSQL: &execinfra.TestingKnobs{
 				BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
-					RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, entry *execinfrapb.RestoreSpanEntry) {
+					RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, entry *execinfrapb.RestoreSpanEntry) error {
 						restoreProcessorKnobCount.Add(1)
+						return nil
 					},
 				},
 			},

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -86,6 +86,10 @@ type restoreDataProcessor struct {
 	// qp is a MemoryBackedQuotaPool that restricts the amount of memory that
 	// can be used by this processor to open iterators on SSTs.
 	qp *backuputils.MemoryBackedQuotaPool
+
+	// progressMade is true if the processor has successfully processed a
+	// restore span entry.
+	progressMade bool
 }
 
 var (
@@ -132,6 +136,8 @@ var defaultNumWorkers = util.ConstantWithMetamorphicTestRange(
 	1, /* metamorphic min */
 	8, /* metamorphic max */
 )
+var retryableRestoreProcError = errors.New("restore processor error after forward progress")
+var restoreProcError = errors.New("restore processor error without forward progress")
 
 // TODO(pbardea): It may be worthwhile to combine this setting with the one that
 // controls the number of concurrent AddSSTable requests if each restore worker
@@ -671,7 +677,9 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 
 	if restoreKnobs, ok := rd.flowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
 		if restoreKnobs.RunAfterProcessingRestoreSpanEntry != nil {
-			restoreKnobs.RunAfterProcessingRestoreSpanEntry(ctx, &entry)
+			if err := restoreKnobs.RunAfterProcessingRestoreSpanEntry(ctx, &entry); err != nil {
+				return summary, err
+			}
 		}
 	}
 
@@ -703,6 +711,11 @@ func (rd *restoreDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Produce
 		if !ok {
 			// Done. Check if any phase exited early with an error.
 			err := rd.phaseGroup.Wait()
+			if rd.progressMade {
+				err = errors.Mark(err, retryableRestoreProcError)
+			} else {
+				err = errors.Mark(err, restoreProcError)
+			}
 			rd.MoveToDraining(err)
 			return nil, rd.DrainHelper()
 		}
@@ -713,6 +726,7 @@ func (rd *restoreDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Produce
 			return nil, rd.DrainHelper()
 		}
 		prog.ProgressDetails = *details
+		rd.progressMade = true
 		return nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &prog}
 	case <-rd.aggTimer.C:
 		rd.aggTimer.Read = true

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -165,11 +165,20 @@ func restoreWithRetry(
 		MaxBackoff: 1 * time.Second,
 		MaxRetries: 5,
 	}
+	if execCtx.ExecCfg().BackupRestoreTestingKnobs != nil &&
+		execCtx.ExecCfg().BackupRestoreTestingKnobs.RestoreDistSQLRetryPolicy != nil {
+		retryOpts = *execCtx.ExecCfg().BackupRestoreTestingKnobs.RestoreDistSQLRetryPolicy
+	}
 
 	// We want to retry a restore if there are transient failures (i.e. worker nodes
 	// dying), so if we receive a retryable error, re-plan and retry the backup.
-	var res roachpb.RowCount
-	var err error
+	var (
+		res                    roachpb.RowCount
+		err                    error
+		previousPersistedSpans jobspb.RestoreFrontierEntries
+		currentPersistedSpans  jobspb.RestoreFrontierEntries
+	)
+
 	for r := retry.StartWithCtx(restoreCtx, retryOpts); r.Next(); {
 		res, err = restore(
 			restoreCtx,
@@ -203,6 +212,14 @@ func restoreWithRetry(
 		}
 
 		log.Warningf(restoreCtx, "encountered retryable error: %+v", err)
+		currentPersistedSpans = resumer.job.Progress().Details.(*jobspb.Progress_Restore).Restore.Checkpoint
+		if !currentPersistedSpans.Equal(previousPersistedSpans) {
+			// If the previous persisted spans are different than the current, it
+			// implies that further progress has been persisted.
+			r.Reset()
+			log.Infof(restoreCtx, "restored frontier has advanced since last retry, resetting retry counter")
+		}
+		previousPersistedSpans = currentPersistedSpans
 	}
 
 	// We have exhausted retries, but we have not seen a "PermanentBulkJobError" so
@@ -451,10 +468,23 @@ func restore(
 		), "running distributed restore")
 	}
 	tasks = append(tasks, runRestore)
+	testingKnobs := execCtx.ExecCfg().BackupRestoreTestingKnobs
+	if testingKnobs != nil && testingKnobs.RunBeforeRestoreFlow != nil {
+		if err := testingKnobs.RunBeforeRestoreFlow(); err != nil {
+			return emptyRowCount, err
+		}
+	}
 
 	if err := ctxgroup.GoAndWait(restoreCtx, tasks...); err != nil {
 		return emptyRowCount, errors.Wrapf(err, "importing %d ranges", numImportSpans)
 	}
+
+	if testingKnobs != nil && testingKnobs.RunAfterRestoreFlow != nil {
+		if err := testingKnobs.RunAfterRestoreFlow(); err != nil {
+			return emptyRowCount, err
+		}
+	}
+
 	// progress go routines should be shutdown, but use lock just to be safe.
 	progressTracker.mu.Lock()
 	defer progressTracker.mu.Unlock()

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -171,23 +171,17 @@ func restoreWithRetry(
 	var res roachpb.RowCount
 	var err error
 	for r := retry.StartWithCtx(restoreCtx, retryOpts); r.Next(); {
-		// Re-plan inner loop (does not count as retries, done by outer loop).
-		for {
-			res, err = restore(
-				restoreCtx,
-				execCtx,
-				backupManifests,
-				backupLocalityInfo,
-				endTime,
-				dataToRestore,
-				resumer,
-				encryption,
-				kmsEnv,
-			)
-			if err == nil || !errors.Is(err, sql.ErrPlanChanged) {
-				break
-			}
-		}
+		res, err = restore(
+			restoreCtx,
+			execCtx,
+			backupManifests,
+			backupLocalityInfo,
+			endTime,
+			dataToRestore,
+			resumer,
+			encryption,
+			kmsEnv,
+		)
 
 		if err == nil {
 			break

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -196,11 +196,11 @@ func restoreWithRetry(
 			break
 		}
 
-		if errors.HasType(err, &kvpb.InsufficientSpaceError{}) {
+		if errors.HasType(err, &kvpb.InsufficientSpaceError{}) || errors.Is(err, restoreProcError) {
 			return roachpb.RowCount{}, jobs.MarkPauseRequestError(errors.UnwrapAll(err))
 		}
 
-		if joberror.IsPermanentBulkJobError(err) {
+		if joberror.IsPermanentBulkJobError(err) && !errors.Is(err, retryableRestoreProcError) {
 			return roachpb.RowCount{}, err
 		}
 

--- a/pkg/ccl/backupccl/restore_progress_test.go
+++ b/pkg/ccl/backupccl/restore_progress_test.go
@@ -48,14 +48,6 @@ func TestProgressTracker(t *testing.T) {
 		return &execinfrapb.RemoteProducerMetadata_BulkProcessorProgress{ProgressDetails: *details}
 	}
 
-	pSp := func(spans ...roachpb.Span) []jobspb.RestoreProgress_FrontierEntry {
-		pSpans := make([]jobspb.RestoreProgress_FrontierEntry, 0)
-		for _, sp := range spans {
-			pSpans = append(pSpans, jobspb.RestoreProgress_FrontierEntry{Span: sp, Timestamp: completedSpanTime})
-		}
-		return pSpans
-	}
-
 	// testStep characterizes an update to the span frontier and the expected
 	// persisted spans after the update.
 	type testStep struct {
@@ -103,5 +95,63 @@ func TestProgressTracker(t *testing.T) {
 
 		persistedSpans = persistFrontier(pt.mu.checkpointFrontier, 0)
 		require.Equal(t, step.expectedPersisted, persistedSpans, "step %d", i)
+	}
+}
+
+func pSp(spans ...roachpb.Span) []jobspb.RestoreProgress_FrontierEntry {
+	pSpans := make([]jobspb.RestoreProgress_FrontierEntry, 0)
+	for _, sp := range spans {
+		pSpans = append(pSpans, jobspb.RestoreProgress_FrontierEntry{Span: sp, Timestamp: completedSpanTime})
+	}
+	return pSpans
+}
+
+func TestPersistedFrontierEqual(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	type testCase struct {
+		ps1   []jobspb.RestoreProgress_FrontierEntry
+		ps2   []jobspb.RestoreProgress_FrontierEntry
+		equal bool
+	}
+
+	sp := func(start, end string) roachpb.Span {
+		return roachpb.Span{Key: roachpb.Key(start), EndKey: roachpb.Key(end)}
+	}
+
+	for _, tc := range []testCase{
+		{
+			ps1:   pSp(sp("a", "c"), sp("d", "e")),
+			ps2:   pSp(sp("a", "c"), sp("d", "e")),
+			equal: true,
+		},
+		{
+			ps1:   pSp(sp("a", "c")),
+			ps2:   pSp(sp("a", "c"), sp("d", "e")),
+			equal: false,
+		},
+		{
+			ps1:   pSp(sp("a", "c")),
+			equal: false,
+		},
+		{
+			ps1:   pSp(sp("a", "c"), sp("d", "e")),
+			ps2:   pSp(sp("a", "c"), sp("d", "f")),
+			equal: false,
+		},
+		{
+			ps1:   pSp(sp("a", "c"), sp("d", "e")),
+			ps2:   pSp(sp("a", "e")),
+			equal: false,
+		},
+	} {
+		var (
+			ps1Entries jobspb.RestoreFrontierEntries
+			ps2Entries jobspb.RestoreFrontierEntries
+		)
+		ps1Entries = tc.ps1
+		ps2Entries = tc.ps2
+		require.Equal(t, tc.equal, ps1Entries.Equal(ps2Entries))
+		require.Equal(t, tc.equal, ps2Entries.Equal(ps1Entries))
+
 	}
 }

--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -591,11 +591,12 @@ func runTestRestoreMemoryMonitoring(t *testing.T, numSplits, numInc, restoreProc
 		Knobs: base.TestingKnobs{
 			DistSQL: &execinfra.TestingKnobs{
 				BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
-					RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, entry *execinfrapb.RestoreSpanEntry) {
+					RunAfterProcessingRestoreSpanEntry: func(ctx context.Context, entry *execinfrapb.RestoreSpanEntry) error {
 						// The total size of the backup files should be less than the target
 						// SST size, thus should all fit in one import span.
 						require.Equal(t, actualNumFiles, len(entry.Files))
 						restoreProcessorKnobCount.Add(1)
+						return nil
 					},
 				},
 			},

--- a/pkg/jobs/joberror/errors.go
+++ b/pkg/jobs/joberror/errors.go
@@ -38,5 +38,4 @@ func IsPermanentBulkJobError(err error) bool {
 		!sysutil.IsErrConnectionReset(err) &&
 		!sysutil.IsErrConnectionRefused(err) &&
 		!errors.Is(err, sqlinstance.NonExistentInstanceError)
-
 }

--- a/pkg/jobs/jobspb/jobs.go
+++ b/pkg/jobs/jobspb/jobs.go
@@ -17,3 +17,21 @@ func (t *TraceData) ToText() []byte {
 	rec := tracingpb.Recording(t.CollectedSpans)
 	return []byte(rec.String())
 }
+
+// RestoreFrontierEntries is a slice of RestoreFrontierEntries.
+type RestoreFrontierEntries []RestoreProgress_FrontierEntry
+
+func (fes RestoreFrontierEntries) Equal(fes2 RestoreFrontierEntries) bool {
+	if len(fes) != len(fes2) {
+		return false
+	}
+	for i := range fes {
+		if !fes[i].Span.Equal(fes2[i].Span) {
+			return false
+		}
+		if !fes[i].Timestamp.Equal(fes2[i].Timestamp) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1767,7 +1767,7 @@ type BackupRestoreTestingKnobs struct {
 
 	// RunAfterProcessingRestoreSpanEntry allows blocking the RESTORE job after a
 	// single RestoreSpanEntry has been processed and added to the SSTBatcher.
-	RunAfterProcessingRestoreSpanEntry func(ctx context.Context, entry *execinfrapb.RestoreSpanEntry)
+	RunAfterProcessingRestoreSpanEntry func(ctx context.Context, entry *execinfrapb.RestoreSpanEntry) error
 
 	// RunAfterExportingSpanEntry allows blocking the BACKUP job after a single
 	// span has been exported.

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1753,6 +1753,8 @@ type SchemaTelemetryTestingKnobs struct {
 func (*SchemaTelemetryTestingKnobs) ModuleTestingKnobs() {}
 
 // BackupRestoreTestingKnobs contains knobs for backup and restore behavior.
+//
+// TODO (msbutler): move these to backupccl
 type BackupRestoreTestingKnobs struct {
 	// CaptureResolvedTableDescSpans allows for intercepting the spans which are
 	// resolved during backup planning, and will eventually be backed up during
@@ -1775,6 +1777,12 @@ type BackupRestoreTestingKnobs struct {
 	// testing. This is typically the bulk mem monitor if not
 	// specified here.
 	BackupMemMonitor *mon.BytesMonitor
+
+	RestoreDistSQLRetryPolicy *retry.Options
+
+	RunBeforeRestoreFlow func() error
+
+	RunAfterRestoreFlow func() error
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}


### PR DESCRIPTION
Backport:
  * 2/2 commits from "backupccl:  reset job level retry counter if progress has advanced" (#116548)
  * 1/1 commits from "backupccl: wrap restore processor errors as retryable after progress is made" (#116957)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: significantly increases the resilience of restore jobs dealing with ephemeral errors