### PR TITLE
pkg/util/tracing: introduce `trace.span.force_verbose_regexp `

### DIFF
--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -1082,3 +1082,15 @@ func BenchmarkStartSpan(b *testing.B) {
 	}
 	b.ReportAllocs()
 }
+
+func BenchmarkStartSpan_OpNameRegexp(b *testing.B) {
+	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
+	require.True(b, tr.AlwaysTrace())
+	// Set some arbitrary regex. In our benchmark, we'll always match, but only the
+	// final clause in the regex.
+	require.NoError(b, tr.setVerboseOpNameRegexp("op1|op2|op3|^op[a-zA-Z]+"))
+	for i := 0; i < b.N; i++ {
+		tr.StartSpan("opAB")
+	}
+	b.ReportAllocs()
+}

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -1021,3 +1021,12 @@ func TestTracerStackHistory(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkStartSpan(b *testing.B) {
+	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
+	require.True(b, tr.AlwaysTrace())
+	for i := 0; i < b.N; i++ {
+		tr.StartSpan("opName")
+	}
+	b.ReportAllocs()
+}


### PR DESCRIPTION
This patch introduces the `trace.verbose.span.operation.regexp` cluster
setting, which provides a surface for CRL employees debugging CRDB to
force certain tracing span operations to record in verbose mode via a
regular expression string. If the regexp matches a span's operation
name, that span will be forced into a verbose recording mode, capturing
all structured logs (recorded via `RecordStructured`) and events (Recorded
via `Recordf`) during the lifetime of the span.

We intentionally avoid release notes, as this setting is only meant
for internal usage.

Release note: none

Epic: CRDB-35278

Addresses: https://github.com/cockroachdb/cockroach/issues/117624