### PR TITLE
release-23.1: roachtest: introduce `registry.ErrorWithOwner`

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
+	"github.com/cockroachdb/errors"
 )
 
 type githubIssues struct {
@@ -139,38 +140,54 @@ func (g *githubIssues) createPostRequest(
 	start time.Time,
 	end time.Time,
 	spec *registry.TestSpec,
-	firstFailure failure,
+	failures []failure,
 	message string,
 	metamorphicBuild bool,
 ) (issues.PostRequest, error) {
 	var mention []string
 	var projColID int
 
-	issueOwner := spec.Owner
-	issueName := testName
-	issueClusterName := ""
+	var (
+		issueOwner    = spec.Owner
+		issueName     = testName
+		messagePrefix string
+		infraFlake    bool
+	)
 
-	messagePrefix := ""
-	var infraFlake bool
-	// Overrides to shield eng teams from potential flakes
+	// handleErrorWithOwnership updates the local variables in this
+	// function that contain the name of the issue being created,
+	// message prefix, and team that will own it.
+	handleErrorWithOwnership := func(err registry.ErrorWithOwnership) {
+		issueOwner = err.Owner
+		infraFlake = err.InfraFlake
+
+		if err.TitleOverride != "" {
+			issueName = err.TitleOverride
+			messagePrefix = fmt.Sprintf("test %s failed: ", testName)
+		}
+	}
+
+	issueClusterName := ""
+	errWithOwnership := failuresSpecifyOwner(failures)
 	switch {
-	case failureContainsError(firstFailure, errClusterProvisioningFailed):
-		issueOwner = registry.OwnerTestEng
-		issueName = "cluster_creation"
-		messagePrefix = fmt.Sprintf("test %s was skipped due to ", testName)
-		infraFlake = true
-	case failureContainsError(firstFailure, rperrors.ErrSSH255):
-		issueOwner = registry.OwnerTestEng
-		issueName = "ssh_problem"
-		messagePrefix = fmt.Sprintf("test %s failed due to ", testName)
-		infraFlake = true
-	case failureContainsError(firstFailure, gce.ErrDNSOperation):
-		issueOwner = registry.OwnerTestEng
-		issueName = "dns_problem"
-		messagePrefix = fmt.Sprintf("test %s failed due to ", testName)
-		infraFlake = true
-	case failureContainsError(firstFailure, errDuringPostAssertions):
-		messagePrefix = fmt.Sprintf("test %s failed during post test assertions (see test-post-assertions.log) due to ", testName)
+	case errWithOwnership != nil:
+		handleErrorWithOwnership(*errWithOwnership)
+
+	// The following error come from various entrypoints in roachprod,
+	// but we know that they should be handled by TestEng whenever they
+	// happen during a test.
+	case failuresContainsError(failures, rperrors.ErrSSH255):
+		handleErrorWithOwnership(registry.ErrorWithOwner(
+			registry.OwnerTestEng, errors.New("SSH problem"),
+			registry.WithTitleOverride("ssh_problem"),
+			registry.InfraFlake,
+		))
+	case failuresContainsError(failures, gce.ErrDNSOperation):
+		handleErrorWithOwnership(registry.ErrorWithOwner(
+			registry.OwnerTestEng, errors.New("DNS problem"),
+			registry.WithTitleOverride("dns_problem"),
+			registry.InfraFlake,
+		))
 	}
 
 	// Issues posted from roachtest are identifiable as such, and they are also release blockers
@@ -261,7 +278,7 @@ func (g *githubIssues) MaybePost(t *testImpl, l *logger.Logger, message string) 
 	default:
 		metamorphicBuild = tests.UsingRuntimeAssertions(t)
 	}
-	postRequest, err := g.createPostRequest(t.Name(), t.start, t.end, t.spec, t.firstFailure(), message, metamorphicBuild)
+	postRequest, err := g.createPostRequest(t.Name(), t.start, t.end, t.spec, t.failures(), message, metamorphicBuild)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/roachtest/registry/BUILD.bazel
+++ b/pkg/cmd/roachtest/registry/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "registry",
     srcs = [
         "encryption.go",
+        "errors.go",
         "filter.go",
         "owners.go",
         "registry_interface.go",

--- a/pkg/cmd/roachtest/registry/errors.go
+++ b/pkg/cmd/roachtest/registry/errors.go
@@ -1,0 +1,56 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package registry
+
+import "fmt"
+
+type (
+	ErrorWithOwnership struct {
+		// TitleOverride allows errors to overwrite the "{testName}
+		// failed" title used in issues. This allows issues to be grouped
+		// even if they happen in different tests.
+		TitleOverride string
+		// InfraFlake indicates that this error is an infrastructure
+		// flake, and the issue will be labeled accordingly.
+		InfraFlake bool
+		Owner      Owner
+		Err        error
+	}
+
+	errorOption func(*ErrorWithOwnership)
+)
+
+func (ewo ErrorWithOwnership) Error() string {
+	return fmt.Sprintf("%s [owner=%s]", ewo.Err.Error(), ewo.Owner)
+}
+
+func WithTitleOverride(title string) errorOption {
+	return func(ewo *ErrorWithOwnership) {
+		ewo.TitleOverride = title
+	}
+}
+
+func InfraFlake(ewo *ErrorWithOwnership) {
+	ewo.InfraFlake = true
+}
+
+// ErrorWithOwner allows the caller to associate `err` with
+// `owner`. When `t.Fatal` is called with an error of this type, the
+// resulting GitHub issue is created and assigned to the team
+// corresponding to `owner`.
+func ErrorWithOwner(owner Owner, err error, opts ...errorOption) ErrorWithOwnership {
+	result := ErrorWithOwnership{Owner: owner, Err: err}
+	for _, opt := range opts {
+		opt(&result)
+	}
+
+	return result
+}

--- a/pkg/cmd/roachtest/test_impl_test.go
+++ b/pkg/cmd/roachtest/test_impl_test.go
@@ -13,6 +13,8 @@ package main
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,4 +41,15 @@ func TestTeamCityEscape(t *testing.T) {
 	require.Equal(t, "|0x00bf", TeamCityEscape("\u00bf"))
 	require.Equal(t, "|0x00bfaaa", TeamCityEscape("\u00bfaaa"))
 	require.Equal(t, "bb|0x00bfaaa", TeamCityEscape("bb\u00bfaaa"))
+}
+
+func Test_failureSpecifyOwnerAndAddFailureCombination(t *testing.T) {
+	ti := testImpl{
+		l: nilLogger(),
+	}
+	ti.addFailure(0, "", errClusterProvisioningFailed(errors.New("oops")))
+	errWithOwnership := failuresSpecifyOwner(ti.failures())
+
+	require.NotNil(t, errWithOwnership)
+	require.Equal(t, registry.OwnerTestEng, errWithOwnership.Owner)
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -58,16 +58,20 @@ var (
 	// reference error used by main.go at the end of a run of tests
 	errSomeClusterProvisioningFailed = fmt.Errorf("some clusters could not be created")
 
-	// reference error used when cluster creation fails for a test
-	errClusterProvisioningFailed = fmt.Errorf("cluster could not be created")
-
-	// reference error for any failures during post test assertions
-	errDuringPostAssertions = fmt.Errorf("error during post test assertions")
-
 	prometheusNameSpace = "roachtest"
 	// prometheusScrapeInterval should be consistent with the scrape interval defined in
 	// https://grafana.testeng.crdb.io/prometheus/config
 	prometheusScrapeInterval = time.Second * 15
+
+	// errClusterProvisioningFailed wraps the error given in an error
+	// that is properly sent to Test Eng and marked as an infra flake.
+	errClusterProvisioningFailed = func(err error) error {
+		return registry.ErrorWithOwner(
+			registry.OwnerTestEng, err,
+			registry.WithTitleOverride("cluster_creation"),
+			registry.InfraFlake,
+		)
+	}
 
 	prng, _ = randutil.NewLockedPseudoRand()
 
@@ -727,13 +731,8 @@ func (r *testRunner) runWorker(
 		// occurred for reasons related to creating or setting up a
 		// cluster for a test.
 		handleClusterCreationFailure := func(err error) {
-			// Marking the error with this sentinel error allows the GitHub
-			// issue poster to detect this is an infrastructure flake and
-			// post the issue accordingly.
-			clusterError := errors.Mark(err, errClusterProvisioningFailed)
-			t.Error(clusterError)
+			t.Error(errClusterProvisioningFailed(err))
 
-			// N.B. issue title is of the form "roachtest: ${t.spec.Name} failed" (see UnitTestFormatter).
 			if err := github.MaybePost(t, l, t.failureMsg()); err != nil {
 				shout(ctx, l, stdout, "failed to post issue: %s", err)
 			}
@@ -1062,7 +1061,7 @@ func (r *testRunner) runTest(
 
 	// Extend the lifetime of the cluster if needed.
 	if err := c.MaybeExtendCluster(ctx, l, t.spec); err != nil {
-		t.Error(errors.Mark(err, errClusterProvisioningFailed))
+		t.Error(errClusterProvisioningFailed(err))
 		return
 	}
 
@@ -1170,7 +1169,9 @@ func (r *testRunner) postTestAssertions(
 	assertionFailed := false
 	postAssertionErr := func(err error) {
 		assertionFailed = true
-		t.Error(errors.Mark(err, errDuringPostAssertions))
+		t.Error(fmt.Errorf(
+			"failed during post test assertions (see test-post-assertions.log): %w", err,
+		))
 	}
 
 	postAssertCh := make(chan struct{})


### PR DESCRIPTION
Backport 1/1 commits from #118324.

/cc @cockroachdb/release

---

This function allows the caller to assign ownership directly when creating an error, which is very useful when we know that a failure during a certain part of the test should always be investigated by a certain team (for instance, if a test fails during setup, Test Eng should investigate, as the owners of the test infrastructure).

Epic: none

Release note: None

Release justification: test only changes.
