### PR TITLE
schemaexpr: Remove checks for dropped or inaccessible column when replaceColumnVars

### DIFF
--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -382,6 +382,14 @@ func TestAlterTableDMLInjection(t *testing.T) {
 			skipIssue:    97813,
 		},
 		{
+			desc: "drop column with check constraint",
+			setup: []string{
+				"ALTER TABLE tbl ADD COLUMN i INT NOT NULL DEFAULT 1",
+				"ALTER TABLE tbl ADD CONSTRAINT check_i CHECK (i > 0)",
+			},
+			schemaChange: "ALTER TABLE tbl DROP COLUMN i",
+		},
+		{
 			desc:         "create expression index",
 			schemaChange: "CREATE INDEX idx ON tbl ((val + 1))",
 		},


### PR DESCRIPTION
Previously, if we have a table with a column `col` and a constraint referencing `col` and during the schema change of dropping `col`, concurrent DML (e.g. INSERT) will use the default value (or NULL if no default) for `col` when it still needs to write to the old primary index. If the default value failed the constraint (when it's still enforced during the schema change), it gives out a somewhat confusing error message:

```
ERROR: failed to satisfy CHECK constraint (crdb_internal_column_2_name_placeholder < 0:::INT8): column "crdb_internal_column_2_name_placeholder" does not exist, referenced in "crdb_internal_column_2_name_placeholder < 0:::INT8"
```

where the outmost error message is right ("failed to satisfy CHECK constraint") but the inner error message is somewhat confusing -- it complains the dropping column cannot be found. The root cause of this is because we have logic such that if a check constraint is violated, we are going to format that check constraint expression via `FormatExprForDisplay` but it throws an error if any column in the expression is non-public or inaccessible. This commit argues that, for schema changes, it is possible to encounter column-in-mutation (i.e. non-public column) whenever we need to format an expression so this commit removes the requirement, so that the error message for the same concurrent DML will only have the outmost error message

```
ERROR: failed to satisfy CHECK constraint (crdb_internal_column_2_name_placeholder < 0:::INT8)
```

It also adds a test to ensure that whenever the default value satisfies the check constraint, concurrent DML stmts completes successfully.

Fixes #118314