### PR TITLE
roachtest: embed helper files instead of using c.Put 

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -187,6 +187,11 @@ go_library(
         "versionupgrade.go",
         "ycsb.go",
     ],
+    embedsrcs = [
+        "ruby_pg_helpers.rb",
+        "tpchvec_smithcmp.toml",
+        "knexfile.js",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -12,6 +12,7 @@ package tests
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"strings"
 
@@ -26,6 +27,13 @@ import (
 // WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
 // This is used by docs automation to produce a list of supported versions for ORM's.
 const supportedKnexTag = "2.5.1"
+
+// Embed the config file, so we don't need to know where it is
+// relative to the roachtest runner, just relative to this test.
+// This way we can still find it if roachtest changes paths.
+//
+//go:embed knexfile.js
+var knexfile string
 
 // This test runs one of knex's test suite against a single cockroach
 // node.
@@ -161,41 +169,3 @@ echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.co
 		},
 	})
 }
-
-const knexfile = `
-'use strict';
-/* eslint no-var: 0 */
-
-const _ = require('lodash');
-
-console.log('Using custom cockroachdb test config');
-
-const testIntegrationDialects = (
-  process.env.DB ||
-  'cockroachdb'
-).match(/[\w-]+/g);
-
-const testConfigs = {
-  cockroachdb: {
-      adapter: 'cockroachdb',
-      port: process.env.PGPORT,
-      host: 'localhost',
-      database: 'test',
-      user: process.env.PGUSER,
-      password: process.env.PGPASSWORD,
-      ssl: {
-        rejectUnauthorized: false,
-        ca: process.env.PGSSLROOTCERT
-      }
-  },
-};
-
-module.exports = _.reduce(
-  testIntegrationDialects,
-  function (res, dialectName) {
-    res[dialectName] = testConfigs[dialectName];
-    return res;
-  },
-  {}
-);
-`

--- a/pkg/cmd/roachtest/tests/knexfile.js
+++ b/pkg/cmd/roachtest/tests/knexfile.js
@@ -1,0 +1,45 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+'use strict';
+/* eslint no-var: 0 */
+
+const _ = require('lodash');
+
+console.log('Using custom cockroachdb test config');
+
+const testIntegrationDialects = (
+  process.env.DB ||
+  'cockroachdb'
+).match(/[\w-]+/g);
+
+const testConfigs = {
+  cockroachdb: {
+    adapter: 'cockroachdb',
+    port: process.env.PGPORT,
+    host: 'localhost',
+    database: 'test',
+    user: process.env.PGUSER,
+    password: process.env.PGPASSWORD,
+    ssl: {
+      rejectUnauthorized: false,
+      ca: process.env.PGSSLROOTCERT
+    }
+  },
+};
+
+module.exports = _.reduce(
+  testIntegrationDialects,
+  function (res, dialectName) {
+    res[dialectName] = testConfigs[dialectName];
+    return res;
+  },
+  {}
+);

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -14,6 +14,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	_ "embed"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -37,6 +38,13 @@ var testSummaryRegexp = regexp.MustCompile("^([0-9]+) examples, [0-9]+ failures"
 // WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
 // This is used by docs automation to produce a list of supported versions for ORM's.
 var rubyPGVersion = "v1.4.6"
+
+// Embed the helper file, so we don't need to know where it is
+// relative to the roachtest runner, just relative to this test.
+// This way we can still find it if roachtest changes paths.
+//
+//go:embed ruby_pg_helpers.rb
+var rubyPGHelpersFile string
 
 // This test runs Ruby PG's full test suite against a single cockroach node.
 func registerRubyPG(r registry.Registry) {
@@ -151,8 +159,7 @@ func registerRubyPG(r registry.Registry) {
 		}
 
 		// Write the cockroach config into the test suite to use.
-		rubyPGHelpersFile := "./pkg/cmd/roachtest/tests/ruby_pg_helpers.rb"
-		err = c.PutE(ctx, t.L(), rubyPGHelpersFile, "/mnt/data1/ruby-pg/spec/helpers.rb", c.All())
+		err = c.PutString(ctx, rubyPGHelpersFile, "/mnt/data1/ruby-pg/spec/helpers.rb", 0755, c.All())
 		require.NoError(t, err)
 
 		t.Status("running ruby-pg test suite")

--- a/pkg/cmd/roachtest/tests/tpchvec_smithcmp.toml
+++ b/pkg/cmd/roachtest/tests/tpchvec_smithcmp.toml
@@ -47,7 +47,7 @@ WHERE
 	p_partkey = ps_partkey
 	AND s_suppkey = ps_suppkey
 	AND p_size = $1
-	AND p_type LIKE '%BRASS'
+	AND p_type LIKE '%%BRASS'
 	AND s_nationkey = n_nationkey
 	AND n_regionkey = r_regionkey
 	AND r_name = 'EUROPE'
@@ -334,7 +334,7 @@ ORDER BY
 """
 SELECT
 	100.00 * sum(CASE
-		WHEN p_type LIKE 'PROMO%'
+		WHEN p_type LIKE 'PROMO%%'
 			THEN l_extendedprice * (1 - l_discount)
 		ELSE 0
 	END) / sum(l_extendedprice * (1 - l_discount)) AS promo_revenue
@@ -438,7 +438,7 @@ WHERE
 				FROM
 					part
 				WHERE
-					p_name LIKE 'forest%'
+					p_name LIKE 'forest%%'
 			)
 			AND ps_availqty > (
 				SELECT
@@ -508,14 +508,14 @@ ORDER BY
 # find and replace it with a valid connection string.
 
 [databases.vec-off]
-addr = "PG_Connection_String"
+addr = "%[1]s"
 allowmutations = true
 initsql = """
 set vectorize=off;
 """
 
 [databases.vec-on]
-addr = "PG_Connection_String"
+addr = "%[1]s"
 allowmutations = true
 initsql = """
 set vectorize=on;


### PR DESCRIPTION
There are a few roachtests that rely on config or helper files that must be copied onto the crdb nodes for the test
to function.

A previous approach to this was to use c.Put() to copy the file from the test runner to the node. However, this requires hardcoding the relative path of the file from the roachtest runner.

By embedding these files instead, the dependency switches to where the helper file lives relative to the test that
needs it, something that is much less likely to change.

Release note: none
Fixes: none
Epic: none