### PR TITLE
roachtest: use simple name generation in sqlsmith

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -332,6 +332,7 @@ func runOneRoundQueryComparison(
 			sqlsmith.LowProbabilityWhereClauseWithJoinTables(),
 			sqlsmith.SetComplexity(.3),
 			sqlsmith.SetScalarComplexity(.1),
+			sqlsmith.SimpleNames(),
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -399,7 +400,9 @@ func newMutatingSmither(
 		sqlsmith.FavorCommonData(), sqlsmith.UnlikelyRandomNulls(),
 		sqlsmith.DisableInsertSelect(), sqlsmith.DisableCrossJoins(),
 		sqlsmith.SetComplexity(.05),
-		sqlsmith.SetScalarComplexity(.01))
+		sqlsmith.SetScalarComplexity(.01),
+		sqlsmith.SimpleNames(),
+	)
 	if disableDelete {
 		smitherOpts = append(smitherOpts, sqlsmith.InsUpdOnly())
 	} else {

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -155,6 +155,7 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 		}
 		logStmt(setStmtTimeout)
 
+		setting.Options = append(setting.Options, sqlsmith.SimpleNames())
 		smither, err := sqlsmith.NewSmither(conn, rng, setting.Options...)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -136,7 +136,7 @@ func runOneTLP(
 	// statements with the MutationsOnly option. Smither.GenerateTLP always
 	// returns SELECT queries, so the MutationsOnly option is used only for
 	// randomly mutating the database.
-	mutSmither, err := sqlsmith.NewSmither(conn, rnd, sqlsmith.MutationsOnly())
+	mutSmither, err := sqlsmith.NewSmither(conn, rnd, sqlsmith.MutationsOnly(), sqlsmith.SimpleNames())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,8 @@ func runOneTLP(
 
 	// Initialize a smither that will never generate mutations.
 	tlpSmither, err := sqlsmith.NewSmither(conn, rnd,
-		sqlsmith.DisableMutations(), sqlsmith.DisableNondeterministicFns())
+		sqlsmith.DisableMutations(), sqlsmith.DisableNondeterministicFns(), sqlsmith.SimpleNames(),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/smith/main.go
+++ b/pkg/cmd/smith/main.go
@@ -77,6 +77,7 @@ var (
 		"OutputSort":                              sqlsmith.OutputSort(),
 		"PostgresMode":                            sqlsmith.PostgresMode(),
 		"SimpleDatums":                            sqlsmith.SimpleDatums(),
+		"SimpleNames":                             sqlsmith.SimpleNames(),
 		"UnlikelyConstantPredicate":               sqlsmith.UnlikelyConstantPredicate(),
 		"UnlikelyRandomNulls":                     sqlsmith.UnlikelyRandomNulls(),
 	}


### PR DESCRIPTION
This effectively reverses 450e5bf83b2f62476ff9ff612a8b7282f52d815f when the sqlsmith is used in the roachtest (which should make it easier to reproduce the failures).

Note that the complex name generation will keep on being used in TestRandomSyntax, so we shouldn't really lose test coverage because of this change.

Epic: None

Release note: None