### PR TITLE
schemachanger: support CREATE SCHEMA ... AUTHORIZATION

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -573,6 +573,9 @@ CREATE USER user1;
 statement ok
 CREATE SCHEMA AUTHORIZATION user1
 
+statement error pq: role/user "typo" does not exist
+CREATE SCHEMA AUTHORIZATION typo
+
 statement error pq: schema "user1" already exists
 CREATE SCHEMA AUTHORIZATION user1
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_schema.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_schema.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -72,9 +71,17 @@ func CreateSchema(b BuildCtx, n *tree.CreateSchema) {
 	// via AUTHORIZATION clause.
 	owner := b.CurrentUser()
 	if !n.AuthRole.Undefined() {
-		// TODO (xiang): Support "CREATE SCHEMA AUTHORIZATION <owner>".
-		panic(scerrors.NotImplementedErrorf(n, "create schema specifying owner with "+
-			"AUTHORIZATION is not implemented yet"))
+		authRole, err := decodeusername.FromRoleSpec(
+			b.SessionData(), username.PurposeValidation, n.AuthRole,
+		)
+		if err != nil {
+			panic(err)
+		}
+		// Block CREATE SCHEMA AUTHORIZATION "foo" when "foo" isn't an existing user.
+		if err = b.CheckRoleExists(b, authRole); err != nil {
+			panic(sqlerrors.NewUndefinedUserError(authRole))
+		}
+		owner = authRole
 	}
 
 	// 6. Finally, create and add constituent elements to builder state.

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_create
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_create
@@ -7,10 +7,6 @@ CREATE DATABASE db PRIMARY REGION "us-east1" REGIONS "us-east1", "us-central1", 
 ----
 
 unimplemented
-CREATE SCHEMA sc AUTHORIZATION roacher;
-----
-
-unimplemented
 CREATE TYPE typ AS ENUM('a','b');
 ----
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.definition
@@ -1,3 +1,7 @@
+setup
+CREATE USER foo WITH LOGIN PASSWORD 'bar';
+----
+
 test
-CREATE SCHEMA sc;
+CREATE SCHEMA sc AUTHORIZATION foo;
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.explain
@@ -1,9 +1,10 @@
 /* setup */
+CREATE USER foo WITH LOGIN PASSWORD 'bar';
 
 /* test */
-EXPLAIN (DDL) CREATE SCHEMA sc;
+EXPLAIN (DDL) CREATE SCHEMA sc AUTHORIZATION foo;
 ----
-Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›;
+Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc› AUTHORIZATION foo;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 6 elements transitioning toward PUBLIC
@@ -18,7 +19,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›;
  │              ├── SetNameInDescriptor {"DescriptorID":104,"Name":"sc"}
  │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"sc"}}
  │              ├── AddSchemaParent {"Parent":{"ParentDatabaseID":100,"SchemaID":104}}
- │              ├── UpdateOwner {"Owner":{"DescriptorID":104,"Owner":"root"}}
+ │              ├── UpdateOwner {"Owner":{"DescriptorID":104,"Owner":"foo"}}
  │              ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":104,"Privileges":2,"UserName":"admin","WithGrantOption":2}}
  │              ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":104,"Privileges":2,"UserName":"root","WithGrantOption":2}}
  │              └── MarkDescriptorAsPublic {"DescriptorID":104}
@@ -46,7 +47,7 @@ Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›;
                 ├── SetNameInDescriptor {"DescriptorID":104,"Name":"sc"}
                 ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"sc"}}
                 ├── AddSchemaParent {"Parent":{"ParentDatabaseID":100,"SchemaID":104}}
-                ├── UpdateOwner {"Owner":{"DescriptorID":104,"Owner":"root"}}
+                ├── UpdateOwner {"Owner":{"DescriptorID":104,"Owner":"foo"}}
                 ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":104,"Privileges":2,"UserName":"admin","WithGrantOption":2}}
                 ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":104,"Privileges":2,"UserName":"root","WithGrantOption":2}}
                 └── MarkDescriptorAsPublic {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.explain_shape
@@ -1,7 +1,8 @@
 /* setup */
+CREATE USER foo WITH LOGIN PASSWORD 'bar';
 
 /* test */
-EXPLAIN (DDL, SHAPE) CREATE SCHEMA sc;
+EXPLAIN (DDL, SHAPE) CREATE SCHEMA sc AUTHORIZATION foo;
 ----
-Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc›;
+Schema change plan for CREATE SCHEMA ‹defaultdb›.‹sc› AUTHORIZATION foo;
  └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_schema/create_schema.side_effects
@@ -1,20 +1,22 @@
 /* setup */
+CREATE USER foo WITH LOGIN PASSWORD 'bar';
 ----
-
+...
 
 /* test */
-CREATE SCHEMA sc;
+CREATE SCHEMA sc AUTHORIZATION foo;
 ----
 begin transaction #1
 # begin StatementPhase
 checking for feature: CREATE SCHEMA
 increment telemetry for sql.schema.create_schema
+checking role/user "foo" exists
 write *eventpb.CreateSchema to event log:
-  owner: root
+  owner: foo
   schemaName: defaultdb.sc
   sql:
     descriptorId: 104
-    statement: CREATE SCHEMA ‹defaultdb›.‹sc›
+    statement: CREATE SCHEMA ‹defaultdb›.‹sc› AUTHORIZATION foo
     tag: CREATE SCHEMA
     user: root
 ## StatementPhase stage 1 of 1 with 8 MutationType ops
@@ -27,7 +29,7 @@ upsert descriptor #104
   +  name: sc
   +  parentId: 100
   +  privileges:
-  +    ownerProto: root
+  +    ownerProto: foo
   +    users:
   +    - privileges: "2"
   +      userProto: admin
@@ -60,7 +62,7 @@ upsert descriptor #104
   +  name: sc
   +  parentId: 100
   +  privileges:
-  +    ownerProto: root
+  +    ownerProto: foo
   +    users:
   +    - privileges: "2"
   +      userProto: admin


### PR DESCRIPTION
This patch enables support for `CREATE SCHEMA ... AUTHORIZATION` in the declarative schema changer

Fixes: https://github.com/cockroachdb/cockroach/issues/115369
Epic: [CRDB-31331](https://cockroachlabs.atlassian.net/browse/CRDB-31331)

Release note: None