### PR TITLE
ui: rewrite query in db details page to retrieve distinct store ids

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
@@ -39,8 +39,7 @@ const withLoadingIndicator: DatabaseTablePageProps = {
     queryError: undefined,
     createStatement: { create_statement: "" },
     replicaData: {
-      nodeIDs: [],
-      nodeCount: 0,
+      storeIDs: [],
       replicaCount: 0,
     },
     indexData: { columns: [], indexes: [] },
@@ -105,8 +104,7 @@ const withData: DatabaseTablePageProps = {
     `,
     },
     replicaData: {
-      nodeIDs: [1, 2, 3, 4, 5, 6, 7],
-      nodeCount: 7,
+      storeIDs: [1, 2, 3, 4, 5, 6, 7],
       replicaCount: 7,
     },
     indexData: {

--- a/pkg/ui/workspaces/cluster-ui/src/databases/combiners.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databases/combiners.ts
@@ -147,7 +147,7 @@ const deriveDatabaseTableDetails = (
   const normalizedPrivileges = normalizePrivileges(
     [].concat(...grants.map(grant => grant.privileges)),
   );
-  const nodes = results?.stats.replicaData.nodeIDs || [];
+  const storeIDs = results?.stats.replicaData.storeIDs || [];
   return {
     name: table,
     loading: !!details?.inFlight,
@@ -164,8 +164,13 @@ const deriveDatabaseTableDetails = (
       statsLastUpdated: results?.heuristicsDetails,
       indexStatRecs: results?.stats.indexStats,
       spanStats: results?.stats.spanStats,
-      nodes: nodes,
-      nodesByRegionString: getNodesByRegionString(nodes, nodeRegions, isTenant),
+      // TODO #118957 (xinhaoz) Store IDs and node IDs cannot be used interchangeably.
+      nodes: storeIDs,
+      nodesByRegionString: getNodesByRegionString(
+        storeIDs,
+        nodeRegions,
+        isTenant,
+      ),
     },
   };
 };
@@ -188,7 +193,7 @@ export const deriveTablePageDetailsMemoized = createSelector(
         user: grant.user,
         privileges: normalizePrivileges(grant.privileges),
       })) || [];
-    const nodes = results?.stats.replicaData.nodeIDs || [];
+    const nodes = results?.stats.replicaData.storeIDs || [];
     return {
       loading: !!details?.inFlight,
       loaded: !!details?.valid,

--- a/pkg/ui/workspaces/cluster-ui/src/store/databaseTableDetails/tableDetails.saga.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databaseTableDetails/tableDetails.saga.spec.ts
@@ -84,8 +84,7 @@ describe("TableDetails sagas", () => {
           live_percentage: 75,
         },
         replicaData: {
-          nodeIDs: [1, 2, 3],
-          nodeCount: 3,
+          storeIDs: [1, 2, 3],
           replicaCount: 3,
         },
         indexStats: {

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -383,7 +383,7 @@ describe("rest api", function () {
           },
           // Table replicas query
           {
-            rows: [{ replicas: [1, 2, 3] }],
+            rows: [{ store_ids: [1, 2, 3], replica_count: 400 }],
           },
         ],
       );
@@ -425,9 +425,7 @@ describe("rest api", function () {
           expect(resp.results.zoneConfigResp.zone_config_level).toBe(
             ZoneConfigurationLevel.DATABASE,
           );
-          expect(resp.results.stats.replicaData.replicaCount).toBe(3);
-          expect(resp.results.stats.replicaData.nodeCount).toBe(3);
-          expect(resp.results.stats.replicaData.nodeIDs).toEqual([1, 2, 3]);
+          expect(resp.results.stats.replicaData.storeIDs).toEqual([1, 2, 3]);
         });
     });
 

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
@@ -320,7 +320,7 @@ describe("Database Details Page", function () {
         {},
         // Table replicas query
         {
-          rows: [{ replicas: [1, 2, 3] }],
+          rows: [{ store_ids: [1, 2, 3], replica_count: 5 }],
         },
       ],
     );
@@ -370,7 +370,7 @@ describe("Database Details Page", function () {
         {},
         // Table replicas query
         {
-          rows: [{ replicas: [1, 2, 3, 4, 5] }],
+          rows: [{ store_ids: [1, 2, 3, 4, 5], replica_count: 5 }],
         },
       ],
     );

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
@@ -279,7 +279,7 @@ describe("Database Table Page", function () {
         {},
         // Table replicas query
         {
-          rows: [{ replicas: [1, 2, 3, 4, 5] }],
+          rows: [{ store_ids: [1, 2, 3, 4, 5], replica_count: 10 }],
         },
       ],
     );
@@ -292,7 +292,7 @@ describe("Database Table Page", function () {
       requestError: null,
       queryError: undefined,
       createStatement: { create_statement: "CREATE TABLE foo" },
-      replicaData: { replicaCount: 5, nodeCount: 5, nodeIDs: [1, 2, 3, 4, 5] },
+      replicaData: { storeIDs: [1, 2, 3, 4, 5], replicaCount: 10 },
       spanStats: {
         approximate_disk_bytes: 23,
         live_bytes: 45,


### PR DESCRIPTION
Previously a query for the db details page that is used to retrieve store ids per table returned all store ids per range such that the deduplication of the store ids would occur on the client side. Returning 1 row per range for a table can quickly get out of hand if the table has lots of ranges - this can then be the cause of a 'max size exceeded' error on the client. We will now use DISTINCT to dedup the results in query execution to reduce the response size. This can fix issues where not all store ids are being shown for a table because the response does not contain the full list of ranges.


The new query also fixes a bug where the replicas count was being misrepresented as the size of the set of stores for the table.

Epic: none
Part of: #114690

Release note: None

<img width="1588" alt="image" src="https://github.com/cockroachdb/cockroach/assets/20136951/cf95df6e-62d6-48cc-8032-b6e885d42877">
