### PR TITLE
release-23.1: roachtest: use simple name generation in sqlsmith

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -201,6 +201,7 @@ func runOneRoundQueryComparison(
 		sqlsmith.LowProbabilityWhereClauseWithJoinTables(),
 		sqlsmith.SetComplexity(.3),
 		sqlsmith.SetScalarComplexity(.1),
+		sqlsmith.SimpleNames(),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -265,7 +266,9 @@ func newMutatingSmither(
 		sqlsmith.FavorCommonData(), sqlsmith.UnlikelyRandomNulls(),
 		sqlsmith.DisableInsertSelect(), sqlsmith.DisableCrossJoins(),
 		sqlsmith.SetComplexity(.05),
-		sqlsmith.SetScalarComplexity(.01))
+		sqlsmith.SetScalarComplexity(.01),
+		sqlsmith.SimpleNames(),
+	)
 	if disableDelete {
 		smitherOpts = append(smitherOpts, sqlsmith.InsUpdOnly())
 	} else {

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -155,6 +155,7 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 		}
 		logStmt(setStmtTimeout)
 
+		setting.Options = append(setting.Options, sqlsmith.SimpleNames())
 		smither, err := sqlsmith.NewSmither(conn, rng, setting.Options...)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -135,7 +135,7 @@ func runOneTLP(
 	// statements with the MutationsOnly option. Smither.GenerateTLP always
 	// returns SELECT queries, so the MutationsOnly option is used only for
 	// randomly mutating the database.
-	mutSmither, err := sqlsmith.NewSmither(conn, rnd, sqlsmith.MutationsOnly())
+	mutSmither, err := sqlsmith.NewSmither(conn, rnd, sqlsmith.MutationsOnly(), sqlsmith.SimpleNames())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,8 @@ func runOneTLP(
 
 	// Initialize a smither that will never generate mutations.
 	tlpSmither, err := sqlsmith.NewSmither(conn, rnd,
-		sqlsmith.DisableMutations(), sqlsmith.DisableNondeterministicFns())
+		sqlsmith.DisableMutations(), sqlsmith.DisableNondeterministicFns(), sqlsmith.SimpleNames(),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/smith/main.go
+++ b/pkg/cmd/smith/main.go
@@ -77,6 +77,7 @@ var (
 		"OutputSort":                              sqlsmith.OutputSort(),
 		"PostgresMode":                            sqlsmith.PostgresMode(),
 		"SimpleDatums":                            sqlsmith.SimpleDatums(),
+		"SimpleNames":                             sqlsmith.SimpleNames(),
 		"UnlikelyConstantPredicate":               sqlsmith.UnlikelyConstantPredicate(),
 		"UnlikelyRandomNulls":                     sqlsmith.UnlikelyRandomNulls(),
 	}

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -59,14 +59,17 @@ const retryCount = 20
 
 // Smither is a sqlsmith generator.
 type Smither struct {
-	rnd              *rand.Rand
-	db               *gosql.DB
-	lock             syncutil.RWMutex
-	dbName           string
-	schemas          []*schemaRef
-	tables           []*tableRef
-	columns          map[tree.TableName]map[tree.Name]*tree.ColumnTableDef
-	indexes          map[tree.TableName]map[tree.Name]*tree.CreateIndex
+	rnd     *rand.Rand
+	db      *gosql.DB
+	lock    syncutil.RWMutex
+	dbName  string
+	schemas []*schemaRef
+	tables  []*tableRef
+	columns map[tree.TableName]map[tree.Name]*tree.ColumnTableDef
+	indexes map[tree.TableName]map[tree.Name]*tree.CreateIndex
+	// Only one of nameCounts and nameGens will be used. nameCounts is used when
+	// simpleNames is true.
+	nameCounts       map[string]int
 	nameGens         map[string]*nameGenInfo
 	nameGenCfg       randidentcfg.Config
 	activeSavepoints []string
@@ -87,6 +90,7 @@ type Smither struct {
 	disableWindowFuncs         bool
 	disableAggregateFuncs      bool
 	simpleDatums               bool
+	simpleNames                bool
 	avoidConsts                bool
 	outputSort                 bool
 	postgres                   bool
@@ -125,6 +129,7 @@ func NewSmither(db *gosql.DB, rnd *rand.Rand, opts ...SmitherOption) (*Smither, 
 	s := &Smither{
 		rnd:        rnd,
 		db:         db,
+		nameCounts: map[string]int{},
 		nameGens:   map[string]*nameGenInfo{},
 		nameGenCfg: randident.DefaultNameGeneratorConfig(),
 
@@ -203,6 +208,11 @@ type nameGenInfo struct {
 func (s *Smither) name(prefix string) tree.Name {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	if s.simpleNames {
+		s.nameCounts[prefix]++
+		count := s.nameCounts[prefix]
+		return tree.Name(fmt.Sprintf("%s_%d", prefix, count))
+	}
 	g := s.nameGens[prefix]
 	if g == nil {
 		g = &nameGenInfo{
@@ -374,6 +384,11 @@ func DisableCRDBFns() SmitherOption {
 // SimpleDatums causes the Smither to emit simpler constant datums.
 var SimpleDatums = simpleOption("simple datums", func(s *Smither) {
 	s.simpleDatums = true
+})
+
+// SimpleNames specifies that complex name generation should be disabled.
+var SimpleNames = simpleOption("simple names", func(s *Smither) {
+	s.simpleNames = true
 })
 
 // MutationsOnly causes the Smither to emit 80% INSERT, 10% UPDATE, and 10%


### PR DESCRIPTION
Backport 1/1 commits from #118989.

/cc @cockroachdb/release

---

This effectively reverses 450e5bf83b2f62476ff9ff612a8b7282f52d815f when the sqlsmith is used in the roachtest (which should make it easier to reproduce the failures).

Note that the complex name generation will keep on being used in TestRandomSyntax, so we shouldn't really lose test coverage because of this change.

Epic: None

Release note: None

Release justification: test-only change.