### PR TITLE
streamingccl: deflake post cutover retention job checker

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -263,6 +263,7 @@ ORDER BY created DESC LIMIT 1`, c.Args.DestTenantName)
 			payload := jobutils.GetJobPayload(c.T, c.DestSysSQL, retentionJobID)
 			require.Contains(c.T, payload.Error, "replication stream")
 			require.Contains(c.T, payload.Error, "timed out")
+			return nil
 		}
 		return errors.Newf("Unexpected status %s", status)
 	})


### PR DESCRIPTION
After a c2c e2e test, the test driver checks that a post cutover retention job began. Peviously, the driver would trigger a failure if the retention failed on a expiration timeout, even though this is expected behavior. This patch prevents the checker from failing on this expected behavior.

Fixes #118623

Release note: none