### PR TITLE
workload/schemachange: ignore constraint error for payload col

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -220,6 +220,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sqlerrors",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/testutils",


### PR DESCRIPTION
This patch ignores an error that occurs during a well timed upgrade, concurrently running with schema changes from our workload. More details are described here[TODO LINK], but since this issue will be quite rare and non-detrimental, we will ignore it in our workload.

Fixes:
Epic:

Release note: None