### PR TITLE
allocatorimpl: return why lease should be transferred

### DIFF
--- a/pkg/kv/kvserver/allocator/plan/replicate.go
+++ b/pkg/kv/kvserver/allocator/plan/replicate.go
@@ -204,8 +204,8 @@ func (rp ReplicaPlanner) ShouldPlanChange(
 	}
 
 	// If the lease is valid, check to see if we should transfer it.
-	if canTransferLeaseFrom(ctx, repl, conf) &&
-		rp.allocator.ShouldTransferLease(
+	if canTransferLeaseFrom(ctx, repl, conf) {
+		decision := rp.allocator.ShouldTransferLease(
 			ctx,
 			rp.storePool,
 			desc,
@@ -213,9 +213,12 @@ func (rp ReplicaPlanner) ShouldPlanChange(
 			voterReplicas,
 			repl,
 			repl.RangeUsageInfo(),
-		) {
-		log.KvDistribution.VEventf(ctx, 2, "lease transfer needed, enqueuing")
-		return true, 0
+		)
+		if decision.ShouldTransfer() {
+			log.KvDistribution.VEventf(ctx,
+				2, "lease transfer needed %v, enqueuing", decision)
+			return true, 0
+		}
 	}
 
 	leaseStatus := repl.LeaseStatusAt(ctx, now)

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -93,9 +93,10 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"LeaseTransferOutcome": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocatorimpl": {
-						"AllocatorAction":   {},
-						"TargetReplicaType": {},
-						"ReplicaStatus":     {},
+						"AllocatorAction":       {},
+						"TargetReplicaType":     {},
+						"ReplicaStatus":         {},
+						"TransferLeaseDecision": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/load": {
 						"Dimension": {},


### PR DESCRIPTION
ShouldTransferLease` is used to determine whether a replica should be
enqueued for a later lease transfer. The reason the lease should be
transferred could be due to preferences, IO overload or balance. Include
the reason why the lease should be transferred, or why the lease should
not be transferred.

Part of: #118966
Release note: None
