### PR TITLE
server: fix MigrationServer.SyncAllEngines

### DIFF
--- a/pkg/server/migration.go
+++ b/pkg/server/migration.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -169,8 +170,7 @@ func (m *migrationServer) SyncAllEngines(
 		m.server.node.waitForAdditionalStoreInit()
 
 		for _, eng := range m.server.engines {
-			batch := eng.NewBatch()
-			if err := batch.LogData(nil); err != nil {
+			if err := storage.WriteSyncNoop(eng); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Since its introduction in 89781b1cd MigrationServer.SyncAllEngines has been a noop. The RPC constructed LogData batches without committing them.

I noticed this during code inspection of LogData usages after finding cockroachdb/pebble#3286.

Epic: none
Release note: none