### PR TITLE
storage: plumbing for DiskWriteCategory for categorized disk write metrics

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1613,11 +1613,9 @@ def go_deps():
         patches = [
             "@com_github_cockroachdb_cockroach//build/patches:com_github_cockroachdb_pebble.patch",
         ],
-        sha256 = "06cbd97d50b1ca2cdd3795b467fb6e3b36ed7bc3c7590cca1004f3337153def2",
-        strip_prefix = "github.com/cockroachdb/pebble@v0.0.0-20240206033832-e49380ba5068",
-        urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/cockroachdb/pebble/com_github_cockroachdb_pebble-v0.0.0-20240206033832-e49380ba5068.zip",
-        ],
+	vcs = "git",
+	remote = "https://github.com/CheranMahalingam/Pebble",
+	commit = "b8c324320e07f3868cd8c455f1c7c7a22049e123",
     )
     go_repository(
         name = "com_github_cockroachdb_redact",

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -782,7 +782,7 @@ func maxInflightBytesFrom(maxInflightMsgs int, maxSizePerMsg uint64) uint64 {
 	return math.MaxUint64
 }
 
-// StorageConfig contains storage configs for all storage engine.
+// StorageConfig contains storage configs for all storage engines.
 type StorageConfig struct {
 	Attrs roachpb.Attributes
 	// Dir is the data directory for the Pebble instance.

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs.go
@@ -112,8 +112,8 @@ type encryptedFS struct {
 }
 
 // Create implements vfs.FS.Create.
-func (fs *encryptedFS) Create(name string) (vfs.File, error) {
-	f, err := fs.FS.Create(name)
+func (fs *encryptedFS) Create(name string, category vfs.DiskWriteCategory) (vfs.File, error) {
+	f, err := fs.FS.Create(name, category)
 	if err != nil {
 		return f, err
 	}
@@ -230,13 +230,15 @@ func (fs *encryptedFS) Rename(oldname, newname string) error {
 // like non-empty WAL files with zero readable entries. There is a todo in env_encryption.cc
 // to change this RocksDB behavior. We need to handle a user switching from Pebble to RocksDB,
 // so cannot generate WAL files that RocksDB will complain about.
-func (fs *encryptedFS) ReuseForWrite(oldname, newname string) (vfs.File, error) {
+func (fs *encryptedFS) ReuseForWrite(
+	oldname, newname string, category vfs.DiskWriteCategory,
+) (vfs.File, error) {
 	// This is slower than simply calling Create(newname) since the Remove() and Create()
 	// will write and sync the file registry file twice. We can optimize this if needed.
 	if err := fs.Remove(oldname); err != nil {
 		return nil, err
 	}
-	return fs.Create(newname)
+	return fs.Create(newname, category)
 }
 
 type encryptionStatsHandler struct {

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -55,7 +55,7 @@ func TestEncryptedFS(t *testing.T) {
 	for i := 0; i < keyIDLength+16; i++ {
 		b = append(b, 'a')
 	}
-	f, err := memFS.Create("keyfile")
+	f, err := memFS.Create("keyfile", storage.UnspecifiedWriteCategory)
 	require.NoError(t, err)
 	bReader := bytes.NewReader(b)
 	_, err = io.Copy(f, bReader)
@@ -128,7 +128,7 @@ func TestEncryptedFS(t *testing.T) {
 		)
 		switch s[0] {
 		case "create":
-			g, err = fs.Create(s[1])
+			g, err = fs.Create(s[1], storage.UnspecifiedWriteCategory)
 		case "link":
 			err = fs.Link(s[1], s[2])
 		case "open":
@@ -140,7 +140,7 @@ func TestEncryptedFS(t *testing.T) {
 		case "rename":
 			err = fs.Rename(s[1], s[2])
 		case "reuseForWrite":
-			g, err = fs.ReuseForWrite(s[1], s[2])
+			g, err = fs.ReuseForWrite(s[1], s[2], storage.UnspecifiedWriteCategory)
 		case "f.write":
 			_, err = f.Write([]byte(s[1]))
 		case "f.read":
@@ -215,7 +215,7 @@ func TestEncryptedFSUnencryptedFiles(t *testing.T) {
 	var filesCreated []string
 	for i := 0; i < 5; i++ {
 		filename := fmt.Sprintf("file%d", i)
-		f, err := fs.Create(filename)
+		f, err := fs.Create(filename, storage.UnspecifiedWriteCategory)
 		require.NoError(t, err)
 		filesCreated = append(filesCreated, filename)
 		require.NoError(t, f.Close())
@@ -612,7 +612,7 @@ func (op *createOp) run(t *fsTest) {
 	// Create is idempotent, so we simply retry on injected errors.
 	withRetry(t, func() error {
 		var f vfs.File
-		f, err := t.fs.fs().Create(op.name)
+		f, err := t.fs.fs().Create(op.name, storage.UnspecifiedWriteCategory)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
+++ b/pkg/ccl/storageccl/engineccl/pebble_key_manager.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -438,7 +439,7 @@ func (m *DataKeyManager) rotateDataKeyAndWrite(
 	// The new file's filename incorporates the marker's iteration
 	// number to ensure we're not overwriting the existing registry.
 	filename := fmt.Sprintf("%s_%06d_%s", keyRegistryFilename, m.mu.marker.NextIter(), registryFormatMonolith)
-	f, err := m.fs.Create(m.fs.PathJoin(m.dbDir, filename))
+	f, err := m.fs.Create(m.fs.PathJoin(m.dbDir, filename), storage.EncryptionRegistryWriteCategory)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/storageccl/engineccl/pebble_key_manager_test.go
+++ b/pkg/ccl/storageccl/engineccl/pebble_key_manager_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -33,7 +34,7 @@ import (
 )
 
 func writeToFile(t *testing.T, fs vfs.FS, filename string, b []byte) {
-	f, err := fs.Create(filename)
+	f, err := fs.Create(filename, storage.UnspecifiedWriteCategory)
 	require.NoError(t, err)
 	breader := bytes.NewReader(b)
 	_, err = io.Copy(f, breader)
@@ -466,9 +467,9 @@ type loggingFS struct {
 	w io.Writer
 }
 
-func (fs loggingFS) Create(name string) (vfs.File, error) {
+func (fs loggingFS) Create(name string, category vfs.DiskWriteCategory) (vfs.File, error) {
 	fmt.Fprintf(fs.w, "create(%q)\n", name)
-	f, err := fs.FS.Create(name)
+	f, err := fs.FS.Create(name, category)
 	if err != nil {
 		return nil, err
 	}
@@ -508,9 +509,11 @@ func (fs loggingFS) Rename(oldname, newname string) error {
 	return fs.FS.Rename(oldname, newname)
 }
 
-func (fs loggingFS) ReuseForWrite(oldname, newname string) (vfs.File, error) {
+func (fs loggingFS) ReuseForWrite(
+	oldname, newname string, category vfs.DiskWriteCategory,
+) (vfs.File, error) {
 	fmt.Fprintf(fs.w, "reuseForWrite(%q, %q)\n", oldname, newname)
-	f, err := fs.FS.ReuseForWrite(oldname, newname)
+	f, err := fs.FS.ReuseForWrite(oldname, newname, category)
 	if err == nil {
 		f = loggingFile{f, newname, fs.w}
 	}

--- a/pkg/cli/auto_decrypt_fs.go
+++ b/pkg/cli/auto_decrypt_fs.go
@@ -54,7 +54,7 @@ func (afs *autoDecryptFS) Init(encryptedDirs []string, resolveFn resolveEncrypte
 	}
 }
 
-func (afs *autoDecryptFS) Create(name string) (vfs.File, error) {
+func (afs *autoDecryptFS) Create(name string, category vfs.DiskWriteCategory) (vfs.File, error) {
 	name, err := filepath.Abs(name)
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func (afs *autoDecryptFS) Create(name string) (vfs.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	return fs.Create(name)
+	return fs.Create(name, category)
 }
 
 func (afs *autoDecryptFS) Link(oldname, newname string) error {
@@ -94,7 +94,9 @@ func (afs *autoDecryptFS) Open(name string, opts ...vfs.OpenOption) (vfs.File, e
 	return fs.Open(name, opts...)
 }
 
-func (afs *autoDecryptFS) OpenReadWrite(name string, opts ...vfs.OpenOption) (vfs.File, error) {
+func (afs *autoDecryptFS) OpenReadWrite(
+	name string, category vfs.DiskWriteCategory, opts ...vfs.OpenOption,
+) (vfs.File, error) {
 	name, err := filepath.Abs(name)
 	if err != nil {
 		return nil, err
@@ -103,7 +105,7 @@ func (afs *autoDecryptFS) OpenReadWrite(name string, opts ...vfs.OpenOption) (vf
 	if err != nil {
 		return nil, err
 	}
-	return fs.OpenReadWrite(name, opts...)
+	return fs.OpenReadWrite(name, category, opts...)
 }
 
 func (afs *autoDecryptFS) OpenDir(name string) (vfs.File, error) {
@@ -150,7 +152,9 @@ func (afs *autoDecryptFS) Rename(oldname, newname string) error {
 	return fs.Rename(oldname, newname)
 }
 
-func (afs *autoDecryptFS) ReuseForWrite(oldname, newname string) (vfs.File, error) {
+func (afs *autoDecryptFS) ReuseForWrite(
+	oldname, newname string, category vfs.DiskWriteCategory,
+) (vfs.File, error) {
 	oldname, err := filepath.Abs(oldname)
 	if err != nil {
 		return nil, err
@@ -163,7 +167,7 @@ func (afs *autoDecryptFS) ReuseForWrite(oldname, newname string) (vfs.File, erro
 	if err != nil {
 		return nil, err
 	}
-	return fs.ReuseForWrite(oldname, newname)
+	return fs.ReuseForWrite(oldname, newname, category)
 }
 
 func (afs *autoDecryptFS) MkdirAll(dir string, perm os.FileMode) error {

--- a/pkg/cli/auto_decrypt_fs_test.go
+++ b/pkg/cli/auto_decrypt_fs_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/pebble/vfs"
@@ -54,7 +55,7 @@ func TestAutoDecryptFS(t *testing.T) {
 	fs.Init([]string{path1, path2}, resolveFn)
 
 	create := func(pathElems ...string) {
-		file, err := fs.Create(filepath.Join(pathElems...))
+		file, err := fs.Create(filepath.Join(pathElems...), storage.UnspecifiedWriteCategory)
 		require.NoError(t, err)
 		file.Close()
 	}

--- a/pkg/cli/log_flags.go
+++ b/pkg/cli/log_flags.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -188,8 +189,9 @@ func setupLogging(ctx context.Context, cmd *cobra.Command, isServerCmd, applyCon
 		return errors.Wrap(err, "unable to create log directory")
 	}
 
+	logBytesWritten := serverCfg.DiskWriteStatsCollector.CreateStat(storage.CRDBLogWriteCategory)
 	// Configuration ready and directories exist; apply it.
-	logShutdownFn, err := log.ApplyConfig(h.Config)
+	logShutdownFn, err := log.ApplyConfig(h.Config, &log.FileSinkMetrics{LogBytesWritten: logBytesWritten})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -181,7 +181,7 @@ func setLogConfig(baseDir string) {
 	if err := logConf.Validate(&baseDir); err != nil {
 		panic(err)
 	}
-	if _, err := log.ApplyConfig(logConf); err != nil {
+	if _, err := log.ApplyConfig(logConf, &log.FileSinkMetrics{}); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
@@ -44,6 +44,7 @@ func TestInOrderResultsBuffer(t *testing.T) {
 		ctx,
 		base.DefaultTestTempStorageConfig(st),
 		base.DefaultTestStoreSpec,
+		nil,
 	)
 	require.NoError(t, err)
 	defer tempEngine.Close()

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -1250,7 +1250,7 @@ func TestEvalAddSSTable(t *testing.T) {
 							require.Nil(t, result.Replicated.AddSSTable)
 						} else {
 							require.NotNil(t, result.Replicated.AddSSTable)
-							require.NoError(t, fs.WriteFile(engine, "sst", result.Replicated.AddSSTable.Data))
+							require.NoError(t, fs.WriteFile(engine, "sst", result.Replicated.AddSSTable.Data, storage.UnspecifiedWriteCategory))
 							require.NoError(t, engine.IngestLocalFiles(ctx, []string{"sst"}))
 						}
 
@@ -1668,7 +1668,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	_, err := batcheval.EvalAddSSTable(ctx, engine, cArgs, &resp)
 	require.NoError(t, err)
 
-	require.NoError(t, fs.WriteFile(engine, "sst", sst))
+	require.NoError(t, fs.WriteFile(engine, "sst", sst, storage.UnspecifiedWriteCategory))
 	require.NoError(t, engine.IngestLocalFiles(ctx, []string{"sst"}))
 
 	statsEvaled := statsBefore

--- a/pkg/kv/kvserver/client_replica_gc_test.go
+++ b/pkg/kv/kvserver/client_replica_gc_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -116,7 +117,7 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 		if err := eng.MkdirAll(dir, os.ModePerm); err != nil {
 			t.Fatal(err)
 		}
-		if err := fs.WriteFile(eng, filepath.Join(dir, "i1000000.t100000"), []byte("foo")); err != nil {
+		if err := fs.WriteFile(eng, filepath.Join(dir, "i1000000.t100000"), []byte("foo"), storage.UnspecifiedWriteCategory); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/kv/kvserver/kvserverbase/syncing_write.go
+++ b/pkg/kv/kvserver/kvserverbase/syncing_write.go
@@ -86,6 +86,7 @@ func WriteFileSyncing(
 	perm os.FileMode,
 	settings *cluster.Settings,
 	limiter *rate.Limiter,
+	category vfs.DiskWriteCategory,
 ) error {
 	chunkSize := sstWriteSyncRate.Get(&settings.SV)
 	sync := true
@@ -94,7 +95,7 @@ func WriteFileSyncing(
 		sync = false
 	}
 
-	f, err := fs.Create(filename)
+	f, err := fs.Create(filename, category)
 	if err != nil {
 		if strings.Contains(err.Error(), "No such file or directory") {
 			return os.ErrNotExist

--- a/pkg/kv/kvserver/logstore/sideload_disk.go
+++ b/pkg/kv/kvserver/logstore/sideload_disk.go
@@ -91,7 +91,7 @@ func (ss *DiskSideloadStorage) Put(
 	for {
 		// Use 0644 since that's what RocksDB uses:
 		// https://github.com/facebook/rocksdb/blob/56656e12d67d8a63f1e4c4214da9feeec2bd442b/env/env_posix.cc#L171
-		if err := kvserverbase.WriteFileSyncing(ctx, filename, contents, ss.eng, 0644, ss.st, ss.limiter); err == nil {
+		if err := kvserverbase.WriteFileSyncing(ctx, filename, contents, ss.eng, 0644, ss.st, ss.limiter, storage.PebbleIngestionWriteCategory); err == nil {
 			return nil
 		} else if !oserror.IsNotExist(err) {
 			return err

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -259,7 +259,7 @@ func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 		// First add a file that shouldn't be in the sideloaded storage to ensure
 		// sane behavior when directory can't be removed after full truncate.
 		nonRemovableFile := filepath.Join(ss.Dir(), "cantremove.xx")
-		f, err := eng.Create(nonRemovableFile)
+		f, err := eng.Create(nonRemovableFile, storage.UnspecifiedWriteCategory)
 		if err != nil {
 			t.Fatalf("could not create non i*.t* file in sideloaded storage: %+v", err)
 		}
@@ -792,7 +792,7 @@ func TestMkdirAllAndSyncParentsErrors(t *testing.T) {
 		require.NoError(t, mkdirAllAndSyncParents(fs, "/a", os.ModePerm))
 
 		// Write a file, and try to trick mkdir into thinking that it's a directory.
-		f, err := fs.Create("/a/file")
+		f, err := fs.Create("/a/file", storage.UnspecifiedWriteCategory)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 

--- a/pkg/kv/kvserver/loqrecovery/store.go
+++ b/pkg/kv/kvserver/loqrecovery/store.go
@@ -15,6 +15,7 @@ import (
 	"os"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery/loqrecoverypb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/vfs"
@@ -54,7 +55,7 @@ func (s PlanStore) SavePlan(plan loqrecoverypb.ReplicaUpdatePlan) error {
 	defer func() { _ = s.fs.Remove(tmpFileName) }()
 
 	if err := func() error {
-		outFile, err := s.fs.Create(tmpFileName)
+		outFile, err := s.fs.Create(tmpFileName, storage.UnspecifiedWriteCategory)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create file %q", tmpFileName)
 		}

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/vfs"
 	"go.etcd.io/raft/v3/raftpb"
 )
 
@@ -2466,6 +2467,7 @@ type StoreMetrics struct {
 	BatchCommitWALRotWaitDuration     *metric.Gauge
 	BatchCommitCommitWaitDuration     *metric.Gauge
 	categoryIterMetrics               pebbleCategoryIterMetricsContainer
+	categoryDiskWriteMetrics          pebbleCategoryDiskWriteMetricsContainer
 
 	RdbCheckpoints *metric.Gauge
 
@@ -3146,6 +3148,9 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		categoryIterMetrics: pebbleCategoryIterMetricsContainer{
 			registry: storeRegistry,
 		},
+		categoryDiskWriteMetrics: pebbleCategoryDiskWriteMetricsContainer{
+			registry: storeRegistry,
+		},
 		WALBytesWritten: metric.NewGauge(metaWALBytesWritten),
 		WALBytesIn:      metric.NewGauge(metaWALBytesIn),
 
@@ -3552,6 +3557,7 @@ func (sm *StoreMetrics) updateEngineMetrics(m storage.Metrics) {
 	sm.BatchCommitWALRotWaitDuration.Update(int64(m.BatchCommitStats.WALRotationDuration))
 	sm.BatchCommitCommitWaitDuration.Update(int64(m.BatchCommitStats.CommitWaitDuration))
 	sm.categoryIterMetrics.update(m.CategoryStats)
+	sm.categoryDiskWriteMetrics.update(m.DiskWriteStats)
 
 	// Update the maximum number of L0 sub-levels seen.
 	sm.l0SublevelsTracker.Lock()
@@ -3768,5 +3774,48 @@ func (m *pebbleCategoryIterMetricsContainer) update(stats []sstable.CategoryStat
 		}
 		cm := val.(*pebbleCategoryIterMetrics)
 		cm.update(s.CategoryStats)
+	}
+}
+
+type pebbleCategoryDiskWriteMetrics struct {
+	BytesWritten *metric.Gauge
+}
+
+func makePebbleCategorizedWriteMetrics(
+	category vfs.DiskWriteCategory,
+) *pebbleCategoryDiskWriteMetrics {
+	metaDiskBytesWritten := metric.Metadata{
+		Name:        fmt.Sprintf("storage.category-%s.bytes-written", category),
+		Help:        "Bytes written to disk",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
+	return &pebbleCategoryDiskWriteMetrics{BytesWritten: metric.NewGauge(metaDiskBytesWritten)}
+}
+
+// MetricStruct implements the metric.Struct interface.
+func (m *pebbleCategoryDiskWriteMetrics) MetricStruct() {}
+
+func (m *pebbleCategoryDiskWriteMetrics) update(stats vfs.DiskWriteStatsAggregate) {
+	m.BytesWritten.Update(int64(stats.BytesWritten))
+}
+
+type pebbleCategoryDiskWriteMetricsContainer struct {
+	registry *metric.Registry
+	// vfs.DiskWriteCategory => *pebbleCategoryDiskWriteMetrics
+	metricsMap sync.Map
+}
+
+func (m *pebbleCategoryDiskWriteMetricsContainer) update(stats []vfs.DiskWriteStatsAggregate) {
+	for _, s := range stats {
+		val, ok := m.metricsMap.Load(s.Category)
+		if !ok {
+			val, ok = m.metricsMap.LoadOrStore(s.Category, makePebbleCategorizedWriteMetrics(s.Category))
+			if !ok {
+				m.registry.AddMetricStruct(val)
+			}
+		}
+		cm := val.(*pebbleCategoryDiskWriteMetrics)
+		cm.update(s)
 	}
 }

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -826,7 +826,7 @@ creation. These directories should be deleted, or inspected with caution.
 `
 		attentionArgs := []any{r, desc.Replicas(), redact.Safe(auxDir), redact.Safe(path)}
 		preventStartupMsg := fmt.Sprintf(attentionFmt, attentionArgs...)
-		if err := fs.WriteFile(r.store.TODOEngine(), path, []byte(preventStartupMsg)); err != nil {
+		if err := fs.WriteFile(r.store.TODOEngine(), path, []byte(preventStartupMsg), storage.UnspecifiedWriteCategory); err != nil {
 			log.Warningf(ctx, "%v", err)
 		}
 

--- a/pkg/kv/kvserver/replica_corruption.go
+++ b/pkg/kv/kvserver/replica_corruption.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -64,7 +65,7 @@ A file preventing this node from restarting was placed at:
 %s
 `, r, path)
 
-	if err := fs.WriteFile(r.store.TODOEngine(), path, []byte(preventStartupMsg)); err != nil {
+	if err := fs.WriteFile(r.store.TODOEngine(), path, []byte(preventStartupMsg), storage.UnspecifiedWriteCategory); err != nil {
 		log.Warningf(ctx, "%v", err)
 	}
 

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -768,7 +768,7 @@ func ingestViaCopy(
 			return errors.Wrapf(err, "while removing existing file during ingestion of %s", ingestPath)
 		}
 	}
-	if err := kvserverbase.WriteFileSyncing(ctx, ingestPath, sst.Data, eng, 0600, st, limiter); err != nil {
+	if err := kvserverbase.WriteFileSyncing(ctx, ingestPath, sst.Data, eng, 0600, st, limiter, storage.PebbleIngestionWriteCategory); err != nil {
 		return errors.Wrapf(err, "while ingesting %s", ingestPath)
 	}
 	if err := eng.IngestLocalFiles(ctx, []string{ingestPath}); err != nil {

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage.go
@@ -209,9 +209,9 @@ func (f *SSTSnapshotStorageFile) ensureFile() error {
 	}
 	var err error
 	if f.bytesPerSync > 0 {
-		f.file, err = fs.CreateWithSync(f.scratch.storage.engine, f.filename, int(f.bytesPerSync))
+		f.file, err = fs.CreateWithSync(f.scratch.storage.engine, f.filename, int(f.bytesPerSync), storage.RaftSnapshotWriteCategory)
 	} else {
-		f.file, err = f.scratch.storage.engine.Create(f.filename)
+		f.file, err = f.scratch.storage.engine.Create(f.filename, storage.RaftSnapshotWriteCategory)
 	}
 	if err != nil {
 		return err

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -171,6 +171,9 @@ type BaseConfig struct {
 	// run-time metrics instead of constructing a fresh one.
 	RuntimeStatSampler *status.RuntimeStatSampler
 
+	// DiskWriteStatsCollector will be used to track disk write metrics.
+	DiskWriteStatsCollector *vfs.DiskWriteStatsCollector
+
 	// GoroutineDumpDirName is the directory name for goroutine dumps using
 	// goroutinedumper. Only used if DisableRuntimeStatsMonitor is false.
 	GoroutineDumpDirName string
@@ -325,6 +328,7 @@ func (cfg *BaseConfig) SetDefaults(
 	cfg.Config.InitDefaults()
 	cfg.InitTestingKnobs()
 	cfg.EarlyBootExternalStorageAccessor = cloud.NewEarlyBootExternalStorageAccessor(st, cfg.ExternalIODirConfig)
+	cfg.DiskWriteStatsCollector = vfs.NewDiskWriteStatsCollector()
 }
 
 // InitTestingKnobs sets up any testing knobs based on e.g. envvars.
@@ -760,6 +764,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 			storage.Attributes(spec.Attributes),
 			storage.EncryptionAtRest(spec.EncryptionOptions),
 			storage.If(storeKnobs.SmallEngineBlocks, storage.BlockSize(1)),
+			storage.DiskWriteStatsCollector(cfg.DiskWriteStatsCollector),
 		}
 		if len(storeKnobs.EngineKnobs) > 0 {
 			storageConfigOpts = append(storageConfigOpts, storeKnobs.EngineKnobs...)

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -716,7 +716,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	// Set up the DistSQL temp engine.
 
 	useStoreSpec := cfg.TempStorageConfig.Spec
-	tempEngine, tempFS, err := storage.NewTempEngine(ctx, cfg.TempStorageConfig, useStoreSpec)
+	tempEngine, tempFS, err := storage.NewTempEngine(ctx, cfg.TempStorageConfig, useStoreSpec, cfg.DiskWriteStatsCollector)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating temp storage")
 	}

--- a/pkg/sql/colcontainer/BUILD.bazel
+++ b/pkg/sql/colcontainer/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/col/colserde",
         "//pkg/sql/colexecerror",
         "//pkg/sql/types",
+        "//pkg/storage",
         "//pkg/storage/fs",
         "//pkg/util/cancelchecker",
         "//pkg/util/metric",

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/colserde"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -494,7 +495,7 @@ func (d *diskQueue) Close(ctx context.Context) error {
 // to write to.
 func (d *diskQueue) rotateFile(ctx context.Context) error {
 	fName := filepath.Join(d.cfg.GetPather.GetPath(ctx), d.dirName, strconv.Itoa(d.seqNo))
-	f, err := fs.CreateWithSync(d.cfg.FS, fName, bytesPerSync)
+	f, err := fs.CreateWithSync(d.cfg.FS, fName, bytesPerSync, storage.SQLColumnSpillWriteCategory)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/colcontainer/partitionedqueue_test.go
+++ b/pkg/sql/colcontainer/partitionedqueue_test.go
@@ -58,8 +58,8 @@ func (f *fdCountingFS) assertOpenFDs(
 	require.Equal(t, expectedReadFDs, f.readFDs)
 }
 
-func (f *fdCountingFS) Create(name string) (vfs.File, error) {
-	file, err := f.FS.Create(name)
+func (f *fdCountingFS) Create(name string, category vfs.DiskWriteCategory) (vfs.File, error) {
+	file, err := f.FS.Create(name, category)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -285,7 +285,7 @@ func startConnExecutor(
 	nodeID := base.TestingIDContainer
 	distSQLMetrics := execinfra.MakeDistSQLMetrics(time.Hour /* histogramWindow */)
 	gw := gossip.MakeOptionalGossip(nil)
-	tempEngine, tempFS, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, tempFS, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -87,7 +87,7 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, tempFS, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, tempFS, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -101,7 +101,7 @@ func TestDiskRowContainer(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -421,7 +421,7 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,7 +462,7 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	alloc := &tree.DatumAlloc{}
 	evalCtx := eval.MakeTestingEvalContext(st)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -591,7 +591,7 @@ func TestDiskRowContainerUnsafeReset(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rowcontainer/hash_row_container_test.go
+++ b/pkg/sql/rowcontainer/hash_row_container_test.go
@@ -39,7 +39,7 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,7 +325,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rowcontainer/numbered_row_container_test.go
+++ b/pkg/sql/rowcontainer/numbered_row_container_test.go
@@ -57,7 +57,7 @@ func TestNumberedRowContainerDeDuping(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +149,7 @@ func TestNumberedRowContainerIteratorCaching(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +252,7 @@ func TestCompareNumberedAndIndexedRowContainers(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -565,7 +565,7 @@ func BenchmarkNumberedContainerIteratorCaching(b *testing.B) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.TempStorageConfig{InMemory: true, Settings: st}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.TempStorageConfig{InMemory: true, Settings: st}, base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -211,6 +211,7 @@ func TestDiskBackedRowContainer(t *testing.T) {
 			Settings: st,
 		},
 		base.DefaultTestStoreSpec,
+		nil,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -421,6 +422,7 @@ func TestDiskBackedRowContainerDeDuping(t *testing.T) {
 			Settings: st,
 		},
 		base.DefaultTestStoreSpec,
+		nil,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -548,6 +550,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 			Settings: st,
 		},
 		base.DefaultTestStoreSpec,
+		nil,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1023,6 +1026,7 @@ func BenchmarkDiskBackedIndexedRowContainer(b *testing.B) {
 			Settings: st,
 		},
 		base.DefaultTestStoreSpec,
+		nil,
 	)
 	if err != nil {
 		b.Fatal(err)

--- a/pkg/sql/rowexec/hashjoiner_test.go
+++ b/pkg/sql/rowexec/hashjoiner_test.go
@@ -1022,7 +1022,7 @@ func TestHashJoiner(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1113,7 +1113,7 @@ func TestHashJoinerError(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1270,7 +1270,7 @@ func TestHashJoinerDrain(t *testing.T) {
 	evalCtx := eval.MakeTestingEvalContext(st)
 	ctx := context.Background()
 	defer evalCtx.Stop(ctx)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1404,7 +1404,7 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 	evalCtx := eval.MakeTestingEvalContext(st)
 	ctx := context.Background()
 	defer evalCtx.Stop(ctx)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1475,7 +1475,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 		},
 		DiskMonitor: diskMonitor,
 	}
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -630,7 +630,7 @@ func TestInvertedJoiner(t *testing.T) {
 	}
 
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -769,7 +769,7 @@ func TestInvertedJoinerDrain(t *testing.T) {
 	ctx, sp := tracer.StartSpanCtx(context.Background(), "test flow ctx", tracing.WithRecording(tracingpb.RecordingVerbose))
 	defer sp.Finish()
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1055,7 +1055,7 @@ func TestJoinReader(t *testing.T) {
 		},
 	}
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1256,7 +1256,7 @@ CREATE TABLE test.t (a INT, s STRING, INDEX (a, s))`); err != nil {
 	td := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "t")
 
 	st := cluster.MakeTestingClusterSettings()
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1370,7 +1370,7 @@ func TestJoinReaderDrain(t *testing.T) {
 	td := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "t")
 
 	st := s.ClusterSettings()
-	tempEngine, _, err := storage.NewTempEngine(context.Background(), base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(context.Background(), base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1705,7 +1705,7 @@ func benchmarkJoinReader(b *testing.B, bc JRBenchConfig) {
 		Path:     tempStoragePath,
 		Mon:      diskMonitor,
 		Settings: st,
-	}, tempStoreSpec)
+	}, tempStoreSpec, nil)
 	require.NoError(b, err)
 	defer tempEngine.Close()
 	flowCtx.Cfg.TempStorage = tempEngine
@@ -1974,7 +1974,7 @@ func BenchmarkJoinReaderLookupStress(b *testing.B) {
 		Path:     tempStoragePath,
 		Mon:      diskMonitor,
 		Settings: st,
-	}, tempStoreSpec)
+	}, tempStoreSpec, nil)
 	require.NoError(b, err)
 	defer tempEngine.Close()
 	flowCtx.Cfg.TempStorage = tempEngine

--- a/pkg/sql/rowexec/sorter_test.go
+++ b/pkg/sql/rowexec/sorter_test.go
@@ -266,7 +266,7 @@ func TestSorter(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					ctx := context.Background()
 					st := cluster.MakeTestingClusterSettings()
-					tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+					tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/sql/rowexec/windower_test.go
+++ b/pkg/sql/rowexec/windower_test.go
@@ -55,7 +55,7 @@ func TestWindowerAccountingForResults(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -764,7 +764,7 @@ func TestRouterDiskSpill(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -2090,7 +2090,7 @@ func BenchmarkMVCCScannerWithIntentsAndVersions(b *testing.B) {
 			return cmp < 0
 		})
 		sstFileName := fmt.Sprintf("tmp-ingest-%d", i)
-		sstFile, err := eng.Create(sstFileName)
+		sstFile, err := eng.Create(sstFileName, UnspecifiedWriteCategory)
 		require.NoError(b, err)
 		// No improvement with v3 since the multiple versions are in different
 		// files.

--- a/pkg/storage/disk_map_test.go
+++ b/pkg/storage/disk_map_test.go
@@ -180,7 +180,7 @@ func TestPebbleMap(t *testing.T) {
 	e, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{
 		Path:     dir,
 		Settings: cluster.MakeClusterSettings(),
-	}, base.StoreSpec{})
+	}, base.StoreSpec{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +199,7 @@ func TestPebbleMultiMap(t *testing.T) {
 	e, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{
 		Path:     dir,
 		Settings: cluster.MakeClusterSettings(),
-	}, base.StoreSpec{})
+	}, base.StoreSpec{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +218,7 @@ func TestPebbleMapClose(t *testing.T) {
 	e, _, err := newPebbleTempEngine(ctx, base.TempStorageConfig{
 		Path:     dir,
 		Settings: cluster.MakeClusterSettings(),
-	}, base.StoreSpec{})
+	}, base.StoreSpec{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,7 +325,7 @@ func BenchmarkPebbleMapWrite(b *testing.B) {
 	tempEngine, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{
 		Path:     dir,
 		Settings: cluster.MakeClusterSettings(),
-	}, base.DefaultTestStoreSpec)
+	}, base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -366,7 +366,7 @@ func BenchmarkPebbleMapIteration(b *testing.B) {
 	tempEngine, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{
 		Path:     dir,
 		Settings: cluster.MakeClusterSettings(),
-	}, base.DefaultTestStoreSpec)
+	}, base.DefaultTestStoreSpec, nil)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1219,6 +1219,7 @@ type Metrics struct {
 	// distinguished in the pebble logs.
 	WriteStallCount    int64
 	WriteStallDuration time.Duration
+	DiskWriteStats     []vfs.DiskWriteStatsAggregate
 }
 
 // AggregatedIteratorStats holds cumulative stats, collected and summed over all
@@ -2214,3 +2215,12 @@ func getCategoryAndQoS(c ReadCategory) sstable.CategoryAndQoS {
 	}
 	return categoryAndQoS
 }
+
+const (
+	UnspecifiedWriteCategory        = vfs.WriteCategoryUnspecified
+	RaftSnapshotWriteCategory       = "raft-snapshot"
+	SQLColumnSpillWriteCategory     = "sql-col-spill"
+	PebbleIngestionWriteCategory    = "pebble-ingestion"
+	CRDBLogWriteCategory            = "crdb-log"
+	EncryptionRegistryWriteCategory = "encryption-registry"
+)

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1286,9 +1286,9 @@ func TestEngineFS(t *testing.T) {
 		)
 		switch s[0] {
 		case "create":
-			g, err = e.Create(s[1])
+			g, err = e.Create(s[1], UnspecifiedWriteCategory)
 		case "create-with-sync":
-			g, err = fs.CreateWithSync(e, s[1], 1)
+			g, err = fs.CreateWithSync(e, s[1], 1, UnspecifiedWriteCategory)
 		case "link":
 			err = e.Link(s[1], s[2])
 		case "open":
@@ -1393,7 +1393,7 @@ func TestEngineFSFileNotFoundError(t *testing.T) {
 
 	fname := filepath.Join(dir, "random.file")
 	data := "random data"
-	if f, err := db.Create(fname); err != nil {
+	if f, err := db.Create(fname, UnspecifiedWriteCategory); err != nil {
 		t.Fatalf("unable to open file with filename %s, got err %v", fname, err)
 	} else {
 		// Write data to file so we can read it later.
@@ -1478,13 +1478,13 @@ func TestFS(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create a file at a/b/c/foo.
-			f, err := fs.Create(path("a/b/c/foo"))
+			f, err := fs.Create(path("a/b/c/foo"), UnspecifiedWriteCategory)
 			require.NoError(t, err)
 			require.NoError(t, f.Close())
 			expectLS(path("a/b/c"), []string{"foo"})
 
 			// Create a file at a/b/c/bar.
-			f, err = fs.Create(path("a/b/c/bar"))
+			f, err = fs.Create(path("a/b/c/bar"), UnspecifiedWriteCategory)
 			require.NoError(t, err)
 			require.NoError(t, f.Close())
 			expectLS(path("a/b/c"), []string{"bar", "foo"})

--- a/pkg/storage/fs/BUILD.bazel
+++ b/pkg/storage/fs/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "//conditions:default": {"test.Pool": "default"},
     }),
     deps = [
+        "//pkg/storage",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/stop",

--- a/pkg/storage/fs/fs.go
+++ b/pkg/storage/fs/fs.go
@@ -19,8 +19,10 @@ import (
 // CreateWithSync creates a file wrapped with logic to periodically sync
 // whenever more than bytesPerSync bytes accumulate. This syncing does not
 // provide any persistency guarantees, but can prevent latency spikes.
-func CreateWithSync(fs vfs.FS, name string, bytesPerSync int) (vfs.File, error) {
-	f, err := fs.Create(name)
+func CreateWithSync(
+	fs vfs.FS, name string, bytesPerSync int, category vfs.DiskWriteCategory,
+) (vfs.File, error) {
+	f, err := fs.Create(name, category)
 	if err != nil {
 		return nil, err
 	}
@@ -28,8 +30,8 @@ func CreateWithSync(fs vfs.FS, name string, bytesPerSync int) (vfs.File, error) 
 }
 
 // WriteFile writes data to a file named by filename.
-func WriteFile(fs vfs.FS, filename string, data []byte) error {
-	f, err := fs.Create(filename)
+func WriteFile(fs vfs.FS, filename string, data []byte, category vfs.DiskWriteCategory) error {
+	f, err := fs.Create(filename, category)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/fs/safewrite.go
+++ b/pkg/storage/fs/safewrite.go
@@ -20,15 +20,17 @@ import (
 const tempFileExtension = ".crdbtmp"
 
 // SafeWriteToFile writes the byte slice to the filename, contained in dir,
-// using the given fs.  It returns after both the file and the containing
+// using the given fs. It returns after both the file and the containing
 // directory are synced.
-func SafeWriteToFile(fs vfs.FS, dir string, filename string, b []byte) error {
+func SafeWriteToFile(
+	fs vfs.FS, dir string, filename string, b []byte, category vfs.DiskWriteCategory,
+) error {
 	// TODO(jackson): Assert that fs supports atomic renames once Pebble
 	// is bumped to the appropriate SHA and non-atomic use cases are
 	// updated to avoid this method.
 
 	tempName := filename + tempFileExtension
-	f, err := fs.Create(tempName)
+	f, err := fs.Create(tempName, category)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/fs/safewrite_test.go
+++ b/pkg/storage/fs/safewrite_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func TestSafeWriteToFile(t *testing.T) {
 
 	require.NoError(t, mem.MkdirAll("foo", os.ModePerm))
 	syncDir("")
-	f, err := mem.Create("foo/bar")
+	f, err := mem.Create("foo/bar", storage.UnspecifiedWriteCategory)
 	require.NoError(t, err)
 	_, err = io.WriteString(f, "Hello world")
 	require.NoError(t, err)
@@ -57,7 +58,7 @@ func TestSafeWriteToFile(t *testing.T) {
 
 	// Use SafeWriteToFile to atomically, durably change the contents of the
 	// file.
-	require.NoError(t, SafeWriteToFile(mem, "foo", "foo/bar", []byte("Hello everyone")))
+	require.NoError(t, SafeWriteToFile(mem, "foo", "foo/bar", []byte("Hello everyone"), storage.UnspecifiedWriteCategory))
 
 	// Discard any unsynced writes.
 	mem.ResetToSyncedState()

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -813,7 +813,7 @@ type ingestOp struct {
 
 func (i ingestOp) run(ctx context.Context) string {
 	sstPath := filepath.Join(i.m.path, "ingest.sst")
-	f, err := i.m.engineFS.Create(sstPath)
+	f, err := i.m.engineFS.Create(sstPath, storage.UnspecifiedWriteCategory)
 	if err != nil {
 		return fmt.Sprintf("error = %s", err.Error())
 	}

--- a/pkg/storage/min_version.go
+++ b/pkg/storage/min_version.go
@@ -47,7 +47,7 @@ func writeMinVersionFile(atomicRenameFS vfs.FS, dir string, version roachpb.Vers
 		return err
 	}
 	filename := atomicRenameFS.PathJoin(dir, MinVersionFilename)
-	if err := fs.SafeWriteToFile(atomicRenameFS, dir, filename, b); err != nil {
+	if err := fs.SafeWriteToFile(atomicRenameFS, dir, filename, b, UnspecifiedWriteCategory); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/storage/min_version_test.go
+++ b/pkg/storage/min_version_test.go
@@ -157,8 +157,8 @@ type fauxEncryptedFS struct {
 	vfs.FS
 }
 
-func (fs fauxEncryptedFS) Create(path string) (vfs.File, error) {
-	f, err := fs.FS.Create(path)
+func (fs fauxEncryptedFS) Create(path string, category vfs.DiskWriteCategory) (vfs.File, error) {
+	f, err := fs.FS.Create(path, category)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -1406,7 +1406,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 		if err := sst.Finish(); err != nil {
 			t.Fatal(err)
 		}
-		if err := fs.WriteFile(db2, `ingest`, memFile.Data()); err != nil {
+		if err := fs.WriteFile(db2, `ingest`, memFile.Data(), UnspecifiedWriteCategory); err != nil {
 			t.Fatal(err)
 		}
 		if err := db2.IngestLocalFiles(ctx, []string{`ingest`}); err != nil {

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -246,6 +246,13 @@ func If(enable bool, opt ConfigOption) ConfigOption {
 	return func(cfg *engineConfig) error { return nil }
 }
 
+func DiskWriteStatsCollector(dsc *vfs.DiskWriteStatsCollector) ConfigOption {
+	return func(cfg *engineConfig) error {
+		cfg.DiskWriteStatsCollector = dsc
+		return nil
+	}
+}
+
 // A Location describes where the storage engine's data will be written. A
 // Location may be in-memory or on the filesystem.
 type Location struct {

--- a/pkg/storage/pebble_file_registry.go
+++ b/pkg/storage/pebble_file_registry.go
@@ -533,7 +533,7 @@ func (r *PebbleFileRegistry) createNewRegistryFile() error {
 	// is moved to the new filename.
 	filename := makeRegistryFilename(r.mu.marker.NextIter())
 	filepath := r.FS.PathJoin(r.DBDir, filename)
-	f, err := r.FS.Create(filepath)
+	f, err := r.FS.Create(filepath, EncryptionRegistryWriteCategory)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/pebble_file_registry_test.go
+++ b/pkg/storage/pebble_file_registry_test.go
@@ -95,7 +95,7 @@ func TestFileRegistryOps(t *testing.T) {
 		for path := range expected {
 			path = mem.PathJoin("/mydb", path)
 			require.NoError(t, mem.MkdirAll(mem.PathDir(path), 0655))
-			f, err := mem.Create(path)
+			f, err := mem.Create(path, UnspecifiedWriteCategory)
 			require.NoError(t, err)
 			require.NoError(t, f.Close())
 		}
@@ -216,7 +216,7 @@ func TestFileRegistryElideUnencrypted(t *testing.T) {
 	mem := vfs.NewMem()
 
 	for _, name := range []string{"test1", "test2"} {
-		f, err := mem.Create(name)
+		f, err := mem.Create(name, UnspecifiedWriteCategory)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 	}
@@ -246,7 +246,7 @@ func TestFileRegistryElideNonexistent(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	mem := vfs.NewMem()
-	f, err := mem.Create("bar")
+	f, err := mem.Create("bar", UnspecifiedWriteCategory)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 	{
@@ -288,7 +288,7 @@ func TestFileRegistryRecordsReadAndWrite(t *testing.T) {
 	// Ensure all the expected paths exist, otherwise Load will elide
 	// them and this test is not designed to test elision.
 	for name := range files {
-		f, err := mem.Create(name)
+		f, err := mem.Create(name, UnspecifiedWriteCategory)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 	}
@@ -379,7 +379,7 @@ func TestFileRegistry(t *testing.T) {
 			return buf.String()
 		case "touch":
 			for _, filename := range strings.Split(d.Input, "\n") {
-				f, err := fs.Create(filename)
+				f, err := fs.Create(filename, UnspecifiedWriteCategory)
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
 			}
@@ -418,9 +418,9 @@ type loggingFS struct {
 	w io.Writer
 }
 
-func (fs loggingFS) Create(name string) (vfs.File, error) {
+func (fs loggingFS) Create(name string, category vfs.DiskWriteCategory) (vfs.File, error) {
 	fmt.Fprintf(fs.w, "create(%q)\n", name)
-	f, err := fs.FS.Create(name)
+	f, err := fs.FS.Create(name, category)
 	if err != nil {
 		return nil, err
 	}
@@ -460,9 +460,11 @@ func (fs loggingFS) Rename(oldname, newname string) error {
 	return fs.FS.Rename(oldname, newname)
 }
 
-func (fs loggingFS) ReuseForWrite(oldname, newname string) (vfs.File, error) {
+func (fs loggingFS) ReuseForWrite(
+	oldname, newname string, category vfs.DiskWriteCategory,
+) (vfs.File, error) {
 	fmt.Fprintf(fs.w, "reuseForWrite(%q, %q)\n", oldname, newname)
-	f, err := fs.FS.ReuseForWrite(oldname, newname)
+	f, err := fs.FS.ReuseForWrite(oldname, newname, category)
 	if err == nil {
 		f = loggingFile{f, newname, fs.w}
 	}
@@ -534,7 +536,7 @@ func (c *fileRegistryEntryChecker) addEntry(r *PebbleFileRegistry) {
 	filename := fmt.Sprintf("%04d", c.numAddedEntries)
 	// Create a file for this added entry so that it doesn't get cleaned up
 	// when we reopen the file registry.
-	f, err := c.fs.Create(c.fs.PathJoin(c.dir, filename))
+	f, err := c.fs.Create(c.fs.PathJoin(c.dir, filename), UnspecifiedWriteCategory)
 	require.NoError(c.t, err)
 	require.NoError(c.t, f.Sync())
 	require.NoError(c.t, f.Close())

--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -24,9 +24,12 @@ import (
 // NewTempEngine creates a new engine for DistSQL processors to use when
 // the working set is larger than can be stored in memory.
 func NewTempEngine(
-	ctx context.Context, tempStorage base.TempStorageConfig, storeSpec base.StoreSpec,
+	ctx context.Context,
+	tempStorage base.TempStorageConfig,
+	storeSpec base.StoreSpec,
+	statsCollector *vfs.DiskWriteStatsCollector,
 ) (diskmap.Factory, vfs.FS, error) {
-	return NewPebbleTempEngine(ctx, tempStorage, storeSpec)
+	return NewPebbleTempEngine(ctx, tempStorage, storeSpec, statsCollector)
 }
 
 type pebbleTempEngine struct {
@@ -57,13 +60,19 @@ func (r *pebbleTempEngine) NewSortedDiskMultiMap() diskmap.SortedDiskMap {
 // NewPebbleTempEngine creates a new Pebble engine for DistSQL processors to use
 // when the working set is larger than can be stored in memory.
 func NewPebbleTempEngine(
-	ctx context.Context, tempStorage base.TempStorageConfig, storeSpec base.StoreSpec,
+	ctx context.Context,
+	tempStorage base.TempStorageConfig,
+	storeSpec base.StoreSpec,
+	statsCollector *vfs.DiskWriteStatsCollector,
 ) (diskmap.Factory, vfs.FS, error) {
-	return newPebbleTempEngine(ctx, tempStorage, storeSpec)
+	return newPebbleTempEngine(ctx, tempStorage, storeSpec, statsCollector)
 }
 
 func newPebbleTempEngine(
-	ctx context.Context, tempStorage base.TempStorageConfig, storeSpec base.StoreSpec,
+	ctx context.Context,
+	tempStorage base.TempStorageConfig,
+	storeSpec base.StoreSpec,
+	statsCollector *vfs.DiskWriteStatsCollector,
 ) (*pebbleTempEngine, vfs.FS, error) {
 	var loc Location
 	var cacheSize int64 = 128 << 20 // 128 MiB, arbitrary, but not "too big"
@@ -89,6 +98,8 @@ func newPebbleTempEngine(
 			cfg.Opts.DisableWAL = true
 			cfg.Opts.Experimental.KeyValidationFunc = nil
 			cfg.Opts.BlockPropertyCollectors = nil
+			cfg.Opts.EnableSQLRowSpillMetrics = true
+			cfg.DiskWriteStatsCollector = statsCollector
 			return nil
 		},
 	)

--- a/pkg/storage/temp_engine_test.go
+++ b/pkg/storage/temp_engine_test.go
@@ -32,7 +32,7 @@ func TestNewPebbleTempEngine(t *testing.T) {
 	db, fs, err := NewPebbleTempEngine(context.Background(), base.TempStorageConfig{
 		Path:     tempDir,
 		Settings: cluster.MakeTestingClusterSettings(),
-	}, base.StoreSpec{Path: tempDir})
+	}, base.StoreSpec{Path: tempDir}, nil)
 	if err != nil {
 		t.Fatalf("error encountered when invoking NewRocksDBTempEngine: %+v", err)
 	}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -366,5 +366,37 @@ export default function (props: GraphDashboardProps) {
         />
       </Axis>
     </LineGraph>,
+
+    <LineGraph
+      title="Disk Write MiB/s Estimation"
+      sources={storeSources}
+      tenantSource={tenantSource}
+      showMetricsInTooltip={true}
+    >
+      <Axis units={AxisUnits.Bytes} label="bytes">
+        {[
+          "pebble-wal",
+          "pebble-compaction",
+          "pebble-ingestion",
+          "pebble-memtable-flush",
+          "raft-snapshot",
+          "encryption-registry",
+          "crdb-log",
+          "sql-row-spill",
+          "sql-col-spill",
+          "unspecified"
+        ].map(category =>
+          _.map(nodeIDs, nid => (
+            <Metric
+              key={category + "-" + nid}
+              name={`cr.store.storage.category-${category}.bytes-written`}
+              title={category + "-" + getNodeNameById(nid)}
+              sources={storeIDsForNode(storeIDsByNodeID, nid)}
+              nonNegativeRate
+            />
+          )))}
+      </Axis>
+    </LineGraph>,
+
   ];
 }

--- a/pkg/util/log/channels_test.go
+++ b/pkg/util/log/channels_test.go
@@ -92,6 +92,7 @@ func TestRepro81025(t *testing.T) {
 		10<<20, /* group max: 20 MB */
 		nil,    /* getStartLines */
 		0777,   /* file mode */
+		nil,    /* logBytesWritten */
 	)
 	defer func() { _ = s.closeFileLocked() }()
 

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -410,7 +410,7 @@ func TestGetLogReader(t *testing.T) {
 	// Validate and apply the config.
 	require.NoError(t, config.Validate(&sc.logDir))
 	TestingResetActive()
-	cleanupFn, err := ApplyConfig(config)
+	cleanupFn, err := ApplyConfig(config, &FileSinkMetrics{})
 	require.NoError(t, err)
 	defer cleanupFn()
 
@@ -622,7 +622,7 @@ func TestFd2Capture(t *testing.T) {
 		t.Fatal(err)
 	}
 	TestingResetActive()
-	cleanupFn, err := ApplyConfig(cfg)
+	cleanupFn, err := ApplyConfig(cfg, &FileSinkMetrics{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -92,6 +92,8 @@ type fileSink struct {
 
 	filePermissions fs.FileMode
 
+	logBytesWritten *atomic.Uint64
+
 	// mu protects the remaining elements of this structure and is
 	// used to synchronize output to this file sink..
 	mu struct {
@@ -137,6 +139,7 @@ func newFileSink(
 	fileMaxSize, combinedMaxSize int64,
 	getStartLines func(time.Time) []*buffer,
 	filePermissions fs.FileMode,
+	logBytesWritten *atomic.Uint64,
 ) *fileSink {
 	f := &fileSink{
 		groupName:               fileGroupName,
@@ -147,6 +150,7 @@ func newFileSink(
 		gcNotify:                make(chan struct{}, 1),
 		getStartLines:           getStartLines,
 		filePermissions:         filePermissions,
+		logBytesWritten:         logBytesWritten,
 	}
 	f.mu.logDir = dir
 	f.enabled.Set(dir != "")

--- a/pkg/util/log/file_log_gc_test.go
+++ b/pkg/util/log/file_log_gc_test.go
@@ -66,7 +66,7 @@ func TestSecondaryGC(t *testing.T) {
 	// Validate and apply the config.
 	require.NoError(t, config.Validate(&s.logDir))
 	TestingResetActive()
-	cleanupFn, err := ApplyConfig(config)
+	cleanupFn, err := ApplyConfig(config, &FileSinkMetrics{})
 	require.NoError(t, err)
 	defer cleanupFn()
 

--- a/pkg/util/log/file_sync_buffer.go
+++ b/pkg/util/log/file_sync_buffer.go
@@ -56,8 +56,12 @@ func (sb *syncBuffer) Write(p []byte) (n int, err error) {
 // writeToFileLocked writes to the file and applies the synchronization policy.
 // Assumes that l.mu is held by the caller.
 func (l *fileSink) writeToFileLocked(data []byte) error {
-	_, err := l.mu.file.Write(data)
-	return err
+	if n, err := l.mu.file.Write(data); err != nil {
+		return err
+	} else if l.logBytesWritten != nil {
+		l.logBytesWritten.Add(uint64(n))
+	}
+	return nil
 }
 
 // ensureFileLocked ensures that l.file is set and valid.

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -16,6 +16,7 @@ import (
 	"io/fs"
 	"math"
 	"strings"
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/channel"
@@ -43,6 +44,10 @@ type config struct {
 	flushWrites syncutil.AtomicBool
 }
 
+type FileSinkMetrics struct {
+	LogBytesWritten *atomic.Uint64
+}
+
 var debugLog *loggerT
 
 // redactionPolicyManaged is the env var used to indicate that the node is being
@@ -66,7 +71,7 @@ func init() {
 	// using TestLogScope.
 	cfg := getTestConfig(nil /* output to files disabled */, true /* mostly inline */)
 
-	if _, err := ApplyConfig(cfg); err != nil {
+	if _, err := ApplyConfig(cfg, &FileSinkMetrics{}); err != nil {
 		panic(err)
 	}
 
@@ -90,7 +95,9 @@ func IsActive() (active bool, firstUse string) {
 // ApplyConfig applies the given configuration.
 //
 // The returned logShutdownFn can be used to gracefully shut down logging facilities.
-func ApplyConfig(config logconfig.Config) (logShutdownFn func(), err error) {
+func ApplyConfig(
+	config logconfig.Config, metrics *FileSinkMetrics,
+) (logShutdownFn func(), err error) {
 	// Sanity check.
 	if active, firstUse := IsActive(); active {
 		reportOrPanic(context.Background(), nil /* sv */, "logging already active; first use:\n%s", firstUse)
@@ -190,7 +197,7 @@ func ApplyConfig(config logconfig.Config) (logShutdownFn func(), err error) {
 		if err := fakeConfig.Channels.Validate(fakeConfig.CommonSinkConfig.Filter); err != nil {
 			return nil, errors.NewAssertionErrorWithWrappedErrf(err, "programming error: incorrect filter config")
 		}
-		fileSinkInfo, fileSink, err := newFileSinkInfo("stderr", fakeConfig)
+		fileSinkInfo, fileSink, err := newFileSinkInfo("stderr", fakeConfig, metrics)
 		if err != nil {
 			return nil, err
 		}
@@ -307,7 +314,7 @@ func ApplyConfig(config logconfig.Config) (logShutdownFn func(), err error) {
 		if fileGroupName == "default" {
 			fileGroupName = ""
 		}
-		fileSinkInfo, fileSink, err := newFileSinkInfo(fileGroupName, *fc)
+		fileSinkInfo, fileSink, err := newFileSinkInfo(fileGroupName, *fc, metrics)
 		if err != nil {
 			return nil, err
 		}
@@ -362,7 +369,7 @@ func ApplyConfig(config logconfig.Config) (logShutdownFn func(), err error) {
 // newFileSinkInfo creates a new fileSink and its accompanying sinkInfo
 // from the provided configuration.
 func newFileSinkInfo(
-	fileGroupName string, c logconfig.FileSinkConfig,
+	fileGroupName string, c logconfig.FileSinkConfig, metrics *FileSinkMetrics,
 ) (*sinkInfo, *fileSink, error) {
 	info := &sinkInfo{}
 	if err := info.applyConfig(c.CommonSinkConfig); err != nil {
@@ -377,6 +384,7 @@ func newFileSinkInfo(
 		int64(*c.MaxGroupSize),
 		info.getStartLines,
 		fs.FileMode(*c.FilePermissions),
+		metrics.LogBytesWritten,
 	)
 	info.sink = fileSink
 	return info, fileSink, nil

--- a/pkg/util/log/flags_test.go
+++ b/pkg/util/log/flags_test.go
@@ -68,7 +68,7 @@ func TestAppliedConfig(t *testing.T) {
 			}
 
 			TestingResetActive()
-			cleanup, err := ApplyConfig(h.Config)
+			cleanup, err := ApplyConfig(h.Config, &FileSinkMetrics{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/util/log/fluent_client_test.go
+++ b/pkg/util/log/fluent_client_test.go
@@ -69,7 +69,7 @@ func TestFluentClient(t *testing.T) {
 
 	// Apply the configuration.
 	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg)
+	cleanup, err := ApplyConfig(cfg, &FileSinkMetrics{})
 	require.NoError(t, err)
 	defer cleanup()
 

--- a/pkg/util/log/formats_test.go
+++ b/pkg/util/log/formats_test.go
@@ -66,7 +66,7 @@ func TestFormatRedaction(t *testing.T) {
 							// Validate and apply the config.
 							require.NoError(t, config.Validate(&sc.logDir))
 							TestingResetActive()
-							cleanupFn, err := ApplyConfig(config)
+							cleanupFn, err := ApplyConfig(config, &FileSinkMetrics{})
 							require.NoError(t, err)
 							defer cleanupFn()
 

--- a/pkg/util/log/http_sink_test.go
+++ b/pkg/util/log/http_sink_test.go
@@ -148,7 +148,7 @@ func testBase(
 
 	// Apply the configuration.
 	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg)
+	cleanup, err := ApplyConfig(cfg, &FileSinkMetrics{})
 	require.NoError(t, err)
 	defer cleanup()
 

--- a/pkg/util/log/logtestutils/log_test_utils.go
+++ b/pkg/util/log/logtestutils/log_test_utils.go
@@ -40,7 +40,7 @@ func InstallLogFileSink(sc *log.TestLogScope, t *testing.T, channel logpb.Channe
 	if err := cfg.Validate(&dir); err != nil {
 		t.Fatal(err)
 	}
-	cleanup, err := log.ApplyConfig(cfg)
+	cleanup, err := log.ApplyConfig(cfg, &log.FileSinkMetrics{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/log/redact_test.go
+++ b/pkg/util/log/redact_test.go
@@ -135,7 +135,7 @@ func TestSafeManaged(t *testing.T) {
 			if err := cfg.Validate(&s.logDir); err != nil {
 				t.Fatal(err)
 			}
-			cleanupFn, err := ApplyConfig(cfg)
+			cleanupFn, err := ApplyConfig(cfg, &FileSinkMetrics{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/util/log/registry_test.go
+++ b/pkg/util/log/registry_test.go
@@ -66,7 +66,7 @@ func TestIterHTTPSinks(t *testing.T) {
 
 	// Apply the configuration
 	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg)
+	cleanup, err := ApplyConfig(cfg, &FileSinkMetrics{})
 	require.NoError(t, err)
 	defer cleanup()
 

--- a/pkg/util/log/secondary_log_test.go
+++ b/pkg/util/log/secondary_log_test.go
@@ -48,7 +48,7 @@ func installSessionsFileSink(sc *TestLogScope, t *testing.T) func() {
 
 	// Apply the configuration.
 	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg)
+	cleanup, err := ApplyConfig(cfg, &FileSinkMetrics{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -162,7 +162,7 @@ func newLogScope(t tShim, mostlyInline bool) (sc *TestLogScope) {
 
 		// Switch to the new configuration.
 		TestingResetActive()
-		sc.cleanupFn, err = ApplyConfig(cfg)
+		sc.cleanupFn, err = ApplyConfig(cfg, &FileSinkMetrics{})
 		if err != nil {
 			return err
 		}
@@ -355,7 +355,7 @@ func (l *TestLogScope) SetupSingleFileLogging() (cleanup func()) {
 
 	// Apply the configuration.
 	TestingResetActive()
-	cleanup, err := ApplyConfig(cfg)
+	cleanup, err := ApplyConfig(cfg, &FileSinkMetrics{})
 	if err != nil {
 		panic(errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error in predefined log config"))
 	}

--- a/pkg/util/log/testshout/shout_test.go
+++ b/pkg/util/log/testshout/shout_test.go
@@ -33,7 +33,7 @@ func Example_shout_before_log() {
 		panic(err)
 	}
 	cfg.Sinks.Stderr.Filter = severity.WARNING
-	cleanup, err := log.ApplyConfig(cfg)
+	cleanup, err := log.ApplyConfig(cfg, &log.FileSinkMetrics{})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -181,7 +181,7 @@ func CmdHelper(
 			if err := cfg.Validate(nil /* no default log directory */); err != nil {
 				return err
 			}
-			if _, err := log.ApplyConfig(cfg); err != nil {
+			if _, err := log.ApplyConfig(cfg, &log.FileSinkMetrics{}); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
This commit updates Pebble file creation calls to categorically track and display disk write metrics at the Cockroach layer.

Fixes #115434.

Epic: None.
Release note: None.