### PR TITLE
process-bep-file: fix compile error

### DIFF
--- a/pkg/cmd/bazci/process-bep-file/main.go
+++ b/pkg/cmd/bazci/process-bep-file/main.go
@@ -108,7 +108,8 @@ func failurePoster(
 	}
 	return func(ctx context.Context, failure githubpost.Failure) error {
 		fmter, req := formatter(ctx, failure)
-		return issues.Post(ctx, log.Default(), fmter, req, postOpts)
+		_, err := issues.Post(ctx, log.Default(), fmter, req, postOpts)
+		return err
 	}
 }
 


### PR DESCRIPTION
This broke with #118914.

Epic: CRDB-8308
Release note: None