### PR TITLE
release-23.2: catalog: fix tracking of id and name state

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -113,5 +113,5 @@ exp,benchmark
 3,UDFResolution/select_from_udf
 1,VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1,VirtualTableQueries/select_crdb_internal.tables_with_1_fk
-9,VirtualTableQueries/virtual_table_cache_with_point_lookups
+3,VirtualTableQueries/virtual_table_cache_with_point_lookups
 15,VirtualTableQueries/virtual_table_cache_with_schema_change

--- a/pkg/sql/catalog/internal/catkv/testdata/testdata_app
+++ b/pkg/sql/catalog/internal/catkv/testdata/testdata_app
@@ -405,6 +405,15 @@ is_desc_id_known_to_not_exist id=123
 ----
 true
 
+# Make sure scan_all properly updated the cache.
+is_id_in_cache id=107
+----
+true
+
+is_id_in_cache id=108
+----
+true
+
 # Get* queries involving IDs or names which don't exist after a
 # ScanAll should bypass storage in the cached CatalogReader.
 get_by_ids id=456

--- a/pkg/sql/catalog/internal/catkv/testdata/testdata_system
+++ b/pkg/sql/catalog/internal/catkv/testdata/testdata_system
@@ -438,6 +438,15 @@ is_desc_id_known_to_not_exist id=123
 ----
 true
 
+# Make sure scan_all properly updated the cache.
+is_id_in_cache id=107
+----
+true
+
+is_id_in_cache id=108
+----
+true
+
 # Get* queries involving IDs or names which don't exist after a
 # ScanAll should bypass storage in the cached CatalogReader.
 get_by_ids id=456


### PR DESCRIPTION
Backport 1/1 commits from #119007.

/cc @cockroachdb/release

Release justification: bug fix

---

The previous code only updated the entries that were already in the
byIDState map. However, some descriptor IDs may not be in that map, so
instead we should add everything we just read into the map.

fixes https://github.com/cockroachdb/cockroach/issues/116795
Release note (bug fix): Fixed a bug where COMMENT statements could
fail with an "unexpected value" error if multiple COMMENT statements
were running concurrently.

