### PR TITLE
spanconfigkvsubscriberccl: run on `heavy` under `race`

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigkvsubscriberccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigkvsubscriberccl/BUILD.bazel
@@ -6,6 +6,10 @@ go_test(
         "kvsubscriber_test.go",
         "main_test.go",
     ],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
Epic: CRDB-8308
Release note: None