### PR TITLE
build: add RC branches to release branches

### DIFF
--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
@@ -10,7 +10,7 @@ tc_start_block "Variable Setup"
 build_name=$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev-parse --short HEAD;)
 
 # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
-is_release_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^(release-[0-9][0-9]\.[0-9](\.0)?)$|master$" || echo "")"
+is_release_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^(release-[0-9][0-9]\.[0-9](\.0)?(-rc)?)$|master$" || echo "")"
 
 if [[ -z "${DRY_RUN}" ]] ; then
   if [[ -z "${is_release_build}" ]] ; then


### PR DESCRIPTION
Previously, we had logic to distinguish release and non-release branches (like customized builds) in the docker script. The pattern didn't cover cases, where we name the branches by adding the "-rc" suffix.

This PR fixes the release branch pattern.

Epic: none
Release note: None