### PR TITLE
plpgsql: misc fixes for parsing and formatting identifiers and constants

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -36,7 +36,7 @@ import (
 
 // TestParseDataDriven verifies that we can parse the supplied SQL and regenerate the SQL
 // string from the syntax tree.
-func TestParseDatadriven(t *testing.T) {
+func TestParseDataDriven(t *testing.T) {
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {

--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -268,6 +268,11 @@ func (l *lexer) readSQLConstruct(
 	startPos = l.lastPos + 1
 	for l.lastPos < len(l.tokens) {
 		tok := l.Peek()
+		if tok.id == ERROR {
+			// This is a tokenizer (lexical) error: the scanner
+			// will have stored the error message in the string field.
+			return 0, 0, 0, errors.Newf("%s", tok.str)
+		}
 		if int(tok.id) == terminator1 && parenLevel == 0 {
 			terminatorMet = terminator1
 			break

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -662,7 +662,9 @@ proc_stmt:pl_block ';'
     $$.val = $1.statement()
   }
 | stmt_while
-  { }
+  {
+    $$.val = $1.statement()
+  }
 | stmt_for
   { }
 | stmt_foreach_a

--- a/pkg/sql/plpgsql/parser/testdata/combo
+++ b/pkg/sql/plpgsql/parser/testdata/combo
@@ -78,9 +78,9 @@ RETURN res;
 END;
  -- literals removed
 DECLARE
-i INT8;
-n INT8 := _(_, 1);
-res INT8[] := ARRAY[]::INT8[];
+_ INT8;
+_ INT8 := _(_, 1);
+_ INT8[] := ARRAY[]::INT8[];
 BEGIN
 _ := 0;
 LOOP

--- a/pkg/sql/plpgsql/parser/testdata/const
+++ b/pkg/sql/plpgsql/parser/testdata/const
@@ -1,0 +1,142 @@
+parse
+DECLARE
+  x STRING := b'1GW\'';
+BEGIN
+  INSERT INTO tab SELECT b'1GW\'';
+END
+----
+DECLARE
+x STRING := b'1GW\'';
+BEGIN
+INSERT INTO tab SELECT b'1GW\'';
+END;
+ -- normalized!
+DECLARE
+x STRING := (b'1GW\'');
+BEGIN
+INSERT INTO tab SELECT (b'1GW\'');
+END;
+ -- fully parenthesized
+DECLARE
+x STRING := '_';
+BEGIN
+INSERT INTO tab SELECT '_';
+END;
+ -- literals removed
+DECLARE
+_ STRING := b'1GW\'';
+BEGIN
+INSERT INTO _ SELECT b'1GW\'';
+END;
+ -- identifiers removed
+
+parse
+DECLARE
+  x STRING := x'deadbeef';
+BEGIN
+  INSERT INTO tab SELECT x'deadbeef';
+END
+----
+DECLARE
+x STRING := b'\xde\xad\xbe\xef';
+BEGIN
+INSERT INTO tab SELECT b'\xde\xad\xbe\xef';
+END;
+ -- normalized!
+DECLARE
+x STRING := (b'\xde\xad\xbe\xef');
+BEGIN
+INSERT INTO tab SELECT (b'\xde\xad\xbe\xef');
+END;
+ -- fully parenthesized
+DECLARE
+x STRING := '_';
+BEGIN
+INSERT INTO tab SELECT '_';
+END;
+ -- literals removed
+DECLARE
+_ STRING := b'\xde\xad\xbe\xef';
+BEGIN
+INSERT INTO _ SELECT b'\xde\xad\xbe\xef';
+END;
+ -- identifiers removed
+
+parse
+DECLARE
+  x STRING := B'010101';
+BEGIN
+  INSERT INTO tab SELECT B'010101';
+END
+----
+DECLARE
+x STRING := B'010101';
+BEGIN
+INSERT INTO tab SELECT B'010101';
+END;
+ -- normalized!
+DECLARE
+x STRING := (B'010101');
+BEGIN
+INSERT INTO tab SELECT (B'010101');
+END;
+ -- fully parenthesized
+DECLARE
+x STRING := _;
+BEGIN
+INSERT INTO tab SELECT _;
+END;
+ -- literals removed
+DECLARE
+_ STRING := B'010101';
+BEGIN
+INSERT INTO _ SELECT B'010101';
+END;
+ -- identifiers removed
+
+# TODO(drewk): This is a valid constant.
+error
+DECLARE
+  x STRING := e'1GW\'';
+BEGIN
+  INSERT INTO tab SELECT e'1GW\'';
+END
+----
+at or near ";": at or near "EOF": syntax error
+DETAIL: source SQL:
+SET ROW (e'1GW\''
+                 ^
+--
+source SQL:
+DECLARE
+  x STRING := e'1GW\'';
+BEGIN
+  INSERT INTO tab SELECT e'1GW\'';
+                                 ^
+HINT: try \h SET SESSION
+
+error
+DECLARE
+  x STRING := 'foo;
+BEGIN
+  RETURN x;
+END
+----
+at or near ":": syntax error: unterminated string
+DETAIL: source SQL:
+DECLARE
+  x STRING := 'foo;
+           ^
+
+error
+DECLARE
+  x STRING := $foo$ foo;
+BEGIN
+  RETURN x;
+END
+----
+at or near ":": syntax error: unterminated string
+DETAIL: source SQL:
+DECLARE
+  x STRING := $foo$ foo;
+           ^

--- a/pkg/sql/plpgsql/parser/testdata/const
+++ b/pkg/sql/plpgsql/parser/testdata/const
@@ -1,5 +1,37 @@
 parse
 DECLARE
+  x STRING := e'1GW\'';
+BEGIN
+  INSERT INTO tab SELECT e'1GW\'';
+END
+----
+DECLARE
+x STRING := e'1GW\'';
+BEGIN
+INSERT INTO tab SELECT e'1GW\'';
+END;
+ -- normalized!
+DECLARE
+x STRING := (e'1GW\'');
+BEGIN
+INSERT INTO tab SELECT (e'1GW\'');
+END;
+ -- fully parenthesized
+DECLARE
+x STRING := '_';
+BEGIN
+INSERT INTO tab SELECT '_';
+END;
+ -- literals removed
+DECLARE
+_ STRING := e'1GW\'';
+BEGIN
+INSERT INTO _ SELECT e'1GW\'';
+END;
+ -- identifiers removed
+
+parse
+DECLARE
   x STRING := b'1GW\'';
 BEGIN
   INSERT INTO tab SELECT b'1GW\'';
@@ -93,27 +125,6 @@ BEGIN
 INSERT INTO _ SELECT B'010101';
 END;
  -- identifiers removed
-
-# TODO(drewk): This is a valid constant.
-error
-DECLARE
-  x STRING := e'1GW\'';
-BEGIN
-  INSERT INTO tab SELECT e'1GW\'';
-END
-----
-at or near ";": at or near "EOF": syntax error
-DETAIL: source SQL:
-SET ROW (e'1GW\''
-                 ^
---
-source SQL:
-DECLARE
-  x STRING := e'1GW\'';
-BEGIN
-  INSERT INTO tab SELECT e'1GW\'';
-                                 ^
-HINT: try \h SET SESSION
 
 error
 DECLARE

--- a/pkg/sql/plpgsql/parser/testdata/decl_header
+++ b/pkg/sql/plpgsql/parser/testdata/decl_header
@@ -25,7 +25,7 @@ END foo;
  -- literals removed
 <<_>>
 DECLARE
-var1 INT8 := 30;
+_ INT8 := 30;
 BEGIN
 END _;
  -- identifiers removed
@@ -57,7 +57,7 @@ END foo;
  -- literals removed
 <<_>>
 DECLARE
-var1 CONSTANT INT8 COLLATE _ NOT NULL := 30;
+_ CONSTANT INT8 COLLATE _ NOT NULL := 30;
 BEGIN
 END _;
  -- identifiers removed
@@ -84,7 +84,34 @@ BEGIN
 END;
  -- literals removed
 DECLARE
-var1 CONSTANT INT8 COLLATE _ NOT NULL := 30;
+_ CONSTANT INT8 COLLATE _ NOT NULL := 30;
+BEGIN
+END;
+ -- identifiers removed
+
+parse
+DECLARE
+  "%_2jd9$f foo" integer := 30;
+BEGIN
+END
+----
+DECLARE
+"%_2jd9$f foo" INT8 := 30;
+BEGIN
+END;
+ -- normalized!
+DECLARE
+"%_2jd9$f foo" INT8 := (30);
+BEGIN
+END;
+ -- fully parenthesized
+DECLARE
+"%_2jd9$f foo" INT8 := _;
+BEGIN
+END;
+ -- literals removed
+DECLARE
+_ INT8 := 30;
 BEGIN
 END;
  -- identifiers removed
@@ -138,7 +165,7 @@ BEGIN
 END;
  -- literals removed
 DECLARE
-var1 CURSOR FOR SELECT * FROM _ WHERE _ = _;
+_ CURSOR FOR SELECT * FROM _ WHERE _ = _;
 BEGIN
 END;
  -- identifiers removed

--- a/pkg/sql/plpgsql/parser/testdata/stmt_assign
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_assign
@@ -57,6 +57,38 @@ _ := NULL;
 END;
  -- identifiers removed
 
+parse
+DECLARE
+  "%_2jd9$f foo" integer := 30;
+BEGIN
+  "%_2jd9$f foo" := 100;
+END
+----
+DECLARE
+"%_2jd9$f foo" INT8 := 30;
+BEGIN
+"%_2jd9$f foo" := 100;
+END;
+ -- normalized!
+DECLARE
+"%_2jd9$f foo" INT8 := (30);
+BEGIN
+"%_2jd9$f foo" := (100);
+END;
+ -- fully parenthesized
+DECLARE
+"%_2jd9$f foo" INT8 := _;
+BEGIN
+"%_2jd9$f foo" := _;
+END;
+ -- literals removed
+DECLARE
+_ INT8 := 30;
+BEGIN
+_ := 100;
+END;
+ -- identifiers removed
+
 error
 DECLARE
 BEGIN

--- a/pkg/sql/plpgsql/parser/testdata/stmt_block
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_block
@@ -135,10 +135,10 @@ RAISE NOTICE '_', x;
 END;
  -- literals removed
 DECLARE
-x INT8;
+_ INT8;
 BEGIN
 DECLARE
-y INT8;
+_ INT8;
 BEGIN
 RAISE NOTICE '% %', _, _;
 END;
@@ -184,7 +184,7 @@ RAISE NOTICE '_', x;
 END;
  -- literals removed
 DECLARE
-x INT8;
+_ INT8;
 BEGIN
 BEGIN
 _ := 100;
@@ -243,7 +243,7 @@ RAISE NOTICE '_', x;
 END;
  -- literals removed
 DECLARE
-x INT8;
+_ INT8;
 BEGIN
 BEGIN
 _ := 1 // 0;

--- a/pkg/sql/plpgsql/parser/testdata/stmt_exec_sql
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_exec_sql
@@ -306,7 +306,7 @@ RETURN i;
 END;
  -- literals removed
 DECLARE
-i INT8;
+_ INT8;
 BEGIN
 SET testing_optimizer_disable_rule_probability = 0;
 INSERT INTO _ VALUES (1, 2);

--- a/pkg/sql/plpgsql/parser/testdata/stmt_raise
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_raise
@@ -198,7 +198,7 @@ RAISE '_', i;
 END;
  -- literals removed
 DECLARE
-i INT8 := 0;
+_ INT8 := 0;
 BEGIN
 RAISE 'foo %', _;
 END;
@@ -230,7 +230,7 @@ RAISE '_', i, i * _, i * _;
 END;
  -- literals removed
 DECLARE
-i INT8 := 0;
+_ INT8 := 0;
 BEGIN
 RAISE 'foo %, %, %.', _, _ * 2, _ * 100;
 END;
@@ -262,7 +262,7 @@ RAISE '_', (SELECT count(*) FROM xy WHERE x = i);
 END;
  -- literals removed
 DECLARE
-i INT8 := 0;
+_ INT8 := 0;
 BEGIN
 RAISE 'foo %', (SELECT _(*) FROM _ WHERE _ = _);
 END;

--- a/pkg/sql/scanner/plpgsql_scan.go
+++ b/pkg/sql/scanner/plpgsql_scan.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"go/constant"
 	"go/token"
+	"strconv"
+	"unicode/utf8"
 
 	sqllex "github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/plpgsql/parser/lexbase"
@@ -142,6 +144,186 @@ func (s *PLpgSQLScanner) Scan(lval ScanSymType) {
 	// lval for above.
 }
 
+// scanString is similar to Scanner.scanString, but uses PL/pgSQL tokens.
+func (s *PLpgSQLScanner) scanString(lval ScanSymType, ch int, allowEscapes, requireUTF8 bool) bool {
+	buf := s.buffer()
+	var runeTmp [utf8.UTFMax]byte
+	start := s.pos
+outer:
+	for {
+		switch s.next() {
+		case ch:
+			buf = append(buf, s.in[start:s.pos-1]...)
+			if s.peek() == ch {
+				// Double quote is translated into a single quote that is part of the
+				// string.
+				start = s.pos
+				s.pos++
+				continue
+			}
+
+			newline, ok := s.skipWhitespace(lval, false)
+			if !ok {
+				return false
+			}
+
+			// SQL allows joining adjacent single-quoted strings separated by
+			// whitespace as long as that whitespace contains at least one
+			// newline. Kind of strange to require the newline, but that is the
+			// standard.
+			if ch == singleQuote && s.peek() == singleQuote && newline {
+				s.pos++
+				start = s.pos
+				continue
+			}
+			break outer
+
+		case '\\':
+			t := s.peek()
+
+			if allowEscapes {
+				buf = append(buf, s.in[start:s.pos-1]...)
+				if t == ch {
+					start = s.pos
+					s.pos++
+					continue
+				}
+
+				switch t {
+				case 'a', 'b', 'f', 'n', 'r', 't', 'v', 'x', 'X', 'u', 'U', '\\',
+					'0', '1', '2', '3', '4', '5', '6', '7':
+					var tmp string
+					if t == 'X' && len(s.in[s.pos:]) >= 3 {
+						// UnquoteChar doesn't handle 'X' so we create a temporary string
+						// for it to parse.
+						tmp = "\\x" + s.in[s.pos+1:s.pos+3]
+					} else {
+						tmp = s.in[s.pos-1:]
+					}
+					v, multibyte, tail, err := strconv.UnquoteChar(tmp, byte(ch))
+					if err != nil {
+						lval.SetID(lexbase.ERROR)
+						lval.SetStr(err.Error())
+						return false
+					}
+					if v < utf8.RuneSelf || !multibyte {
+						buf = append(buf, byte(v))
+					} else {
+						n := utf8.EncodeRune(runeTmp[:], v)
+						buf = append(buf, runeTmp[:n]...)
+					}
+					s.pos += len(tmp) - len(tail) - 1
+					start = s.pos
+					continue
+				}
+
+				// If we end up here, it's a redundant escape - simply drop the
+				// backslash. For example, e'\"' is equivalent to e'"', and
+				// e'\d\b' to e'd\b'. This is what Postgres does:
+				// http://www.postgresql.org/docs/9.4/static/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS-ESCAPE
+				start = s.pos
+			}
+
+		case eof:
+			lval.SetID(lexbase.ERROR)
+			lval.SetStr(errUnterminated)
+			return false
+		}
+	}
+
+	if requireUTF8 && !utf8.Valid(buf) {
+		lval.SetID(lexbase.ERROR)
+		lval.SetStr(errInvalidUTF8)
+		return false
+	}
+
+	if ch == identQuote {
+		lval.SetStr(sqllex.NormalizeString(s.finishString(buf)))
+	} else {
+		lval.SetStr(s.finishString(buf))
+	}
+	return true
+}
+
+// scanDollarQuotedString is similar to Scanner.scanDollarQuotedString, but uses
+// PL/pgSQL tokens.
+func (s *PLpgSQLScanner) scanDollarQuotedString(lval ScanSymType) bool {
+	s.lastAttemptedID = int32(lexbase.SCONST)
+	buf := s.buffer()
+	start := s.pos
+
+	foundStartTag := false
+	possibleEndTag := false
+	startTagIndex := -1
+	var startTag string
+
+outer:
+	for {
+		ch := s.peek()
+		switch ch {
+		case '$':
+			s.pos++
+			if foundStartTag {
+				if possibleEndTag {
+					if len(startTag) == startTagIndex {
+						// Found end tag.
+						buf = append(buf, s.in[start+len(startTag)+1:s.pos-len(startTag)-2]...)
+						break outer
+					} else {
+						// Was not the end tag but the current $ might be the start of the end tag we are looking for, so
+						// just reset the startTagIndex.
+						startTagIndex = 0
+					}
+				} else {
+					possibleEndTag = true
+					startTagIndex = 0
+				}
+			} else {
+				startTag = s.in[start : s.pos-1]
+				foundStartTag = true
+			}
+
+		case eof:
+			if foundStartTag {
+				// A start tag was found, therefore we expect an end tag before the eof, otherwise it is an error.
+				lval.SetID(lexbase.ERROR)
+				lval.SetStr(errUnterminated)
+			} else {
+				// This is not a dollar-quoted string, reset the pos back to the start.
+				s.pos = start
+			}
+			return false
+
+		default:
+			// If we haven't found a start tag yet, check whether the current characters is a valid for a tag.
+			if !foundStartTag && !sqllex.IsIdentStart(ch) && !sqllex.IsDigit(ch) {
+				return false
+			}
+			s.pos++
+			if possibleEndTag {
+				// Check whether this could be the end tag.
+				if startTagIndex >= len(startTag) || ch != int(startTag[startTagIndex]) {
+					// This is not the end tag we are looking for.
+					possibleEndTag = false
+					startTagIndex = -1
+				} else {
+					startTagIndex++
+				}
+			}
+		}
+	}
+
+	if !utf8.Valid(buf) {
+		lval.SetID(lexbase.ERROR)
+		lval.SetStr(errInvalidUTF8)
+		return false
+	}
+
+	lval.SetStr(s.finishString(buf))
+	return true
+}
+
+// scanNumber is similar to Scanner.scanNumber, but uses PL/pgSQL tokens.
 func (s *PLpgSQLScanner) scanNumber(lval ScanSymType, ch int) {
 	start := s.pos - 1
 	isHex := false
@@ -240,6 +422,7 @@ func (s *PLpgSQLScanner) scanNumber(lval ScanSymType, ch int) {
 	}
 }
 
+// scanIdent is similar to Scanner.scanIdent, but uses PL/pgSQL tokens.
 func (s *PLpgSQLScanner) scanIdent(lval ScanSymType) {
 	s.lowerCaseAndNormalizeIdent(lval)
 	lval.SetID(lexbase.GetKeywordID(lval.Str()))

--- a/pkg/sql/scanner/plpgsql_scan.go
+++ b/pkg/sql/scanner/plpgsql_scan.go
@@ -70,6 +70,20 @@ func (s *PLpgSQLScanner) Scan(lval ScanSymType) {
 		s.scanIdent(lval)
 		return
 
+	case 'e', 'E':
+		// Escaped string?
+		if s.peek() == singleQuote {
+			// [eE]'[^']'
+			s.lastAttemptedID = int32(lexbase.SCONST)
+			s.pos++
+			if s.scanString(lval, singleQuote, true /* allowEscapes */, true /* requireUTF8 */) {
+				lval.SetID(lexbase.SCONST)
+			}
+			return
+		}
+		s.scanIdent(lval)
+		return
+
 	case '.':
 		switch t := s.peek(); {
 		case t == '.': // ..

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -160,7 +160,7 @@ func (s *Declaration) CopyNode() *Declaration {
 }
 
 func (s *Declaration) Format(ctx *tree.FmtCtx) {
-	ctx.WriteString(string(s.Var))
+	ctx.FormatNode(&s.Var)
 	if s.Constant {
 		ctx.WriteString(" CONSTANT")
 	}
@@ -202,7 +202,7 @@ func (s *CursorDeclaration) CopyNode() *CursorDeclaration {
 }
 
 func (s *CursorDeclaration) Format(ctx *tree.FmtCtx) {
-	ctx.WriteString(string(s.Name))
+	ctx.FormatNode(&s.Name)
 	switch s.Scroll {
 	case tree.Scroll:
 		ctx.WriteString(" SCROLL")
@@ -225,7 +225,7 @@ func (s *CursorDeclaration) WalkStmt(visitor StatementVisitor) Statement {
 
 // stmt_assign
 type Assignment struct {
-	Statement
+	StatementImpl
 	Var   Variable
 	Value Expr
 }


### PR DESCRIPTION
#### plpgsql: correctly format variable names in declarations

This commit fixes formatting for variable and cursor declarations to
use `FmtCtx.FormatNode` instead of `FormatString`. This ensures that
variable names are correctly redacted when applicable, and that
complex identifiers round-trip through the parser.

Informs #106368

Release note (bug fix): Fixed a bug that prevented the use of PL/pgSQL
routines with complex variable names that require double quotes. This
bug has existed since v23.2.

#### plpgsql/parser: propagate errors during string scanning

This commit fixes handling for string constants in the PL/pgSQL parser.
Now, the PL/pgSQL scanner handles string scanning itself instead of delegating
to the SQL scanner. This ensures that the correct token ID is used when an
error occurs (e.g. unterminated string). This commit also adds a check for the
ERROR token during PL/pgSQL lexing, so that a scanning error is noticed and
propagated back to the user.

Informs #106368

Release note (bug fix): Fixed a bug that could cause creation of a
syntactically invalid PL/pgSQL routine to return the wrong error. This bug has
existed since v23.2.

#### plpgsql/parser: fix parsing for escaped strings

This commit adds support for scanning an escaped string constant in a
PL/pgSQL routine. This is necessary because escaped strings have imbalanced
quotes (like `e'foobar''`), which previously caused the scanner to return
an "unterminated string" error.

Informs #106368

Release note (bug fix): Fixed a bug that could result in a syntax error
if a PL/pgSQL routine was created with an escaped string constant in
the routine body. This bug has existed since v23.2.