### PR TITLE
builtins,workload: add setseed function; use it to make RSW more deterministic

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -978,6 +978,8 @@ available replica will error.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="round"></a><code>round(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Rounds <code>val</code> to the nearest integer using half to even (banker’s) rounding.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="setseed"></a><code>setseed(seed: <a href="float.html">float</a>) &rarr; void</code></td><td><span class="funcdesc"><p>Sets the seed for subsequent random() calls in this session (value between -1.0 and 1.0, inclusive). There are no guarantees as to how this affects the seed of random() calls that appear in the same query as setseed().</p>
+</span></td><td>Volatile</td></tr>
 <tr><td><a name="sign"></a><code>sign(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Determines the sign of <code>val</code>: <strong>1</strong> for positive; <strong>0</strong> for 0 values; <strong>-1</strong> for negative.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="sign"></a><code>sign(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Determines the sign of <code>val</code>: <strong>1</strong> for positive; <strong>0</strong> for 0 values; <strong>-1</strong> for negative.</p>

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -81,6 +81,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/sentryutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -3650,6 +3651,8 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 		indexUsageStats:      ex.indexUsageStats,
 		statementPreparer:    ex,
 	}
+	rng, _ := randutil.NewPseudoRand()
+	evalCtx.RNG = rng
 	evalCtx.copyFromExecCfg(ex.server.cfg)
 }
 

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/pprofutil",
+        "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "//pkg/util/tochar",
         "//pkg/util/tracing",

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/pprofutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tochar"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -375,6 +376,8 @@ func (ds *ServerImpl) setupFlow(
 			RangeStatsFetcher:         ds.ServerConfig.RangeStatsFetcher,
 			ULIDEntropy:               ulid.Monotonic(crypto_rand.Reader, 0),
 		}
+		rng, _ := randutil.NewPseudoRand()
+		evalCtx.RNG = rng
 		// Most processors will override this Context with their own context in
 		// ProcessorBase. StartInternal().
 		evalCtx.SetDeprecatedContext(ctx)

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -150,6 +150,31 @@ SELECT random() * 0.0
 ----
 0
 
+statement ok
+SELECT setseed(0.1)
+
+# The previous call to setseed() should affect the next query.
+query IR
+SELECT i, random() FROM ROWS FROM (generate_series(1, 5)) AS i ORDER by i
+----
+1  0.8090535001228529
+2  0.33363615433097443
+3  0.10208231032120892
+4  0.43716650508717286
+5  0.16686635296305902
+
+statement ok
+SELECT setseed(0.1)
+
+query IR
+SELECT i, random() FROM ROWS FROM (generate_series(1, 5)) AS i ORDER by i
+----
+1  0.8090535001228529
+2  0.33363615433097443
+3  0.10208231032120892
+4  0.43716650508717286
+5  0.16686635296305902
+
 # Concatenating 'empty' because the empty string doesn't work in these tests.
 query T
 SELECT concat() || 'empty'

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -557,6 +558,8 @@ func internalExtendedEvalCtx(
 		statsProvider:   sqlStatsProvider,
 		jobs:            newTxnJobsCollection(),
 	}
+	rng, _ := randutil.NewPseudoRand()
+	ret.RNG = rng
 	ret.SetDeprecatedContext(ctx)
 	ret.copyFromExecCfg(execCfg)
 	return ret

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -66,6 +66,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ulid"
@@ -2646,6 +2647,8 @@ func createSchemaChangeEvalCtx(
 			ULIDEntropy:          ulid.Monotonic(crypto_rand.Reader, 0),
 		},
 	}
+	rng, _ := randutil.NewPseudoRand()
+	evalCtx.RNG = rng
 	// TODO(andrei): This is wrong (just like on the main code path on
 	// setupFlow). Each processor should override Ctx with its own context.
 	evalCtx.SetDeprecatedContext(ctx)

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logpb",
         "//pkg/util/mon",
+        "//pkg/util/randutil",
         "//pkg/util/ulid",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/schemachanger/scbuild/tree_context_builder.go
+++ b/pkg/sql/schemachanger/scbuild/tree_context_builder.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ulid"
 )
 
@@ -64,6 +65,8 @@ func newEvalCtx(ctx context.Context, d Dependencies) *eval.Context {
 		DescIDGenerator:      d.DescIDGenerator(),
 		ULIDEntropy:          ulid.Monotonic(crypto_rand.Reader, 0),
 	}
+	rng, _ := randutil.NewPseudoRand()
+	evalCtx.RNG = rng
 	evalCtx.SetDeprecatedContext(ctx)
 	return evalCtx
 }

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2563,6 +2563,7 @@ var builtinOidsArray = []string{
 	2595: `array_agg(arg1: pg_lsn[]) -> pg_lsn[][]`,
 	2596: `array_agg(arg1: refcursor[]) -> refcursor[][]`,
 	2597: `array_agg(arg1: tuple[]) -> tuple[][]`,
+	2598: `setseed(seed: float) -> void`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -13,6 +13,7 @@ package eval
 import (
 	"context"
 	"math"
+	"math/rand"
 	"time"
 
 	apd "github.com/cockroachdb/apd/v3"
@@ -288,6 +289,9 @@ type Context struct {
 
 	// ULIDEntropy is the entropy source for ULID generation.
 	ULIDEntropy ulid.MonotonicReader
+
+	// RNG is the random number generator use for the "random" built-in function.
+	RNG *rand.Rand
 }
 
 // JobsProfiler is the interface used to fetch job specific execution details

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3256,6 +3256,9 @@ func (og *operationGenerator) getTableColumns(
 func (og *operationGenerator) randColumn(
 	ctx context.Context, tx pgx.Tx, tableName tree.TableName, pctExisting int,
 ) (string, error) {
+	if err := og.setSeedInDB(ctx, tx); err != nil {
+		return "", err
+	}
 	if og.randIntn(100) >= pctExisting {
 		// We make a unique name for all columns by prefixing them with the table
 		// index to make it easier to reference columns from different tables.
@@ -3282,6 +3285,9 @@ ORDER BY random()
 func (og *operationGenerator) randColumnWithMeta(
 	ctx context.Context, tx pgx.Tx, tableName tree.TableName, pctExisting int,
 ) (column, error) {
+	if err := og.setSeedInDB(ctx, tx); err != nil {
+		return column{}, err
+	}
 	if og.randIntn(100) >= pctExisting {
 		// We make a unique name for all columns by prefixing them with the table
 		// index to make it easier to reference columns from different tables.
@@ -3371,7 +3377,9 @@ func (og *operationGenerator) randChildColumnForFkRelation(
 func (og *operationGenerator) randParentColumnForFkRelation(
 	ctx context.Context, tx pgx.Tx, unique bool,
 ) (*tree.TableName, *column, error) {
-
+	if err := og.setSeedInDB(ctx, tx); err != nil {
+		return nil, nil, err
+	}
 	subQuery := strings.Builder{}
 	subQuery.WriteString(`
 		SELECT table_schema, table_name, column_name, crdb_sql_type, is_nullable, contype, conkey
@@ -3444,6 +3452,9 @@ func (og *operationGenerator) randParentColumnForFkRelation(
 func (og *operationGenerator) randConstraint(
 	ctx context.Context, tx pgx.Tx, tableName string,
 ) (string, error) {
+	if err := og.setSeedInDB(ctx, tx); err != nil {
+		return "", err
+	}
 	q := fmt.Sprintf(`
   SELECT constraint_name
     FROM [SHOW CONSTRAINTS FROM %s]
@@ -3461,6 +3472,9 @@ ORDER BY random()
 func (og *operationGenerator) randIndex(
 	ctx context.Context, tx pgx.Tx, tableName tree.TableName, pctExisting int,
 ) (string, error) {
+	if err := og.setSeedInDB(ctx, tx); err != nil {
+		return "", err
+	}
 	if og.randIntn(100) >= pctExisting {
 		// We make a unique name for all indices by prefixing them with the table
 		// index to make it easier to reference columns from different tables.
@@ -3485,7 +3499,9 @@ ORDER BY random()
 func (og *operationGenerator) randSequence(
 	ctx context.Context, tx pgx.Tx, pctExisting int, desiredSchema string,
 ) (*tree.TableName, error) {
-
+	if err := og.setSeedInDB(ctx, tx); err != nil {
+		return nil, err
+	}
 	if desiredSchema != "" {
 		if og.randIntn(100) >= pctExisting {
 			treeSeqName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
@@ -3587,7 +3603,9 @@ ORDER BY random()
 func (og *operationGenerator) randTable(
 	ctx context.Context, tx pgx.Tx, pctExisting int, desiredSchema string,
 ) (*tree.TableName, error) {
-
+	if err := og.setSeedInDB(ctx, tx); err != nil {
+		return nil, err
+	}
 	if desiredSchema != "" {
 		if og.randIntn(100) >= pctExisting {
 			treeTableName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
@@ -3658,6 +3676,9 @@ ORDER BY random()
 func (og *operationGenerator) randView(
 	ctx context.Context, tx pgx.Tx, pctExisting int, desiredSchema string,
 ) (*tree.TableName, error) {
+	if err := og.setSeedInDB(ctx, tx); err != nil {
+		return nil, err
+	}
 	if desiredSchema != "" {
 		if og.randIntn(100) >= pctExisting {
 			treeViewName := tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
@@ -3701,6 +3722,9 @@ func (og *operationGenerator) randView(
 			ExplicitSchema: true,
 		}, tree.Name(fmt.Sprintf("view_%s", og.newUniqueSeqNumSuffix())))
 		return &treeViewName, nil
+	}
+	if err := og.setSeedInDB(ctx, tx); err != nil {
+		return nil, err
 	}
 	const q = `
   SELECT schema_name, table_name
@@ -3812,6 +3836,9 @@ func (og *operationGenerator) createSchema(ctx context.Context, tx pgx.Tx) (*opS
 func (og *operationGenerator) randSchema(
 	ctx context.Context, tx pgx.Tx, pctExisting int,
 ) (string, error) {
+	if err := og.setSeedInDB(ctx, tx); err != nil {
+		return "", err
+	}
 	if og.randIntn(100) >= pctExisting {
 		return fmt.Sprintf("schema_%s", og.newUniqueSeqNumSuffix()), nil
 	}
@@ -4309,6 +4336,11 @@ func (og *operationGenerator) randIntn(topBound int) int {
 	return og.params.rng.Intn(topBound)
 }
 
+// randFloat64 returns an float64 in the range [0,1.0).
+func (og *operationGenerator) randFloat64() float64 {
+	return og.params.rng.Float64()
+}
+
 func (og *operationGenerator) newUniqueSeqNumSuffix() string {
 	og.params.seqNum++
 	return fmt.Sprintf("w%d_%d", og.params.workerID, og.params.seqNum)
@@ -4335,7 +4367,7 @@ func (og *operationGenerator) typeFromTypeName(
 }
 
 // Check if the test is running with a mixed version cluster, with a version
-// less than or equal to the target version number. This can be used to detect
+// less than the target version number. This can be used to detect
 // in mixed version environments if certain errors should be encountered.
 func isClusterVersionLessThan(
 	ctx context.Context, tx pgx.Tx, targetVersion roachpb.Version,
@@ -4349,5 +4381,19 @@ func isClusterVersionLessThan(
 	if err != nil {
 		return false, err
 	}
-	return clusterVersion.LessEq(targetVersion), nil
+	return clusterVersion.Less(targetVersion), nil
+}
+
+func (og *operationGenerator) setSeedInDB(ctx context.Context, tx pgx.Tx) error {
+	if notSupported, err := isClusterVersionLessThan(ctx, tx, clusterversion.V24_1.Version()); err != nil {
+		return err
+	} else if notSupported {
+		// To allow the schemachange workload to work in a mixed-version state,
+		// this should not be treated as an error.
+		return nil
+	}
+	if _, err := tx.Exec(ctx, "SELECT setseed($1)", og.randFloat64()); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This implements the setseed function that appears in PostgreSQL.

We then use it to make the ORDER BY random()
clauses used in the random schema workload (RSW) deterministic.

Each worker goroutine of the RSW now runs a determistic sequence of
operations given the same COCKROACH_RANDOM_SEED. However, since the
workload is concurrent, the overall RSW is not deterministic, since the
interleaving of goroutine execution is random.

informs https://github.com/cockroachdb/cockroach/issues/117422

Release note (sql change): Added the setseed() builtin function. It sets
the seed for the random generator used by the random() builtin function.