### PR TITLE
workload/schemachange: enable DROP SCHEMA statements

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3841,18 +3841,10 @@ func (og *operationGenerator) dropSchema(ctx context.Context, tx pgx.Tx) (*opStm
 	if err != nil {
 		return nil, err
 	}
-	crossReferences := false
-	if schemaExists {
-		crossReferences, err = og.schemaContainsTypesWithCrossSchemaReferences(ctx, tx, schemaName)
-		if err != nil {
-			return nil, err
-		}
-	}
 	stmt := makeOpStmt(OpStmtDDL)
 	stmt.expectedExecErrors.addAll(codesWithConditions{
 		{pgcode.UndefinedSchema, !schemaExists},
 		{pgcode.InvalidSchemaName, schemaName == catconstants.PublicSchemaName},
-		{pgcode.FeatureNotSupported, crossReferences},
 	})
 
 	stmt.sql = fmt.Sprintf(`DROP SCHEMA "%s" CASCADE`, schemaName)

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -290,7 +290,7 @@ var opWeights = []int{
 	createView:                        1,
 	dropFunction:                      1,
 	dropIndex:                         1,
-	dropSchema:                        0, // Disabled and tracked with 116792.
+	dropSchema:                        1,
 	dropSequence:                      1,
 	dropTable:                         1,
 	dropView:                          1,


### PR DESCRIPTION
This removes an outdated check for cross-schema type references. DROP
SCHEMA used to not support that, but it does now.

fixes https://github.com/cockroachdb/cockroach/issues/116792
Release note: None