### PR TITLE
release: fix release branch pattern

### DIFF
--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -105,3 +105,14 @@ verify_docker_image(){
   return $error
 }
 
+
+function is_release_or_master_build(){
+  # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
+  echo "$1" | grep -Eo "^((staging|release|rc)-(v)?[0-9][0-9]\.[0-9]).*|master$" || echo ""
+  #                        ^ Match branches that start with "staging" (extra-ordinary relases),
+  #                        "release" (regular releases, including baking releases, e.g. release-v23.1.15-rc),
+  #                        "rc" (will be used for baking releases in the furure).
+  #                                             ^ "v" is optional to match main release branches, e.g. release-23.2
+  #                                                ^ calver prefix, e.g. 25.1
+  # We don't strictly match the suffix to allow different ones, e.g. "rc" or have none.
+}

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
@@ -10,10 +10,10 @@ tc_start_block "Variable Setup"
 build_name=$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev-parse --short HEAD;)
 
 # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
-is_release_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^(release-[0-9][0-9]\.[0-9](\.0)?(-rc)?)$|master$" || echo "")"
+release_build_match="$(is_release_or_master_build "$TC_BUILD_BRANCH")"
 
 if [[ -z "${DRY_RUN}" ]] ; then
-  if [[ -z "${is_release_build}" ]] ; then
+  if [[ -z "${release_build_match}" ]] ; then
     google_credentials=$GOOGLE_CREDENTIALS_CUSTOMIZED
     gcr_repository="us-docker.pkg.dev/cockroach-cloud-images/cockroachdb-customized/cockroach-customized"
     gcr_hostname="us-docker.pkg.dev"
@@ -32,9 +32,9 @@ fi
 
 cat << EOF
 
-  build_name:          $build_name
-  gcr_repository:      $gcr_repository
-  is_release_build:    $is_release_build
+  build_name:             $build_name
+  gcr_repository:         $gcr_repository
+  release_build_match:    $release_build_match
 
 EOF
 tc_end_block "Variable Setup"

--- a/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
@@ -12,7 +12,7 @@ build_name=$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev
 
 # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
 release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"
-is_release_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^((staging|release|rc)-(v)?[0-9][0-9]\.[0-9](\.0)?).*" || echo "")"
+release_build_match="$(is_release_or_master_build "$TC_BUILD_BRANCH")"
 is_customized_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^custombuild-" || echo "")"
 github_ssh_key="${GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY}"
 
@@ -60,7 +60,7 @@ if [[ -z "${is_customized_build}" ]] ; then
   tc_start_block "Tag docker image as latest-build"
   # Only tag the image as "latest-vX.Y-build" if the tag is on a release branch
   # (or master for the alphas for the next major release).
-  if [[ -n "${is_release_build}" ]] ; then
+  if [[ -n "${release_build_match}" ]] ; then
     log_into_gcloud
     gcloud container images add-tag "${gcr_repository}:${build_name}" "${gcr_repository}:latest-${release_branch}-build"
   fi


### PR DESCRIPTION
Previously, we used different patterns to match release branches in `make-and-publish-build-tagging.sh` and
`make-and-publish-build=artifacts-docker.sh`.

This PR syncs the patterns they use.

Epic: none
Release note: none
Release justification: release automation changes