### PR TITLE
roachprod: add port flags for start commands

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -339,6 +339,10 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd} {
 		cmd.Flags().Int64Var(&startOpts.NumFilesLimit, "num-files-limit", startOpts.NumFilesLimit,
 			"limit the number of files that can be created by the cockroach process")
+		cmd.Flags().IntVar(&startOpts.SQLPort,
+			"sql-port", startOpts.SQLPort, "port on which to listen for SQL clients")
+		cmd.Flags().IntVar(&startOpts.AdminUIPort,
+			"admin-ui-port", startOpts.AdminUIPort, "port to serve the admin UI on")
 	}
 
 	for _, cmd := range []*cobra.Command{


### PR DESCRIPTION
Previously, `roachprod` did not provide a way to specify ports, when starting cockroach. This change adds the ability to pass a `sql-port` and `admin-ui-port` if the user wishes to start an instance with specific ports.

Resolves: #118945
Release Note: None