### PR TITLE
release-23.2: sql: add telemetry block regexps and fix flake

### DIFF
--- a/pkg/ccl/telemetryccl/testdata/telemetry/index
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/index
@@ -1,6 +1,6 @@
 # This file contains telemetry tests for CCL-related index creation counters.
 
-feature-allowlist
+feature-list
 sql.schema.partitioned_inverted_index
 ----
 

--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
@@ -1,4 +1,4 @@
-feature-allowlist
+feature-list
 sql.multiregion.*
 ----
 
@@ -45,7 +45,7 @@ exec
 SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '10ms';
 ----
 
-feature-allowlist
+feature-list
 sql.plan.opt.locality-optimized-search
 ----
 
@@ -70,7 +70,7 @@ USE survive_region;
 CREATE TABLE t9 (a INT PRIMARY KEY) LOCALITY REGIONAL BY ROW
 ----
 
-feature-allowlist
+feature-list
 sql.multiregion.zone_configuration.override.*
 ----
 

--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion_db
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion_db
@@ -1,4 +1,4 @@
-feature-allowlist
+feature-list
 sql.multiregion.*
 ----
 

--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion_row
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion_row
@@ -1,4 +1,4 @@
-feature-allowlist
+feature-list
 sql.multiregion.*
 ----
 

--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion_table
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion_table
@@ -1,4 +1,4 @@
-feature-allowlist
+feature-list
 sql.multiregion.*
 ----
 

--- a/pkg/sql/sqltestutils/telemetry.go
+++ b/pkg/sql/sqltestutils/telemetry.go
@@ -49,19 +49,21 @@ import (
 //     Executes SQL statements against the database. Outputs no results on
 //     success. In case of error, outputs the error message.
 //
-//   - feature-allowlist
+//   - feature-list
 //
-//     The input for this command is not SQL, but a list of regular expressions.
-//     Tests that follow (until the next feature-allowlist command) will only
-//     output counters that match a regexp in this allow list.
+//     The input for this command is not SQL, but a list of regular expressions
+//     that are allowed. Lines starting with the "!" prefix are regexps that are
+//     blocked. Tests that follow (until the next feature-list command) will
+//     only output counters that match at least one allow regexp in this list,
+//     and do not match any block regexps in this list.
 //
 //   - feature-usage, feature-counters
 //
 //     Executes SQL statements and then outputs the feature counters from the
-//     allowlist that have been reported to the diagnostic server. The first
+//     feature-list that have been reported to the diagnostic server. The first
 //     variant outputs only the names of the counters that changed; the second
 //     variant outputs the counts as well. It is necessary to use
-//     feature-allowlist before these commands to avoid test flakes (e.g. because
+//     feature-list before these commands to avoid test flakes (e.g. because
 //     of counters that are changed by looking up descriptors).
 //     TODO(yuzefovich): counters currently don't really work because they are
 //     reset before executing every statement by reporter.ReportDiagnostics.
@@ -126,7 +128,7 @@ type telemetryTest struct {
 	tenant         serverutils.ApplicationLayerInterface
 	tenantDB       *gosql.DB
 	tempDirCleanup func()
-	allowlist      featureAllowlist
+	features       featureList
 	rewrites       []rewrite
 }
 
@@ -219,9 +221,9 @@ func (tt *telemetryTest) RunTest(
 		}
 		return buf.String()
 
-	case "feature-allowlist":
+	case "feature-list":
 		var err error
-		tt.allowlist, err = makeAllowlist(strings.Split(td.Input, "\n"))
+		tt.features, err = makeFeatureList(strings.Split(td.Input, "\n"))
 		if err != nil {
 			td.Fatalf(tt.t, "error parsing feature regex: %s", err)
 		}
@@ -244,8 +246,8 @@ func (tt *telemetryTest) RunTest(
 				// Ignore zero values (shouldn't happen in practice)
 				continue
 			}
-			if !tt.allowlist.Match(k) {
-				// Feature key not in allowlist.
+			if !tt.features.Match(k) {
+				// Feature key not in features.
 				continue
 			}
 			keys = append(keys, k)
@@ -310,31 +312,42 @@ func (tt *telemetryTest) prepareCluster(db *gosql.DB) {
 	runner.Exec(tt.t, "SET CLUSTER SETTING sql.query_cache.enabled = false")
 }
 
-type featureAllowlist []*regexp.Regexp
+type featureList []struct {
+	r     *regexp.Regexp
+	block bool
+}
 
-func makeAllowlist(strings []string) (featureAllowlist, error) {
-	w := make(featureAllowlist, len(strings))
-	for i := range strings {
+func makeFeatureList(strings []string) (featureList, error) {
+	l := make(featureList, len(strings))
+	for i, s := range strings {
 		var err error
-		w[i], err = regexp.Compile("^" + strings[i] + "$")
+		if s[0] == '!' {
+			l[i].block = true
+			s = s[1:]
+		}
+		l[i].r, err = regexp.Compile("^" + s + "$")
 		if err != nil {
 			return nil, err
 		}
 	}
-	return w, nil
+	return l, nil
 }
 
-func (w featureAllowlist) Match(feature string) bool {
-	if w == nil {
-		// Unset allowlist matches all counters.
+func (l featureList) Match(feature string) bool {
+	if l == nil {
+		// An unset features list matches all counters.
 		return true
 	}
-	for _, r := range w {
-		if r.MatchString(feature) {
-			return true
+	matchFound := false
+	for _, f := range l {
+		if f.r.MatchString(feature) {
+			if f.block {
+				return false
+			}
+			matchFound = true
 		}
 	}
-	return false
+	return matchFound
 }
 
 func formatTableDescriptor(desc *descpb.TableDescriptor) string {

--- a/pkg/sql/testdata/telemetry/drop_owned_by
+++ b/pkg/sql/testdata/telemetry/drop_owned_by
@@ -1,6 +1,6 @@
 # This file contains telemetry tests for the sql.drop_owned_by counter.
 
-feature-allowlist
+feature-list
 sql.drop_owned_by.*
 ----
 

--- a/pkg/sql/testdata/telemetry/enums
+++ b/pkg/sql/testdata/telemetry/enums
@@ -1,4 +1,4 @@
-feature-allowlist
+feature-list
 sql.udts.*
 sql.schema.alter_type.*
 ----

--- a/pkg/sql/testdata/telemetry/error
+++ b/pkg/sql/testdata/telemetry/error
@@ -1,6 +1,6 @@
 # This file contains telemetry tests for counters triggered by errors.
 
-feature-allowlist
+feature-list
 othererror.*
 errorcodes.*
 unimplemented.*

--- a/pkg/sql/testdata/telemetry/execution
+++ b/pkg/sql/testdata/telemetry/execution
@@ -1,7 +1,7 @@
 # This file contains telemetry tests for sql.exec.* counters.
 
 # Tests for vectorization counters.
-feature-allowlist
+feature-list
 sql.exec.vectorized-setting.on
 sql.exec.vectorized-setting.off
 ----
@@ -18,7 +18,7 @@ sql.exec.vectorized-setting.off
 
 # Test for the hash aggregation disk spilling counter. Note that it is
 # incremented only when changing the setting to `false`.
-feature-allowlist
+feature-list
 sql.exec.hash-agg-spilling-disabled
 ----
 

--- a/pkg/sql/testdata/telemetry/extension
+++ b/pkg/sql/testdata/telemetry/extension
@@ -1,4 +1,4 @@
-feature-allowlist
+feature-list
 sql.extension.*
 unimplemented.*
 ----

--- a/pkg/sql/testdata/telemetry/feature_flags
+++ b/pkg/sql/testdata/telemetry/feature_flags
@@ -1,6 +1,6 @@
 # This file contains telemetry tests for the sql.feature_flag.denied counter.
 
-feature-allowlist
+feature-list
 sql.feature_flag_denied.*
 ----
 

--- a/pkg/sql/testdata/telemetry/geospatial
+++ b/pkg/sql/testdata/telemetry/geospatial
@@ -1,4 +1,4 @@
-feature-allowlist
+feature-list
 unimplemented.*
 ----
 

--- a/pkg/sql/testdata/telemetry/hashed
+++ b/pkg/sql/testdata/telemetry/hashed
@@ -1,6 +1,6 @@
 # This file contains telemetry tests for the hashed.* counter.
 
-feature-allowlist
+feature-list
 sql.hashed.*
 ----
 

--- a/pkg/sql/testdata/telemetry/index
+++ b/pkg/sql/testdata/telemetry/index
@@ -1,7 +1,7 @@
 # This file contains telemetry tests for sql.schema partial index creation
 # counters.
 
-feature-allowlist
+feature-list
 sql.schema.hash_sharded_index
 sql.schema.inverted_index
 sql.schema.multi_column_inverted_index

--- a/pkg/sql/testdata/telemetry/isolation_level
+++ b/pkg/sql/testdata/telemetry/isolation_level
@@ -6,7 +6,7 @@ exec
 SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = false
 ----
 
-feature-allowlist
+feature-list
 sql.txn.isolation.*
 ----
 

--- a/pkg/sql/testdata/telemetry/json
+++ b/pkg/sql/testdata/telemetry/json
@@ -1,4 +1,4 @@
-feature-allowlist
+feature-list
 sql.plan.ops.jsonb.subscript
 ----
 

--- a/pkg/sql/testdata/telemetry/materialized_view
+++ b/pkg/sql/testdata/telemetry/materialized_view
@@ -1,6 +1,6 @@
 # This file contains telemetry tests for sql.schema.*_materialized_view.* counters.
 
-feature-allowlist
+feature-list
 sql.schema.create_materialized_view
 sql.schema.alter_materialized_view.owner_to
 sql.schema.alter_materialized_view.set_schema

--- a/pkg/sql/testdata/telemetry/planning
+++ b/pkg/sql/testdata/telemetry/planning
@@ -10,7 +10,7 @@ CREATE TABLE y (a INT PRIMARY KEY, b JSONB, INVERTED INDEX (b))
 
 # Tests for EXPLAIN counters.
 
-feature-allowlist
+feature-list
 sql.plan.explain
 sql.plan.explain-analyze
 sql.plan.explain-opt
@@ -55,7 +55,7 @@ sql.plan.explain-gist
 
 # Tests for hints.
 
-feature-allowlist
+feature-list
 sql.plan.hints.*
 ----
 
@@ -99,7 +99,7 @@ sql.plan.hints.index.delete
 
 # Tests for tracking important setting changes.
 
-feature-allowlist
+feature-list
 sql.plan.reorder-joins.*
 sql.plan.automatic-stats.*
 ----
@@ -140,7 +140,7 @@ RESET CLUSTER SETTING sql.stats.automatic_collection.enabled
 sql.plan.automatic-stats.enabled
 
 # Test telemetry for manual statistics creation.
-feature-allowlist
+feature-list
 sql.plan.stats.created
 ----
 
@@ -150,7 +150,7 @@ CREATE STATISTICS stats FROM x
 sql.plan.stats.created
 
 # Test various planning counters.
-feature-allowlist
+feature-list
 sql.plan.cte.*
 ----
 
@@ -165,7 +165,7 @@ WITH RECURSIVE a AS (SELECT 1 UNION ALL SELECT * FROM a WHERE false) SELECT * FR
 sql.plan.cte
 sql.plan.cte.recursive
 
-feature-allowlist
+feature-list
 sql.plan.lateral-join
 ----
 
@@ -179,7 +179,7 @@ SELECT * FROM (VALUES (1), (2)) AS a(x) JOIN LATERAL (SELECT a.x+1 AS x) AS b ON
 ----
 sql.plan.lateral-join
 
-feature-allowlist
+feature-list
 sql.plan.subquery
 ----
 
@@ -188,7 +188,7 @@ SELECT 1 = (SELECT a FROM x LIMIT 1)
 ----
 sql.plan.subquery
 
-feature-allowlist
+feature-list
 sql.plan.subquery.correlated
 ----
 
@@ -199,7 +199,7 @@ sql.plan.subquery.correlated
 
 # Test some sql.plan.ops counters, using some esoteric operators unlikely to be
 # executed in background activity).
-feature-allowlist
+feature-list
 sql.plan.ops.cast.string::inet
 sql.plan.ops.bin.jsonb - string
 sql.plan.ops.array.*
@@ -227,7 +227,7 @@ INSERT INTO x SELECT unnest(ARRAY[9, 10, 11, 12])
 sql.plan.ops.array.cons
 
 # Test a few sql.plan.opt.node counters.
-feature-allowlist
+feature-list
 sql.plan.opt.node.project-set
 ----
 
@@ -236,7 +236,7 @@ SELECT EXISTS(SELECT * FROM generate_series(1,2))
 ----
 sql.plan.opt.node.project-set
 
-feature-allowlist
+feature-list
 sql.plan.opt.node.join.algo.merge
 sql.plan.opt.node.join.type.inner
 ----
@@ -251,7 +251,7 @@ sql.plan.opt.node.join.type.inner
 
 # Tests for partial index counters.
 
-feature-allowlist
+feature-list
 sql.plan.opt.partial-index.scan
 ----
 
@@ -264,7 +264,7 @@ SELECT a FROM x@i WHERE a > 0
 ----
 sql.plan.opt.partial-index.scan
 
-feature-allowlist
+feature-list
 sql.plan.opt.partial-index.scan
 sql.plan.opt.partial-index.lookup-join
 ----
@@ -277,7 +277,7 @@ sql.plan.opt.partial-index.scan
 
 # ORDER BY nulls non-standard tests.
 
-feature-allowlist
+feature-list
 sql.plan.opt.order-by-nulls-non-standard
 ----
 

--- a/pkg/sql/testdata/telemetry/reassign_owned_by
+++ b/pkg/sql/testdata/telemetry/reassign_owned_by
@@ -1,6 +1,6 @@
 # This file contains telemetry tests for the sql.reassign_owned_by counter.
 
-feature-allowlist
+feature-list
 sql.reassign_owned_by.*
 ----
 

--- a/pkg/sql/testdata/telemetry/role_options
+++ b/pkg/sql/testdata/telemetry/role_options
@@ -1,6 +1,6 @@
 # This file contains telemetry tests for the iam.roles counter.
 
-feature-allowlist
+feature-list
 iam.roles.alter.*
 iam.roles.create.*
 ----

--- a/pkg/sql/testdata/telemetry/schema
+++ b/pkg/sql/testdata/telemetry/schema
@@ -36,7 +36,7 @@ table:_
       ├── _: _
       └── _: _
 
-feature-allowlist
+feature-list
 sql.schema.*
 ----
 

--- a/pkg/sql/testdata/telemetry/schema
+++ b/pkg/sql/testdata/telemetry/schema
@@ -38,6 +38,7 @@ table:_
 
 feature-list
 sql.schema.*
+!sql.schema.create_stats
 ----
 
 feature-usage

--- a/pkg/sql/testdata/telemetry/set
+++ b/pkg/sql/testdata/telemetry/set
@@ -1,4 +1,4 @@
-feature-allowlist
+feature-list
 sql.session_var.dummy.*
 ----
 

--- a/pkg/sql/testdata/telemetry/set_schema
+++ b/pkg/sql/testdata/telemetry/set_schema
@@ -1,6 +1,6 @@
 # This file contains telemetry tests for sql.schema.alter_*.set_schema counters.
 
-feature-allowlist
+feature-list
 sql.schema.alter_table.set_schema
 sql.schema.alter_sequence.set_schema
 sql.schema.alter_view.set_schema

--- a/pkg/sql/testdata/telemetry/trigrams
+++ b/pkg/sql/testdata/telemetry/trigrams
@@ -1,4 +1,4 @@
-feature-allowlist
+feature-list
 unimplemented.*
 ----
 

--- a/pkg/sql/testdata/telemetry/ttl
+++ b/pkg/sql/testdata/telemetry/ttl
@@ -1,4 +1,4 @@
-feature-allowlist
+feature-list
 sql.schema.alter_table\..*
 sql.schema.table_storage_parameter.*
 sql.row_level_ttl.created

--- a/pkg/sql/testdata/telemetry/user_defined_schemas
+++ b/pkg/sql/testdata/telemetry/user_defined_schemas
@@ -1,4 +1,4 @@
-feature-allowlist
+feature-list
 sql.uds.*
 ----
 

--- a/pkg/sql/testdata/telemetry/virtual_schema
+++ b/pkg/sql/testdata/telemetry/virtual_schema
@@ -1,4 +1,4 @@
-feature-allowlist
+feature-list
 sql.schema.get_virtual_table.*
 ----
 


### PR DESCRIPTION
Backport 2/2 commits from #117558.

/cc @cockroachdb/release

---

#### sqltestutils: allow blocking regexps in telemetry feature list

The `feature-allowlist` directive for telemetry tests has been renamed
`feature-list` and it now supports blocking regexps. Any line in the
`feature-list` that starts with "!" is a block regexp that prevents any
features matching the regexp from being included in the output of the
`feature-usage` and `feature-counters` directives. This is helpful
because Go's regexps do not support negative look-aheads, so adding
features that should not be matched is difficult and tedious.

Release note: None

#### sql: ignore "sql.schema.create_stats" in schema telemetry test

This commit ignores the `sql.schema.create_stats` in the `schema`
telemetry tests because it causes sporadic failures.

Fixes #117309

Release note: None

---

Release justification: Test-only fixes for flaky tests.

