### PR TITLE
opt/exec: use Fatal in plan gist tests

### DIFF
--- a/pkg/sql/opt/exec/explain/plan_gist_test.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_test.go
@@ -73,10 +73,10 @@ func plan(ot *opttester.OptTester, t *testing.T) string {
 	}
 	explainPlan, err := ot.ExecBuild(f, mem, expr)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if explainPlan == nil {
-		t.Error("Couldn't ExecBuild memo, use a logictest instead?")
+		t.Fatal("Couldn't ExecBuild memo, use a logictest instead?")
 	}
 	flags := explain.Flags{HideValues: true, Deflake: explain.DeflakeAll, OnlyShape: true}
 	ob := explain.NewOutputBuilder(flags)


### PR DESCRIPTION
This commit replaces some usages of `testing.Error` with `testing.Fatal`
so that tests exit when they encounter unexpected state rather than
trying to continue.

Epic: None

Release note: None
