### PR TITLE
roachprod/install: start shared service in a separate stmt

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -1296,20 +1296,15 @@ func (c *SyncedCluster) upsertVirtualClusterMetadata(
 		serviceMode = "EXTERNAL"
 	}
 
-	var virtualClusterStmts []string
 	if virtualClusterID <= 0 {
 		// If the virtual cluster metadata does not exist yet, create it.
-		virtualClusterStmts = append(virtualClusterStmts,
-			fmt.Sprintf("CREATE TENANT '%s'", startOpts.VirtualClusterName),
-		)
+		_, err = runSQL(fmt.Sprintf("CREATE TENANT '%s'", startOpts.VirtualClusterName))
+		if err != nil {
+			return -1, err
+		}
 	}
 
-	virtualClusterStmts = append(virtualClusterStmts, fmt.Sprintf(
-		"ALTER TENANT '%s' START SERVICE %s",
-		startOpts.VirtualClusterName, serviceMode),
-	)
-
-	_, err = runSQL(strings.Join(virtualClusterStmts, "; "))
+	_, err = runSQL(fmt.Sprintf("ALTER TENANT '%s' START SERVICE %s", startOpts.VirtualClusterName, serviceMode))
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
`ALTER VIRTUAL CLUSTER ... START SERVICE` apparently no longer can be used inside a multi-statement txn, so this commit splits it out into a separate one.

Fixes: #119050.
Fixes: #119062.

Release note: None