### PR TITLE
roachprod: avoid adding new keys to project metadata when creating clusters

### DIFF
--- a/pkg/roachprod/config/BUILD.bazel
+++ b/pkg/roachprod/config/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/util/envutil",
         "//pkg/util/log",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_errors//oserror",
     ],
 )
 

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1568,11 +1568,10 @@ fi
 	}
 
 	if len(c.AuthorizedKeys) > 0 {
-		// When clusters are created using cloud APIs they only have a subset of
-		// desired keys installed on a subset of users. This code distributes
-		// additional authorized_keys to both the current user (your username on
-		// gce and the shared user on aws) as well as to the shared user on both
-		// platforms.
+		// When clusters are created using cloud APIs they only have a
+		// subset of desired keys installed on a subset of users. This
+		// code distributes additional authorized_keys the current user
+		// (i.e., the shared user).
 		if err := c.Parallel(ctx, l, WithNodes(c.Nodes).WithDisplay("adding additional authorized keys"),
 			func(ctx context.Context, node Node) (*RunResultDetails, error) {
 				const cmd = `
@@ -1584,20 +1583,11 @@ on_exit() {
     rm -f "${tmp1}" "${tmp2}"
 }
 trap on_exit EXIT
-if [[ -f ~/.ssh/authorized_keys ]]; then
-    cat ~/.ssh/authorized_keys > "${tmp1}"
-fi
+cat ~/.ssh/authorized_keys > "${tmp1}"
 echo "${keys_data}" >> "${tmp1}"
 sort -u < "${tmp1}" > "${tmp2}"
 install --mode 0600 "${tmp2}" ~/.ssh/authorized_keys
-if [[ "$(whoami)" != "` + config.SharedUser + `" ]]; then
-    sudo install --mode 0600 \
-        --owner ` + config.SharedUser + `\
-        --group ` + config.SharedUser + `\
-        "${tmp2}" ~` + config.SharedUser + `/.ssh/authorized_keys
-fi
 `
-
 				runOpts := defaultCmdOpts("ssh-add-extra-keys")
 				runOpts.stdin = bytes.NewReader(c.AuthorizedKeys)
 				return c.runCmdOnSingleNode(ctx, l, node, cmd, runOpts)

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -620,13 +620,6 @@ func SetupSSH(ctx context.Context, l *logger.Logger, clusterName string) error {
 	if err != nil {
 		return err
 	}
-	// For GCP clusters we need to use the config.OSUser even if the client
-	// requested the shared user.
-	for i := range installCluster.VMs {
-		if cloudCluster.VMs[i].Provider == gce.ProviderName {
-			installCluster.VMs[i].RemoteUser = config.OSUser.Username
-		}
-	}
 	if err := installCluster.Wait(ctx, l); err != nil {
 		return err
 	}
@@ -1466,11 +1459,11 @@ func Create(
 			if retErr == nil {
 				return
 			}
-			l.Errorf("Cleaning up partially-created cluster (prev err: %s)\n", retErr)
+			l.Errorf("Cleaning up partially-created cluster (prev err: %s)", retErr)
 			if err := cleanupFailedCreate(l, clusterName); err != nil {
-				l.Errorf("Error while cleaning up partially-created cluster: %s\n", err)
+				l.Errorf("Error while cleaning up partially-created cluster: %s", err)
 			} else {
-				l.Printf("Cleaning up OK\n")
+				l.Printf("Cleaning up OK")
 			}
 		}()
 	} else {

--- a/pkg/roachprod/vm/aws/BUILD.bazel
+++ b/pkg/roachprod/vm/aws/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/vm/aws",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachprod/config",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/flagstub",
@@ -22,7 +23,6 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_errors//oserror",
         "@com_github_spf13_pflag//:pflag",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_time//rate",

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/flagstub"
@@ -437,7 +438,7 @@ func (p *Provider) ConfigSSH(l *logger.Logger, zones []string) error {
 				if err != nil {
 					return err
 				}
-				l.Printf("imported %s as %s in region %s", sshPublicKeyFile, keyName, region)
+				l.Printf("imported %s as %s in region %s", config.SSHPublicKeyPath, keyName, region)
 			}
 			return nil
 		})

--- a/pkg/roachprod/vm/azure/BUILD.bazel
+++ b/pkg/roachprod/vm/azure/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/vm/azure",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachprod/config",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/flagstub",

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/subscriptions"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/flagstub"
@@ -194,16 +195,9 @@ func (p *Provider) Create(
 ) error {
 	providerOpts := vmProviderOpts.(*ProviderOpts)
 	// Load the user's SSH public key to configure the resulting VMs.
-	var sshKey string
-	sshFile := os.ExpandEnv("${HOME}/.ssh/id_rsa.pub")
-	if _, err := os.Stat(sshFile); err == nil {
-		if bytes, err := os.ReadFile(sshFile); err == nil {
-			sshKey = string(bytes)
-		} else {
-			return errors.Wrapf(err, "could not read SSH public key file")
-		}
-	} else {
-		return errors.Wrapf(err, "could not find SSH public key file")
+	sshKey, err := config.SSHPublicKey()
+	if err != nil {
+		return err
 	}
 
 	m := getAzureDefaultLabelMap(opts)

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -979,19 +979,12 @@ func (p *Provider) CleanSSH(l *logger.Logger) error {
 	return nil
 }
 
-// ConfigSSH is part of the vm.Provider interface
+// ConfigSSH is part of the vm.Provider interface. For this provider,
+// it verifies that the test runner has a public SSH key, as that is
+// required when setting up new clusters.
 func (p *Provider) ConfigSSH(l *logger.Logger, zones []string) error {
-	// Populate SSH config files with Host entries from each instance in active projects.
-	for _, prj := range p.GetProjects() {
-		args := []string{"compute", "config-ssh", "--project", prj, "--quiet"}
-		cmd := exec.Command("gcloud", args...)
-
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
-		}
-	}
-	return nil
+	_, err := config.SSHPublicKey()
+	return err
 }
 
 func (p *Provider) editLabels(

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
@@ -234,6 +235,9 @@ sysctl --system  # reload sysctl settings
 sudo ua enable fips --assume-yes
 {{ end }}
 
+sudo -u {{ .SharedUser }} bash -c "mkdir ~/.ssh && chmod 700 ~/.ssh"
+sudo -u {{ .SharedUser }} bash -c 'echo "{{ .PublicKey }}" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
+
 sudo touch /mnt/data1/.roachprod-initialized
 `
 
@@ -251,6 +255,13 @@ func writeStartupScript(
 		UseMultipleDisks bool
 		Zfs              bool
 		EnableFIPS       bool
+		SharedUser       string
+		PublicKey        string
+	}
+
+	publicKey, err := config.SSHPublicKey()
+	if err != nil {
+		return "", err
 	}
 
 	args := tmplParams{
@@ -258,6 +269,8 @@ func writeStartupScript(
 		UseMultipleDisks: useMultiple,
 		Zfs:              fileSystem == vm.Zfs,
 		EnableFIPS:       enableFIPS,
+		SharedUser:       config.SharedUser,
+		PublicKey:        publicKey,
 	}
 
 	tmpfile, err := os.CreateTemp("", "gce-startup-script")


### PR DESCRIPTION
Roachprod uses GCP's 'project metadata' feature[^1] to manage SSH
keys. This is useful to make sure every cluster created by roachprod,
regardless of the cloud used, gets the same set of keys in the "shared
user" (`ubuntu`) account.

However, roachprod also calls `gcloud config-ssh` when creating new
clusters. This command, among other things, adds the caller's public
key to the project metadata.

TeamCity agents (where a lot of roachprod clusters are created in the
process of running roachtests) run in ephemeral environments with
public keys that are only valid during that run. As a consequence,
these ephemeral keys keep being added to the project metadata, making
us hit the storage limitation of 256KB for these keys.

This limit should be more than enough for our current usage. At the
time of writing, out of the 447 public keys stored in the project
metadata, only 50 are *not* from `agent` or `roach` (usernames
associated with TeamCity agents).

In this commit, we change how cluster provisioning in GCP works:
instead of relying on `config-ssh` to provide access to the newly
created VM, we include the caller's public key in the shared user's
`authorized_keys` right on startup. As a result, TeamCity agents can
run as usual (since creating a public key is already part of their
scripts -- it's required by the AWS provider) while *not* adding any
keys to the project metadata. This should allow the GCP project
metadata to be used exclusively for employee keys that should exist in
every cluster.

Informs: #90104

Release note: None

[^1]: https://cloud.google.com/compute/docs/connect/add-ssh-keys