### PR TITLE
engflow: handle unfinished build stream

### DIFF
--- a/pkg/cmd/bazci/bazel-github-helper/main.go
+++ b/pkg/cmd/bazci/bazel-github-helper/main.go
@@ -94,7 +94,9 @@ func process() error {
 
 func dumpSummary(f *os.File, invocation *engflow.InvocationInfo) error {
 	var title string
-	if invocation.ExitCode == 0 {
+	if !invocation.Finished {
+		title = "# Build did not succeed"
+	} else if invocation.ExitCode == 0 {
 		title = "# Build Succeeded"
 	} else {
 		title = fmt.Sprintf("# Build Failed (code: %s)", invocation.ExitCodeName)


### PR DESCRIPTION
1. If the stream is incomplete, don't fail immediately, instead process as much of the stream as we can.
2. When reporting build results on GitHub, only say the build succeeded if the stream actually finished.

Epic: CRDB-8308
Release note: None