### PR TITLE
sql/schemachanger: CREATE SEQUENCE is incorrectly adding a rowid column

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -772,7 +772,7 @@ func addIndexMutationWithSpecificPrimaryKey(
 	if err := table.AddIndexMutationMaybeWithTempIndex(toAdd, descpb.DescriptorMutation_ADD); err != nil {
 		return err
 	}
-	if err := table.AllocateIDsWithoutValidation(ctx); err != nil {
+	if err := table.AllocateIDsWithoutValidation(ctx, true /*createMissingPrimaryKey*/); err != nil {
 		return err
 	}
 

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -526,7 +526,7 @@ func (desc *Mutable) MaybeFillColumnID(
 // or index which has an ID of 0. It's the same as AllocateIDsWithoutValidation,
 // but does validation on the table elements.
 func (desc *Mutable) AllocateIDs(ctx context.Context, version clusterversion.ClusterVersion) error {
-	if err := desc.AllocateIDsWithoutValidation(ctx); err != nil {
+	if err := desc.AllocateIDsWithoutValidation(ctx, true /*createMissingPrimaryKey*/); err != nil {
 		return err
 	}
 
@@ -545,9 +545,13 @@ func (desc *Mutable) AllocateIDs(ctx context.Context, version clusterversion.Clu
 
 // AllocateIDsWithoutValidation allocates column, family, and index ids for any
 // column, family, or index which has an ID of 0.
-func (desc *Mutable) AllocateIDsWithoutValidation(ctx context.Context) error {
-	// Only tables with physical data can have / need a primary key.
-	if desc.IsPhysicalTable() {
+func (desc *Mutable) AllocateIDsWithoutValidation(
+	ctx context.Context, createMissingPrimaryKey bool,
+) error {
+	// Only tables with physical data can have / need a primary key. In the
+	// declarative schema changer the primary key is always created explicitly,
+	// so we don't need to create it here.
+	if desc.IsPhysicalTable() && createMissingPrimaryKey {
 		if err := desc.ensurePrimaryKey(); err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2449,3 +2449,17 @@ RESET serial_normalization;
 RESET default_int_size;
 
 subtest end
+
+# The following subtest ensures sequences do not have any unexpected columns
+# on creation. Previously, we were incorrectly creating a rowid column.
+subtest regression_119108
+
+statement ok
+CREATE SEQUENCE sq_119108;
+
+query T
+SELECT column_name from [SHOW COLUMNS FROM sq_119108]
+----
+value
+
+subtest end

--- a/pkg/sql/schemachanger/scexec/scmutationexec/column.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/column.go
@@ -85,7 +85,7 @@ func (i *immediateVisitor) SetAddedColumnType(
 	}
 	// Empty names are allowed for families, in which case AllocateIDs will assign
 	// one.
-	return tbl.AllocateIDsWithoutValidation(ctx)
+	return tbl.AllocateIDsWithoutValidation(ctx, false /* createMissingPrimaryKey */)
 }
 
 func (i *immediateVisitor) MakeDeleteOnlyColumnWriteOnly(

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence/create_sequence.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence/create_sequence.side_effects
@@ -29,21 +29,13 @@ upsert descriptor #104
   +      family: IntFamily
   +      oid: 20
   +      width: 64
-  +  - defaultExpr: unique_rowid()
-  +    hidden: true
-  +    id: 2
-  +    name: rowid
-  +    type:
-  +      family: IntFamily
-  +      oid: 20
-  +      width: 64
   +  createAsOfTime: {}
   +  formatVersion: 3
   +  id: 104
   +  modificationTime: {}
   +  mutations: []
   +  name: sq1
-  +  nextColumnId: 3
+  +  nextColumnId: 2
   +  nextConstraintId: 1
   +  nextIndexId: 2
   +  parentId: 100
@@ -112,21 +104,13 @@ upsert descriptor #104
   +      family: IntFamily
   +      oid: 20
   +      width: 64
-  +  - defaultExpr: unique_rowid()
-  +    hidden: true
-  +    id: 2
-  +    name: rowid
-  +    type:
-  +      family: IntFamily
-  +      oid: 20
-  +      width: 64
   +  createAsOfTime: {}
   +  formatVersion: 3
   +  id: 104
   +  modificationTime: {}
   +  mutations: []
   +  name: sq1
-  +  nextColumnId: 3
+  +  nextColumnId: 2
   +  nextConstraintId: 1
   +  nextIndexId: 2
   +  parentId: 100

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column.side_effects
@@ -32,21 +32,13 @@ upsert descriptor #105
   +      family: IntFamily
   +      oid: 20
   +      width: 64
-  +  - defaultExpr: unique_rowid()
-  +    hidden: true
-  +    id: 2
-  +    name: rowid
-  +    type:
-  +      family: IntFamily
-  +      oid: 20
-  +      width: 64
   +  createAsOfTime: {}
   +  formatVersion: 3
   +  id: 105
   +  modificationTime: {}
   +  mutations: []
   +  name: sq1
-  +  nextColumnId: 3
+  +  nextColumnId: 2
   +  nextConstraintId: 1
   +  nextIndexId: 2
   +  parentId: 100
@@ -229,15 +221,6 @@ upsert descriptor #105
   -
   +table:
   +  checks: []
-  +  columns:
-  +  - defaultExpr: unique_rowid()
-  +    hidden: true
-  +    id: 2
-  +    name: rowid
-  +    type:
-  +      family: IntFamily
-  +      oid: 20
-  +      width: 64
   +  createAsOfTime: {}
   +  declarativeSchemaChangerState:
   +    authorization:
@@ -278,7 +261,7 @@ upsert descriptor #105
   +    direction: ADD
   +    state: WRITE_ONLY
   +  name: sq1
-  +  nextColumnId: 3
+  +  nextColumnId: 2
   +  nextConstraintId: 1
   +  nextIndexId: 2
   +  parentId: 100
@@ -720,17 +703,17 @@ upsert descriptor #104
   -  version: "6"
   +  version: "7"
 upsert descriptor #105
-  ...
+   table:
      checks: []
-     columns:
+  +  columns:
   +  - id: 1
   +    name: value
   +    type:
   +      family: IntFamily
   +      oid: 20
   +      width: 64
-     - defaultExpr: unique_rowid()
-       hidden: true
+     createAsOfTime: {}
+     declarativeSchemaChangerState:
   ...
            statement: CREATE SEQUENCE sq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32
            statementTag: CREATE SEQUENCE
@@ -752,7 +735,7 @@ upsert descriptor #105
   -    state: WRITE_ONLY
   +  mutations: []
      name: sq1
-     nextColumnId: 3
+     nextColumnId: 2
   ...
        sequenceOwner: {}
        start: "32"

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence.side_effects
@@ -30,21 +30,13 @@ upsert descriptor #104
   +      family: IntFamily
   +      oid: 20
   +      width: 64
-  +  - defaultExpr: unique_rowid()
-  +    hidden: true
-  +    id: 2
-  +    name: rowid
-  +    type:
-  +      family: IntFamily
-  +      oid: 20
-  +      width: 64
   +  createAsOfTime: {}
   +  formatVersion: 3
   +  id: 104
   +  modificationTime: {}
   +  mutations: []
   +  name: sq1
-  +  nextColumnId: 3
+  +  nextColumnId: 2
   +  nextConstraintId: 1
   +  nextIndexId: 2
   +  parentId: 100


### PR DESCRIPTION
Previously, CREATE SEQUENCE in the declarative schema changer incorrectly created a rowid column. This occurred because the default logic for allocating column IDs also created a primary index with the rowid column, if one was missing. To address this, this patch modifies the allocation logic to make primary index creation optional and adds a regression test.

Fixes: #119108
Release note: None