### PR TITLE
batcheval: don't take out latches for `LeaseInfo`

### DIFF
--- a/pkg/kv/kvserver/batcheval/declare_test.go
+++ b/pkg/kv/kvserver/batcheval/declare_test.go
@@ -47,6 +47,10 @@ func TestRequestsSerializeWithAllKeys(t *testing.T) {
 			// Lease requests ignore latches, since they can be evaluated on
 			// any replica.
 			continue
+		case kvpb.LeaseInfo:
+			// LeaseInfo can ignore latches since RequestLease does too. The lease
+			// is read from the in-memory state.
+			continue
 		}
 		t.Run(method.String(), func(t *testing.T) {
 			var otherLatchSpans spanset.SpanSet

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -202,9 +202,6 @@ func (rec SpanSetReplicaEvalContext) GetLastReplicaGCTimestamp(
 
 // GetLease returns the Replica's current and next lease (if any).
 func (rec SpanSetReplicaEvalContext) GetLease() (roachpb.Lease, roachpb.Lease) {
-	rec.ss.AssertAllowed(spanset.SpanReadOnly,
-		roachpb.Span{Key: keys.RangeLeaseKey(rec.GetRangeID())},
-	)
 	return rec.i.GetLease()
 }
 


### PR DESCRIPTION
Extracted from #118943.

---

This patch removes the `LeaseInfo` read latch on `RangeLeaseKey`. This makes the request latchless, which allows the request to be used as a simple replica health check without worrying about latch delays (e.g. with DistSender circuit breaker probes).

This latch was ineffectual anyway, since lease requests don't take out write latches (they're evaluated on the proposer). The lease is read from the replica's in-memory state.

Touches #104262.
Touches #118943.
Epic: none
Release note: None