### PR TITLE
restore: use exclusive end keys in 24.1+ or non-rev backups

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -483,6 +483,7 @@ func restore(
 			spanFilter:         filter,
 			numImportSpans:     numImportSpans,
 			execLocality:       details.ExecutionLocality,
+			exclusiveEndKeys:   fsc.isExclusive(),
 		}
 		return errors.Wrap(distRestore(
 			ctx,

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -53,6 +53,7 @@ type restoreJobMetadata struct {
 	spanFilter         spanCoveringFilter
 	numImportSpans     int
 	execLocality       roachpb.Locality
+	exclusiveEndKeys   bool
 }
 
 // distRestore plans a 2 stage distSQL flow for a distributed restore. It
@@ -173,22 +174,23 @@ func distRestore(
 		id := execCtx.ExecCfg().NodeInfo.NodeID.SQLInstanceID()
 
 		spec := &execinfrapb.GenerativeSplitAndScatterSpec{
-			TableRekeys:              md.dataToRestore.getRekeys(),
-			TenantRekeys:             md.dataToRestore.getTenantRekeys(),
-			ValidateOnly:             md.dataToRestore.isValidateOnly(),
-			URIs:                     md.uris,
-			Encryption:               md.encryption,
-			EndTime:                  md.restoreTime,
-			Spans:                    md.dataToRestore.getSpans(),
-			BackupLocalityInfo:       md.backupLocalityInfo,
-			HighWater:                md.spanFilter.highWaterMark,
-			UserProto:                execCtx.User().EncodeProto(),
-			TargetSize:               md.spanFilter.targetSize,
-			ChunkSize:                int64(chunkSize),
-			NumEntries:               int64(md.numImportSpans),
-			NumNodes:                 int64(numNodes),
-			UseFrontierCheckpointing: md.spanFilter.useFrontierCheckpointing,
-			JobID:                    int64(md.jobID),
+			TableRekeys:                 md.dataToRestore.getRekeys(),
+			TenantRekeys:                md.dataToRestore.getTenantRekeys(),
+			ValidateOnly:                md.dataToRestore.isValidateOnly(),
+			URIs:                        md.uris,
+			Encryption:                  md.encryption,
+			EndTime:                     md.restoreTime,
+			Spans:                       md.dataToRestore.getSpans(),
+			BackupLocalityInfo:          md.backupLocalityInfo,
+			HighWater:                   md.spanFilter.highWaterMark,
+			UserProto:                   execCtx.User().EncodeProto(),
+			TargetSize:                  md.spanFilter.targetSize,
+			ChunkSize:                   int64(chunkSize),
+			NumEntries:                  int64(md.numImportSpans),
+			NumNodes:                    int64(numNodes),
+			UseFrontierCheckpointing:    md.spanFilter.useFrontierCheckpointing,
+			JobID:                       int64(md.jobID),
+			ExclusiveFileSpanComparison: md.exclusiveEndKeys,
 		}
 		if md.spanFilter.useFrontierCheckpointing {
 			spec.CheckpointedSpans = persistFrontier(md.spanFilter.checkpointFrontier, 0)

--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -647,21 +647,26 @@ func getNewIntersectingFilesByLayer(
 
 type fileSpanComparator interface {
 	overlaps(targetSpan, fileSpan roachpb.Span) bool
+	isExclusive() bool
 }
 
 // inclusiveEndKeyComparator assumes that file spans have inclusive
 // end keys.
 type inclusiveEndKeyComparator struct{}
 
-func (*inclusiveEndKeyComparator) overlaps(targetSpan, inclusiveEndKeyFileSpan roachpb.Span) bool {
+func (inclusiveEndKeyComparator) overlaps(targetSpan, inclusiveEndKeyFileSpan roachpb.Span) bool {
 	// TODO(ssd): Could ContainsKey here be replaced with targetSpan.Key.Equal(inclusiveEndKeyFileSpan.EndKey)?
 	return targetSpan.Overlaps(inclusiveEndKeyFileSpan) || targetSpan.ContainsKey(inclusiveEndKeyFileSpan.EndKey)
 }
+
+func (inclusiveEndKeyComparator) isExclusive() bool { return false }
 
 // exclusiveEndKeyComparator assumes that file spans have exclusive
 // end keys.
 type exclusiveEndKeyComparator struct{}
 
-func (*exclusiveEndKeyComparator) overlaps(targetSpan, inclusiveEndKeyFileSpan roachpb.Span) bool {
+func (exclusiveEndKeyComparator) overlaps(targetSpan, inclusiveEndKeyFileSpan roachpb.Span) bool {
 	return targetSpan.Overlaps(inclusiveEndKeyFileSpan)
 }
+
+func (exclusiveEndKeyComparator) isExclusive() bool { return true }


### PR DESCRIPTION
Release note: none.
Epic: none.