### PR TITLE
release-23.1: jobs: add version gate for DeleteTerminalJobByID

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1341,10 +1341,16 @@ func (r *Registry) DeleteTerminalJobByID(ctx context.Context, id jobspb.JobID) e
 			if err != nil {
 				return err
 			}
-			_, err = txn.Exec(
-				ctx, "delete-job-info", txn.KV(), "DELETE FROM system.job_info WHERE job_id = $1", id,
-			)
-			return err
+
+			if r.settings.Version.IsActive(ctx, clusterversion.V23_1CreateSystemJobInfoTable) {
+				if _, err := txn.Exec(
+					ctx, "delete-job-info", txn.KV(), "DELETE FROM system.job_info WHERE job_id = $1", id,
+				); err != nil {
+					return err
+				}
+			}
+
+			return nil
 		default:
 			return errors.Newf("job %d has non-terminal status: %q", id, status)
 		}


### PR DESCRIPTION
The job_info table may not exist while a cluster is upgrading.

Epic: None

Release note: None

Release justification: Bug fix for missing version gate in recent backported fix.