### PR TITLE
roachtest: run follower-reads/mixed-version on insecure mode

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/httpclient.go
+++ b/pkg/cmd/roachtest/roachtestutil/httpclient.go
@@ -124,6 +124,10 @@ func (r *RoachtestHTTPClient) ResetSession() {
 }
 
 func (r *RoachtestHTTPClient) addCookie(ctx context.Context, cookieUrl string) error {
+	// If the cluster is not running in secure mode, don't try to add cookies.
+	if !r.cluster.IsSecure() {
+		return nil
+	}
 	// If we haven't extracted the sessionID yet, do so.
 	if r.sessionID == "" {
 		id, err := getSessionID(ctx, r.cluster, r.l, r.cluster.All())


### PR DESCRIPTION
Due to a new field added in 23.1, authentication will fail if the cluster is migrating from 22.2 to 23.1. We disable secure mode to avoid this issue all together.

This change also adds a check in RoachtestHTTPClient to only add cookies if the cluster is running in secure mode. This is so we can use the same HTTP Client for both mixed-version and non mixed-version follower-reads tests.

Release note: none
Epic: none
Fixes: #119064