### PR TITLE
pcr: delete physical_replication.enabled setting

### DIFF
--- a/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
+++ b/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
@@ -397,9 +397,6 @@ func newBackupNemesis(
 						n.t.Log("already hit replication limit")
 						return nil
 					}
-					if _, err := hostDB.Exec("SET CLUSTER SETTING physical_replication.enabled = true"); err != nil {
-						return err
-					}
 					if _, err := hostDB.Exec("SET CLUSTER SETTING kv.rangefeed.enabled = true"); err != nil {
 						return err
 					}

--- a/pkg/ccl/streamingccl/replicationtestutils/replication_helpers.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/replication_helpers.go
@@ -223,7 +223,6 @@ func NewReplicationHelper(
 	sqlDB.ExecMultiple(t,
 		// Required for replication stremas to work.
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true`,
-		`SET CLUSTER SETTING physical_replication.enabled = true`,
 
 		// Speeds up the tests a bit.
 		`SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '200ms'`,

--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -154,8 +154,6 @@ func (c *TenantStreamingClusters) init(ctx context.Context) {
 	if c.Args.DestInitFunc != nil {
 		c.Args.DestInitFunc(c.T, c.DestSysSQL)
 	}
-	c.SrcSysSQL.Exec(c.T, `SET CLUSTER SETTING physical_replication.enabled = true;`)
-	c.DestSysSQL.Exec(c.T, `SET CLUSTER SETTING physical_replication.enabled = true;`)
 }
 
 // StartDestTenant starts the destination tenant and returns a cleanup function

--- a/pkg/ccl/streamingccl/settings.go
+++ b/pkg/ccl/streamingccl/settings.go
@@ -14,16 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 )
 
-// CrossClusterReplicationEnabled enables the ability to setup and control a
-// cross cluster replication stream.
-var CrossClusterReplicationEnabled = settings.RegisterBoolSetting(
-	settings.SystemVisible,
-	"cross_cluster_replication.enabled",
-	"enables the ability to setup and control a cross cluster replication stream",
-	false,
-	settings.WithName("physical_replication.enabled"),
-)
-
 // StreamReplicationStreamLivenessTrackFrequency controls frequency to check
 // the liveness of a streaming replication producer job.
 var StreamReplicationStreamLivenessTrackFrequency = settings.RegisterDurationSetting(

--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job.go
@@ -138,26 +138,12 @@ func alterReplicationJobTypeCheck(
 	return true, nil, nil
 }
 
-var physicalReplicationDisabledErr = errors.WithTelemetry(
-	pgerror.WithCandidateCode(
-		errors.WithHint(
-			errors.Newf("physical replication is disabled"),
-			"You can enable physical replication by running `SET CLUSTER SETTING physical_replication.enabled = true`.",
-		),
-		pgcode.ExperimentalFeature,
-	),
-	"physical_replication.enabled")
-
 func alterReplicationJobHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
 ) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
 	alterTenantStmt, ok := stmt.(*tree.AlterTenantReplication)
 	if !ok {
 		return nil, nil, nil, false, nil
-	}
-
-	if !streamingccl.CrossClusterReplicationEnabled.Get(&p.ExecCfg().Settings.SV) {
-		return nil, nil, nil, false, physicalReplicationDisabledErr
 	}
 
 	if !p.ExecCfg().Codec.ForSystemTenant() {

--- a/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
@@ -218,13 +218,6 @@ func TestStreamIngestionJobWithRandomClient(t *testing.T) {
 	streamAddr := getTestRandomClientURI(roachpb.MustMakeTenantID(oldTenantID), oldTenantName)
 	query := fmt.Sprintf(`CREATE TENANT "30" FROM REPLICATION OF "10" ON '%s'`, streamAddr)
 
-	// Attempt to run the ingestion job without enabling the experimental setting.
-	_, err = conn.Exec(query)
-	require.True(t, testutils.IsError(err, "physical replication is disabled"))
-
-	_, err = conn.Exec(`SET CLUSTER SETTING physical_replication.enabled = true;`)
-	require.NoError(t, err)
-
 	_, err = conn.Exec(query)
 	require.NoError(t, err)
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -51,7 +51,6 @@ func TestTenantStreamingCreationErrors(t *testing.T) {
 
 	sysSQL := sqlutils.MakeSQLRunner(db)
 	sysSQL.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-	sysSQL.Exec(t, `SET CLUSTER SETTING physical_replication.enabled = true`)
 
 	srcPgURL, cleanupSink := sqlutils.PGUrl(t, srv.SystemLayer().AdvSQLAddr(), t.Name(), url.User(username.RootUser))
 	defer cleanupSink()
@@ -129,7 +128,6 @@ func TestTenantStreamingFailback(t *testing.T) {
 	defer cleanupURLB()
 
 	for _, s := range []string{
-		"SET CLUSTER SETTING physical_replication.enabled = true",
 		"SET CLUSTER SETTING kv.rangefeed.enabled = true",
 		"SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '200ms'",
 		"SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'",

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -99,10 +99,6 @@ func ingestionPlanHook(
 		return nil, nil, nil, false, nil
 	}
 
-	if !streamingccl.CrossClusterReplicationEnabled.Get(&p.ExecCfg().Settings.SV) {
-		return nil, nil, nil, false, physicalReplicationDisabledErr
-	}
-
 	if !p.ExecCfg().Codec.ForSystemTenant() {
 		return nil, nil, nil, false, pgerror.Newf(pgcode.InsufficientPrivilege,
 			"only the system tenant can create other tenants")

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -187,11 +187,7 @@ func startReplication(
 	conn, err := pgx.ConnectConfig(queryCtx, pgxConfig)
 	require.NoError(t, err)
 
-	rows, err := conn.Query(queryCtx, `SET CLUSTER SETTING physical_replication.enabled = true;`)
-	require.NoError(t, err)
-	rows.Close()
-
-	rows, err = conn.Query(queryCtx, `SET avoid_buffering = true`)
+	rows, err := conn.Query(queryCtx, `SET avoid_buffering = true`)
 	require.NoError(t, err)
 	rows.Close()
 	rows, err = conn.Query(queryCtx, create, args...)

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1756,7 +1756,7 @@ func srcClusterSettings(t test.Test, db *sqlutils.SQLRunner) {
 }
 
 func destClusterSettings(t test.Test, db *sqlutils.SQLRunner, additionalDuration time.Duration) {
-	db.ExecMultiple(t, `SET CLUSTER SETTING cross_cluster_replication.enabled = true;`,
+	db.ExecMultiple(t,
 		`SET CLUSTER SETTING kv.rangefeed.enabled = true;`,
 		`SET CLUSTER SETTING stream_replication.replan_flow_threshold = 0.1;`,
 		`SET CLUSTER SETTING physical_replication.consumer.node_lag_replanning_threshold = '5m';`)

--- a/pkg/configprofiles/profiles.go
+++ b/pkg/configprofiles/profiles.go
@@ -137,7 +137,6 @@ func enableReplication(baseTasks []autoconfigpb.Task) []autoconfigpb.Task {
 		makeTask("enable rangefeeds and replication",
 			/* nonTxnSQL */ []string{
 				"SET CLUSTER SETTING kv.rangefeed.enabled = true",
-				"SET CLUSTER SETTING physical_replication.enabled = true",
 			},
 			nil, /* txnSQL */
 		),

--- a/pkg/configprofiles/testdata/virtual-app
+++ b/pkg/configprofiles/testdata/virtual-app
@@ -14,13 +14,11 @@ SELECT variable, value FROM [SHOW ALL CLUSTER SETTINGS]
 WHERE variable IN (
 'sql.create_virtual_cluster.default_template',
 'server.controller.default_target_cluster',
-'kv.rangefeed.enabled',
-'physical_replication.enabled'
+'kv.rangefeed.enabled'
 )
 ORDER BY variable
 ----
 kv.rangefeed.enabled false
-physical_replication.enabled false
 server.controller.default_target_cluster application
 sql.create_virtual_cluster.default_template template
 

--- a/pkg/configprofiles/testdata/virtual-app-repl
+++ b/pkg/configprofiles/testdata/virtual-app-repl
@@ -14,13 +14,11 @@ SELECT variable, value FROM [SHOW ALL CLUSTER SETTINGS]
 WHERE variable IN (
 'sql.create_virtual_cluster.default_template',
 'server.controller.default_target_cluster',
-'kv.rangefeed.enabled',
-'physical_replication.enabled'
+'kv.rangefeed.enabled'
 )
 ORDER BY variable
 ----
 kv.rangefeed.enabled true
-physical_replication.enabled true
 server.controller.default_target_cluster application
 sql.create_virtual_cluster.default_template template
 

--- a/pkg/configprofiles/testdata/virtual-noapp
+++ b/pkg/configprofiles/testdata/virtual-noapp
@@ -9,13 +9,11 @@ SELECT variable, value FROM [SHOW ALL CLUSTER SETTINGS]
 WHERE variable IN (
 'sql.create_virtual_cluster.default_template',
 'server.controller.default_target_cluster',
-'kv.rangefeed.enabled',
-'physical_replication.enabled'
+'kv.rangefeed.enabled'
 )
 ORDER BY variable
 ----
 kv.rangefeed.enabled false
-physical_replication.enabled false
 server.controller.default_target_cluster system
 sql.create_virtual_cluster.default_template template
 

--- a/pkg/configprofiles/testdata/virtual-noapp-repl
+++ b/pkg/configprofiles/testdata/virtual-noapp-repl
@@ -9,13 +9,11 @@ SELECT variable, value FROM [SHOW ALL CLUSTER SETTINGS]
 WHERE variable IN (
 'sql.create_virtual_cluster.default_template',
 'server.controller.default_target_cluster',
-'kv.rangefeed.enabled',
-'physical_replication.enabled'
+'kv.rangefeed.enabled'
 )
 ORDER BY variable
 ----
 kv.rangefeed.enabled true
-physical_replication.enabled true
 server.controller.default_target_cluster system
 sql.create_virtual_cluster.default_template template
 

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -372,7 +372,6 @@ func ConsoleKeys() (res []InternalKey) {
 }
 
 var allConsoleKeys = []InternalKey{
-	"cross_cluster_replication.enabled",
 	"keyvisualizer.enabled",
 	"keyvisualizer.sample_interval",
 	"sql.index_recommendation.drop_unused_duration",

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -239,6 +239,7 @@ var retiredSettings = map[InternalKey]struct{}{
 	"sql.trace.session_eventlog.enabled":                   {},
 	"sql.show_ranges_deprecated_behavior.enabled":          {},
 	"sql.drop_virtual_cluster.enabled":                     {},
+	"cross_cluster_replication.enabled":                    {},
 }
 
 // sqlDefaultSettings is the list of "grandfathered" existing sql.defaults

--- a/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/clusterSettings/clusterSettings.selectors.ts
@@ -64,17 +64,6 @@ export const selectAutomaticStatsCollectionEnabled = createSelector(
   },
 );
 
-export const selectCrossClusterReplicationEnabled = createSelector(
-  selectClusterSettings,
-  (settings): boolean | undefined => {
-    if (!settings) {
-      return undefined;
-    }
-    const value = settings["cross_cluster_replication.enabled"]?.value;
-    return value === "true";
-  },
-);
-
 export const selectIndexRecommendationsEnabled = createSelector(
   selectClusterSettings,
   (settings): boolean => {

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -88,7 +88,6 @@ import moment from "moment-timezone";
 import {
   selectResolution10sStorageTTL,
   selectResolution30mStorageTTL,
-  selectCrossClusterReplicationEnabled,
 } from "src/redux/clusterSettings";
 import { getDataFromServer } from "src/util/dataFromServer";
 import { getCookieValue } from "src/redux/cookies";
@@ -184,7 +183,6 @@ type MapStateToProps = {
   nodeDisplayNameByID: ReturnType<
     typeof nodeDisplayNameByIDSelector.resultFunc
   >;
-  crossClusterReplicationEnabled: boolean;
   tenantOptions: ReturnType<() => DropdownOption[]>;
   currentTenant: string | null;
 };
@@ -397,13 +395,7 @@ export class NodeGraphs extends React.Component<
       nodeIDs.length > 8 ? 90 + Math.ceil(nodeIDs.length / 3) * 10 : 50;
     const filteredDropdownOptions = dashboardDropdownOptions
       // Don't show KV dashboards if the logged-in user doesn't have permission to view them.
-      .filter(option => canViewKvGraphs || !option.isKvDashboard)
-      // Don't show the replication dashboard if not enabled.
-      .filter(
-        option =>
-          this.props.crossClusterReplicationEnabled ||
-          option.label !== "Physical Cluster Replication",
-      );
+      .filter(option => canViewKvGraphs || !option.isKvDashboard);
 
     return (
       <div style={{ paddingBottom }}>
@@ -543,7 +535,6 @@ const mapStateToProps = (state: AdminUIState): MapStateToProps => ({
   storeIDsByNodeID: selectStoreIDsByNodeID(state),
   nodeDropdownOptions: nodeDropdownOptionsSelector(state),
   nodeDisplayNameByID: nodeDisplayNameByIDSelector(state),
-  crossClusterReplicationEnabled: selectCrossClusterReplicationEnabled(state),
   tenantOptions: tenantDropdownOptions(state),
   currentTenant: getCookieValue("tenant"),
 });


### PR DESCRIPTION
Release note (enterprise change): Physical Cluster Replication no longer requires toggling the setting `physical_replication.enabled` to be used, and the setting has been removed.