### PR TITLE
opt/execbuilder: reduce memory footprint of colOrdMap

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -3321,13 +3321,13 @@ limit
  │    │    └── semi-join (lookup regional_by_row_table_virt_partial)
  │    │         ├── lookup columns are key
  │    │         ├── scan regional_by_row_table [as=t1]
- │    │         │    └── constraint: /93/88: [/'ap-southeast-2' - /'ap-southeast-2']
+ │    │         │    └── constraint: /94/89: [/'ap-southeast-2' - /'ap-southeast-2']
  │    │         └── filters (true)
  │    └── project
  │         └── semi-join (lookup regional_by_row_table_virt_partial)
  │              ├── lookup columns are key
  │              ├── scan regional_by_row_table [as=t1]
- │              │    └── constraint: /102/97: [/'ca-central-1' - /'us-east-1']
+ │              │    └── constraint: /103/98: [/'ca-central-1' - /'us-east-1']
  │              └── filters (true)
  └── 1
 

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "builder.go",
         "cascades.go",
+        "col_ord_map.go",
         "format.go",
         "mutation.go",
         "relational.go",
@@ -65,6 +66,7 @@ go_test(
     name = "execbuilder_test",
     size = "small",
     srcs = [
+        "col_ord_map_test.go",
         "main_test.go",
         "mutation_test.go",
     ],

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -303,7 +303,9 @@ func (b *Builder) BuildScalar() (tree.TypedExpr, error) {
 	b.colOrdsAlloc.Init(md.MaxColumn())
 	cols := b.colOrdsAlloc.Alloc()
 	for i := 0; i < md.NumColumns(); i++ {
-		cols.Set(opt.ColumnID(i+1), i)
+		if err := cols.Set(opt.ColumnID(i+1), i); err != nil {
+			return nil, err
+		}
 	}
 	ctx := makeBuildScalarCtx(cols)
 	return b.buildScalar(&ctx, scalar)

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -230,7 +230,7 @@ func New(
 // Build constructs the execution node tree and returns its root node if no
 // error occurred.
 func (b *Builder) Build() (_ exec.Plan, err error) {
-	plan, err := b.build(b.e)
+	plan, _, err := b.build(b.e)
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func (b *Builder) wrapFunction(fnName string) (tree.ResolvableFunctionReference,
 	return tree.WrapFunction(fnName), nil
 }
 
-func (b *Builder) build(e opt.Expr) (_ execPlan, err error) {
+func (b *Builder) build(e opt.Expr) (_ execPlan, outputCols opt.ColMap, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			// This code allows us to propagate errors without adding lots of checks
@@ -274,7 +274,7 @@ func (b *Builder) build(e opt.Expr) (_ execPlan, err error) {
 
 	rel, ok := e.(memo.RelExpr)
 	if !ok {
-		return execPlan{}, errors.AssertionFailedf(
+		return execPlan{}, opt.ColMap{}, errors.AssertionFailedf(
 			"building execution for non-relational operator %s", redact.Safe(e.Op()),
 		)
 	}

--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -142,7 +142,7 @@ func makeCascadeBuilder(b *Builder, mutationWithID opt.WithID) (*cascadeBuilder,
 	// Remember the column metadata, as we will need to recreate it in the new
 	// memo.
 	md := b.mem.Metadata()
-	cb.colMeta = make([]opt.ColumnMeta, 0, cb.mutationBufferCols.MaxOrd())
+	cb.colMeta = make([]opt.ColumnMeta, 0, cb.mutationBufferCols.OrdUpperBound())
 	cb.mutationBufferCols.ForEach(func(col opt.ColumnID, ord int) {
 		cb.colMeta = append(cb.colMeta, *md.ColumnMeta(col))
 	})

--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -143,8 +143,9 @@ func makeCascadeBuilder(b *Builder, mutationWithID opt.WithID) (*cascadeBuilder,
 	// memo.
 	md := b.mem.Metadata()
 	cb.colMeta = make([]opt.ColumnMeta, 0, cb.mutationBufferCols.OrdUpperBound())
-	cb.mutationBufferCols.ForEach(func(col opt.ColumnID, ord int) {
+	_ = cb.mutationBufferCols.ForEach(func(col opt.ColumnID, ord int) error {
 		cb.colMeta = append(cb.colMeta, *md.ColumnMeta(col))
+		return nil
 	})
 
 	return cb, nil
@@ -230,7 +231,9 @@ func (cb *cascadeBuilder) planCascade(
 			id := md.AddColumn(cb.colMeta[i].Alias, cb.colMeta[i].Type)
 			withCols.Add(id)
 			ordinal, _ := cb.mutationBufferCols.Get(cb.colMeta[i].MetaID)
-			bufferColMap.Set(id, ordinal)
+			if err := bufferColMap.Set(id, ordinal); err != nil {
+				return nil, err
+			}
 			withColRemap.Set(int(cb.colMeta[i].MetaID), int(id))
 		}
 

--- a/pkg/sql/opt/exec/execbuilder/col_ord_map.go
+++ b/pkg/sql/opt/exec/execbuilder/col_ord_map.go
@@ -16,6 +16,31 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// colOrdMapAllocator is used to allocate colOrdMaps.
+//
+type colOrdMapAllocator struct {
+	maxCol opt.ColumnID
+}
+
+// Init initialized the allocator that can allocate maps that support column IDs
+// up to maxCol.
+func (a *colOrdMapAllocator) Init(maxCol opt.ColumnID) {
+	a.maxCol = maxCol
+}
+
+// Alloc returns an empty colOrdMap. It will return a previously Free'd
+// colOrdMap, if one is available.
+func (a *colOrdMapAllocator) Alloc() colOrdMap {
+	return newColOrdMap(a.maxCol)
+}
+
+// Copy returns a copy of the given colOrdMap.
+func (a *colOrdMapAllocator) Copy(from colOrdMap) colOrdMap {
+	m := a.Alloc()
+	m.CopyFrom(from)
+	return m
+}
+
 // colOrdMap is a map from column IDs to ordinals.
 //
 // The map is implemented as a slice of integers, with the slice's indexes

--- a/pkg/sql/opt/exec/execbuilder/col_ord_map.go
+++ b/pkg/sql/opt/exec/execbuilder/col_ord_map.go
@@ -1,0 +1,124 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package execbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/errors"
+)
+
+// colOrdMap is a map from column IDs to ordinals.
+//
+// The map is implemented as a slice of integers, with the slice's indexes
+// representing column IDs and the slice's elements representing ordinals. This
+// makes Set and Get operations on the map extremely fast.
+//
+// This implementation does have some drawbacks. First, the map can only store
+// column IDs less than or equal to the length of the slice. Column IDs are
+// assigned as sequential integers starting at 1, so in most cases the length of
+// the slice should be in the hundreds or thousands.
+//
+// Second, the map currently does not permit resizing, so the maximum column ID
+// must be known when the map is initialized. This makes the map suitable for
+// use within execbuilder after all column IDs have been assigned, but not
+// elsewhere.
+//
+// Finally, the memory footprint of the map is dependent on the maximum column
+// ID it can store, rather than on the number of entries in the map. A map with
+// only a few entries has the same memory footprint as a map with every column
+// ID set. This can be mitigated by reusing already-allocated maps when
+// possible.
+type colOrdMap struct {
+	// ords is a mapping from column ID to an ordinal. The values are biased by
+	// 1, which allows the map to store the zero ordinal and have the zero value
+	// in the map represent an unset column ID.
+	//
+	// TODO(mgartner): It is probably unreasonable to have more than 2^31
+	// ordinals in an execution node, so this could be []int32.
+	ords []int
+}
+
+// newColOrdMap returns a new column mapping that can store column IDs less than
+// or equal to maxCol.
+func newColOrdMap(maxCol opt.ColumnID) colOrdMap {
+	return colOrdMap{
+		ords: make([]int, maxCol+1),
+	}
+}
+
+// Set maps a column to the given ordinal.
+func (m *colOrdMap) Set(col opt.ColumnID, ord int) {
+	if buildutil.CrdbTestBuild && int(col) >= len(m.ords) {
+		panic(errors.AssertionFailedf("column %d exceeds max column of map %d", col, len(m.ords)-1))
+	}
+	// Bias the ordinal by 1 when adding it to the map.
+	ord++
+	m.ords[col] = ord
+}
+
+// Get returns the current value mapped to key, or (-1, false) if the
+// key is unmapped.
+func (m colOrdMap) Get(col opt.ColumnID) (ord int, ok bool) {
+	if int(col) >= len(m.ords) {
+		return -1, false
+	}
+	ord = m.ords[col]
+	if ord == 0 {
+		return -1, false
+	}
+	// Reverse the bias when fetching from the map.
+	return ord - 1, true
+}
+
+// MaxOrd returns the maximum ordinal stored in the map, or -1 if the map is
+// empty.
+func (m colOrdMap) MaxOrd() int {
+	maxOrd := -1
+	for _, ord := range m.ords {
+		if ord == 0 {
+			continue
+		}
+		// Reverse the bias when fetching the max ordinal from the map.
+		ord--
+		maxOrd = max(maxOrd, ord)
+	}
+	return maxOrd
+}
+
+// ForEach calls the given function for each column ID and ordinal pair in the
+// map.
+func (m colOrdMap) ForEach(fn func(col opt.ColumnID, ord int)) {
+	for col, ord := range m.ords {
+		if ord == 0 {
+			continue
+		}
+		// Reverse the bias when fetching from the map.
+		fn(opt.ColumnID(col), ord-1)
+	}
+}
+
+// CopyFrom copies all entries from the given map, and unsets any column IDs not
+// in the given map.
+func (m *colOrdMap) CopyFrom(other colOrdMap) {
+	if buildutil.CrdbTestBuild && len(m.ords) < len(other.ords) {
+		panic(errors.AssertionFailedf("map of size %d is too small to copy from map of size %d",
+			len(m.ords), len(other.ords)))
+	}
+	copy(m.ords, other.ords)
+}
+
+// clear clears the map. The allocated memory is retained for future reuse.
+func (m *colOrdMap) clear() {
+	for i := range m.ords {
+		m.ords[i] = 0
+	}
+}

--- a/pkg/sql/opt/exec/execbuilder/col_ord_map_test.go
+++ b/pkg/sql/opt/exec/execbuilder/col_ord_map_test.go
@@ -1,0 +1,79 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package execbuilder
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestColOrdMap(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const maxCol = 100
+	m := newColOrdMap(maxCol)
+	oracle := make(map[opt.ColumnID]int)
+
+	if m.MaxOrd() != -1 {
+		t.Errorf("expected empty map to have MaxOrd of -1, got %d", m.MaxOrd())
+	}
+
+	rng, _ := randutil.NewTestRand()
+
+	const numOps = 1000
+	for i := 0; i < numOps; i++ {
+		col := opt.ColumnID(rng.Intn(maxCol + 1))
+		ord := int(rng.Int31())
+
+		oracle[col] = ord
+		m.Set(col, ord)
+
+		validate(t, m, oracle)
+
+		// Periodically clear or copy the map.
+		n := rng.Intn(100)
+		switch {
+		case n < 5:
+			oracle = make(map[opt.ColumnID]int)
+			m.clear()
+			validate(t, m, oracle)
+		case n < 15:
+			cpy := newColOrdMap(maxCol)
+			cpy.CopyFrom(m)
+			m = cpy
+			validate(t, m, oracle)
+		}
+	}
+}
+
+func validate(t *testing.T, m colOrdMap, oracle map[opt.ColumnID]int) {
+	maxOracleOrd := -1
+	for col, oracleOrd := range oracle {
+		if ord, ok := m.Get(col); !ok || ord != oracleOrd {
+			t.Errorf("expected map to contain %d:%d", col, oracleOrd)
+		}
+		maxOracleOrd = max(maxOracleOrd, oracleOrd)
+	}
+
+	if m.MaxOrd() != maxOracleOrd {
+		t.Errorf("expected max ordinal of %d, found %d", maxOracleOrd, m.MaxOrd())
+	}
+
+	m.ForEach(func(col opt.ColumnID, ord int) {
+		oracleOrd, ok := oracle[col]
+		if !ok || ord != oracleOrd {
+			t.Errorf("unexpected col:ord in map %d:%d, oracle: %v", col, ord, oracle)
+		}
+	})
+}

--- a/pkg/sql/opt/exec/execbuilder/col_ord_map_test.go
+++ b/pkg/sql/opt/exec/execbuilder/col_ord_map_test.go
@@ -46,7 +46,7 @@ func TestColOrdMap(t *testing.T) {
 		switch {
 		case n < 5:
 			oracle = make(map[opt.ColumnID]int)
-			m.clear()
+			m.Clear()
 			validate(t, m, oracle)
 		case n < 15:
 			cpy := newColOrdMap(maxCol)

--- a/pkg/sql/opt/exec/execbuilder/col_ord_map_test.go
+++ b/pkg/sql/opt/exec/execbuilder/col_ord_map_test.go
@@ -25,8 +25,8 @@ func TestColOrdMap(t *testing.T) {
 	m := newColOrdMap(maxCol)
 	oracle := make(map[opt.ColumnID]int)
 
-	if m.MaxOrd() != -1 {
-		t.Errorf("expected empty map to have MaxOrd of -1, got %d", m.MaxOrd())
+	if m.OrdUpperBound() != -1 {
+		t.Errorf("expected empty map to have OrdUpperBound of -1, got %d", m.OrdUpperBound())
 	}
 
 	rng, _ := randutil.NewTestRand()
@@ -66,8 +66,8 @@ func validate(t *testing.T, m colOrdMap, oracle map[opt.ColumnID]int) {
 		maxOracleOrd = max(maxOracleOrd, oracleOrd)
 	}
 
-	if m.MaxOrd() != maxOracleOrd {
-		t.Errorf("expected max ordinal of %d, found %d", maxOracleOrd, m.MaxOrd())
+	if m.OrdUpperBound() != maxOracleOrd {
+		t.Errorf("expected max ordinal of %d, found %d", maxOracleOrd, m.OrdUpperBound())
 	}
 
 	m.ForEach(func(col opt.ColumnID, ord int) {

--- a/pkg/sql/opt/exec/execbuilder/col_ord_map_test.go
+++ b/pkg/sql/opt/exec/execbuilder/col_ord_map_test.go
@@ -52,7 +52,9 @@ func TestColOrdMap(t *testing.T) {
 			validate(t, m, oracle)
 		case n < 15:
 			cpy := newColOrdMap(maxCol)
-			cpy.CopyFrom(m)
+			if err := cpy.CopyFrom(m); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
 			m = cpy
 			validate(t, m, oracle)
 		}

--- a/pkg/sql/opt/exec/execbuilder/col_ord_map_test.go
+++ b/pkg/sql/opt/exec/execbuilder/col_ord_map_test.go
@@ -37,7 +37,9 @@ func TestColOrdMap(t *testing.T) {
 		ord := int(rng.Int31())
 
 		oracle[col] = ord
-		m.Set(col, ord)
+		if err := m.Set(col, ord); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
 
 		validate(t, m, oracle)
 
@@ -70,10 +72,11 @@ func validate(t *testing.T, m colOrdMap, oracle map[opt.ColumnID]int) {
 		t.Errorf("expected max ordinal of %d, found %d", maxOracleOrd, m.OrdUpperBound())
 	}
 
-	m.ForEach(func(col opt.ColumnID, ord int) {
+	_ = m.ForEach(func(col opt.ColumnID, ord int) error {
 		oracleOrd, ok := oracle[col]
 		if !ok || ord != oracleOrd {
 			t.Errorf("unexpected col:ord in map %d:%d, oracle: %v", col, ord, oracle)
 		}
+		return nil
 	})
 }

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -30,10 +30,10 @@ import (
 
 func (b *Builder) buildMutationInput(
 	mutExpr, inputExpr memo.RelExpr, colList opt.ColList, p *memo.MutationPrivate,
-) (_ execPlan, outputCols opt.ColMap, err error) {
+) (_ execPlan, outputCols colOrdMap, err error) {
 	shouldApplyImplicitLocking, err := b.shouldApplyImplicitLockingToMutationInput(mutExpr)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 	if shouldApplyImplicitLocking {
 		// Re-entrance is not possible because mutations are never nested.
@@ -43,7 +43,7 @@ func (b *Builder) buildMutationInput(
 
 	input, inputCols, err := b.buildRelational(inputExpr)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	// TODO(mgartner/radu): This can incorrectly append columns in a FK cascade
@@ -62,14 +62,14 @@ func (b *Builder) buildMutationInput(
 
 	input, inputCols, err = b.ensureColumns(input, inputCols, inputExpr, colList, inputExpr.ProvidedPhysical().Ordering)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	if p.WithID != 0 {
 		label := fmt.Sprintf("buffer %d", p.WithID)
 		bufferNode, err := b.factory.ConstructBuffer(input.root, label)
 		if err != nil {
-			return execPlan{}, opt.ColMap{}, err
+			return execPlan{}, colOrdMap{}, err
 		}
 
 		b.addBuiltWithExpr(p.WithID, inputCols, bufferNode)
@@ -78,7 +78,7 @@ func (b *Builder) buildMutationInput(
 	return input, inputCols, nil
 }
 
-func (b *Builder) buildInsert(ins *memo.InsertExpr) (_ execPlan, outputCols opt.ColMap, err error) {
+func (b *Builder) buildInsert(ins *memo.InsertExpr) (_ execPlan, outputCols colOrdMap, err error) {
 	if ep, outputCols, ok, err := b.tryBuildFastPathInsert(ins); err != nil || ok {
 		return ep, outputCols, err
 	}
@@ -90,7 +90,7 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (_ execPlan, outputCols opt.
 	colList = appendColsWhenPresent(colList, ins.PartialIndexPutCols)
 	input, _, err := b.buildMutationInput(ins, ins.Input, colList, &ins.MutationPrivate)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	// Construct the Insert node.
@@ -110,20 +110,20 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (_ execPlan, outputCols opt.
 			len(ins.FKChecks) == 0 && len(ins.FKCascades) == 0,
 	)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 	// Construct the output column map.
 	ep := execPlan{root: node}
 	if ins.NeedResults() {
-		outputCols = mutationOutputColMap(ins)
+		outputCols = b.mutationOutputColMap(ins)
 	}
 
 	if err := b.buildUniqueChecks(ins.UniqueChecks); err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	if err := b.buildFKChecks(ins.FKChecks); err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	return ep, outputCols, nil
@@ -133,7 +133,7 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (_ execPlan, outputCols opt.
 // checking all required conditions. See exec.Factory.ConstructInsertFastPath.
 func (b *Builder) tryBuildFastPathInsert(
 	ins *memo.InsertExpr,
-) (_ execPlan, outputCols opt.ColMap, ok bool, _ error) {
+) (_ execPlan, outputCols colOrdMap, ok bool, _ error) {
 	// Conditions from ConstructFastPathInsert:
 	//
 	//  - there are no other mutations in the statement, and the output of the
@@ -142,12 +142,12 @@ func (b *Builder) tryBuildFastPathInsert(
 	//
 	// This condition was taken into account in build().
 	if !b.allowInsertFastPath {
-		return execPlan{}, opt.ColMap{}, false, nil
+		return execPlan{}, colOrdMap{}, false, nil
 	}
 	// If there are unique checks required, there must be the same number of fast
 	// path unique checks.
 	if len(ins.UniqueChecks) != len(ins.FastPathUniqueChecks) {
-		return execPlan{}, opt.ColMap{}, false, nil
+		return execPlan{}, colOrdMap{}, false, nil
 	}
 
 	insInput := ins.Input
@@ -155,7 +155,7 @@ func (b *Builder) tryBuildFastPathInsert(
 	// Values expressions containing subqueries or UDFs, or having a size larger
 	// than the max mutation batch size are disallowed.
 	if !ok || !memo.ValuesLegalForInsertFastPath(values) {
-		return execPlan{}, opt.ColMap{}, false, nil
+		return execPlan{}, colOrdMap{}, false, nil
 	}
 
 	md := b.mem.Metadata()
@@ -169,7 +169,7 @@ func (b *Builder) tryBuildFastPathInsert(
 			// uniqueness checks during fast-path insert. Even if DatumsFromConstraint
 			// contains no Datums, that case indicates that all values to check come
 			// from the input row.
-			return execPlan{}, opt.ColMap{}, false, nil
+			return execPlan{}, colOrdMap{}, false, nil
 		}
 		execFastPathCheck := &uniqChecks[i]
 		// Set up the execbuilder structure from the elements built during
@@ -179,7 +179,7 @@ func (b *Builder) tryBuildFastPathInsert(
 		execFastPathCheck.CheckOrdinal = c.CheckOrdinal
 		locking, err := b.buildLocking(c.Locking)
 		if err != nil {
-			return execPlan{}, opt.ColMap{}, false, err
+			return execPlan{}, colOrdMap{}, false, err
 		}
 		execFastPathCheck.Locking = locking
 		execFastPathCheck.InsertCols = make([]exec.TableColumnOrdinal, len(c.InsertCols))
@@ -212,19 +212,19 @@ func (b *Builder) tryBuildFastPathInsert(
 		c := &ins.FKChecks[i]
 		if md.Table(c.ReferencedTable).ID() == md.Table(ins.Table).ID() {
 			// Self-referencing FK.
-			return execPlan{}, opt.ColMap{}, false, nil
+			return execPlan{}, colOrdMap{}, false, nil
 		}
 		fk := tab.OutboundForeignKey(c.FKOrdinal)
 		lookupJoin, isLookupJoin := c.Check.(*memo.LookupJoinExpr)
 		if !isLookupJoin || lookupJoin.JoinType != opt.AntiJoinOp {
 			// Not a lookup anti-join.
-			return execPlan{}, opt.ColMap{}, false, nil
+			return execPlan{}, colOrdMap{}, false, nil
 		}
 		// TODO(rytaft): see if we can remove the requirement that LookupExpr is
 		// empty.
 		if len(lookupJoin.On) > 0 || len(lookupJoin.LookupExpr) > 0 ||
 			len(lookupJoin.KeyCols) != fk.ColumnCount() {
-			return execPlan{}, opt.ColMap{}, false, nil
+			return execPlan{}, colOrdMap{}, false, nil
 		}
 		inputExpr := lookupJoin.Input
 		// Ignore any select (used to deal with NULLs).
@@ -233,15 +233,15 @@ func (b *Builder) tryBuildFastPathInsert(
 		}
 		withScan, isWithScan := inputExpr.(*memo.WithScanExpr)
 		if !isWithScan {
-			return execPlan{}, opt.ColMap{}, false, nil
+			return execPlan{}, colOrdMap{}, false, nil
 		}
 		if withScan.With != ins.WithID {
-			return execPlan{}, opt.ColMap{}, false, nil
+			return execPlan{}, colOrdMap{}, false, nil
 		}
 
 		locking, err := b.buildLocking(lookupJoin.Locking)
 		if err != nil {
-			return execPlan{}, opt.ColMap{}, false, err
+			return execPlan{}, colOrdMap{}, false, err
 		}
 
 		out := &fkChecks[i]
@@ -252,12 +252,12 @@ func (b *Builder) tryBuildFastPathInsert(
 			var withColOrd, inputColOrd int
 			withColOrd, ok = withScan.OutCols.Find(keyCol)
 			if !ok {
-				return execPlan{}, opt.ColMap{}, false, errors.AssertionFailedf("cannot find column %d", keyCol)
+				return execPlan{}, colOrdMap{}, false, errors.AssertionFailedf("cannot find column %d", keyCol)
 			}
 			inputCol := withScan.InCols[withColOrd]
 			inputColOrd, ok = ins.InsertCols.Find(inputCol)
 			if !ok {
-				return execPlan{}, opt.ColMap{}, false, errors.AssertionFailedf("cannot find column %d", inputCol)
+				return execPlan{}, colOrdMap{}, false, errors.AssertionFailedf("cannot find column %d", inputCol)
 			}
 			out.InsertCols[j] = exec.TableColumnOrdinal(inputColOrd)
 		}
@@ -296,12 +296,12 @@ func (b *Builder) tryBuildFastPathInsert(
 	colList = appendColsWhenPresent(colList, ins.PartialIndexPutCols)
 	rows, err := b.buildValuesRows(values)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, false, err
+		return execPlan{}, colOrdMap{}, false, err
 	}
 	// We may need to rearrange the columns.
 	rows, err = rearrangeColumns(values.Cols, rows, colList)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, false, err
+		return execPlan{}, colOrdMap{}, false, err
 	}
 
 	// Construct the InsertFastPath node.
@@ -319,12 +319,12 @@ func (b *Builder) tryBuildFastPathInsert(
 		b.allowAutoCommit,
 	)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, false, err
+		return execPlan{}, colOrdMap{}, false, err
 	}
 	// Construct the output column map.
 	ep := execPlan{root: node}
 	if ins.NeedResults() {
-		outputCols = mutationOutputColMap(ins)
+		outputCols = b.mutationOutputColMap(ins)
 	}
 	return ep, outputCols, true, nil
 }
@@ -359,7 +359,7 @@ func rearrangeColumns(
 	return outRows, nil
 }
 
-func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (_ execPlan, outputCols opt.ColMap, err error) {
+func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (_ execPlan, outputCols colOrdMap, err error) {
 	// Currently, the execution engine requires one input column for each fetch
 	// and update expression, so use ensureColumns to map and reorder columns so
 	// that they correspond to target table columns. For example:
@@ -389,7 +389,7 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (_ execPlan, outputCols opt.
 
 	input, _, err := b.buildMutationInput(upd, upd.Input, colList, &upd.MutationPrivate)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	// Construct the Update node.
@@ -421,30 +421,30 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (_ execPlan, outputCols opt.
 			len(upd.FKChecks) == 0 && len(upd.FKCascades) == 0,
 	)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	if err := b.buildUniqueChecks(upd.UniqueChecks); err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	if err := b.buildFKChecks(upd.FKChecks); err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	if err := b.buildFKCascades(upd.WithID, upd.FKCascades); err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	// Construct the output column map.
 	ep := execPlan{root: node}
 	if upd.NeedResults() {
-		outputCols = mutationOutputColMap(upd)
+		outputCols = b.mutationOutputColMap(upd)
 	}
 	return ep, outputCols, nil
 }
 
-func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (_ execPlan, outputCols opt.ColMap, err error) {
+func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (_ execPlan, outputCols colOrdMap, err error) {
 	// Currently, the execution engine requires one input column for each insert,
 	// fetch, and update expression, so use ensureColumns to map and reorder
 	// columns so that they correspond to target table columns. For example:
@@ -478,7 +478,7 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (_ execPlan, outputCols opt.
 
 	input, inputCols, err := b.buildMutationInput(ups, ups.Input, colList, &ups.MutationPrivate)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	// Construct the Upsert node.
@@ -488,7 +488,7 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (_ execPlan, outputCols opt.
 	if ups.CanaryCol != 0 {
 		canaryCol, err = getNodeColumnOrdinal(inputCols, ups.CanaryCol)
 		if err != nil {
-			return execPlan{}, opt.ColMap{}, err
+			return execPlan{}, colOrdMap{}, err
 		}
 	}
 	insertColOrds := ordinalSetFromColList(ups.InsertCols)
@@ -511,19 +511,19 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (_ execPlan, outputCols opt.
 			len(ups.FKChecks) == 0 && len(ups.FKCascades) == 0,
 	)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	if err := b.buildUniqueChecks(ups.UniqueChecks); err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	if err := b.buildFKChecks(ups.FKChecks); err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	if err := b.buildFKCascades(ups.WithID, ups.FKCascades); err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	// If UPSERT returns rows, they contain all non-mutation columns from the
@@ -532,15 +532,15 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (_ execPlan, outputCols opt.
 	// result of the UPSERT operation for that row.
 	ep := execPlan{root: node}
 	if ups.NeedResults() {
-		outputCols = mutationOutputColMap(ups)
+		outputCols = b.mutationOutputColMap(ups)
 	}
 	return ep, outputCols, nil
 }
 
-func (b *Builder) buildDelete(del *memo.DeleteExpr) (_ execPlan, outputCols opt.ColMap, err error) {
+func (b *Builder) buildDelete(del *memo.DeleteExpr) (_ execPlan, outputCols colOrdMap, err error) {
 	// Check for the fast-path delete case that can use a range delete.
 	if ep, ok, err := b.tryBuildDeleteRange(del); err != nil || ok {
-		return ep, opt.ColMap{}, err
+		return ep, colOrdMap{}, err
 	}
 
 	// Ensure that order of input columns matches order of target table columns.
@@ -559,7 +559,7 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (_ execPlan, outputCols opt.
 
 	input, _, err := b.buildMutationInput(del, del.Input, colList, &del.MutationPrivate)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 	// Construct the Delete node.
 	md := b.mem.Metadata()
@@ -586,21 +586,21 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (_ execPlan, outputCols opt.
 		b.allowAutoCommit && len(del.FKChecks) == 0 && len(del.FKCascades) == 0,
 	)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	if err := b.buildFKChecks(del.FKChecks); err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	if err := b.buildFKCascades(del.WithID, del.FKCascades); err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 
 	// Construct the output column map.
 	ep := execPlan{root: node}
 	if del.NeedResults() {
-		outputCols = mutationOutputColMap(del)
+		outputCols = b.mutationOutputColMap(del)
 	}
 
 	return ep, outputCols, nil
@@ -722,18 +722,18 @@ func ordinalSetFromColList(colList opt.OptionalColList) intsets.Fast {
 // mutationOutputColMap constructs a ColMap for the execPlan that maps from the
 // opt.ColumnID of each output column to the ordinal position of that column in
 // the result.
-func mutationOutputColMap(mutation memo.RelExpr) opt.ColMap {
+func (b *Builder) mutationOutputColMap(mutation memo.RelExpr) colOrdMap {
 	private := mutation.Private().(*memo.MutationPrivate)
 	tab := mutation.Memo().Metadata().Table(private.Table)
 	outCols := mutation.Relational().OutputCols
 
-	var colMap opt.ColMap
+	colMap := b.colOrdsAlloc.Alloc()
 	ord := 0
 	for i, n := 0, tab.ColumnCount(); i < n; i++ {
 		colID := private.Table.ColumnID(i)
 		// System columns should not be included in mutations.
 		if outCols.Contains(colID) && tab.Column(i).Kind() != cat.System {
-			colMap.Set(int(colID), ord)
+			colMap.Set(colID, ord)
 			ord++
 		}
 	}
@@ -742,7 +742,7 @@ func mutationOutputColMap(mutation memo.RelExpr) opt.ColMap {
 	// columns it allowed to pass through.
 	for _, colID := range private.PassthroughCols {
 		if colID != 0 {
-			colMap.Set(int(colID), ord)
+			colMap.Set(colID, ord)
 			ord++
 		}
 	}
@@ -1142,11 +1142,11 @@ func unwrapProjectExprs(input memo.RelExpr) memo.RelExpr {
 	return input
 }
 
-func (b *Builder) buildLock(lock *memo.LockExpr) (_ execPlan, outputCols opt.ColMap, err error) {
+func (b *Builder) buildLock(lock *memo.LockExpr) (_ execPlan, outputCols colOrdMap, err error) {
 	// Don't bother creating the lookup join if we don't need it.
 	locking, err := b.buildLocking(lock.Locking)
 	if err != nil {
-		return execPlan{}, opt.ColMap{}, err
+		return execPlan{}, colOrdMap{}, err
 	}
 	if !locking.IsLocking() {
 		return b.buildRelational(lock.Input)

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -60,7 +60,10 @@ func (b *Builder) buildMutationInput(
 		}
 	}
 
-	input, inputCols, err = b.ensureColumns(input, inputCols, inputExpr, colList, inputExpr.ProvidedPhysical().Ordering)
+	input, inputCols, err = b.ensureColumns(
+		input, inputCols, inputExpr, colList,
+		inputExpr.ProvidedPhysical().Ordering, true, /* reuseInputCols */
+	)
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -30,10 +30,10 @@ import (
 
 func (b *Builder) buildMutationInput(
 	mutExpr, inputExpr memo.RelExpr, colList opt.ColList, p *memo.MutationPrivate,
-) (execPlan, error) {
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	shouldApplyImplicitLocking, err := b.shouldApplyImplicitLockingToMutationInput(mutExpr)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	if shouldApplyImplicitLocking {
 		// Re-entrance is not possible because mutations are never nested.
@@ -41,9 +41,9 @@ func (b *Builder) buildMutationInput(
 		defer func() { b.forceForUpdateLocking = false }()
 	}
 
-	input, err := b.buildRelational(inputExpr)
+	input, inputCols, err := b.buildRelational(inputExpr)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// TODO(mgartner/radu): This can incorrectly append columns in a FK cascade
@@ -60,27 +60,27 @@ func (b *Builder) buildMutationInput(
 		}
 	}
 
-	input, err = b.ensureColumns(input, inputExpr, colList, inputExpr.ProvidedPhysical().Ordering)
+	input, inputCols, err = b.ensureColumns(input, inputCols, inputExpr, colList, inputExpr.ProvidedPhysical().Ordering)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	if p.WithID != 0 {
 		label := fmt.Sprintf("buffer %d", p.WithID)
 		bufferNode, err := b.factory.ConstructBuffer(input.root, label)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 
-		b.addBuiltWithExpr(p.WithID, input.outputCols, bufferNode)
+		b.addBuiltWithExpr(p.WithID, inputCols, bufferNode)
 		input.root = bufferNode
 	}
-	return input, nil
+	return input, inputCols, nil
 }
 
-func (b *Builder) buildInsert(ins *memo.InsertExpr) (execPlan, error) {
-	if ep, ok, err := b.tryBuildFastPathInsert(ins); err != nil || ok {
-		return ep, err
+func (b *Builder) buildInsert(ins *memo.InsertExpr) (_ execPlan, outputCols opt.ColMap, err error) {
+	if ep, outputCols, ok, err := b.tryBuildFastPathInsert(ins); err != nil || ok {
+		return ep, outputCols, err
 	}
 	// Construct list of columns that only contains columns that need to be
 	// inserted (e.g. delete-only mutation columns don't need to be inserted).
@@ -88,9 +88,9 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (execPlan, error) {
 	colList = appendColsWhenPresent(colList, ins.InsertCols)
 	colList = appendColsWhenPresent(colList, ins.CheckCols)
 	colList = appendColsWhenPresent(colList, ins.PartialIndexPutCols)
-	input, err := b.buildMutationInput(ins, ins.Input, colList, &ins.MutationPrivate)
+	input, _, err := b.buildMutationInput(ins, ins.Input, colList, &ins.MutationPrivate)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Construct the Insert node.
@@ -110,28 +110,30 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (execPlan, error) {
 			len(ins.FKChecks) == 0 && len(ins.FKCascades) == 0,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	// Construct the output column map.
 	ep := execPlan{root: node}
 	if ins.NeedResults() {
-		ep.outputCols = mutationOutputColMap(ins)
+		outputCols = mutationOutputColMap(ins)
 	}
 
 	if err := b.buildUniqueChecks(ins.UniqueChecks); err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	if err := b.buildFKChecks(ins.FKChecks); err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	return ep, nil
+	return ep, outputCols, nil
 }
 
 // tryBuildFastPathInsert attempts to construct an insert using the fast path,
 // checking all required conditions. See exec.Factory.ConstructInsertFastPath.
-func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok bool, _ error) {
+func (b *Builder) tryBuildFastPathInsert(
+	ins *memo.InsertExpr,
+) (_ execPlan, outputCols opt.ColMap, ok bool, _ error) {
 	// Conditions from ConstructFastPathInsert:
 	//
 	//  - there are no other mutations in the statement, and the output of the
@@ -140,12 +142,12 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 	//
 	// This condition was taken into account in build().
 	if !b.allowInsertFastPath {
-		return execPlan{}, false, nil
+		return execPlan{}, opt.ColMap{}, false, nil
 	}
 	// If there are unique checks required, there must be the same number of fast
 	// path unique checks.
 	if len(ins.UniqueChecks) != len(ins.FastPathUniqueChecks) {
-		return execPlan{}, false, nil
+		return execPlan{}, opt.ColMap{}, false, nil
 	}
 
 	insInput := ins.Input
@@ -153,7 +155,7 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 	// Values expressions containing subqueries or UDFs, or having a size larger
 	// than the max mutation batch size are disallowed.
 	if !ok || !memo.ValuesLegalForInsertFastPath(values) {
-		return execPlan{}, false, nil
+		return execPlan{}, opt.ColMap{}, false, nil
 	}
 
 	md := b.mem.Metadata()
@@ -167,7 +169,7 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 			// uniqueness checks during fast-path insert. Even if DatumsFromConstraint
 			// contains no Datums, that case indicates that all values to check come
 			// from the input row.
-			return execPlan{}, false, nil
+			return execPlan{}, opt.ColMap{}, false, nil
 		}
 		execFastPathCheck := &uniqChecks[i]
 		// Set up the execbuilder structure from the elements built during
@@ -177,7 +179,7 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 		execFastPathCheck.CheckOrdinal = c.CheckOrdinal
 		locking, err := b.buildLocking(c.Locking)
 		if err != nil {
-			return execPlan{}, false, err
+			return execPlan{}, opt.ColMap{}, false, err
 		}
 		execFastPathCheck.Locking = locking
 		execFastPathCheck.InsertCols = make([]exec.TableColumnOrdinal, len(c.InsertCols))
@@ -210,19 +212,19 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 		c := &ins.FKChecks[i]
 		if md.Table(c.ReferencedTable).ID() == md.Table(ins.Table).ID() {
 			// Self-referencing FK.
-			return execPlan{}, false, nil
+			return execPlan{}, opt.ColMap{}, false, nil
 		}
 		fk := tab.OutboundForeignKey(c.FKOrdinal)
 		lookupJoin, isLookupJoin := c.Check.(*memo.LookupJoinExpr)
 		if !isLookupJoin || lookupJoin.JoinType != opt.AntiJoinOp {
 			// Not a lookup anti-join.
-			return execPlan{}, false, nil
+			return execPlan{}, opt.ColMap{}, false, nil
 		}
 		// TODO(rytaft): see if we can remove the requirement that LookupExpr is
 		// empty.
 		if len(lookupJoin.On) > 0 || len(lookupJoin.LookupExpr) > 0 ||
 			len(lookupJoin.KeyCols) != fk.ColumnCount() {
-			return execPlan{}, false, nil
+			return execPlan{}, opt.ColMap{}, false, nil
 		}
 		inputExpr := lookupJoin.Input
 		// Ignore any select (used to deal with NULLs).
@@ -231,15 +233,15 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 		}
 		withScan, isWithScan := inputExpr.(*memo.WithScanExpr)
 		if !isWithScan {
-			return execPlan{}, false, nil
+			return execPlan{}, opt.ColMap{}, false, nil
 		}
 		if withScan.With != ins.WithID {
-			return execPlan{}, false, nil
+			return execPlan{}, opt.ColMap{}, false, nil
 		}
 
 		locking, err := b.buildLocking(lookupJoin.Locking)
 		if err != nil {
-			return execPlan{}, false, err
+			return execPlan{}, opt.ColMap{}, false, err
 		}
 
 		out := &fkChecks[i]
@@ -250,12 +252,12 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 			var withColOrd, inputColOrd int
 			withColOrd, ok = withScan.OutCols.Find(keyCol)
 			if !ok {
-				return execPlan{}, false, errors.AssertionFailedf("cannot find column %d", keyCol)
+				return execPlan{}, opt.ColMap{}, false, errors.AssertionFailedf("cannot find column %d", keyCol)
 			}
 			inputCol := withScan.InCols[withColOrd]
 			inputColOrd, ok = ins.InsertCols.Find(inputCol)
 			if !ok {
-				return execPlan{}, false, errors.AssertionFailedf("cannot find column %d", inputCol)
+				return execPlan{}, opt.ColMap{}, false, errors.AssertionFailedf("cannot find column %d", inputCol)
 			}
 			out.InsertCols[j] = exec.TableColumnOrdinal(inputColOrd)
 		}
@@ -294,12 +296,12 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 	colList = appendColsWhenPresent(colList, ins.PartialIndexPutCols)
 	rows, err := b.buildValuesRows(values)
 	if err != nil {
-		return execPlan{}, false, err
+		return execPlan{}, opt.ColMap{}, false, err
 	}
 	// We may need to rearrange the columns.
 	rows, err = rearrangeColumns(values.Cols, rows, colList)
 	if err != nil {
-		return execPlan{}, false, err
+		return execPlan{}, opt.ColMap{}, false, err
 	}
 
 	// Construct the InsertFastPath node.
@@ -317,14 +319,14 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 		b.allowAutoCommit,
 	)
 	if err != nil {
-		return execPlan{}, false, err
+		return execPlan{}, opt.ColMap{}, false, err
 	}
 	// Construct the output column map.
 	ep := execPlan{root: node}
 	if ins.NeedResults() {
-		ep.outputCols = mutationOutputColMap(ins)
+		outputCols = mutationOutputColMap(ins)
 	}
-	return ep, true, nil
+	return ep, outputCols, true, nil
 }
 
 // rearrangeColumns rearranges the columns in a matrix of TypedExpr values.
@@ -357,7 +359,7 @@ func rearrangeColumns(
 	return outRows, nil
 }
 
-func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (execPlan, error) {
+func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (_ execPlan, outputCols opt.ColMap, err error) {
 	// Currently, the execution engine requires one input column for each fetch
 	// and update expression, so use ensureColumns to map and reorder columns so
 	// that they correspond to target table columns. For example:
@@ -385,9 +387,9 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (execPlan, error) {
 	colList = appendColsWhenPresent(colList, upd.PartialIndexPutCols)
 	colList = appendColsWhenPresent(colList, upd.PartialIndexDelCols)
 
-	input, err := b.buildMutationInput(upd, upd.Input, colList, &upd.MutationPrivate)
+	input, _, err := b.buildMutationInput(upd, upd.Input, colList, &upd.MutationPrivate)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Construct the Update node.
@@ -419,30 +421,30 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (execPlan, error) {
 			len(upd.FKChecks) == 0 && len(upd.FKCascades) == 0,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	if err := b.buildUniqueChecks(upd.UniqueChecks); err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	if err := b.buildFKChecks(upd.FKChecks); err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	if err := b.buildFKCascades(upd.WithID, upd.FKCascades); err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Construct the output column map.
 	ep := execPlan{root: node}
 	if upd.NeedResults() {
-		ep.outputCols = mutationOutputColMap(upd)
+		outputCols = mutationOutputColMap(upd)
 	}
-	return ep, nil
+	return ep, outputCols, nil
 }
 
-func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
+func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (_ execPlan, outputCols opt.ColMap, err error) {
 	// Currently, the execution engine requires one input column for each insert,
 	// fetch, and update expression, so use ensureColumns to map and reorder
 	// columns so that they correspond to target table columns. For example:
@@ -474,9 +476,9 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 	colList = appendColsWhenPresent(colList, ups.PartialIndexPutCols)
 	colList = appendColsWhenPresent(colList, ups.PartialIndexDelCols)
 
-	input, err := b.buildMutationInput(ups, ups.Input, colList, &ups.MutationPrivate)
+	input, inputCols, err := b.buildMutationInput(ups, ups.Input, colList, &ups.MutationPrivate)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Construct the Upsert node.
@@ -484,9 +486,9 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 	tab := md.Table(ups.Table)
 	canaryCol := exec.NodeColumnOrdinal(-1)
 	if ups.CanaryCol != 0 {
-		canaryCol, err = input.getNodeColumnOrdinal(ups.CanaryCol)
+		canaryCol, err = getNodeColumnOrdinal(inputCols, ups.CanaryCol)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
 	insertColOrds := ordinalSetFromColList(ups.InsertCols)
@@ -509,19 +511,19 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 			len(ups.FKChecks) == 0 && len(ups.FKCascades) == 0,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	if err := b.buildUniqueChecks(ups.UniqueChecks); err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	if err := b.buildFKChecks(ups.FKChecks); err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	if err := b.buildFKCascades(ups.WithID, ups.FKCascades); err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// If UPSERT returns rows, they contain all non-mutation columns from the
@@ -530,15 +532,15 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 	// result of the UPSERT operation for that row.
 	ep := execPlan{root: node}
 	if ups.NeedResults() {
-		ep.outputCols = mutationOutputColMap(ups)
+		outputCols = mutationOutputColMap(ups)
 	}
-	return ep, nil
+	return ep, outputCols, nil
 }
 
-func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
+func (b *Builder) buildDelete(del *memo.DeleteExpr) (_ execPlan, outputCols opt.ColMap, err error) {
 	// Check for the fast-path delete case that can use a range delete.
 	if ep, ok, err := b.tryBuildDeleteRange(del); err != nil || ok {
-		return ep, err
+		return ep, opt.ColMap{}, err
 	}
 
 	// Ensure that order of input columns matches order of target table columns.
@@ -555,9 +557,9 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
 	}
 	colList = appendColsWhenPresent(colList, del.PartialIndexDelCols)
 
-	input, err := b.buildMutationInput(del, del.Input, colList, &del.MutationPrivate)
+	input, _, err := b.buildMutationInput(del, del.Input, colList, &del.MutationPrivate)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	// Construct the Delete node.
 	md := b.mem.Metadata()
@@ -584,24 +586,24 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
 		b.allowAutoCommit && len(del.FKChecks) == 0 && len(del.FKCascades) == 0,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	if err := b.buildFKChecks(del.FKChecks); err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	if err := b.buildFKCascades(del.WithID, del.FKCascades); err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Construct the output column map.
 	ep := execPlan{root: node}
 	if del.NeedResults() {
-		ep.outputCols = mutationOutputColMap(del)
+		outputCols = mutationOutputColMap(del)
 	}
 
-	return ep, nil
+	return ep, outputCols, nil
 }
 
 // tryBuildDeleteRange attempts to construct a fast DeleteRange execution for a
@@ -772,7 +774,7 @@ func (b *Builder) buildUniqueChecks(checks memo.UniqueChecksExpr) error {
 	for i := range checks {
 		c := &checks[i]
 		// Construct the query that returns uniqueness violations.
-		query, err := b.buildRelational(c.Check)
+		query, queryCols, err := b.buildRelational(c.Check)
 		if err != nil {
 			return err
 		}
@@ -780,7 +782,7 @@ func (b *Builder) buildUniqueChecks(checks memo.UniqueChecksExpr) error {
 		mkErr := func(row tree.Datums) error {
 			keyVals := make(tree.Datums, len(c.KeyCols))
 			for i, col := range c.KeyCols {
-				ord, err := query.getNodeColumnOrdinal(col)
+				ord, err := getNodeColumnOrdinal(queryCols, col)
 				if err != nil {
 					return err
 				}
@@ -804,7 +806,7 @@ func (b *Builder) buildFKChecks(checks memo.FKChecksExpr) error {
 	for i := range checks {
 		c := &checks[i]
 		// Construct the query that returns FK violations.
-		query, err := b.buildRelational(c.Check)
+		query, queryCols, err := b.buildRelational(c.Check)
 		if err != nil {
 			return err
 		}
@@ -812,7 +814,7 @@ func (b *Builder) buildFKChecks(checks memo.FKChecksExpr) error {
 		mkErr := func(row tree.Datums) error {
 			keyVals := make(tree.Datums, len(c.KeyCols))
 			for i, col := range c.KeyCols {
-				ord, err := query.getNodeColumnOrdinal(col)
+				ord, err := getNodeColumnOrdinal(queryCols, col)
 				if err != nil {
 					return err
 				}
@@ -1140,11 +1142,11 @@ func unwrapProjectExprs(input memo.RelExpr) memo.RelExpr {
 	return input
 }
 
-func (b *Builder) buildLock(lock *memo.LockExpr) (execPlan, error) {
+func (b *Builder) buildLock(lock *memo.LockExpr) (_ execPlan, outputCols opt.ColMap, err error) {
 	// Don't bother creating the lookup join if we don't need it.
 	locking, err := b.buildLocking(lock.Locking)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	if !locking.IsLocking() {
 		return b.buildRelational(lock.Input)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -57,39 +57,6 @@ import (
 
 type execPlan struct {
 	root exec.Node
-
-	// outputCols is a map from opt.ColumnID to exec.NodeColumnOrdinal. It maps
-	// columns in the output set of a relational expression to indices in the
-	// result columns of the exec.Node.
-	//
-	// The reason we need to keep track of this (instead of using just the
-	// relational properties) is that the relational properties don't force a
-	// single "schema": any ordering of the output columns is possible. We choose
-	// the schema that is most convenient: for scans, we use the table's column
-	// ordering. Consider:
-	//   SELECT a, b FROM t WHERE a = b
-	// and the following two cases:
-	//   1. The table is defined as (k INT PRIMARY KEY, a INT, b INT). The scan will
-	//      return (k, a, b).
-	//   2. The table is defined as (k INT PRIMARY KEY, b INT, a INT). The scan will
-	//      return (k, b, a).
-	// In these two cases, the relational properties are effectively the same.
-	//
-	// An alternative to this would be to always use a "canonical" schema, for
-	// example the output columns in increasing index order. However, this would
-	// require a lot of otherwise unnecessary projections.
-	//
-	// Note: conceptually, this could be a ColList; however, the map is more
-	// convenient when converting VariableOps to IndexedVars.
-	outputCols opt.ColMap
-}
-
-// numOutputCols returns the number of columns emitted by the execPlan's Node.
-// This will typically be equal to ep.outputCols.Len(), but might be different
-// if the node outputs the same optimizer ColumnID multiple times.
-// TODO(justin): we should keep track of this instead of computing it each time.
-func (ep *execPlan) numOutputCols() int {
-	return numOutputColsInMap(ep.outputCols)
 }
 
 // numOutputColsInMap returns the number of slots required to fill in all of
@@ -104,28 +71,30 @@ func numOutputColsInMap(m opt.ColMap) int {
 
 // makeBuildScalarCtx returns a buildScalarCtx that can be used with expressions
 // that refer the output columns of this plan.
-func (ep *execPlan) makeBuildScalarCtx() buildScalarCtx {
+func makeBuildScalarCtx(cols opt.ColMap) buildScalarCtx {
 	return buildScalarCtx{
-		ivh:     tree.MakeIndexedVarHelper(nil /* container */, ep.numOutputCols()),
-		ivarMap: ep.outputCols,
+		ivh:     tree.MakeIndexedVarHelper(nil /* container */, numOutputColsInMap(cols)),
+		ivarMap: cols,
 	}
 }
 
 // getNodeColumnOrdinal takes a column that is known to be produced by the execPlan
 // and returns the ordinal index of that column in the result columns of the
 // node.
-func (ep *execPlan) getNodeColumnOrdinal(col opt.ColumnID) (exec.NodeColumnOrdinal, error) {
-	ord, ok := ep.outputCols.Get(int(col))
+func getNodeColumnOrdinal(colMap opt.ColMap, col opt.ColumnID) (exec.NodeColumnOrdinal, error) {
+	ord, ok := colMap.Get(int(col))
 	if !ok {
 		return 0, errors.AssertionFailedf("column %d not in input", redact.Safe(col))
 	}
 	return exec.NodeColumnOrdinal(ord), nil
 }
 
-func (ep *execPlan) getNodeColumnOrdinalSet(cols opt.ColSet) (exec.NodeColumnOrdinalSet, error) {
+func getNodeColumnOrdinalSet(
+	colMap opt.ColMap, cols opt.ColSet,
+) (exec.NodeColumnOrdinalSet, error) {
 	var res exec.NodeColumnOrdinalSet
 	for colID, ok := cols.Next(0); ok; colID, ok = cols.Next(colID + 1) {
-		colOrd, err := ep.getNodeColumnOrdinal(colID)
+		colOrd, err := getNodeColumnOrdinal(colMap, colID)
 		if err != nil {
 			return exec.NodeColumnOrdinalSet{}, err
 		}
@@ -136,20 +105,20 @@ func (ep *execPlan) getNodeColumnOrdinalSet(cols opt.ColSet) (exec.NodeColumnOrd
 
 // reqOrdering converts the provided ordering of a relational expression to an
 // OutputOrdering (according to the outputCols map).
-func (ep *execPlan) reqOrdering(expr memo.RelExpr) (exec.OutputOrdering, error) {
-	ordering, err := ep.sqlOrdering(expr.ProvidedPhysical().Ordering)
+func reqOrdering(expr memo.RelExpr, cols opt.ColMap) (exec.OutputOrdering, error) {
+	ordering, err := sqlOrdering(expr.ProvidedPhysical().Ordering, cols)
 	return exec.OutputOrdering(ordering), err
 }
 
 // sqlOrdering converts an Ordering to a ColumnOrdering (according to the
 // outputCols map).
-func (ep *execPlan) sqlOrdering(ordering opt.Ordering) (colinfo.ColumnOrdering, error) {
+func sqlOrdering(ordering opt.Ordering, cols opt.ColMap) (colinfo.ColumnOrdering, error) {
 	if ordering.Empty() {
 		return nil, nil
 	}
 	colOrder := make(colinfo.ColumnOrdering, len(ordering))
 	for i := range ordering {
-		ord, err := ep.getNodeColumnOrdinal(ordering[i].ID())
+		ord, err := getNodeColumnOrdinal(cols, ordering[i].ID())
 		if err != nil {
 			return nil, err
 		}
@@ -164,9 +133,37 @@ func (ep *execPlan) sqlOrdering(ordering opt.Ordering) (colinfo.ColumnOrdering, 
 	return colOrder, nil
 }
 
-func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
+// builRelational builds a relational expression into an execPlan.
+//
+// outputCols is a map from opt.ColumnID to exec.NodeColumnOrdinal. It maps
+// columns in the output set of a relational expression to indices in the
+// result columns of the exec.Node.
+//
+// The reason we need to keep track of this (instead of using just the
+// relational properties) is that the relational properties don't force a
+// single "schema": any ordering of the output columns is possible. We choose
+// the schema that is most convenient: for scans, we use the table's column
+// ordering. Consider:
+//
+//	SELECT a, b FROM t WHERE a = b
+//
+// and the following two cases:
+//  1. The table is defined as (k INT PRIMARY KEY, a INT, b INT). The scan will
+//     return (k, a, b).
+//  2. The table is defined as (k INT PRIMARY KEY, b INT, a INT). The scan will
+//     return (k, b, a).
+//
+// In these two cases, the relational properties are effectively the same.
+//
+// An alternative to this would be to always use a "canonical" schema, for
+// example the output columns in increasing index order. However, this would
+// require a lot of otherwise unnecessary projections.
+//
+// Note: conceptually, this could be a ColList; however, the map is more
+// convenient when converting VariableOps to IndexedVars.
+// outputCols opt.ColMap
+func (b *Builder) buildRelational(e memo.RelExpr) (_ execPlan, outputCols opt.ColMap, err error) {
 	var ep execPlan
-	var err error
 
 	if opt.IsDDLOp(e) {
 		// Mark the statement as containing DDL for use
@@ -178,7 +175,7 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 		b.flags.Set(exec.PlanFlagContainsMutation)
 		// Raise error if mutation op is part of a read-only transaction.
 		if b.evalCtx.TxnReadOnly {
-			return execPlan{}, pgerror.Newf(pgcode.ReadOnlySQLTransaction,
+			return execPlan{}, opt.ColMap{}, pgerror.Newf(pgcode.ReadOnlySQLTransaction,
 				"cannot execute %s in a read-only transaction", b.statementTag(e))
 		}
 	}
@@ -186,7 +183,7 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	// Raise error if bounded staleness is used incorrectly.
 	if b.boundedStaleness() {
 		if _, ok := boundedStalenessAllowList[e.Op()]; !ok {
-			return execPlan{}, unimplemented.NewWithIssuef(67562,
+			return execPlan{}, opt.ColMap{}, unimplemented.NewWithIssuef(67562,
 				"cannot use bounded staleness for %s", b.statementTag(e),
 			)
 		}
@@ -211,176 +208,176 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 
 	switch t := e.(type) {
 	case *memo.ValuesExpr:
-		ep, err = b.buildValues(t)
+		ep, outputCols, err = b.buildValues(t)
 
 	case *memo.LiteralValuesExpr:
-		ep, err = b.buildLiteralValues(t)
+		ep, outputCols, err = b.buildLiteralValues(t)
 
 	case *memo.ScanExpr:
-		ep, err = b.buildScan(t)
+		ep, outputCols, err = b.buildScan(t)
 
 	case *memo.PlaceholderScanExpr:
-		ep, err = b.buildPlaceholderScan(t)
+		ep, outputCols, err = b.buildPlaceholderScan(t)
 
 	case *memo.SelectExpr:
-		ep, err = b.buildSelect(t)
+		ep, outputCols, err = b.buildSelect(t)
 
 	case *memo.ProjectExpr:
-		ep, err = b.buildProject(t)
+		ep, outputCols, err = b.buildProject(t)
 
 	case *memo.GroupByExpr, *memo.ScalarGroupByExpr:
-		ep, err = b.buildGroupBy(e)
+		ep, outputCols, err = b.buildGroupBy(e)
 
 	case *memo.DistinctOnExpr, *memo.EnsureDistinctOnExpr, *memo.UpsertDistinctOnExpr,
 		*memo.EnsureUpsertDistinctOnExpr:
-		ep, err = b.buildDistinct(t)
+		ep, outputCols, err = b.buildDistinct(t)
 
 	case *memo.TopKExpr:
-		ep, err = b.buildTopK(t)
+		ep, outputCols, err = b.buildTopK(t)
 
 	case *memo.LimitExpr, *memo.OffsetExpr:
-		ep, err = b.buildLimitOffset(e)
+		ep, outputCols, err = b.buildLimitOffset(e)
 
 	case *memo.SortExpr:
-		ep, err = b.buildSort(t)
+		ep, outputCols, err = b.buildSort(t)
 
 	case *memo.DistributeExpr:
-		ep, err = b.buildDistribute(t)
+		ep, outputCols, err = b.buildDistribute(t)
 
 	case *memo.IndexJoinExpr:
-		ep, err = b.buildIndexJoin(t)
+		ep, outputCols, err = b.buildIndexJoin(t)
 
 	case *memo.LookupJoinExpr:
-		ep, err = b.buildLookupJoin(t)
+		ep, outputCols, err = b.buildLookupJoin(t)
 
 	case *memo.InvertedJoinExpr:
-		ep, err = b.buildInvertedJoin(t)
+		ep, outputCols, err = b.buildInvertedJoin(t)
 
 	case *memo.ZigzagJoinExpr:
-		ep, err = b.buildZigzagJoin(t)
+		ep, outputCols, err = b.buildZigzagJoin(t)
 
 	case *memo.OrdinalityExpr:
-		ep, err = b.buildOrdinality(t)
+		ep, outputCols, err = b.buildOrdinality(t)
 
 	case *memo.MergeJoinExpr:
-		ep, err = b.buildMergeJoin(t)
+		ep, outputCols, err = b.buildMergeJoin(t)
 
 	case *memo.Max1RowExpr:
-		ep, err = b.buildMax1Row(t)
+		ep, outputCols, err = b.buildMax1Row(t)
 
 	case *memo.ProjectSetExpr:
-		ep, err = b.buildProjectSet(t)
+		ep, outputCols, err = b.buildProjectSet(t)
 
 	case *memo.WindowExpr:
-		ep, err = b.buildWindow(t)
+		ep, outputCols, err = b.buildWindow(t)
 
 	case *memo.SequenceSelectExpr:
-		ep, err = b.buildSequenceSelect(t)
+		ep, outputCols, err = b.buildSequenceSelect(t)
 
 	case *memo.InsertExpr:
-		ep, err = b.buildInsert(t)
+		ep, outputCols, err = b.buildInsert(t)
 
 	case *memo.InvertedFilterExpr:
-		ep, err = b.buildInvertedFilter(t)
+		ep, outputCols, err = b.buildInvertedFilter(t)
 
 	case *memo.UpdateExpr:
-		ep, err = b.buildUpdate(t)
+		ep, outputCols, err = b.buildUpdate(t)
 
 	case *memo.UpsertExpr:
-		ep, err = b.buildUpsert(t)
+		ep, outputCols, err = b.buildUpsert(t)
 
 	case *memo.DeleteExpr:
-		ep, err = b.buildDelete(t)
+		ep, outputCols, err = b.buildDelete(t)
 
 	case *memo.LockExpr:
-		ep, err = b.buildLock(t)
+		ep, outputCols, err = b.buildLock(t)
 
 	case *memo.BarrierExpr:
-		ep, err = b.buildBarrier(t)
+		ep, outputCols, err = b.buildBarrier(t)
 
 	case *memo.CreateTableExpr:
-		ep, err = b.buildCreateTable(t)
+		ep, outputCols, err = b.buildCreateTable(t)
 
 	case *memo.CreateViewExpr:
-		ep, err = b.buildCreateView(t)
+		ep, outputCols, err = b.buildCreateView(t)
 
 	case *memo.CreateFunctionExpr:
-		ep, err = b.buildCreateFunction(t)
+		ep, outputCols, err = b.buildCreateFunction(t)
 
 	case *memo.WithExpr:
-		ep, err = b.buildWith(t)
+		ep, outputCols, err = b.buildWith(t)
 
 	case *memo.WithScanExpr:
-		ep, err = b.buildWithScan(t)
+		ep, outputCols, err = b.buildWithScan(t)
 
 	case *memo.RecursiveCTEExpr:
-		ep, err = b.buildRecursiveCTE(t)
+		ep, outputCols, err = b.buildRecursiveCTE(t)
 
 	case *memo.CallExpr:
-		ep, err = b.buildCall(t)
+		ep, outputCols, err = b.buildCall(t)
 
 	case *memo.ExplainExpr:
-		ep, err = b.buildExplain(t)
+		ep, outputCols, err = b.buildExplain(t)
 
 	case *memo.ShowTraceForSessionExpr:
-		ep, err = b.buildShowTrace(t)
+		ep, outputCols, err = b.buildShowTrace(t)
 
 	case *memo.OpaqueRelExpr, *memo.OpaqueMutationExpr, *memo.OpaqueDDLExpr:
-		ep, err = b.buildOpaque(t.Private().(*memo.OpaqueRelPrivate))
+		ep, outputCols, err = b.buildOpaque(t.Private().(*memo.OpaqueRelPrivate))
 
 	case *memo.AlterTableSplitExpr:
-		ep, err = b.buildAlterTableSplit(t)
+		ep, outputCols, err = b.buildAlterTableSplit(t)
 
 	case *memo.AlterTableUnsplitExpr:
-		ep, err = b.buildAlterTableUnsplit(t)
+		ep, outputCols, err = b.buildAlterTableUnsplit(t)
 
 	case *memo.AlterTableUnsplitAllExpr:
-		ep, err = b.buildAlterTableUnsplitAll(t)
+		ep, outputCols, err = b.buildAlterTableUnsplitAll(t)
 
 	case *memo.AlterTableRelocateExpr:
-		ep, err = b.buildAlterTableRelocate(t)
+		ep, outputCols, err = b.buildAlterTableRelocate(t)
 
 	case *memo.AlterRangeRelocateExpr:
-		ep, err = b.buildAlterRangeRelocate(t)
+		ep, outputCols, err = b.buildAlterRangeRelocate(t)
 
 	case *memo.ControlJobsExpr:
-		ep, err = b.buildControlJobs(t)
+		ep, outputCols, err = b.buildControlJobs(t)
 
 	case *memo.ControlSchedulesExpr:
-		ep, err = b.buildControlSchedules(t)
+		ep, outputCols, err = b.buildControlSchedules(t)
 
 	case *memo.ShowCompletionsExpr:
-		ep, err = b.buildShowCompletions(t)
+		ep, outputCols, err = b.buildShowCompletions(t)
 
 	case *memo.CancelQueriesExpr:
-		ep, err = b.buildCancelQueries(t)
+		ep, outputCols, err = b.buildCancelQueries(t)
 
 	case *memo.CancelSessionsExpr:
-		ep, err = b.buildCancelSessions(t)
+		ep, outputCols, err = b.buildCancelSessions(t)
 
 	case *memo.CreateStatisticsExpr:
-		ep, err = b.buildCreateStatistics(t)
+		ep, outputCols, err = b.buildCreateStatistics(t)
 
 	case *memo.ExportExpr:
-		ep, err = b.buildExport(t)
+		ep, outputCols, err = b.buildExport(t)
 
 	default:
 		switch {
 		case opt.IsSetOp(e):
-			ep, err = b.buildSetOp(e)
+			ep, outputCols, err = b.buildSetOp(e)
 
 		case opt.IsJoinNonApplyOp(e):
-			ep, err = b.buildHashJoin(e)
+			ep, outputCols, err = b.buildHashJoin(e)
 
 		case opt.IsJoinApplyOp(e):
-			ep, err = b.buildApplyJoin(e)
+			ep, outputCols, err = b.buildApplyJoin(e)
 
 		default:
 			err = errors.AssertionFailedf("no execbuild for %T", t)
 		}
 	}
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// In test builds, assert that the exec plan output columns match the opt
@@ -388,11 +385,11 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	if buildutil.CrdbTestBuild {
 		optCols := e.Relational().OutputCols
 		var execCols opt.ColSet
-		ep.outputCols.ForEach(func(key, val int) {
+		outputCols.ForEach(func(key, val int) {
 			execCols.Add(opt.ColumnID(key))
 		})
 		if !execCols.Equals(optCols) {
-			return execPlan{}, errors.AssertionFailedf(
+			return execPlan{}, opt.ColMap{}, errors.AssertionFailedf(
 				"exec columns do not match opt columns: expected %v, got %v. op: %T", optCols, execCols, e)
 		}
 	}
@@ -400,17 +397,18 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	b.maybeAnnotateWithEstimates(ep.root, e)
 
 	if saveTableName != "" {
-		ep, err = b.applySaveTable(ep, e, saveTableName)
+		// The output columns do not change in applySaveTable.
+		ep, err = b.applySaveTable(ep, outputCols, e, saveTableName)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
 
 	// Wrap the expression in a render expression if presentation requires it.
 	if p := e.RequiredPhysical(); !p.Presentation.Any() {
-		ep, err = b.applyPresentation(ep, p.Presentation)
+		ep, outputCols, err = b.applyPresentation(ep, outputCols, p.Presentation)
 	}
-	return ep, err
+	return ep, outputCols, err
 }
 
 // maybeAnnotateWithEstimates checks if we are building against an
@@ -461,10 +459,12 @@ func (b *Builder) maybeAnnotateWithEstimates(node exec.Node, e memo.RelExpr) {
 	}
 }
 
-func (b *Builder) buildValues(values *memo.ValuesExpr) (execPlan, error) {
+func (b *Builder) buildValues(
+	values *memo.ValuesExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	rows, err := b.buildValuesRows(values)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	return b.constructValues(rows, values.Cols)
 }
@@ -502,7 +502,9 @@ func makeTypedExprMatrix(numRows, numCols int) [][]tree.TypedExpr {
 	return rows
 }
 
-func (b *Builder) constructValues(rows [][]tree.TypedExpr, cols opt.ColList) (execPlan, error) {
+func (b *Builder) constructValues(
+	rows [][]tree.TypedExpr, cols opt.ColList,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	md := b.mem.Metadata()
 	resultCols := make(colinfo.ResultColumns, len(cols))
 	for i, col := range cols {
@@ -512,17 +514,19 @@ func (b *Builder) constructValues(rows [][]tree.TypedExpr, cols opt.ColList) (ex
 	}
 	node, err := b.factory.ConstructValues(rows, resultCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	ep := execPlan{root: node}
 	for i, col := range cols {
-		ep.outputCols.Set(int(col), i)
+		outputCols.Set(int(col), i)
 	}
 
-	return ep, nil
+	return ep, outputCols, nil
 }
 
-func (b *Builder) buildLiteralValues(values *memo.LiteralValuesExpr) (execPlan, error) {
+func (b *Builder) buildLiteralValues(
+	values *memo.LiteralValuesExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	md := b.mem.Metadata()
 	resultCols := make(colinfo.ResultColumns, len(values.ColList()))
 	for i, col := range values.ColList() {
@@ -532,14 +536,14 @@ func (b *Builder) buildLiteralValues(values *memo.LiteralValuesExpr) (execPlan, 
 	}
 	node, err := b.factory.ConstructLiteralValues(values.Rows.Rows, resultCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	ep := execPlan{root: node}
 	for i, col := range values.ColList() {
-		ep.outputCols.Set(int(col), i)
+		outputCols.Set(int(col), i)
 	}
 
-	return ep, nil
+	return ep, outputCols, nil
 }
 
 // getColumns returns the set of column ordinals in the table for the set of
@@ -737,7 +741,7 @@ func (b *Builder) scanParams(
 	}, outputMap, nil
 }
 
-func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
+func (b *Builder) buildScan(scan *memo.ScanExpr) (_ execPlan, outputCols opt.ColMap, err error) {
 	md := b.mem.Metadata()
 	tab := md.Table(scan.Table)
 
@@ -746,7 +750,7 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 	}
 
 	if scan.Flags.ForceZigzag {
-		return execPlan{}, fmt.Errorf("could not produce a query plan conforming to the FORCE_ZIGZAG hint")
+		return execPlan{}, opt.ColMap{}, fmt.Errorf("could not produce a query plan conforming to the FORCE_ZIGZAG hint")
 	}
 
 	isUnfiltered := scan.IsUnfiltered(md)
@@ -756,13 +760,13 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		// user has explicitly forced the partial index *and* used NO_FULL_SCAN, we
 		// disallow the full index scan.
 		if isUnfiltered || (scan.Flags.ForceIndex && scan.IsFullIndexScan(md)) {
-			return execPlan{}, fmt.Errorf("could not produce a query plan conforming to the NO_FULL_SCAN hint")
+			return execPlan{}, opt.ColMap{}, fmt.Errorf("could not produce a query plan conforming to the NO_FULL_SCAN hint")
 		}
 	}
 
 	idx := tab.Index(scan.Index)
 	if idx.IsInverted() && len(scan.InvertedConstraint) == 0 {
-		return execPlan{},
+		return execPlan{}, opt.ColMap{},
 			errors.AssertionFailedf("expected inverted index scan to have an inverted constraint")
 	}
 	b.IndexesUsed = util.CombineUnique(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), idx.ID())})
@@ -840,14 +844,14 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		}
 	}
 
-	params, outputCols, err := b.scanParams(tab, &scan.ScanPrivate, scan.Relational(), scan.RequiredPhysical())
+	var params exec.ScanParams
+	params, outputCols, err = b.scanParams(tab, &scan.ScanPrivate, scan.Relational(), scan.RequiredPhysical())
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	res := execPlan{outputCols: outputCols}
-	reqOrdering, err := res.reqOrdering(scan)
+	reqOrdering, err := reqOrdering(scan, outputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	root, err := b.factory.ConstructScan(
 		tab,
@@ -856,9 +860,10 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		reqOrdering,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
+	var res execPlan
 	res.root = root
 	if b.evalCtx.SessionData().EnforceHomeRegion && b.IsANSIDML && b.doScanExprCollection {
 		if b.builtScans == nil {
@@ -868,12 +873,14 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		}
 		b.builtScans = append(b.builtScans, scan)
 	}
-	return res, nil
+	return res, outputCols, nil
 }
 
-func (b *Builder) buildPlaceholderScan(scan *memo.PlaceholderScanExpr) (execPlan, error) {
+func (b *Builder) buildPlaceholderScan(
+	scan *memo.PlaceholderScanExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	if scan.Constraint != nil || scan.InvertedConstraint != nil {
-		return execPlan{}, errors.AssertionFailedf("PlaceholderScan cannot have constraints")
+		return execPlan{}, opt.ColMap{}, errors.AssertionFailedf("PlaceholderScan cannot have constraints")
 	}
 
 	md := b.mem.Metadata()
@@ -898,7 +905,7 @@ func (b *Builder) buildPlaceholderScan(scan *memo.PlaceholderScanExpr) (execPlan
 		if p, ok := expr.(*memo.PlaceholderExpr); ok {
 			val, err := eval.Expr(b.ctx, b.evalCtx, p.Value)
 			if err != nil {
-				return execPlan{}, err
+				return execPlan{}, opt.ColMap{}, err
 			}
 			values[i] = val
 		} else {
@@ -918,14 +925,14 @@ func (b *Builder) buildPlaceholderScan(scan *memo.PlaceholderScanExpr) (execPlan
 	private := scan.ScanPrivate
 	private.SetConstraint(b.evalCtx, &c)
 
-	params, outputCols, err := b.scanParams(tab, &private, scan.Relational(), scan.RequiredPhysical())
+	var params exec.ScanParams
+	params, outputCols, err = b.scanParams(tab, &private, scan.Relational(), scan.RequiredPhysical())
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	res := execPlan{outputCols: outputCols}
-	reqOrdering, err := res.reqOrdering(scan)
+	reqOrdering, err := reqOrdering(scan, outputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	root, err := b.factory.ConstructScan(
 		tab,
@@ -934,45 +941,48 @@ func (b *Builder) buildPlaceholderScan(scan *memo.PlaceholderScanExpr) (execPlan
 		reqOrdering,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
+	var res execPlan
 	res.root = root
-	return res, nil
+	return res, outputCols, nil
 }
 
-func (b *Builder) buildSelect(sel *memo.SelectExpr) (execPlan, error) {
-	input, err := b.buildRelational(sel.Input)
+func (b *Builder) buildSelect(sel *memo.SelectExpr) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, inputCols, err := b.buildRelational(sel.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	filter, err := b.buildScalarWithMap(input.outputCols, &sel.Filters)
+	filter, err := b.buildScalarWithMap(inputCols, &sel.Filters)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	// A filtering node does not modify the schema.
-	res := execPlan{outputCols: input.outputCols}
-	reqOrder, err := res.reqOrdering(sel)
+	reqOrder, err := reqOrdering(sel, inputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
+	var res execPlan
 	res.root, err = b.factory.ConstructFilter(input.root, filter, reqOrder)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return res, nil
+	// A filtering node does not modify the schema, so we can pass along the
+	// input's output columns.
+	return res, inputCols, nil
 }
 
-func (b *Builder) buildInvertedFilter(invFilter *memo.InvertedFilterExpr) (execPlan, error) {
-	input, err := b.buildRelational(invFilter.Input)
+func (b *Builder) buildInvertedFilter(
+	invFilter *memo.InvertedFilterExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, inputCols, err := b.buildRelational(invFilter.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	// A filtering node does not modify the schema.
-	res := execPlan{outputCols: input.outputCols}
-	invertedCol, err := input.getNodeColumnOrdinal(invFilter.InvertedColumn)
+	var res execPlan
+	invertedCol, err := getNodeColumnOrdinal(inputCols, invFilter.InvertedColumn)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	var typedPreFilterExpr tree.TypedExpr
 	var typ *types.T
@@ -987,27 +997,31 @@ func (b *Builder) buildInvertedFilter(invFilter *memo.InvertedFilterExpr) (execP
 		}
 		typedPreFilterExpr, err = b.buildScalar(&ctx, invFilter.PreFiltererState.Expr)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 		typ = invFilter.PreFiltererState.Typ
 	}
 	res.root, err = b.factory.ConstructInvertedFilter(
 		input.root, invFilter.InvertedExpression, typedPreFilterExpr, typ, invertedCol)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	// Apply a post-projection to remove the inverted column.
 	//
 	// TODO(rytaft): the invertedFilter used to do this post-projection, but we
 	// had difficulty integrating that behavior. Investigate and restore that
 	// original behavior.
-	return b.applySimpleProject(res, invFilter, invFilter.Relational().OutputCols, invFilter.ProvidedPhysical().Ordering)
+	return b.applySimpleProject(res, inputCols, invFilter, invFilter.Relational().OutputCols, invFilter.ProvidedPhysical().Ordering)
 }
 
 // applySimpleProject adds a simple projection on top of an existing plan.
 func (b *Builder) applySimpleProject(
-	input execPlan, inputExpr memo.RelExpr, cols opt.ColSet, providedOrd opt.Ordering,
-) (execPlan, error) {
+	input execPlan,
+	inputCols opt.ColMap,
+	inputExpr memo.RelExpr,
+	cols opt.ColSet,
+	providedOrd opt.Ordering,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	// Since we are constructing a simple project on top of the main operator,
 	// we need to explicitly annotate the latter with estimates since the code
 	// in buildRelational() will attach them to the project.
@@ -1016,52 +1030,52 @@ func (b *Builder) applySimpleProject(
 	colList := make([]exec.NodeColumnOrdinal, 0, cols.Len())
 	var res execPlan
 	for i, ok := cols.Next(0); ok; i, ok = cols.Next(i + 1) {
-		res.outputCols.Set(int(i), len(colList))
-		ord, err := input.getNodeColumnOrdinal(i)
+		outputCols.Set(int(i), len(colList))
+		ord, err := getNodeColumnOrdinal(inputCols, i)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 		colList = append(colList, ord)
 	}
-	var err error
-	sqlOrdering, err := res.sqlOrdering(providedOrd)
+	sqlOrdering, err := sqlOrdering(providedOrd, outputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	res.root, err = b.factory.ConstructSimpleProject(
 		input.root, colList, exec.OutputOrdering(sqlOrdering),
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return res, nil
+	return res, outputCols, nil
 }
 
-func (b *Builder) buildProject(prj *memo.ProjectExpr) (execPlan, error) {
+func (b *Builder) buildProject(
+	prj *memo.ProjectExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	md := b.mem.Metadata()
-	input, err := b.buildRelational(prj.Input)
+	input, inputCols, err := b.buildRelational(prj.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	projections := prj.Projections
 	if len(projections) == 0 {
 		// We have only pass-through columns.
-		return b.applySimpleProject(input, prj.Input, prj.Passthrough, prj.ProvidedPhysical().Ordering)
+		return b.applySimpleProject(input, inputCols, prj.Input, prj.Passthrough, prj.ProvidedPhysical().Ordering)
 	}
 
-	var res execPlan
 	numExprs := len(projections) + prj.Passthrough.Len()
 	exprs := make(tree.TypedExprs, 0, numExprs)
 	cols := make(colinfo.ResultColumns, 0, numExprs)
-	ctx := input.makeBuildScalarCtx()
+	ctx := makeBuildScalarCtx(inputCols)
 	for i := range projections {
 		item := &projections[i]
 		expr, err := b.buildScalar(&ctx, item.Element)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
-		res.outputCols.Set(int(item.Col), i)
+		outputCols.Set(int(item.Col), i)
 		exprs = append(exprs, expr)
 		cols = append(cols, colinfo.ResultColumn{
 			Name: md.ColumnMeta(item.Col).Alias,
@@ -1069,10 +1083,10 @@ func (b *Builder) buildProject(prj *memo.ProjectExpr) (execPlan, error) {
 		})
 	}
 	for colID, ok := prj.Passthrough.Next(0); ok; colID, ok = prj.Passthrough.Next(colID + 1) {
-		res.outputCols.Set(int(colID), len(exprs))
+		outputCols.Set(int(colID), len(exprs))
 		indexedVar, err := b.indexedVar(&ctx, md, colID)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 		exprs = append(exprs, indexedVar)
 		meta := md.ColumnMeta(colID)
@@ -1081,26 +1095,27 @@ func (b *Builder) buildProject(prj *memo.ProjectExpr) (execPlan, error) {
 			Typ:  meta.Type,
 		})
 	}
-	reqOrdering, err := res.reqOrdering(prj)
+	reqOrdering, err := reqOrdering(prj, outputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
+	var res execPlan
 	res.root, err = b.factory.ConstructRender(input.root, cols, exprs, reqOrdering)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return res, nil
+	return res, outputCols, nil
 }
 
-func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
+func (b *Builder) buildApplyJoin(join memo.RelExpr) (_ execPlan, outputCols opt.ColMap, err error) {
 	switch join.Op() {
 	case opt.InnerJoinApplyOp, opt.LeftJoinApplyOp, opt.SemiJoinApplyOp, opt.AntiJoinApplyOp:
 	default:
-		return execPlan{}, fmt.Errorf("couldn't execute correlated subquery with op %s", join.Op())
+		return execPlan{}, opt.ColMap{}, fmt.Errorf("couldn't execute correlated subquery with op %s", join.Op())
 	}
 	joinType, err := joinOpToJoinType(join.Op())
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	leftExpr := join.Child(0).(memo.RelExpr)
 	leftProps := leftExpr.Relational()
@@ -1112,9 +1127,9 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 	withExprs := make([]builtWithExpr, len(b.withExprs))
 	copy(withExprs, b.withExprs)
 
-	leftPlan, err := b.buildRelational(leftExpr)
+	leftPlan, leftCols, err := b.buildRelational(leftExpr)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Make a copy of the required props for the right side.
@@ -1129,9 +1144,9 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 	// in the left side that contains the binding.
 	var leftBoundColMap opt.ColMap
 	for col, ok := leftBoundCols.Next(0); ok; col, ok = leftBoundCols.Next(col + 1) {
-		v, ok := leftPlan.outputCols.Get(int(col))
+		v, ok := leftCols.Get(int(col))
 		if !ok {
-			return execPlan{}, fmt.Errorf("couldn't find binding column %d in left output columns", col)
+			return execPlan{}, opt.ColMap{}, fmt.Errorf("couldn't find binding column %d in left output columns", col)
 		}
 		leftBoundColMap.Set(int(col), v)
 	}
@@ -1237,7 +1252,7 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 	for i := range rightRequiredProps.Presentation {
 		rightOutputCols.Set(int(rightRequiredProps.Presentation[i].ID), i)
 	}
-	allCols := joinOutputMap(leftPlan.outputCols, rightOutputCols)
+	allCols := joinOutputMap(leftCols, rightOutputCols)
 
 	var onExpr tree.TypedExpr
 	if len(*filters) != 0 {
@@ -1247,18 +1262,17 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 		}
 		onExpr, err = b.buildScalar(&scalarCtx, filters)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
 
-	var outputCols opt.ColMap
 	if !joinType.ShouldIncludeRightColsInOutput() {
-		outputCols = leftPlan.outputCols
+		outputCols = leftCols
 	} else {
 		outputCols = allCols
 	}
 
-	ep := execPlan{outputCols: outputCols}
+	var ep execPlan
 
 	b.recordJoinType(joinType)
 	b.recordJoinAlgorithm(exec.ApplyJoin)
@@ -1270,9 +1284,9 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 		planRightSideFn,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return ep, nil
+	return ep, outputCols, nil
 }
 
 // makePresentation creates a Presentation that contains the given columns, in
@@ -1303,7 +1317,7 @@ func (b *Builder) presentationToResultColumns(pres physical.Presentation) colinf
 	return result
 }
 
-func (b *Builder) buildHashJoin(join memo.RelExpr) (execPlan, error) {
+func (b *Builder) buildHashJoin(join memo.RelExpr) (_ execPlan, outputCols opt.ColMap, err error) {
 	if f := join.Private().(*memo.JoinPrivate).Flags; f.Has(memo.DisallowHashJoinStoreRight) {
 		// We need to do a bit of reverse engineering here to determine what the
 		// hint was.
@@ -1314,14 +1328,14 @@ func (b *Builder) buildHashJoin(join memo.RelExpr) (execPlan, error) {
 			hint = tree.AstInverted
 		}
 
-		return execPlan{}, errors.Errorf(
+		return execPlan{}, opt.ColMap{}, errors.Errorf(
 			"could not produce a query plan conforming to the %s JOIN hint", hint,
 		)
 	}
 
 	joinType, err := joinOpToJoinType(join.Op())
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	leftExpr := join.Child(0).(memo.RelExpr)
 	rightExpr := join.Child(1).(memo.RelExpr)
@@ -1363,29 +1377,28 @@ func (b *Builder) buildHashJoin(join memo.RelExpr) (execPlan, error) {
 		telemetry.Inc(opt.JoinTypeToUseCounter(join.Op()))
 	}
 
-	left, right, onExpr, outputCols, err := b.initJoinBuild(
+	left, right, onExpr, leftCols, rightCols, outputCols, err := b.initJoinBuild(
 		leftExpr,
 		rightExpr,
 		memo.ExtractRemainingJoinFilters(*filters, leftEq, rightEq),
 		joinType,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	ep := execPlan{outputCols: outputCols}
 
 	// Convert leftEq/rightEq to ordinals.
 	eqColsBuf := make([]exec.NodeColumnOrdinal, 2*len(leftEq))
 	leftEqOrdinals := eqColsBuf[:len(leftEq):len(leftEq)]
 	rightEqOrdinals := eqColsBuf[len(leftEq):]
 	for i := range leftEq {
-		leftEqOrdinals[i], err = left.getNodeColumnOrdinal(leftEq[i])
+		leftEqOrdinals[i], err = getNodeColumnOrdinal(leftCols, leftEq[i])
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
-		rightEqOrdinals[i], err = right.getNodeColumnOrdinal(rightEq[i])
+		rightEqOrdinals[i], err = getNodeColumnOrdinal(rightCols, rightEq[i])
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
 
@@ -1398,6 +1411,7 @@ func (b *Builder) buildHashJoin(join memo.RelExpr) (execPlan, error) {
 	} else {
 		b.recordJoinAlgorithm(exec.HashJoin)
 	}
+	var ep execPlan
 	ep.root, err = b.factory.ConstructHashJoin(
 		joinType,
 		left.root, right.root,
@@ -1406,12 +1420,14 @@ func (b *Builder) buildHashJoin(join memo.RelExpr) (execPlan, error) {
 		onExpr,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return ep, nil
+	return ep, outputCols, nil
 }
 
-func (b *Builder) buildMergeJoin(join *memo.MergeJoinExpr) (execPlan, error) {
+func (b *Builder) buildMergeJoin(
+	join *memo.MergeJoinExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	if !b.disableTelemetry {
 		telemetry.Inc(sqltelemetry.JoinAlgoMergeUseCounter)
 		telemetry.Inc(opt.JoinTypeToUseCounter(join.JoinType))
@@ -1419,7 +1435,7 @@ func (b *Builder) buildMergeJoin(join *memo.MergeJoinExpr) (execPlan, error) {
 
 	joinType, err := joinOpToJoinType(join.JoinType)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	leftExpr, rightExpr := join.Left, join.Right
 	leftEq, rightEq := join.LeftEq, join.RightEq
@@ -1443,29 +1459,29 @@ func (b *Builder) buildMergeJoin(join *memo.MergeJoinExpr) (execPlan, error) {
 		}
 	}
 
-	left, right, onExpr, outputCols, err := b.initJoinBuild(
+	left, right, onExpr, leftCols, rightCols, outputCols, err := b.initJoinBuild(
 		leftExpr, rightExpr, join.On, joinType,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	leftOrd, err := left.sqlOrdering(leftEq)
+	leftOrd, err := sqlOrdering(leftEq, leftCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	rightOrd, err := right.sqlOrdering(rightEq)
+	rightOrd, err := sqlOrdering(rightEq, rightCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	ep := execPlan{outputCols: outputCols}
-	reqOrd, err := ep.reqOrdering(join)
+	reqOrd, err := reqOrdering(join, outputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	leftEqColsAreKey := leftExpr.Relational().FuncDeps.ColsAreStrictKey(leftEq.ColSet())
 	rightEqColsAreKey := rightExpr.Relational().FuncDeps.ColsAreStrictKey(rightEq.ColSet())
 	b.recordJoinType(joinType)
 	b.recordJoinAlgorithm(exec.MergeJoin)
+	var ep execPlan
 	ep.root, err = b.factory.ConstructMergeJoin(
 		joinType,
 		left.root, right.root,
@@ -1474,9 +1490,9 @@ func (b *Builder) buildMergeJoin(join *memo.MergeJoinExpr) (execPlan, error) {
 		leftEqColsAreKey, rightEqColsAreKey,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return ep, nil
+	return ep, outputCols, nil
 }
 
 // initJoinBuild builds the inputs to the join as well as the ON expression.
@@ -1485,32 +1501,37 @@ func (b *Builder) initJoinBuild(
 	rightChild memo.RelExpr,
 	filters memo.FiltersExpr,
 	joinType descpb.JoinType,
-) (leftPlan, rightPlan execPlan, onExpr tree.TypedExpr, outputCols opt.ColMap, _ error) {
-	leftPlan, err := b.buildRelational(leftChild)
+) (
+	leftPlan, rightPlan execPlan,
+	onExpr tree.TypedExpr,
+	leftCols, rightCols, outputCols opt.ColMap,
+	_ error,
+) {
+	leftPlan, leftCols, err := b.buildRelational(leftChild)
 	if err != nil {
-		return execPlan{}, execPlan{}, nil, opt.ColMap{}, err
+		return execPlan{}, execPlan{}, nil, opt.ColMap{}, opt.ColMap{}, opt.ColMap{}, err
 	}
-	rightPlan, err = b.buildRelational(rightChild)
+	rightPlan, rightCols, err = b.buildRelational(rightChild)
 	if err != nil {
-		return execPlan{}, execPlan{}, nil, opt.ColMap{}, err
+		return execPlan{}, execPlan{}, nil, opt.ColMap{}, opt.ColMap{}, opt.ColMap{}, err
 	}
 
-	allCols := joinOutputMap(leftPlan.outputCols, rightPlan.outputCols)
+	allCols := joinOutputMap(leftCols, rightCols)
 
 	if len(filters) != 0 {
 		onExpr, err = b.buildScalarWithMap(allCols, &filters)
 		if err != nil {
-			return execPlan{}, execPlan{}, nil, opt.ColMap{}, err
+			return execPlan{}, execPlan{}, nil, opt.ColMap{}, opt.ColMap{}, opt.ColMap{}, err
 		}
 	}
 
 	if !joinType.ShouldIncludeLeftColsInOutput() {
-		return leftPlan, rightPlan, onExpr, rightPlan.outputCols, nil
+		return leftPlan, rightPlan, onExpr, leftCols, rightCols, rightCols, nil
 	}
 	if !joinType.ShouldIncludeRightColsInOutput() {
-		return leftPlan, rightPlan, onExpr, leftPlan.outputCols, nil
+		return leftPlan, rightPlan, onExpr, leftCols, rightCols, leftCols, nil
 	}
-	return leftPlan, rightPlan, onExpr, allCols, nil
+	return leftPlan, rightPlan, onExpr, leftCols, rightCols, allCols, nil
 }
 
 // joinOutputMap determines the outputCols map for a (non-semi/anti) join, given
@@ -1550,20 +1571,21 @@ func joinOpToJoinType(op opt.Operator) (descpb.JoinType, error) {
 	}
 }
 
-func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
-	input, err := b.buildGroupByInput(groupBy)
+func (b *Builder) buildGroupBy(
+	groupBy memo.RelExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, inputCols, err := b.buildGroupByInput(groupBy)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	var ep execPlan
 	groupingCols := groupBy.Private().(*memo.GroupingPrivate).GroupingCols
 	groupingColIdx := make([]exec.NodeColumnOrdinal, 0, groupingCols.Len())
 	for i, ok := groupingCols.Next(0); ok; i, ok = groupingCols.Next(i + 1) {
-		ep.outputCols.Set(int(i), len(groupingColIdx))
-		ord, err := input.getNodeColumnOrdinal(i)
+		outputCols.Set(int(i), len(groupingColIdx))
+		ord, err := getNodeColumnOrdinal(inputCols, i)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 		groupingColIdx = append(groupingColIdx, ord)
 	}
@@ -1578,11 +1600,11 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 		if aggFilter, ok := agg.(*memo.AggFilterExpr); ok {
 			filter, ok := aggFilter.Filter.(*memo.VariableExpr)
 			if !ok {
-				return execPlan{}, errors.AssertionFailedf("only VariableOp args supported")
+				return execPlan{}, opt.ColMap{}, errors.AssertionFailedf("only VariableOp args supported")
 			}
-			filterOrd, err = input.getNodeColumnOrdinal(filter.Col)
+			filterOrd, err = getNodeColumnOrdinal(inputCols, filter.Col)
 			if err != nil {
-				return execPlan{}, err
+				return execPlan{}, opt.ColMap{}, err
 			}
 			agg = aggFilter.Input
 		}
@@ -1603,16 +1625,16 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 			child := agg.Child(j)
 			if variable, ok := child.(*memo.VariableExpr); ok {
 				if len(constArgs) != 0 {
-					return execPlan{}, errors.Errorf("constant args must come after variable args")
+					return execPlan{}, opt.ColMap{}, errors.Errorf("constant args must come after variable args")
 				}
-				ord, err := input.getNodeColumnOrdinal(variable.Col)
+				ord, err := getNodeColumnOrdinal(inputCols, variable.Col)
 				if err != nil {
-					return execPlan{}, err
+					return execPlan{}, opt.ColMap{}, err
 				}
 				argCols = append(argCols, ord)
 			} else {
 				if len(argCols) == 0 {
-					return execPlan{}, errors.Errorf("a constant arg requires at least one variable arg")
+					return execPlan{}, opt.ColMap{}, errors.Errorf("a constant arg requires at least one variable arg")
 				}
 				constArgs = append(constArgs, memo.ExtractConstDatum(child))
 			}
@@ -1627,24 +1649,25 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 			Filter:           filterOrd,
 			DistsqlBlocklist: overload.DistsqlBlocklist,
 		}
-		ep.outputCols.Set(int(item.Col), len(groupingColIdx)+i)
+		outputCols.Set(int(item.Col), len(groupingColIdx)+i)
 	}
 
+	var ep execPlan
 	if groupBy.Op() == opt.ScalarGroupByOp {
 		ep.root, err = b.factory.ConstructScalarGroupBy(input.root, aggInfos)
 	} else {
 		groupBy := groupBy.(*memo.GroupByExpr)
 		var groupingColOrder colinfo.ColumnOrdering
-		groupingColOrder, err = input.sqlOrdering(ordering.StreamingGroupingColOrdering(
+		groupingColOrder, err = sqlOrdering(ordering.StreamingGroupingColOrdering(
 			&groupBy.GroupingPrivate, &groupBy.RequiredPhysical().Ordering,
-		))
+		), inputCols)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
-		var reqOrdering exec.OutputOrdering
-		reqOrdering, err = ep.reqOrdering(groupBy)
+		var reqOrd exec.OutputOrdering
+		reqOrd, err = reqOrdering(groupBy, outputCols)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 		orderType := exec.GroupingOrderType(groupBy.GroupingOrderType(&groupBy.RequiredPhysical().Ordering))
 		var rowCount uint64
@@ -1652,70 +1675,74 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 			rowCount = uint64(math.Ceil(relProps.Statistics().RowCount))
 		}
 		ep.root, err = b.factory.ConstructGroupBy(
-			input.root, groupingColIdx, groupingColOrder, aggInfos, reqOrdering, orderType, rowCount,
+			input.root, groupingColIdx, groupingColOrder, aggInfos, reqOrd, orderType, rowCount,
 		)
 	}
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return ep, nil
+	return ep, outputCols, nil
 }
 
-func (b *Builder) buildDistinct(distinct memo.RelExpr) (execPlan, error) {
+func (b *Builder) buildDistinct(
+	distinct memo.RelExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	private := distinct.Private().(*memo.GroupingPrivate)
 
 	if private.GroupingCols.Empty() {
 		// A DistinctOn with no grouping columns should have been converted to a
 		// LIMIT 1 or Max1Row by normalization rules.
-		return execPlan{}, fmt.Errorf("cannot execute distinct on no columns")
+		return execPlan{}, opt.ColMap{}, fmt.Errorf("cannot execute distinct on no columns")
 	}
-	input, err := b.buildGroupByInput(distinct)
+	input, inputCols, err := b.buildGroupByInput(distinct)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	distinctCols, err := input.getNodeColumnOrdinalSet(private.GroupingCols)
+	distinctCols, err := getNodeColumnOrdinalSet(inputCols, private.GroupingCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	var orderedCols exec.NodeColumnOrdinalSet
 	ordering := ordering.StreamingGroupingColOrdering(
 		private, &distinct.RequiredPhysical().Ordering,
 	)
 	for i := range ordering {
-		ord, err := input.getNodeColumnOrdinal(ordering[i].ID())
+		ord, err := getNodeColumnOrdinal(inputCols, ordering[i].ID())
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 		orderedCols.Add(int(ord))
 	}
-	ep := execPlan{outputCols: input.outputCols}
 
-	reqOrdering, err := ep.reqOrdering(distinct)
+	reqOrdering, err := reqOrdering(distinct, inputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
+	var ep execPlan
 	ep.root, err = b.factory.ConstructDistinct(
 		input.root, distinctCols, orderedCols, reqOrdering,
 		private.NullsAreDistinct, private.ErrorOnDup)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// buildGroupByInput can add extra sort column(s), so discard those if they
 	// are present by using an additional projection.
 	outCols := distinct.Relational().OutputCols
-	if input.outputCols.Len() == outCols.Len() {
-		return ep, nil
+	if inputCols.Len() == outCols.Len() {
+		return ep, inputCols, nil
 	}
-	return b.ensureColumns(ep, distinct, outCols.ToList(), distinct.ProvidedPhysical().Ordering)
+	return b.ensureColumns(ep, inputCols, distinct, outCols.ToList(), distinct.ProvidedPhysical().Ordering)
 }
 
-func (b *Builder) buildGroupByInput(groupBy memo.RelExpr) (execPlan, error) {
+func (b *Builder) buildGroupByInput(
+	groupBy memo.RelExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	groupByInput := groupBy.Child(0).(memo.RelExpr)
-	input, err := b.buildRelational(groupByInput)
+	input, inputCols, err := b.buildRelational(groupByInput)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// TODO(radu): this is a one-off fix for an otherwise bigger gap: we should
@@ -1743,44 +1770,42 @@ func (b *Builder) buildGroupByInput(groupBy memo.RelExpr) (execPlan, error) {
 
 	if neededCols.Equals(groupByInput.Relational().OutputCols) {
 		// All columns produced by the input are used.
-		return input, nil
+		return input, inputCols, nil
 	}
 
 	// The input is producing columns that are not useful; set up a projection.
 	cols := make([]exec.NodeColumnOrdinal, 0, neededCols.Len())
-	var newOutputCols opt.ColMap
 	for colID, ok := neededCols.Next(0); ok; colID, ok = neededCols.Next(colID + 1) {
-		ordinal, ordOk := input.outputCols.Get(int(colID))
+		ordinal, ordOk := inputCols.Get(int(colID))
 		if !ordOk {
-			return execPlan{},
+			return execPlan{}, opt.ColMap{},
 				errors.AssertionFailedf("needed column not produced by group-by input")
 		}
-		newOutputCols.Set(int(colID), len(cols))
+		outputCols.Set(int(colID), len(cols))
 		cols = append(cols, exec.NodeColumnOrdinal(ordinal))
 	}
 
-	input.outputCols = newOutputCols
-	reqOrdering, err := input.reqOrdering(groupByInput)
+	reqOrdering, err := reqOrdering(groupByInput, inputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	input.root, err = b.factory.ConstructSimpleProject(input.root, cols, reqOrdering)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return input, nil
+	return input, outputCols, nil
 }
 
-func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
+func (b *Builder) buildSetOp(set memo.RelExpr) (_ execPlan, outputCols opt.ColMap, err error) {
 	leftExpr := set.Child(0).(memo.RelExpr)
-	left, err := b.buildRelational(leftExpr)
+	left, leftCols, err := b.buildRelational(leftExpr)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	rightExpr := set.Child(1).(memo.RelExpr)
-	right, err := b.buildRelational(rightExpr)
+	right, rightCols, err := b.buildRelational(rightExpr)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	private := set.Private().(*memo.SetPrivate)
@@ -1804,13 +1829,13 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 	// Note that (unless this is part of a larger query) the presentation property
 	// will ensure that the columns are presented correctly in the output (i.e. in
 	// the order `b, c, a`).
-	left, err = b.ensureColumns(left, leftExpr, private.LeftCols, leftExpr.ProvidedPhysical().Ordering)
+	left, leftCols, err = b.ensureColumns(left, leftCols, leftExpr, private.LeftCols, leftExpr.ProvidedPhysical().Ordering)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	right, err = b.ensureColumns(right, rightExpr, private.RightCols, rightExpr.ProvidedPhysical().Ordering)
+	right, rightCols, err = b.ensureColumns(right, rightCols, rightExpr, private.RightCols, rightExpr.ProvidedPhysical().Ordering)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	var typ tree.UnionType
@@ -1829,7 +1854,7 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 	case opt.ExceptAllOp:
 		typ, all = tree.ExceptOp, true
 	default:
-		return execPlan{}, errors.AssertionFailedf("invalid operator %s", redact.Safe(set.Op()))
+		return execPlan{}, opt.ColMap{}, errors.AssertionFailedf("invalid operator %s", redact.Safe(set.Op()))
 	}
 
 	switch typ {
@@ -1858,21 +1883,22 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 		enforceHomeRegion = b.IsANSIDML && b.evalCtx.SessionData().EnforceHomeRegion
 	}
 
-	ep := execPlan{}
 	for i, col := range private.OutCols {
-		ep.outputCols.Set(int(col), i)
+		outputCols.Set(int(col), i)
 	}
-	streamingOrdering, err := ep.sqlOrdering(
-		ordering.StreamingSetOpOrdering(set, &set.RequiredPhysical().Ordering),
+	streamingOrdering, err := sqlOrdering(
+		ordering.StreamingSetOpOrdering(set, &set.RequiredPhysical().Ordering), outputCols,
 	)
 	if err != nil {
-		return execPlan{}, err
-	}
-	reqOrdering, err := ep.reqOrdering(set)
-	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
+	reqOrdering, err := reqOrdering(set, outputCols)
+	if err != nil {
+		return execPlan{}, opt.ColMap{}, err
+	}
+
+	var ep execPlan
 	if typ == tree.UnionOp && all {
 		ep.root, err = b.factory.ConstructUnionAll(left.root, right.root, reqOrdering, hardLimit, enforceHomeRegion)
 	} else if len(streamingOrdering) > 0 {
@@ -1882,7 +1908,7 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 		ep.root, err = b.factory.ConstructStreamingSetOp(typ, all, left.root, right.root, streamingOrdering, reqOrdering)
 	} else {
 		if len(reqOrdering) > 0 {
-			return execPlan{}, errors.AssertionFailedf("hash set op is not supported with a required ordering")
+			return execPlan{}, opt.ColMap{}, errors.AssertionFailedf("hash set op is not supported with a required ordering")
 		}
 		if typ != tree.UnionOp {
 			b.recordJoinAlgorithm(exec.HashJoin)
@@ -1890,73 +1916,74 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 		ep.root, err = b.factory.ConstructHashSetOp(typ, all, left.root, right.root)
 	}
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return ep, nil
+	return ep, outputCols, nil
 }
 
 // buildTopK builds a plan for a TopKOp, which is like a combined SortOp and LimitOp.
-func (b *Builder) buildTopK(e *memo.TopKExpr) (execPlan, error) {
+func (b *Builder) buildTopK(e *memo.TopKExpr) (_ execPlan, outputCols opt.ColMap, err error) {
 	inputExpr := e.Input
-	input, err := b.buildRelational(inputExpr)
+	input, inputCols, err := b.buildRelational(inputExpr)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	ordering := e.Ordering.ToOrdering()
 	inputOrdering := e.Input.ProvidedPhysical().Ordering
 	alreadyOrderedPrefix := 0
 	for i := range inputOrdering {
 		if i == len(ordering) {
-			return execPlan{}, errors.AssertionFailedf("sort ordering already provided by input")
+			return execPlan{}, opt.ColMap{}, errors.AssertionFailedf("sort ordering already provided by input")
 		}
 		if inputOrdering[i] != ordering[i] {
 			break
 		}
 		alreadyOrderedPrefix = i + 1
 	}
-	sqlOrdering, err := input.sqlOrdering(ordering)
+	sqlOrdering, err := sqlOrdering(ordering, inputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	node, err := b.factory.ConstructTopK(
+	var ep execPlan
+	ep.root, err = b.factory.ConstructTopK(
 		input.root,
 		e.K,
 		exec.OutputOrdering(sqlOrdering),
 		alreadyOrderedPrefix)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return execPlan{root: node, outputCols: input.outputCols}, nil
+	return ep, inputCols, nil
 }
 
 // buildLimitOffset builds a plan for a LimitOp or OffsetOp
-func (b *Builder) buildLimitOffset(e memo.RelExpr) (execPlan, error) {
-	input, err := b.buildRelational(e.Child(0).(memo.RelExpr))
+func (b *Builder) buildLimitOffset(e memo.RelExpr) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, inputCols, err := b.buildRelational(e.Child(0).(memo.RelExpr))
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	// LIMIT/OFFSET expression should never need buildScalarContext, because it
 	// can't refer to the input expression.
 	expr, err := b.buildScalar(nil, e.Child(1).(opt.ScalarExpr))
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	var node exec.Node
+	var ep execPlan
 	if e.Op() == opt.LimitOp {
-		node, err = b.factory.ConstructLimit(input.root, expr, nil)
+		ep.root, err = b.factory.ConstructLimit(input.root, expr, nil)
 	} else {
-		node, err = b.factory.ConstructLimit(input.root, nil, expr)
+		ep.root, err = b.factory.ConstructLimit(input.root, nil, expr)
 	}
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return execPlan{root: node, outputCols: input.outputCols}, nil
+	return ep, inputCols, nil
 }
 
-func (b *Builder) buildSort(sort *memo.SortExpr) (execPlan, error) {
-	input, err := b.buildRelational(sort.Input)
+func (b *Builder) buildSort(sort *memo.SortExpr) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, inputCols, err := b.buildRelational(sort.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	ordering := sort.ProvidedPhysical().Ordering
@@ -1964,7 +1991,7 @@ func (b *Builder) buildSort(sort *memo.SortExpr) (execPlan, error) {
 	alreadyOrderedPrefix := 0
 	for i := range inputOrdering {
 		if i == len(ordering) {
-			return execPlan{}, errors.AssertionFailedf("sort ordering already provided by input")
+			return execPlan{}, opt.ColMap{}, errors.AssertionFailedf("sort ordering already provided by input")
 		}
 		if inputOrdering[i] != ordering[i] {
 			break
@@ -1972,19 +1999,20 @@ func (b *Builder) buildSort(sort *memo.SortExpr) (execPlan, error) {
 		alreadyOrderedPrefix = i + 1
 	}
 
-	sqlOrdering, err := input.sqlOrdering(ordering)
+	sqlOrdering, err := sqlOrdering(ordering, inputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	node, err := b.factory.ConstructSort(
+	var ep execPlan
+	ep.root, err = b.factory.ConstructSort(
 		input.root,
 		exec.OutputOrdering(sqlOrdering),
 		alreadyOrderedPrefix,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return execPlan{root: node, outputCols: input.outputCols}, nil
+	return ep, inputCols, nil
 }
 
 func (b *Builder) enforceScanWithHomeRegion(skipID cat.StableID) error {
@@ -2082,17 +2110,19 @@ func (b *Builder) enforceScanWithHomeRegion(skipID cat.StableID) error {
 	return nil
 }
 
-func (b *Builder) buildDistribute(distribute *memo.DistributeExpr) (input execPlan, err error) {
-	input, err = b.buildRelational(distribute.Input)
+func (b *Builder) buildDistribute(
+	distribute *memo.DistributeExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, inputCols, err := b.buildRelational(distribute.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	if distribute.NoOpDistribution() {
 		// Don't bother creating a no-op distribution. This likely exists because
 		// the input is a Sort expression, and this is an artifact of how physical
 		// properties are enforced.
-		return input, err
+		return input, inputCols, err
 	}
 
 	if b.evalCtx.SessionData().EnforceHomeRegion && b.IsANSIDML {
@@ -2113,14 +2143,15 @@ func (b *Builder) buildDistribute(distribute *memo.DistributeExpr) (input execPl
 		b.doScanExprCollection = true
 		// Traverse the tree again, this time collecting ScanExprs that should
 		// be processed for error handling.
-		_, err = b.buildRelational(distribute.Input)
+		// TODO(mgartner): Can we avoid re-traversing the tree?
+		_, _, err = b.buildRelational(distribute.Input)
 		b.doScanExprCollection = saveDoScanExprCollection
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 		err = b.enforceScanWithHomeRegion(mutationStableID)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 
 		homeRegion, ok := distribute.GetInputHomeRegion()
@@ -2146,39 +2177,45 @@ func (b *Builder) buildDistribute(distribute *memo.DistributeExpr) (input execPl
 			msgString := errorStringBuilder.String()
 			err = pgerror.Newf(errCode, "%s", msgString)
 		}
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// TODO(rytaft): This is currently a no-op. We should pass this distribution
 	// info to the DistSQL planner.
-	return input, err
+	return input, inputCols, err
 }
 
-func (b *Builder) buildOrdinality(ord *memo.OrdinalityExpr) (execPlan, error) {
-	input, err := b.buildRelational(ord.Input)
+func (b *Builder) buildOrdinality(
+	ord *memo.OrdinalityExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, inputCols, err := b.buildRelational(ord.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	colName := b.mem.Metadata().ColumnMeta(ord.ColID).Alias
 
-	node, err := b.factory.ConstructOrdinality(input.root, colName)
+	var ep execPlan
+	ep.root, err = b.factory.ConstructOrdinality(input.root, colName)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// We have one additional ordinality column, which is ordered at the end of
 	// the list.
-	outputCols := input.outputCols.Copy()
+	// TODO(mgartner): Is the copy here necessary?
+	outputCols = inputCols.Copy()
 	outputCols.Set(int(ord.ColID), outputCols.Len())
 
-	return execPlan{root: node, outputCols: outputCols}, nil
+	return ep, outputCols, nil
 }
 
-func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
-	input, err := b.buildRelational(join.Input)
+func (b *Builder) buildIndexJoin(
+	join *memo.IndexJoinExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, inputCols, err := b.buildRelational(join.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	md := b.mem.Metadata()
@@ -2190,34 +2227,34 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	b.IndexesUsed = util.CombineUnique(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), pri.ID())})
 	keyCols := make([]exec.NodeColumnOrdinal, pri.KeyColumnCount())
 	for i := range keyCols {
-		keyCols[i], err = input.getNodeColumnOrdinal(join.Table.ColumnID(pri.Column(i).Ordinal()))
+		keyCols[i], err = getNodeColumnOrdinal(inputCols, join.Table.ColumnID(pri.Column(i).Ordinal()))
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
 
-	cols := join.Cols
-	needed, output := b.getColumns(cols, join.Table)
+	var needed exec.TableColumnOrdinalSet
+	needed, outputCols = b.getColumns(join.Cols, join.Table)
 
 	locking, err := b.buildLocking(join.Locking)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	res := execPlan{outputCols: output}
 	b.recordJoinAlgorithm(exec.IndexJoin)
-	reqOrdering, err := res.reqOrdering(join)
+	reqOrdering, err := reqOrdering(join, outputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
+	var res execPlan
 	res.root, err = b.factory.ConstructIndexJoin(
 		input.root, tab, keyCols, needed, reqOrdering, locking, join.RequiredPhysical().LimitHintInt64(),
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	return res, nil
+	return res, outputCols, nil
 }
 
 func (b *Builder) indexColumnNames(
@@ -2428,7 +2465,9 @@ func (b *Builder) handleRemoteLookupJoinError(join *memo.LookupJoinExpr) (err er
 	return nil
 }
 
-func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
+func (b *Builder) buildLookupJoin(
+	join *memo.LookupJoinExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	md := b.mem.Metadata()
 	if !b.disableTelemetry {
 		telemetry.Inc(sqltelemetry.JoinAlgoLookupUseCounter)
@@ -2451,9 +2490,9 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 			b.doScanExprCollection = false
 		}
 	}
-	input, err := b.buildRelational(join.Input)
+	input, inputCols, err := b.buildRelational(join.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	if enforceHomeRegion {
 		b.doScanExprCollection = saveDoScanExprCollection
@@ -2462,26 +2501,26 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 		//               merged.
 		err = b.handleRemoteLookupJoinError(join)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
 	keyCols := make([]exec.NodeColumnOrdinal, len(join.KeyCols))
 	for i, c := range join.KeyCols {
-		keyCols[i], err = input.getNodeColumnOrdinal(c)
+		keyCols[i], err = getNodeColumnOrdinal(inputCols, c)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
 
-	inputCols := join.Input.Relational().OutputCols
-	lookupCols := join.Cols.Difference(inputCols)
+	joinInputCols := join.Input.Relational().OutputCols
+	lookupCols := join.Cols.Difference(joinInputCols)
 	if join.IsFirstJoinInPairedJoiner {
 		lookupCols.Remove(join.ContinuationCol)
 	}
 
 	lookupOrdinals, lookupColMap := b.getColumns(lookupCols, join.Table)
 	// allExprCols are the columns used in expressions evaluated by this join.
-	allExprCols := joinOutputMap(input.outputCols, lookupColMap)
+	allExprCols := joinOutputMap(inputCols, lookupColMap)
 	allCols := allExprCols
 	if join.IsFirstJoinInPairedJoiner {
 		// allCols needs to include the continuation column since it will be
@@ -2489,15 +2528,15 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 		allCols = allExprCols.Copy()
 		maxValue, ok := allCols.MaxValue()
 		if !ok {
-			return execPlan{}, errors.AssertionFailedf("allCols should not be empty")
+			return execPlan{}, opt.ColMap{}, errors.AssertionFailedf("allCols should not be empty")
 		}
 		// Assign the continuation column the next unused value in the map.
 		allCols.Set(int(join.ContinuationCol), maxValue+1)
 	}
-	res := execPlan{outputCols: allCols}
+	outputCols = allCols
 	if join.JoinType == opt.SemiJoinOp || join.JoinType == opt.AntiJoinOp {
 		// For semi and anti join, only the left columns are output.
-		res.outputCols = input.outputCols
+		outputCols = inputCols
 	}
 
 	ctx := buildScalarCtx{
@@ -2509,14 +2548,14 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 		var err error
 		lookupExpr, err = b.buildScalar(&ctx, &join.LookupExpr)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
 	if len(join.RemoteLookupExpr) > 0 {
 		var err error
 		remoteLookupExpr, err = b.buildScalar(&ctx, &join.RemoteLookupExpr)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
 	var onExpr tree.TypedExpr
@@ -2524,7 +2563,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 		var err error
 		onExpr, err = b.buildScalar(&ctx, &join.On)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
 
@@ -2534,19 +2573,20 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 
 	locking, err := b.buildLocking(join.Locking)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	joinType, err := joinOpToJoinType(join.JoinType)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	b.recordJoinType(joinType)
 	b.recordJoinAlgorithm(exec.LookupJoin)
-	reqOrdering, err := res.reqOrdering(join)
+	reqOrdering, err := reqOrdering(join, outputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
+	var res execPlan
 	res.root, err = b.factory.ConstructLookupJoin(
 		joinType,
 		input.root,
@@ -2566,7 +2606,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 		join.RemoteOnlyLookups,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Apply a post-projection if Cols doesn't contain all input columns.
@@ -2574,14 +2614,14 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 	// NB: For paired-joins, this is where the continuation column and the PK
 	// columns for the right side, which were part of the inputCols, are projected
 	// away.
-	if !inputCols.SubsetOf(join.Cols) {
+	if !joinInputCols.SubsetOf(join.Cols) {
 		outCols := join.Cols
 		if join.JoinType == opt.SemiJoinOp || join.JoinType == opt.AntiJoinOp {
-			outCols = join.Cols.Intersection(inputCols)
+			outCols = join.Cols.Intersection(joinInputCols)
 		}
-		return b.applySimpleProject(res, join, outCols, join.ProvidedPhysical().Ordering)
+		return b.applySimpleProject(res, outputCols, join, outCols, join.ProvidedPhysical().Ordering)
 	}
-	return res, nil
+	return res, outputCols, nil
 }
 
 func (b *Builder) handleRemoteInvertedJoinError(join *memo.InvertedJoinExpr) (err error) {
@@ -2672,7 +2712,9 @@ func (b *Builder) handleRemoteInvertedJoinError(join *memo.InvertedJoinExpr) (er
 	return nil
 }
 
-func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, error) {
+func (b *Builder) buildInvertedJoin(
+	join *memo.InvertedJoinExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	enforceHomeRegion := b.evalCtx.SessionData().EnforceHomeRegion && b.IsANSIDML
 	saveDoScanExprCollection := false
 	if enforceHomeRegion {
@@ -2686,9 +2728,9 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 			b.doScanExprCollection = false
 		}
 	}
-	input, err := b.buildRelational(join.Input)
+	input, inputCols, err := b.buildRelational(join.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	if enforceHomeRegion {
@@ -2698,7 +2740,7 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 		//               merged.
 		err = b.handleRemoteInvertedJoinError(join)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
 	md := b.mem.Metadata()
@@ -2708,14 +2750,14 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 
 	prefixEqCols := make([]exec.NodeColumnOrdinal, len(join.PrefixKeyCols))
 	for i, c := range join.PrefixKeyCols {
-		prefixEqCols[i], err = input.getNodeColumnOrdinal(c)
+		prefixEqCols[i], err = getNodeColumnOrdinal(inputCols, c)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
 
-	inputCols := join.Input.Relational().OutputCols
-	lookupCols := join.Cols.Difference(inputCols)
+	joinInputCols := join.Input.Relational().OutputCols
+	lookupCols := join.Cols.Difference(joinInputCols)
 	if join.IsFirstJoinInPairedJoiner {
 		lookupCols.Remove(join.ContinuationCol)
 	}
@@ -2729,7 +2771,7 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 
 	lookupOrdinals, lookupColMap := b.getColumns(lookupCols, join.Table)
 	// allExprCols are the columns used in expressions evaluated by this join.
-	allExprCols := joinOutputMap(input.outputCols, lookupColMap)
+	allExprCols := joinOutputMap(inputCols, lookupColMap)
 
 	allCols := allExprCols
 	if join.IsFirstJoinInPairedJoiner {
@@ -2738,15 +2780,15 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 		allCols = allExprCols.Copy()
 		maxValue, ok := allCols.MaxValue()
 		if !ok {
-			return execPlan{}, errors.AssertionFailedf("allCols should not be empty")
+			return execPlan{}, opt.ColMap{}, errors.AssertionFailedf("allCols should not be empty")
 		}
 		// Assign the continuation column the next unused value in the map.
 		allCols.Set(int(join.ContinuationCol), maxValue+1)
 	}
-	res := execPlan{outputCols: allCols}
+	outputCols = allCols
 	if join.JoinType == opt.SemiJoinOp || join.JoinType == opt.AntiJoinOp {
 		// For semi and anti join, only the left columns are output.
-		res.outputCols = input.outputCols
+		outputCols = inputCols
 	}
 
 	ctx := buildScalarCtx{
@@ -2755,7 +2797,7 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 	}
 	onExpr, err := b.buildScalar(&ctx, &join.On)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// The inverted filter refers to the inverted column's source column, but it
@@ -2770,24 +2812,25 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 	ctx.ivarMap.Set(int(join.Table.ColumnID(invertedColumn.InvertedSourceColumnOrdinal())), ord)
 	invertedExpr, err := b.buildScalar(&ctx, join.InvertedExpr)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	locking, err := b.buildLocking(join.Locking)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	joinType, err := joinOpToJoinType(join.JoinType)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	b.recordJoinType(joinType)
 	b.recordJoinAlgorithm(exec.InvertedJoin)
-	reqOrdering, err := res.reqOrdering(join)
+	reqOrdering, err := reqOrdering(join, outputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
+	var res execPlan
 	res.root, err = b.factory.ConstructInvertedJoin(
 		joinType,
 		invertedExpr,
@@ -2802,14 +2845,16 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 		locking,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Apply a post-projection to remove the inverted column.
-	return b.applySimpleProject(res, join, join.Cols, join.ProvidedPhysical().Ordering)
+	return b.applySimpleProject(res, outputCols, join, join.Cols, join.ProvidedPhysical().Ordering)
 }
 
-func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
+func (b *Builder) buildZigzagJoin(
+	join *memo.ZigzagJoinExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	md := b.mem.Metadata()
 
 	leftTable := md.Table(join.LeftTable)
@@ -2854,16 +2899,15 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 
 	leftLocking, err := b.buildLocking(join.LeftLocking)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	rightLocking, err := b.buildLocking(join.RightLocking)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	allCols := joinOutputMap(leftColMap, rightColMap)
-
-	res := execPlan{outputCols: allCols}
+	outputCols = allCols
 
 	ctx := buildScalarCtx{
 		ivh:     tree.MakeIndexedVarHelper(nil /* container */, leftColMap.Len()+rightColMap.Len()),
@@ -2871,7 +2915,7 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 	}
 	onExpr, err := b.buildScalar(&ctx, &join.On)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Build the fixed value scalars.
@@ -2888,18 +2932,19 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 
 	leftFixedVals, err := tupleToExprs(join.FixedVals[0].(*memo.TupleExpr))
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	rightFixedVals, err := tupleToExprs(join.FixedVals[1].(*memo.TupleExpr))
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	b.recordJoinAlgorithm(exec.ZigZagJoin)
-	reqOrdering, err := res.reqOrdering(join)
+	reqOrdering, err := reqOrdering(join, outputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
+	var res execPlan
 	res.root, err = b.factory.ConstructZigzagJoin(
 		leftTable,
 		leftIndex,
@@ -2917,11 +2962,11 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 		reqOrdering,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Apply a post-projection to retain only the columns we need.
-	return b.applySimpleProject(res, join, join.Cols, join.ProvidedPhysical().Ordering)
+	return b.applySimpleProject(res, outputCols, join, join.Cols, join.ProvidedPhysical().Ordering)
 }
 
 func (b *Builder) buildLocking(locking opt.Locking) (opt.Locking, error) {
@@ -2960,23 +3005,26 @@ func (b *Builder) buildLocking(locking opt.Locking) (opt.Locking, error) {
 	return locking, nil
 }
 
-func (b *Builder) buildMax1Row(max1Row *memo.Max1RowExpr) (execPlan, error) {
-	input, err := b.buildRelational(max1Row.Input)
+func (b *Builder) buildMax1Row(
+	max1Row *memo.Max1RowExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, inputCols, err := b.buildRelational(max1Row.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	node, err := b.factory.ConstructMax1Row(input.root, max1Row.ErrorText)
+	var ep execPlan
+	ep.root, err = b.factory.ConstructMax1Row(input.root, max1Row.ErrorText)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return execPlan{root: node, outputCols: input.outputCols}, nil
+	return ep, inputCols, nil
 }
 
-func (b *Builder) buildWith(with *memo.WithExpr) (execPlan, error) {
-	value, err := b.buildRelational(with.Binding)
+func (b *Builder) buildWith(with *memo.WithExpr) (_ execPlan, outputCols opt.ColMap, err error) {
+	value, valuesCols, err := b.buildRelational(with.Binding)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	var label bytes.Buffer
@@ -2987,7 +3035,7 @@ func (b *Builder) buildWith(with *memo.WithExpr) (execPlan, error) {
 
 	buffer, err := b.factory.ConstructBuffer(value.root, label.String())
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// TODO(justin): if the binding here has a spoolNode at its root, we can
@@ -3008,28 +3056,30 @@ func (b *Builder) buildWith(with *memo.WithExpr) (execPlan, error) {
 		RowCount: int64(with.Relational().Statistics().RowCountIfAvailable()),
 	})
 
-	b.addBuiltWithExpr(with.ID, value.outputCols, buffer)
+	b.addBuiltWithExpr(with.ID, valuesCols, buffer)
 
 	return b.buildRelational(with.Main)
 }
 
-func (b *Builder) buildRecursiveCTE(rec *memo.RecursiveCTEExpr) (execPlan, error) {
-	initial, err := b.buildRelational(rec.Initial)
+func (b *Builder) buildRecursiveCTE(
+	rec *memo.RecursiveCTEExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	initial, initialCols, err := b.buildRelational(rec.Initial)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Make sure we have the columns in the correct order.
-	initial, err = b.ensureColumns(initial, rec.Initial, rec.InitialCols, nil /* ordering */)
+	initial, initialCols, err = b.ensureColumns(initial, initialCols, rec.Initial, rec.InitialCols, nil /* ordering */)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Renumber the columns so they match the columns expected by the recursive
 	// query.
-	initial.outputCols = util.FastIntMap{}
+	initialCols = util.FastIntMap{}
 	for i, col := range rec.OutCols {
-		initial.outputCols.Set(int(col), i)
+		initialCols.Set(int(col), i)
 	}
 
 	// To implement exec.RecursiveCTEIterationFn, we create a special Builder.
@@ -3051,13 +3101,13 @@ func (b *Builder) buildRecursiveCTE(rec *memo.RecursiveCTEExpr) (execPlan, error
 		// Use a separate builder each time.
 		innerBld := *innerBldTemplate
 		innerBld.factory = ef
-		innerBld.addBuiltWithExpr(rec.WithID, initial.outputCols, bufferRef)
-		plan, err := innerBld.build(rec.Recursive)
+		innerBld.addBuiltWithExpr(rec.WithID, initialCols, bufferRef)
+		plan, planCols, err := innerBld.build(rec.Recursive)
 		if err != nil {
 			return nil, err
 		}
 		// Ensure columns are output in the same order.
-		plan, err = innerBld.ensureColumns(plan, rec.Recursive, rec.RecursiveCols, opt.Ordering{})
+		plan, planCols, err = innerBld.ensureColumns(plan, planCols, rec.Recursive, rec.RecursiveCols, opt.Ordering{})
 		if err != nil {
 			return nil, err
 		}
@@ -3072,18 +3122,20 @@ func (b *Builder) buildRecursiveCTE(rec *memo.RecursiveCTEExpr) (execPlan, error
 	var ep execPlan
 	ep.root, err = b.factory.ConstructRecursiveCTE(initial.root, fn, label, rec.Deduplicate)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	for i, col := range rec.OutCols {
-		ep.outputCols.Set(int(col), i)
+		outputCols.Set(int(col), i)
 	}
-	return ep, nil
+	return ep, outputCols, nil
 }
 
-func (b *Builder) buildWithScan(withScan *memo.WithScanExpr) (execPlan, error) {
+func (b *Builder) buildWithScan(
+	withScan *memo.WithScanExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	e := b.findBuiltWithExpr(withScan.With)
 	if e == nil {
-		return execPlan{}, errors.AssertionFailedf(
+		return execPlan{}, opt.ColMap{}, errors.AssertionFailedf(
 			"couldn't find With expression with ID %d", withScan.With,
 		)
 	}
@@ -3096,76 +3148,75 @@ func (b *Builder) buildWithScan(withScan *memo.WithScanExpr) (execPlan, error) {
 
 	node, err := b.factory.ConstructScanBuffer(e.bufferNode, label.String())
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	res := execPlan{root: node, outputCols: e.outputCols}
+	res := execPlan{root: node}
 
 	// Apply any necessary projection to produce the InCols in the given order.
-	res, err = b.ensureColumns(res, withScan, withScan.InCols, withScan.ProvidedPhysical().Ordering)
+	res, _, err = b.ensureColumns(res, e.outputCols, withScan, withScan.InCols, withScan.ProvidedPhysical().Ordering)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Renumber the columns.
-	res.outputCols = opt.ColMap{}
 	for i, col := range withScan.OutCols {
-		res.outputCols.Set(int(col), i)
+		outputCols.Set(int(col), i)
 	}
 
-	return res, nil
+	return res, outputCols, nil
 }
 
-func (b *Builder) buildProjectSet(projectSet *memo.ProjectSetExpr) (execPlan, error) {
-	input, err := b.buildRelational(projectSet.Input)
+func (b *Builder) buildProjectSet(
+	projectSet *memo.ProjectSetExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, inputCols, err := b.buildRelational(projectSet.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	zip := projectSet.Zip
 	md := b.mem.Metadata()
-	scalarCtx := input.makeBuildScalarCtx()
+	scalarCtx := makeBuildScalarCtx(inputCols)
 
 	exprs := make(tree.TypedExprs, len(zip))
 	zipCols := make(colinfo.ResultColumns, 0, len(zip))
 	numColsPerGen := make([]int, len(zip))
 
-	ep := execPlan{outputCols: input.outputCols}
-	n := ep.numOutputCols()
-
+	n := numOutputColsInMap(inputCols)
 	for i := range zip {
 		item := &zip[i]
 		exprs[i], err = b.buildScalar(&scalarCtx, item.Fn)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 
 		for _, col := range item.Cols {
 			colMeta := md.ColumnMeta(col)
 			zipCols = append(zipCols, colinfo.ResultColumn{Name: colMeta.Alias, Typ: colMeta.Type})
 
-			ep.outputCols.Set(int(col), n)
+			outputCols.Set(int(col), n)
 			n++
 		}
 
 		numColsPerGen[i] = len(item.Cols)
 	}
 
+	var ep execPlan
 	ep.root, err = b.factory.ConstructProjectSet(input.root, exprs, zipCols, numColsPerGen)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	return ep, nil
+	return ep, outputCols, nil
 }
 
-func (b *Builder) buildCall(c *memo.CallExpr) (execPlan, error) {
+func (b *Builder) buildCall(c *memo.CallExpr) (_ execPlan, outputCols opt.ColMap, err error) {
 	udf := c.Proc.(*memo.UDFCallExpr)
 	if udf.Def == nil {
-		return execPlan{}, errors.AssertionFailedf("expected non-nil UDF definition")
+		return execPlan{}, opt.ColMap{}, errors.AssertionFailedf("expected non-nil UDF definition")
 	}
 
 	// Build the argument expressions.
-	var err error
 	var args tree.TypedExprs
 	ctx := buildScalarCtx{}
 	if len(udf.Args) > 0 {
@@ -3173,7 +3224,7 @@ func (b *Builder) buildCall(c *memo.CallExpr) (execPlan, error) {
 		for i := range udf.Args {
 			args[i], err = b.buildScalar(&ctx, udf.Args[i])
 			if err != nil {
-				return execPlan{}, err
+				return execPlan{}, opt.ColMap{}, err
 			}
 		}
 	}
@@ -3212,9 +3263,9 @@ func (b *Builder) buildCall(c *memo.CallExpr) (execPlan, error) {
 	var ep execPlan
 	ep.root, err = b.factory.ConstructCall(r)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return ep, nil
+	return ep, opt.ColMap{}, nil
 }
 
 func (b *Builder) resultColumn(id opt.ColumnID) colinfo.ResultColumn {
@@ -3275,8 +3326,8 @@ func (b *Builder) isOffsetMode(boundType treewindow.WindowFrameBoundType) bool {
 	return boundType == treewindow.OffsetPreceding || boundType == treewindow.OffsetFollowing
 }
 
-func (b *Builder) buildFrame(input execPlan, w *memo.WindowsItem) (*tree.WindowFrame, error) {
-	scalarCtx := input.makeBuildScalarCtx()
+func (b *Builder) buildFrame(inputCols opt.ColMap, w *memo.WindowsItem) (*tree.WindowFrame, error) {
+	scalarCtx := makeBuildScalarCtx(inputCols)
 	newDef := &tree.WindowFrame{
 		Mode: w.Frame.Mode,
 		Bounds: tree.WindowFrameBounds{
@@ -3319,10 +3370,10 @@ func (b *Builder) buildFrame(input execPlan, w *memo.WindowsItem) (*tree.WindowF
 	return newDef, nil
 }
 
-func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
-	input, err := b.buildRelational(w.Input)
+func (b *Builder) buildWindow(w *memo.WindowExpr) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, inputCols, err := b.buildRelational(w.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	// Rearrange the input so that the input has all the passthrough columns
@@ -3338,12 +3389,12 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 	// TODO(justin): this call to ensureColumns is kind of unfortunate because it
 	// can result in an extra render beneath each window function. Figure out a
 	// way to alleviate this.
-	input, err = b.ensureColumns(input, w, desiredCols, opt.Ordering{})
+	input, inputCols, err = b.ensureColumns(input, inputCols, w, desiredCols, opt.Ordering{})
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	ctx := input.makeBuildScalarCtx()
+	ctx := makeBuildScalarCtx(inputCols)
 
 	ord := w.Ordering.ToOrdering()
 
@@ -3355,7 +3406,7 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		}
 		indexedVar, err := b.indexedVar(&ctx, b.mem.Metadata(), c.ID())
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 		orderingExprs[i] = &tree.Order{
 			Expr:      indexedVar,
@@ -3368,11 +3419,11 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 
 	i := 0
 	for col, ok := w.Partition.Next(0); ok; col, ok = w.Partition.Next(col + 1) {
-		ordinal, _ := input.outputCols.Get(int(col))
+		ordinal, _ := inputCols.Get(int(col))
 		partitionIdxs[i] = exec.NodeColumnOrdinal(ordinal)
 		indexedVar, err := b.indexedVar(&ctx, b.mem.Metadata(), col)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 		partitionExprs[i] = indexedVar
 		i++
@@ -3398,16 +3449,16 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 			col := fn.Child(j).(*memo.VariableExpr).Col
 			indexedVar, err := b.indexedVar(&ctx, b.mem.Metadata(), col)
 			if err != nil {
-				return execPlan{}, err
+				return execPlan{}, opt.ColMap{}, err
 			}
 			args[j] = indexedVar
-			idx, _ := input.outputCols.Get(int(col))
+			idx, _ := inputCols.Get(int(col))
 			argIdxs[i][j] = exec.NodeColumnOrdinal(idx)
 		}
 
-		frame, err := b.buildFrame(input, item)
+		frame, err := b.buildFrame(inputCols, item)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 
 		var builtFilter tree.TypedExpr
@@ -3415,14 +3466,14 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		if ok {
 			f, ok := filter.(*memo.VariableExpr)
 			if !ok {
-				return execPlan{},
+				return execPlan{}, opt.ColMap{},
 					errors.AssertionFailedf("expected FILTER expression to be a VariableExpr")
 			}
-			filterIdxs[i], _ = input.outputCols.Get(int(f.Col))
+			filterIdxs[i], _ = inputCols.Get(int(f.Col))
 
 			builtFilter, err = b.buildScalar(&ctx, filter)
 			if err != nil {
-				return execPlan{}, err
+				return execPlan{}, opt.ColMap{}, err
 			}
 		} else {
 			filterIdxs[i] = -1
@@ -3435,7 +3486,7 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		}
 		wrappedFn, err := b.wrapFunction(name)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 		exprs[i] = tree.NewTypedFuncExpr(
 			wrappedFn,
@@ -3453,12 +3504,11 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 
 	// All the passthrough cols will keep their ordinal index.
 	passthrough.ForEach(func(col opt.ColumnID) {
-		ordinal, _ := input.outputCols.Get(int(col))
+		ordinal, _ := inputCols.Get(int(col))
 		resultCols[ordinal] = b.resultColumn(col)
 	})
 
-	var outputCols opt.ColMap
-	input.outputCols.ForEach(func(key, val int) {
+	inputCols.ForEach(func(key, val int) {
 		if passthrough.Contains(opt.ColumnID(key)) {
 			outputCols.Set(key, val)
 		}
@@ -3476,11 +3526,12 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		outputIdxs[i] = windowStart + i
 	}
 
-	sqlOrdering, err := input.sqlOrdering(ord)
+	sqlOrdering, err := sqlOrdering(ord, inputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	node, err := b.factory.ConstructWindow(input.root, exec.WindowInfo{
+	var ep execPlan
+	ep.root, err = b.factory.ConstructWindow(input.root, exec.WindowInfo{
 		Cols:       resultCols,
 		Exprs:      exprs,
 		OutputIdxs: outputIdxs,
@@ -3490,32 +3541,31 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		Ordering:   sqlOrdering,
 	})
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	return execPlan{
-		root:       node,
-		outputCols: outputCols,
-	}, nil
+	return ep, outputCols, nil
 }
 
-func (b *Builder) buildSequenceSelect(seqSel *memo.SequenceSelectExpr) (execPlan, error) {
+func (b *Builder) buildSequenceSelect(
+	seqSel *memo.SequenceSelectExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	seq := b.mem.Metadata().Sequence(seqSel.Sequence)
-	node, err := b.factory.ConstructSequenceSelect(seq)
+	var ep execPlan
+	ep.root, err = b.factory.ConstructSequenceSelect(seq)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	ep := execPlan{root: node}
 	for i, c := range seqSel.Cols {
-		ep.outputCols.Set(int(c), i)
+		outputCols.Set(int(c), i)
 	}
 
-	return ep, nil
+	return ep, outputCols, nil
 }
 
 func (b *Builder) applySaveTable(
-	input execPlan, e memo.RelExpr, saveTableName string,
+	input execPlan, inputCols opt.ColMap, e memo.RelExpr, saveTableName string,
 ) (execPlan, error) {
 	name := tree.NewTableNameWithSchema(tree.Name(opt.SaveTablesDatabase), catconstants.PublicSchemaName, tree.Name(saveTableName))
 
@@ -3525,7 +3575,7 @@ func (b *Builder) applySaveTable(
 	colNames := make([]string, outputCols.Len())
 	colNameGen := memo.NewColumnNameGenerator(e)
 	for col, ok := outputCols.Next(0); ok; col, ok = outputCols.Next(col + 1) {
-		ord, _ := input.outputCols.Get(int(col))
+		ord, _ := inputCols.Get(int(col))
 		colNames[ord] = colNameGen.GenerateName(col)
 	}
 
@@ -3537,21 +3587,25 @@ func (b *Builder) applySaveTable(
 	return input, err
 }
 
-func (b *Builder) buildOpaque(opaque *memo.OpaqueRelPrivate) (execPlan, error) {
-	node, err := b.factory.ConstructOpaque(opaque.Metadata)
+func (b *Builder) buildOpaque(
+	opaque *memo.OpaqueRelPrivate,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	var ep execPlan
+	ep.root, err = b.factory.ConstructOpaque(opaque.Metadata)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	ep := execPlan{root: node}
 	for i, c := range opaque.Columns {
-		ep.outputCols.Set(int(c), i)
+		outputCols.Set(int(c), i)
 	}
 
-	return ep, nil
+	return ep, outputCols, nil
 }
 
-func (b *Builder) buildBarrier(barrier *memo.BarrierExpr) (execPlan, error) {
+func (b *Builder) buildBarrier(
+	barrier *memo.BarrierExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	// BarrierExpr is only used as an optimization barrier. In the execution plan,
 	// it is replaced with its input.
 	return b.buildRelational(barrier.Input)
@@ -3561,12 +3615,12 @@ func (b *Builder) buildBarrier(barrier *memo.BarrierExpr) (execPlan, error) {
 // to produce the given list of columns. If the input plan already produces
 // the columns (in the same order), returns needProj=false.
 func (b *Builder) needProjection(
-	input execPlan, colList opt.ColList,
+	inputCols opt.ColMap, colList opt.ColList,
 ) (_ []exec.NodeColumnOrdinal, needProj bool, err error) {
-	if input.numOutputCols() == len(colList) {
+	if numOutputColsInMap(inputCols) == len(colList) {
 		identity := true
 		for i, col := range colList {
-			if ord, ok := input.outputCols.Get(int(col)); !ok || ord != i {
+			if ord, ok := inputCols.Get(int(col)); !ok || ord != i {
 				identity = false
 				break
 			}
@@ -3578,7 +3632,7 @@ func (b *Builder) needProjection(
 	cols := make([]exec.NodeColumnOrdinal, 0, len(colList))
 	for _, col := range colList {
 		if col != 0 {
-			ord, err := input.getNodeColumnOrdinal(col)
+			ord, err := getNodeColumnOrdinal(inputCols, col)
 			if err != nil {
 				return nil, false, err
 			}
@@ -3591,50 +3645,55 @@ func (b *Builder) needProjection(
 // ensureColumns applies a projection as necessary to make the output match the
 // given list of columns; colNames is optional.
 func (b *Builder) ensureColumns(
-	input execPlan, inputExpr memo.RelExpr, colList opt.ColList, provided opt.Ordering,
-) (execPlan, error) {
-	cols, needProj, err := b.needProjection(input, colList)
+	input execPlan,
+	inputCols opt.ColMap,
+	inputExpr memo.RelExpr,
+	colList opt.ColList,
+	provided opt.Ordering,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	cols, needProj, err := b.needProjection(inputCols, colList)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	if !needProj {
-		return input, nil
+		return input, inputCols, nil
 	}
 	// Since we are constructing a simple project on top of the main operator,
 	// we need to explicitly annotate the latter with estimates since the code
 	// in buildRelational() will attach them to the project.
 	b.maybeAnnotateWithEstimates(input.root, inputExpr)
-	var res execPlan
 	for i, col := range colList {
-		res.outputCols.Set(int(col), i)
+		outputCols.Set(int(col), i)
 	}
-	sqlOrdering, err := res.sqlOrdering(provided)
+	sqlOrdering, err := sqlOrdering(provided, outputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	reqOrdering := exec.OutputOrdering(sqlOrdering)
+	var res execPlan
 	res.root, err = b.factory.ConstructSimpleProject(input.root, cols, reqOrdering)
-	return res, err
+	return res, outputCols, err
 }
 
 // applyPresentation adds a projection to a plan to satisfy a required
 // Presentation property.
-func (b *Builder) applyPresentation(input execPlan, pres physical.Presentation) (execPlan, error) {
+func (b *Builder) applyPresentation(
+	input execPlan, inputCols opt.ColMap, pres physical.Presentation,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	cols := make([]exec.NodeColumnOrdinal, len(pres))
 	colNames := make([]string, len(pres))
 	var res execPlan
 	for i := range pres {
-		ord, err := input.getNodeColumnOrdinal(pres[i].ID)
+		ord, err := getNodeColumnOrdinal(inputCols, pres[i].ID)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 		cols[i] = ord
-		res.outputCols.Set(int(pres[i].ID), i)
+		outputCols.Set(int(pres[i].ID), i)
 		colNames[i] = pres[i].Alias
 	}
-	var err error
 	res.root, err = b.factory.ConstructSerializingProject(input.root, cols, colNames)
-	return res, err
+	return res, outputCols, err
 }
 
 // getEnvData consolidates the information that must be presented in

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -63,7 +63,7 @@ type execPlan struct {
 // that refer the output columns of this plan.
 func makeBuildScalarCtx(cols colOrdMap) buildScalarCtx {
 	return buildScalarCtx{
-		ivh:     tree.MakeIndexedVarHelper(nil /* container */, cols.MaxOrd()+1),
+		ivh:     tree.MakeIndexedVarHelper(nil /* container */, cols.OrdUpperBound()+1),
 		ivarMap: cols,
 	}
 }
@@ -1256,7 +1256,7 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (_ execPlan, outputCols colO
 	var onExpr tree.TypedExpr
 	if len(*filters) != 0 {
 		scalarCtx := buildScalarCtx{
-			ivh:     tree.MakeIndexedVarHelper(nil /* container */, allCols.MaxOrd()+1),
+			ivh:     tree.MakeIndexedVarHelper(nil /* container */, allCols.OrdUpperBound()+1),
 			ivarMap: allCols,
 		}
 		onExpr, err = b.buildScalar(&scalarCtx, filters)
@@ -1573,7 +1573,10 @@ func (b *Builder) initJoinBuild(
 // joinOutputMap determines the outputCols map for a (non-semi/anti) join, given
 // the outputCols maps for its inputs.
 func (b *Builder) joinOutputMap(left, right colOrdMap) colOrdMap {
-	numLeftCols := left.MaxOrd() + 1
+	// TODO(mgartner): It's currently safe to use OrdUpperBound like this, but
+	// it is not robust because it's not guaranteed to be the max ordinal, only
+	// an approximate upper-bound.
+	numLeftCols := left.OrdUpperBound() + 1
 
 	res := b.colOrdsAlloc.Copy(left)
 	right.ForEach(func(col opt.ColumnID, rightIdx int) {
@@ -1768,7 +1771,7 @@ func (b *Builder) buildDistinct(
 	// buildGroupByInput can add extra sort column(s), so discard those if they
 	// are present by using an additional projection.
 	outCols := distinct.Relational().OutputCols
-	if inputCols.MaxOrd()+1 == outCols.Len() {
+	if inputCols.OrdUpperBound()+1 == outCols.Len() {
 		return ep, inputCols, nil
 	}
 	return b.ensureColumns(
@@ -2261,7 +2264,7 @@ func (b *Builder) buildOrdinality(
 
 	// We have one additional ordinality column, which is ordered at the end of
 	// the list.
-	inputCols.Set(ord.ColID, outputCols.MaxOrd()+1)
+	inputCols.Set(ord.ColID, outputCols.OrdUpperBound()+1)
 
 	return ep, inputCols, nil
 }
@@ -2594,11 +2597,14 @@ func (b *Builder) buildLookupJoin(
 		// join.
 		outputCols = b.colOrdsAlloc.Copy(leftAndRightCols)
 
-		maxOrd := outputCols.MaxOrd()
+		maxOrd := outputCols.OrdUpperBound()
 		if maxOrd == -1 {
 			return execPlan{}, colOrdMap{}, errors.AssertionFailedf("outputCols should not be empty")
 		}
 		// Assign the continuation column the next unused value in the map.
+		// TODO(mgartner): It's currently safe to use maxOrd like this, but it
+		// is not robust because it's not guaranteed to be the max ordinal, only
+		// an approximate upper-bound.
 		outputCols.Set(join.ContinuationCol, maxOrd+1)
 
 		// allExprCols is only needed for the lifetime of the function, so free
@@ -2864,7 +2870,7 @@ func (b *Builder) buildInvertedJoin(
 		// allCols needs to include the continuation column since it will be
 		// in the result output by this join.
 		allCols = b.colOrdsAlloc.Copy(allExprCols)
-		maxOrd := allCols.MaxOrd()
+		maxOrd := allCols.OrdUpperBound()
 		if maxOrd == -1 {
 			return execPlan{}, colOrdMap{}, errors.AssertionFailedf("allCols should not be empty")
 		}
@@ -2878,7 +2884,7 @@ func (b *Builder) buildInvertedJoin(
 	}
 
 	ctx := buildScalarCtx{
-		ivh:     tree.MakeIndexedVarHelper(nil /* container */, allExprCols.MaxOrd()+1),
+		ivh:     tree.MakeIndexedVarHelper(nil /* container */, allExprCols.OrdUpperBound()+1),
 		ivarMap: b.colOrdsAlloc.Copy(allExprCols),
 	}
 	onExpr, err := b.buildScalar(&ctx, &join.On)
@@ -2998,7 +3004,7 @@ func (b *Builder) buildZigzagJoin(
 	outputCols = allCols
 
 	ctx := buildScalarCtx{
-		ivh:     tree.MakeIndexedVarHelper(nil /* container */, leftColMap.MaxOrd()+rightColMap.MaxOrd()+2),
+		ivh:     tree.MakeIndexedVarHelper(nil /* container */, leftColMap.OrdUpperBound()+rightColMap.OrdUpperBound()+2),
 		ivarMap: allCols,
 	}
 	onExpr, err := b.buildScalar(&ctx, &join.On)
@@ -3283,7 +3289,7 @@ func (b *Builder) buildProjectSet(
 	zipCols := make(colinfo.ResultColumns, 0, len(zip))
 	numColsPerGen := make([]int, len(zip))
 
-	n := inputCols.MaxOrd() + 1
+	n := inputCols.OrdUpperBound() + 1
 	outputCols = b.colOrdsAlloc.Alloc()
 	for i := range zip {
 		item := &zip[i]
@@ -3725,7 +3731,7 @@ func (b *Builder) buildBarrier(
 func (b *Builder) needProjection(
 	inputCols colOrdMap, colList opt.ColList,
 ) (_ []exec.NodeColumnOrdinal, needProj bool, err error) {
-	if inputCols.MaxOrd()+1 == len(colList) {
+	if inputCols.OrdUpperBound()+1 == len(colList) {
 		identity := true
 		for i, col := range colList {
 			if ord, ok := inputCols.Get(col); !ok || ord != i {

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -657,10 +657,8 @@ func (b *Builder) buildExistsSubquery(
 			args[i] = indexedVar
 		}
 
-		// Create a new column for the boolean result.
-		existsCol := b.mem.Metadata().AddColumn("exists", types.Bool)
-
 		// Create a single-element RelListExpr representing the subquery.
+		existsCol := exists.LazyEvalProjectionCol
 		aliasedCol := opt.AliasedColumn{
 			Alias: b.mem.Metadata().ColumnMeta(existsCol).Alias,
 			ID:    existsCol,

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -517,7 +517,7 @@ func (b *Builder) buildArrayFlatten(
 		return nil, b.decorrelationError()
 	}
 
-	root, err := b.buildRelational(af.Input)
+	root, _, err := b.buildRelational(af.Input)
 	if err != nil {
 		return nil, err
 	}
@@ -577,14 +577,14 @@ func (b *Builder) buildAny(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 	}
 
 	// Build the execution plan for the input subquery.
-	plan, err := b.buildRelational(any.Input)
+	plan, planCols, err := b.buildRelational(any.Input)
 	if err != nil {
 		return nil, err
 	}
 
 	// Construct tuple type of columns in the row.
-	contents := make([]*types.T, plan.numOutputCols())
-	plan.outputCols.ForEach(func(key, val int) {
+	contents := make([]*types.T, numOutputColsInMap(planCols))
+	planCols.ForEach(func(key, val int) {
 		contents[val] = b.mem.Metadata().ColumnMeta(opt.ColumnID(key)).Type
 	})
 	typs := types.MakeTuple(contents)
@@ -722,7 +722,7 @@ func (b *Builder) buildExistsSubquery(
 	// ConvertUncorrelatedExistsToCoalesceSubquery converts all uncorrelated
 	// Exists with Coalesce+Subquery expressions. Remove this and the execution
 	// support for the Exists mode.
-	plan, err := b.buildRelational(exists.Input)
+	plan, _, err := b.buildRelational(exists.Input)
 	if err != nil {
 		return nil, err
 	}
@@ -841,7 +841,7 @@ func (b *Builder) buildSubquery(
 			eb.withExprs = withExprs
 			eb.disableTelemetry = true
 			eb.planLazySubqueries = true
-			ePlan, err := eb.buildRelational(input)
+			ePlan, _, err := eb.buildRelational(input)
 			if err != nil {
 				return err
 			}
@@ -885,7 +885,7 @@ func (b *Builder) buildSubquery(
 
 	// Build the execution plan for the subquery. Note that the subquery could
 	// have subqueries of its own which are added to b.subqueries.
-	plan, err := b.buildRelational(input)
+	plan, _, err := b.buildRelational(input)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -584,8 +584,9 @@ func (b *Builder) buildAny(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 
 	// Construct tuple type of columns in the row.
 	contents := make([]*types.T, planCols.OrdUpperBound()+1)
-	planCols.ForEach(func(col opt.ColumnID, ord int) {
+	_ = planCols.ForEach(func(col opt.ColumnID, ord int) error {
 		contents[ord] = b.mem.Metadata().ColumnMeta(col).Type
+		return nil
 	})
 	typs := types.MakeTuple(contents)
 	subqueryExpr := b.addSubquery(

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -118,7 +118,7 @@ func (b *Builder) buildScalarWithMap(
 	colMap colOrdMap, scalar opt.ScalarExpr,
 ) (tree.TypedExpr, error) {
 	ctx := buildScalarCtx{
-		ivh:     tree.MakeIndexedVarHelper(nil /* container */, colMap.MaxOrd()+1),
+		ivh:     tree.MakeIndexedVarHelper(nil /* container */, colMap.OrdUpperBound()+1),
 		ivarMap: colMap,
 	}
 	return b.buildScalar(&ctx, scalar)
@@ -583,7 +583,7 @@ func (b *Builder) buildAny(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 	}
 
 	// Construct tuple type of columns in the row.
-	contents := make([]*types.T, planCols.MaxOrd()+1)
+	contents := make([]*types.T, planCols.OrdUpperBound()+1)
 	planCols.ForEach(func(col opt.ColumnID, ord int) {
 		contents[ord] = b.mem.Metadata().ColumnMeta(col).Type
 	})

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -154,7 +154,8 @@ func (b *Builder) buildExplainOpt(
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
-	return ep, b.outputColsFromList(explain.ColList), nil
+	outputCols, err = b.outputColsFromList(explain.ColList)
+	return ep, outputCols, err
 }
 
 func (b *Builder) buildExplain(
@@ -194,7 +195,8 @@ func (b *Builder) buildExplain(
 		return execPlan{}, colOrdMap{}, err
 	}
 
-	return ep, b.outputColsFromList(explainExpr.ColList), nil
+	outputCols, err = b.outputColsFromList(explainExpr.ColList)
+	return ep, outputCols, err
 }
 
 func (b *Builder) buildShowTrace(
@@ -205,7 +207,8 @@ func (b *Builder) buildShowTrace(
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
-	return ep, b.outputColsFromList(show.ColList), nil
+	outputCols, err = b.outputColsFromList(show.ColList)
+	return ep, outputCols, err
 }
 
 func (b *Builder) buildAlterTableSplit(
@@ -230,7 +233,8 @@ func (b *Builder) buildAlterTableSplit(
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
-	return ep, b.outputColsFromList(split.Columns), nil
+	outputCols, err = b.outputColsFromList(split.Columns)
+	return ep, outputCols, err
 }
 
 func (b *Builder) buildAlterTableUnsplit(
@@ -249,7 +253,8 @@ func (b *Builder) buildAlterTableUnsplit(
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
-	return ep, b.outputColsFromList(unsplit.Columns), nil
+	outputCols, err = b.outputColsFromList(unsplit.Columns)
+	return ep, outputCols, err
 }
 
 func (b *Builder) buildAlterTableUnsplitAll(
@@ -261,7 +266,8 @@ func (b *Builder) buildAlterTableUnsplitAll(
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
-	return ep, b.outputColsFromList(unsplitAll.Columns), nil
+	outputCols, err = b.outputColsFromList(unsplitAll.Columns)
+	return ep, outputCols, err
 }
 
 func (b *Builder) buildAlterTableRelocate(
@@ -281,7 +287,8 @@ func (b *Builder) buildAlterTableRelocate(
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
-	return ep, b.outputColsFromList(relocate.Columns), nil
+	outputCols, err = b.outputColsFromList(relocate.Columns)
+	return ep, outputCols, err
 }
 
 func (b *Builder) buildAlterRangeRelocate(
@@ -310,7 +317,8 @@ func (b *Builder) buildAlterRangeRelocate(
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
-	return ep, b.outputColsFromList(relocate.Columns), nil
+	outputCols, err = b.outputColsFromList(relocate.Columns)
+	return ep, outputCols, err
 }
 
 func (b *Builder) buildControlJobs(
@@ -369,7 +377,8 @@ func (b *Builder) buildShowCompletions(
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
-	return ep, b.outputColsFromList(ctl.Columns), nil
+	outputCols, err = b.outputColsFromList(ctl.Columns)
+	return ep, outputCols, err
 }
 
 func (b *Builder) buildCancelQueries(
@@ -459,15 +468,18 @@ func (b *Builder) buildExport(
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
-	return ep, b.outputColsFromList(export.Columns), nil
+	outputCols, err = b.outputColsFromList(export.Columns)
+	return ep, outputCols, err
 }
 
 // planWithColumns creates an execPlan for a node which has a fixed output
 // schema.
-func (b *Builder) outputColsFromList(cols opt.ColList) colOrdMap {
+func (b *Builder) outputColsFromList(cols opt.ColList) (colOrdMap, error) {
 	outputCols := b.colOrdsAlloc.Alloc()
 	for i, c := range cols {
-		outputCols.Set(c, i)
+		if err := outputCols.Set(c, i); err != nil {
+			return colOrdMap{}, err
+		}
 	}
-	return outputCols
+	return outputCols, nil
 }

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -27,31 +27,35 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-func (b *Builder) buildCreateTable(ct *memo.CreateTableExpr) (execPlan, error) {
+func (b *Builder) buildCreateTable(
+	ct *memo.CreateTableExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 
 	schema := b.mem.Metadata().Schema(ct.Schema)
 	if !ct.Syntax.As() {
 		root, err := b.factory.ConstructCreateTable(schema, ct.Syntax)
-		return execPlan{root: root}, err
+		return execPlan{root: root}, opt.ColMap{}, err
 	}
 
 	// Construct AS input to CREATE TABLE.
-	input, err := b.buildRelational(ct.Input)
+	input, inputCols, err := b.buildRelational(ct.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	// Impose ordering and naming on input columns, so that they match the
 	// order and names of the table columns into which values will be
 	// inserted.
-	input, err = b.applyPresentation(input, ct.InputCols)
+	input, _, err = b.applyPresentation(input, inputCols, ct.InputCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	root, err := b.factory.ConstructCreateTableAs(input.root, schema, ct.Syntax)
-	return execPlan{root: root}, err
+	return execPlan{root: root}, opt.ColMap{}, err
 }
 
-func (b *Builder) buildCreateView(cv *memo.CreateViewExpr) (execPlan, error) {
+func (b *Builder) buildCreateView(
+	cv *memo.CreateViewExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	md := b.mem.Metadata()
 	schema := md.Schema(cv.Schema)
 	cols := make(colinfo.ResultColumns, len(cv.Columns))
@@ -67,10 +71,12 @@ func (b *Builder) buildCreateView(cv *memo.CreateViewExpr) (execPlan, error) {
 		cv.Deps,
 		cv.TypeDeps,
 	)
-	return execPlan{root: root}, err
+	return execPlan{root: root}, opt.ColMap{}, err
 }
 
-func (b *Builder) buildCreateFunction(cf *memo.CreateFunctionExpr) (execPlan, error) {
+func (b *Builder) buildCreateFunction(
+	cf *memo.CreateFunctionExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	md := b.mem.Metadata()
 	schema := md.Schema(cf.Schema)
 	root, err := b.factory.ConstructCreateFunction(
@@ -79,10 +85,12 @@ func (b *Builder) buildCreateFunction(cf *memo.CreateFunctionExpr) (execPlan, er
 		cf.Deps,
 		cf.TypeDeps,
 	)
-	return execPlan{root: root}, err
+	return execPlan{root: root}, opt.ColMap{}, err
 }
 
-func (b *Builder) buildExplainOpt(explain *memo.ExplainExpr) (execPlan, error) {
+func (b *Builder) buildExplainOpt(
+	explain *memo.ExplainExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	fmtFlags := memo.ExprFmtHideAll
 	switch {
 	case explain.Options.Flags[tree.ExplainFlagVerbose]:
@@ -137,23 +145,27 @@ func (b *Builder) buildExplainOpt(explain *memo.ExplainExpr) (execPlan, error) {
 		var err error
 		envOpts, err = b.getEnvData()
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
 
-	node, err := b.factory.ConstructExplainOpt(planText.String(), envOpts)
+	var ep execPlan
+	ep.root, err = b.factory.ConstructExplainOpt(planText.String(), envOpts)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return planWithColumns(node, explain.ColList), nil
+	return ep, outputColsFromList(explain.ColList), nil
 }
 
-func (b *Builder) buildExplain(explainExpr *memo.ExplainExpr) (execPlan, error) {
+func (b *Builder) buildExplain(
+	explainExpr *memo.ExplainExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	if explainExpr.Options.Mode == tree.ExplainOpt {
 		return b.buildExplainOpt(explainExpr)
 	}
 
-	node, err := b.factory.ConstructExplain(
+	var ep execPlan
+	ep.root, err = b.factory.ConstructExplain(
 		&explainExpr.Options,
 		explainExpr.StmtType,
 		func(f exec.Factory) (exec.Plan, error) {
@@ -179,213 +191,247 @@ func (b *Builder) buildExplain(explainExpr *memo.ExplainExpr) (execPlan, error) 
 		},
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	return planWithColumns(node, explainExpr.ColList), nil
+	return ep, outputColsFromList(explainExpr.ColList), nil
 }
 
-func (b *Builder) buildShowTrace(show *memo.ShowTraceForSessionExpr) (execPlan, error) {
-	node, err := b.factory.ConstructShowTrace(show.TraceType, show.Compact)
+func (b *Builder) buildShowTrace(
+	show *memo.ShowTraceForSessionExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	var ep execPlan
+	ep.root, err = b.factory.ConstructShowTrace(show.TraceType, show.Compact)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return planWithColumns(node, show.ColList), nil
+	return ep, outputColsFromList(show.ColList), nil
 }
 
-func (b *Builder) buildAlterTableSplit(split *memo.AlterTableSplitExpr) (execPlan, error) {
-	input, err := b.buildRelational(split.Input)
+func (b *Builder) buildAlterTableSplit(
+	split *memo.AlterTableSplitExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, _, err := b.buildRelational(split.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	scalarCtx := buildScalarCtx{}
 	expiration, err := b.buildScalar(&scalarCtx, split.Expiration)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	table := b.mem.Metadata().Table(split.Table)
-	node, err := b.factory.ConstructAlterTableSplit(
+	var ep execPlan
+	ep.root, err = b.factory.ConstructAlterTableSplit(
 		table.Index(split.Index),
 		input.root,
 		expiration,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return planWithColumns(node, split.Columns), nil
+	return ep, outputColsFromList(split.Columns), nil
 }
 
-func (b *Builder) buildAlterTableUnsplit(unsplit *memo.AlterTableUnsplitExpr) (execPlan, error) {
-	input, err := b.buildRelational(unsplit.Input)
+func (b *Builder) buildAlterTableUnsplit(
+	unsplit *memo.AlterTableUnsplitExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, _, err := b.buildRelational(unsplit.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	table := b.mem.Metadata().Table(unsplit.Table)
-	node, err := b.factory.ConstructAlterTableUnsplit(
+	var ep execPlan
+	ep.root, err = b.factory.ConstructAlterTableUnsplit(
 		table.Index(unsplit.Index),
 		input.root,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return planWithColumns(node, unsplit.Columns), nil
+	return ep, outputColsFromList(unsplit.Columns), nil
 }
 
 func (b *Builder) buildAlterTableUnsplitAll(
 	unsplitAll *memo.AlterTableUnsplitAllExpr,
-) (execPlan, error) {
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	table := b.mem.Metadata().Table(unsplitAll.Table)
-	node, err := b.factory.ConstructAlterTableUnsplitAll(table.Index(unsplitAll.Index))
+	var ep execPlan
+	ep.root, err = b.factory.ConstructAlterTableUnsplitAll(table.Index(unsplitAll.Index))
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return planWithColumns(node, unsplitAll.Columns), nil
+	return ep, outputColsFromList(unsplitAll.Columns), nil
 }
 
-func (b *Builder) buildAlterTableRelocate(relocate *memo.AlterTableRelocateExpr) (execPlan, error) {
-	input, err := b.buildRelational(relocate.Input)
+func (b *Builder) buildAlterTableRelocate(
+	relocate *memo.AlterTableRelocateExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, _, err := b.buildRelational(relocate.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	table := b.mem.Metadata().Table(relocate.Table)
-	node, err := b.factory.ConstructAlterTableRelocate(
+	var ep execPlan
+	ep.root, err = b.factory.ConstructAlterTableRelocate(
 		table.Index(relocate.Index),
 		input.root,
 		relocate.SubjectReplicas,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return planWithColumns(node, relocate.Columns), nil
+	return ep, outputColsFromList(relocate.Columns), nil
 }
 
-func (b *Builder) buildAlterRangeRelocate(relocate *memo.AlterRangeRelocateExpr) (execPlan, error) {
-	input, err := b.buildRelational(relocate.Input)
+func (b *Builder) buildAlterRangeRelocate(
+	relocate *memo.AlterRangeRelocateExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, _, err := b.buildRelational(relocate.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	scalarCtx := buildScalarCtx{}
 	toStoreID, err := b.buildScalar(&scalarCtx, relocate.ToStoreID)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	fromStoreID, err := b.buildScalar(&scalarCtx, relocate.FromStoreID)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	node, err := b.factory.ConstructAlterRangeRelocate(
+	var ep execPlan
+	ep.root, err = b.factory.ConstructAlterRangeRelocate(
 		input.root,
 		relocate.SubjectReplicas,
 		toStoreID,
 		fromStoreID,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return planWithColumns(node, relocate.Columns), nil
+	return ep, outputColsFromList(relocate.Columns), nil
 }
 
-func (b *Builder) buildControlJobs(ctl *memo.ControlJobsExpr) (execPlan, error) {
-	input, err := b.buildRelational(ctl.Input)
+func (b *Builder) buildControlJobs(
+	ctl *memo.ControlJobsExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, _, err := b.buildRelational(ctl.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	scalarCtx := buildScalarCtx{}
 	reason, err := b.buildScalar(&scalarCtx, ctl.Reason)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	node, err := b.factory.ConstructControlJobs(
+	var ep execPlan
+	ep.root, err = b.factory.ConstructControlJobs(
 		ctl.Command,
 		input.root,
 		reason,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	// ControlJobs returns no columns.
-	return execPlan{root: node}, nil
+	return ep, opt.ColMap{}, nil
 }
 
-func (b *Builder) buildControlSchedules(ctl *memo.ControlSchedulesExpr) (execPlan, error) {
-	input, err := b.buildRelational(ctl.Input)
+func (b *Builder) buildControlSchedules(
+	ctl *memo.ControlSchedulesExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, _, err := b.buildRelational(ctl.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	node, err := b.factory.ConstructControlSchedules(
+	var ep execPlan
+	ep.root, err = b.factory.ConstructControlSchedules(
 		ctl.Command,
 		input.root,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	// ControlSchedules returns no columns.
-	return execPlan{root: node}, nil
+	return ep, opt.ColMap{}, nil
 }
 
-func (b *Builder) buildShowCompletions(ctl *memo.ShowCompletionsExpr) (execPlan, error) {
-	node, err := b.factory.ConstructShowCompletions(
+func (b *Builder) buildShowCompletions(
+	ctl *memo.ShowCompletionsExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	var ep execPlan
+	ep.root, err = b.factory.ConstructShowCompletions(
 		ctl.Command,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return planWithColumns(node, ctl.Columns), nil
+	return ep, outputColsFromList(ctl.Columns), nil
 }
 
-func (b *Builder) buildCancelQueries(cancel *memo.CancelQueriesExpr) (execPlan, error) {
-	input, err := b.buildRelational(cancel.Input)
+func (b *Builder) buildCancelQueries(
+	cancel *memo.CancelQueriesExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, _, err := b.buildRelational(cancel.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	node, err := b.factory.ConstructCancelQueries(input.root, cancel.IfExists)
+	var ep execPlan
+	ep.root, err = b.factory.ConstructCancelQueries(input.root, cancel.IfExists)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	if !b.disableTelemetry {
 		telemetry.Inc(sqltelemetry.CancelQueriesUseCounter)
 	}
 	// CancelQueries returns no columns.
-	return execPlan{root: node}, nil
+	return ep, opt.ColMap{}, nil
 }
 
-func (b *Builder) buildCancelSessions(cancel *memo.CancelSessionsExpr) (execPlan, error) {
-	input, err := b.buildRelational(cancel.Input)
+func (b *Builder) buildCancelSessions(
+	cancel *memo.CancelSessionsExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, _, err := b.buildRelational(cancel.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	node, err := b.factory.ConstructCancelSessions(input.root, cancel.IfExists)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	if !b.disableTelemetry {
 		telemetry.Inc(sqltelemetry.CancelSessionsUseCounter)
 	}
 	// CancelSessions returns no columns.
-	return execPlan{root: node}, nil
+	return execPlan{root: node}, opt.ColMap{}, nil
 }
 
-func (b *Builder) buildCreateStatistics(c *memo.CreateStatisticsExpr) (execPlan, error) {
+func (b *Builder) buildCreateStatistics(
+	c *memo.CreateStatisticsExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
 	node, err := b.factory.ConstructCreateStatistics(c.Syntax)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 	// CreateStatistics returns no columns.
-	return execPlan{root: node}, nil
+	return execPlan{root: node}, opt.ColMap{}, nil
 }
 
-func (b *Builder) buildExport(export *memo.ExportExpr) (execPlan, error) {
-	input, err := b.buildRelational(export.Input)
+func (b *Builder) buildExport(
+	export *memo.ExportExpr,
+) (_ execPlan, outputCols opt.ColMap, err error) {
+	input, inputCols, err := b.buildRelational(export.Input)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	scalarCtx := buildScalarCtx{}
 	fileName, err := b.buildScalar(&scalarCtx, export.FileName)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
 	opts := make([]exec.KVOption, len(export.Options))
@@ -394,15 +440,16 @@ func (b *Builder) buildExport(export *memo.ExportExpr) (execPlan, error) {
 		var err error
 		opts[i].Value, err = b.buildScalar(&scalarCtx, o.Value)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, opt.ColMap{}, err
 		}
 	}
-	notNullColsSet, err := input.getNodeColumnOrdinalSet(export.Input.Relational().NotNullCols)
+	notNullColsSet, err := getNodeColumnOrdinalSet(inputCols, export.Input.Relational().NotNullCols)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
 
-	node, err := b.factory.ConstructExport(
+	var ep execPlan
+	ep.root, err = b.factory.ConstructExport(
 		input.root,
 		fileName,
 		export.FileFormat,
@@ -410,17 +457,17 @@ func (b *Builder) buildExport(export *memo.ExportExpr) (execPlan, error) {
 		notNullColsSet,
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, opt.ColMap{}, err
 	}
-	return planWithColumns(node, export.Columns), nil
+	return ep, outputColsFromList(export.Columns), nil
 }
 
 // planWithColumns creates an execPlan for a node which has a fixed output
 // schema.
-func planWithColumns(node exec.Node, cols opt.ColList) execPlan {
-	ep := execPlan{root: node}
+func outputColsFromList(cols opt.ColList) opt.ColMap {
+	var outputCols opt.ColMap
 	for i, c := range cols {
-		ep.outputCols.Set(int(c), i)
+		outputCols.Set(int(c), i)
 	}
-	return ep
+	return outputCols
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -3103,9 +3103,9 @@ anti-join-apply
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT * FROM a WHERE a > ALL (SELECT c::int + 2 FROM bc WHERE b > a::float * 3)
 ----
-memo (optimized, ~21KB, required=[presentation: info:10] [distribution: test])
+memo (optimized, ~21KB, required=[presentation: info:11] [distribution: test])
  ├── G1: (explain G2 [presentation: a:1] [distribution: test])
- │    └── [presentation: info:10] [distribution: test]
+ │    └── [presentation: info:11] [distribution: test]
  │         ├── best: (explain G2="[presentation: a:1] [distribution: test]" [presentation: a:1] [distribution: test])
  │         └── cost: 5525.49
  ├── G2: (anti-join-apply G3 G4 G5)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -3422,7 +3422,7 @@ WHERE ST_Intersects(geo_table2.geom, geo_table.geom))
 ----
 semi-join (lookup geo_table)
  ├── columns: k:1 geom:2
- ├── key columns: [11] = [5]
+ ├── key columns: [12] = [5]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── immutable
@@ -3433,14 +3433,14 @@ semi-join (lookup geo_table)
  ├── distribution: test
  ├── prune: (1)
  ├── inner-join (inverted geo_table@geom_index)
- │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:11 continuation:16
- │    ├── first join in paired joiner; continuation column: continuation:16
+ │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:12 continuation:17
+ │    ├── first join in paired joiner; continuation column: continuation:17
  │    ├── inverted-expr
- │    │    └── st_intersects(geo_table2.geom:2, geo_table.geom:12)
- │    ├── stats: [rows=10000, distinct(11)=999.957, null(11)=0]
+ │    │    └── st_intersects(geo_table2.geom:2, geo_table.geom:13)
+ │    ├── stats: [rows=10000, distinct(12)=999.957, null(12)=0]
  │    ├── cost: 41812.84
- │    ├── key: (1,11)
- │    ├── fd: (1)-->(2), (11)-->(16)
+ │    ├── key: (1,12)
+ │    ├── fd: (1)-->(2), (12)-->(17)
  │    ├── distribution: test
  │    ├── scan geo_table2
  │    │    ├── columns: geo_table2.k:1 geo_table2.geom:2
@@ -3462,7 +3462,7 @@ WHERE ST_Intersects(geo_table2.geom, geo_table.geom))
 ----
 anti-join (lookup geo_table)
  ├── columns: k:1 geom:2
- ├── key columns: [11] = [5]
+ ├── key columns: [12] = [5]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── immutable
@@ -3473,14 +3473,14 @@ anti-join (lookup geo_table)
  ├── distribution: test
  ├── prune: (1)
  ├── left-join (inverted geo_table@geom_index)
- │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:11 continuation:16
- │    ├── first join in paired joiner; continuation column: continuation:16
+ │    ├── columns: geo_table2.k:1 geo_table2.geom:2 geo_table.k:12 continuation:17
+ │    ├── first join in paired joiner; continuation column: continuation:17
  │    ├── inverted-expr
- │    │    └── st_intersects(geo_table2.geom:2, geo_table.geom:12)
- │    ├── stats: [rows=10000, distinct(11)=999.957, null(11)=0]
+ │    │    └── st_intersects(geo_table2.geom:2, geo_table.geom:13)
+ │    ├── stats: [rows=10000, distinct(12)=999.957, null(12)=0]
  │    ├── cost: 41812.84
- │    ├── key: (1,11)
- │    ├── fd: (1)-->(2), (11)-->(16)
+ │    ├── key: (1,12)
+ │    ├── fd: (1)-->(2), (12)-->(17)
  │    ├── distribution: test
  │    ├── scan geo_table2
  │    │    ├── columns: geo_table2.k:1 geo_table2.geom:2

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -122,8 +122,8 @@ vectorized: true
     │ exec mode: one row
     │
     └── • render
-        │ columns: (column16)
-        │ render column16: true
+        │ columns: (column17)
+        │ render column17: true
         │
         └── • limit
             │ columns: (a, c)
@@ -324,7 +324,7 @@ vectorized: true
 • hash join (semi)
 │ columns: (x, y)
 │ estimated row count: 1,000 (missing stats)
-│ equality: (x) = (column9)
+│ equality: (x) = (column10)
 │ left cols are key
 │
 ├── • scan
@@ -334,8 +334,8 @@ vectorized: true
 │     spans: FULL SCAN
 │
 └── • render
-    │ columns: (column9)
-    │ render column9: x - 1
+    │ columns: (column10)
+    │ render column10: x - 1
     │
     └── • scan
           columns: (x)
@@ -380,7 +380,7 @@ vectorized: true
 • hash join (anti)
 │ columns: (x, z)
 │ estimated row count: 0 (missing stats)
-│ equality: (x) = (column9)
+│ equality: (x) = (column10)
 │ left cols are key
 │
 ├── • scan
@@ -390,8 +390,8 @@ vectorized: true
 │     spans: FULL SCAN
 │
 └── • render
-    │ columns: (column9)
-    │ render column9: x - 1
+    │ columns: (column10)
+    │ render column10: x - 1
     │
     └── • scan
           columns: (x)
@@ -590,7 +590,7 @@ SELECT * FROM ab WHERE (a, b) IN (SELECT x+1, y+1 FROM xy)] OFFSET 2;
 • hash join (semi)
 │ columns: (a, b)
 │ estimated row count: 1,000 (missing stats)
-│ equality: (a, b) = (column14, column15)
+│ equality: (a, b) = (column15, column16)
 │
 ├── • scan
 │     columns: (a, b)
@@ -599,9 +599,9 @@ SELECT * FROM ab WHERE (a, b) IN (SELECT x+1, y+1 FROM xy)] OFFSET 2;
 │     spans: FULL SCAN
 │
 └── • render
-    │ columns: (column15, column14)
-    │ render column15: y + 1
-    │ render column14: x + 1
+    │ columns: (column16, column15)
+    │ render column16: y + 1
+    │ render column15: x + 1
     │
     └── • scan
           columns: (x, y)

--- a/pkg/sql/opt/indexrec/testdata/index
+++ b/pkg/sql/opt/indexrec/testdata/index
@@ -1225,11 +1225,11 @@ sort (segmented)
            │         └── coalesce [subquery]
            │              ├── subquery
            │              │    └── project
-           │              │         ├── columns: column21:21!null
+           │              │         ├── columns: column22:22!null
            │              │         ├── cardinality: [0 - 1]
            │              │         ├── cost: 21.3435466
            │              │         ├── key: ()
-           │              │         ├── fd: ()-->(21)
+           │              │         ├── fd: ()-->(22)
            │              │         ├── limit
            │              │         │    ├── columns: t3.k:14!null t3.f:16!null
            │              │         │    ├── cardinality: [0 - 1]
@@ -1249,7 +1249,7 @@ sort (segmented)
            │              │         │    │         └── t3.f:16 > t3.k:14 [outer=(14,16), constraints=(/14: (/NULL - ]; /16: (/NULL - ])]
            │              │         │    └── 1
            │              │         └── projections
-           │              │              └── true [as=column21:21]
+           │              │              └── true [as=column22:22]
            │              └── false
            ├── select
            │    ├── columns: t2.k:8 t2.i:9
@@ -1263,11 +1263,11 @@ sort (segmented)
            │         └── coalesce [subquery]
            │              ├── subquery
            │              │    └── project
-           │              │         ├── columns: column21:21!null
+           │              │         ├── columns: column22:22!null
            │              │         ├── cardinality: [0 - 1]
            │              │         ├── cost: 21.3435466
            │              │         ├── key: ()
-           │              │         ├── fd: ()-->(21)
+           │              │         ├── fd: ()-->(22)
            │              │         ├── limit
            │              │         │    ├── columns: t3.k:14!null t3.f:16!null
            │              │         │    ├── cardinality: [0 - 1]
@@ -1287,7 +1287,7 @@ sort (segmented)
            │              │         │    │         └── t3.f:16 > t3.k:14 [outer=(14,16), constraints=(/14: (/NULL - ]; /16: (/NULL - ])]
            │              │         │    └── 1
            │              │         └── projections
-           │              │              └── true [as=column21:21]
+           │              │              └── true [as=column22:22]
            │              └── false
            └── filters (true)
 

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1715,9 +1715,9 @@ SELECT (SELECT m FROM
 ) FROM uv
 ----
 with &1
- ├── columns: m:29(int)
+ ├── columns: m:30(int)
  ├── volatile, mutations
- ├── prune: (29)
+ ├── prune: (30)
  ├── project
  │    ├── columns: uv.u:6(int!null) uv.v:7(int!null)
  │    ├── cardinality: [1 - 1]
@@ -1751,11 +1751,11 @@ with &1
  │                   ├── const: 2 [type=int]
  │                   └── function: unique_rowid [type=int]
  └── project
-      ├── columns: m:29(int)
-      ├── prune: (29)
+      ├── columns: m:30(int)
+      ├── prune: (30)
       ├── scan uv
       └── projections
-           └── subquery [as=m:29, type=int, subquery]
+           └── subquery [as=m:30, type=int, subquery]
                 └── values
                      ├── columns: mn.m:21(int!null)
                      ├── cardinality: [0 - 0]
@@ -1770,11 +1770,11 @@ FROM uv
 WHERE NOT EXISTS(SELECT uv.u);
 ----
 values
- ├── columns: "?column?":7(unknown!null)
+ ├── columns: "?column?":8(unknown!null)
  ├── cardinality: [0 - 0]
  ├── key: ()
- ├── fd: ()-->(7)
- └── prune: (7)
+ ├── fd: ()-->(8)
+ └── prune: (8)
 
 # Regression test #43651: outer join with empty key.
 opt
@@ -3067,19 +3067,19 @@ project
  ├── fd: ()-->(1,2)
  ├── prune: (1,2)
  └── semi-join (hash)
-      ├── columns: m:1(int!null) n:2(int) column12:12(float)
+      ├── columns: m:1(int!null) n:2(int) column13:13(float)
       ├── cardinality: [0 - 0]
       ├── immutable
       ├── key: ()
-      ├── fd: ()-->(1,2,12)
+      ├── fd: ()-->(1,2,13)
       ├── prune: (1,2)
       ├── project
-      │    ├── columns: column12:12(float) m:1(int!null) n:2(int)
+      │    ├── columns: column13:13(float) m:1(int!null) n:2(int)
       │    ├── cardinality: [0 - 1]
       │    ├── immutable
       │    ├── key: ()
-      │    ├── fd: ()-->(1,2,12)
-      │    ├── prune: (1,2,12)
+      │    ├── fd: ()-->(1,2,13)
+      │    ├── prune: (1,2,13)
       │    ├── select
       │    │    ├── columns: m:1(int!null) n:2(int)
       │    │    ├── cardinality: [0 - 1]
@@ -3097,7 +3097,7 @@ project
       │    │              ├── variable: m:1 [type=int]
       │    │              └── const: 5 [type=int]
       │    └── projections
-      │         └── cast: FLOAT8 [as=column12:12, type=float, outer=(2), immutable]
+      │         └── cast: FLOAT8 [as=column13:13, type=float, outer=(2), immutable]
       │              └── variable: n:2 [type=int]
       ├── project
       │    ├── columns: x:11(float!null)
@@ -3116,8 +3116,8 @@ project
       │         └── cast: FLOAT8 [as=x:11, type=float, outer=(5), immutable]
       │              └── variable: xysd.x:5 [type=int]
       └── filters
-           └── eq [type=bool, outer=(11,12), constraints=(/11: (/NULL - ]; /12: (/NULL - ]), fd=(11)==(12), (12)==(11)]
-                ├── variable: column12:12 [type=float]
+           └── eq [type=bool, outer=(11,13), constraints=(/11: (/NULL - ]; /13: (/NULL - ]), fd=(11)==(13), (13)==(11)]
+                ├── variable: column13:13 [type=float]
                 └── variable: x:11 [type=float]
 
 # Anti-joins with right side cardinality of 0 have cardinality equal to left side cardinality.

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -248,18 +248,18 @@ WHERE t1.b IN (
 ORDER BY t1.a ASC;
 ----
 sort
- ├── columns: "?column?":22(int!null)  [hidden: t1.a:1(int!null)]
+ ├── columns: "?column?":23(int!null)  [hidden: t1.a:1(int!null)]
  ├── key: (1)
- ├── fd: ()-->(22)
- ├── ordering: +1 opt(22) [actual: +1]
- ├── prune: (1,22)
- ├── interesting orderings: (+1 opt(22))
+ ├── fd: ()-->(23)
+ ├── ordering: +1 opt(23) [actual: +1]
+ ├── prune: (1,23)
+ ├── interesting orderings: (+1 opt(23))
  └── project
-      ├── columns: "?column?":22(int!null) t1.a:1(int!null)
+      ├── columns: "?column?":23(int!null) t1.a:1(int!null)
       ├── key: (1)
-      ├── fd: ()-->(22)
-      ├── prune: (1,22)
-      ├── interesting orderings: (+1 opt(22))
+      ├── fd: ()-->(23)
+      ├── prune: (1,23)
+      ├── interesting orderings: (+1 opt(23))
       ├── semi-join (cross)
       │    ├── columns: t1.a:1(int!null) t1.b:2(int!null)
       │    ├── key: (1)
@@ -323,7 +323,7 @@ sort
       │    │         └── filters (true)
       │    └── filters (true)
       └── projections
-           └── const: 1 [as="?column?":22, type=int]
+           └── const: 1 [as="?column?":23, type=int]
 
 opt
 SELECT * FROM xyzs ORDER BY y DESC LIMIT 10

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -268,10 +268,10 @@ build
 SELECT k, EXISTS(SELECT EXISTS(SELECT y FROM xysd WHERE x=k) FROM xysd) FROM kuv
 ----
 project
- ├── columns: k:1(int!null) exists:19(bool)
+ ├── columns: k:1(int!null) exists:21(bool)
  ├── key: (1)
- ├── fd: (1)-->(19)
- ├── prune: (1,19)
+ ├── fd: (1)-->(21)
+ ├── prune: (1,21)
  ├── interesting orderings: (+1)
  ├── scan kuv
  │    ├── columns: k:1(int!null) u:2(float) v:3(string) kuv.crdb_internal_mvcc_timestamp:4(decimal) kuv.tableoid:5(oid)
@@ -280,11 +280,11 @@ project
  │    ├── prune: (1-5)
  │    └── interesting orderings: (+1)
  └── projections
-      └── exists [as=exists:19, type=bool, outer=(1), correlated-subquery]
+      └── exists [as=exists:21, type=bool, outer=(1), correlated-subquery]
            └── project
-                ├── columns: exists:18(bool)
+                ├── columns: exists:19(bool)
                 ├── outer: (1)
-                ├── prune: (18)
+                ├── prune: (19)
                 ├── scan xysd
                 │    ├── columns: x:6(int!null) y:7(int) s:8(string) d:9(decimal!null) xysd.crdb_internal_mvcc_timestamp:10(decimal) xysd.tableoid:11(oid)
                 │    ├── key: (6)
@@ -292,7 +292,7 @@ project
                 │    ├── prune: (6-11)
                 │    └── interesting orderings: (+6) (-8,+9,+6)
                 └── projections
-                     └── exists [as=exists:18, type=bool, outer=(1), correlated-subquery]
+                     └── exists [as=exists:19, type=bool, outer=(1), correlated-subquery]
                           └── project
                                ├── columns: y:13(int)
                                ├── outer: (1)

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -440,16 +440,16 @@ FROM (SELECT * FROM xysd WHERE EXISTS (SELECT * FROM uv WHERE x=u AND y+v=5)) AS
 GROUP BY y
 ----
 project
- ├── columns: count:12(int!null)
+ ├── columns: count:13(int!null)
  ├── immutable
  ├── stats: [rows=138.1701]
  └── group-by (hash)
-      ├── columns: y:2(int) count_rows:12(int!null)
+      ├── columns: y:2(int) count_rows:13(int!null)
       ├── grouping columns: y:2(int)
       ├── immutable
       ├── stats: [rows=138.1701, distinct(2)=138.17, null(2)=0]
       ├── key: (2)
-      ├── fd: (2)-->(12)
+      ├── fd: (2)-->(13)
       ├── semi-join (hash)
       │    ├── columns: x:1(int!null) y:2(int)
       │    ├── immutable
@@ -468,7 +468,7 @@ project
       │         ├── x:1 = u:7 [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
       │         └── (y:2 + v:8) = 5 [type=bool, outer=(2,8), immutable]
       └── aggregations
-           └── count-rows [as=count_rows:12, type=int]
+           └── count-rows [as=count_rows:13, type=int]
 
 # Force column statistics calculation for anti-join.
 norm
@@ -477,16 +477,16 @@ FROM (SELECT * FROM xysd WHERE NOT EXISTS (SELECT * FROM uv WHERE x=u AND y+v=5)
 GROUP BY y
 ----
 project
- ├── columns: count:12(int!null)
+ ├── columns: count:13(int!null)
  ├── immutable
  ├── stats: [rows=400]
  └── group-by (hash)
-      ├── columns: y:2(int) count_rows:12(int!null)
+      ├── columns: y:2(int) count_rows:13(int!null)
       ├── grouping columns: y:2(int)
       ├── immutable
       ├── stats: [rows=400, distinct(2)=400, null(2)=0]
       ├── key: (2)
-      ├── fd: (2)-->(12)
+      ├── fd: (2)-->(13)
       ├── anti-join (hash)
       │    ├── columns: x:1(int!null) y:2(int)
       │    ├── immutable
@@ -505,7 +505,7 @@ project
       │         ├── x:1 = u:7 [type=bool, outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
       │         └── (y:2 + v:8) = 5 [type=bool, outer=(2,8), immutable]
       └── aggregations
-           └── count-rows [as=count_rows:12, type=int]
+           └── count-rows [as=count_rows:13, type=int]
 
 # Force column statistics calculation for left join.
 norm

--- a/pkg/sql/opt/memo/testdata/stats/with
+++ b/pkg/sql/opt/memo/testdata/stats/with
@@ -76,9 +76,9 @@ WHERE
   );
 ----
 with &1 (t0)
- ├── columns: "?column?":29(unknown)
+ ├── columns: "?column?":30(unknown)
  ├── stats: [rows=10000]
- ├── fd: ()-->(29)
+ ├── fd: ()-->(30)
  ├── union
  │    ├── columns: column1:10(int) column2:11(oid!null) column3:12(date) column4:13(string)
  │    ├── left columns: column1:1(int) column2:2(oid) column3:9(date) column4:4(string)
@@ -101,9 +101,9 @@ with &1 (t0)
  │         ├── fd: ()-->(5-8)
  │         └── (NULL, 0, '1970-09-08', NULL) [type=tuple{int, oid, date, string}]
  └── with &2 (t1)
-      ├── columns: "?column?":29(unknown)
+      ├── columns: "?column?":30(unknown)
       ├── stats: [rows=10000]
-      ├── fd: ()-->(29)
+      ├── fd: ()-->(30)
       ├── values
       │    ├── columns: "?column?":23(unknown)
       │    ├── cardinality: [1 - 1]
@@ -112,53 +112,53 @@ with &1 (t0)
       │    ├── fd: ()-->(23)
       │    └── (NULL,) [type=tuple{unknown}]
       └── project
-           ├── columns: "?column?":29(unknown)
+           ├── columns: "?column?":30(unknown)
            ├── stats: [rows=10000]
-           ├── fd: ()-->(29)
+           ├── fd: ()-->(30)
            ├── inner-join (cross)
-           │    ├── columns: true_agg:27(bool!null)
+           │    ├── columns: true_agg:28(bool!null)
            │    ├── stats: [rows=10000]
-           │    ├── fd: ()-->(27)
+           │    ├── fd: ()-->(28)
            │    ├── scan a
            │    │    └── stats: [rows=5000]
            │    ├── inner-join (cross)
-           │    │    ├── columns: true_agg:27(bool!null)
+           │    │    ├── columns: true_agg:28(bool!null)
            │    │    ├── cardinality: [0 - 2]
            │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(one-or-more)
            │    │    ├── stats: [rows=2]
-           │    │    ├── fd: ()-->(27)
+           │    │    ├── fd: ()-->(28)
            │    │    ├── with-scan &1 (t0)
            │    │    │    ├── mapping:
            │    │    │    ├── cardinality: [1 - 2]
            │    │    │    └── stats: [rows=2]
            │    │    ├── select
-           │    │    │    ├── columns: true_agg:27(bool!null)
+           │    │    │    ├── columns: true_agg:28(bool!null)
            │    │    │    ├── cardinality: [0 - 1]
-           │    │    │    ├── stats: [rows=1, distinct(27)=1, null(27)=0]
+           │    │    │    ├── stats: [rows=1, distinct(28)=1, null(28)=0]
            │    │    │    ├── key: ()
-           │    │    │    ├── fd: ()-->(27)
+           │    │    │    ├── fd: ()-->(28)
            │    │    │    ├── scalar-group-by
-           │    │    │    │    ├── columns: true_agg:27(bool)
+           │    │    │    │    ├── columns: true_agg:28(bool)
            │    │    │    │    ├── cardinality: [1 - 1]
-           │    │    │    │    ├── stats: [rows=1, distinct(27)=1, null(27)=0]
+           │    │    │    │    ├── stats: [rows=1, distinct(28)=1, null(28)=0]
            │    │    │    │    ├── key: ()
-           │    │    │    │    ├── fd: ()-->(27)
+           │    │    │    │    ├── fd: ()-->(28)
            │    │    │    │    ├── values
-           │    │    │    │    │    ├── columns: true:26(bool!null)
+           │    │    │    │    │    ├── columns: true:27(bool!null)
            │    │    │    │    │    ├── cardinality: [1 - 1]
            │    │    │    │    │    ├── stats: [rows=1]
            │    │    │    │    │    ├── key: ()
-           │    │    │    │    │    ├── fd: ()-->(26)
+           │    │    │    │    │    ├── fd: ()-->(27)
            │    │    │    │    │    └── (true,) [type=tuple{bool}]
            │    │    │    │    └── aggregations
-           │    │    │    │         └── const-agg [as=true_agg:27, type=bool, outer=(26)]
-           │    │    │    │              └── true:26 [type=bool]
+           │    │    │    │         └── const-agg [as=true_agg:28, type=bool, outer=(27)]
+           │    │    │    │              └── true:27 [type=bool]
            │    │    │    └── filters
-           │    │    │         └── true_agg:27 IS NOT NULL [type=bool, outer=(27), constraints=(/27: (/NULL - ]; tight)]
+           │    │    │         └── true_agg:28 IS NOT NULL [type=bool, outer=(28), constraints=(/28: (/NULL - ]; tight)]
            │    │    └── filters (true)
            │    └── filters (true)
            └── projections
-                └── NULL [as="?column?":29, type=unknown]
+                └── NULL [as="?column?":30, type=unknown]
 
 exec-ddl
 CREATE TABLE test (

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q04
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q04
@@ -41,18 +41,18 @@ ORDER BY
 ----
 sort
  ├── save-table-name: q4_sort_1
- ├── columns: o_orderpriority:6(char!null) order_count:30(int!null)
- ├── stats: [rows=5, distinct(6)=5, null(6)=0, distinct(30)=5, null(30)=0]
+ ├── columns: o_orderpriority:6(char!null) order_count:31(int!null)
+ ├── stats: [rows=5, distinct(6)=5, null(6)=0, distinct(31)=5, null(31)=0]
  ├── key: (6)
- ├── fd: (6)-->(30)
+ ├── fd: (6)-->(31)
  ├── ordering: +6
  └── group-by (hash)
       ├── save-table-name: q4_group_by_2
-      ├── columns: o_orderpriority:6(char!null) count_rows:30(int!null)
+      ├── columns: o_orderpriority:6(char!null) count_rows:31(int!null)
       ├── grouping columns: o_orderpriority:6(char!null)
-      ├── stats: [rows=5, distinct(6)=5, null(6)=0, distinct(30)=5, null(30)=0]
+      ├── stats: [rows=5, distinct(6)=5, null(6)=0, distinct(31)=5, null(31)=0]
       ├── key: (6)
-      ├── fd: (6)-->(30)
+      ├── fd: (6)-->(31)
       ├── semi-join (lookup lineitem)
       │    ├── save-table-name: q4_lookup_join_3
       │    ├── columns: o_orderkey:1(int!null) o_orderdate:5(date!null) o_orderpriority:6(char!null)
@@ -82,7 +82,7 @@ sort
       │    └── filters
       │         └── l_commitdate:23 < l_receiptdate:24 [type=bool, outer=(23,24), constraints=(/23: (/NULL - ]; /24: (/NULL - ])]
       └── aggregations
-           └── count-rows [as=count_rows:30, type=int]
+           └── count-rows [as=count_rows:31, type=int]
 
 ----Stats for q4_sort_1----
 column_names       row_count  distinct_count  null_count

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q16
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q16
@@ -53,18 +53,18 @@ ORDER BY
 ----
 sort
  ├── save-table-name: q16_sort_1
- ├── columns: p_brand:11(char!null) p_type:12(varchar!null) p_size:13(int!null) supplier_cnt:28(int!null)
- ├── stats: [rows=9929.297, distinct(11)=24.9999, null(11)=0, distinct(12)=150, null(12)=0, distinct(13)=8, null(13)=0, distinct(28)=9929.3, null(28)=0, distinct(11-13)=9929.3, null(11-13)=0]
+ ├── columns: p_brand:11(char!null) p_type:12(varchar!null) p_size:13(int!null) supplier_cnt:29(int!null)
+ ├── stats: [rows=9929.297, distinct(11)=24.9999, null(11)=0, distinct(12)=150, null(12)=0, distinct(13)=8, null(13)=0, distinct(29)=9929.3, null(29)=0, distinct(11-13)=9929.3, null(11-13)=0]
  ├── key: (11-13)
- ├── fd: (11-13)-->(28)
- ├── ordering: -28,+11,+12,+13
+ ├── fd: (11-13)-->(29)
+ ├── ordering: -29,+11,+12,+13
  └── group-by (hash)
       ├── save-table-name: q16_group_by_2
-      ├── columns: p_brand:11(char!null) p_type:12(varchar!null) p_size:13(int!null) count:28(int!null)
+      ├── columns: p_brand:11(char!null) p_type:12(varchar!null) p_size:13(int!null) count:29(int!null)
       ├── grouping columns: p_brand:11(char!null) p_type:12(varchar!null) p_size:13(int!null)
-      ├── stats: [rows=9929.297, distinct(11)=24.9999, null(11)=0, distinct(12)=150, null(12)=0, distinct(13)=8, null(13)=0, distinct(28)=9929.3, null(28)=0, distinct(11-13)=9929.3, null(11-13)=0]
+      ├── stats: [rows=9929.297, distinct(11)=24.9999, null(11)=0, distinct(12)=150, null(12)=0, distinct(13)=8, null(13)=0, distinct(29)=9929.3, null(29)=0, distinct(11-13)=9929.3, null(11-13)=0]
       ├── key: (11-13)
-      ├── fd: (11-13)-->(28)
+      ├── fd: (11-13)-->(29)
       ├── distinct-on
       │    ├── save-table-name: q16_distinct_on_3
       │    ├── columns: ps_suppkey:2(int!null) p_brand:11(char!null) p_type:12(varchar!null) p_size:13(int!null)
@@ -134,7 +134,7 @@ sort
       │         └── filters
       │              └── ps_suppkey:2 = s_suppkey:19 [type=bool, outer=(2,19), constraints=(/2: (/NULL - ]; /19: (/NULL - ]), fd=(2)==(19), (19)==(2)]
       └── aggregations
-           └── count-rows [as=count:28, type=int]
+           └── count-rows [as=count:29, type=int]
 
 ----Stats for q16_sort_1----
 column_names    row_count  distinct_count  null_count

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q18
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q18
@@ -53,21 +53,21 @@ LIMIT 100;
 ----
 limit
  ├── save-table-name: q18_limit_1
- ├── columns: c_name:2(varchar!null) c_custkey:1(int!null) o_orderkey:11(int!null) o_orderdate:15(date!null) o_totalprice:14(float!null) sum:59(float!null)
+ ├── columns: c_name:2(varchar!null) c_custkey:1(int!null) o_orderkey:11(int!null) o_orderdate:15(date!null) o_totalprice:14(float!null) sum:60(float!null)
  ├── internal-ordering: -14,+15
  ├── cardinality: [0 - 100]
- ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(11)=100, null(11)=0, distinct(14)=100, null(14)=0, distinct(15)=100, null(15)=0, distinct(59)=100, null(59)=0]
+ ├── stats: [rows=100, distinct(1)=100, null(1)=0, distinct(2)=100, null(2)=0, distinct(11)=100, null(11)=0, distinct(14)=100, null(14)=0, distinct(15)=100, null(15)=0, distinct(60)=100, null(60)=0]
  ├── key: (11)
- ├── fd: (1)-->(2), (11)-->(1,2,14,15,59)
+ ├── fd: (1)-->(2), (11)-->(1,2,14,15,60)
  ├── ordering: -14,+15
  ├── group-by (partial streaming)
  │    ├── save-table-name: q18_group_by_2
- │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) o_orderkey:11(int!null) o_totalprice:14(float!null) o_orderdate:15(date!null) sum:59(float!null)
+ │    ├── columns: c_custkey:1(int!null) c_name:2(varchar!null) o_orderkey:11(int!null) o_totalprice:14(float!null) o_orderdate:15(date!null) sum:60(float!null)
  │    ├── grouping columns: o_orderkey:11(int!null) o_totalprice:14(float!null) o_orderdate:15(date!null)
  │    ├── internal-ordering: -14,+15
- │    ├── stats: [rows=499392.2, distinct(1)=499392, null(1)=0, distinct(2)=499392, null(2)=0, distinct(11)=499392, null(11)=0, distinct(14)=488044, null(14)=0, distinct(15)=2406, null(15)=0, distinct(59)=499392, null(59)=0, distinct(11,14,15)=499392, null(11,14,15)=0]
+ │    ├── stats: [rows=499392.2, distinct(1)=499392, null(1)=0, distinct(2)=499392, null(2)=0, distinct(11)=499392, null(11)=0, distinct(14)=488044, null(14)=0, distinct(15)=2406, null(15)=0, distinct(60)=499392, null(60)=0, distinct(11,14,15)=499392, null(11,14,15)=0]
  │    ├── key: (11)
- │    ├── fd: (1)-->(2), (11)-->(1,2,14,15,59)
+ │    ├── fd: (1)-->(2), (11)-->(1,2,14,15,60)
  │    ├── ordering: -14,+15
  │    ├── limit hint: 100.00
  │    ├── inner-join (lookup lineitem)
@@ -152,7 +152,7 @@ limit
  │    │    │    └── filters (true)
  │    │    └── filters (true)
  │    └── aggregations
- │         ├── sum [as=sum:59, type=float, outer=(26)]
+ │         ├── sum [as=sum:60, type=float, outer=(26)]
  │         │    └── l_quantity:26 [type=float]
  │         ├── const-agg [as=c_custkey:1, type=int, outer=(1)]
  │         │    └── c_custkey:1 [type=int]

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q21
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q21
@@ -59,21 +59,21 @@ LIMIT 100;
 ----
 top-k
  ├── save-table-name: q21_top_k_1
- ├── columns: s_name:2(char!null) numwait:81(int!null)
- ├── internal-ordering: -81,+2
+ ├── columns: s_name:2(char!null) numwait:83(int!null)
+ ├── internal-ordering: -83,+2
  ├── k: 100
  ├── cardinality: [0 - 100]
- ├── stats: [rows=100, distinct(2)=100, null(2)=0, distinct(81)=100, null(81)=0]
+ ├── stats: [rows=100, distinct(2)=100, null(2)=0, distinct(83)=100, null(83)=0]
  ├── key: (2)
- ├── fd: (2)-->(81)
- ├── ordering: -81,+2
+ ├── fd: (2)-->(83)
+ ├── ordering: -83,+2
  └── group-by (hash)
       ├── save-table-name: q21_group_by_2
-      ├── columns: s_name:2(char!null) count_rows:81(int!null)
+      ├── columns: s_name:2(char!null) count_rows:83(int!null)
       ├── grouping columns: s_name:2(char!null)
-      ├── stats: [rows=8389.301, distinct(2)=8389.3, null(2)=0, distinct(81)=8389.3, null(81)=0]
+      ├── stats: [rows=8389.301, distinct(2)=8389.3, null(2)=0, distinct(83)=8389.3, null(83)=0]
       ├── key: (2)
-      ├── fd: (2)-->(81)
+      ├── fd: (2)-->(83)
       ├── inner-join (lookup orders)
       │    ├── save-table-name: q21_lookup_join_3
       │    ├── columns: s_suppkey:1(int!null) s_name:2(char!null) s_nationkey:4(int!null) l1.l_orderkey:10(int!null) l1.l_suppkey:12(int!null) l1.l_commitdate:21(date!null) l1.l_receiptdate:22(date!null) o_orderkey:28(int!null) o_orderstatus:30(char!null) n_nationkey:39(int!null) n_name:40(char!null)
@@ -155,7 +155,7 @@ top-k
       │    └── filters
       │         └── o_orderstatus:30 = 'F' [type=bool, outer=(30), constraints=(/30: [/'F' - /'F']; tight), fd=()-->(30)]
       └── aggregations
-           └── count-rows [as=count_rows:81, type=int]
+           └── count-rows [as=count_rows:83, type=int]
 
 ----Stats for q21_top_k_1----
 column_names  row_count  distinct_count  null_count

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpch/q22
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpch/q22
@@ -56,25 +56,25 @@ ORDER BY
 ----
 sort
  ├── save-table-name: q22_sort_1
- ├── columns: cntrycode:33(string) numcust:34(int!null) totacctbal:35(float!null)
+ ├── columns: cntrycode:34(string) numcust:35(int!null) totacctbal:36(float!null)
  ├── immutable
- ├── stats: [rows=1e-10, distinct(33)=1e-10, null(33)=0, distinct(34)=1e-10, null(34)=0, distinct(35)=1e-10, null(35)=0]
- ├── key: (33)
- ├── fd: (33)-->(34,35)
- ├── ordering: +33
+ ├── stats: [rows=1e-10, distinct(34)=1e-10, null(34)=0, distinct(35)=1e-10, null(35)=0, distinct(36)=1e-10, null(36)=0]
+ ├── key: (34)
+ ├── fd: (34)-->(35,36)
+ ├── ordering: +34
  └── group-by (hash)
       ├── save-table-name: q22_group_by_2
-      ├── columns: cntrycode:33(string) count_rows:34(int!null) sum:35(float!null)
-      ├── grouping columns: cntrycode:33(string)
+      ├── columns: cntrycode:34(string) count_rows:35(int!null) sum:36(float!null)
+      ├── grouping columns: cntrycode:34(string)
       ├── immutable
-      ├── stats: [rows=1e-10, distinct(33)=1e-10, null(33)=0, distinct(34)=1e-10, null(34)=0, distinct(35)=1e-10, null(35)=0]
-      ├── key: (33)
-      ├── fd: (33)-->(34,35)
+      ├── stats: [rows=1e-10, distinct(34)=1e-10, null(34)=0, distinct(35)=1e-10, null(35)=0, distinct(36)=1e-10, null(36)=0]
+      ├── key: (34)
+      ├── fd: (34)-->(35,36)
       ├── project
       │    ├── save-table-name: q22_project_3
-      │    ├── columns: cntrycode:33(string) c_acctbal:6(float!null)
+      │    ├── columns: cntrycode:34(string) c_acctbal:6(float!null)
       │    ├── immutable
-      │    ├── stats: [rows=1e-10, distinct(6)=1e-10, null(6)=0, distinct(33)=1e-10, null(33)=0]
+      │    ├── stats: [rows=1e-10, distinct(6)=1e-10, null(6)=0, distinct(34)=1e-10, null(34)=0]
       │    ├── anti-join (lookup orders@o_ck)
       │    │    ├── save-table-name: q22_lookup_join_4
       │    │    ├── columns: c_custkey:1(int!null) c_phone:5(char!null) c_acctbal:6(float!null)
@@ -138,10 +138,10 @@ sort
       │    │    │                                  └── c_acctbal:16 [type=float]
       │    │    └── filters (true)
       │    └── projections
-      │         └── substring(c_phone:5, 1, 2) [as=cntrycode:33, type=string, outer=(5), immutable]
+      │         └── substring(c_phone:5, 1, 2) [as=cntrycode:34, type=string, outer=(5), immutable]
       └── aggregations
-           ├── count-rows [as=count_rows:34, type=int]
-           └── sum [as=sum:35, type=float, outer=(6)]
+           ├── count-rows [as=count_rows:35, type=int]
+           └── sum [as=sum:36, type=float, outer=(6)]
                 └── c_acctbal:6 [type=float]
 
 ----Stats for q22_sort_1----

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -417,14 +417,14 @@ opt
 SELECT EXISTS(SELECT * FROM a WHERE expr<0) FROM (SELECT x+1 AS expr FROM a)
 ----
 project
- ├── columns: exists:10(bool!null)
+ ├── columns: exists:11(bool!null)
  ├── group-by (hash)
- │    ├── columns: true_agg:12(bool) rownum:14(int!null)
- │    ├── grouping columns: rownum:14(int!null)
+ │    ├── columns: true_agg:13(bool) rownum:15(int!null)
+ │    ├── grouping columns: rownum:15(int!null)
  │    ├── left-join (cross)
- │    │    ├── columns: expr:5(int!null) true:11(bool) rownum:14(int!null)
+ │    │    ├── columns: expr:5(int!null) true:12(bool) rownum:15(int!null)
  │    │    ├── ordinality
- │    │    │    ├── columns: expr:5(int!null) rownum:14(int!null)
+ │    │    │    ├── columns: expr:5(int!null) rownum:15(int!null)
  │    │    │    └── project
  │    │    │         ├── columns: expr:5(int!null)
  │    │    │         ├── scan a
@@ -432,17 +432,17 @@ project
  │    │    │         └── projections
  │    │    │              └── x:1 + 1 [as=expr:5, type=int]
  │    │    ├── project
- │    │    │    ├── columns: true:11(bool!null)
+ │    │    │    ├── columns: true:12(bool!null)
  │    │    │    ├── scan a
  │    │    │    └── projections
- │    │    │         └── true [as=true:11, type=bool]
+ │    │    │         └── true [as=true:12, type=bool]
  │    │    └── filters
  │    │         └── expr:5 < 0 [type=bool]
  │    └── aggregations
- │         └── const-not-null-agg [as=true_agg:12, type=bool]
- │              └── true:11 [type=bool]
+ │         └── const-not-null-agg [as=true_agg:13, type=bool]
+ │              └── true:12 [type=bool]
  └── projections
-      └── true_agg:12 IS NOT NULL [as=exists:10, type=bool]
+      └── true_agg:13 IS NOT NULL [as=exists:11, type=bool]
 
 # Cast
 build

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -779,6 +779,11 @@ func (md *Metadata) NumColumns() int {
 	return len(md.cols)
 }
 
+// MaxColumn returns the maxium column ID tracked by this Metadata instance.
+func (md *Metadata) MaxColumn() ColumnID {
+	return ColumnID(len(md.cols))
+}
+
 // ColumnMeta looks up the metadata for the column associated with the given
 // column id. The same column can be added multiple times to the query metadata
 // and associated with multiple column ids.

--- a/pkg/sql/opt/norm/decorrelate_funcs.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs.go
@@ -733,6 +733,16 @@ func (c *CustomFuncs) ConstructAnyCondition(
 	return c.ConstructBinary(private.Cmp, scalar, inputVar)
 }
 
+// ConvertSubToExistsPrivate converts the given SubqueryPrivate to an
+// ExistsPrivate.
+func (c *CustomFuncs) ConvertSubToExistsPrivate(sub *memo.SubqueryPrivate) *memo.ExistsPrivate {
+	col := c.f.Metadata().AddColumn("exists", types.Bool)
+	return &memo.ExistsPrivate{
+		LazyEvalProjectionCol: col,
+		SubqueryPrivate:       *sub,
+	}
+}
+
 // ConstructBinary builds a dynamic binary expression, given the binary
 // operator's type and its two arguments.
 func (c *CustomFuncs) ConstructBinary(op opt.Operator, left, right opt.ScalarExpr) opt.ScalarExpr {

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -1008,7 +1008,7 @@
                     )
                 ]
             )
-            $anyPrivate
+            (ConvertSubToExistsPrivate $anyPrivate)
         )
     )
 )
@@ -1048,7 +1048,7 @@
                     )
                 ]
             )
-            $anyPrivate
+            (ConvertSubToExistsPrivate $anyPrivate)
         )
     )
     $private
@@ -1097,7 +1097,7 @@
                         )
                     ]
                 )
-                $anyPrivate
+                (ConvertSubToExistsPrivate $anyPrivate)
             )
         )
     )
@@ -1143,7 +1143,7 @@
                         )
                     ]
                 )
-                $anyPrivate
+                (ConvertSubToExistsPrivate $anyPrivate)
             )
         )
     )

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -145,9 +145,9 @@ $input
 # Project operator never changes the row cardinality of its input, and row
 # cardinality is the only thing that Exists cares about, so Project is a no-op.
 [EliminateExistsProject, Normalize]
-(Exists (Project $input:*) $subqueryPrivate:*)
+(Exists (Project $input:*) $existsPrivate:*)
 =>
-(Exists $input $subqueryPrivate)
+(Exists $input $existsPrivate)
 
 # EliminateExistsGroupBy discards a non-scalar GroupBy input to the Exists
 # operator. While non-scalar GroupBy (or DistinctOn) can change row cardinality,
@@ -158,9 +158,9 @@ $input
 # NOTE: EnsureDistinctOn has the side effect of error'ing if the input has
 # duplicates, so do not eliminate it.
 [EliminateExistsGroupBy, Normalize]
-(Exists (GroupBy | DistinctOn $input:*) $subqueryPrivate:*)
+(Exists (GroupBy | DistinctOn $input:*) $existsPrivate:*)
 =>
-(Exists $input $subqueryPrivate)
+(Exists $input $existsPrivate)
 
 # InlineExistsSelectTuple splits a tuple equality filter into multiple
 # (per-column) equalities, in the case where the tuple on one side is being
@@ -202,7 +202,7 @@ $input
             ...
         ]
     )
-    $subqueryPrivate:*
+    $existsPrivate:*
 )
 =>
 (Exists
@@ -213,7 +213,7 @@ $input
             (SplitTupleEq $tuple $rhs)
         )
     )
-    $subqueryPrivate
+    $existsPrivate
 )
 
 # ConvertUncorrelatedExistsToCoalesceSubquery converts an uncorrelated Exists
@@ -234,7 +234,7 @@ $input
 # Note: We can use an empty ordering for the Limit because Exists never have an
 # ordering.
 [ConvertUncorrelatedExistsToCoalesceSubquery, Normalize]
-(Exists $input:* & ^(HasOuterCols $input) $subqueryPrivate:*)
+(Exists $input:* & ^(HasOuterCols $input) $existsPrivate:*)
 =>
 (Coalesce
     [
@@ -244,7 +244,7 @@ $input
                 [ (ProjectionsItem (True) (MakeBoolCol)) ]
                 (MakeEmptyColSet)
             )
-            $subqueryPrivate
+            (EmbeddedSubqueryPrivate $existsPrivate)
         )
         (False)
     ]
@@ -269,12 +269,12 @@ $input
 [IntroduceExistsLimit, Normalize]
 (Exists
     $input:* & ^(HasOuterCols $input) & ^(HasZeroOrOneRow $input)
-    $subqueryPrivate:* & ^(IsLimited $subqueryPrivate)
+    $existsPrivate:* & ^(IsLimited $existsPrivate)
 )
 =>
 (Exists
     (Limit $input (IntConst 1) (EmptyOrdering))
-    (MakeLimited $subqueryPrivate)
+    (MakeLimited $existsPrivate)
 )
 
 # EliminateExistsLimit discards a Limit operator with a positive limit inside an
@@ -294,10 +294,10 @@ $input
         $input:* & (HasOuterCols $input)
         (Const $limit:*) & (IsPositiveInt $limit)
     )
-    $subqueryPrivate:*
+    $existsPrivate:*
 )
 =>
-(Exists $input $subqueryPrivate)
+(Exists $input $existsPrivate)
 
 # EliminateConstValuesSubquery replaces a subquery with a constant value if the
 # subquery's input is a single-row, single-column Values expression with a

--- a/pkg/sql/opt/norm/scalar_funcs.go
+++ b/pkg/sql/opt/norm/scalar_funcs.go
@@ -288,6 +288,12 @@ func (c *CustomFuncs) SubqueryCmp(sub *memo.SubqueryPrivate) opt.Operator {
 	return sub.Cmp
 }
 
+// EmbeddedSubqueryPrivate returns the SubqueryPrivate embedded in the given
+// ExistsPrivate.
+func (c *CustomFuncs) EmbeddedSubqueryPrivate(ex *memo.ExistsPrivate) *memo.SubqueryPrivate {
+	return &ex.SubqueryPrivate
+}
+
 // MakeArrayAggCol returns a ColumnID with the given type and an "array_agg"
 // label.
 func (c *CustomFuncs) MakeArrayAggCol(typ *types.T) opt.ColumnID {
@@ -296,17 +302,16 @@ func (c *CustomFuncs) MakeArrayAggCol(typ *types.T) opt.ColumnID {
 
 // IsLimited indicates whether a limit was pushed under the subquery
 // already. See e.g. the rule IntroduceExistsLimit.
-func (c *CustomFuncs) IsLimited(sub *memo.SubqueryPrivate) bool {
-	return sub.WasLimited
+func (c *CustomFuncs) IsLimited(ex *memo.ExistsPrivate) bool {
+	return ex.WasLimited
 }
 
-// MakeLimited specifies that the subquery has a limit set
-// already. This prevents e.g. the rule IntroduceExistsLimit from
-// applying twice.
-func (c *CustomFuncs) MakeLimited(sub *memo.SubqueryPrivate) *memo.SubqueryPrivate {
-	newSub := *sub
-	newSub.WasLimited = true
-	return &newSub
+// MakeLimited specifies that the Exists subquery has a limit set already. This
+// prevents e.g. the rule IntroduceExistsLimit from applying twice.
+func (c *CustomFuncs) MakeLimited(ex *memo.ExistsPrivate) *memo.ExistsPrivate {
+	newEx := *ex
+	newEx.WasLimited = true
+	return &newEx
 }
 
 // InlineValues converts a Values operator to a tuple. If there are

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1566,10 +1566,10 @@ select
       └── coalesce [subquery]
            ├── subquery
            │    └── project
-           │         ├── columns: column18:18!null
+           │         ├── columns: column19:19!null
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()
-           │         ├── fd: ()-->(18)
+           │         ├── fd: ()-->(19)
            │         ├── limit
            │         │    ├── columns: k:2!null i:3!null x:9!null y:10!null
            │         │    ├── cardinality: [0 - 1]
@@ -1594,7 +1594,7 @@ select
            │         │    │         └── i:3 = y:10 [outer=(3,10), constraints=(/3: (/NULL - ]; /10: (/NULL - ]), fd=(3)==(10), (10)==(3)]
            │         │    └── 1
            │         └── projections
-           │              └── true [as=column18:18]
+           │              └── true [as=column19:19]
            └── false
 
 norm expect=TryDecorrelateInnerLeftJoin
@@ -2067,8 +2067,8 @@ WHERE
   );
 ----
 with &1 (w0)
- ├── columns: "?column?":72
- ├── fd: ()-->(72)
+ ├── columns: "?column?":74
+ ├── fd: ()-->(74)
  ├── values
  │    ├── columns: "?column?":46
  │    ├── cardinality: [1 - 1]
@@ -2076,20 +2076,20 @@ with &1 (w0)
  │    ├── fd: ()-->(46)
  │    └── (NULL,)
  └── project
-      ├── columns: "?column?":72
-      ├── fd: ()-->(72)
+      ├── columns: "?column?":74
+      ├── fd: ()-->(74)
       ├── semi-join-apply
       │    ├── columns: t0._string:6
       │    ├── scan tab_orig [as=t0]
       │    │    └── columns: t0._string:6
       │    ├── inner-join (hash)
-      │    │    ├── columns: tab_orig.rowid:16!null t1._decimal:23!null t1.rowid:25!null t2._bool:31!null t2.rowid:34!null t3._int2:37!null t3._timestamptz:39!null t3.rowid:43!null t4._int8:54!null t4._timestamptz:55!null t5._decimal:66!null
+      │    │    ├── columns: tab_orig.rowid:16!null t1._decimal:23!null t1.rowid:25!null t2._bool:31!null t2.rowid:34!null t3._int2:37!null t3._timestamptz:39!null t3.rowid:43!null t4._int8:55!null t4._timestamptz:56!null t5._decimal:67!null
       │    │    ├── outer: (6)
-      │    │    ├── fd: ()-->(31), (25)-->(23), (43)-->(37,39), (16,25,34,43)-->(23,37,39), (39)==(55), (55)==(39), (37)==(54), (54)==(37), (23)==(66), (66)==(23)
+      │    │    ├── fd: ()-->(31), (25)-->(23), (43)-->(37,39), (16,25,34,43)-->(23,37,39), (39)==(56), (56)==(39), (37)==(55), (55)==(37), (23)==(67), (67)==(23)
       │    │    ├── inner-join (hash)
-      │    │    │    ├── columns: tab_orig.rowid:16!null t1._decimal:23 t1.rowid:25!null t2._bool:31 t2.rowid:34!null t3._int2:37!null t3._timestamptz:39!null t3.rowid:43!null t4._int8:54!null t4._timestamptz:55!null
+      │    │    │    ├── columns: tab_orig.rowid:16!null t1._decimal:23 t1.rowid:25!null t2._bool:31 t2.rowid:34!null t3._int2:37!null t3._timestamptz:39!null t3.rowid:43!null t4._int8:55!null t4._timestamptz:56!null
       │    │    │    ├── outer: (6)
-      │    │    │    ├── fd: (25)-->(23), (34)-->(31), (43)-->(37,39), (16,25,34,43)-->(23,31,37,39), (39)==(55), (55)==(39), (37)==(54), (54)==(37)
+      │    │    │    ├── fd: (25)-->(23), (34)-->(31), (43)-->(37,39), (16,25,34,43)-->(23,31,37,39), (39)==(56), (56)==(39), (37)==(55), (55)==(37)
       │    │    │    ├── group-by (hash)
       │    │    │    │    ├── columns: tab_orig.rowid:16!null t1._decimal:23 t1.rowid:25!null t2._bool:31 t2.rowid:34!null t3._int2:37 t3._timestamptz:39 t3.rowid:43!null
       │    │    │    │    ├── grouping columns: tab_orig.rowid:16!null t1.rowid:25!null t2.rowid:34!null t3.rowid:43!null
@@ -2138,18 +2138,18 @@ with &1 (w0)
       │    │    │    │         └── const-agg [as=t1._decimal:23, outer=(23)]
       │    │    │    │              └── t1._decimal:23
       │    │    │    ├── scan tab_orig [as=t4]
-      │    │    │    │    └── columns: t4._int8:54 t4._timestamptz:55
+      │    │    │    │    └── columns: t4._int8:55 t4._timestamptz:56
       │    │    │    └── filters
-      │    │    │         ├── t3._timestamptz:39 = t4._timestamptz:55 [outer=(39,55), constraints=(/39: (/NULL - ]; /55: (/NULL - ]), fd=(39)==(55), (55)==(39)]
-      │    │    │         └── t3._int2:37 = t4._int8:54 [outer=(37,54), constraints=(/37: (/NULL - ]; /54: (/NULL - ]), fd=(37)==(54), (54)==(37)]
+      │    │    │         ├── t3._timestamptz:39 = t4._timestamptz:56 [outer=(39,56), constraints=(/39: (/NULL - ]; /56: (/NULL - ]), fd=(39)==(56), (56)==(39)]
+      │    │    │         └── t3._int2:37 = t4._int8:55 [outer=(37,55), constraints=(/37: (/NULL - ]; /55: (/NULL - ]), fd=(37)==(55), (55)==(37)]
       │    │    ├── scan tab_orig [as=t5]
-      │    │    │    └── columns: t5._decimal:66
+      │    │    │    └── columns: t5._decimal:67
       │    │    └── filters
       │    │         ├── t2._bool:31 [outer=(31), constraints=(/31: [/true - /true]; tight), fd=()-->(31)]
-      │    │         └── t1._decimal:23 = t5._decimal:66 [outer=(23,66), constraints=(/23: (/NULL - ]; /66: (/NULL - ]), fd=(23)==(66), (66)==(23)]
+      │    │         └── t1._decimal:23 = t5._decimal:67 [outer=(23,67), constraints=(/23: (/NULL - ]; /67: (/NULL - ]), fd=(23)==(67), (67)==(23)]
       │    └── filters (true)
       └── projections
-           └── NULL [as="?column?":72]
+           └── NULL [as="?column?":74]
 
 # --------------------------------------------------
 # TryDecorrelateScalarGroupBy
@@ -2685,24 +2685,24 @@ group-by (hash)
  │    │    ├── key: (1,5)
  │    │    ├── fd: (1)-->(2), (5)-->(6), (1,5)-->(2,6,19)
  │    │    ├── inner-join (cross)
- │    │    │    ├── columns: x:1!null y:2 k:5!null i:6 i:13!null f:14!null column20:20!null
+ │    │    │    ├── columns: x:1!null y:2 k:5!null i:6 i:13!null f:14!null column21:21!null
  │    │    │    ├── immutable
- │    │    │    ├── fd: (1)-->(2), (2)-->(20), (14)==(20), (20)==(14), (5)-->(6)
+ │    │    │    ├── fd: (1)-->(2), (2)-->(21), (14)==(21), (21)==(14), (5)-->(6)
  │    │    │    ├── inner-join (hash)
- │    │    │    │    ├── columns: x:1!null y:2 i:13!null f:14!null column20:20!null
+ │    │    │    │    ├── columns: x:1!null y:2 i:13!null f:14!null column21:21!null
  │    │    │    │    ├── immutable
- │    │    │    │    ├── fd: (1)-->(2), (2)-->(20), (14)==(20), (20)==(14)
+ │    │    │    │    ├── fd: (1)-->(2), (2)-->(21), (14)==(21), (21)==(14)
  │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: column20:20 x:1!null y:2
+ │    │    │    │    │    ├── columns: column21:21 x:1!null y:2
  │    │    │    │    │    ├── immutable
  │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    ├── fd: (1)-->(2), (2)-->(20)
+ │    │    │    │    │    ├── fd: (1)-->(2), (2)-->(21)
  │    │    │    │    │    ├── scan xy
  │    │    │    │    │    │    ├── columns: x:1!null y:2
  │    │    │    │    │    │    ├── key: (1)
  │    │    │    │    │    │    └── fd: (1)-->(2)
  │    │    │    │    │    └── projections
- │    │    │    │    │         └── y:2::FLOAT8 [as=column20:20, outer=(2), immutable]
+ │    │    │    │    │         └── y:2::FLOAT8 [as=column21:21, outer=(2), immutable]
  │    │    │    │    ├── select
  │    │    │    │    │    ├── columns: i:13!null f:14
  │    │    │    │    │    ├── scan a
@@ -2710,7 +2710,7 @@ group-by (hash)
  │    │    │    │    │    └── filters
  │    │    │    │    │         └── i:13 IS NOT NULL [outer=(13), constraints=(/13: (/NULL - ]; tight)]
  │    │    │    │    └── filters
- │    │    │    │         └── column20:20 = f:14 [outer=(14,20), constraints=(/14: (/NULL - ]; /20: (/NULL - ]), fd=(14)==(20), (20)==(14)]
+ │    │    │    │         └── column21:21 = f:14 [outer=(14,21), constraints=(/14: (/NULL - ]; /21: (/NULL - ]), fd=(14)==(21), (21)==(14)]
  │    │    │    ├── scan a
  │    │    │    │    ├── columns: k:5!null i:6
  │    │    │    │    ├── key: (5)
@@ -2860,21 +2860,21 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2)
  └── semi-join (hash)
-      ├── columns: x:1!null y:2 column20:20
+      ├── columns: x:1!null y:2 column22:22
       ├── immutable
       ├── key: (1)
-      ├── fd: (1)-->(2), (2)-->(20)
+      ├── fd: (1)-->(2), (2)-->(22)
       ├── project
-      │    ├── columns: column20:20 x:1!null y:2
+      │    ├── columns: column22:22 x:1!null y:2
       │    ├── immutable
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2), (2)-->(20)
+      │    ├── fd: (1)-->(2), (2)-->(22)
       │    ├── scan xy
       │    │    ├── columns: x:1!null y:2
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2)
       │    └── projections
-      │         └── y:2::FLOAT8 [as=column20:20, outer=(2), immutable]
+      │         └── y:2::FLOAT8 [as=column22:22, outer=(2), immutable]
       ├── inner-join (cross)
       │    ├── columns: f:14
       │    ├── scan a
@@ -2882,7 +2882,7 @@ project
       │    │    └── columns: f:14
       │    └── filters (true)
       └── filters
-           └── column20:20 = f:14 [outer=(14,20), constraints=(/14: (/NULL - ]; /20: (/NULL - ]), fd=(14)==(20), (20)==(14)]
+           └── column22:22 = f:14 [outer=(14,22), constraints=(/14: (/NULL - ]; /22: (/NULL - ]), fd=(14)==(22), (22)==(14)]
 
 # --------------------------------------------------
 # TryDecorrelateLimitOne
@@ -3852,10 +3852,10 @@ select
       └── coalesce [subquery]
            ├── subquery
            │    └── project
-           │         ├── columns: column12:12!null
+           │         ├── columns: column13:13!null
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()
-           │         ├── fd: ()-->(12)
+           │         ├── fd: ()-->(13)
            │         ├── limit
            │         │    ├── cardinality: [0 - 1]
            │         │    ├── key: ()
@@ -3863,7 +3863,7 @@ select
            │         │    │    └── limit hint: 1.00
            │         │    └── 1
            │         └── projections
-           │              └── true [as=column12:12]
+           │              └── true [as=column13:13]
            └── false
 
 # Hoist nested EXISTS.
@@ -3983,10 +3983,10 @@ select
            └── coalesce
                 ├── subquery
                 │    └── project
-                │         ├── columns: column12:12!null
+                │         ├── columns: column13:13!null
                 │         ├── cardinality: [0 - 1]
                 │         ├── key: ()
-                │         ├── fd: ()-->(12)
+                │         ├── fd: ()-->(13)
                 │         ├── limit
                 │         │    ├── cardinality: [0 - 1]
                 │         │    ├── key: ()
@@ -3994,7 +3994,7 @@ select
                 │         │    │    └── limit hint: 1.00
                 │         │    └── 1
                 │         └── projections
-                │              └── true [as=column12:12]
+                │              └── true [as=column13:13]
                 └── false
 
 # --------------------------------------------------
@@ -4393,33 +4393,33 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
-      ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:13
+      ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:14
       ├── key: (1)
-      ├── fd: (1)-->(2-5,13)
+      ├── fd: (1)-->(2-5,14)
       ├── group-by (hash)
-      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:13
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:14
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,13)
+      │    ├── fd: (1)-->(2-5,14)
       │    ├── left-join (hash)
-      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 y:9 true:12
+      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 y:9 true:13
       │    │    ├── fd: (1)-->(2-5)
       │    │    ├── scan a
       │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    │    ├── key: (1)
       │    │    │    └── fd: (1)-->(2-5)
       │    │    ├── project
-      │    │    │    ├── columns: true:12!null y:9
-      │    │    │    ├── fd: ()-->(12)
+      │    │    │    ├── columns: true:13!null y:9
+      │    │    │    ├── fd: ()-->(13)
       │    │    │    ├── scan xy
       │    │    │    │    └── columns: y:9
       │    │    │    └── projections
-      │    │    │         └── true [as=true:12]
+      │    │    │         └── true [as=true:13]
       │    │    └── filters
       │    │         └── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
       │    └── aggregations
-      │         ├── const-not-null-agg [as=true_agg:13, outer=(12)]
-      │         │    └── true:12
+      │         ├── const-not-null-agg [as=true_agg:14, outer=(13)]
+      │         │    └── true:13
       │         ├── const-agg [as=i:2, outer=(2)]
       │         │    └── i:2
       │         ├── const-agg [as=f:3, outer=(3)]
@@ -4429,7 +4429,7 @@ project
       │         └── const-agg [as=j:5, outer=(5)]
       │              └── j:5
       └── filters
-           └── (i:2 = 1) OR (true_agg:13 IS NOT NULL) [outer=(2,13)]
+           └── (i:2 = 1) OR (true_agg:14 IS NOT NULL) [outer=(2,14)]
 
 # Any with IS NULL.
 norm expect=HoistSelectSubquery
@@ -4662,28 +4662,28 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
-      ├── columns: k:1!null i:2 f:3 s:4 j:5 x:12 column16:16 true:17
+      ├── columns: k:1!null i:2 f:3 s:4 j:5 x:12 column17:17 true:19
       ├── key: (1)
-      ├── fd: (1)-->(2-5,12,16,17)
+      ├── fd: (1)-->(2-5,12,17,19)
       ├── left-join (hash)
-      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:12 column16:16 true:17
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:12 column17:17 true:19
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,12,16,17)
+      │    ├── fd: (1)-->(2-5,12,17,19)
       │    ├── left-join (cross)
-      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 column16:16
+      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 column17:17
       │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-5,16)
+      │    │    ├── fd: (1)-->(2-5,17)
       │    │    ├── scan a
       │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    │    ├── key: (1)
       │    │    │    └── fd: (1)-->(2-5)
       │    │    ├── project
-      │    │    │    ├── columns: column16:16!null
+      │    │    │    ├── columns: column17:17!null
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(16)
+      │    │    │    ├── fd: ()-->(17)
       │    │    │    ├── limit
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── key: ()
@@ -4691,21 +4691,21 @@ project
       │    │    │    │    │    └── limit hint: 1.00
       │    │    │    │    └── 1
       │    │    │    └── projections
-      │    │    │         └── true [as=column16:16]
+      │    │    │         └── true [as=column17:17]
       │    │    └── filters (true)
       │    ├── project
-      │    │    ├── columns: true:17!null x:12!null
+      │    │    ├── columns: true:19!null x:12!null
       │    │    ├── key: (12)
-      │    │    ├── fd: ()-->(17)
+      │    │    ├── fd: ()-->(19)
       │    │    ├── scan xy
       │    │    │    ├── columns: x:12!null
       │    │    │    └── key: (12)
       │    │    └── projections
-      │    │         └── true [as=true:17]
+      │    │         └── true [as=true:19]
       │    └── filters
       │         └── x:12 = k:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
       └── filters
-           └── COALESCE(column16:16, false) OR (true:17 IS NOT NULL) [outer=(16,17)]
+           └── COALESCE(column17:17, false) OR (true:19 IS NOT NULL) [outer=(17,19)]
 
 # Hoist an uncorrelated equality subquery.
 norm expect=HoistSelectSubquery
@@ -5098,7 +5098,7 @@ SELECT
 FROM a
 ----
 project
- ├── columns: a:29!null x:30 y:31 b:32 exists:34 count:35!null
+ ├── columns: a:29!null x:30 y:31 b:32 exists:35 count:36!null
  ├── fd: ()-->(29)
  ├── group-by (hash)
  │    ├── columns: k:1!null xy.x:8 count_rows:28!null
@@ -5148,13 +5148,13 @@ project
       │    ├── scan xy
       │    │    └── columns: xy.y:17
       │    └── 5
-      ├── coalesce [as=exists:34, subquery]
+      ├── coalesce [as=exists:35, subquery]
       │    ├── subquery
       │    │    └── project
-      │    │         ├── columns: column33:33!null
+      │    │         ├── columns: column34:34!null
       │    │         ├── cardinality: [0 - 1]
       │    │         ├── key: ()
-      │    │         ├── fd: ()-->(33)
+      │    │         ├── fd: ()-->(34)
       │    │         ├── limit
       │    │         │    ├── cardinality: [0 - 1]
       │    │         │    ├── key: ()
@@ -5162,9 +5162,9 @@ project
       │    │         │    │    └── limit hint: 1.00
       │    │         │    └── 1
       │    │         └── projections
-      │    │              └── true [as=column33:33]
+      │    │              └── true [as=column34:34]
       │    └── false
-      └── count_rows:28 [as=count:35, outer=(28)]
+      └── count_rows:28 [as=count:36, outer=(28)]
 
 # Subquery in GroupBy aggregate (optbuilder creates correlated Project).
 norm expect=HoistProjectSubquery
@@ -5295,33 +5295,33 @@ norm expect=HoistProjectSubquery
 SELECT EXISTS(SELECT * FROM xy WHERE y=i) FROM a
 ----
 project
- ├── columns: exists:12!null
+ ├── columns: exists:13!null
  ├── group-by (hash)
- │    ├── columns: k:1!null true_agg:14
+ │    ├── columns: k:1!null true_agg:15
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)
- │    ├── fd: (1)-->(14)
+ │    ├── fd: (1)-->(15)
  │    ├── left-join (hash)
- │    │    ├── columns: k:1!null i:2 y:9 true:13
+ │    │    ├── columns: k:1!null i:2 y:9 true:14
  │    │    ├── fd: (1)-->(2)
  │    │    ├── scan a
  │    │    │    ├── columns: k:1!null i:2
  │    │    │    ├── key: (1)
  │    │    │    └── fd: (1)-->(2)
  │    │    ├── project
- │    │    │    ├── columns: true:13!null y:9
- │    │    │    ├── fd: ()-->(13)
+ │    │    │    ├── columns: true:14!null y:9
+ │    │    │    ├── fd: ()-->(14)
  │    │    │    ├── scan xy
  │    │    │    │    └── columns: y:9
  │    │    │    └── projections
- │    │    │         └── true [as=true:13]
+ │    │    │         └── true [as=true:14]
  │    │    └── filters
  │    │         └── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
  │    └── aggregations
- │         └── const-not-null-agg [as=true_agg:14, outer=(13)]
- │              └── true:13
+ │         └── const-not-null-agg [as=true_agg:15, outer=(14)]
+ │              └── true:14
  └── projections
-      └── true_agg:14 IS NOT NULL [as=exists:12, outer=(14)]
+      └── true_agg:15 IS NOT NULL [as=exists:13, outer=(15)]
 
 # Any in projection list.
 norm expect=HoistProjectSubquery
@@ -5426,18 +5426,18 @@ norm expect=HoistProjectSubquery
 SELECT EXISTS(SELECT EXISTS(SELECT * FROM xy WHERE y=i) FROM a)
 ----
 values
- ├── columns: exists:17
+ ├── columns: exists:19
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(17)
+ ├── fd: ()-->(19)
  └── tuple
       └── coalesce
            ├── subquery
            │    └── project
-           │         ├── columns: column16:16!null
+           │         ├── columns: column18:18!null
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()
-           │         ├── fd: ()-->(16)
+           │         ├── fd: ()-->(18)
            │         ├── limit
            │         │    ├── columns: i:2 y:9
            │         │    ├── cardinality: [0 - 1]
@@ -5463,7 +5463,7 @@ values
            │         │    │         └── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
            │         │    └── 1
            │         └── projections
-           │              └── true [as=column16:16]
+           │              └── true [as=column18:18]
            └── false
 
 # Hoist an uncorrelated equality subquery.
@@ -5612,41 +5612,41 @@ SELECT s, x FROM a INNER JOIN xy ON EXISTS(SELECT * FROM uv WHERE u=y) OR k=x
 project
  ├── columns: s:4 x:8!null
  └── inner-join (cross)
-      ├── columns: k:1!null s:4 x:8!null exists:18!null
+      ├── columns: k:1!null s:4 x:8!null exists:19!null
       ├── key: (1,8)
-      ├── fd: (1)-->(4), (8)-->(18)
+      ├── fd: (1)-->(4), (8)-->(19)
       ├── scan a
       │    ├── columns: k:1!null s:4
       │    ├── key: (1)
       │    └── fd: (1)-->(4)
       ├── project
-      │    ├── columns: exists:18!null x:8!null
+      │    ├── columns: exists:19!null x:8!null
       │    ├── key: (8)
-      │    ├── fd: (8)-->(18)
+      │    ├── fd: (8)-->(19)
       │    ├── left-join (hash)
-      │    │    ├── columns: x:8!null y:9 u:12 true:16
+      │    │    ├── columns: x:8!null y:9 u:12 true:17
       │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    │    ├── key: (8)
-      │    │    ├── fd: (8)-->(9,12,16)
+      │    │    ├── fd: (8)-->(9,12,17)
       │    │    ├── scan xy
       │    │    │    ├── columns: x:8!null y:9
       │    │    │    ├── key: (8)
       │    │    │    └── fd: (8)-->(9)
       │    │    ├── project
-      │    │    │    ├── columns: true:16!null u:12!null
+      │    │    │    ├── columns: true:17!null u:12!null
       │    │    │    ├── key: (12)
-      │    │    │    ├── fd: ()-->(16)
+      │    │    │    ├── fd: ()-->(17)
       │    │    │    ├── scan uv
       │    │    │    │    ├── columns: u:12!null
       │    │    │    │    └── key: (12)
       │    │    │    └── projections
-      │    │    │         └── true [as=true:16]
+      │    │    │         └── true [as=true:17]
       │    │    └── filters
       │    │         └── u:12 = y:9 [outer=(9,12), constraints=(/9: (/NULL - ]; /12: (/NULL - ]), fd=(9)==(12), (12)==(9)]
       │    └── projections
-      │         └── true:16 IS NOT NULL [as=exists:18, outer=(16)]
+      │         └── true:17 IS NOT NULL [as=exists:19, outer=(17)]
       └── filters
-           └── exists:18 OR (k:1 = x:8) [outer=(1,8,18)]
+           └── exists:19 OR (k:1 = x:8) [outer=(1,8,19)]
 
 # Any in Join filter disjunction.
 norm expect=HoistJoinSubquery
@@ -5768,28 +5768,28 @@ norm expect=HoistValuesSubquery
 SELECT (VALUES (EXISTS(SELECT * FROM xy WHERE x=k))) FROM a
 ----
 project
- ├── columns: column1:16!null
+ ├── columns: column1:17!null
  ├── left-join (hash)
- │    ├── columns: k:1!null x:8 true:13
+ │    ├── columns: k:1!null x:8 true:14
  │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  │    ├── key: (1)
- │    ├── fd: (1)-->(8,13)
+ │    ├── fd: (1)-->(8,14)
  │    ├── scan a
  │    │    ├── columns: k:1!null
  │    │    └── key: (1)
  │    ├── project
- │    │    ├── columns: true:13!null x:8!null
+ │    │    ├── columns: true:14!null x:8!null
  │    │    ├── key: (8)
- │    │    ├── fd: ()-->(13)
+ │    │    ├── fd: ()-->(14)
  │    │    ├── scan xy
  │    │    │    ├── columns: x:8!null
  │    │    │    └── key: (8)
  │    │    └── projections
- │    │         └── true [as=true:13]
+ │    │         └── true [as=true:14]
  │    └── filters
  │         └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
  └── projections
-      └── true:13 IS NOT NULL [as=column1:16, outer=(13)]
+      └── true:14 IS NOT NULL [as=column1:17, outer=(14)]
 
 # Any in values row.
 norm expect=HoistValuesSubquery
@@ -6121,18 +6121,18 @@ project
  ├── key: (1,12)
  ├── fd: (1)-->(2-9), (1,12)-->(2-9,13)
  └── select
-      ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:12!null y:13 true_agg:21!null
+      ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:12!null y:13 true_agg:22!null
       ├── immutable
       ├── key: (1,12)
-      ├── fd: (1)-->(2-9), (1,12)-->(2-9,13,21)
+      ├── fd: (1)-->(2-9), (1,12)-->(2-9,13,22)
       ├── group-by (hash)
-      │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:12!null y:13 true_agg:21
+      │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:12!null y:13 true_agg:22
       │    ├── grouping columns: id:1!null x:12!null
       │    ├── immutable
       │    ├── key: (1,12)
-      │    ├── fd: (1)-->(2-9), (1,12)-->(2-9,13,21)
+      │    ├── fd: (1)-->(2-9), (1,12)-->(2-9,13,22)
       │    ├── inner-join-apply
-      │    │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:12!null y:13 true:20
+      │    │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:12!null y:13 true:21
       │    │    ├── immutable
       │    │    ├── fd: (1)-->(2-9), (1,12)-->(13)
       │    │    ├── scan articles
@@ -6140,7 +6140,7 @@ project
       │    │    │    ├── key: (1)
       │    │    │    └── fd: (1)-->(2-9)
       │    │    ├── left-join-apply
-      │    │    │    ├── columns: x:12!null y:13 true:20
+      │    │    │    ├── columns: x:12!null y:13 true:21
       │    │    │    ├── outer: (1,4,6)
       │    │    │    ├── immutable
       │    │    │    ├── fd: (12)-->(13)
@@ -6149,10 +6149,10 @@ project
       │    │    │    │    ├── key: (12)
       │    │    │    │    └── fd: (12)-->(13)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: true:20!null
+      │    │    │    │    ├── columns: true:21!null
       │    │    │    │    ├── outer: (1,4,6,12)
       │    │    │    │    ├── immutable
-      │    │    │    │    ├── fd: ()-->(20)
+      │    │    │    │    ├── fd: ()-->(21)
       │    │    │    │    ├── project-set
       │    │    │    │    │    ├── columns: generate_series:16 length:17 upper:18 unnest:19
       │    │    │    │    │    ├── outer: (1,4,6,12)
@@ -6167,12 +6167,12 @@ project
       │    │    │    │    │         ├── upper(title:4) [outer=(4), immutable]
       │    │    │    │    │         └── unnest(tag_list:6) [outer=(6), immutable]
       │    │    │    │    └── projections
-      │    │    │    │         └── true [as=true:20]
+      │    │    │    │         └── true [as=true:21]
       │    │    │    └── filters (true)
       │    │    └── filters (true)
       │    └── aggregations
-      │         ├── const-not-null-agg [as=true_agg:21, outer=(20)]
-      │         │    └── true:20
+      │         ├── const-not-null-agg [as=true_agg:22, outer=(21)]
+      │         │    └── true:21
       │         ├── const-agg [as=y:13, outer=(13)]
       │         │    └── y:13
       │         ├── const-agg [as=body:2, outer=(2)]
@@ -6192,7 +6192,7 @@ project
       │         └── const-agg [as=updated_at:9, outer=(9)]
       │              └── updated_at:9
       └── filters
-           └── true_agg:21 IS NOT NULL [outer=(21), constraints=(/21: (/NULL - ]; tight)]
+           └── true_agg:22 IS NOT NULL [outer=(22), constraints=(/22: (/NULL - ]; tight)]
 
 norm expect=TryDecorrelateProjectSet
 SELECT id FROM articles WHERE title = ANY(
@@ -6317,10 +6317,10 @@ select
       └── coalesce [subquery]
            ├── subquery
            │    └── project
-           │         ├── columns: column12:12!null
+           │         ├── columns: column13:13!null
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()
-           │         ├── fd: ()-->(12)
+           │         ├── fd: ()-->(13)
            │         ├── limit
            │         │    ├── columns: y:9!null
            │         │    ├── cardinality: [0 - 1]
@@ -6337,7 +6337,7 @@ select
            │         │    │         └── y:9 = 5 [outer=(9), constraints=(/9: [/5 - /5]; tight), fd=()-->(9)]
            │         │    └── 1
            │         └── projections
-           │              └── true [as=column12:12]
+           │              └── true [as=column13:13]
            └── false
 
 # ANY in Join On condition.
@@ -6462,10 +6462,10 @@ select
            └── coalesce
                 ├── subquery
                 │    └── project
-                │         ├── columns: column12:12!null
+                │         ├── columns: column13:13!null
                 │         ├── cardinality: [0 - 1]
                 │         ├── key: ()
-                │         ├── fd: ()-->(12)
+                │         ├── fd: ()-->(13)
                 │         ├── limit
                 │         │    ├── columns: y:9
                 │         │    ├── cardinality: [0 - 1]
@@ -6481,7 +6481,7 @@ select
                 │         │    │         └── (y:9 = 5) IS NOT false [outer=(9)]
                 │         │    └── 1
                 │         └── projections
-                │              └── true [as=column12:12]
+                │              └── true [as=column13:13]
                 └── false
 
 # NOT ANY in Join On condition.

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -1133,12 +1133,12 @@ FROM xy
 WHERE y = 2
 ----
 project
- ├── columns: case:13!null
+ ├── columns: case:14!null
  ├── left-join (hash)
- │    ├── columns: x:1!null y:2!null k:5 true:14
+ │    ├── columns: x:1!null y:2!null k:5 true:15
  │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  │    ├── key: (1)
- │    ├── fd: ()-->(2), (1)-->(5,14)
+ │    ├── fd: ()-->(2), (1)-->(5,15)
  │    ├── select
  │    │    ├── columns: x:1!null y:2!null
  │    │    ├── key: (1)
@@ -1150,9 +1150,9 @@ project
  │    │    └── filters
  │    │         └── y:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
  │    ├── project
- │    │    ├── columns: true:14!null k:5!null
+ │    │    ├── columns: true:15!null k:5!null
  │    │    ├── key: (5)
- │    │    ├── fd: ()-->(14)
+ │    │    ├── fd: ()-->(15)
  │    │    ├── select
  │    │    │    ├── columns: k:5!null i:6!null
  │    │    │    ├── key: (5)
@@ -1164,11 +1164,11 @@ project
  │    │    │    └── filters
  │    │    │         └── i:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
  │    │    └── projections
- │    │         └── true [as=true:14]
+ │    │         └── true [as=true:15]
  │    └── filters
  │         └── k:5 = x:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  └── projections
-      └── CASE WHEN true:14 IS NOT NULL THEN 'Y' ELSE 'N' END [as=case:13, outer=(14)]
+      └── CASE WHEN true:15 IS NOT NULL THEN 'Y' ELSE 'N' END [as=case:14, outer=(15)]
 
 # Don't eliminate the GroupBy if there is an aggregate function other than
 # ConstAgg, ConstNotNullAgg, or AnyNotNullAgg.
@@ -1384,26 +1384,26 @@ ON CONFLICT (c1) DO UPDATE SET c3=1
 upsert nullablecols
  ├── arbiter indexes: nullablecols_c1_key
  ├── columns: <none>
- ├── canary column: rowid:25
- ├── fetch columns: c1:22 c2:23 c3:24 rowid:25
+ ├── canary column: rowid:26
+ ├── fetch columns: c1:23 c2:24 c3:25 rowid:26
  ├── insert-mapping:
  │    ├── i:8 => c1:1
  │    ├── i:8 => c2:2
  │    ├── i:8 => c3:3
  │    └── i:8 => rowid:4
  ├── update-mapping:
- │    └── upsert_c3:31 => c3:3
+ │    └── upsert_c3:32 => c3:3
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: upsert_c3:31!null i:8!null c1:22 c2:23 c3:24 rowid:25
-      ├── key: (8,25)
-      ├── fd: (25)-->(22-24), (22)~~>(23-25), (23,24)~~>(22,25), (8,25)-->(31)
+      ├── columns: upsert_c3:32!null i:8!null c1:23 c2:24 c3:25 rowid:26
+      ├── key: (8,26)
+      ├── fd: (26)-->(23-25), (23)~~>(24-26), (24,25)~~>(23,26), (8,26)-->(32)
       ├── left-join (hash)
-      │    ├── columns: i:8!null c1:22 c2:23 c3:24 rowid:25
+      │    ├── columns: i:8!null c1:23 c2:24 c3:25 rowid:26
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
-      │    ├── key: (8,25)
-      │    ├── fd: (25)-->(22-24), (22)~~>(23-25), (23,24)~~>(22,25)
+      │    ├── key: (8,26)
+      │    ├── fd: (26)-->(23-25), (23)~~>(24-26), (24,25)~~>(23,26)
       │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: i:8!null
       │    │    ├── grouping columns: i:8!null
@@ -1421,10 +1421,10 @@ upsert nullablecols
       │    │              ├── coalesce [subquery]
       │    │              │    ├── subquery
       │    │              │    │    └── project
-      │    │              │    │         ├── columns: column21:21!null
+      │    │              │    │         ├── columns: column22:22!null
       │    │              │    │         ├── cardinality: [0 - 1]
       │    │              │    │         ├── key: ()
-      │    │              │    │         ├── fd: ()-->(21)
+      │    │              │    │         ├── fd: ()-->(22)
       │    │              │    │         ├── limit
       │    │              │    │         │    ├── cardinality: [0 - 1]
       │    │              │    │         │    ├── key: ()
@@ -1432,17 +1432,17 @@ upsert nullablecols
       │    │              │    │         │    │    └── limit hint: 1.00
       │    │              │    │         │    └── 1
       │    │              │    │         └── projections
-      │    │              │    │              └── true [as=column21:21]
+      │    │              │    │              └── true [as=column22:22]
       │    │              │    └── false
       │    │              └── k:7 > 0 [outer=(7), constraints=(/7: [/1 - ]; tight)]
       │    ├── scan nullablecols
-      │    │    ├── columns: c1:22 c2:23 c3:24 rowid:25!null
-      │    │    ├── key: (25)
-      │    │    └── fd: (25)-->(22-24), (22)~~>(23-25), (23,24)~~>(22,25)
+      │    │    ├── columns: c1:23 c2:24 c3:25 rowid:26!null
+      │    │    ├── key: (26)
+      │    │    └── fd: (26)-->(23-25), (23)~~>(24-26), (24,25)~~>(23,26)
       │    └── filters
-      │         └── i:8 = c1:22 [outer=(8,22), constraints=(/8: (/NULL - ]; /22: (/NULL - ]), fd=(8)==(22), (22)==(8)]
+      │         └── i:8 = c1:23 [outer=(8,23), constraints=(/8: (/NULL - ]; /23: (/NULL - ]), fd=(8)==(23), (23)==(8)]
       └── projections
-           └── CASE WHEN rowid:25 IS NULL THEN i:8 ELSE 1 END [as=upsert_c3:31, outer=(8,25)]
+           └── CASE WHEN rowid:26 IS NULL THEN i:8 ELSE 1 END [as=upsert_c3:32, outer=(8,26)]
 
 # Don't eliminate project if it computes extra column(s).
 norm expect-not=EliminateGroupByProject

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -253,18 +253,18 @@ norm expect=InlineProjectConstants
 SELECT EXISTS(SELECT * FROM a WHERE k=one AND i=two) FROM (VALUES (1, 2)) AS t(one, two)
 ----
 values
- ├── columns: exists:10
+ ├── columns: exists:11
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(10)
+ ├── fd: ()-->(11)
  └── tuple
       └── coalesce
            ├── subquery
            │    └── project
-           │         ├── columns: column11:11!null
+           │         ├── columns: column12:12!null
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()
-           │         ├── fd: ()-->(11)
+           │         ├── fd: ()-->(12)
            │         ├── select
            │         │    ├── columns: k:3!null i:4!null
            │         │    ├── cardinality: [0 - 1]
@@ -278,7 +278,7 @@ values
            │         │         ├── k:3 = 1 [outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
            │         │         └── i:4 = 2 [outer=(4), constraints=(/4: [/2 - /2]; tight), fd=()-->(4)]
            │         └── projections
-           │              └── true [as=column11:11]
+           │              └── true [as=column12:12]
            └── false
 
 # Do not inline constants from Values expression with multiple rows.
@@ -999,19 +999,19 @@ norm expect=InlineProjectInProject
 SELECT EXISTS(SELECT * FROM xy WHERE x=1 OR x=2), expr*2 AS r FROM (SELECT k+1 AS expr FROM a)
 ----
 project
- ├── columns: exists:14 r:15!null
+ ├── columns: exists:15 r:16!null
  ├── immutable
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── projections
-      ├── coalesce [as=exists:14, subquery]
+      ├── coalesce [as=exists:15, subquery]
       │    ├── subquery
       │    │    └── project
-      │    │         ├── columns: column13:13!null
+      │    │         ├── columns: column14:14!null
       │    │         ├── cardinality: [0 - 1]
       │    │         ├── key: ()
-      │    │         ├── fd: ()-->(13)
+      │    │         ├── fd: ()-->(14)
       │    │         ├── limit
       │    │         │    ├── columns: x:9!null
       │    │         │    ├── cardinality: [0 - 1]
@@ -1030,32 +1030,32 @@ project
       │    │         │    │         └── (x:9 = 1) OR (x:9 = 2) [outer=(9), constraints=(/9: [/1 - /1] [/2 - /2]; tight)]
       │    │         │    └── 1
       │    │         └── projections
-      │    │              └── true [as=column13:13]
+      │    │              └── true [as=column14:14]
       │    └── false
-      └── (k:1 + 1) * 2 [as=r:15, outer=(1), immutable]
+      └── (k:1 + 1) * 2 [as=r:16, outer=(1), immutable]
 
 # Correlated subquery should be hoisted as usual.
 norm expect=InlineProjectInProject
 SELECT EXISTS(SELECT * FROM xy WHERE expr<0) FROM (SELECT k+1 AS expr FROM a)
 ----
 project
- ├── columns: exists:13!null
+ ├── columns: exists:14!null
  ├── immutable
  ├── group-by (hash)
- │    ├── columns: true_agg:15 rownum:17!null
- │    ├── grouping columns: rownum:17!null
+ │    ├── columns: true_agg:16 rownum:18!null
+ │    ├── grouping columns: rownum:18!null
  │    ├── immutable
- │    ├── key: (17)
- │    ├── fd: (17)-->(15)
+ │    ├── key: (18)
+ │    ├── fd: (18)-->(16)
  │    ├── left-join (cross)
- │    │    ├── columns: expr:8!null true:14 rownum:17!null
+ │    │    ├── columns: expr:8!null true:15 rownum:18!null
  │    │    ├── immutable
- │    │    ├── fd: (17)-->(8)
+ │    │    ├── fd: (18)-->(8)
  │    │    ├── ordinality
- │    │    │    ├── columns: expr:8!null rownum:17!null
+ │    │    │    ├── columns: expr:8!null rownum:18!null
  │    │    │    ├── immutable
- │    │    │    ├── key: (17)
- │    │    │    ├── fd: (17)-->(8)
+ │    │    │    ├── key: (18)
+ │    │    │    ├── fd: (18)-->(8)
  │    │    │    └── project
  │    │    │         ├── columns: expr:8!null
  │    │    │         ├── immutable
@@ -1065,18 +1065,18 @@ project
  │    │    │         └── projections
  │    │    │              └── k:1 + 1 [as=expr:8, outer=(1), immutable]
  │    │    ├── project
- │    │    │    ├── columns: true:14!null
- │    │    │    ├── fd: ()-->(14)
+ │    │    │    ├── columns: true:15!null
+ │    │    │    ├── fd: ()-->(15)
  │    │    │    ├── scan xy
  │    │    │    └── projections
- │    │    │         └── true [as=true:14]
+ │    │    │         └── true [as=true:15]
  │    │    └── filters
  │    │         └── expr:8 < 0 [outer=(8), constraints=(/8: (/NULL - /-1]; tight)]
  │    └── aggregations
- │         └── const-not-null-agg [as=true_agg:15, outer=(14)]
- │              └── true:14
+ │         └── const-not-null-agg [as=true_agg:16, outer=(15)]
+ │              └── true:15
  └── projections
-      └── true_agg:15 IS NOT NULL [as=exists:13, outer=(15)]
+      └── true_agg:16 IS NOT NULL [as=exists:14, outer=(16)]
 
 # After c is replaced with k+2, (k+2) > 2 should be simplified to k > 0.
 norm

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1219,8 +1219,8 @@ WHERE EXISTS (
 )
 ----
 project
- ├── columns: "?column?":32!null
- ├── fd: ()-->(32)
+ ├── columns: "?column?":34!null
+ ├── fd: ()-->(34)
  ├── semi-join (cross)
  │    ├── columns: s:4!null
  │    ├── select
@@ -1237,13 +1237,13 @@ project
  │    │    │    │         └── eq [subquery]
  │    │    │    │              ├── subquery
  │    │    │    │              │    └── max1-row
- │    │    │    │              │         ├── columns: s:27
+ │    │    │    │              │         ├── columns: s:28
  │    │    │    │              │         ├── error: "more than one row returned by a subquery used as an expression"
  │    │    │    │              │         ├── cardinality: [0 - 1]
  │    │    │    │              │         ├── key: ()
- │    │    │    │              │         ├── fd: ()-->(27)
+ │    │    │    │              │         ├── fd: ()-->(28)
  │    │    │    │              │         └── scan a
- │    │    │    │              │              └── columns: s:27
+ │    │    │    │              │              └── columns: s:28
  │    │    │    │              └── 'foo'
  │    │    │    ├── select
  │    │    │    │    ├── scan uv
@@ -1251,13 +1251,13 @@ project
  │    │    │    │         └── eq [subquery]
  │    │    │    │              ├── subquery
  │    │    │    │              │    └── max1-row
- │    │    │    │              │         ├── columns: s:27
+ │    │    │    │              │         ├── columns: s:28
  │    │    │    │              │         ├── error: "more than one row returned by a subquery used as an expression"
  │    │    │    │              │         ├── cardinality: [0 - 1]
  │    │    │    │              │         ├── key: ()
- │    │    │    │              │         ├── fd: ()-->(27)
+ │    │    │    │              │         ├── fd: ()-->(28)
  │    │    │    │              │         └── scan a
- │    │    │    │              │              └── columns: s:27
+ │    │    │    │              │              └── columns: s:28
  │    │    │    │              └── 'foo'
  │    │    │    └── filters (true)
  │    │    ├── select
@@ -1266,18 +1266,18 @@ project
  │    │    │         └── eq [subquery]
  │    │    │              ├── subquery
  │    │    │              │    └── max1-row
- │    │    │              │         ├── columns: s:27
+ │    │    │              │         ├── columns: s:28
  │    │    │              │         ├── error: "more than one row returned by a subquery used as an expression"
  │    │    │              │         ├── cardinality: [0 - 1]
  │    │    │              │         ├── key: ()
- │    │    │              │         ├── fd: ()-->(27)
+ │    │    │              │         ├── fd: ()-->(28)
  │    │    │              │         └── scan a
- │    │    │              │              └── columns: s:27
+ │    │    │              │              └── columns: s:28
  │    │    │              └── 'foo'
  │    │    └── filters (true)
  │    └── filters (true)
  └── projections
-      └── 1 [as="?column?":32]
+      └── 1 [as="?column?":34]
 
 # Regression for issue 36137. Try to trigger undetectable cycle between the
 # PushFilterIntoJoinLeftAndRight and TryDecorrelateSelect rules.
@@ -1436,34 +1436,34 @@ SELECT (SELECT i_name FROM item LIMIT 1)
     OR (SELECT ol_i_id FROM order_line LIMIT 1) IS NOT NULL;
 ----
 project
- ├── columns: i_name:57
+ ├── columns: i_name:58
  ├── inner-join (hash)
- │    ├── columns: h_data:9!null ol_dist_info:21!null ol_i_id:39 exists:49!null
+ │    ├── columns: h_data:9!null ol_dist_info:21!null ol_i_id:39 exists:50!null
  │    ├── fd: (9)==(21), (21)==(9)
  │    ├── scan history
  │    │    └── columns: h_data:9
  │    ├── select
- │    │    ├── columns: ol_dist_info:21 ol_i_id:39 exists:49!null
+ │    │    ├── columns: ol_dist_info:21 ol_i_id:39 exists:50!null
  │    │    ├── left-join (cross)
- │    │    │    ├── columns: ol_dist_info:21 ol_i_id:39 exists:49!null
+ │    │    │    ├── columns: ol_dist_info:21 ol_i_id:39 exists:50!null
  │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  │    │    │    ├── project
- │    │    │    │    ├── columns: exists:49!null ol_dist_info:21
+ │    │    │    │    ├── columns: exists:50!null ol_dist_info:21
  │    │    │    │    ├── group-by (hash)
- │    │    │    │    │    ├── columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null ol_dist_info:21 true_agg:48
+ │    │    │    │    │    ├── columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null ol_dist_info:21 true_agg:49
  │    │    │    │    │    ├── grouping columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null
  │    │    │    │    │    ├── key: (12-15)
- │    │    │    │    │    ├── fd: (12-15)-->(21,48)
+ │    │    │    │    │    ├── fd: (12-15)-->(21,49)
  │    │    │    │    │    ├── left-join (cross)
- │    │    │    │    │    │    ├── columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null ol_dist_info:21 true:47
+ │    │    │    │    │    │    ├── columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null ol_dist_info:21 true:48
  │    │    │    │    │    │    ├── fd: (12-15)-->(21)
  │    │    │    │    │    │    ├── scan order_line
  │    │    │    │    │    │    │    ├── columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null ol_dist_info:21
  │    │    │    │    │    │    │    ├── key: (12-15)
  │    │    │    │    │    │    │    └── fd: (12-15)-->(21)
  │    │    │    │    │    │    ├── project
- │    │    │    │    │    │    │    ├── columns: true:47!null
- │    │    │    │    │    │    │    ├── fd: ()-->(47)
+ │    │    │    │    │    │    │    ├── columns: true:48!null
+ │    │    │    │    │    │    │    ├── fd: ()-->(48)
  │    │    │    │    │    │    │    ├── select
  │    │    │    │    │    │    │    │    ├── columns: h_data:32!null
  │    │    │    │    │    │    │    │    ├── scan history
@@ -1471,16 +1471,16 @@ project
  │    │    │    │    │    │    │    │    └── filters
  │    │    │    │    │    │    │    │         └── h_data:32 IS NOT NULL [outer=(32), constraints=(/32: (/NULL - ]; tight)]
  │    │    │    │    │    │    │    └── projections
- │    │    │    │    │    │    │         └── true [as=true:47]
+ │    │    │    │    │    │    │         └── true [as=true:48]
  │    │    │    │    │    │    └── filters
  │    │    │    │    │    │         └── ol_dist_info:21 IS NOT NULL [outer=(21), constraints=(/21: (/NULL - ]; tight)]
  │    │    │    │    │    └── aggregations
- │    │    │    │    │         ├── const-not-null-agg [as=true_agg:48, outer=(47)]
- │    │    │    │    │         │    └── true:47
+ │    │    │    │    │         ├── const-not-null-agg [as=true_agg:49, outer=(48)]
+ │    │    │    │    │         │    └── true:48
  │    │    │    │    │         └── const-agg [as=ol_dist_info:21, outer=(21)]
  │    │    │    │    │              └── ol_dist_info:21
  │    │    │    │    └── projections
- │    │    │    │         └── true_agg:48 IS NOT NULL [as=exists:49, outer=(48)]
+ │    │    │    │         └── true_agg:49 IS NOT NULL [as=exists:50, outer=(49)]
  │    │    │    ├── limit
  │    │    │    │    ├── columns: ol_i_id:39!null
  │    │    │    │    ├── cardinality: [0 - 1]
@@ -1492,18 +1492,18 @@ project
  │    │    │    │    └── 1
  │    │    │    └── filters (true)
  │    │    └── filters
- │    │         └── exists:49 OR (ol_i_id:39 IS NOT NULL) [outer=(39,49)]
+ │    │         └── exists:50 OR (ol_i_id:39 IS NOT NULL) [outer=(39,50)]
  │    └── filters
  │         └── h_data:9 = ol_dist_info:21 [outer=(9,21), constraints=(/9: (/NULL - ]; /21: (/NULL - ]), fd=(9)==(21), (21)==(9)]
  └── projections
-      └── subquery [as=i_name:57, subquery]
+      └── subquery [as=i_name:58, subquery]
            └── limit
-                ├── columns: item.i_name:52
+                ├── columns: item.i_name:53
                 ├── cardinality: [0 - 1]
                 ├── key: ()
-                ├── fd: ()-->(52)
+                ├── fd: ()-->(53)
                 ├── scan item
-                │    ├── columns: item.i_name:52
+                │    ├── columns: item.i_name:53
                 │    └── limit hint: 1.00
                 └── 1
 

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -4998,19 +4998,19 @@ semi-join (hash)
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3), (2,3)~~>(1)
  ├── project
- │    ├── columns: column15:15 "family".a:8!null
+ │    ├── columns: column16:16 "family".a:8!null
  │    ├── immutable
  │    ├── key: (8)
- │    ├── fd: (8)-->(15)
+ │    ├── fd: (8)-->(16)
  │    ├── scan family
  │    │    ├── columns: "family".a:8!null "family".b:9 "family".c:10
  │    │    ├── key: (8)
  │    │    └── fd: (8)-->(9,10)
  │    └── projections
- │         └── "family".b:9 + "family".c:10 [as=column15:15, outer=(9,10), immutable]
+ │         └── "family".b:9 + "family".c:10 [as=column16:16, outer=(9,10), immutable]
  └── filters
       ├── abcde.a:1 = "family".a:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
-      └── abcde.b:2 > column15:15 [outer=(2,15), constraints=(/2: (/NULL - ]; /15: (/NULL - ])]
+      └── abcde.b:2 > column16:16 [outer=(2,16), constraints=(/2: (/NULL - ]; /16: (/NULL - ])]
 
 norm expect=PruneSemiAntiJoinRightCols
 SELECT a, b, c FROM abcde WHERE NOT EXISTS (SELECT * FROM family WHERE abcde.a=family.a)

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -547,31 +547,31 @@ norm
 SELECT 1 FROM a AS ref_0 LEFT JOIN a AS ref_1 ON EXISTS(SELECT 1 FROM a WHERE a.s = ref_0.s)
 ----
 project
- ├── columns: "?column?":23!null
- ├── fd: ()-->(23)
+ ├── columns: "?column?":24!null
+ ├── fd: ()-->(24)
  ├── left-join-apply
- │    ├── columns: ref_0.s:4 exists:22
+ │    ├── columns: ref_0.s:4 exists:23
  │    ├── scan a [as=ref_0]
  │    │    └── columns: ref_0.s:4
  │    ├── project
- │    │    ├── columns: exists:22!null
+ │    │    ├── columns: exists:23!null
  │    │    ├── outer: (4)
  │    │    ├── group-by (hash)
- │    │    │    ├── columns: ref_1.k:7!null true_agg:21
+ │    │    │    ├── columns: ref_1.k:7!null true_agg:22
  │    │    │    ├── grouping columns: ref_1.k:7!null
  │    │    │    ├── outer: (4)
  │    │    │    ├── key: (7)
- │    │    │    ├── fd: (7)-->(21)
+ │    │    │    ├── fd: (7)-->(22)
  │    │    │    ├── left-join (cross)
- │    │    │    │    ├── columns: ref_1.k:7!null true:20
+ │    │    │    │    ├── columns: ref_1.k:7!null true:21
  │    │    │    │    ├── outer: (4)
  │    │    │    │    ├── scan a [as=ref_1]
  │    │    │    │    │    ├── columns: ref_1.k:7!null
  │    │    │    │    │    └── key: (7)
  │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: true:20!null
+ │    │    │    │    │    ├── columns: true:21!null
  │    │    │    │    │    ├── outer: (4)
- │    │    │    │    │    ├── fd: ()-->(20)
+ │    │    │    │    │    ├── fd: ()-->(21)
  │    │    │    │    │    ├── select
  │    │    │    │    │    │    ├── columns: a.s:16!null
  │    │    │    │    │    │    ├── outer: (4)
@@ -581,17 +581,17 @@ project
  │    │    │    │    │    │    └── filters
  │    │    │    │    │    │         └── a.s:16 = ref_0.s:4 [outer=(4,16), constraints=(/4: (/NULL - ]; /16: (/NULL - ]), fd=(4)==(16), (16)==(4)]
  │    │    │    │    │    └── projections
- │    │    │    │    │         └── true [as=true:20]
+ │    │    │    │    │         └── true [as=true:21]
  │    │    │    │    └── filters (true)
  │    │    │    └── aggregations
- │    │    │         └── const-not-null-agg [as=true_agg:21, outer=(20)]
- │    │    │              └── true:20
+ │    │    │         └── const-not-null-agg [as=true_agg:22, outer=(21)]
+ │    │    │              └── true:21
  │    │    └── projections
- │    │         └── true_agg:21 IS NOT NULL [as=exists:22, outer=(21)]
+ │    │         └── true_agg:22 IS NOT NULL [as=exists:23, outer=(22)]
  │    └── filters
- │         └── exists:22 [outer=(22), constraints=(/22: [/true - /true]; tight), fd=()-->(22)]
+ │         └── exists:23 [outer=(23), constraints=(/23: [/true - /true]; tight), fd=()-->(23)]
  └── projections
-      └── 1 [as="?column?":23]
+      └── 1 [as="?column?":24]
 
 # Use with multi-argument aggregate function.
 norm expect=RejectNullsGroupBy
@@ -1678,9 +1678,9 @@ SELECT tab_3663.col2_3,
  ORDER BY tab_3663.crdb_internal_mvcc_timestamp DESC, tab_3663.tableoid DESC, tab_3663.col2_5
 ----
 project
- ├── columns: col2_3:2 "?column?":66!null "?column?":67!null col_12038:68!null col2_6:5!null "?column?":66!null  [hidden: tab_3663.col2_5:4 tab_3663.crdb_internal_mvcc_timestamp:11 tab_3663.tableoid:12]
- ├── fd: ()-->(66-68)
- ├── ordering: -11,-12,+4 opt(66-68) [actual: -11,-12,+4]
+ ├── columns: col2_3:2 "?column?":67!null "?column?":68!null col_12038:69!null col2_6:5!null "?column?":67!null  [hidden: tab_3663.col2_5:4 tab_3663.crdb_internal_mvcc_timestamp:11 tab_3663.tableoid:12]
+ ├── fd: ()-->(67-69)
+ ├── ordering: -11,-12,+4 opt(67-69) [actual: -11,-12,+4]
  ├── sort
  │    ├── columns: tab_3663.col2_3:2 tab_3663.col2_5:4 tab_3663.col2_6:5!null tab_3663.col2_9:6 tab_3663.crdb_internal_mvcc_timestamp:11 tab_3663.tableoid:12
  │    ├── ordering: -11,-12,+4
@@ -1724,9 +1724,9 @@ project
  │         │         └── tab_3664.col2_12:21 = col1_3:28 [outer=(21,28), constraints=(/21: (/NULL - ]; /28: (/NULL - ]), fd=(21)==(28), (28)==(21)]
  │         └── filters (true)
  └── projections
-      ├── 0 [as="?column?":66]
-      ├── '23:43:20-08:00:00' [as="?column?":67]
-      └── '2026-09-17 11:54:13.000946' [as=col_12038:68]
+      ├── 0 [as="?column?":67]
+      ├── '23:43:20-08:00:00' [as="?column?":68]
+      └── '2026-09-17 11:54:13.000946' [as=col_12038:69]
 
 # Regression test for #100559 - don't panic when exploration uncovers possible
 # null-rejection that normalization failed to find.

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -407,10 +407,10 @@ norm expect=EliminateExistsZeroRows
 SELECT EXISTS(SELECT * FROM (VALUES (1)) WHERE false)
 ----
 values
- ├── columns: exists:2!null
+ ├── columns: exists:3!null
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(2)
+ ├── fd: ()-->(3)
  └── (false,)
 
 # --------------------------------------------------
@@ -418,6 +418,176 @@ values
 # --------------------------------------------------
 norm expect=EliminateExistsProject
 SELECT * FROM a WHERE EXISTS(SELECT i+1, i*k FROM a)
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column18:18!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(18)
+           │         ├── limit
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── scan a
+           │         │    │    └── limit hint: 1.00
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column18:18]
+           └── false
+
+# --------------------------------------------------
+# EliminateExistsGroupBy
+# --------------------------------------------------
+
+# Scalar group by shouldn't get eliminated.
+norm expect-not=EliminateExistsGroupBy
+SELECT * FROM a WHERE EXISTS(SELECT max(s) FROM a WHERE False)
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column17:17!null
+           │         ├── cardinality: [1 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(17)
+           │         ├── scalar-group-by
+           │         │    ├── cardinality: [1 - 1]
+           │         │    ├── key: ()
+           │         │    └── values
+           │         │         ├── cardinality: [0 - 0]
+           │         │         └── key: ()
+           │         └── projections
+           │              └── true [as=column17:17]
+           └── false
+
+norm expect=EliminateExistsGroupBy
+SELECT * FROM a WHERE EXISTS(SELECT DISTINCT s FROM a)
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column16:16!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(16)
+           │         ├── limit
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── scan a
+           │         │    │    └── limit hint: 1.00
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column16:16]
+           └── false
+
+norm expect=EliminateExistsGroupBy
+SELECT * FROM a WHERE EXISTS(SELECT DISTINCT ON (i) s FROM a)
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column16:16!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(16)
+           │         ├── limit
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── scan a
+           │         │    │    └── limit hint: 1.00
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column16:16]
+           └── false
+
+# Ensure that EliminateExistsGroupBy does not activate for an EnsureDistinctOn.
+norm expect-not=EliminateExistsGroupBy
+SELECT * FROM a WHERE EXISTS(SELECT (SELECT y FROM xy WHERE y=k) FROM a)
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column21:21!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(21)
+           │         ├── limit
+           │         │    ├── columns: k:8!null
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── fd: ()-->(8)
+           │         │    ├── ensure-distinct-on
+           │         │    │    ├── columns: k:8!null
+           │         │    │    ├── grouping columns: k:8!null
+           │         │    │    ├── error: "more than one row returned by a subquery used as an expression"
+           │         │    │    ├── key: (8)
+           │         │    │    ├── limit hint: 1.00
+           │         │    │    └── left-join (hash)
+           │         │    │         ├── columns: k:8!null xy.y:16
+           │         │    │         ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+           │         │    │         ├── scan a
+           │         │    │         │    ├── columns: k:8!null
+           │         │    │         │    └── key: (8)
+           │         │    │         ├── scan xy
+           │         │    │         │    └── columns: xy.y:16
+           │         │    │         └── filters
+           │         │    │              └── xy.y:16 = k:8 [outer=(8,16), constraints=(/8: (/NULL - ]; /16: (/NULL - ]), fd=(8)==(16), (16)==(8)]
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column21:21]
+           └── false
+
+# --------------------------------------------------
+# EliminateExistsGroupBy + EliminateExistsProject
+# --------------------------------------------------
+norm expect=(EliminateExistsGroupBy,EliminateExistsProject)
+SELECT * FROM a WHERE EXISTS(SELECT max(s) FROM a GROUP BY i)
 ----
 select
  ├── columns: k:1!null i:2 f:3 s:4 arr:5
@@ -443,176 +613,6 @@ select
            │         │    └── 1
            │         └── projections
            │              └── true [as=column17:17]
-           └── false
-
-# --------------------------------------------------
-# EliminateExistsGroupBy
-# --------------------------------------------------
-
-# Scalar group by shouldn't get eliminated.
-norm expect-not=EliminateExistsGroupBy
-SELECT * FROM a WHERE EXISTS(SELECT max(s) FROM a WHERE False)
-----
-select
- ├── columns: k:1!null i:2 f:3 s:4 arr:5
- ├── key: (1)
- ├── fd: (1)-->(2-5)
- ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- └── filters
-      └── coalesce [subquery]
-           ├── subquery
-           │    └── project
-           │         ├── columns: column16:16!null
-           │         ├── cardinality: [1 - 1]
-           │         ├── key: ()
-           │         ├── fd: ()-->(16)
-           │         ├── scalar-group-by
-           │         │    ├── cardinality: [1 - 1]
-           │         │    ├── key: ()
-           │         │    └── values
-           │         │         ├── cardinality: [0 - 0]
-           │         │         └── key: ()
-           │         └── projections
-           │              └── true [as=column16:16]
-           └── false
-
-norm expect=EliminateExistsGroupBy
-SELECT * FROM a WHERE EXISTS(SELECT DISTINCT s FROM a)
-----
-select
- ├── columns: k:1!null i:2 f:3 s:4 arr:5
- ├── key: (1)
- ├── fd: (1)-->(2-5)
- ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- └── filters
-      └── coalesce [subquery]
-           ├── subquery
-           │    └── project
-           │         ├── columns: column15:15!null
-           │         ├── cardinality: [0 - 1]
-           │         ├── key: ()
-           │         ├── fd: ()-->(15)
-           │         ├── limit
-           │         │    ├── cardinality: [0 - 1]
-           │         │    ├── key: ()
-           │         │    ├── scan a
-           │         │    │    └── limit hint: 1.00
-           │         │    └── 1
-           │         └── projections
-           │              └── true [as=column15:15]
-           └── false
-
-norm expect=EliminateExistsGroupBy
-SELECT * FROM a WHERE EXISTS(SELECT DISTINCT ON (i) s FROM a)
-----
-select
- ├── columns: k:1!null i:2 f:3 s:4 arr:5
- ├── key: (1)
- ├── fd: (1)-->(2-5)
- ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- └── filters
-      └── coalesce [subquery]
-           ├── subquery
-           │    └── project
-           │         ├── columns: column15:15!null
-           │         ├── cardinality: [0 - 1]
-           │         ├── key: ()
-           │         ├── fd: ()-->(15)
-           │         ├── limit
-           │         │    ├── cardinality: [0 - 1]
-           │         │    ├── key: ()
-           │         │    ├── scan a
-           │         │    │    └── limit hint: 1.00
-           │         │    └── 1
-           │         └── projections
-           │              └── true [as=column15:15]
-           └── false
-
-# Ensure that EliminateExistsGroupBy does not activate for an EnsureDistinctOn.
-norm expect-not=EliminateExistsGroupBy
-SELECT * FROM a WHERE EXISTS(SELECT (SELECT y FROM xy WHERE y=k) FROM a)
-----
-select
- ├── columns: k:1!null i:2 f:3 s:4 arr:5
- ├── key: (1)
- ├── fd: (1)-->(2-5)
- ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- └── filters
-      └── coalesce [subquery]
-           ├── subquery
-           │    └── project
-           │         ├── columns: column20:20!null
-           │         ├── cardinality: [0 - 1]
-           │         ├── key: ()
-           │         ├── fd: ()-->(20)
-           │         ├── limit
-           │         │    ├── columns: k:8!null
-           │         │    ├── cardinality: [0 - 1]
-           │         │    ├── key: ()
-           │         │    ├── fd: ()-->(8)
-           │         │    ├── ensure-distinct-on
-           │         │    │    ├── columns: k:8!null
-           │         │    │    ├── grouping columns: k:8!null
-           │         │    │    ├── error: "more than one row returned by a subquery used as an expression"
-           │         │    │    ├── key: (8)
-           │         │    │    ├── limit hint: 1.00
-           │         │    │    └── left-join (hash)
-           │         │    │         ├── columns: k:8!null xy.y:16
-           │         │    │         ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
-           │         │    │         ├── scan a
-           │         │    │         │    ├── columns: k:8!null
-           │         │    │         │    └── key: (8)
-           │         │    │         ├── scan xy
-           │         │    │         │    └── columns: xy.y:16
-           │         │    │         └── filters
-           │         │    │              └── xy.y:16 = k:8 [outer=(8,16), constraints=(/8: (/NULL - ]; /16: (/NULL - ]), fd=(8)==(16), (16)==(8)]
-           │         │    └── 1
-           │         └── projections
-           │              └── true [as=column20:20]
-           └── false
-
-# --------------------------------------------------
-# EliminateExistsGroupBy + EliminateExistsProject
-# --------------------------------------------------
-norm expect=(EliminateExistsGroupBy,EliminateExistsProject)
-SELECT * FROM a WHERE EXISTS(SELECT max(s) FROM a GROUP BY i)
-----
-select
- ├── columns: k:1!null i:2 f:3 s:4 arr:5
- ├── key: (1)
- ├── fd: (1)-->(2-5)
- ├── scan a
- │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
- │    ├── key: (1)
- │    └── fd: (1)-->(2-5)
- └── filters
-      └── coalesce [subquery]
-           ├── subquery
-           │    └── project
-           │         ├── columns: column16:16!null
-           │         ├── cardinality: [0 - 1]
-           │         ├── key: ()
-           │         ├── fd: ()-->(16)
-           │         ├── limit
-           │         │    ├── cardinality: [0 - 1]
-           │         │    ├── key: ()
-           │         │    ├── scan a
-           │         │    │    └── limit hint: 1.00
-           │         │    └── 1
-           │         └── projections
-           │              └── true [as=column16:16]
            └── false
 
 # --------------------------------------------------
@@ -722,18 +722,18 @@ semi-join (hash)
  ├── scan abcd
  │    └── columns: a:1 b:2 c:3 d:4
  ├── project
- │    ├── columns: column15:15 column14:14!null
+ │    ├── columns: column16:16 column15:15!null
  │    ├── immutable
  │    ├── scan xy
  │    │    ├── columns: x:8!null y:9
  │    │    ├── key: (8)
  │    │    └── fd: (8)-->(9)
  │    └── projections
- │         ├── y:9 + 1 [as=column15:15, outer=(9), immutable]
- │         └── x:8 + 1 [as=column14:14, outer=(8), immutable]
+ │         ├── y:9 + 1 [as=column16:16, outer=(9), immutable]
+ │         └── x:8 + 1 [as=column15:15, outer=(8), immutable]
  └── filters
-      ├── a:1 = column14:14 [outer=(1,14), constraints=(/1: (/NULL - ]; /14: (/NULL - ]), fd=(1)==(14), (14)==(1)]
-      └── b:2 = column15:15 [outer=(2,15), constraints=(/2: (/NULL - ]; /15: (/NULL - ]), fd=(2)==(15), (15)==(2)]
+      ├── a:1 = column15:15 [outer=(1,15), constraints=(/1: (/NULL - ]; /15: (/NULL - ]), fd=(1)==(15), (15)==(1)]
+      └── b:2 = column16:16 [outer=(2,16), constraints=(/2: (/NULL - ]; /16: (/NULL - ]), fd=(2)==(16), (16)==(2)]
 
 # --------------------------------------------------
 # ConvertUncorrelatedExistsToCoalesceSubquery
@@ -754,10 +754,10 @@ select
       └── coalesce [subquery]
            ├── subquery
            │    └── project
-           │         ├── columns: column15:15!null
+           │         ├── columns: column16:16!null
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()
-           │         ├── fd: ()-->(15)
+           │         ├── fd: ()-->(16)
            │         ├── limit
            │         │    ├── cardinality: [0 - 1]
            │         │    ├── key: ()
@@ -765,23 +765,23 @@ select
            │         │    │    └── limit hint: 1.00
            │         │    └── 1
            │         └── projections
-           │              └── true [as=column15:15]
+           │              └── true [as=column16:16]
            └── false
 
 norm expect=ConvertUncorrelatedExistsToCoalesceSubquery
 SELECT EXISTS(SELECT * FROM (VALUES (1))) FROM a
 ----
 project
- ├── columns: exists:10
+ ├── columns: exists:11
  ├── scan a
  └── projections
-      └── coalesce [as=exists:10, subquery]
+      └── coalesce [as=exists:11, subquery]
            ├── subquery
            │    └── values
-           │         ├── columns: column9:9!null
+           │         ├── columns: column10:10!null
            │         ├── cardinality: [1 - 1]
            │         ├── key: ()
-           │         ├── fd: ()-->(9)
+           │         ├── fd: ()-->(10)
            │         └── (true,)
            └── false
 
@@ -804,10 +804,10 @@ inner-join (cross)
  │         └── coalesce [subquery]
  │              ├── subquery
  │              │    └── values
- │              │         ├── columns: column16:16!null
+ │              │         ├── columns: column17:17!null
  │              │         ├── cardinality: [1 - 1]
  │              │         ├── key: ()
- │              │         ├── fd: ()-->(16)
+ │              │         ├── fd: ()-->(17)
  │              │         └── (true,)
  │              └── false
  ├── select
@@ -822,10 +822,10 @@ inner-join (cross)
  │         └── coalesce [subquery]
  │              ├── subquery
  │              │    └── values
- │              │         ├── columns: column16:16!null
+ │              │         ├── columns: column17:17!null
  │              │         ├── cardinality: [1 - 1]
  │              │         ├── key: ()
- │              │         ├── fd: ()-->(16)
+ │              │         ├── fd: ()-->(17)
  │              │         └── (true,)
  │              └── false
  └── filters (true)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1958,10 +1958,10 @@ select
       └── coalesce [subquery]
            ├── subquery
            │    └── project
-           │         ├── columns: column39:39!null
+           │         ├── columns: column40:40!null
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()
-           │         ├── fd: ()-->(39)
+           │         ├── fd: ()-->(40)
            │         ├── select
            │         │    ├── columns: a.k:32!null
            │         │    ├── cardinality: [0 - 1]
@@ -1973,7 +1973,7 @@ select
            │         │    └── filters
            │         │         └── a.k:32 = 1 [outer=(32), constraints=(/32: [/1 - /1]; tight), fd=()-->(32)]
            │         └── projections
-           │              └── true [as=column39:39]
+           │              └── true [as=column40:40]
            └── false
 
 # No-op case because the filter references outer columns.

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -2155,14 +2155,14 @@ WITH RECURSIVE cte (i) AS (
 SELECT i FROM cte;
 ----
 project
- ├── columns: i:9
+ ├── columns: i:10
  ├── cardinality: [1 - ]
  ├── immutable
  ├── recursive-c-t-e
  │    ├── columns: i:2
  │    ├── working table binding: &2
  │    ├── initial columns: "?column?":1
- │    ├── recursive columns: "?column?":8
+ │    ├── recursive columns: "?column?":9
  │    ├── cardinality: [1 - ]
  │    ├── immutable
  │    ├── fake-rel
@@ -2177,11 +2177,11 @@ project
  │    │    ├── fd: ()-->(1)
  │    │    └── (1,)
  │    └── project
- │         ├── columns: "?column?":8!null
+ │         ├── columns: "?column?":9!null
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
- │         ├── fd: ()-->(8)
+ │         ├── fd: ()-->(9)
  │         ├── semi-join (hash)
  │         │    ├── columns: i:3!null
  │         │    ├── cardinality: [0 - 1]
@@ -2212,9 +2212,9 @@ project
  │         │    └── filters
  │         │         └── i:3 = x:4 [outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ]), fd=(3)==(4), (4)==(3)]
  │         └── projections
- │              └── i:3 + 1 [as="?column?":8, outer=(3), immutable]
+ │              └── i:3 + 1 [as="?column?":9, outer=(3), immutable]
  └── projections
-      └── i:2 [as=i:9, outer=(2)]
+      └── i:2 [as=i:10, outer=(2)]
 
 # Case with AntiJoin.
 norm expect=TryAddLimitToRecursiveBranch
@@ -2226,14 +2226,14 @@ WITH RECURSIVE cte (i) AS (
 SELECT i FROM cte;
 ----
 project
- ├── columns: i:9
+ ├── columns: i:10
  ├── cardinality: [1 - ]
  ├── immutable
  ├── recursive-c-t-e
  │    ├── columns: i:2
  │    ├── working table binding: &2
  │    ├── initial columns: "?column?":1
- │    ├── recursive columns: "?column?":8
+ │    ├── recursive columns: "?column?":9
  │    ├── cardinality: [1 - ]
  │    ├── immutable
  │    ├── fake-rel
@@ -2248,11 +2248,11 @@ project
  │    │    ├── fd: ()-->(1)
  │    │    └── (1,)
  │    └── project
- │         ├── columns: "?column?":8!null
+ │         ├── columns: "?column?":9!null
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
- │         ├── fd: ()-->(8)
+ │         ├── fd: ()-->(9)
  │         ├── anti-join (hash)
  │         │    ├── columns: i:3!null
  │         │    ├── cardinality: [0 - 1]
@@ -2283,9 +2283,9 @@ project
  │         │    └── filters
  │         │         └── i:3 = x:4 [outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ]), fd=(3)==(4), (4)==(3)]
  │         └── projections
- │              └── i:3 + 1 [as="?column?":8, outer=(3), immutable]
+ │              └── i:3 + 1 [as="?column?":9, outer=(3), immutable]
  └── projections
-      └── i:2 [as=i:9, outer=(2)]
+      └── i:2 [as=i:10, outer=(2)]
 
 # Case with child CTE.
 norm expect=TryAddLimitToRecursiveBranch disable=InlineWith

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -49,11 +49,6 @@ define SubqueryPrivate {
 
     # Cmp is only used for AnyOp.
     Cmp Operator
-
-    # WasLimited indicates a limit was applied "under" the subquery to
-    # restrict how many rows are fetched to determine the result.  See
-    # e.g. the rule IntroduceExistsLimit.
-    WasLimited bool
 }
 
 # Any is a SQL operator that applies a comparison to every row of an input
@@ -100,6 +95,11 @@ define ExistsPrivate {
     # execbuilder-time, so all Exists expressions are assigned a column during
     # optimization.
     LazyEvalProjectionCol ColumnID
+
+    # WasLimited indicates a limit was applied "under" the subquery to
+    # restrict how many rows are fetched to determine the result.  See
+    # e.g. the rule IntroduceExistsLimit.
+    WasLimited bool
     _ SubqueryPrivate
 }
 

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -31,8 +31,8 @@ define Subquery {
 }
 
 # SubqueryPrivate contains information related to a subquery (Subquery, Any,
-# Exists). It is shared between the operators so that the same rules can be used
-# across all the subquery operators.
+# Exists). It is shared between the Subquery and Any operators so that the same
+# rules can be used across all both expressions.
 [Private]
 define SubqueryPrivate {
     OriginalExpr Subquery
@@ -88,6 +88,18 @@ define Any {
 [Scalar, Bool]
 define Exists {
     Input RelExpr
+    _ ExistsPrivate
+}
+
+# ExistsPrivate contains information related to an Exists subquery.
+[Private]
+define ExistsPrivate {
+    # LazyEvalProjectionCol is used when the Exists is planned as a
+    # lazily-evaluated routine (see execbuilder.Builder.buildExistsSubquery).
+    # The decision to execute the Exists lazily is not made until
+    # execbuilder-time, so all Exists expressions are assigned a column during
+    # optimization.
+    LazyEvalProjectionCol ColumnID
     _ SubqueryPrivate
 }
 

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -335,7 +335,12 @@ func (b *Builder) buildSingleRowSubquery(
 ) (out opt.ScalarExpr, outScope *scope) {
 	subqueryPrivate := memo.SubqueryPrivate{OriginalExpr: s.Subquery}
 	if s.Exists {
-		return b.factory.ConstructExists(s.node, &subqueryPrivate), inScope
+		col := b.factory.Metadata().AddColumn("exists", types.Bool)
+		ex := memo.ExistsPrivate{
+			LazyEvalProjectionCol: col,
+			SubqueryPrivate:       subqueryPrivate,
+		}
+		return b.factory.ConstructExists(s.node, &ex), inScope
 	}
 
 	var input memo.RelExpr

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
@@ -99,18 +99,18 @@ root
  └── cascade
       └── delete child
            ├── columns: <none>
-           ├── fetch columns: c:14 child.p:15
+           ├── fetch columns: c:15 child.p:16
            └── semi-join (hash)
-                ├── columns: c:14!null child.p:15!null
+                ├── columns: c:15!null child.p:16!null
                 ├── scan child
-                │    ├── columns: c:14!null child.p:15!null
+                │    ├── columns: c:15!null child.p:16!null
                 │    └── flags: disabled not visible index feature
                 ├── with-scan &1
-                │    ├── columns: p:18!null
+                │    ├── columns: p:19!null
                 │    └── mapping:
-                │         └──  parent.p:4 => p:18
+                │         └──  parent.p:4 => p:19
                 └── filters
-                     └── child.p:15 = p:18
+                     └── child.p:16 = p:19
 
 # Delete with volatile UDF; no fast path.
 build-cascades

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -655,11 +655,11 @@ build
 SELECT EXISTS (SELECT a FROM abc)
 ----
 project
- ├── columns: exists:6
+ ├── columns: exists:7
  ├── values
  │    └── ()
  └── projections
-      └── exists [as=exists:6]
+      └── exists [as=exists:7]
            └── project
                 ├── columns: a:1!null
                 └── scan abc
@@ -669,11 +669,11 @@ build
 SELECT true = EXISTS (SELECT 1)
 ----
 project
- ├── columns: "?column?":2
+ ├── columns: "?column?":3
  ├── values
  │    └── ()
  └── projections
-      └── eq [as="?column?":2]
+      └── eq [as="?column?":3]
            ├── true
            └── exists
                 └── project
@@ -855,11 +855,11 @@ build
 SELECT EXISTS(SELECT 1 r FROM kv AS x WHERE x.k = 1)
 ----
 project
- ├── columns: exists:6
+ ├── columns: exists:7
  ├── values
  │    └── ()
  └── projections
-      └── exists [as=exists:6]
+      └── exists [as=exists:7]
            └── project
                 ├── columns: r:5!null
                 ├── select
@@ -875,11 +875,11 @@ build
 SELECT EXISTS(SELECT 1 r FROM kv WHERE k = 2)
 ----
 project
- ├── columns: exists:6
+ ├── columns: exists:7
  ├── values
  │    └── ()
  └── projections
-      └── exists [as=exists:6]
+      └── exists [as=exists:7]
            └── project
                 ├── columns: r:5!null
                 ├── select

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1348,10 +1348,10 @@ with &1 (cte)
       ├── fetch columns: a:14 b:15 c:16 d:17 e:18 rowid:19
       ├── update-mapping:
       │    ├── b:15 => a:6
-      │    ├── d_comp:23 => d:9
+      │    ├── d_comp:24 => d:9
       │    └── b:15 => e:10
       └── project
-           ├── columns: d_comp:23 a:14!null b:15 c:16 d:17 e:18 rowid:19!null abcde.crdb_internal_mvcc_timestamp:20 abcde.tableoid:21
+           ├── columns: d_comp:24 a:14!null b:15 c:16 d:17 e:18 rowid:19!null abcde.crdb_internal_mvcc_timestamp:20 abcde.tableoid:21
            ├── select
            │    ├── columns: a:14!null b:15 c:16 d:17 e:18 rowid:19!null abcde.crdb_internal_mvcc_timestamp:20 abcde.tableoid:21
            │    ├── scan abcde
@@ -1368,7 +1368,7 @@ with &1 (cte)
            │                   └── mapping:
            │                        └──  xyz.x:1 => x:22
            └── projections
-                └── (b:15 + c:16) + 1 [as=d_comp:23]
+                └── (b:15 + c:16) + 1 [as=d_comp:24]
 
 # Use CTE within SET expression.
 build

--- a/pkg/sql/opt/xform/cycle_funcs.go
+++ b/pkg/sql/opt/xform/cycle_funcs.go
@@ -10,9 +10,13 @@
 
 package xform
 
-import "github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
 
-// EmptySubqueryPrivate returns an empty SubqueryPrivate.
-func (c *CustomFuncs) EmptySubqueryPrivate() *memo.SubqueryPrivate {
-	return &memo.SubqueryPrivate{}
+// EmptyExistsPrivate returns an empty SubqueryPrivate.
+func (c *CustomFuncs) EmptyExistsPrivate() *memo.ExistsPrivate {
+	col := c.e.f.Metadata().AddColumn("exists", types.Bool)
+	return &memo.ExistsPrivate{LazyEvalProjectionCol: col}
 }

--- a/pkg/sql/opt/xform/rules/cycle.opt
+++ b/pkg/sql/opt/xform/rules/cycle.opt
@@ -22,7 +22,7 @@
         (FiltersItem
             (Exists
                 (MemoCycleTestRel $input $filters)
-                (EmptySubqueryPrivate)
+                (EmptyExistsPrivate)
             )
         )
     ]

--- a/pkg/sql/opt/xform/testdata/coster/zone
+++ b/pkg/sql/opt/xform/testdata/coster/zone
@@ -868,8 +868,8 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: a1.r:1!null a1.a:2!null a1.b:3!null a1.c:4!null
- │    │    ├── left columns: a1.r:13 a1.a:14 a1.b:15 a1.c:16
- │    │    ├── right columns: a1.r:19 a1.a:20 a1.b:21 a1.c:22
+ │    │    ├── left columns: a1.r:14 a1.a:15 a1.b:16 a1.c:17
+ │    │    ├── right columns: a1.r:20 a1.a:21 a1.b:22 a1.c:23
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── stats: [rows=0.91, distinct(2)=0.91, null(2)=0, distinct(3)=0.91, null(3)=0, distinct(4)=0.91, null(4)=0, distinct(3,4)=0.91, null(3,4)=0]
  │    │    ├── cost: 5.6885176
@@ -877,20 +877,20 @@ anti-join (lookup abc_part@bc_idx [as=a2])
  │    │    ├── fd: ()-->(1-4)
  │    │    ├── distribution: east
  │    │    ├── scan abc_part@bc_idx [as=a1]
- │    │    │    ├── columns: a1.r:13!null a1.a:14!null a1.b:15!null a1.c:16!null
- │    │    │    ├── constraint: /13/15/16: [/'east'/1/'foo' - /'east'/1/'foo']
+ │    │    │    ├── columns: a1.r:14!null a1.a:15!null a1.b:16!null a1.c:17!null
+ │    │    │    ├── constraint: /14/16/17: [/'east'/1/'foo' - /'east'/1/'foo']
  │    │    │    ├── cardinality: [0 - 1]
- │    │    │    ├── stats: [rows=0.9001, distinct(13)=0.9001, null(13)=0, distinct(15)=0.9001, null(15)=0, distinct(16)=0.9001, null(16)=0, distinct(13,15,16)=0.9001, null(13,15,16)=0]
+ │    │    │    ├── stats: [rows=0.9001, distinct(14)=0.9001, null(14)=0, distinct(16)=0.9001, null(16)=0, distinct(17)=0.9001, null(17)=0, distinct(14,16,17)=0.9001, null(14,16,17)=0]
  │    │    │    ├── cost: 5.154016
  │    │    │    ├── key: ()
- │    │    │    └── fd: ()-->(13-16)
+ │    │    │    └── fd: ()-->(14-17)
  │    │    └── scan abc_part@bc_idx [as=a1]
- │    │         ├── columns: a1.r:19!null a1.a:20!null a1.b:21!null a1.c:22!null
- │    │         ├── constraint: /19/21/22: [/'west'/1/'foo' - /'west'/1/'foo']
+ │    │         ├── columns: a1.r:20!null a1.a:21!null a1.b:22!null a1.c:23!null
+ │    │         ├── constraint: /20/22/23: [/'west'/1/'foo' - /'west'/1/'foo']
  │    │         ├── cardinality: [0 - 1]
- │    │         ├── stats: [rows=0.9001, distinct(19)=0.9001, null(19)=0, distinct(21)=0.9001, null(21)=0, distinct(22)=0.9001, null(22)=0, distinct(19,21,22)=0.9001, null(19,21,22)=0]
+ │    │         ├── stats: [rows=0.9001, distinct(20)=0.9001, null(20)=0, distinct(22)=0.9001, null(22)=0, distinct(23)=0.9001, null(23)=0, distinct(20,22,23)=0.9001, null(20,22,23)=0]
  │    │         ├── cost: 5.154016
  │    │         ├── key: ()
- │    │         └── fd: ()-->(19-22)
+ │    │         └── fd: ()-->(20-23)
  │    └── filters (true)
  └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -1853,27 +1853,27 @@ where
     bids0_.auctionId=$1
 ----
 project
- ├── columns: auctioni4_1_0_:4!null id1_1_0_:1!null id1_1_1_:1!null amount2_1_1_:2 createdd3_1_1_:3 auctioni4_1_1_:4!null formula41_1_:13!null
+ ├── columns: auctioni4_1_0_:4!null id1_1_0_:1!null id1_1_1_:1!null amount2_1_1_:2 createdd3_1_1_:3 auctioni4_1_1_:4!null formula41_1_:14!null
  ├── has-placeholder
  ├── key: (1)
- ├── fd: ()-->(4), (1)-->(2,3,13)
+ ├── fd: ()-->(4), (1)-->(2,3,14)
  ├── group-by (hash)
- │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null true_agg:15
+ │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null true_agg:16
  │    ├── grouping columns: bids0_.id:1!null
  │    ├── has-placeholder
  │    ├── key: (1)
- │    ├── fd: ()-->(4), (1)-->(2-4,15)
+ │    ├── fd: ()-->(4), (1)-->(2-4,16)
  │    ├── right-join (hash)
- │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null successfulbid:10 true:14
+ │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null successfulbid:10 true:15
  │    │    ├── has-placeholder
  │    │    ├── fd: ()-->(4), (1)-->(2,3)
  │    │    ├── project
- │    │    │    ├── columns: true:14!null successfulbid:10
- │    │    │    ├── fd: ()-->(14)
+ │    │    │    ├── columns: true:15!null successfulbid:10
+ │    │    │    ├── fd: ()-->(15)
  │    │    │    ├── scan tauction2 [as=a]
  │    │    │    │    └── columns: successfulbid:10
  │    │    │    └── projections
- │    │    │         └── true [as=true:14]
+ │    │    │         └── true [as=true:15]
  │    │    ├── select
  │    │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null
  │    │    │    ├── has-placeholder
@@ -1888,8 +1888,8 @@ project
  │    │    └── filters
  │    │         └── successfulbid:10 = bids0_.id:1 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
  │    └── aggregations
- │         ├── const-not-null-agg [as=true_agg:15, outer=(14)]
- │         │    └── true:14
+ │         ├── const-not-null-agg [as=true_agg:16, outer=(15)]
+ │         │    └── true:15
  │         ├── const-agg [as=amount:2, outer=(2)]
  │         │    └── amount:2
  │         ├── const-agg [as=createddatetime:3, outer=(3)]
@@ -1897,7 +1897,7 @@ project
  │         └── const-agg [as=auctionid:4, outer=(4)]
  │              └── auctionid:4
  └── projections
-      └── true_agg:15 IS NOT NULL [as=formula41_1_:13, outer=(15)]
+      └── true_agg:16 IS NOT NULL [as=formula41_1_:14, outer=(16)]
 
 exec-ddl
 drop table TAuction2, TBid2;

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -158,47 +158,47 @@ from (select flavors.created_at as flavors_created_at,
 order by anon_1.flavors_id asc
 ----
 project
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
  ├── immutable, has-placeholder
- ├── key: (29)
- ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
+ ├── key: (30)
+ ├── fd: ()-->(1-12,14,15,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
-      ├── key columns: [29] = [29]
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
+      ├── key columns: [30] = [30]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (29)
-      ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
+      ├── key: (30)
+      ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
-      │    ├── key columns: [1] = [32]
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 flavor_extra_specs_1.flavor_id:33
+      │    ├── key columns: [1] = [33]
       │    ├── immutable, has-placeholder
-      │    ├── key: (29)
-      │    ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30), (30)-->(29)
+      │    ├── key: (30)
+      │    ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31), (31)-->(30)
       │    ├── limit
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    ├── offset
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:26 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
+      │    │    │    │    │    ├── columns: true:27 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
       │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    │    │    │    │    ├── key columns: [1] = [19]
@@ -221,9 +221,9 @@ project
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:26, outer=(19)]
+      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:27, outer=(19)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
+      │    │    │    │         └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
       │    │    │    └── $3
       │    │    └── $4
       │    └── filters (true)
@@ -285,69 +285,69 @@ from (select flavors.created_at as flavors_created_at,
 order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11!null anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:44 flavor_extra_specs_1_updated_at:45 flavor_extra_specs_1_id:40 flavor_extra_specs_1_key:41 flavor_extra_specs_1_value:42 flavor_extra_specs_1_flavor_id:43
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11!null anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:46 flavor_extra_specs_1_updated_at:47 flavor_extra_specs_1_id:42 flavor_extra_specs_1_key:43 flavor_extra_specs_1_value:44 flavor_extra_specs_1_flavor_id:45
  ├── immutable, has-placeholder
- ├── key: (1,40)
- ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (40)-->(41-45), (41,43)-->(40,42,44,45)
+ ├── key: (1,42)
+ ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (42)-->(43-47), (43,45)-->(42,44,46,47)
  ├── ordering: +7 opt(11) [actual: +7]
  └── project
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:40 key:41 value:42 flavor_extra_specs_1.flavor_id:43 flavor_extra_specs_1.created_at:44 flavor_extra_specs_1.updated_at:45
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:42 key:43 value:44 flavor_extra_specs_1.flavor_id:45 flavor_extra_specs_1.created_at:46 flavor_extra_specs_1.updated_at:47
       ├── immutable, has-placeholder
-      ├── key: (1,40)
-      ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (40)-->(41-45), (41,43)-->(40,42,44,45)
+      ├── key: (1,42)
+      ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (42)-->(43-47), (43,45)-->(42,44,46,47)
       └── right-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:34 true:37 flavor_extra_specs_1.id:40 key:41 value:42 flavor_extra_specs_1.flavor_id:43 flavor_extra_specs_1.created_at:44 flavor_extra_specs_1.updated_at:45
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:36 true:39 flavor_extra_specs_1.id:42 key:43 value:44 flavor_extra_specs_1.flavor_id:45 flavor_extra_specs_1.created_at:46 flavor_extra_specs_1.updated_at:47
            ├── immutable, has-placeholder
-           ├── key: (1,40)
-           ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,34,37), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (40)-->(41-45), (41,43)-->(40,42,44,45)
+           ├── key: (1,42)
+           ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,36,39), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (42)-->(43-47), (43,45)-->(42,44,46,47)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-           │    ├── columns: flavor_extra_specs_1.id:40!null key:41!null value:42 flavor_extra_specs_1.flavor_id:43!null flavor_extra_specs_1.created_at:44 flavor_extra_specs_1.updated_at:45
-           │    ├── key: (40)
-           │    └── fd: (40)-->(41-45), (41,43)-->(40,42,44,45)
+           │    ├── columns: flavor_extra_specs_1.id:42!null key:43!null value:44 flavor_extra_specs_1.flavor_id:45!null flavor_extra_specs_1.created_at:46 flavor_extra_specs_1.updated_at:47
+           │    ├── key: (42)
+           │    └── fd: (42)-->(43-47), (43,45)-->(42,44,46,47)
            ├── limit
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:34 true:37
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:36 true:39
            │    ├── internal-ordering: +7 opt(11)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,34,37), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,36,39), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    ├── offset
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:34 true:37
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:36 true:39
            │    │    ├── internal-ordering: +7 opt(11)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,34,37), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,36,39), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    ├── ordering: +7 opt(11) [actual: +7]
            │    │    ├── sort
-           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:34 true:37
+           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:36 true:39
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,34,37), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,36,39), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │    ├── ordering: +7 opt(11) [actual: +7]
            │    │    │    └── select
-           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:34 true:37
+           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:36 true:39
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,34,37), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,36,39), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:34 true:37
+           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:36 true:39
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +27
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,34,37), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,36,39), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │         │    ├── select
-           │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:34
+           │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:36
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (1)
-           │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,34), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,36), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
            │    │    │         │    │    ├── left-join (merge)
-           │    │    │         │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:34
+           │    │    │         │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:36
            │    │    │         │    │    │    ├── left ordering: +1
            │    │    │         │    │    │    ├── right ordering: +19
            │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,34), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,36), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
            │    │    │         │    │    │    ├── select
            │    │    │         │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15
@@ -362,11 +362,11 @@ sort
            │    │    │         │    │    │    │    └── filters
            │    │    │         │    │    │    │         └── NOT disabled:11 [outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
            │    │    │         │    │    │    ├── project
-           │    │    │         │    │    │    │    ├── columns: true:34!null flavor_projects.flavor_id:19!null
+           │    │    │         │    │    │    │    ├── columns: true:36!null flavor_projects.flavor_id:19!null
            │    │    │         │    │    │    │    ├── has-placeholder
            │    │    │         │    │    │    │    ├── key: (19)
-           │    │    │         │    │    │    │    ├── fd: ()-->(34)
-           │    │    │         │    │    │    │    ├── ordering: +19 opt(34) [actual: +19]
+           │    │    │         │    │    │    │    ├── fd: ()-->(36)
+           │    │    │         │    │    │    │    ├── ordering: +19 opt(36) [actual: +19]
            │    │    │         │    │    │    │    ├── select
            │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
            │    │    │         │    │    │    │    │    ├── has-placeholder
@@ -380,16 +380,16 @@ sort
            │    │    │         │    │    │    │    │    └── filters
            │    │    │         │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
            │    │    │         │    │    │    │    └── projections
-           │    │    │         │    │    │    │         └── true [as=true:34]
+           │    │    │         │    │    │    │         └── true [as=true:36]
            │    │    │         │    │    │    └── filters (true)
            │    │    │         │    │    └── filters
-           │    │    │         │    │         └── is_public:12 OR (true:34 IS NOT NULL) [outer=(12,34)]
+           │    │    │         │    │         └── is_public:12 OR (true:36 IS NOT NULL) [outer=(12,36)]
            │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:37!null flavor_projects.flavor_id:27!null
+           │    │    │         │    │    ├── columns: true:39!null flavor_projects.flavor_id:27!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (27)
-           │    │    │         │    │    ├── fd: ()-->(37)
-           │    │    │         │    │    ├── ordering: +27 opt(37) [actual: +27]
+           │    │    │         │    │    ├── fd: ()-->(39)
+           │    │    │         │    │    ├── ordering: +27 opt(39) [actual: +27]
            │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
            │    │    │         │    │    │    ├── has-placeholder
@@ -403,14 +403,14 @@ sort
            │    │    │         │    │    │    └── filters
            │    │    │         │    │    │         └── project_id:28 = $2 [outer=(28), constraints=(/28: (/NULL - ]), fd=()-->(28)]
            │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:37]
+           │    │    │         │    │         └── true [as=true:39]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:37 IS NOT NULL) [outer=(12,37)]
+           │    │    │              └── is_public:12 OR (true:39 IS NOT NULL) [outer=(12,39)]
            │    │    └── $3
            │    └── $4
            └── filters
-                └── flavor_extra_specs_1.flavor_id:43 = flavors.id:1 [outer=(1,43), constraints=(/1: (/NULL - ]; /43: (/NULL - ]), fd=(1)==(43), (43)==(1)]
+                └── flavor_extra_specs_1.flavor_id:45 = flavors.id:1 [outer=(1,45), constraints=(/1: (/NULL - ]; /45: (/NULL - ]), fd=(1)==(45), (45)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -473,63 +473,63 @@ order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
 sort
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
  ├── immutable, has-placeholder
- ├── key: (1,32)
- ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
+ ├── key: (1,33)
+ ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
  ├── ordering: +7,+1 opt(13) [actual: +7,+1]
  └── project
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
       ├── immutable, has-placeholder
-      ├── key: (1,32)
-      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
+      ├── key: (1,33)
+      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
       └── right-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
            ├── immutable, has-placeholder
-           ├── key: (1,32)
-           ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
+           ├── key: (1,33)
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
            ├── select
-           │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36!null instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+           │    ├── columns: instance_type_extra_specs_1.id:33!null key:34 value:35 instance_type_extra_specs_1.instance_type_id:36!null instance_type_extra_specs_1.deleted:37!null instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
            │    ├── has-placeholder
-           │    ├── key: (32)
-           │    ├── fd: ()-->(36), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39)
+           │    ├── key: (33)
+           │    ├── fd: ()-->(37), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40)
            │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-           │    │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
-           │    │    ├── key: (32)
-           │    │    └── fd: (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
+           │    │    ├── columns: instance_type_extra_specs_1.id:33!null key:34 value:35 instance_type_extra_specs_1.instance_type_id:36!null instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+           │    │    ├── key: (33)
+           │    │    └── fd: (33)-->(34-40), (34,36,37)~~>(33,35,38-40)
            │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:36 = $7 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
+           │         └── instance_type_extra_specs_1.deleted:37 = $7 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
            ├── limit
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    ├── internal-ordering: +7,+1 opt(13)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    │    ├── internal-ordering: +7,+1 opt(13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
            │    │    ├── sort
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
            │    │    │    └── select
-           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +20
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         │    ├── select
            │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    ├── has-placeholder
@@ -544,11 +544,11 @@ sort
            │    │    │         │    │    └── filters
            │    │    │         │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:29!null instance_type_projects.instance_type_id:20!null
+           │    │    │         │    │    ├── columns: true:30!null instance_type_projects.instance_type_id:20!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (20)
-           │    │    │         │    │    ├── fd: ()-->(29)
-           │    │    │         │    │    ├── ordering: +20 opt(29) [actual: +20]
+           │    │    │         │    │    ├── fd: ()-->(30)
+           │    │    │         │    │    ├── ordering: +20 opt(30) [actual: +20]
            │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
            │    │    │         │    │    │    ├── has-placeholder
@@ -564,14 +564,14 @@ sort
            │    │    │         │    │    │         ├── instance_type_projects.deleted:22 = $3 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
            │    │    │         │    │    │         └── project_id:21 = $4 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
            │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:29]
+           │    │    │         │    │         └── true [as=true:30]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
+           │    │    │              └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
            │    │    └── $5
            │    └── $6
            └── filters
-                └── instance_type_extra_specs_1.instance_type_id:35 = instance_types.id:1 [outer=(1,35), constraints=(/1: (/NULL - ]; /35: (/NULL - ]), fd=(1)==(35), (35)==(1)]
+                └── instance_type_extra_specs_1.instance_type_id:36 = instance_types.id:1 [outer=(1,36), constraints=(/1: (/NULL - ]; /36: (/NULL - ]), fd=(1)==(36), (36)==(1)]
 
 opt
 select instance_types.created_at as instance_types_created_at,
@@ -623,10 +623,10 @@ sort
       ├── key: (1,19)
       ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (19)-->(20-22,24-26), (20,22,23)~~>(19,21,24-26), (1,19)-->(23)
       └── right-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:19 key:20 value:21 instance_type_extra_specs_1.instance_type_id:22 instance_type_extra_specs_1.deleted:23 instance_type_extra_specs_1.deleted_at:24 instance_type_extra_specs_1.created_at:25 instance_type_extra_specs_1.updated_at:26 instance_type_projects.instance_type_id:30 true:39
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:19 key:20 value:21 instance_type_extra_specs_1.instance_type_id:22 instance_type_extra_specs_1.deleted:23 instance_type_extra_specs_1.deleted_at:24 instance_type_extra_specs_1.created_at:25 instance_type_extra_specs_1.updated_at:26 instance_type_projects.instance_type_id:30 true:40
            ├── has-placeholder
            ├── key: (1,19)
-           ├── fd: ()-->(13), (1)-->(2-12,14-16,30,39), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (19)-->(20-22,24-26), (20,22,23)~~>(19,21,24-26), (1,19)-->(23)
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,30,40), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (19)-->(20-22,24-26), (20,22,23)~~>(19,21,24-26), (1,19)-->(23)
            ├── select
            │    ├── columns: instance_type_extra_specs_1.id:19!null key:20 value:21 instance_type_extra_specs_1.instance_type_id:22!null instance_type_extra_specs_1.deleted:23!null instance_type_extra_specs_1.deleted_at:24 instance_type_extra_specs_1.created_at:25 instance_type_extra_specs_1.updated_at:26
            │    ├── has-placeholder
@@ -639,17 +639,17 @@ sort
            │    └── filters
            │         └── instance_type_extra_specs_1.deleted:23 = $1 [outer=(23), constraints=(/23: (/NULL - ]), fd=()-->(23)]
            ├── select
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:30 true:39
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:30 true:40
            │    ├── has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30,39), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30,40), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── left-join (merge)
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:30 true:39
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:30 true:40
            │    │    ├── left ordering: +1
            │    │    ├── right ordering: +30
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30,39), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30,40), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    ├── select
            │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │    ├── has-placeholder
@@ -664,11 +664,11 @@ sort
            │    │    │    └── filters
            │    │    │         └── instance_types.deleted:13 = $2 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    ├── project
-           │    │    │    ├── columns: true:39!null instance_type_projects.instance_type_id:30!null
+           │    │    │    ├── columns: true:40!null instance_type_projects.instance_type_id:30!null
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (30)
-           │    │    │    ├── fd: ()-->(39)
-           │    │    │    ├── ordering: +30 opt(39) [actual: +30]
+           │    │    │    ├── fd: ()-->(40)
+           │    │    │    ├── ordering: +30 opt(40) [actual: +30]
            │    │    │    ├── select
            │    │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31!null instance_type_projects.deleted:32!null
            │    │    │    │    ├── has-placeholder
@@ -683,10 +683,10 @@ sort
            │    │    │    │         ├── instance_type_projects.deleted:32 = $3 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
            │    │    │    │         └── project_id:31 = $4 [outer=(31), constraints=(/31: (/NULL - ]), fd=()-->(31)]
            │    │    │    └── projections
-           │    │    │         └── true [as=true:39]
+           │    │    │         └── true [as=true:40]
            │    │    └── filters (true)
            │    └── filters
-           │         └── is_public:12 OR (true:39 IS NOT NULL) [outer=(12,39)]
+           │         └── is_public:12 OR (true:40 IS NOT NULL) [outer=(12,40)]
            └── filters
                 └── instance_type_extra_specs_1.instance_type_id:22 = instance_types.id:1 [outer=(1,22), constraints=(/1: (/NULL - ]; /22: (/NULL - ]), fd=(1)==(22), (22)==(1)]
 
@@ -748,47 +748,47 @@ from (select instance_types.created_at as instance_types_created_at,
         and instance_type_extra_specs_1.deleted = $7
 ----
 project
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2!null anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2!null anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
  ├── immutable, has-placeholder
- ├── key: (32)
- ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
+ ├── key: (33)
+ ├── fd: ()-->(1-16,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
-      ├── key columns: [32] = [32]
+      ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+      ├── key columns: [33] = [33]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (32)
-      ├── fd: ()-->(1-16,20,29,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
+      ├── key: (33)
+      ├── fd: ()-->(1-16,20,30,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
-      │    ├── key columns: [1] = [35]
+      │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37
+      │    ├── key columns: [1] = [36]
       │    ├── immutable, has-placeholder
-      │    ├── key: (32)
-      │    ├── fd: ()-->(1-16,20,29,35,36), (32)-->(33), (33,35,36)~~>(32)
+      │    ├── key: (33)
+      │    ├── fd: ()-->(1-16,20,30,36,37), (33)-->(34), (34,36,37)~~>(33)
       │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+      │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    ├── fd: ()-->(1-16,20,30)
       │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+      │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    ├── fd: ()-->(1-16,20,30)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+      │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    ├── fd: ()-->(1-16,20,30)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:29 instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
+      │    │    │    │    │    ├── columns: true:30 instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    │    ├── fd: ()-->(1-16,20,30)
       │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
       │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    │    │    │    │    ├── key columns: [1] = [20]
@@ -820,13 +820,13 @@ project
       │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
       │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:29, outer=(20)]
+      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:30, outer=(20)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
+      │    │    │    │         └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
       │    │    │    └── $5
       │    │    └── $6
       │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:36 = $7 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
+      │         └── instance_type_extra_specs_1.deleted:37 = $7 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
       └── filters (true)
 
 opt
@@ -887,47 +887,47 @@ from (select instance_types.created_at as instance_types_created_at,
         and instance_type_extra_specs_1.deleted = $7
 ----
 project
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
  ├── immutable, has-placeholder
- ├── key: (32)
- ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
+ ├── key: (33)
+ ├── fd: ()-->(1-16,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
-      ├── key columns: [32] = [32]
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+      ├── key columns: [33] = [33]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (32)
-      ├── fd: ()-->(1-16,20,29,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
+      ├── key: (33)
+      ├── fd: ()-->(1-16,20,30,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
-      │    ├── key columns: [1] = [35]
+      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37
+      │    ├── key columns: [1] = [36]
       │    ├── immutable, has-placeholder
-      │    ├── key: (32)
-      │    ├── fd: ()-->(1-16,20,29,35,36), (32)-->(33), (33,35,36)~~>(32)
+      │    ├── key: (33)
+      │    ├── fd: ()-->(1-16,20,30,36,37), (33)-->(34), (34,36,37)~~>(33)
       │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    ├── fd: ()-->(1-16,20,30)
       │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    ├── fd: ()-->(1-16,20,30)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    ├── fd: ()-->(1-16,20,30)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:29 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
+      │    │    │    │    │    ├── columns: true:30 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    │    ├── fd: ()-->(1-16,20,30)
       │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
       │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    │    │    │    │    ├── key columns: [1] = [20]
@@ -953,13 +953,13 @@ project
       │    │    │    │    │    │         ├── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
       │    │    │    │    │    │         └── instance_type_projects.instance_type_id:20 = $4 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:29, outer=(20)]
+      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:30, outer=(20)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
+      │    │    │    │         └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
       │    │    │    └── $5
       │    │    └── $6
       │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:36 = $7 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
+      │         └── instance_type_extra_specs_1.deleted:37 = $7 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
       └── filters (true)
 
 opt
@@ -1011,47 +1011,47 @@ from (select flavors.created_at as flavors_created_at,
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 ----
 project
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
  ├── immutable, has-placeholder
- ├── key: (29)
- ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
+ ├── key: (30)
+ ├── fd: ()-->(1-12,14,15,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
-      ├── key columns: [29] = [29]
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
+      ├── key columns: [30] = [30]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (29)
-      ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
+      ├── key: (30)
+      ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
-      │    ├── key columns: [1] = [32]
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 flavor_extra_specs_1.flavor_id:33
+      │    ├── key columns: [1] = [33]
       │    ├── immutable, has-placeholder
-      │    ├── key: (29)
-      │    ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30), (30)-->(29)
+      │    ├── key: (30)
+      │    ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31), (31)-->(30)
       │    ├── limit
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    ├── offset
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:26 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
+      │    │    │    │    │    ├── columns: true:27 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
       │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    │    │    │    │    ├── key columns: [1] = [19]
@@ -1074,9 +1074,9 @@ project
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:26, outer=(19)]
+      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:27, outer=(19)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
+      │    │    │    │         └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
       │    │    │    └── $3
       │    │    └── $4
       │    └── filters (true)
@@ -1131,47 +1131,47 @@ from (select flavors.created_at as flavors_created_at,
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 ----
 project
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
  ├── immutable, has-placeholder
- ├── key: (29)
- ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
+ ├── key: (30)
+ ├── fd: ()-->(1-12,14,15,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
-      ├── key columns: [29] = [29]
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
+      ├── key columns: [30] = [30]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (29)
-      ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
+      ├── key: (30)
+      ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
-      │    ├── key columns: [1] = [32]
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 flavor_extra_specs_1.flavor_id:33
+      │    ├── key columns: [1] = [33]
       │    ├── immutable, has-placeholder
-      │    ├── key: (29)
-      │    ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30), (30)-->(29)
+      │    ├── key: (30)
+      │    ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31), (31)-->(30)
       │    ├── limit
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    ├── offset
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:26 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
+      │    │    │    │    │    ├── columns: true:27 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
       │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    │    │    │    │    ├── key columns: [1] = [19]
@@ -1194,9 +1194,9 @@ project
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:26, outer=(19)]
+      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:27, outer=(19)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
+      │    │    │    │         └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
       │    │    │    └── $3
       │    │    └── $4
       │    └── filters (true)
@@ -1255,56 +1255,56 @@ from (select flavors.created_at as flavors_created_at,
 order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
  ├── immutable, has-placeholder
- ├── key: (1,29)
- ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+ ├── key: (1,30)
+ ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (30)-->(31-35), (31,33)-->(30,32,34,35)
  ├── ordering: +7
  └── project
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
       ├── immutable, has-placeholder
-      ├── key: (1,29)
-      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+      ├── key: (1,30)
+      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (30)-->(31-35), (31,33)-->(30,32,34,35)
       └── right-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
            ├── immutable, has-placeholder
-           ├── key: (1,29)
-           ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+           ├── key: (1,30)
+           ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (30)-->(31-35), (31,33)-->(30,32,34,35)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-           │    ├── columns: flavor_extra_specs_1.id:29!null key:30!null value:31 flavor_extra_specs_1.flavor_id:32!null flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
-           │    ├── key: (29)
-           │    └── fd: (29)-->(30-34), (30,32)-->(29,31,33,34)
+           │    ├── columns: flavor_extra_specs_1.id:30!null key:31!null value:32 flavor_extra_specs_1.flavor_id:33!null flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
+           │    ├── key: (30)
+           │    └── fd: (30)-->(31-35), (31,33)-->(30,32,34,35)
            ├── limit
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    ├── internal-ordering: +7
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    ├── offset
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    │    ├── internal-ordering: +7
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    ├── ordering: +7
            │    │    ├── sort
-           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │    ├── ordering: +7
            │    │    │    └── select
-           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +19
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │         │    ├── select
            │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
            │    │    │         │    │    ├── has-placeholder
@@ -1319,11 +1319,11 @@ sort
            │    │    │         │    │    └── filters
            │    │    │         │    │         └── (flavorid:7 > $2) OR ((flavorid:7 = $3) AND (flavors.id:1 > $4)) [outer=(1,7), constraints=(/7: (/NULL - ])]
            │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:26!null flavor_projects.flavor_id:19!null
+           │    │    │         │    │    ├── columns: true:27!null flavor_projects.flavor_id:19!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (19)
-           │    │    │         │    │    ├── fd: ()-->(26)
-           │    │    │         │    │    ├── ordering: +19 opt(26) [actual: +19]
+           │    │    │         │    │    ├── fd: ()-->(27)
+           │    │    │         │    │    ├── ordering: +19 opt(27) [actual: +19]
            │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
            │    │    │         │    │    │    ├── has-placeholder
@@ -1337,14 +1337,14 @@ sort
            │    │    │         │    │    │    └── filters
            │    │    │         │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
            │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:26]
+           │    │    │         │    │         └── true [as=true:27]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
+           │    │    │              └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
            │    │    └── $5
            │    └── $6
            └── filters
-                └── flavor_extra_specs_1.flavor_id:32 = flavors.id:1 [outer=(1,32), constraints=(/1: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(32), (32)==(1)]
+                └── flavor_extra_specs_1.flavor_id:33 = flavors.id:1 [outer=(1,33), constraints=(/1: (/NULL - ]; /33: (/NULL - ]), fd=(1)==(33), (33)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -1406,63 +1406,63 @@ order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
 sort
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
  ├── immutable, has-placeholder
- ├── key: (1,32)
- ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
+ ├── key: (1,33)
+ ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
  ├── ordering: +7,+1 opt(13) [actual: +7,+1]
  └── project
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
       ├── immutable, has-placeholder
-      ├── key: (1,32)
-      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
+      ├── key: (1,33)
+      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
       └── right-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
            ├── immutable, has-placeholder
-           ├── key: (1,32)
-           ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
+           ├── key: (1,33)
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
            ├── select
-           │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36!null instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+           │    ├── columns: instance_type_extra_specs_1.id:33!null key:34 value:35 instance_type_extra_specs_1.instance_type_id:36!null instance_type_extra_specs_1.deleted:37!null instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
            │    ├── has-placeholder
-           │    ├── key: (32)
-           │    ├── fd: ()-->(36), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39)
+           │    ├── key: (33)
+           │    ├── fd: ()-->(37), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40)
            │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-           │    │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
-           │    │    ├── key: (32)
-           │    │    └── fd: (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
+           │    │    ├── columns: instance_type_extra_specs_1.id:33!null key:34 value:35 instance_type_extra_specs_1.instance_type_id:36!null instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+           │    │    ├── key: (33)
+           │    │    └── fd: (33)-->(34-40), (34,36,37)~~>(33,35,38-40)
            │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:36 = $6 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
+           │         └── instance_type_extra_specs_1.deleted:37 = $6 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
            ├── limit
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    ├── internal-ordering: +7,+1 opt(13)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    │    ├── internal-ordering: +7,+1 opt(13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
            │    │    ├── sort
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
            │    │    │    └── select
-           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +20
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         │    ├── select
            │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    ├── has-placeholder
@@ -1477,11 +1477,11 @@ sort
            │    │    │         │    │    └── filters
            │    │    │         │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:29!null instance_type_projects.instance_type_id:20!null
+           │    │    │         │    │    ├── columns: true:30!null instance_type_projects.instance_type_id:20!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (20)
-           │    │    │         │    │    ├── fd: ()-->(29)
-           │    │    │         │    │    ├── ordering: +20 opt(29) [actual: +20]
+           │    │    │         │    │    ├── fd: ()-->(30)
+           │    │    │         │    │    ├── ordering: +20 opt(30) [actual: +20]
            │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
            │    │    │         │    │    │    ├── has-placeholder
@@ -1496,14 +1496,14 @@ sort
            │    │    │         │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
            │    │    │         │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
            │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:29]
+           │    │    │         │    │         └── true [as=true:30]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
+           │    │    │              └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
            │    │    └── $4
            │    └── $5
            └── filters
-                └── instance_type_extra_specs_1.instance_type_id:35 = instance_types.id:1 [outer=(1,35), constraints=(/1: (/NULL - ]; /35: (/NULL - ]), fd=(1)==(35), (35)==(1)]
+                └── instance_type_extra_specs_1.instance_type_id:36 = instance_types.id:1 [outer=(1,36), constraints=(/1: (/NULL - ]; /36: (/NULL - ]), fd=(1)==(36), (36)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -1563,47 +1563,47 @@ from (select instance_types.created_at as instance_types_created_at,
         and instance_type_extra_specs_1.deleted = $7
 ----
 project
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
  ├── immutable, has-placeholder
- ├── key: (32)
- ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
+ ├── key: (33)
+ ├── fd: ()-->(1-16,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
-      ├── key columns: [32] = [32]
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+      ├── key columns: [33] = [33]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (32)
-      ├── fd: ()-->(1-16,20,29,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
+      ├── key: (33)
+      ├── fd: ()-->(1-16,20,30,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
-      │    ├── key columns: [1] = [35]
+      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37
+      │    ├── key columns: [1] = [36]
       │    ├── immutable, has-placeholder
-      │    ├── key: (32)
-      │    ├── fd: ()-->(1-16,20,29,35,36), (32)-->(33), (33,35,36)~~>(32)
+      │    ├── key: (33)
+      │    ├── fd: ()-->(1-16,20,30,36,37), (33)-->(34), (34,36,37)~~>(33)
       │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    ├── fd: ()-->(1-16,20,30)
       │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    ├── fd: ()-->(1-16,20,30)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    ├── fd: ()-->(1-16,20,30)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:29 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
+      │    │    │    │    │    ├── columns: true:30 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    │    ├── fd: ()-->(1-16,20,30)
       │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
       │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    │    │    │    │    ├── key columns: [1] = [20]
@@ -1635,13 +1635,13 @@ project
       │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
       │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:29, outer=(20)]
+      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:30, outer=(20)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
+      │    │    │    │         └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
       │    │    │    └── $5
       │    │    └── $6
       │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:36 = $7 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
+      │         └── instance_type_extra_specs_1.deleted:37 = $7 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
       └── filters (true)
 
 opt
@@ -1687,37 +1687,37 @@ sort
       ├── key: (1,18)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (18)-->(19-23), (19,21)-->(18,20,22,23)
       └── right-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:18 key:19 value:20 flavor_extra_specs_1.flavor_id:21 flavor_extra_specs_1.created_at:22 flavor_extra_specs_1.updated_at:23 flavor_projects.flavor_id:27 true:34
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:18 key:19 value:20 flavor_extra_specs_1.flavor_id:21 flavor_extra_specs_1.created_at:22 flavor_extra_specs_1.updated_at:23 flavor_projects.flavor_id:27 true:35
            ├── has-placeholder
            ├── key: (1,18)
-           ├── fd: (1)-->(2-12,14,15,27,34), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (18)-->(19-23), (19,21)-->(18,20,22,23)
+           ├── fd: (1)-->(2-12,14,15,27,35), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (18)-->(19-23), (19,21)-->(18,20,22,23)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
            │    ├── columns: flavor_extra_specs_1.id:18!null key:19!null value:20 flavor_extra_specs_1.flavor_id:21!null flavor_extra_specs_1.created_at:22 flavor_extra_specs_1.updated_at:23
            │    ├── key: (18)
            │    └── fd: (18)-->(19-23), (19,21)-->(18,20,22,23)
            ├── select
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:27 true:34
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:27 true:35
            │    ├── has-placeholder
            │    ├── key: (1)
-           │    ├── fd: (1)-->(2-12,14,15,27,34), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    ├── fd: (1)-->(2-12,14,15,27,35), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    ├── left-join (merge)
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:27 true:34
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:27 true:35
            │    │    ├── left ordering: +1
            │    │    ├── right ordering: +27
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-12,14,15,27,34), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    ├── fd: (1)-->(2-12,14,15,27,35), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    ├── scan flavors
            │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
            │    │    │    ├── key: (1)
            │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │    └── ordering: +1
            │    │    ├── project
-           │    │    │    ├── columns: true:34!null flavor_projects.flavor_id:27!null
+           │    │    │    ├── columns: true:35!null flavor_projects.flavor_id:27!null
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (27)
-           │    │    │    ├── fd: ()-->(34)
-           │    │    │    ├── ordering: +27 opt(34) [actual: +27]
+           │    │    │    ├── fd: ()-->(35)
+           │    │    │    ├── ordering: +27 opt(35) [actual: +27]
            │    │    │    ├── select
            │    │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
            │    │    │    │    ├── has-placeholder
@@ -1731,10 +1731,10 @@ sort
            │    │    │    │    └── filters
            │    │    │    │         └── project_id:28 = $1 [outer=(28), constraints=(/28: (/NULL - ]), fd=()-->(28)]
            │    │    │    └── projections
-           │    │    │         └── true [as=true:34]
+           │    │    │         └── true [as=true:35]
            │    │    └── filters (true)
            │    └── filters
-           │         └── is_public:12 OR (true:34 IS NOT NULL) [outer=(12,34)]
+           │         └── is_public:12 OR (true:35 IS NOT NULL) [outer=(12,35)]
            └── filters
                 └── flavor_extra_specs_1.flavor_id:21 = flavors.id:1 [outer=(1,21), constraints=(/1: (/NULL - ]; /21: (/NULL - ]), fd=(1)==(21), (21)==(1)]
 
@@ -1801,63 +1801,63 @@ order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
 sort
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
  ├── immutable, has-placeholder
- ├── key: (1,32)
- ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
+ ├── key: (1,33)
+ ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
  ├── ordering: +7 opt(13) [actual: +7]
  └── project
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
       ├── immutable, has-placeholder
-      ├── key: (1,32)
-      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
+      ├── key: (1,33)
+      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
       └── right-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
            ├── immutable, has-placeholder
-           ├── key: (1,32)
-           ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
+           ├── key: (1,33)
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
            ├── select
-           │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36!null instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+           │    ├── columns: instance_type_extra_specs_1.id:33!null key:34 value:35 instance_type_extra_specs_1.instance_type_id:36!null instance_type_extra_specs_1.deleted:37!null instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
            │    ├── has-placeholder
-           │    ├── key: (32)
-           │    ├── fd: ()-->(36), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39)
+           │    ├── key: (33)
+           │    ├── fd: ()-->(37), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40)
            │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-           │    │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
-           │    │    ├── key: (32)
-           │    │    └── fd: (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
+           │    │    ├── columns: instance_type_extra_specs_1.id:33!null key:34 value:35 instance_type_extra_specs_1.instance_type_id:36!null instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+           │    │    ├── key: (33)
+           │    │    └── fd: (33)-->(34-40), (34,36,37)~~>(33,35,38-40)
            │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:36 = $9 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
+           │         └── instance_type_extra_specs_1.deleted:37 = $9 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
            ├── limit
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    ├── internal-ordering: +7 opt(13)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    │    ├── internal-ordering: +7 opt(13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    ├── ordering: +7 opt(13) [actual: +7]
            │    │    ├── sort
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │    ├── ordering: +7 opt(13) [actual: +7]
            │    │    │    └── select
-           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +20
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,29), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         │    ├── select
            │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    ├── has-placeholder
@@ -1873,11 +1873,11 @@ sort
            │    │    │         │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │         │    │         └── (flavorid:7 > $4) OR ((flavorid:7 = $5) AND (instance_types.id:1 > $6)) [outer=(1,7), constraints=(/7: (/NULL - ])]
            │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:29!null instance_type_projects.instance_type_id:20!null
+           │    │    │         │    │    ├── columns: true:30!null instance_type_projects.instance_type_id:20!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (20)
-           │    │    │         │    │    ├── fd: ()-->(29)
-           │    │    │         │    │    ├── ordering: +20 opt(29) [actual: +20]
+           │    │    │         │    │    ├── fd: ()-->(30)
+           │    │    │         │    │    ├── ordering: +20 opt(30) [actual: +20]
            │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
            │    │    │         │    │    │    ├── has-placeholder
@@ -1892,14 +1892,14 @@ sort
            │    │    │         │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
            │    │    │         │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
            │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:29]
+           │    │    │         │    │         └── true [as=true:30]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
+           │    │    │              └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
            │    │    └── $7
            │    └── $8
            └── filters
-                └── instance_type_extra_specs_1.instance_type_id:35 = instance_types.id:1 [outer=(1,35), constraints=(/1: (/NULL - ]; /35: (/NULL - ]), fd=(1)==(35), (35)==(1)]
+                └── instance_type_extra_specs_1.instance_type_id:36 = instance_types.id:1 [outer=(1,36), constraints=(/1: (/NULL - ]; /36: (/NULL - ]), fd=(1)==(36), (36)==(1)]
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -1951,67 +1951,67 @@ from (select flavors.created_at as flavors_created_at,
 order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
  ├── immutable, has-placeholder
- ├── key: (1,29)
- ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+ ├── key: (1,30)
+ ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (30)-->(31-35), (31,33)-->(30,32,34,35)
  ├── ordering: +7
  └── project
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
       ├── immutable, has-placeholder
-      ├── key: (1,29)
-      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+      ├── key: (1,30)
+      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (30)-->(31-35), (31,33)-->(30,32,34,35)
       └── right-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
            ├── immutable, has-placeholder
-           ├── key: (1,29)
-           ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+           ├── key: (1,30)
+           ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (30)-->(31-35), (31,33)-->(30,32,34,35)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-           │    ├── columns: flavor_extra_specs_1.id:29!null key:30!null value:31 flavor_extra_specs_1.flavor_id:32!null flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
-           │    ├── key: (29)
-           │    └── fd: (29)-->(30-34), (30,32)-->(29,31,33,34)
+           │    ├── columns: flavor_extra_specs_1.id:30!null key:31!null value:32 flavor_extra_specs_1.flavor_id:33!null flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
+           │    ├── key: (30)
+           │    └── fd: (30)-->(31-35), (31,33)-->(30,32,34,35)
            ├── limit
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    ├── internal-ordering: +7
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    ├── offset
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    │    ├── internal-ordering: +7
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    ├── ordering: +7
            │    │    ├── sort
-           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │    ├── ordering: +7
            │    │    │    └── select
-           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +19
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: (1)-->(2-12,14,15,19,26), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │         │    ├── scan flavors
            │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
            │    │    │         │    │    ├── key: (1)
            │    │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │         │    │    └── ordering: +1
            │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:26!null flavor_projects.flavor_id:19!null
+           │    │    │         │    │    ├── columns: true:27!null flavor_projects.flavor_id:19!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (19)
-           │    │    │         │    │    ├── fd: ()-->(26)
-           │    │    │         │    │    ├── ordering: +19 opt(26) [actual: +19]
+           │    │    │         │    │    ├── fd: ()-->(27)
+           │    │    │         │    │    ├── ordering: +19 opt(27) [actual: +19]
            │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
            │    │    │         │    │    │    ├── has-placeholder
@@ -2025,14 +2025,14 @@ sort
            │    │    │         │    │    │    └── filters
            │    │    │         │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
            │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:26]
+           │    │    │         │    │         └── true [as=true:27]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
+           │    │    │              └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
            │    │    └── $2
            │    └── $3
            └── filters
-                └── flavor_extra_specs_1.flavor_id:32 = flavors.id:1 [outer=(1,32), constraints=(/1: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(32), (32)==(1)]
+                └── flavor_extra_specs_1.flavor_id:33 = flavors.id:1 [outer=(1,33), constraints=(/1: (/NULL - ]; /33: (/NULL - ]), fd=(1)==(33), (33)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -2102,76 +2102,76 @@ order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
 sort
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11!null anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:51 instance_type_extra_specs_1_updated_at:52 instance_type_extra_specs_1_deleted_at:50 instance_type_extra_specs_1_deleted:49 instance_type_extra_specs_1_id:45 instance_type_extra_specs_1_key:46 instance_type_extra_specs_1_value:47 instance_type_extra_specs_1_instance_type_id:48
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11!null anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:53 instance_type_extra_specs_1_updated_at:54 instance_type_extra_specs_1_deleted_at:52 instance_type_extra_specs_1_deleted:51 instance_type_extra_specs_1_id:47 instance_type_extra_specs_1_key:48 instance_type_extra_specs_1_value:49 instance_type_extra_specs_1_instance_type_id:50
  ├── immutable, has-placeholder
- ├── key: (1,45)
- ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (45)-->(46-48,50-52), (46,48,49)~~>(45,47,50-52), (1,45)-->(49)
+ ├── key: (1,47)
+ ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (47)-->(48-50,52-54), (48,50,51)~~>(47,49,52-54), (1,47)-->(51)
  ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
  └── project
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:45 key:46 value:47 instance_type_extra_specs_1.instance_type_id:48 instance_type_extra_specs_1.deleted:49 instance_type_extra_specs_1.deleted_at:50 instance_type_extra_specs_1.created_at:51 instance_type_extra_specs_1.updated_at:52
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:47 key:48 value:49 instance_type_extra_specs_1.instance_type_id:50 instance_type_extra_specs_1.deleted:51 instance_type_extra_specs_1.deleted_at:52 instance_type_extra_specs_1.created_at:53 instance_type_extra_specs_1.updated_at:54
       ├── immutable, has-placeholder
-      ├── key: (1,45)
-      ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (45)-->(46-48,50-52), (46,48,49)~~>(45,47,50-52), (1,45)-->(49)
+      ├── key: (1,47)
+      ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (47)-->(48-50,52-54), (48,50,51)~~>(47,49,52-54), (1,47)-->(51)
       └── right-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:39 true:42 instance_type_extra_specs_1.id:45 key:46 value:47 instance_type_extra_specs_1.instance_type_id:48 instance_type_extra_specs_1.deleted:49 instance_type_extra_specs_1.deleted_at:50 instance_type_extra_specs_1.created_at:51 instance_type_extra_specs_1.updated_at:52
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:41 true:44 instance_type_extra_specs_1.id:47 key:48 value:49 instance_type_extra_specs_1.instance_type_id:50 instance_type_extra_specs_1.deleted:51 instance_type_extra_specs_1.deleted_at:52 instance_type_extra_specs_1.created_at:53 instance_type_extra_specs_1.updated_at:54
            ├── immutable, has-placeholder
-           ├── key: (1,45)
-           ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,39,42), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (45)-->(46-48,50-52), (46,48,49)~~>(45,47,50-52), (1,45)-->(49)
+           ├── key: (1,47)
+           ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,41,44), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (47)-->(48-50,52-54), (48,50,51)~~>(47,49,52-54), (1,47)-->(51)
            ├── select
-           │    ├── columns: instance_type_extra_specs_1.id:45!null key:46 value:47 instance_type_extra_specs_1.instance_type_id:48!null instance_type_extra_specs_1.deleted:49!null instance_type_extra_specs_1.deleted_at:50 instance_type_extra_specs_1.created_at:51 instance_type_extra_specs_1.updated_at:52
+           │    ├── columns: instance_type_extra_specs_1.id:47!null key:48 value:49 instance_type_extra_specs_1.instance_type_id:50!null instance_type_extra_specs_1.deleted:51!null instance_type_extra_specs_1.deleted_at:52 instance_type_extra_specs_1.created_at:53 instance_type_extra_specs_1.updated_at:54
            │    ├── has-placeholder
-           │    ├── key: (45)
-           │    ├── fd: ()-->(49), (45)-->(46-48,50-52), (46,48,49)~~>(45,47,50-52)
+           │    ├── key: (47)
+           │    ├── fd: ()-->(51), (47)-->(48-50,52-54), (48,50,51)~~>(47,49,52-54)
            │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-           │    │    ├── columns: instance_type_extra_specs_1.id:45!null key:46 value:47 instance_type_extra_specs_1.instance_type_id:48!null instance_type_extra_specs_1.deleted:49 instance_type_extra_specs_1.deleted_at:50 instance_type_extra_specs_1.created_at:51 instance_type_extra_specs_1.updated_at:52
-           │    │    ├── key: (45)
-           │    │    └── fd: (45)-->(46-52), (46,48,49)~~>(45,47,50-52)
+           │    │    ├── columns: instance_type_extra_specs_1.id:47!null key:48 value:49 instance_type_extra_specs_1.instance_type_id:50!null instance_type_extra_specs_1.deleted:51 instance_type_extra_specs_1.deleted_at:52 instance_type_extra_specs_1.created_at:53 instance_type_extra_specs_1.updated_at:54
+           │    │    ├── key: (47)
+           │    │    └── fd: (47)-->(48-54), (48,50,51)~~>(47,49,52-54)
            │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:49 = $9 [outer=(49), constraints=(/49: (/NULL - ]), fd=()-->(49)]
+           │         └── instance_type_extra_specs_1.deleted:51 = $9 [outer=(51), constraints=(/51: (/NULL - ]), fd=()-->(51)]
            ├── limit
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:39 true:42
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:41 true:44
            │    ├── internal-ordering: +7,+1 opt(11,13)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,39,42), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,41,44), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    ├── offset
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:39 true:42
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:41 true:44
            │    │    ├── internal-ordering: +7,+1 opt(11,13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,39,42), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,41,44), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
            │    │    ├── sort
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:39 true:42
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:41 true:44
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,39,42), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,41,44), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
            │    │    │    └── select
-           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:39 true:42
+           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:41 true:44
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,39,42), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,41,44), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:39 true:42
+           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:41 true:44
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +30
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,39,42), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,41,44), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │         │    ├── select
-           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:39
+           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:41
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (1)
-           │    │    │         │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,39), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,41), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │         │    │    ├── ordering: +1 opt(11,13) [actual: +1]
            │    │    │         │    │    ├── left-join (merge)
-           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:39
+           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:41
            │    │    │         │    │    │    ├── left ordering: +1
            │    │    │         │    │    │    ├── right ordering: +20
            │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,39), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,41), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │         │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
            │    │    │         │    │    │    ├── select
            │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
@@ -2188,11 +2188,11 @@ sort
            │    │    │         │    │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │         │    │    │    │         └── NOT disabled:11 [outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
            │    │    │         │    │    │    ├── project
-           │    │    │         │    │    │    │    ├── columns: true:39!null instance_type_projects.instance_type_id:20!null
+           │    │    │         │    │    │    │    ├── columns: true:41!null instance_type_projects.instance_type_id:20!null
            │    │    │         │    │    │    │    ├── has-placeholder
            │    │    │         │    │    │    │    ├── key: (20)
-           │    │    │         │    │    │    │    ├── fd: ()-->(39)
-           │    │    │         │    │    │    │    ├── ordering: +20 opt(39) [actual: +20]
+           │    │    │         │    │    │    │    ├── fd: ()-->(41)
+           │    │    │         │    │    │    │    ├── ordering: +20 opt(41) [actual: +20]
            │    │    │         │    │    │    │    ├── select
            │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
            │    │    │         │    │    │    │    │    ├── has-placeholder
@@ -2207,16 +2207,16 @@ sort
            │    │    │         │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
            │    │    │         │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
            │    │    │         │    │    │    │    └── projections
-           │    │    │         │    │    │    │         └── true [as=true:39]
+           │    │    │         │    │    │    │         └── true [as=true:41]
            │    │    │         │    │    │    └── filters (true)
            │    │    │         │    │    └── filters
-           │    │    │         │    │         └── is_public:12 OR (true:39 IS NOT NULL) [outer=(12,39)]
+           │    │    │         │    │         └── is_public:12 OR (true:41 IS NOT NULL) [outer=(12,41)]
            │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:42!null instance_type_projects.instance_type_id:30!null
+           │    │    │         │    │    ├── columns: true:44!null instance_type_projects.instance_type_id:30!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (30)
-           │    │    │         │    │    ├── fd: ()-->(42)
-           │    │    │         │    │    ├── ordering: +30 opt(42) [actual: +30]
+           │    │    │         │    │    ├── fd: ()-->(44)
+           │    │    │         │    │    ├── ordering: +30 opt(44) [actual: +30]
            │    │    │         │    │    ├── select
            │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31!null instance_type_projects.deleted:32!null
            │    │    │         │    │    │    ├── has-placeholder
@@ -2232,14 +2232,14 @@ sort
            │    │    │         │    │    │         ├── instance_type_projects.deleted:32 = $5 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
            │    │    │         │    │    │         └── project_id:31 = $6 [outer=(31), constraints=(/31: (/NULL - ]), fd=()-->(31)]
            │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:42]
+           │    │    │         │    │         └── true [as=true:44]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:42 IS NOT NULL) [outer=(12,42)]
+           │    │    │              └── is_public:12 OR (true:44 IS NOT NULL) [outer=(12,44)]
            │    │    └── $7
            │    └── $8
            └── filters
-                └── instance_type_extra_specs_1.instance_type_id:48 = instance_types.id:1 [outer=(1,48), constraints=(/1: (/NULL - ]; /48: (/NULL - ]), fd=(1)==(48), (48)==(1)]
+                └── instance_type_extra_specs_1.instance_type_id:50 = instance_types.id:1 [outer=(1,50), constraints=(/1: (/NULL - ]; /50: (/NULL - ]), fd=(1)==(50), (50)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -2302,47 +2302,47 @@ order by anon_1.instance_types_deleted asc,
          anon_1.instance_types_id asc
 ----
 project
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
  ├── immutable, has-placeholder
- ├── key: (32)
- ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
+ ├── key: (33)
+ ├── fd: ()-->(1-16,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
-      ├── key columns: [32] = [32]
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+      ├── key columns: [33] = [33]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (32)
-      ├── fd: ()-->(1-16,20,29,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
+      ├── key: (33)
+      ├── fd: ()-->(1-16,20,30,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
-      │    ├── key columns: [1] = [35]
+      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37
+      │    ├── key columns: [1] = [36]
       │    ├── immutable, has-placeholder
-      │    ├── key: (32)
-      │    ├── fd: ()-->(1-16,20,29,35,36), (32)-->(33), (33,35,36)~~>(32)
+      │    ├── key: (33)
+      │    ├── fd: ()-->(1-16,20,30,36,37), (33)-->(34), (34,36,37)~~>(33)
       │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    ├── fd: ()-->(1-16,20,30)
       │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    ├── fd: ()-->(1-16,20,30)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:29
+      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    ├── fd: ()-->(1-16,20,30)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:29 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
+      │    │    │    │    │    ├── columns: true:30 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-16,20,29)
+      │    │    │    │    │    ├── fd: ()-->(1-16,20,30)
       │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
       │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    │    │    │    │    ├── key columns: [1] = [20]
@@ -2374,13 +2374,13 @@ project
       │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
       │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:29, outer=(20)]
+      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:30, outer=(20)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:29 IS NOT NULL) [outer=(12,29)]
+      │    │    │    │         └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
       │    │    │    └── $5
       │    │    └── $6
       │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:36 = $7 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
+      │         └── instance_type_extra_specs_1.deleted:37 = $7 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
       └── filters (true)
 
 opt
@@ -2432,47 +2432,47 @@ from (select flavors.created_at as flavors_created_at,
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 ----
 project
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
  ├── immutable, has-placeholder
- ├── key: (29)
- ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
+ ├── key: (30)
+ ├── fd: ()-->(1-12,14,15,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
-      ├── key columns: [29] = [29]
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
+      ├── key columns: [30] = [30]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (29)
-      ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
+      ├── key: (30)
+      ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
-      │    ├── key columns: [1] = [32]
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 flavor_extra_specs_1.flavor_id:33
+      │    ├── key columns: [1] = [33]
       │    ├── immutable, has-placeholder
-      │    ├── key: (29)
-      │    ├── fd: ()-->(1-12,14,15,19,26,32), (29)-->(30), (30)-->(29)
+      │    ├── key: (30)
+      │    ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31), (31)-->(30)
       │    ├── limit
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    ├── offset
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:26 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
+      │    │    │    │    │    ├── columns: true:27 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,26)
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
       │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
       │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    │    │    │    │    ├── key columns: [1] = [19]
@@ -2496,9 +2496,9 @@ project
       │    │    │    │    │    │         ├── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │    │    │         └── flavor_projects.flavor_id:19 = $2 [outer=(19), constraints=(/19: (/NULL - ]), fd=()-->(19)]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:26, outer=(19)]
+      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:27, outer=(19)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
+      │    │    │    │         └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
       │    │    │    └── $3
       │    │    └── $4
       │    └── filters (true)
@@ -2555,60 +2555,60 @@ from (select flavors.created_at as flavors_created_at,
 order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 anon_1_flavors_description:13 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 anon_1_flavors_description:13 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
  ├── immutable, has-placeholder
- ├── key: (1,29)
- ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+ ├── key: (1,30)
+ ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (30)-->(31-35), (31,33)-->(30,32,34,35)
  ├── ordering: +7
  └── project
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
       ├── immutable, has-placeholder
-      ├── key: (1,29)
-      ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+      ├── key: (1,30)
+      ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (30)-->(31-35), (31,33)-->(30,32,34,35)
       └── right-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
            ├── immutable, has-placeholder
-           ├── key: (1,29)
-           ├── fd: (1)-->(2-15,19,26), (7)-->(1-6,8-15), (2)-->(1,3-15), (29)-->(30-34), (30,32)-->(29,31,33,34)
+           ├── key: (1,30)
+           ├── fd: (1)-->(2-15,19,27), (7)-->(1-6,8-15), (2)-->(1,3-15), (30)-->(31-35), (31,33)-->(30,32,34,35)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-           │    ├── columns: flavor_extra_specs_1.id:29!null key:30!null value:31 flavor_extra_specs_1.flavor_id:32!null flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
-           │    ├── key: (29)
-           │    └── fd: (29)-->(30-34), (30,32)-->(29,31,33,34)
+           │    ├── columns: flavor_extra_specs_1.id:30!null key:31!null value:32 flavor_extra_specs_1.flavor_id:33!null flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
+           │    ├── key: (30)
+           │    └── fd: (30)-->(31-35), (31,33)-->(30,32,34,35)
            ├── limit
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    ├── internal-ordering: +7
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: (1)-->(2-15,19,26), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    ├── fd: (1)-->(2-15,19,27), (7)-->(1-6,8-15), (2)-->(1,3-15)
            │    ├── sort
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-15,19,26), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │    ├── fd: (1)-->(2-15,19,27), (7)-->(1-6,8-15), (2)-->(1,3-15)
            │    │    ├── ordering: +7
            │    │    └── select
-           │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    │         ├── has-placeholder
            │    │         ├── key: (1)
-           │    │         ├── fd: (1)-->(2-15,19,26), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │         ├── fd: (1)-->(2-15,19,27), (7)-->(1-6,8-15), (2)-->(1,3-15)
            │    │         ├── left-join (merge)
-           │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:26
+           │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
            │    │         │    ├── left ordering: +1
            │    │         │    ├── right ordering: +19
            │    │         │    ├── has-placeholder
            │    │         │    ├── key: (1)
-           │    │         │    ├── fd: (1)-->(2-15,19,26), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │         │    ├── fd: (1)-->(2-15,19,27), (7)-->(1-6,8-15), (2)-->(1,3-15)
            │    │         │    ├── scan flavors
            │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15
            │    │         │    │    ├── key: (1)
            │    │         │    │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15)
            │    │         │    │    └── ordering: +1
            │    │         │    ├── project
-           │    │         │    │    ├── columns: true:26!null flavor_projects.flavor_id:19!null
+           │    │         │    │    ├── columns: true:27!null flavor_projects.flavor_id:19!null
            │    │         │    │    ├── has-placeholder
            │    │         │    │    ├── key: (19)
-           │    │         │    │    ├── fd: ()-->(26)
-           │    │         │    │    ├── ordering: +19 opt(26) [actual: +19]
+           │    │         │    │    ├── fd: ()-->(27)
+           │    │         │    │    ├── ordering: +19 opt(27) [actual: +19]
            │    │         │    │    ├── select
            │    │         │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
            │    │         │    │    │    ├── has-placeholder
@@ -2622,10 +2622,10 @@ sort
            │    │         │    │    │    └── filters
            │    │         │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
            │    │         │    │    └── projections
-           │    │         │    │         └── true [as=true:26]
+           │    │         │    │         └── true [as=true:27]
            │    │         │    └── filters (true)
            │    │         └── filters
-           │    │              └── is_public:12 OR (true:26 IS NOT NULL) [outer=(12,26)]
+           │    │              └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
            │    └── $2
            └── filters
-                └── flavor_extra_specs_1.flavor_id:32 = flavors.id:1 [outer=(1,32), constraints=(/1: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(32), (32)==(1)]
+                └── flavor_extra_specs_1.flavor_id:33 = flavors.id:1 [outer=(1,33), constraints=(/1: (/NULL - ]; /33: (/NULL - ]), fd=(1)==(33), (33)==(1)]

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -552,10 +552,10 @@ update_trade_submitted AS (
 SELECT * FROM request_list;
 ----
 with &1 (update_last_trade)
- ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
+ ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
  ├── volatile, mutations
- ├── key: (139)
- ├── fd: (139)-->(140-142)
+ ├── key: (141)
+ ├── fd: (141)-->(142-144)
  ├── project
  │    ├── columns: "?column?":19
  │    ├── cardinality: [0 - 1]
@@ -594,10 +594,10 @@ with &1 (update_last_trade)
  │    └── projections
  │         └── NULL [as="?column?":19]
  └── with &2 (request_list)
-      ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
+      ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
       ├── volatile, mutations
-      ├── key: (139)
-      ├── fd: (139)-->(140-142)
+      ├── key: (141)
+      ├── fd: (141)-->(142-144)
       ├── project
       │    ├── columns: tr_bid_price:28!null trade_request.tr_t_id:20!null trade_request.tr_tt_id:21!null trade_request.tr_qty:23!null
       │    ├── immutable
@@ -624,26 +624,26 @@ with &1 (update_last_trade)
       │    └── projections
       │         └── trade_request.tr_bid_price:24::FLOAT8 [as=tr_bid_price:28, outer=(24), immutable]
       └── with &3 (delete_trade_request)
-           ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
+           ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
            ├── volatile, mutations
-           ├── key: (139)
-           ├── fd: (139)-->(140-142)
+           ├── key: (141)
+           ├── fd: (141)-->(142-144)
            ├── project
-           │    ├── columns: "?column?":50
+           │    ├── columns: "?column?":51
            │    ├── volatile, mutations
-           │    ├── fd: ()-->(50)
+           │    ├── fd: ()-->(51)
            │    ├── delete trade_request
            │    │    ├── columns: trade_request.tr_t_id:29!null
            │    │    ├── fetch columns: trade_request.tr_t_id:37 tr_s_symb:39 tr_b_id:42
            │    │    ├── return-mapping:
            │    │    │    └── trade_request.tr_t_id:37 => trade_request.tr_t_id:29
-           │    │    ├── partial index del columns: partial_index_del1:49
+           │    │    ├── partial index del columns: partial_index_del1:50
            │    │    ├── volatile, mutations
            │    │    ├── key: (29)
            │    │    └── project
-           │    │         ├── columns: partial_index_del1:49!null trade_request.tr_t_id:37!null tr_s_symb:39!null tr_b_id:42!null
+           │    │         ├── columns: partial_index_del1:50!null trade_request.tr_t_id:37!null tr_s_symb:39!null tr_b_id:42!null
            │    │         ├── key: (37)
-           │    │         ├── fd: (37)-->(39,42,49)
+           │    │         ├── fd: (37)-->(39,42,50)
            │    │         ├── project
            │    │         │    ├── columns: trade_request.tr_t_id:37!null trade_request.tr_tt_id:38!null tr_s_symb:39!null tr_b_id:42!null
            │    │         │    ├── key: (37)
@@ -661,137 +661,137 @@ with &1 (update_last_trade)
            │    │         │         │    └── key: (45)
            │    │         │         └── filters (true)
            │    │         └── projections
-           │    │              └── trade_request.tr_tt_id:38 IN ('TLB', 'TLS', 'TSL') [as=partial_index_del1:49, outer=(38)]
+           │    │              └── trade_request.tr_tt_id:38 IN ('TLB', 'TLS', 'TSL') [as=partial_index_del1:50, outer=(38)]
            │    └── projections
-           │         └── NULL [as="?column?":50]
+           │         └── NULL [as="?column?":51]
            └── with &5 (insert_trade_history)
-                ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
+                ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
                 ├── volatile, mutations
-                ├── key: (139)
-                ├── fd: (139)-->(140-142)
+                ├── key: (141)
+                ├── fd: (141)-->(142-144)
                 ├── project
-                │    ├── columns: "?column?":86
+                │    ├── columns: "?column?":87
                 │    ├── volatile, mutations
-                │    ├── fd: ()-->(86)
+                │    ├── fd: ()-->(87)
                 │    ├── insert trade_history
-                │    │    ├── columns: trade_history.th_t_id:51!null trade_history.th_st_id:53!null
+                │    │    ├── columns: trade_history.th_t_id:52!null trade_history.th_st_id:54!null
                 │    │    ├── insert-mapping:
-                │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
-                │    │    │    ├── timestamp:61 => th_dts:52
-                │    │    │    └── th_st_id_cast:62 => trade_history.th_st_id:53
+                │    │    │    ├── tr_t_id:57 => trade_history.th_t_id:52
+                │    │    │    ├── timestamp:62 => th_dts:53
+                │    │    │    └── th_st_id_cast:63 => trade_history.th_st_id:54
                 │    │    ├── return-mapping:
-                │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
-                │    │    │    └── th_st_id_cast:62 => trade_history.th_st_id:53
+                │    │    │    ├── tr_t_id:57 => trade_history.th_t_id:52
+                │    │    │    └── th_st_id_cast:63 => trade_history.th_st_id:54
                 │    │    ├── input binding: &4
                 │    │    ├── volatile, mutations
-                │    │    ├── key: (51)
-                │    │    ├── fd: ()-->(53)
+                │    │    ├── key: (52)
+                │    │    ├── fd: ()-->(54)
                 │    │    ├── project
-                │    │    │    ├── columns: th_st_id_cast:62!null timestamp:61!null tr_t_id:56!null
-                │    │    │    ├── key: (56)
-                │    │    │    ├── fd: ()-->(61,62)
+                │    │    │    ├── columns: th_st_id_cast:63!null timestamp:62!null tr_t_id:57!null
+                │    │    │    ├── key: (57)
+                │    │    │    ├── fd: ()-->(62,63)
                 │    │    │    ├── with-scan &2 (request_list)
-                │    │    │    │    ├── columns: tr_t_id:56!null
+                │    │    │    │    ├── columns: tr_t_id:57!null
                 │    │    │    │    ├── mapping:
-                │    │    │    │    │    └──  trade_request.tr_t_id:20 => tr_t_id:56
-                │    │    │    │    └── key: (56)
+                │    │    │    │    │    └──  trade_request.tr_t_id:20 => tr_t_id:57
+                │    │    │    │    └── key: (57)
                 │    │    │    └── projections
-                │    │    │         ├── 'SBMT' [as=th_st_id_cast:62]
-                │    │    │         └── '2020-06-15 22:27:42.148484' [as=timestamp:61]
+                │    │    │         ├── 'SBMT' [as=th_st_id_cast:63]
+                │    │    │         └── '2020-06-15 22:27:42.148484' [as=timestamp:62]
                 │    │    └── f-k-checks
                 │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
                 │    │         │    └── anti-join (lookup trade)
-                │    │         │         ├── columns: th_t_id:63!null
-                │    │         │         ├── key columns: [63] = [64]
+                │    │         │         ├── columns: th_t_id:64!null
+                │    │         │         ├── key columns: [64] = [65]
                 │    │         │         ├── lookup columns are key
-                │    │         │         ├── key: (63)
+                │    │         │         ├── key: (64)
                 │    │         │         ├── with-scan &4
-                │    │         │         │    ├── columns: th_t_id:63!null
+                │    │         │         │    ├── columns: th_t_id:64!null
                 │    │         │         │    ├── mapping:
-                │    │         │         │    │    └──  tr_t_id:56 => th_t_id:63
-                │    │         │         │    └── key: (63)
+                │    │         │         │    │    └──  tr_t_id:57 => th_t_id:64
+                │    │         │         │    └── key: (64)
                 │    │         │         └── filters (true)
                 │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
                 │    │              └── anti-join (lookup status_type)
-                │    │                   ├── columns: th_st_id:81!null
-                │    │                   ├── key columns: [81] = [82]
+                │    │                   ├── columns: th_st_id:82!null
+                │    │                   ├── key columns: [82] = [83]
                 │    │                   ├── lookup columns are key
-                │    │                   ├── fd: ()-->(81)
+                │    │                   ├── fd: ()-->(82)
                 │    │                   ├── with-scan &4
-                │    │                   │    ├── columns: th_st_id:81!null
+                │    │                   │    ├── columns: th_st_id:82!null
                 │    │                   │    ├── mapping:
-                │    │                   │    │    └──  th_st_id_cast:62 => th_st_id:81
-                │    │                   │    └── fd: ()-->(81)
+                │    │                   │    │    └──  th_st_id_cast:63 => th_st_id:82
+                │    │                   │    └── fd: ()-->(82)
                 │    │                   └── filters (true)
                 │    └── projections
-                │         └── NULL [as="?column?":86]
+                │         └── NULL [as="?column?":87]
                 └── with &7 (update_trade_submitted)
-                     ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
+                     ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
                      ├── volatile, mutations
-                     ├── key: (139)
-                     ├── fd: (139)-->(140-142)
+                     ├── key: (141)
+                     ├── fd: (141)-->(142-144)
                      ├── project
-                     │    ├── columns: "?column?":138
+                     │    ├── columns: "?column?":140
                      │    ├── volatile, mutations
-                     │    ├── fd: ()-->(138)
+                     │    ├── fd: ()-->(140)
                      │    ├── update trade
-                     │    │    ├── columns: t_id:87!null
-                     │    │    ├── fetch columns: t_id:104 t_dts:105 trade.t_st_id:106 t_tt_id:107 t_is_cash:108 t_s_symb:109 t_qty:110 t_bid_price:111 t_ca_id:112 t_exec_name:113 t_trade_price:114 t_chrg:115 t_comm:116 t_lifo:118
+                     │    │    ├── columns: t_id:88!null
+                     │    │    ├── fetch columns: t_id:105 t_dts:106 trade.t_st_id:107 t_tt_id:108 t_is_cash:109 t_s_symb:110 t_qty:111 t_bid_price:112 t_ca_id:113 t_exec_name:114 t_trade_price:115 t_chrg:116 t_comm:117 t_lifo:119
                      │    │    ├── update-mapping:
-                     │    │    │    ├── t_dts_new:126 => t_dts:88
-                     │    │    │    └── t_st_id_cast:127 => trade.t_st_id:89
+                     │    │    │    ├── t_dts_new:128 => t_dts:89
+                     │    │    │    └── t_st_id_cast:129 => trade.t_st_id:90
                      │    │    ├── return-mapping:
-                     │    │    │    └── t_id:104 => t_id:87
+                     │    │    │    └── t_id:105 => t_id:88
                      │    │    ├── input binding: &6
                      │    │    ├── volatile, mutations
-                     │    │    ├── key: (87)
+                     │    │    ├── key: (88)
                      │    │    ├── project
-                     │    │    │    ├── columns: t_st_id_cast:127!null t_dts_new:126!null t_id:104!null t_dts:105!null trade.t_st_id:106!null t_tt_id:107!null t_is_cash:108!null t_s_symb:109!null t_qty:110!null t_bid_price:111!null t_ca_id:112!null t_exec_name:113!null t_trade_price:114 t_chrg:115!null t_comm:116!null t_lifo:118!null
-                     │    │    │    ├── key: (104)
-                     │    │    │    ├── fd: ()-->(126,127), (104)-->(105-116,118)
+                     │    │    │    ├── columns: t_st_id_cast:129!null t_dts_new:128!null t_id:105!null t_dts:106!null trade.t_st_id:107!null t_tt_id:108!null t_is_cash:109!null t_s_symb:110!null t_qty:111!null t_bid_price:112!null t_ca_id:113!null t_exec_name:114!null t_trade_price:115 t_chrg:116!null t_comm:117!null t_lifo:119!null
+                     │    │    │    ├── key: (105)
+                     │    │    │    ├── fd: ()-->(128,129), (105)-->(106-117,119)
                      │    │    │    ├── project
-                     │    │    │    │    ├── columns: t_id:104!null t_dts:105!null trade.t_st_id:106!null t_tt_id:107!null t_is_cash:108!null t_s_symb:109!null t_qty:110!null t_bid_price:111!null t_ca_id:112!null t_exec_name:113!null t_trade_price:114 t_chrg:115!null t_comm:116!null t_lifo:118!null
-                     │    │    │    │    ├── key: (104)
-                     │    │    │    │    ├── fd: (104)-->(105-116,118)
+                     │    │    │    │    ├── columns: t_id:105!null t_dts:106!null trade.t_st_id:107!null t_tt_id:108!null t_is_cash:109!null t_s_symb:110!null t_qty:111!null t_bid_price:112!null t_ca_id:113!null t_exec_name:114!null t_trade_price:115 t_chrg:116!null t_comm:117!null t_lifo:119!null
+                     │    │    │    │    ├── key: (105)
+                     │    │    │    │    ├── fd: (105)-->(106-117,119)
                      │    │    │    │    └── inner-join (lookup trade)
-                     │    │    │    │         ├── columns: t_id:104!null t_dts:105!null trade.t_st_id:106!null t_tt_id:107!null t_is_cash:108!null t_s_symb:109!null t_qty:110!null t_bid_price:111!null t_ca_id:112!null t_exec_name:113!null t_trade_price:114 t_chrg:115!null t_comm:116!null t_lifo:118!null tr_t_id:121!null
-                     │    │    │    │         ├── key columns: [121] = [104]
+                     │    │    │    │         ├── columns: t_id:105!null t_dts:106!null trade.t_st_id:107!null t_tt_id:108!null t_is_cash:109!null t_s_symb:110!null t_qty:111!null t_bid_price:112!null t_ca_id:113!null t_exec_name:114!null t_trade_price:115 t_chrg:116!null t_comm:117!null t_lifo:119!null tr_t_id:122!null
+                     │    │    │    │         ├── key columns: [122] = [105]
                      │    │    │    │         ├── lookup columns are key
-                     │    │    │    │         ├── key: (121)
-                     │    │    │    │         ├── fd: (104)-->(105-116,118), (104)==(121), (121)==(104)
+                     │    │    │    │         ├── key: (122)
+                     │    │    │    │         ├── fd: (105)-->(106-117,119), (105)==(122), (122)==(105)
                      │    │    │    │         ├── with-scan &2 (request_list)
-                     │    │    │    │         │    ├── columns: tr_t_id:121!null
+                     │    │    │    │         │    ├── columns: tr_t_id:122!null
                      │    │    │    │         │    ├── mapping:
-                     │    │    │    │         │    │    └──  trade_request.tr_t_id:20 => tr_t_id:121
-                     │    │    │    │         │    └── key: (121)
+                     │    │    │    │         │    │    └──  trade_request.tr_t_id:20 => tr_t_id:122
+                     │    │    │    │         │    └── key: (122)
                      │    │    │    │         └── filters (true)
                      │    │    │    └── projections
-                     │    │    │         ├── 'SBMT' [as=t_st_id_cast:127]
-                     │    │    │         └── '2020-06-15 22:27:42.148484' [as=t_dts_new:126]
+                     │    │    │         ├── 'SBMT' [as=t_st_id_cast:129]
+                     │    │    │         └── '2020-06-15 22:27:42.148484' [as=t_dts_new:128]
                      │    │    └── f-k-checks
                      │    │         └── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
                      │    │              └── anti-join (lookup status_type)
-                     │    │                   ├── columns: t_st_id:133!null
-                     │    │                   ├── key columns: [133] = [134]
+                     │    │                   ├── columns: t_st_id:135!null
+                     │    │                   ├── key columns: [135] = [136]
                      │    │                   ├── lookup columns are key
-                     │    │                   ├── fd: ()-->(133)
+                     │    │                   ├── fd: ()-->(135)
                      │    │                   ├── with-scan &6
-                     │    │                   │    ├── columns: t_st_id:133!null
+                     │    │                   │    ├── columns: t_st_id:135!null
                      │    │                   │    ├── mapping:
-                     │    │                   │    │    └──  t_st_id_cast:127 => t_st_id:133
-                     │    │                   │    └── fd: ()-->(133)
+                     │    │                   │    │    └──  t_st_id_cast:129 => t_st_id:135
+                     │    │                   │    └── fd: ()-->(135)
                      │    │                   └── filters (true)
                      │    └── projections
-                     │         └── NULL [as="?column?":138]
+                     │         └── NULL [as="?column?":140]
                      └── with-scan &2 (request_list)
-                          ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
+                          ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
                           ├── mapping:
-                          │    ├──  trade_request.tr_t_id:20 => tr_t_id:139
-                          │    ├──  tr_bid_price:28 => tr_bid_price:140
-                          │    ├──  trade_request.tr_tt_id:21 => tr_tt_id:141
-                          │    └──  trade_request.tr_qty:23 => tr_qty:142
-                          ├── key: (139)
-                          └── fd: (139)-->(140-142)
+                          │    ├──  trade_request.tr_t_id:20 => tr_t_id:141
+                          │    ├──  tr_bid_price:28 => tr_bid_price:142
+                          │    ├──  trade_request.tr_tt_id:21 => tr_tt_id:143
+                          │    └──  trade_request.tr_qty:23 => tr_qty:144
+                          ├── key: (141)
+                          └── fd: (141)-->(142-144)
 
 # --------------------------------------------------
 # T4
@@ -2727,16 +2727,16 @@ SELECT sum(tx_rate)::FLOAT8
  WHERE tx_id IN (SELECT cx_tx_id FROM customer_taxrate WHERE cx_c_id = 0);
 ----
 project
- ├── columns: sum:11
+ ├── columns: sum:12
  ├── cardinality: [1 - 1]
  ├── immutable
  ├── key: ()
- ├── fd: ()-->(11)
+ ├── fd: ()-->(12)
  ├── scalar-group-by
- │    ├── columns: sum:10
+ │    ├── columns: sum:11
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    ├── fd: ()-->(10)
+ │    ├── fd: ()-->(11)
  │    ├── inner-join (lookup taxrate)
  │    │    ├── columns: tx_id:1!null tx_rate:3!null cx_tx_id:6!null cx_c_id:7!null
  │    │    ├── key columns: [6] = [1]
@@ -2750,10 +2750,10 @@ project
  │    │    │    └── fd: ()-->(7)
  │    │    └── filters (true)
  │    └── aggregations
- │         └── sum [as=sum:10, outer=(3)]
+ │         └── sum [as=sum:11, outer=(3)]
  │              └── tx_rate:3
  └── projections
-      └── sum:10::FLOAT8 [as=sum:11, outer=(10), immutable]
+      └── sum:11::FLOAT8 [as=sum:12, outer=(11), immutable]
 
 # Q9
 opt
@@ -3957,36 +3957,36 @@ opt
 RETURNING t_tax::FLOAT8;
 ----
 project
- ├── columns: t_tax:52!null
+ ├── columns: t_tax:53!null
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
- ├── fd: ()-->(52)
+ ├── fd: ()-->(53)
  ├── update trade
  │    ├── columns: t_id:1!null trade.t_tax:14!null
  │    ├── fetch columns: t_id:18 trade.t_tax:31
  │    ├── update-mapping:
- │    │    └── t_tax_cast:46 => trade.t_tax:14
+ │    │    └── t_tax_cast:47 => trade.t_tax:14
  │    ├── return-mapping:
  │    │    ├── t_id:18 => t_id:1
- │    │    └── t_tax_cast:46 => trade.t_tax:14
- │    ├── check columns: check5:51
+ │    │    └── t_tax_cast:47 => trade.t_tax:14
+ │    ├── check columns: check5:52
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1,14)
  │    └── project
- │         ├── columns: check5:51 t_id:18!null trade.t_tax:31!null t_tax_cast:46
+ │         ├── columns: check5:52 t_id:18!null trade.t_tax:31!null t_tax_cast:47
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
- │         ├── fd: ()-->(18,31,46,51)
+ │         ├── fd: ()-->(18,31,47,52)
  │         ├── project
- │         │    ├── columns: t_tax_cast:46 t_id:18!null trade.t_tax:31!null
+ │         │    ├── columns: t_tax_cast:47 t_id:18!null trade.t_tax:31!null
  │         │    ├── cardinality: [0 - 1]
  │         │    ├── immutable
  │         │    ├── key: ()
- │         │    ├── fd: ()-->(18,31,46)
+ │         │    ├── fd: ()-->(18,31,47)
  │         │    ├── scan trade
  │         │    │    ├── columns: t_id:18!null trade.t_tax:31!null
  │         │    │    ├── constraint: /18: [/0 - /0]
@@ -3994,14 +3994,14 @@ project
  │         │    │    ├── key: ()
  │         │    │    └── fd: ()-->(18,31)
  │         │    └── projections
- │         │         └── assignment-cast: DECIMAL(10,2) [as=t_tax_cast:46, immutable, subquery]
+ │         │         └── assignment-cast: DECIMAL(10,2) [as=t_tax_cast:47, immutable, subquery]
  │         │              └── mult
  │         │                   ├── subquery
  │         │                   │    └── scalar-group-by
- │         │                   │         ├── columns: sum:44
+ │         │                   │         ├── columns: sum:45
  │         │                   │         ├── cardinality: [1 - 1]
  │         │                   │         ├── key: ()
- │         │                   │         ├── fd: ()-->(44)
+ │         │                   │         ├── fd: ()-->(45)
  │         │                   │         ├── inner-join (lookup taxrate)
  │         │                   │         │    ├── columns: tx_id:35!null tx_rate:37!null cx_tx_id:40!null cx_c_id:41!null
  │         │                   │         │    ├── key columns: [40] = [35]
@@ -4015,13 +4015,13 @@ project
  │         │                   │         │    │    └── fd: ()-->(41)
  │         │                   │         │    └── filters (true)
  │         │                   │         └── aggregations
- │         │                   │              └── sum [as=sum:44, outer=(37)]
+ │         │                   │              └── sum [as=sum:45, outer=(37)]
  │         │                   │                   └── tx_rate:37
  │         │                   └── 2E+1
  │         └── projections
- │              └── t_tax_cast:46 >= 0 [as=check5:51, outer=(46), immutable]
+ │              └── t_tax_cast:47 >= 0 [as=check5:52, outer=(47), immutable]
  └── projections
-      └── trade.t_tax:14::FLOAT8 [as=t_tax:52, outer=(14), immutable]
+      └── trade.t_tax:14::FLOAT8 [as=t_tax:53, outer=(14), immutable]
 
 # Q13
 opt
@@ -5931,14 +5931,14 @@ update news_item
  ├── columns: <none>
  ├── fetch columns: ni_id:10 ni_headline:11 ni_summary:12 ni_dts:14 ni_source:15 ni_author:16
  ├── update-mapping:
- │    └── ni_dts_new:23 => ni_dts:5
+ │    └── ni_dts_new:24 => ni_dts:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: ni_dts_new:23!null ni_id:10!null ni_headline:11!null ni_summary:12!null ni_dts:14!null ni_source:15!null ni_author:16
+      ├── columns: ni_dts_new:24!null ni_id:10!null ni_headline:11!null ni_summary:12!null ni_dts:14!null ni_source:15!null ni_author:16
       ├── immutable
       ├── key: (10)
-      ├── fd: (10)-->(11,12,14-16), (14)-->(23)
+      ├── fd: (10)-->(11,12,14-16), (14)-->(24)
       ├── project
       │    ├── columns: ni_id:10!null ni_headline:11!null ni_summary:12!null ni_dts:14!null ni_source:15!null ni_author:16
       │    ├── key: (10)
@@ -5960,7 +5960,7 @@ update news_item
       │              │    └── fd: ()-->(20)
       │              └── filters (true)
       └── projections
-           └── ni_dts:14 + '1 day' [as=ni_dts_new:23, outer=(14), immutable]
+           └── ni_dts:14 + '1 day' [as=ni_dts_new:24, outer=(14), immutable]
 
 # Q13
 opt

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -570,10 +570,10 @@ update_trade_submitted AS (
 SELECT * FROM request_list;
 ----
 with &1 (update_last_trade)
- ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
+ ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
  ├── volatile, mutations
- ├── key: (139)
- ├── fd: (139)-->(140-142)
+ ├── key: (141)
+ ├── fd: (141)-->(142-144)
  ├── project
  │    ├── columns: "?column?":19
  │    ├── cardinality: [0 - 1]
@@ -612,10 +612,10 @@ with &1 (update_last_trade)
  │    └── projections
  │         └── NULL [as="?column?":19]
  └── with &2 (request_list)
-      ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
+      ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
       ├── volatile, mutations
-      ├── key: (139)
-      ├── fd: (139)-->(140-142)
+      ├── key: (141)
+      ├── fd: (141)-->(142-144)
       ├── project
       │    ├── columns: tr_bid_price:28!null trade_request.tr_t_id:20!null trade_request.tr_tt_id:21!null trade_request.tr_qty:23!null
       │    ├── immutable
@@ -642,26 +642,26 @@ with &1 (update_last_trade)
       │    └── projections
       │         └── trade_request.tr_bid_price:24::FLOAT8 [as=tr_bid_price:28, outer=(24), immutable]
       └── with &3 (delete_trade_request)
-           ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
+           ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
            ├── volatile, mutations
-           ├── key: (139)
-           ├── fd: (139)-->(140-142)
+           ├── key: (141)
+           ├── fd: (141)-->(142-144)
            ├── project
-           │    ├── columns: "?column?":50
+           │    ├── columns: "?column?":51
            │    ├── volatile, mutations
-           │    ├── fd: ()-->(50)
+           │    ├── fd: ()-->(51)
            │    ├── delete trade_request
            │    │    ├── columns: trade_request.tr_t_id:29!null
            │    │    ├── fetch columns: trade_request.tr_t_id:37 tr_s_symb:39 tr_b_id:42
            │    │    ├── return-mapping:
            │    │    │    └── trade_request.tr_t_id:37 => trade_request.tr_t_id:29
-           │    │    ├── partial index del columns: partial_index_del1:49
+           │    │    ├── partial index del columns: partial_index_del1:50
            │    │    ├── volatile, mutations
            │    │    ├── key: (29)
            │    │    └── project
-           │    │         ├── columns: partial_index_del1:49!null trade_request.tr_t_id:37!null tr_s_symb:39!null tr_b_id:42!null
+           │    │         ├── columns: partial_index_del1:50!null trade_request.tr_t_id:37!null tr_s_symb:39!null tr_b_id:42!null
            │    │         ├── key: (37)
-           │    │         ├── fd: (37)-->(39,42,49)
+           │    │         ├── fd: (37)-->(39,42,50)
            │    │         ├── project
            │    │         │    ├── columns: trade_request.tr_t_id:37!null trade_request.tr_tt_id:38!null tr_s_symb:39!null tr_b_id:42!null
            │    │         │    ├── key: (37)
@@ -679,137 +679,137 @@ with &1 (update_last_trade)
            │    │         │         │    └── key: (45)
            │    │         │         └── filters (true)
            │    │         └── projections
-           │    │              └── trade_request.tr_tt_id:38 IN ('TLB', 'TLS', 'TSL') [as=partial_index_del1:49, outer=(38)]
+           │    │              └── trade_request.tr_tt_id:38 IN ('TLB', 'TLS', 'TSL') [as=partial_index_del1:50, outer=(38)]
            │    └── projections
-           │         └── NULL [as="?column?":50]
+           │         └── NULL [as="?column?":51]
            └── with &5 (insert_trade_history)
-                ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
+                ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
                 ├── volatile, mutations
-                ├── key: (139)
-                ├── fd: (139)-->(140-142)
+                ├── key: (141)
+                ├── fd: (141)-->(142-144)
                 ├── project
-                │    ├── columns: "?column?":86
+                │    ├── columns: "?column?":87
                 │    ├── volatile, mutations
-                │    ├── fd: ()-->(86)
+                │    ├── fd: ()-->(87)
                 │    ├── insert trade_history
-                │    │    ├── columns: trade_history.th_t_id:51!null trade_history.th_st_id:53!null
+                │    │    ├── columns: trade_history.th_t_id:52!null trade_history.th_st_id:54!null
                 │    │    ├── insert-mapping:
-                │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
-                │    │    │    ├── timestamp:61 => th_dts:52
-                │    │    │    └── th_st_id_cast:62 => trade_history.th_st_id:53
+                │    │    │    ├── tr_t_id:57 => trade_history.th_t_id:52
+                │    │    │    ├── timestamp:62 => th_dts:53
+                │    │    │    └── th_st_id_cast:63 => trade_history.th_st_id:54
                 │    │    ├── return-mapping:
-                │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
-                │    │    │    └── th_st_id_cast:62 => trade_history.th_st_id:53
+                │    │    │    ├── tr_t_id:57 => trade_history.th_t_id:52
+                │    │    │    └── th_st_id_cast:63 => trade_history.th_st_id:54
                 │    │    ├── input binding: &4
                 │    │    ├── volatile, mutations
-                │    │    ├── key: (51)
-                │    │    ├── fd: ()-->(53)
+                │    │    ├── key: (52)
+                │    │    ├── fd: ()-->(54)
                 │    │    ├── project
-                │    │    │    ├── columns: th_st_id_cast:62!null timestamp:61!null tr_t_id:56!null
-                │    │    │    ├── key: (56)
-                │    │    │    ├── fd: ()-->(61,62)
+                │    │    │    ├── columns: th_st_id_cast:63!null timestamp:62!null tr_t_id:57!null
+                │    │    │    ├── key: (57)
+                │    │    │    ├── fd: ()-->(62,63)
                 │    │    │    ├── with-scan &2 (request_list)
-                │    │    │    │    ├── columns: tr_t_id:56!null
+                │    │    │    │    ├── columns: tr_t_id:57!null
                 │    │    │    │    ├── mapping:
-                │    │    │    │    │    └──  trade_request.tr_t_id:20 => tr_t_id:56
-                │    │    │    │    └── key: (56)
+                │    │    │    │    │    └──  trade_request.tr_t_id:20 => tr_t_id:57
+                │    │    │    │    └── key: (57)
                 │    │    │    └── projections
-                │    │    │         ├── 'SBMT' [as=th_st_id_cast:62]
-                │    │    │         └── '2020-06-15 22:27:42.148484' [as=timestamp:61]
+                │    │    │         ├── 'SBMT' [as=th_st_id_cast:63]
+                │    │    │         └── '2020-06-15 22:27:42.148484' [as=timestamp:62]
                 │    │    └── f-k-checks
                 │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
                 │    │         │    └── anti-join (lookup trade)
-                │    │         │         ├── columns: th_t_id:63!null
-                │    │         │         ├── key columns: [63] = [64]
+                │    │         │         ├── columns: th_t_id:64!null
+                │    │         │         ├── key columns: [64] = [65]
                 │    │         │         ├── lookup columns are key
-                │    │         │         ├── key: (63)
+                │    │         │         ├── key: (64)
                 │    │         │         ├── with-scan &4
-                │    │         │         │    ├── columns: th_t_id:63!null
+                │    │         │         │    ├── columns: th_t_id:64!null
                 │    │         │         │    ├── mapping:
-                │    │         │         │    │    └──  tr_t_id:56 => th_t_id:63
-                │    │         │         │    └── key: (63)
+                │    │         │         │    │    └──  tr_t_id:57 => th_t_id:64
+                │    │         │         │    └── key: (64)
                 │    │         │         └── filters (true)
                 │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
                 │    │              └── anti-join (lookup status_type)
-                │    │                   ├── columns: th_st_id:81!null
-                │    │                   ├── key columns: [81] = [82]
+                │    │                   ├── columns: th_st_id:82!null
+                │    │                   ├── key columns: [82] = [83]
                 │    │                   ├── lookup columns are key
-                │    │                   ├── fd: ()-->(81)
+                │    │                   ├── fd: ()-->(82)
                 │    │                   ├── with-scan &4
-                │    │                   │    ├── columns: th_st_id:81!null
+                │    │                   │    ├── columns: th_st_id:82!null
                 │    │                   │    ├── mapping:
-                │    │                   │    │    └──  th_st_id_cast:62 => th_st_id:81
-                │    │                   │    └── fd: ()-->(81)
+                │    │                   │    │    └──  th_st_id_cast:63 => th_st_id:82
+                │    │                   │    └── fd: ()-->(82)
                 │    │                   └── filters (true)
                 │    └── projections
-                │         └── NULL [as="?column?":86]
+                │         └── NULL [as="?column?":87]
                 └── with &7 (update_trade_submitted)
-                     ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
+                     ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
                      ├── volatile, mutations
-                     ├── key: (139)
-                     ├── fd: (139)-->(140-142)
+                     ├── key: (141)
+                     ├── fd: (141)-->(142-144)
                      ├── project
-                     │    ├── columns: "?column?":138
+                     │    ├── columns: "?column?":140
                      │    ├── volatile, mutations
-                     │    ├── fd: ()-->(138)
+                     │    ├── fd: ()-->(140)
                      │    ├── update trade
-                     │    │    ├── columns: t_id:87!null
-                     │    │    ├── fetch columns: t_id:104 t_dts:105 trade.t_st_id:106 t_tt_id:107 t_is_cash:108 t_s_symb:109 t_qty:110 t_bid_price:111 t_ca_id:112 t_exec_name:113 t_trade_price:114 t_chrg:115 t_comm:116 t_lifo:118
+                     │    │    ├── columns: t_id:88!null
+                     │    │    ├── fetch columns: t_id:105 t_dts:106 trade.t_st_id:107 t_tt_id:108 t_is_cash:109 t_s_symb:110 t_qty:111 t_bid_price:112 t_ca_id:113 t_exec_name:114 t_trade_price:115 t_chrg:116 t_comm:117 t_lifo:119
                      │    │    ├── update-mapping:
-                     │    │    │    ├── t_dts_new:126 => t_dts:88
-                     │    │    │    └── t_st_id_cast:127 => trade.t_st_id:89
+                     │    │    │    ├── t_dts_new:128 => t_dts:89
+                     │    │    │    └── t_st_id_cast:129 => trade.t_st_id:90
                      │    │    ├── return-mapping:
-                     │    │    │    └── t_id:104 => t_id:87
+                     │    │    │    └── t_id:105 => t_id:88
                      │    │    ├── input binding: &6
                      │    │    ├── volatile, mutations
-                     │    │    ├── key: (87)
+                     │    │    ├── key: (88)
                      │    │    ├── project
-                     │    │    │    ├── columns: t_st_id_cast:127!null t_dts_new:126!null t_id:104!null t_dts:105!null trade.t_st_id:106!null t_tt_id:107!null t_is_cash:108!null t_s_symb:109!null t_qty:110!null t_bid_price:111!null t_ca_id:112!null t_exec_name:113!null t_trade_price:114 t_chrg:115!null t_comm:116!null t_lifo:118!null
-                     │    │    │    ├── key: (104)
-                     │    │    │    ├── fd: ()-->(126,127), (104)-->(105-116,118)
+                     │    │    │    ├── columns: t_st_id_cast:129!null t_dts_new:128!null t_id:105!null t_dts:106!null trade.t_st_id:107!null t_tt_id:108!null t_is_cash:109!null t_s_symb:110!null t_qty:111!null t_bid_price:112!null t_ca_id:113!null t_exec_name:114!null t_trade_price:115 t_chrg:116!null t_comm:117!null t_lifo:119!null
+                     │    │    │    ├── key: (105)
+                     │    │    │    ├── fd: ()-->(128,129), (105)-->(106-117,119)
                      │    │    │    ├── project
-                     │    │    │    │    ├── columns: t_id:104!null t_dts:105!null trade.t_st_id:106!null t_tt_id:107!null t_is_cash:108!null t_s_symb:109!null t_qty:110!null t_bid_price:111!null t_ca_id:112!null t_exec_name:113!null t_trade_price:114 t_chrg:115!null t_comm:116!null t_lifo:118!null
-                     │    │    │    │    ├── key: (104)
-                     │    │    │    │    ├── fd: (104)-->(105-116,118)
+                     │    │    │    │    ├── columns: t_id:105!null t_dts:106!null trade.t_st_id:107!null t_tt_id:108!null t_is_cash:109!null t_s_symb:110!null t_qty:111!null t_bid_price:112!null t_ca_id:113!null t_exec_name:114!null t_trade_price:115 t_chrg:116!null t_comm:117!null t_lifo:119!null
+                     │    │    │    │    ├── key: (105)
+                     │    │    │    │    ├── fd: (105)-->(106-117,119)
                      │    │    │    │    └── inner-join (lookup trade)
-                     │    │    │    │         ├── columns: t_id:104!null t_dts:105!null trade.t_st_id:106!null t_tt_id:107!null t_is_cash:108!null t_s_symb:109!null t_qty:110!null t_bid_price:111!null t_ca_id:112!null t_exec_name:113!null t_trade_price:114 t_chrg:115!null t_comm:116!null t_lifo:118!null tr_t_id:121!null
-                     │    │    │    │         ├── key columns: [121] = [104]
+                     │    │    │    │         ├── columns: t_id:105!null t_dts:106!null trade.t_st_id:107!null t_tt_id:108!null t_is_cash:109!null t_s_symb:110!null t_qty:111!null t_bid_price:112!null t_ca_id:113!null t_exec_name:114!null t_trade_price:115 t_chrg:116!null t_comm:117!null t_lifo:119!null tr_t_id:122!null
+                     │    │    │    │         ├── key columns: [122] = [105]
                      │    │    │    │         ├── lookup columns are key
-                     │    │    │    │         ├── key: (121)
-                     │    │    │    │         ├── fd: (104)-->(105-116,118), (104)==(121), (121)==(104)
+                     │    │    │    │         ├── key: (122)
+                     │    │    │    │         ├── fd: (105)-->(106-117,119), (105)==(122), (122)==(105)
                      │    │    │    │         ├── with-scan &2 (request_list)
-                     │    │    │    │         │    ├── columns: tr_t_id:121!null
+                     │    │    │    │         │    ├── columns: tr_t_id:122!null
                      │    │    │    │         │    ├── mapping:
-                     │    │    │    │         │    │    └──  trade_request.tr_t_id:20 => tr_t_id:121
-                     │    │    │    │         │    └── key: (121)
+                     │    │    │    │         │    │    └──  trade_request.tr_t_id:20 => tr_t_id:122
+                     │    │    │    │         │    └── key: (122)
                      │    │    │    │         └── filters (true)
                      │    │    │    └── projections
-                     │    │    │         ├── 'SBMT' [as=t_st_id_cast:127]
-                     │    │    │         └── '2020-06-15 22:27:42.148484' [as=t_dts_new:126]
+                     │    │    │         ├── 'SBMT' [as=t_st_id_cast:129]
+                     │    │    │         └── '2020-06-15 22:27:42.148484' [as=t_dts_new:128]
                      │    │    └── f-k-checks
                      │    │         └── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
                      │    │              └── anti-join (lookup status_type)
-                     │    │                   ├── columns: t_st_id:133!null
-                     │    │                   ├── key columns: [133] = [134]
+                     │    │                   ├── columns: t_st_id:135!null
+                     │    │                   ├── key columns: [135] = [136]
                      │    │                   ├── lookup columns are key
-                     │    │                   ├── fd: ()-->(133)
+                     │    │                   ├── fd: ()-->(135)
                      │    │                   ├── with-scan &6
-                     │    │                   │    ├── columns: t_st_id:133!null
+                     │    │                   │    ├── columns: t_st_id:135!null
                      │    │                   │    ├── mapping:
-                     │    │                   │    │    └──  t_st_id_cast:127 => t_st_id:133
-                     │    │                   │    └── fd: ()-->(133)
+                     │    │                   │    │    └──  t_st_id_cast:129 => t_st_id:135
+                     │    │                   │    └── fd: ()-->(135)
                      │    │                   └── filters (true)
                      │    └── projections
-                     │         └── NULL [as="?column?":138]
+                     │         └── NULL [as="?column?":140]
                      └── with-scan &2 (request_list)
-                          ├── columns: tr_t_id:139!null tr_bid_price:140!null tr_tt_id:141!null tr_qty:142!null
+                          ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
                           ├── mapping:
-                          │    ├──  trade_request.tr_t_id:20 => tr_t_id:139
-                          │    ├──  tr_bid_price:28 => tr_bid_price:140
-                          │    ├──  trade_request.tr_tt_id:21 => tr_tt_id:141
-                          │    └──  trade_request.tr_qty:23 => tr_qty:142
-                          ├── key: (139)
-                          └── fd: (139)-->(140-142)
+                          │    ├──  trade_request.tr_t_id:20 => tr_t_id:141
+                          │    ├──  tr_bid_price:28 => tr_bid_price:142
+                          │    ├──  trade_request.tr_tt_id:21 => tr_tt_id:143
+                          │    └──  trade_request.tr_qty:23 => tr_qty:144
+                          ├── key: (141)
+                          └── fd: (141)-->(142-144)
 
 # --------------------------------------------------
 # T4
@@ -2758,16 +2758,16 @@ SELECT sum(tx_rate)::FLOAT8
  WHERE tx_id IN (SELECT cx_tx_id FROM customer_taxrate WHERE cx_c_id = 0);
 ----
 project
- ├── columns: sum:11
+ ├── columns: sum:12
  ├── cardinality: [1 - 1]
  ├── immutable
  ├── key: ()
- ├── fd: ()-->(11)
+ ├── fd: ()-->(12)
  ├── scalar-group-by
- │    ├── columns: sum:10
+ │    ├── columns: sum:11
  │    ├── cardinality: [1 - 1]
  │    ├── key: ()
- │    ├── fd: ()-->(10)
+ │    ├── fd: ()-->(11)
  │    ├── inner-join (lookup taxrate)
  │    │    ├── columns: tx_id:1!null tx_rate:3!null cx_tx_id:6!null cx_c_id:7!null
  │    │    ├── key columns: [6] = [1]
@@ -2781,10 +2781,10 @@ project
  │    │    │    └── fd: ()-->(7)
  │    │    └── filters (true)
  │    └── aggregations
- │         └── sum [as=sum:10, outer=(3)]
+ │         └── sum [as=sum:11, outer=(3)]
  │              └── tx_rate:3
  └── projections
-      └── sum:10::FLOAT8 [as=sum:11, outer=(10), immutable]
+      └── sum:11::FLOAT8 [as=sum:12, outer=(11), immutable]
 
 # Q9
 opt
@@ -3987,36 +3987,36 @@ opt
 RETURNING t_tax::FLOAT8;
 ----
 project
- ├── columns: t_tax:52!null
+ ├── columns: t_tax:53!null
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
- ├── fd: ()-->(52)
+ ├── fd: ()-->(53)
  ├── update trade
  │    ├── columns: t_id:1!null trade.t_tax:14!null
  │    ├── fetch columns: t_id:18 trade.t_tax:31
  │    ├── update-mapping:
- │    │    └── t_tax_cast:46 => trade.t_tax:14
+ │    │    └── t_tax_cast:47 => trade.t_tax:14
  │    ├── return-mapping:
  │    │    ├── t_id:18 => t_id:1
- │    │    └── t_tax_cast:46 => trade.t_tax:14
- │    ├── check columns: check5:51
+ │    │    └── t_tax_cast:47 => trade.t_tax:14
+ │    ├── check columns: check5:52
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1,14)
  │    └── project
- │         ├── columns: check5:51 t_id:18!null trade.t_tax:31!null t_tax_cast:46
+ │         ├── columns: check5:52 t_id:18!null trade.t_tax:31!null t_tax_cast:47
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
- │         ├── fd: ()-->(18,31,46,51)
+ │         ├── fd: ()-->(18,31,47,52)
  │         ├── project
- │         │    ├── columns: t_tax_cast:46 t_id:18!null trade.t_tax:31!null
+ │         │    ├── columns: t_tax_cast:47 t_id:18!null trade.t_tax:31!null
  │         │    ├── cardinality: [0 - 1]
  │         │    ├── immutable
  │         │    ├── key: ()
- │         │    ├── fd: ()-->(18,31,46)
+ │         │    ├── fd: ()-->(18,31,47)
  │         │    ├── scan trade
  │         │    │    ├── columns: t_id:18!null trade.t_tax:31!null
  │         │    │    ├── constraint: /18: [/0 - /0]
@@ -4024,14 +4024,14 @@ project
  │         │    │    ├── key: ()
  │         │    │    └── fd: ()-->(18,31)
  │         │    └── projections
- │         │         └── assignment-cast: DECIMAL(10,2) [as=t_tax_cast:46, immutable, subquery]
+ │         │         └── assignment-cast: DECIMAL(10,2) [as=t_tax_cast:47, immutable, subquery]
  │         │              └── mult
  │         │                   ├── subquery
  │         │                   │    └── scalar-group-by
- │         │                   │         ├── columns: sum:44
+ │         │                   │         ├── columns: sum:45
  │         │                   │         ├── cardinality: [1 - 1]
  │         │                   │         ├── key: ()
- │         │                   │         ├── fd: ()-->(44)
+ │         │                   │         ├── fd: ()-->(45)
  │         │                   │         ├── inner-join (lookup taxrate)
  │         │                   │         │    ├── columns: tx_id:35!null tx_rate:37!null cx_tx_id:40!null cx_c_id:41!null
  │         │                   │         │    ├── key columns: [40] = [35]
@@ -4045,13 +4045,13 @@ project
  │         │                   │         │    │    └── fd: ()-->(41)
  │         │                   │         │    └── filters (true)
  │         │                   │         └── aggregations
- │         │                   │              └── sum [as=sum:44, outer=(37)]
+ │         │                   │              └── sum [as=sum:45, outer=(37)]
  │         │                   │                   └── tx_rate:37
  │         │                   └── 2E+1
  │         └── projections
- │              └── t_tax_cast:46 >= 0 [as=check5:51, outer=(46), immutable]
+ │              └── t_tax_cast:47 >= 0 [as=check5:52, outer=(47), immutable]
  └── projections
-      └── trade.t_tax:14::FLOAT8 [as=t_tax:52, outer=(14), immutable]
+      └── trade.t_tax:14::FLOAT8 [as=t_tax:53, outer=(14), immutable]
 
 # Q13
 opt
@@ -5948,14 +5948,14 @@ update news_item
  ├── columns: <none>
  ├── fetch columns: ni_id:10 ni_headline:11 ni_summary:12 ni_dts:14 ni_source:15 ni_author:16
  ├── update-mapping:
- │    └── ni_dts_new:23 => ni_dts:5
+ │    └── ni_dts_new:24 => ni_dts:5
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: ni_dts_new:23!null ni_id:10!null ni_headline:11!null ni_summary:12!null ni_dts:14!null ni_source:15!null ni_author:16
+      ├── columns: ni_dts_new:24!null ni_id:10!null ni_headline:11!null ni_summary:12!null ni_dts:14!null ni_source:15!null ni_author:16
       ├── immutable
       ├── key: (10)
-      ├── fd: (10)-->(11,12,14-16), (14)-->(23)
+      ├── fd: (10)-->(11,12,14-16), (14)-->(24)
       ├── project
       │    ├── columns: ni_id:10!null ni_headline:11!null ni_summary:12!null ni_dts:14!null ni_source:15!null ni_author:16
       │    ├── key: (10)
@@ -5977,7 +5977,7 @@ update news_item
       │              │    └── fd: ()-->(20)
       │              └── filters (true)
       └── projections
-           └── ni_dts:14 + '1 day' [as=ni_dts_new:23, outer=(14), immutable]
+           └── ni_dts:14 + '1 day' [as=ni_dts_new:24, outer=(14), immutable]
 
 # Q13
 opt

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -415,15 +415,15 @@ ORDER BY
     o_orderpriority;
 ----
 sort
- ├── columns: o_orderpriority:6!null order_count:30!null
+ ├── columns: o_orderpriority:6!null order_count:31!null
  ├── key: (6)
- ├── fd: (6)-->(30)
+ ├── fd: (6)-->(31)
  ├── ordering: +6
  └── group-by (hash)
-      ├── columns: o_orderpriority:6!null count_rows:30!null
+      ├── columns: o_orderpriority:6!null count_rows:31!null
       ├── grouping columns: o_orderpriority:6!null
       ├── key: (6)
-      ├── fd: (6)-->(30)
+      ├── fd: (6)-->(31)
       ├── semi-join (lookup lineitem)
       │    ├── columns: o_orderkey:1!null o_orderdate:5!null o_orderpriority:6!null
       │    ├── key columns: [1] = [12]
@@ -441,7 +441,7 @@ sort
       │    └── filters
       │         └── l_commitdate:23 < l_receiptdate:24 [outer=(23,24), constraints=(/23: (/NULL - ]; /24: (/NULL - ])]
       └── aggregations
-           └── count-rows [as=count_rows:30]
+           └── count-rows [as=count_rows:31]
 
 # --------------------------------------------------
 # Q5
@@ -1704,15 +1704,15 @@ ORDER BY
     p_size;
 ----
 sort
- ├── columns: p_brand:11!null p_type:12!null p_size:13!null supplier_cnt:28!null
+ ├── columns: p_brand:11!null p_type:12!null p_size:13!null supplier_cnt:29!null
  ├── key: (11-13)
- ├── fd: (11-13)-->(28)
- ├── ordering: -28,+11,+12,+13
+ ├── fd: (11-13)-->(29)
+ ├── ordering: -29,+11,+12,+13
  └── group-by (hash)
-      ├── columns: p_brand:11!null p_type:12!null p_size:13!null count:28!null
+      ├── columns: p_brand:11!null p_type:12!null p_size:13!null count:29!null
       ├── grouping columns: p_brand:11!null p_type:12!null p_size:13!null
       ├── key: (11-13)
-      ├── fd: (11-13)-->(28)
+      ├── fd: (11-13)-->(29)
       ├── distinct-on
       │    ├── columns: ps_suppkey:2!null p_brand:11!null p_type:12!null p_size:13!null
       │    ├── grouping columns: ps_suppkey:2!null p_brand:11!null p_type:12!null p_size:13!null
@@ -1752,7 +1752,7 @@ sort
       │         └── filters
       │              └── ps_suppkey:2 = s_suppkey:19 [outer=(2,19), constraints=(/2: (/NULL - ]; /19: (/NULL - ]), fd=(2)==(19), (19)==(2)]
       └── aggregations
-           └── count-rows [as=count:28]
+           └── count-rows [as=count:29]
 
 # --------------------------------------------------
 # Q17
@@ -1909,18 +1909,18 @@ ORDER BY
 LIMIT 100;
 ----
 limit
- ├── columns: c_name:2!null c_custkey:1!null o_orderkey:11!null o_orderdate:15!null o_totalprice:14!null sum:59!null
+ ├── columns: c_name:2!null c_custkey:1!null o_orderkey:11!null o_orderdate:15!null o_totalprice:14!null sum:60!null
  ├── internal-ordering: -14,+15
  ├── cardinality: [0 - 100]
  ├── key: (11)
- ├── fd: (1)-->(2), (11)-->(1,2,14,15,59)
+ ├── fd: (1)-->(2), (11)-->(1,2,14,15,60)
  ├── ordering: -14,+15
  ├── group-by (partial streaming)
- │    ├── columns: c_custkey:1!null c_name:2!null o_orderkey:11!null o_totalprice:14!null o_orderdate:15!null sum:59!null
+ │    ├── columns: c_custkey:1!null c_name:2!null o_orderkey:11!null o_totalprice:14!null o_orderdate:15!null sum:60!null
  │    ├── grouping columns: o_orderkey:11!null o_totalprice:14!null o_orderdate:15!null
  │    ├── internal-ordering: -14,+15
  │    ├── key: (11)
- │    ├── fd: (1)-->(2), (11)-->(1,2,14,15,59)
+ │    ├── fd: (1)-->(2), (11)-->(1,2,14,15,60)
  │    ├── ordering: -14,+15
  │    ├── limit hint: 100.00
  │    ├── inner-join (lookup lineitem)
@@ -1977,7 +1977,7 @@ limit
  │    │    │    └── filters (true)
  │    │    └── filters (true)
  │    └── aggregations
- │         ├── sum [as=sum:59, outer=(26)]
+ │         ├── sum [as=sum:60, outer=(26)]
  │         │    └── l_quantity:26
  │         ├── const-agg [as=c_custkey:1, outer=(1)]
  │         │    └── c_custkey:1
@@ -2383,18 +2383,18 @@ ORDER BY
 LIMIT 100;
 ----
 top-k
- ├── columns: s_name:2!null numwait:81!null
- ├── internal-ordering: -81,+2
+ ├── columns: s_name:2!null numwait:83!null
+ ├── internal-ordering: -83,+2
  ├── k: 100
  ├── cardinality: [0 - 100]
  ├── key: (2)
- ├── fd: (2)-->(81)
- ├── ordering: -81,+2
+ ├── fd: (2)-->(83)
+ ├── ordering: -83,+2
  └── group-by (hash)
-      ├── columns: s_name:2!null count_rows:81!null
+      ├── columns: s_name:2!null count_rows:83!null
       ├── grouping columns: s_name:2!null
       ├── key: (2)
-      ├── fd: (2)-->(81)
+      ├── fd: (2)-->(83)
       ├── inner-join (lookup orders)
       │    ├── columns: s_suppkey:1!null s_name:2!null s_nationkey:4!null l1.l_orderkey:10!null l1.l_suppkey:12!null l1.l_commitdate:21!null l1.l_receiptdate:22!null o_orderkey:28!null o_orderstatus:30!null n_nationkey:39!null n_name:40!null
       │    ├── key columns: [10] = [28]
@@ -2452,7 +2452,7 @@ top-k
       │    └── filters
       │         └── o_orderstatus:30 = 'F' [outer=(30), constraints=(/30: [/'F' - /'F']; tight), fd=()-->(30)]
       └── aggregations
-           └── count-rows [as=count_rows:81]
+           └── count-rows [as=count_rows:83]
 
 # --------------------------------------------------
 # Q22
@@ -2504,19 +2504,19 @@ ORDER BY
     cntrycode;
 ----
 sort
- ├── columns: cntrycode:33 numcust:34!null totacctbal:35!null
+ ├── columns: cntrycode:34 numcust:35!null totacctbal:36!null
  ├── immutable
- ├── key: (33)
- ├── fd: (33)-->(34,35)
- ├── ordering: +33
+ ├── key: (34)
+ ├── fd: (34)-->(35,36)
+ ├── ordering: +34
  └── group-by (hash)
-      ├── columns: cntrycode:33 count_rows:34!null sum:35!null
-      ├── grouping columns: cntrycode:33
+      ├── columns: cntrycode:34 count_rows:35!null sum:36!null
+      ├── grouping columns: cntrycode:34
       ├── immutable
-      ├── key: (33)
-      ├── fd: (33)-->(34,35)
+      ├── key: (34)
+      ├── fd: (34)-->(35,36)
       ├── project
-      │    ├── columns: cntrycode:33 c_acctbal:6!null
+      │    ├── columns: cntrycode:34 c_acctbal:6!null
       │    ├── immutable
       │    ├── anti-join (lookup orders@o_ck)
       │    │    ├── columns: c_custkey:1!null c_phone:5!null c_acctbal:6!null
@@ -2557,8 +2557,8 @@ sort
       │    │    │                                  └── c_acctbal:16
       │    │    └── filters (true)
       │    └── projections
-      │         └── substring(c_phone:5, 1, 2) [as=cntrycode:33, outer=(5), immutable]
+      │         └── substring(c_phone:5, 1, 2) [as=cntrycode:34, outer=(5), immutable]
       └── aggregations
-           ├── count-rows [as=count_rows:34]
-           └── sum [as=sum:35, outer=(6)]
+           ├── count-rows [as=count_rows:35]
+           └── sum [as=sum:36, outer=(6)]
                 └── c_acctbal:6

--- a/pkg/sql/opt/xform/testdata/external/tpch-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpch-no-stats
@@ -433,15 +433,15 @@ ORDER BY
     o_orderpriority;
 ----
 sort
- ├── columns: o_orderpriority:6!null order_count:30!null
+ ├── columns: o_orderpriority:6!null order_count:31!null
  ├── key: (6)
- ├── fd: (6)-->(30)
+ ├── fd: (6)-->(31)
  ├── ordering: +6
  └── group-by (hash)
-      ├── columns: o_orderpriority:6!null count_rows:30!null
+      ├── columns: o_orderpriority:6!null count_rows:31!null
       ├── grouping columns: o_orderpriority:6!null
       ├── key: (6)
-      ├── fd: (6)-->(30)
+      ├── fd: (6)-->(31)
       ├── inner-join (lookup orders)
       │    ├── columns: o_orderkey:1!null o_orderdate:5!null o_orderpriority:6!null l_orderkey:12!null
       │    ├── key columns: [12] = [1]
@@ -464,7 +464,7 @@ sort
       │    └── filters
       │         └── (o_orderdate:5 >= '1993-07-01') AND (o_orderdate:5 < '1993-10-01') [outer=(5), constraints=(/5: [/'1993-07-01' - /'1993-09-30']; tight)]
       └── aggregations
-           └── count-rows [as=count_rows:30]
+           └── count-rows [as=count_rows:31]
 
 # --------------------------------------------------
 # Q5
@@ -1678,15 +1678,15 @@ ORDER BY
     p_size;
 ----
 sort
- ├── columns: p_brand:11!null p_type:12!null p_size:13!null supplier_cnt:28!null
+ ├── columns: p_brand:11!null p_type:12!null p_size:13!null supplier_cnt:29!null
  ├── key: (11-13)
- ├── fd: (11-13)-->(28)
- ├── ordering: -28,+11,+12,+13
+ ├── fd: (11-13)-->(29)
+ ├── ordering: -29,+11,+12,+13
  └── group-by (hash)
-      ├── columns: p_brand:11!null p_type:12!null p_size:13!null count:28!null
+      ├── columns: p_brand:11!null p_type:12!null p_size:13!null count:29!null
       ├── grouping columns: p_brand:11!null p_type:12!null p_size:13!null
       ├── key: (11-13)
-      ├── fd: (11-13)-->(28)
+      ├── fd: (11-13)-->(29)
       ├── distinct-on
       │    ├── columns: ps_suppkey:2!null p_brand:11!null p_type:12!null p_size:13!null
       │    ├── grouping columns: ps_suppkey:2!null p_brand:11!null p_type:12!null p_size:13!null
@@ -1724,7 +1724,7 @@ sort
       │              ├── p_type:12 NOT LIKE 'MEDIUM POLISHED %' [outer=(12), constraints=(/12: (/NULL - ])]
       │              └── p_size:13 IN (3, 9, 14, 19, 23, 36, 45, 49) [outer=(13), constraints=(/13: [/3 - /3] [/9 - /9] [/14 - /14] [/19 - /19] [/23 - /23] [/36 - /36] [/45 - /45] [/49 - /49]; tight)]
       └── aggregations
-           └── count-rows [as=count:28]
+           └── count-rows [as=count:29]
 
 # --------------------------------------------------
 # Q17
@@ -1884,19 +1884,19 @@ ORDER BY
 LIMIT 100;
 ----
 top-k
- ├── columns: c_name:2!null c_custkey:1!null o_orderkey:11!null o_orderdate:15!null o_totalprice:14!null sum:59!null
+ ├── columns: c_name:2!null c_custkey:1!null o_orderkey:11!null o_orderdate:15!null o_totalprice:14!null sum:60!null
  ├── internal-ordering: -14,+15
  ├── k: 100
  ├── cardinality: [0 - 100]
  ├── key: (11)
- ├── fd: (1)-->(2), (11)-->(1,2,14,15,59)
+ ├── fd: (1)-->(2), (11)-->(1,2,14,15,60)
  ├── ordering: -14,+15
  └── group-by (streaming)
-      ├── columns: c_custkey:1!null c_name:2!null o_orderkey:11!null o_totalprice:14!null o_orderdate:15!null sum:59!null
+      ├── columns: c_custkey:1!null c_name:2!null o_orderkey:11!null o_totalprice:14!null o_orderdate:15!null sum:60!null
       ├── grouping columns: o_orderkey:11!null
       ├── internal-ordering: +(11|22)
       ├── key: (11)
-      ├── fd: (1)-->(2), (11)-->(1,2,14,15,59)
+      ├── fd: (1)-->(2), (11)-->(1,2,14,15,60)
       ├── inner-join (merge)
       │    ├── columns: c_custkey:1!null c_name:2!null o_orderkey:11!null o_custkey:12!null o_totalprice:14!null o_orderdate:15!null l_orderkey:22!null l_quantity:26!null
       │    ├── left ordering: +22
@@ -1953,7 +1953,7 @@ top-k
       │    │    └── filters (true)
       │    └── filters (true)
       └── aggregations
-           ├── sum [as=sum:59, outer=(26)]
+           ├── sum [as=sum:60, outer=(26)]
            │    └── l_quantity:26
            ├── const-agg [as=c_custkey:1, outer=(1)]
            │    └── c_custkey:1
@@ -2228,18 +2228,18 @@ ORDER BY
 LIMIT 100;
 ----
 top-k
- ├── columns: s_name:2!null numwait:81!null
- ├── internal-ordering: -81,+2
+ ├── columns: s_name:2!null numwait:83!null
+ ├── internal-ordering: -83,+2
  ├── k: 100
  ├── cardinality: [0 - 100]
  ├── key: (2)
- ├── fd: (2)-->(81)
- ├── ordering: -81,+2
+ ├── fd: (2)-->(83)
+ ├── ordering: -83,+2
  └── group-by (hash)
-      ├── columns: s_name:2!null count_rows:81!null
+      ├── columns: s_name:2!null count_rows:83!null
       ├── grouping columns: s_name:2!null
       ├── key: (2)
-      ├── fd: (2)-->(81)
+      ├── fd: (2)-->(83)
       ├── inner-join (lookup nation)
       │    ├── columns: s_suppkey:1!null s_name:2!null s_nationkey:4!null l1.l_orderkey:10!null l1.l_suppkey:12!null l1.l_commitdate:21!null l1.l_receiptdate:22!null o_orderkey:28!null o_orderstatus:30!null n_nationkey:39!null n_name:40!null
       │    ├── key columns: [4] = [39]
@@ -2285,7 +2285,7 @@ top-k
       │    └── filters
       │         └── n_name:40 = 'SAUDI ARABIA' [outer=(40), constraints=(/40: [/'SAUDI ARABIA' - /'SAUDI ARABIA']; tight), fd=()-->(40)]
       └── aggregations
-           └── count-rows [as=count_rows:81]
+           └── count-rows [as=count_rows:83]
 
 # --------------------------------------------------
 # Q22
@@ -2337,18 +2337,18 @@ ORDER BY
     cntrycode;
 ----
 group-by (streaming)
- ├── columns: cntrycode:33 numcust:34!null totacctbal:35!null
- ├── grouping columns: cntrycode:33
+ ├── columns: cntrycode:34 numcust:35!null totacctbal:36!null
+ ├── grouping columns: cntrycode:34
  ├── immutable
- ├── key: (33)
- ├── fd: (33)-->(34,35)
- ├── ordering: +33
+ ├── key: (34)
+ ├── fd: (34)-->(35,36)
+ ├── ordering: +34
  ├── sort
- │    ├── columns: c_acctbal:6!null cntrycode:33
+ │    ├── columns: c_acctbal:6!null cntrycode:34
  │    ├── immutable
- │    ├── ordering: +33
+ │    ├── ordering: +34
  │    └── project
- │         ├── columns: cntrycode:33 c_acctbal:6!null
+ │         ├── columns: cntrycode:34 c_acctbal:6!null
  │         ├── immutable
  │         ├── anti-join (merge)
  │         │    ├── columns: c_custkey:1!null c_phone:5!null c_acctbal:6!null
@@ -2395,8 +2395,8 @@ group-by (streaming)
  │         │    │    └── ordering: +23
  │         │    └── filters (true)
  │         └── projections
- │              └── substring(c_phone:5, 1, 2) [as=cntrycode:33, outer=(5), immutable]
+ │              └── substring(c_phone:5, 1, 2) [as=cntrycode:34, outer=(5), immutable]
  └── aggregations
-      ├── count-rows [as=count_rows:34]
-      └── sum [as=sum:35, outer=(6)]
+      ├── count-rows [as=count_rows:35]
+      └── sum [as=sum:36, outer=(6)]
            └── c_acctbal:6

--- a/pkg/sql/opt/xform/testdata/rules/cycle
+++ b/pkg/sql/opt/xform/testdata/rules/cycle
@@ -106,7 +106,7 @@ memo (not optimized, ~6KB, required=[], cycle=[G1->G4->G6->G9->G10->G12->G13->G1
  ├── G7: (variable v)
  ├── G8: (const 1)
  ├── G9: (scalar-list G10 G11)
- ├── G10: (subquery G12 &{<nil>  0 false unknown false})
+ ├── G10: (subquery G12 &{<nil>  0 false unknown})
  ├── G11: (false)
  ├── G12: (project G13 G14)
  ├── G13: (limit G1 G8)

--- a/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
+++ b/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
@@ -949,10 +949,10 @@ select
       └── coalesce [subquery]
            ├── subquery
            │    └── project
-           │         ├── columns: column15:15!null
+           │         ├── columns: column16:16!null
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()
-           │         ├── fd: ()-->(15)
+           │         ├── fd: ()-->(16)
            │         ├── limit
            │         │    ├── columns: d1:7 d2:8
            │         │    ├── cardinality: [0 - 1]
@@ -968,7 +968,7 @@ select
            │         │    │         └── (d1:7 = 4) OR (d2:8 = 50) [outer=(7,8)]
            │         │    └── 1
            │         └── projections
-           │              └── true [as=column15:15]
+           │              └── true [as=column16:16]
            └── false
 
 opt expect=SplitDisjunctionOfJoinTerms
@@ -985,11 +985,11 @@ select
       └── coalesce [immutable, subquery]
            ├── subquery
            │    └── project
-           │         ├── columns: column23:23!null
+           │         ├── columns: column24:24!null
            │         ├── cardinality: [0 - 1]
            │         ├── immutable
            │         ├── key: ()
-           │         ├── fd: ()-->(23)
+           │         ├── fd: ()-->(24)
            │         ├── select
            │         │    ├── columns: sum:21!null
            │         │    ├── cardinality: [0 - 1]
@@ -1008,40 +1008,40 @@ select
            │         │    │    │    ├── fd: (11,18)-->(8,14,17)
            │         │    │    │    ├── union-all
            │         │    │    │    │    ├── columns: c2:8 c.rowid:11!null d1:14 d4:17 d.rowid:18!null
-           │         │    │    │    │    ├── left columns: c2:25 c.rowid:28 d1:31 d4:34 d.rowid:35
-           │         │    │    │    │    ├── right columns: c2:39 c.rowid:42 d1:45 d4:48 d.rowid:49
+           │         │    │    │    │    ├── left columns: c2:26 c.rowid:29 d1:32 d4:35 d.rowid:36
+           │         │    │    │    │    ├── right columns: c2:40 c.rowid:43 d1:46 d4:49 d.rowid:50
            │         │    │    │    │    ├── inner-join (cross)
-           │         │    │    │    │    │    ├── columns: c2:25 c.rowid:28!null d1:31!null d4:34 d.rowid:35!null
-           │         │    │    │    │    │    ├── key: (28,35)
-           │         │    │    │    │    │    ├── fd: ()-->(31), (28)-->(25), (35)-->(34)
+           │         │    │    │    │    │    ├── columns: c2:26 c.rowid:29!null d1:32!null d4:35 d.rowid:36!null
+           │         │    │    │    │    │    ├── key: (29,36)
+           │         │    │    │    │    │    ├── fd: ()-->(32), (29)-->(26), (36)-->(35)
            │         │    │    │    │    │    ├── scan c
-           │         │    │    │    │    │    │    ├── columns: c2:25 c.rowid:28!null
-           │         │    │    │    │    │    │    ├── key: (28)
-           │         │    │    │    │    │    │    └── fd: (28)-->(25)
+           │         │    │    │    │    │    │    ├── columns: c2:26 c.rowid:29!null
+           │         │    │    │    │    │    │    ├── key: (29)
+           │         │    │    │    │    │    │    └── fd: (29)-->(26)
            │         │    │    │    │    │    ├── scan d@d
-           │         │    │    │    │    │    │    ├── columns: d1:31!null d4:34 d.rowid:35!null
-           │         │    │    │    │    │    │    ├── constraint: /31/35: [/4 - /4]
-           │         │    │    │    │    │    │    ├── key: (35)
-           │         │    │    │    │    │    │    └── fd: ()-->(31), (35)-->(34)
+           │         │    │    │    │    │    │    ├── columns: d1:32!null d4:35 d.rowid:36!null
+           │         │    │    │    │    │    │    ├── constraint: /32/36: [/4 - /4]
+           │         │    │    │    │    │    │    ├── key: (36)
+           │         │    │    │    │    │    │    └── fd: ()-->(32), (36)-->(35)
            │         │    │    │    │    │    └── filters (true)
            │         │    │    │    │    └── inner-join (cross)
-           │         │    │    │    │         ├── columns: c2:39!null c.rowid:42!null d1:45 d4:48 d.rowid:49!null
-           │         │    │    │    │         ├── key: (42,49)
-           │         │    │    │    │         ├── fd: ()-->(39), (49)-->(45,48)
+           │         │    │    │    │         ├── columns: c2:40!null c.rowid:43!null d1:46 d4:49 d.rowid:50!null
+           │         │    │    │    │         ├── key: (43,50)
+           │         │    │    │    │         ├── fd: ()-->(40), (50)-->(46,49)
            │         │    │    │    │         ├── scan d
-           │         │    │    │    │         │    ├── columns: d1:45 d4:48 d.rowid:49!null
-           │         │    │    │    │         │    ├── key: (49)
-           │         │    │    │    │         │    └── fd: (49)-->(45,48)
+           │         │    │    │    │         │    ├── columns: d1:46 d4:49 d.rowid:50!null
+           │         │    │    │    │         │    ├── key: (50)
+           │         │    │    │    │         │    └── fd: (50)-->(46,49)
            │         │    │    │    │         ├── select
-           │         │    │    │    │         │    ├── columns: c2:39!null c.rowid:42!null
-           │         │    │    │    │         │    ├── key: (42)
-           │         │    │    │    │         │    ├── fd: ()-->(39)
+           │         │    │    │    │         │    ├── columns: c2:40!null c.rowid:43!null
+           │         │    │    │    │         │    ├── key: (43)
+           │         │    │    │    │         │    ├── fd: ()-->(40)
            │         │    │    │    │         │    ├── scan c
-           │         │    │    │    │         │    │    ├── columns: c2:39 c.rowid:42!null
-           │         │    │    │    │         │    │    ├── key: (42)
-           │         │    │    │    │         │    │    └── fd: (42)-->(39)
+           │         │    │    │    │         │    │    ├── columns: c2:40 c.rowid:43!null
+           │         │    │    │    │         │    │    ├── key: (43)
+           │         │    │    │    │         │    │    └── fd: (43)-->(40)
            │         │    │    │    │         │    └── filters
-           │         │    │    │    │         │         └── c2:39 = 50 [outer=(39), constraints=(/39: [/50 - /50]; tight), fd=()-->(39)]
+           │         │    │    │    │         │         └── c2:40 = 50 [outer=(40), constraints=(/40: [/50 - /50]; tight), fd=()-->(40)]
            │         │    │    │    │         └── filters (true)
            │         │    │    │    └── aggregations
            │         │    │    │         ├── const-agg [as=c2:8, outer=(8)]
@@ -1056,7 +1056,7 @@ select
            │         │    └── filters
            │         │         └── sum:21 > 40 [outer=(21), immutable, constraints=(/21: (/40 - ]; tight)]
            │         └── projections
-           │              └── true [as=column23:23]
+           │              └── true [as=column24:24]
            └── false
 
 opt expect=SplitDisjunctionOfJoinTerms
@@ -1072,10 +1072,10 @@ select
       └── coalesce [subquery]
            ├── subquery
            │    └── project
-           │         ├── columns: column22:22!null
+           │         ├── columns: column23:23!null
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()
-           │         ├── fd: ()-->(22)
+           │         ├── fd: ()-->(23)
            │         ├── limit
            │         │    ├── columns: c1:7 c2:8 d1:14 d2:15
            │         │    ├── cardinality: [0 - 1]
@@ -1092,39 +1092,39 @@ select
            │         │    │         ├── limit hint: 1.00
            │         │    │         ├── union-all
            │         │    │         │    ├── columns: c1:7 c2:8 c.rowid:11!null d1:14 d2:15 d.rowid:18!null
-           │         │    │         │    ├── left columns: c1:23 c2:24 c.rowid:27 d1:30 d2:31 d.rowid:34
-           │         │    │         │    ├── right columns: c1:37 c2:38 c.rowid:41 d1:44 d2:45 d.rowid:48
+           │         │    │         │    ├── left columns: c1:24 c2:25 c.rowid:28 d1:31 d2:32 d.rowid:35
+           │         │    │         │    ├── right columns: c1:38 c2:39 c.rowid:42 d1:45 d2:46 d.rowid:49
            │         │    │         │    ├── limit hint: 1.20
            │         │    │         │    ├── inner-join (hash)
-           │         │    │         │    │    ├── columns: c1:23!null c2:24 c.rowid:27!null d1:30 d2:31!null d.rowid:34!null
-           │         │    │         │    │    ├── key: (27,34)
-           │         │    │         │    │    ├── fd: (27)-->(23,24), (34)-->(30,31), (23)==(31), (31)==(23)
+           │         │    │         │    │    ├── columns: c1:24!null c2:25 c.rowid:28!null d1:31 d2:32!null d.rowid:35!null
+           │         │    │         │    │    ├── key: (28,35)
+           │         │    │         │    │    ├── fd: (28)-->(24,25), (35)-->(31,32), (24)==(32), (32)==(24)
            │         │    │         │    │    ├── limit hint: 1.20
            │         │    │         │    │    ├── scan c
-           │         │    │         │    │    │    ├── columns: c1:23 c2:24 c.rowid:27!null
-           │         │    │         │    │    │    ├── key: (27)
-           │         │    │         │    │    │    └── fd: (27)-->(23,24)
+           │         │    │         │    │    │    ├── columns: c1:24 c2:25 c.rowid:28!null
+           │         │    │         │    │    │    ├── key: (28)
+           │         │    │         │    │    │    └── fd: (28)-->(24,25)
            │         │    │         │    │    ├── scan d
-           │         │    │         │    │    │    ├── columns: d1:30 d2:31 d.rowid:34!null
-           │         │    │         │    │    │    ├── key: (34)
-           │         │    │         │    │    │    └── fd: (34)-->(30,31)
+           │         │    │         │    │    │    ├── columns: d1:31 d2:32 d.rowid:35!null
+           │         │    │         │    │    │    ├── key: (35)
+           │         │    │         │    │    │    └── fd: (35)-->(31,32)
            │         │    │         │    │    └── filters
-           │         │    │         │    │         └── c1:23 = d2:31 [outer=(23,31), constraints=(/23: (/NULL - ]; /31: (/NULL - ]), fd=(23)==(31), (31)==(23)]
+           │         │    │         │    │         └── c1:24 = d2:32 [outer=(24,32), constraints=(/24: (/NULL - ]; /32: (/NULL - ]), fd=(24)==(32), (32)==(24)]
            │         │    │         │    └── inner-join (hash)
-           │         │    │         │         ├── columns: c1:37 c2:38!null c.rowid:41!null d1:44!null d2:45 d.rowid:48!null
-           │         │    │         │         ├── key: (41,48)
-           │         │    │         │         ├── fd: (41)-->(37,38), (48)-->(44,45), (38)==(44), (44)==(38)
+           │         │    │         │         ├── columns: c1:38 c2:39!null c.rowid:42!null d1:45!null d2:46 d.rowid:49!null
+           │         │    │         │         ├── key: (42,49)
+           │         │    │         │         ├── fd: (42)-->(38,39), (49)-->(45,46), (39)==(45), (45)==(39)
            │         │    │         │         ├── limit hint: 1.20
            │         │    │         │         ├── scan c
-           │         │    │         │         │    ├── columns: c1:37 c2:38 c.rowid:41!null
-           │         │    │         │         │    ├── key: (41)
-           │         │    │         │         │    └── fd: (41)-->(37,38)
+           │         │    │         │         │    ├── columns: c1:38 c2:39 c.rowid:42!null
+           │         │    │         │         │    ├── key: (42)
+           │         │    │         │         │    └── fd: (42)-->(38,39)
            │         │    │         │         ├── scan d
-           │         │    │         │         │    ├── columns: d1:44 d2:45 d.rowid:48!null
-           │         │    │         │         │    ├── key: (48)
-           │         │    │         │         │    └── fd: (48)-->(44,45)
+           │         │    │         │         │    ├── columns: d1:45 d2:46 d.rowid:49!null
+           │         │    │         │         │    ├── key: (49)
+           │         │    │         │         │    └── fd: (49)-->(45,46)
            │         │    │         │         └── filters
-           │         │    │         │              └── c2:38 = d1:44 [outer=(38,44), constraints=(/38: (/NULL - ]; /44: (/NULL - ]), fd=(38)==(44), (44)==(38)]
+           │         │    │         │              └── c2:39 = d1:45 [outer=(39,45), constraints=(/39: (/NULL - ]; /45: (/NULL - ]), fd=(39)==(45), (45)==(39)]
            │         │    │         └── aggregations
            │         │    │              ├── const-agg [as=c1:7, outer=(7)]
            │         │    │              │    └── c1:7
@@ -1136,7 +1136,7 @@ select
            │         │    │                   └── d2:15
            │         │    └── 1
            │         └── projections
-           │              └── true [as=column22:22]
+           │              └── true [as=column23:23]
            └── false
 
 opt expect=SplitDisjunctionOfJoinTerms
@@ -1157,36 +1157,36 @@ semi-join (hash)
  │         ├── fd: (11,18)-->(7,9,14,16,17)
  │         ├── union-all
  │         │    ├── columns: c1:7 c3:9!null c.rowid:11!null d1:14 d3:16 d4:17 d.rowid:18!null
- │         │    ├── left columns: c1:22 c3:24 c.rowid:26 d1:29 d3:31 d4:32 d.rowid:33
- │         │    ├── right columns: c1:36 c3:38 c.rowid:40 d1:43 d3:45 d4:46 d.rowid:47
+ │         │    ├── left columns: c1:23 c3:25 c.rowid:27 d1:30 d3:32 d4:33 d.rowid:34
+ │         │    ├── right columns: c1:37 c3:39 c.rowid:41 d1:44 d3:46 d4:47 d.rowid:48
  │         │    ├── inner-join (hash)
- │         │    │    ├── columns: c1:22 c3:24!null c.rowid:26!null d1:29 d3:31!null d4:32 d.rowid:33!null
- │         │    │    ├── key: (26,33)
- │         │    │    ├── fd: (26)-->(22,24), (33)-->(29,31,32), (24)==(31), (31)==(24)
+ │         │    │    ├── columns: c1:23 c3:25!null c.rowid:27!null d1:30 d3:32!null d4:33 d.rowid:34!null
+ │         │    │    ├── key: (27,34)
+ │         │    │    ├── fd: (27)-->(23,25), (34)-->(30,32,33), (25)==(32), (32)==(25)
  │         │    │    ├── scan c
- │         │    │    │    ├── columns: c1:22 c3:24 c.rowid:26!null
- │         │    │    │    ├── key: (26)
- │         │    │    │    └── fd: (26)-->(22,24)
+ │         │    │    │    ├── columns: c1:23 c3:25 c.rowid:27!null
+ │         │    │    │    ├── key: (27)
+ │         │    │    │    └── fd: (27)-->(23,25)
  │         │    │    ├── scan d
- │         │    │    │    ├── columns: d1:29 d3:31 d4:32 d.rowid:33!null
- │         │    │    │    ├── key: (33)
- │         │    │    │    └── fd: (33)-->(29,31,32)
+ │         │    │    │    ├── columns: d1:30 d3:32 d4:33 d.rowid:34!null
+ │         │    │    │    ├── key: (34)
+ │         │    │    │    └── fd: (34)-->(30,32,33)
  │         │    │    └── filters
- │         │    │         └── c3:24 = d3:31 [outer=(24,31), constraints=(/24: (/NULL - ]; /31: (/NULL - ]), fd=(24)==(31), (31)==(24)]
+ │         │    │         └── c3:25 = d3:32 [outer=(25,32), constraints=(/25: (/NULL - ]; /32: (/NULL - ]), fd=(25)==(32), (32)==(25)]
  │         │    └── inner-join (hash)
- │         │         ├── columns: c1:36 c3:38!null c.rowid:40!null d1:43 d3:45 d4:46!null d.rowid:47!null
- │         │         ├── key: (40,47)
- │         │         ├── fd: (40)-->(36,38), (47)-->(43,45,46), (38)==(46), (46)==(38)
+ │         │         ├── columns: c1:37 c3:39!null c.rowid:41!null d1:44 d3:46 d4:47!null d.rowid:48!null
+ │         │         ├── key: (41,48)
+ │         │         ├── fd: (41)-->(37,39), (48)-->(44,46,47), (39)==(47), (47)==(39)
  │         │         ├── scan c
- │         │         │    ├── columns: c1:36 c3:38 c.rowid:40!null
- │         │         │    ├── key: (40)
- │         │         │    └── fd: (40)-->(36,38)
+ │         │         │    ├── columns: c1:37 c3:39 c.rowid:41!null
+ │         │         │    ├── key: (41)
+ │         │         │    └── fd: (41)-->(37,39)
  │         │         ├── scan d
- │         │         │    ├── columns: d1:43 d3:45 d4:46 d.rowid:47!null
- │         │         │    ├── key: (47)
- │         │         │    └── fd: (47)-->(43,45,46)
+ │         │         │    ├── columns: d1:44 d3:46 d4:47 d.rowid:48!null
+ │         │         │    ├── key: (48)
+ │         │         │    └── fd: (48)-->(44,46,47)
  │         │         └── filters
- │         │              └── c3:38 = d4:46 [outer=(38,46), constraints=(/38: (/NULL - ]; /46: (/NULL - ]), fd=(38)==(46), (46)==(38)]
+ │         │              └── c3:39 = d4:47 [outer=(39,47), constraints=(/39: (/NULL - ]; /47: (/NULL - ]), fd=(39)==(47), (47)==(39)]
  │         └── aggregations
  │              ├── const-agg [as=c1:7, outer=(7)]
  │              │    └── c1:7
@@ -1227,36 +1227,36 @@ semi-join (hash)
  │    │              ├── fd: (11,18)-->(7-9,14-16)
  │    │              ├── union-all
  │    │              │    ├── columns: c1:7 c2:8 c3:9 c.rowid:11!null d1:14 d2:15 d3:16 d.rowid:18!null
- │    │              │    ├── left columns: c1:36 c2:37 c3:38 c.rowid:40 d1:43 d2:44 d3:45 d.rowid:47
- │    │              │    ├── right columns: c1:50 c2:51 c3:52 c.rowid:54 d1:57 d2:58 d3:59 d.rowid:61
+ │    │              │    ├── left columns: c1:37 c2:38 c3:39 c.rowid:41 d1:44 d2:45 d3:46 d.rowid:48
+ │    │              │    ├── right columns: c1:51 c2:52 c3:53 c.rowid:55 d1:58 d2:59 d3:60 d.rowid:62
  │    │              │    ├── inner-join (hash)
- │    │              │    │    ├── columns: c1:36 c2:37 c3:38!null c.rowid:40!null d1:43 d2:44 d3:45!null d.rowid:47!null
- │    │              │    │    ├── key: (40,47)
- │    │              │    │    ├── fd: (40)-->(36-38), (47)-->(43-45), (38)==(45), (45)==(38)
+ │    │              │    │    ├── columns: c1:37 c2:38 c3:39!null c.rowid:41!null d1:44 d2:45 d3:46!null d.rowid:48!null
+ │    │              │    │    ├── key: (41,48)
+ │    │              │    │    ├── fd: (41)-->(37-39), (48)-->(44-46), (39)==(46), (46)==(39)
  │    │              │    │    ├── scan c
- │    │              │    │    │    ├── columns: c1:36 c2:37 c3:38 c.rowid:40!null
- │    │              │    │    │    ├── key: (40)
- │    │              │    │    │    └── fd: (40)-->(36-38)
+ │    │              │    │    │    ├── columns: c1:37 c2:38 c3:39 c.rowid:41!null
+ │    │              │    │    │    ├── key: (41)
+ │    │              │    │    │    └── fd: (41)-->(37-39)
  │    │              │    │    ├── scan d
- │    │              │    │    │    ├── columns: d1:43 d2:44 d3:45 d.rowid:47!null
- │    │              │    │    │    ├── key: (47)
- │    │              │    │    │    └── fd: (47)-->(43-45)
+ │    │              │    │    │    ├── columns: d1:44 d2:45 d3:46 d.rowid:48!null
+ │    │              │    │    │    ├── key: (48)
+ │    │              │    │    │    └── fd: (48)-->(44-46)
  │    │              │    │    └── filters
- │    │              │    │         └── c3:38 = d3:45 [outer=(38,45), constraints=(/38: (/NULL - ]; /45: (/NULL - ]), fd=(38)==(45), (45)==(38)]
+ │    │              │    │         └── c3:39 = d3:46 [outer=(39,46), constraints=(/39: (/NULL - ]; /46: (/NULL - ]), fd=(39)==(46), (46)==(39)]
  │    │              │    └── inner-join (hash)
- │    │              │         ├── columns: c1:50 c2:51!null c3:52 c.rowid:54!null d1:57 d2:58!null d3:59 d.rowid:61!null
- │    │              │         ├── key: (54,61)
- │    │              │         ├── fd: (54)-->(50-52), (61)-->(57-59), (51)==(58), (58)==(51)
+ │    │              │         ├── columns: c1:51 c2:52!null c3:53 c.rowid:55!null d1:58 d2:59!null d3:60 d.rowid:62!null
+ │    │              │         ├── key: (55,62)
+ │    │              │         ├── fd: (55)-->(51-53), (62)-->(58-60), (52)==(59), (59)==(52)
  │    │              │         ├── scan c
- │    │              │         │    ├── columns: c1:50 c2:51 c3:52 c.rowid:54!null
- │    │              │         │    ├── key: (54)
- │    │              │         │    └── fd: (54)-->(50-52)
+ │    │              │         │    ├── columns: c1:51 c2:52 c3:53 c.rowid:55!null
+ │    │              │         │    ├── key: (55)
+ │    │              │         │    └── fd: (55)-->(51-53)
  │    │              │         ├── scan d
- │    │              │         │    ├── columns: d1:57 d2:58 d3:59 d.rowid:61!null
- │    │              │         │    ├── key: (61)
- │    │              │         │    └── fd: (61)-->(57-59)
+ │    │              │         │    ├── columns: d1:58 d2:59 d3:60 d.rowid:62!null
+ │    │              │         │    ├── key: (62)
+ │    │              │         │    └── fd: (62)-->(58-60)
  │    │              │         └── filters
- │    │              │              └── c2:51 = d2:58 [outer=(51,58), constraints=(/51: (/NULL - ]; /58: (/NULL - ]), fd=(51)==(58), (58)==(51)]
+ │    │              │              └── c2:52 = d2:59 [outer=(52,59), constraints=(/52: (/NULL - ]; /59: (/NULL - ]), fd=(52)==(59), (59)==(52)]
  │    │              └── aggregations
  │    │                   ├── const-agg [as=c1:7, outer=(7)]
  │    │                   │    └── c1:7
@@ -1281,36 +1281,36 @@ semi-join (hash)
  │                   ├── fd: (25,32)-->(21-23,28-30)
  │                   ├── union-all
  │                   │    ├── columns: c1:21 c2:22 c3:23 c.rowid:25!null d1:28 d2:29 d3:30 d.rowid:32!null
- │                   │    ├── left columns: c1:92 c2:93 c3:94 c.rowid:96 d1:99 d2:100 d3:101 d.rowid:103
- │                   │    ├── right columns: c1:106 c2:107 c3:108 c.rowid:110 d1:113 d2:114 d3:115 d.rowid:117
+ │                   │    ├── left columns: c1:93 c2:94 c3:95 c.rowid:97 d1:100 d2:101 d3:102 d.rowid:104
+ │                   │    ├── right columns: c1:107 c2:108 c3:109 c.rowid:111 d1:114 d2:115 d3:116 d.rowid:118
  │                   │    ├── inner-join (hash)
- │                   │    │    ├── columns: c1:92 c2:93 c3:94!null c.rowid:96!null d1:99 d2:100 d3:101!null d.rowid:103!null
- │                   │    │    ├── key: (96,103)
- │                   │    │    ├── fd: (96)-->(92-94), (103)-->(99-101), (94)==(101), (101)==(94)
+ │                   │    │    ├── columns: c1:93 c2:94 c3:95!null c.rowid:97!null d1:100 d2:101 d3:102!null d.rowid:104!null
+ │                   │    │    ├── key: (97,104)
+ │                   │    │    ├── fd: (97)-->(93-95), (104)-->(100-102), (95)==(102), (102)==(95)
  │                   │    │    ├── scan c
- │                   │    │    │    ├── columns: c1:92 c2:93 c3:94 c.rowid:96!null
- │                   │    │    │    ├── key: (96)
- │                   │    │    │    └── fd: (96)-->(92-94)
+ │                   │    │    │    ├── columns: c1:93 c2:94 c3:95 c.rowid:97!null
+ │                   │    │    │    ├── key: (97)
+ │                   │    │    │    └── fd: (97)-->(93-95)
  │                   │    │    ├── scan d
- │                   │    │    │    ├── columns: d1:99 d2:100 d3:101 d.rowid:103!null
- │                   │    │    │    ├── key: (103)
- │                   │    │    │    └── fd: (103)-->(99-101)
+ │                   │    │    │    ├── columns: d1:100 d2:101 d3:102 d.rowid:104!null
+ │                   │    │    │    ├── key: (104)
+ │                   │    │    │    └── fd: (104)-->(100-102)
  │                   │    │    └── filters
- │                   │    │         └── c3:94 = d3:101 [outer=(94,101), constraints=(/94: (/NULL - ]; /101: (/NULL - ]), fd=(94)==(101), (101)==(94)]
+ │                   │    │         └── c3:95 = d3:102 [outer=(95,102), constraints=(/95: (/NULL - ]; /102: (/NULL - ]), fd=(95)==(102), (102)==(95)]
  │                   │    └── inner-join (hash)
- │                   │         ├── columns: c1:106 c2:107!null c3:108 c.rowid:110!null d1:113 d2:114!null d3:115 d.rowid:117!null
- │                   │         ├── key: (110,117)
- │                   │         ├── fd: (110)-->(106-108), (117)-->(113-115), (107)==(114), (114)==(107)
+ │                   │         ├── columns: c1:107 c2:108!null c3:109 c.rowid:111!null d1:114 d2:115!null d3:116 d.rowid:118!null
+ │                   │         ├── key: (111,118)
+ │                   │         ├── fd: (111)-->(107-109), (118)-->(114-116), (108)==(115), (115)==(108)
  │                   │         ├── scan c
- │                   │         │    ├── columns: c1:106 c2:107 c3:108 c.rowid:110!null
- │                   │         │    ├── key: (110)
- │                   │         │    └── fd: (110)-->(106-108)
+ │                   │         │    ├── columns: c1:107 c2:108 c3:109 c.rowid:111!null
+ │                   │         │    ├── key: (111)
+ │                   │         │    └── fd: (111)-->(107-109)
  │                   │         ├── scan d
- │                   │         │    ├── columns: d1:113 d2:114 d3:115 d.rowid:117!null
- │                   │         │    ├── key: (117)
- │                   │         │    └── fd: (117)-->(113-115)
+ │                   │         │    ├── columns: d1:114 d2:115 d3:116 d.rowid:118!null
+ │                   │         │    ├── key: (118)
+ │                   │         │    └── fd: (118)-->(114-116)
  │                   │         └── filters
- │                   │              └── c2:107 = d2:114 [outer=(107,114), constraints=(/107: (/NULL - ]; /114: (/NULL - ]), fd=(107)==(114), (114)==(107)]
+ │                   │              └── c2:108 = d2:115 [outer=(108,115), constraints=(/108: (/NULL - ]; /115: (/NULL - ]), fd=(108)==(115), (115)==(108)]
  │                   └── aggregations
  │                        ├── const-agg [as=c1:21, outer=(21)]
  │                        │    └── c1:21
@@ -1350,41 +1350,41 @@ project
       │         ├── fd: (11,18)-->(7,14)
       │         ├── union-all
       │         │    ├── columns: c1:7 c.rowid:11!null d1:14 d.rowid:18!null
-      │         │    ├── left columns: c1:34 c.rowid:38 d1:41 d.rowid:45
-      │         │    ├── right columns: c1:48 c.rowid:52 d1:55 d.rowid:59
+      │         │    ├── left columns: c1:35 c.rowid:39 d1:42 d.rowid:46
+      │         │    ├── right columns: c1:49 c.rowid:53 d1:56 d.rowid:60
       │         │    ├── inner-join (cross)
-      │         │    │    ├── columns: c1:34 c.rowid:38!null d1:41 d.rowid:45!null
-      │         │    │    ├── key: (38,45)
-      │         │    │    ├── fd: ()-->(34), (45)-->(41)
+      │         │    │    ├── columns: c1:35 c.rowid:39!null d1:42 d.rowid:46!null
+      │         │    │    ├── key: (39,46)
+      │         │    │    ├── fd: ()-->(35), (46)-->(42)
       │         │    │    ├── scan d
-      │         │    │    │    ├── columns: d1:41 d.rowid:45!null
-      │         │    │    │    ├── key: (45)
-      │         │    │    │    └── fd: (45)-->(41)
+      │         │    │    │    ├── columns: d1:42 d.rowid:46!null
+      │         │    │    │    ├── key: (46)
+      │         │    │    │    └── fd: (46)-->(42)
       │         │    │    ├── select
-      │         │    │    │    ├── columns: c1:34 c.rowid:38!null
-      │         │    │    │    ├── key: (38)
-      │         │    │    │    ├── fd: ()-->(34)
+      │         │    │    │    ├── columns: c1:35 c.rowid:39!null
+      │         │    │    │    ├── key: (39)
+      │         │    │    │    ├── fd: ()-->(35)
       │         │    │    │    ├── scan c
-      │         │    │    │    │    ├── columns: c1:34 c.rowid:38!null
-      │         │    │    │    │    ├── key: (38)
-      │         │    │    │    │    └── fd: (38)-->(34)
+      │         │    │    │    │    ├── columns: c1:35 c.rowid:39!null
+      │         │    │    │    │    ├── key: (39)
+      │         │    │    │    │    └── fd: (39)-->(35)
       │         │    │    │    └── filters
-      │         │    │    │         └── c1:34 IS NULL [outer=(34), constraints=(/34: [/NULL - /NULL]; tight), fd=()-->(34)]
+      │         │    │    │         └── c1:35 IS NULL [outer=(35), constraints=(/35: [/NULL - /NULL]; tight), fd=()-->(35)]
       │         │    │    └── filters (true)
       │         │    └── inner-join (hash)
-      │         │         ├── columns: c1:48!null c.rowid:52!null d1:55!null d.rowid:59!null
-      │         │         ├── key: (52,59)
-      │         │         ├── fd: (52)-->(48), (59)-->(55), (48)==(55), (55)==(48)
+      │         │         ├── columns: c1:49!null c.rowid:53!null d1:56!null d.rowid:60!null
+      │         │         ├── key: (53,60)
+      │         │         ├── fd: (53)-->(49), (60)-->(56), (49)==(56), (56)==(49)
       │         │         ├── scan c
-      │         │         │    ├── columns: c1:48 c.rowid:52!null
-      │         │         │    ├── key: (52)
-      │         │         │    └── fd: (52)-->(48)
+      │         │         │    ├── columns: c1:49 c.rowid:53!null
+      │         │         │    ├── key: (53)
+      │         │         │    └── fd: (53)-->(49)
       │         │         ├── scan d
-      │         │         │    ├── columns: d1:55 d.rowid:59!null
-      │         │         │    ├── key: (59)
-      │         │         │    └── fd: (59)-->(55)
+      │         │         │    ├── columns: d1:56 d.rowid:60!null
+      │         │         │    ├── key: (60)
+      │         │         │    └── fd: (60)-->(56)
       │         │         └── filters
-      │         │              └── c1:48 = d1:55 [outer=(48,55), constraints=(/48: (/NULL - ]; /55: (/NULL - ]), fd=(48)==(55), (55)==(48)]
+      │         │              └── c1:49 = d1:56 [outer=(49,56), constraints=(/49: (/NULL - ]; /56: (/NULL - ]), fd=(49)==(56), (56)==(49)]
       │         └── aggregations
       │              ├── const-agg [as=c1:7, outer=(7)]
       │              │    └── c1:7
@@ -1418,41 +1418,41 @@ anti-join (cross)
  │         ├── fd: (12,19)-->(8,15)
  │         ├── union-all
  │         │    ├── columns: c1:8 c.rowid:12!null d1:15 d.rowid:19!null
- │         │    ├── left columns: c1:22 c.rowid:26 d1:29 d.rowid:33
- │         │    ├── right columns: c1:36 c.rowid:40 d1:43 d.rowid:47
+ │         │    ├── left columns: c1:23 c.rowid:27 d1:30 d.rowid:34
+ │         │    ├── right columns: c1:37 c.rowid:41 d1:44 d.rowid:48
  │         │    ├── inner-join (cross)
- │         │    │    ├── columns: c1:22 c.rowid:26!null d1:29 d.rowid:33!null
- │         │    │    ├── key: (26,33)
- │         │    │    ├── fd: ()-->(22), (33)-->(29)
+ │         │    │    ├── columns: c1:23 c.rowid:27!null d1:30 d.rowid:34!null
+ │         │    │    ├── key: (27,34)
+ │         │    │    ├── fd: ()-->(23), (34)-->(30)
  │         │    │    ├── scan d
- │         │    │    │    ├── columns: d1:29 d.rowid:33!null
- │         │    │    │    ├── key: (33)
- │         │    │    │    └── fd: (33)-->(29)
+ │         │    │    │    ├── columns: d1:30 d.rowid:34!null
+ │         │    │    │    ├── key: (34)
+ │         │    │    │    └── fd: (34)-->(30)
  │         │    │    ├── select
- │         │    │    │    ├── columns: c1:22 c.rowid:26!null
- │         │    │    │    ├── key: (26)
- │         │    │    │    ├── fd: ()-->(22)
+ │         │    │    │    ├── columns: c1:23 c.rowid:27!null
+ │         │    │    │    ├── key: (27)
+ │         │    │    │    ├── fd: ()-->(23)
  │         │    │    │    ├── scan c
- │         │    │    │    │    ├── columns: c1:22 c.rowid:26!null
- │         │    │    │    │    ├── key: (26)
- │         │    │    │    │    └── fd: (26)-->(22)
+ │         │    │    │    │    ├── columns: c1:23 c.rowid:27!null
+ │         │    │    │    │    ├── key: (27)
+ │         │    │    │    │    └── fd: (27)-->(23)
  │         │    │    │    └── filters
- │         │    │    │         └── c1:22 IS NULL [outer=(22), constraints=(/22: [/NULL - /NULL]; tight), fd=()-->(22)]
+ │         │    │    │         └── c1:23 IS NULL [outer=(23), constraints=(/23: [/NULL - /NULL]; tight), fd=()-->(23)]
  │         │    │    └── filters (true)
  │         │    └── inner-join (hash)
- │         │         ├── columns: c1:36!null c.rowid:40!null d1:43!null d.rowid:47!null
- │         │         ├── key: (40,47)
- │         │         ├── fd: (40)-->(36), (47)-->(43), (36)==(43), (43)==(36)
+ │         │         ├── columns: c1:37!null c.rowid:41!null d1:44!null d.rowid:48!null
+ │         │         ├── key: (41,48)
+ │         │         ├── fd: (41)-->(37), (48)-->(44), (37)==(44), (44)==(37)
  │         │         ├── scan c
- │         │         │    ├── columns: c1:36 c.rowid:40!null
- │         │         │    ├── key: (40)
- │         │         │    └── fd: (40)-->(36)
+ │         │         │    ├── columns: c1:37 c.rowid:41!null
+ │         │         │    ├── key: (41)
+ │         │         │    └── fd: (41)-->(37)
  │         │         ├── scan d
- │         │         │    ├── columns: d1:43 d.rowid:47!null
- │         │         │    ├── key: (47)
- │         │         │    └── fd: (47)-->(43)
+ │         │         │    ├── columns: d1:44 d.rowid:48!null
+ │         │         │    ├── key: (48)
+ │         │         │    └── fd: (48)-->(44)
  │         │         └── filters
- │         │              └── c1:36 = d1:43 [outer=(36,43), constraints=(/36: (/NULL - ]; /43: (/NULL - ]), fd=(36)==(43), (43)==(36)]
+ │         │              └── c1:37 = d1:44 [outer=(37,44), constraints=(/37: (/NULL - ]; /44: (/NULL - ]), fd=(37)==(44), (44)==(37)]
  │         └── aggregations
  │              ├── const-agg [as=c1:8, outer=(8)]
  │              │    └── c1:8
@@ -1480,41 +1480,41 @@ anti-join (cross)
  │    │         ├── fd: (12,19)-->(8,9,15)
  │    │         ├── union-all
  │    │         │    ├── columns: c1:8 c2:9 c.rowid:12!null d1:15 d.rowid:19!null
- │    │         │    ├── left columns: c1:23 c2:24 c.rowid:27 d1:30 d.rowid:34
- │    │         │    ├── right columns: c1:37 c2:38 c.rowid:41 d1:44 d.rowid:48
+ │    │         │    ├── left columns: c1:24 c2:25 c.rowid:28 d1:31 d.rowid:35
+ │    │         │    ├── right columns: c1:38 c2:39 c.rowid:42 d1:45 d.rowid:49
  │    │         │    ├── inner-join (cross)
- │    │         │    │    ├── columns: c1:23 c2:24 c.rowid:27!null d1:30 d.rowid:34!null
- │    │         │    │    ├── key: (27,34)
- │    │         │    │    ├── fd: ()-->(23), (27)-->(24), (34)-->(30)
+ │    │         │    │    ├── columns: c1:24 c2:25 c.rowid:28!null d1:31 d.rowid:35!null
+ │    │         │    │    ├── key: (28,35)
+ │    │         │    │    ├── fd: ()-->(24), (28)-->(25), (35)-->(31)
  │    │         │    │    ├── scan d
- │    │         │    │    │    ├── columns: d1:30 d.rowid:34!null
- │    │         │    │    │    ├── key: (34)
- │    │         │    │    │    └── fd: (34)-->(30)
+ │    │         │    │    │    ├── columns: d1:31 d.rowid:35!null
+ │    │         │    │    │    ├── key: (35)
+ │    │         │    │    │    └── fd: (35)-->(31)
  │    │         │    │    ├── select
- │    │         │    │    │    ├── columns: c1:23 c2:24 c.rowid:27!null
- │    │         │    │    │    ├── key: (27)
- │    │         │    │    │    ├── fd: ()-->(23), (27)-->(24)
+ │    │         │    │    │    ├── columns: c1:24 c2:25 c.rowid:28!null
+ │    │         │    │    │    ├── key: (28)
+ │    │         │    │    │    ├── fd: ()-->(24), (28)-->(25)
  │    │         │    │    │    ├── scan c
- │    │         │    │    │    │    ├── columns: c1:23 c2:24 c.rowid:27!null
- │    │         │    │    │    │    ├── key: (27)
- │    │         │    │    │    │    └── fd: (27)-->(23,24)
+ │    │         │    │    │    │    ├── columns: c1:24 c2:25 c.rowid:28!null
+ │    │         │    │    │    │    ├── key: (28)
+ │    │         │    │    │    │    └── fd: (28)-->(24,25)
  │    │         │    │    │    └── filters
- │    │         │    │    │         └── c1:23 IS NULL [outer=(23), constraints=(/23: [/NULL - /NULL]; tight), fd=()-->(23)]
+ │    │         │    │    │         └── c1:24 IS NULL [outer=(24), constraints=(/24: [/NULL - /NULL]; tight), fd=()-->(24)]
  │    │         │    │    └── filters (true)
  │    │         │    └── inner-join (hash)
- │    │         │         ├── columns: c1:37!null c2:38 c.rowid:41!null d1:44!null d.rowid:48!null
- │    │         │         ├── key: (41,48)
- │    │         │         ├── fd: (41)-->(37,38), (48)-->(44), (37)==(44), (44)==(37)
+ │    │         │         ├── columns: c1:38!null c2:39 c.rowid:42!null d1:45!null d.rowid:49!null
+ │    │         │         ├── key: (42,49)
+ │    │         │         ├── fd: (42)-->(38,39), (49)-->(45), (38)==(45), (45)==(38)
  │    │         │         ├── scan c
- │    │         │         │    ├── columns: c1:37 c2:38 c.rowid:41!null
- │    │         │         │    ├── key: (41)
- │    │         │         │    └── fd: (41)-->(37,38)
+ │    │         │         │    ├── columns: c1:38 c2:39 c.rowid:42!null
+ │    │         │         │    ├── key: (42)
+ │    │         │         │    └── fd: (42)-->(38,39)
  │    │         │         ├── scan d
- │    │         │         │    ├── columns: d1:44 d.rowid:48!null
- │    │         │         │    ├── key: (48)
- │    │         │         │    └── fd: (48)-->(44)
+ │    │         │         │    ├── columns: d1:45 d.rowid:49!null
+ │    │         │         │    ├── key: (49)
+ │    │         │         │    └── fd: (49)-->(45)
  │    │         │         └── filters
- │    │         │              └── c1:37 = d1:44 [outer=(37,44), constraints=(/37: (/NULL - ]; /44: (/NULL - ]), fd=(37)==(44), (44)==(37)]
+ │    │         │              └── c1:38 = d1:45 [outer=(38,45), constraints=(/38: (/NULL - ]; /45: (/NULL - ]), fd=(38)==(45), (45)==(38)]
  │    │         └── aggregations
  │    │              ├── const-agg [as=c1:8, outer=(8)]
  │    │              │    └── c1:8
@@ -1545,10 +1545,10 @@ select
            └── coalesce
                 ├── subquery
                 │    └── project
-                │         ├── columns: column15:15!null
+                │         ├── columns: column16:16!null
                 │         ├── cardinality: [0 - 1]
                 │         ├── key: ()
-                │         ├── fd: ()-->(15)
+                │         ├── fd: ()-->(16)
                 │         ├── limit
                 │         │    ├── columns: b1:7 b2:8
                 │         │    ├── cardinality: [0 - 1]
@@ -1565,20 +1565,20 @@ select
                 │         │    │         ├── limit hint: 1.00
                 │         │    │         ├── union-all
                 │         │    │         │    ├── columns: b1:7 b2:8 rowid:11!null
-                │         │    │         │    ├── left columns: b1:16 b2:17 rowid:20
-                │         │    │         │    ├── right columns: b1:23 b2:24 rowid:27
+                │         │    │         │    ├── left columns: b1:17 b2:18 rowid:21
+                │         │    │         │    ├── right columns: b1:24 b2:25 rowid:28
                 │         │    │         │    ├── limit hint: 1.21
                 │         │    │         │    ├── scan b@b_b1_b2_idx
-                │         │    │         │    │    ├── columns: b1:16!null b2:17 rowid:20!null
-                │         │    │         │    │    ├── constraint: /16/17/20: [/4 - /4]
-                │         │    │         │    │    ├── key: (20)
-                │         │    │         │    │    ├── fd: ()-->(16), (20)-->(17)
+                │         │    │         │    │    ├── columns: b1:17!null b2:18 rowid:21!null
+                │         │    │         │    │    ├── constraint: /17/18/21: [/4 - /4]
+                │         │    │         │    │    ├── key: (21)
+                │         │    │         │    │    ├── fd: ()-->(17), (21)-->(18)
                 │         │    │         │    │    └── limit hint: 1.21
                 │         │    │         │    └── scan b@b_b2_idx
-                │         │    │         │         ├── columns: b1:23 b2:24!null rowid:27!null
-                │         │    │         │         ├── constraint: /24/27: [/50 - /50]
-                │         │    │         │         ├── key: (27)
-                │         │    │         │         ├── fd: ()-->(24), (27)-->(23)
+                │         │    │         │         ├── columns: b1:24 b2:25!null rowid:28!null
+                │         │    │         │         ├── constraint: /25/28: [/50 - /50]
+                │         │    │         │         ├── key: (28)
+                │         │    │         │         ├── fd: ()-->(25), (28)-->(24)
                 │         │    │         │         └── limit hint: 1.21
                 │         │    │         └── aggregations
                 │         │    │              ├── const-agg [as=b1:7, outer=(7)]
@@ -1587,7 +1587,7 @@ select
                 │         │    │                   └── b2:8
                 │         │    └── 1
                 │         └── projections
-                │              └── true [as=column15:15]
+                │              └── true [as=column16:16]
                 └── false
 
 opt expect=SplitDisjunctionOfJoinTerms
@@ -1605,11 +1605,11 @@ select
            └── coalesce
                 ├── subquery
                 │    └── project
-                │         ├── columns: column22:22!null
+                │         ├── columns: column23:23!null
                 │         ├── cardinality: [0 - 1]
                 │         ├── immutable
                 │         ├── key: ()
-                │         ├── fd: ()-->(22)
+                │         ├── fd: ()-->(23)
                 │         ├── limit
                 │         │    ├── columns: c2:8 c3:9 d1:14 d2:15
                 │         │    ├── cardinality: [0 - 1]
@@ -1628,7 +1628,7 @@ select
                 │         │    │         └── ((d1:14 = 4) OR (c2:8 = 50)) OR ((d2:15 + c3:9) > 5) [outer=(8,9,14,15), immutable]
                 │         │    └── 1
                 │         └── projections
-                │              └── true [as=column22:22]
+                │              └── true [as=column23:23]
                 └── false
 
 opt expect=SplitDisjunctionOfJoinTerms
@@ -1645,10 +1645,10 @@ select
            └── coalesce
                 ├── subquery
                 │    └── project
-                │         ├── columns: column22:22!null
+                │         ├── columns: column23:23!null
                 │         ├── cardinality: [0 - 1]
                 │         ├── key: ()
-                │         ├── fd: ()-->(22)
+                │         ├── fd: ()-->(23)
                 │         ├── limit
                 │         │    ├── columns: c3:9 c4:10 d3:16 d4:17
                 │         │    ├── cardinality: [0 - 1]
@@ -1665,39 +1665,39 @@ select
                 │         │    │         ├── limit hint: 1.00
                 │         │    │         ├── union-all
                 │         │    │         │    ├── columns: c3:9 c4:10 c.rowid:11!null d3:16 d4:17 d.rowid:18!null
-                │         │    │         │    ├── left columns: c3:25 c4:26 c.rowid:27 d3:32 d4:33 d.rowid:34
-                │         │    │         │    ├── right columns: c3:39 c4:40 c.rowid:41 d3:46 d4:47 d.rowid:48
+                │         │    │         │    ├── left columns: c3:26 c4:27 c.rowid:28 d3:33 d4:34 d.rowid:35
+                │         │    │         │    ├── right columns: c3:40 c4:41 c.rowid:42 d3:47 d4:48 d.rowid:49
                 │         │    │         │    ├── limit hint: 1.20
                 │         │    │         │    ├── inner-join (hash)
-                │         │    │         │    │    ├── columns: c3:25!null c4:26 c.rowid:27!null d3:32 d4:33!null d.rowid:34!null
-                │         │    │         │    │    ├── key: (27,34)
-                │         │    │         │    │    ├── fd: (27)-->(25,26), (34)-->(32,33), (25)==(33), (33)==(25)
+                │         │    │         │    │    ├── columns: c3:26!null c4:27 c.rowid:28!null d3:33 d4:34!null d.rowid:35!null
+                │         │    │         │    │    ├── key: (28,35)
+                │         │    │         │    │    ├── fd: (28)-->(26,27), (35)-->(33,34), (26)==(34), (34)==(26)
                 │         │    │         │    │    ├── limit hint: 1.20
                 │         │    │         │    │    ├── scan c
-                │         │    │         │    │    │    ├── columns: c3:25 c4:26 c.rowid:27!null
-                │         │    │         │    │    │    ├── key: (27)
-                │         │    │         │    │    │    └── fd: (27)-->(25,26)
+                │         │    │         │    │    │    ├── columns: c3:26 c4:27 c.rowid:28!null
+                │         │    │         │    │    │    ├── key: (28)
+                │         │    │         │    │    │    └── fd: (28)-->(26,27)
                 │         │    │         │    │    ├── scan d
-                │         │    │         │    │    │    ├── columns: d3:32 d4:33 d.rowid:34!null
-                │         │    │         │    │    │    ├── key: (34)
-                │         │    │         │    │    │    └── fd: (34)-->(32,33)
+                │         │    │         │    │    │    ├── columns: d3:33 d4:34 d.rowid:35!null
+                │         │    │         │    │    │    ├── key: (35)
+                │         │    │         │    │    │    └── fd: (35)-->(33,34)
                 │         │    │         │    │    └── filters
-                │         │    │         │    │         └── c3:25 = d4:33 [outer=(25,33), constraints=(/25: (/NULL - ]; /33: (/NULL - ]), fd=(25)==(33), (33)==(25)]
+                │         │    │         │    │         └── c3:26 = d4:34 [outer=(26,34), constraints=(/26: (/NULL - ]; /34: (/NULL - ]), fd=(26)==(34), (34)==(26)]
                 │         │    │         │    └── inner-join (hash)
-                │         │    │         │         ├── columns: c3:39 c4:40!null c.rowid:41!null d3:46!null d4:47 d.rowid:48!null
-                │         │    │         │         ├── key: (41,48)
-                │         │    │         │         ├── fd: (41)-->(39,40), (48)-->(46,47), (40)==(46), (46)==(40)
+                │         │    │         │         ├── columns: c3:40 c4:41!null c.rowid:42!null d3:47!null d4:48 d.rowid:49!null
+                │         │    │         │         ├── key: (42,49)
+                │         │    │         │         ├── fd: (42)-->(40,41), (49)-->(47,48), (41)==(47), (47)==(41)
                 │         │    │         │         ├── limit hint: 1.20
                 │         │    │         │         ├── scan c
-                │         │    │         │         │    ├── columns: c3:39 c4:40 c.rowid:41!null
-                │         │    │         │         │    ├── key: (41)
-                │         │    │         │         │    └── fd: (41)-->(39,40)
+                │         │    │         │         │    ├── columns: c3:40 c4:41 c.rowid:42!null
+                │         │    │         │         │    ├── key: (42)
+                │         │    │         │         │    └── fd: (42)-->(40,41)
                 │         │    │         │         ├── scan d
-                │         │    │         │         │    ├── columns: d3:46 d4:47 d.rowid:48!null
-                │         │    │         │         │    ├── key: (48)
-                │         │    │         │         │    └── fd: (48)-->(46,47)
+                │         │    │         │         │    ├── columns: d3:47 d4:48 d.rowid:49!null
+                │         │    │         │         │    ├── key: (49)
+                │         │    │         │         │    └── fd: (49)-->(47,48)
                 │         │    │         │         └── filters
-                │         │    │         │              └── c4:40 = d3:46 [outer=(40,46), constraints=(/40: (/NULL - ]; /46: (/NULL - ]), fd=(40)==(46), (46)==(40)]
+                │         │    │         │              └── c4:41 = d3:47 [outer=(41,47), constraints=(/41: (/NULL - ]; /47: (/NULL - ]), fd=(41)==(47), (47)==(41)]
                 │         │    │         └── aggregations
                 │         │    │              ├── const-agg [as=c3:9, outer=(9)]
                 │         │    │              │    └── c3:9
@@ -1709,7 +1709,7 @@ select
                 │         │    │                   └── d4:17
                 │         │    └── 1
                 │         └── projections
-                │              └── true [as=column22:22]
+                │              └── true [as=column23:23]
                 └── false
 
 opt expect=SplitDisjunctionOfJoinTerms
@@ -1733,36 +1733,36 @@ anti-join (cross)
  │    │         ├── fd: (11,18)-->(7,9,14,16,17)
  │    │         ├── union-all
  │    │         │    ├── columns: c1:7 c3:9!null c.rowid:11!null d1:14 d3:16 d4:17 d.rowid:18!null
- │    │         │    ├── left columns: c1:22 c3:24 c.rowid:26 d1:29 d3:31 d4:32 d.rowid:33
- │    │         │    ├── right columns: c1:36 c3:38 c.rowid:40 d1:43 d3:45 d4:46 d.rowid:47
+ │    │         │    ├── left columns: c1:23 c3:25 c.rowid:27 d1:30 d3:32 d4:33 d.rowid:34
+ │    │         │    ├── right columns: c1:37 c3:39 c.rowid:41 d1:44 d3:46 d4:47 d.rowid:48
  │    │         │    ├── inner-join (hash)
- │    │         │    │    ├── columns: c1:22 c3:24!null c.rowid:26!null d1:29 d3:31!null d4:32 d.rowid:33!null
- │    │         │    │    ├── key: (26,33)
- │    │         │    │    ├── fd: (26)-->(22,24), (33)-->(29,31,32), (24)==(31), (31)==(24)
+ │    │         │    │    ├── columns: c1:23 c3:25!null c.rowid:27!null d1:30 d3:32!null d4:33 d.rowid:34!null
+ │    │         │    │    ├── key: (27,34)
+ │    │         │    │    ├── fd: (27)-->(23,25), (34)-->(30,32,33), (25)==(32), (32)==(25)
  │    │         │    │    ├── scan c
- │    │         │    │    │    ├── columns: c1:22 c3:24 c.rowid:26!null
- │    │         │    │    │    ├── key: (26)
- │    │         │    │    │    └── fd: (26)-->(22,24)
+ │    │         │    │    │    ├── columns: c1:23 c3:25 c.rowid:27!null
+ │    │         │    │    │    ├── key: (27)
+ │    │         │    │    │    └── fd: (27)-->(23,25)
  │    │         │    │    ├── scan d
- │    │         │    │    │    ├── columns: d1:29 d3:31 d4:32 d.rowid:33!null
- │    │         │    │    │    ├── key: (33)
- │    │         │    │    │    └── fd: (33)-->(29,31,32)
+ │    │         │    │    │    ├── columns: d1:30 d3:32 d4:33 d.rowid:34!null
+ │    │         │    │    │    ├── key: (34)
+ │    │         │    │    │    └── fd: (34)-->(30,32,33)
  │    │         │    │    └── filters
- │    │         │    │         └── c3:24 = d3:31 [outer=(24,31), constraints=(/24: (/NULL - ]; /31: (/NULL - ]), fd=(24)==(31), (31)==(24)]
+ │    │         │    │         └── c3:25 = d3:32 [outer=(25,32), constraints=(/25: (/NULL - ]; /32: (/NULL - ]), fd=(25)==(32), (32)==(25)]
  │    │         │    └── inner-join (hash)
- │    │         │         ├── columns: c1:36 c3:38!null c.rowid:40!null d1:43 d3:45 d4:46!null d.rowid:47!null
- │    │         │         ├── key: (40,47)
- │    │         │         ├── fd: (40)-->(36,38), (47)-->(43,45,46), (38)==(46), (46)==(38)
+ │    │         │         ├── columns: c1:37 c3:39!null c.rowid:41!null d1:44 d3:46 d4:47!null d.rowid:48!null
+ │    │         │         ├── key: (41,48)
+ │    │         │         ├── fd: (41)-->(37,39), (48)-->(44,46,47), (39)==(47), (47)==(39)
  │    │         │         ├── scan c
- │    │         │         │    ├── columns: c1:36 c3:38 c.rowid:40!null
- │    │         │         │    ├── key: (40)
- │    │         │         │    └── fd: (40)-->(36,38)
+ │    │         │         │    ├── columns: c1:37 c3:39 c.rowid:41!null
+ │    │         │         │    ├── key: (41)
+ │    │         │         │    └── fd: (41)-->(37,39)
  │    │         │         ├── scan d
- │    │         │         │    ├── columns: d1:43 d3:45 d4:46 d.rowid:47!null
- │    │         │         │    ├── key: (47)
- │    │         │         │    └── fd: (47)-->(43,45,46)
+ │    │         │         │    ├── columns: d1:44 d3:46 d4:47 d.rowid:48!null
+ │    │         │         │    ├── key: (48)
+ │    │         │         │    └── fd: (48)-->(44,46,47)
  │    │         │         └── filters
- │    │         │              └── c3:38 = d4:46 [outer=(38,46), constraints=(/38: (/NULL - ]; /46: (/NULL - ]), fd=(38)==(46), (46)==(38)]
+ │    │         │              └── c3:39 = d4:47 [outer=(39,47), constraints=(/39: (/NULL - ]; /47: (/NULL - ]), fd=(39)==(47), (47)==(39)]
  │    │         └── aggregations
  │    │              ├── const-agg [as=c1:7, outer=(7)]
  │    │              │    └── c1:7
@@ -1807,36 +1807,36 @@ anti-join (cross)
  │    │    │              ├── fd: (11,18)-->(7-9,14-16)
  │    │    │              ├── union-all
  │    │    │              │    ├── columns: c1:7 c2:8 c3:9 c.rowid:11!null d1:14 d2:15 d3:16 d.rowid:18!null
- │    │    │              │    ├── left columns: c1:36 c2:37 c3:38 c.rowid:40 d1:43 d2:44 d3:45 d.rowid:47
- │    │    │              │    ├── right columns: c1:50 c2:51 c3:52 c.rowid:54 d1:57 d2:58 d3:59 d.rowid:61
+ │    │    │              │    ├── left columns: c1:37 c2:38 c3:39 c.rowid:41 d1:44 d2:45 d3:46 d.rowid:48
+ │    │    │              │    ├── right columns: c1:51 c2:52 c3:53 c.rowid:55 d1:58 d2:59 d3:60 d.rowid:62
  │    │    │              │    ├── inner-join (hash)
- │    │    │              │    │    ├── columns: c1:36 c2:37 c3:38!null c.rowid:40!null d1:43 d2:44 d3:45!null d.rowid:47!null
- │    │    │              │    │    ├── key: (40,47)
- │    │    │              │    │    ├── fd: (40)-->(36-38), (47)-->(43-45), (38)==(45), (45)==(38)
+ │    │    │              │    │    ├── columns: c1:37 c2:38 c3:39!null c.rowid:41!null d1:44 d2:45 d3:46!null d.rowid:48!null
+ │    │    │              │    │    ├── key: (41,48)
+ │    │    │              │    │    ├── fd: (41)-->(37-39), (48)-->(44-46), (39)==(46), (46)==(39)
  │    │    │              │    │    ├── scan c
- │    │    │              │    │    │    ├── columns: c1:36 c2:37 c3:38 c.rowid:40!null
- │    │    │              │    │    │    ├── key: (40)
- │    │    │              │    │    │    └── fd: (40)-->(36-38)
+ │    │    │              │    │    │    ├── columns: c1:37 c2:38 c3:39 c.rowid:41!null
+ │    │    │              │    │    │    ├── key: (41)
+ │    │    │              │    │    │    └── fd: (41)-->(37-39)
  │    │    │              │    │    ├── scan d
- │    │    │              │    │    │    ├── columns: d1:43 d2:44 d3:45 d.rowid:47!null
- │    │    │              │    │    │    ├── key: (47)
- │    │    │              │    │    │    └── fd: (47)-->(43-45)
+ │    │    │              │    │    │    ├── columns: d1:44 d2:45 d3:46 d.rowid:48!null
+ │    │    │              │    │    │    ├── key: (48)
+ │    │    │              │    │    │    └── fd: (48)-->(44-46)
  │    │    │              │    │    └── filters
- │    │    │              │    │         └── c3:38 = d3:45 [outer=(38,45), constraints=(/38: (/NULL - ]; /45: (/NULL - ]), fd=(38)==(45), (45)==(38)]
+ │    │    │              │    │         └── c3:39 = d3:46 [outer=(39,46), constraints=(/39: (/NULL - ]; /46: (/NULL - ]), fd=(39)==(46), (46)==(39)]
  │    │    │              │    └── inner-join (hash)
- │    │    │              │         ├── columns: c1:50 c2:51!null c3:52 c.rowid:54!null d1:57 d2:58!null d3:59 d.rowid:61!null
- │    │    │              │         ├── key: (54,61)
- │    │    │              │         ├── fd: (54)-->(50-52), (61)-->(57-59), (51)==(58), (58)==(51)
+ │    │    │              │         ├── columns: c1:51 c2:52!null c3:53 c.rowid:55!null d1:58 d2:59!null d3:60 d.rowid:62!null
+ │    │    │              │         ├── key: (55,62)
+ │    │    │              │         ├── fd: (55)-->(51-53), (62)-->(58-60), (52)==(59), (59)==(52)
  │    │    │              │         ├── scan c
- │    │    │              │         │    ├── columns: c1:50 c2:51 c3:52 c.rowid:54!null
- │    │    │              │         │    ├── key: (54)
- │    │    │              │         │    └── fd: (54)-->(50-52)
+ │    │    │              │         │    ├── columns: c1:51 c2:52 c3:53 c.rowid:55!null
+ │    │    │              │         │    ├── key: (55)
+ │    │    │              │         │    └── fd: (55)-->(51-53)
  │    │    │              │         ├── scan d
- │    │    │              │         │    ├── columns: d1:57 d2:58 d3:59 d.rowid:61!null
- │    │    │              │         │    ├── key: (61)
- │    │    │              │         │    └── fd: (61)-->(57-59)
+ │    │    │              │         │    ├── columns: d1:58 d2:59 d3:60 d.rowid:62!null
+ │    │    │              │         │    ├── key: (62)
+ │    │    │              │         │    └── fd: (62)-->(58-60)
  │    │    │              │         └── filters
- │    │    │              │              └── c2:51 = d2:58 [outer=(51,58), constraints=(/51: (/NULL - ]; /58: (/NULL - ]), fd=(51)==(58), (58)==(51)]
+ │    │    │              │              └── c2:52 = d2:59 [outer=(52,59), constraints=(/52: (/NULL - ]; /59: (/NULL - ]), fd=(52)==(59), (59)==(52)]
  │    │    │              └── aggregations
  │    │    │                   ├── const-agg [as=c1:7, outer=(7)]
  │    │    │                   │    └── c1:7
@@ -1861,36 +1861,36 @@ anti-join (cross)
  │    │                   ├── fd: (25,32)-->(21-23,28-30)
  │    │                   ├── union-all
  │    │                   │    ├── columns: c1:21 c2:22 c3:23 c.rowid:25!null d1:28 d2:29 d3:30 d.rowid:32!null
- │    │                   │    ├── left columns: c1:92 c2:93 c3:94 c.rowid:96 d1:99 d2:100 d3:101 d.rowid:103
- │    │                   │    ├── right columns: c1:106 c2:107 c3:108 c.rowid:110 d1:113 d2:114 d3:115 d.rowid:117
+ │    │                   │    ├── left columns: c1:93 c2:94 c3:95 c.rowid:97 d1:100 d2:101 d3:102 d.rowid:104
+ │    │                   │    ├── right columns: c1:107 c2:108 c3:109 c.rowid:111 d1:114 d2:115 d3:116 d.rowid:118
  │    │                   │    ├── inner-join (hash)
- │    │                   │    │    ├── columns: c1:92 c2:93 c3:94!null c.rowid:96!null d1:99 d2:100 d3:101!null d.rowid:103!null
- │    │                   │    │    ├── key: (96,103)
- │    │                   │    │    ├── fd: (96)-->(92-94), (103)-->(99-101), (94)==(101), (101)==(94)
+ │    │                   │    │    ├── columns: c1:93 c2:94 c3:95!null c.rowid:97!null d1:100 d2:101 d3:102!null d.rowid:104!null
+ │    │                   │    │    ├── key: (97,104)
+ │    │                   │    │    ├── fd: (97)-->(93-95), (104)-->(100-102), (95)==(102), (102)==(95)
  │    │                   │    │    ├── scan c
- │    │                   │    │    │    ├── columns: c1:92 c2:93 c3:94 c.rowid:96!null
- │    │                   │    │    │    ├── key: (96)
- │    │                   │    │    │    └── fd: (96)-->(92-94)
+ │    │                   │    │    │    ├── columns: c1:93 c2:94 c3:95 c.rowid:97!null
+ │    │                   │    │    │    ├── key: (97)
+ │    │                   │    │    │    └── fd: (97)-->(93-95)
  │    │                   │    │    ├── scan d
- │    │                   │    │    │    ├── columns: d1:99 d2:100 d3:101 d.rowid:103!null
- │    │                   │    │    │    ├── key: (103)
- │    │                   │    │    │    └── fd: (103)-->(99-101)
+ │    │                   │    │    │    ├── columns: d1:100 d2:101 d3:102 d.rowid:104!null
+ │    │                   │    │    │    ├── key: (104)
+ │    │                   │    │    │    └── fd: (104)-->(100-102)
  │    │                   │    │    └── filters
- │    │                   │    │         └── c3:94 = d3:101 [outer=(94,101), constraints=(/94: (/NULL - ]; /101: (/NULL - ]), fd=(94)==(101), (101)==(94)]
+ │    │                   │    │         └── c3:95 = d3:102 [outer=(95,102), constraints=(/95: (/NULL - ]; /102: (/NULL - ]), fd=(95)==(102), (102)==(95)]
  │    │                   │    └── inner-join (hash)
- │    │                   │         ├── columns: c1:106 c2:107!null c3:108 c.rowid:110!null d1:113 d2:114!null d3:115 d.rowid:117!null
- │    │                   │         ├── key: (110,117)
- │    │                   │         ├── fd: (110)-->(106-108), (117)-->(113-115), (107)==(114), (114)==(107)
+ │    │                   │         ├── columns: c1:107 c2:108!null c3:109 c.rowid:111!null d1:114 d2:115!null d3:116 d.rowid:118!null
+ │    │                   │         ├── key: (111,118)
+ │    │                   │         ├── fd: (111)-->(107-109), (118)-->(114-116), (108)==(115), (115)==(108)
  │    │                   │         ├── scan c
- │    │                   │         │    ├── columns: c1:106 c2:107 c3:108 c.rowid:110!null
- │    │                   │         │    ├── key: (110)
- │    │                   │         │    └── fd: (110)-->(106-108)
+ │    │                   │         │    ├── columns: c1:107 c2:108 c3:109 c.rowid:111!null
+ │    │                   │         │    ├── key: (111)
+ │    │                   │         │    └── fd: (111)-->(107-109)
  │    │                   │         ├── scan d
- │    │                   │         │    ├── columns: d1:113 d2:114 d3:115 d.rowid:117!null
- │    │                   │         │    ├── key: (117)
- │    │                   │         │    └── fd: (117)-->(113-115)
+ │    │                   │         │    ├── columns: d1:114 d2:115 d3:116 d.rowid:118!null
+ │    │                   │         │    ├── key: (118)
+ │    │                   │         │    └── fd: (118)-->(114-116)
  │    │                   │         └── filters
- │    │                   │              └── c2:107 = d2:114 [outer=(107,114), constraints=(/107: (/NULL - ]; /114: (/NULL - ]), fd=(107)==(114), (114)==(107)]
+ │    │                   │              └── c2:108 = d2:115 [outer=(108,115), constraints=(/108: (/NULL - ]; /115: (/NULL - ]), fd=(108)==(115), (115)==(108)]
  │    │                   └── aggregations
  │    │                        ├── const-agg [as=c1:21, outer=(21)]
  │    │                        │    └── c1:21
@@ -1930,41 +1930,41 @@ anti-join (cross)
  │    │         ├── fd: (11,18)-->(7,14)
  │    │         ├── union-all
  │    │         │    ├── columns: c1:7 c.rowid:11!null d1:14 d.rowid:18!null
- │    │         │    ├── left columns: c1:22 c.rowid:26 d1:29 d.rowid:33
- │    │         │    ├── right columns: c1:36 c.rowid:40 d1:43 d.rowid:47
+ │    │         │    ├── left columns: c1:23 c.rowid:27 d1:30 d.rowid:34
+ │    │         │    ├── right columns: c1:37 c.rowid:41 d1:44 d.rowid:48
  │    │         │    ├── inner-join (cross)
- │    │         │    │    ├── columns: c1:22 c.rowid:26!null d1:29 d.rowid:33!null
- │    │         │    │    ├── key: (26,33)
- │    │         │    │    ├── fd: ()-->(22), (33)-->(29)
+ │    │         │    │    ├── columns: c1:23 c.rowid:27!null d1:30 d.rowid:34!null
+ │    │         │    │    ├── key: (27,34)
+ │    │         │    │    ├── fd: ()-->(23), (34)-->(30)
  │    │         │    │    ├── scan d
- │    │         │    │    │    ├── columns: d1:29 d.rowid:33!null
- │    │         │    │    │    ├── key: (33)
- │    │         │    │    │    └── fd: (33)-->(29)
+ │    │         │    │    │    ├── columns: d1:30 d.rowid:34!null
+ │    │         │    │    │    ├── key: (34)
+ │    │         │    │    │    └── fd: (34)-->(30)
  │    │         │    │    ├── select
- │    │         │    │    │    ├── columns: c1:22 c.rowid:26!null
- │    │         │    │    │    ├── key: (26)
- │    │         │    │    │    ├── fd: ()-->(22)
+ │    │         │    │    │    ├── columns: c1:23 c.rowid:27!null
+ │    │         │    │    │    ├── key: (27)
+ │    │         │    │    │    ├── fd: ()-->(23)
  │    │         │    │    │    ├── scan c
- │    │         │    │    │    │    ├── columns: c1:22 c.rowid:26!null
- │    │         │    │    │    │    ├── key: (26)
- │    │         │    │    │    │    └── fd: (26)-->(22)
+ │    │         │    │    │    │    ├── columns: c1:23 c.rowid:27!null
+ │    │         │    │    │    │    ├── key: (27)
+ │    │         │    │    │    │    └── fd: (27)-->(23)
  │    │         │    │    │    └── filters
- │    │         │    │    │         └── c1:22 IS NULL [outer=(22), constraints=(/22: [/NULL - /NULL]; tight), fd=()-->(22)]
+ │    │         │    │    │         └── c1:23 IS NULL [outer=(23), constraints=(/23: [/NULL - /NULL]; tight), fd=()-->(23)]
  │    │         │    │    └── filters (true)
  │    │         │    └── inner-join (hash)
- │    │         │         ├── columns: c1:36!null c.rowid:40!null d1:43!null d.rowid:47!null
- │    │         │         ├── key: (40,47)
- │    │         │         ├── fd: (40)-->(36), (47)-->(43), (36)==(43), (43)==(36)
+ │    │         │         ├── columns: c1:37!null c.rowid:41!null d1:44!null d.rowid:48!null
+ │    │         │         ├── key: (41,48)
+ │    │         │         ├── fd: (41)-->(37), (48)-->(44), (37)==(44), (44)==(37)
  │    │         │         ├── scan c
- │    │         │         │    ├── columns: c1:36 c.rowid:40!null
- │    │         │         │    ├── key: (40)
- │    │         │         │    └── fd: (40)-->(36)
+ │    │         │         │    ├── columns: c1:37 c.rowid:41!null
+ │    │         │         │    ├── key: (41)
+ │    │         │         │    └── fd: (41)-->(37)
  │    │         │         ├── scan d
- │    │         │         │    ├── columns: d1:43 d.rowid:47!null
- │    │         │         │    ├── key: (47)
- │    │         │         │    └── fd: (47)-->(43)
+ │    │         │         │    ├── columns: d1:44 d.rowid:48!null
+ │    │         │         │    ├── key: (48)
+ │    │         │         │    └── fd: (48)-->(44)
  │    │         │         └── filters
- │    │         │              └── c1:36 = d1:43 [outer=(36,43), constraints=(/36: (/NULL - ]; /43: (/NULL - ]), fd=(36)==(43), (43)==(36)]
+ │    │         │              └── c1:37 = d1:44 [outer=(37,44), constraints=(/37: (/NULL - ]; /44: (/NULL - ]), fd=(37)==(44), (44)==(37)]
  │    │         └── aggregations
  │    │              ├── const-agg [as=c1:7, outer=(7)]
  │    │              │    └── c1:7
@@ -1990,50 +1990,50 @@ project
       ├── key: (1-4)
       └── union-all
            ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-           ├── left columns: a1:14 a2:15 a3:16 a4:17
-           ├── right columns: a1:27 a2:28 a3:29 a4:30
+           ├── left columns: a1:15 a2:16 a3:17 a4:18
+           ├── right columns: a1:28 a2:29 a3:30 a4:31
            ├── project
-           │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-           │    ├── key: (14-17)
+           │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+           │    ├── key: (15-18)
            │    └── inner-join (hash)
-           │         ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null b2:21!null
+           │         ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null b2:22!null
            │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-           │         ├── key: (14,16,17,21)
-           │         ├── fd: (15)==(21), (21)==(15)
+           │         ├── key: (15,17,18,22)
+           │         ├── fd: (16)==(22), (22)==(16)
            │         ├── scan a
-           │         │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-           │         │    └── key: (14-17)
+           │         │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+           │         │    └── key: (15-18)
            │         ├── distinct-on
-           │         │    ├── columns: b2:21
-           │         │    ├── grouping columns: b2:21
-           │         │    ├── internal-ordering: +21
-           │         │    ├── key: (21)
+           │         │    ├── columns: b2:22
+           │         │    ├── grouping columns: b2:22
+           │         │    ├── internal-ordering: +22
+           │         │    ├── key: (22)
            │         │    └── scan b@b_b2_idx
-           │         │         ├── columns: b2:21
-           │         │         └── ordering: +21
+           │         │         ├── columns: b2:22
+           │         │         └── ordering: +22
            │         └── filters
-           │              └── a2:15 = b2:21 [outer=(15,21), constraints=(/15: (/NULL - ]; /21: (/NULL - ]), fd=(15)==(21), (21)==(15)]
+           │              └── a2:16 = b2:22 [outer=(16,22), constraints=(/16: (/NULL - ]; /22: (/NULL - ]), fd=(16)==(22), (22)==(16)]
            └── project
-                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                ├── key: (27-30)
+                ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                ├── key: (28-31)
                 └── inner-join (hash)
-                     ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null b3:35!null
+                     ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null b3:36!null
                      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-                     ├── key: (27,28,30,35)
-                     ├── fd: (29)==(35), (35)==(29)
+                     ├── key: (28,29,31,36)
+                     ├── fd: (30)==(36), (36)==(30)
                      ├── scan a
-                     │    ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                     │    └── key: (27-30)
+                     │    ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                     │    └── key: (28-31)
                      ├── distinct-on
-                     │    ├── columns: b3:35
-                     │    ├── grouping columns: b3:35
-                     │    ├── internal-ordering: +35
-                     │    ├── key: (35)
+                     │    ├── columns: b3:36
+                     │    ├── grouping columns: b3:36
+                     │    ├── internal-ordering: +36
+                     │    ├── key: (36)
                      │    └── scan b@b_b3_idx
-                     │         ├── columns: b3:35
-                     │         └── ordering: +35
+                     │         ├── columns: b3:36
+                     │         └── ordering: +36
                      └── filters
-                          └── a3:29 = b3:35 [outer=(29,35), constraints=(/29: (/NULL - ]; /35: (/NULL - ]), fd=(29)==(35), (35)==(29)]
+                          └── a3:30 = b3:36 [outer=(30,36), constraints=(/30: (/NULL - ]; /36: (/NULL - ]), fd=(30)==(36), (36)==(30)]
 
 opt expect=SplitDisjunctionOfJoinTerms
 SELECT a1,a2,a3 FROM a WHERE EXISTS (SELECT * FROM b WHERE a1 = b1 OR a1 = b2)
@@ -2046,51 +2046,51 @@ project
       ├── key: (1-4)
       └── union-all
            ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-           ├── left columns: a1:14 a2:15 a3:16 a4:17
-           ├── right columns: a1:27 a2:28 a3:29 a4:30
+           ├── left columns: a1:15 a2:16 a3:17 a4:18
+           ├── right columns: a1:28 a2:29 a3:30 a4:31
            ├── project
-           │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-           │    ├── key: (14-17)
+           │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+           │    ├── key: (15-18)
            │    └── inner-join (merge)
-           │         ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null b1:20!null
-           │         ├── left ordering: +14
-           │         ├── right ordering: +20
-           │         ├── key: (15-17,20)
-           │         ├── fd: (14)==(20), (20)==(14)
+           │         ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null b1:21!null
+           │         ├── left ordering: +15
+           │         ├── right ordering: +21
+           │         ├── key: (16-18,21)
+           │         ├── fd: (15)==(21), (21)==(15)
            │         ├── scan a
-           │         │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-           │         │    ├── key: (14-17)
-           │         │    └── ordering: +14
+           │         │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+           │         │    ├── key: (15-18)
+           │         │    └── ordering: +15
            │         ├── distinct-on
-           │         │    ├── columns: b1:20
-           │         │    ├── grouping columns: b1:20
-           │         │    ├── key: (20)
-           │         │    ├── ordering: +20
+           │         │    ├── columns: b1:21
+           │         │    ├── grouping columns: b1:21
+           │         │    ├── key: (21)
+           │         │    ├── ordering: +21
            │         │    └── scan b@b_b1_b2_idx
-           │         │         ├── columns: b1:20
-           │         │         └── ordering: +20
+           │         │         ├── columns: b1:21
+           │         │         └── ordering: +21
            │         └── filters (true)
            └── project
-                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                ├── key: (27-30)
+                ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                ├── key: (28-31)
                 └── inner-join (merge)
-                     ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null b2:34!null
-                     ├── left ordering: +27
-                     ├── right ordering: +34
-                     ├── key: (28-30,34)
-                     ├── fd: (27)==(34), (34)==(27)
+                     ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null b2:35!null
+                     ├── left ordering: +28
+                     ├── right ordering: +35
+                     ├── key: (29-31,35)
+                     ├── fd: (28)==(35), (35)==(28)
                      ├── scan a
-                     │    ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                     │    ├── key: (27-30)
-                     │    └── ordering: +27
+                     │    ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                     │    ├── key: (28-31)
+                     │    └── ordering: +28
                      ├── distinct-on
-                     │    ├── columns: b2:34
-                     │    ├── grouping columns: b2:34
-                     │    ├── key: (34)
-                     │    ├── ordering: +34
+                     │    ├── columns: b2:35
+                     │    ├── grouping columns: b2:35
+                     │    ├── key: (35)
+                     │    ├── ordering: +35
                      │    └── scan b@b_b2_idx
-                     │         ├── columns: b2:34
-                     │         └── ordering: +34
+                     │         ├── columns: b2:35
+                     │         └── ordering: +35
                      └── filters (true)
 
 # The left side of the join already produces key columns
@@ -2106,113 +2106,113 @@ project
       ├── key: (1-4)
       └── union-all
            ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-           ├── left columns: a1:14 a2:15 a3:16 a4:17
-           ├── right columns: a1:27 a2:28 a3:29 a4:30
+           ├── left columns: a1:15 a2:16 a3:17 a4:18
+           ├── right columns: a1:28 a2:29 a3:30 a4:31
            ├── project
-           │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-           │    ├── key: (14-17)
+           │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+           │    ├── key: (15-18)
            │    └── inner-join (merge)
-           │         ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null b1:20!null
-           │         ├── left ordering: +14
-           │         ├── right ordering: +20
-           │         ├── key: (15-17,20)
-           │         ├── fd: (14)==(20), (20)==(14)
+           │         ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null b1:21!null
+           │         ├── left ordering: +15
+           │         ├── right ordering: +21
+           │         ├── key: (16-18,21)
+           │         ├── fd: (15)==(21), (21)==(15)
            │         ├── scan a
-           │         │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-           │         │    ├── key: (14-17)
-           │         │    └── ordering: +14
+           │         │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+           │         │    ├── key: (15-18)
+           │         │    └── ordering: +15
            │         ├── distinct-on
-           │         │    ├── columns: b1:20
-           │         │    ├── grouping columns: b1:20
-           │         │    ├── key: (20)
-           │         │    ├── ordering: +20
+           │         │    ├── columns: b1:21
+           │         │    ├── grouping columns: b1:21
+           │         │    ├── key: (21)
+           │         │    ├── ordering: +21
            │         │    └── scan b@b_b1_b2_idx
-           │         │         ├── columns: b1:20
-           │         │         └── ordering: +20
+           │         │         ├── columns: b1:21
+           │         │         └── ordering: +21
            │         └── filters (true)
            └── project
-                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                ├── key: (27-30)
+                ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                ├── key: (28-31)
                 └── distinct-on
-                     ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                     ├── grouping columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                     ├── key: (27-30)
+                     ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                     ├── grouping columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                     ├── key: (28-31)
                      └── union-all
-                          ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                          ├── left columns: a1:274 a2:275 a3:276 a4:277
-                          ├── right columns: a1:287 a2:288 a3:289 a4:290
+                          ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                          ├── left columns: a1:275 a2:276 a3:277 a4:278
+                          ├── right columns: a1:288 a2:289 a3:290 a4:291
                           ├── project
-                          │    ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null
-                          │    ├── key: (274-277)
+                          │    ├── columns: a1:275!null a2:276!null a3:277!null a4:278!null
+                          │    ├── key: (275-278)
                           │    └── inner-join (hash)
-                          │         ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null b4:283!null
+                          │         ├── columns: a1:275!null a2:276!null a3:277!null a4:278!null b4:284!null
                           │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-                          │         ├── key: (274-276,283)
-                          │         ├── fd: (277)==(283), (283)==(277)
+                          │         ├── key: (275-277,284)
+                          │         ├── fd: (278)==(284), (284)==(278)
                           │         ├── scan a
-                          │         │    ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null
-                          │         │    └── key: (274-277)
+                          │         │    ├── columns: a1:275!null a2:276!null a3:277!null a4:278!null
+                          │         │    └── key: (275-278)
                           │         ├── distinct-on
-                          │         │    ├── columns: b4:283
-                          │         │    ├── grouping columns: b4:283
-                          │         │    ├── key: (283)
+                          │         │    ├── columns: b4:284
+                          │         │    ├── grouping columns: b4:284
+                          │         │    ├── key: (284)
                           │         │    └── scan b
-                          │         │         └── columns: b4:283
+                          │         │         └── columns: b4:284
                           │         └── filters
-                          │              └── a4:277 = b4:283 [outer=(277,283), constraints=(/277: (/NULL - ]; /283: (/NULL - ]), fd=(277)==(283), (283)==(277)]
+                          │              └── a4:278 = b4:284 [outer=(278,284), constraints=(/278: (/NULL - ]; /284: (/NULL - ]), fd=(278)==(284), (284)==(278)]
                           └── project
-                               ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
-                               ├── key: (287-290)
+                               ├── columns: a1:288!null a2:289!null a3:290!null a4:291!null
+                               ├── key: (288-291)
                                └── distinct-on
-                                    ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
-                                    ├── grouping columns: a1:287!null a2:288!null a3:289!null a4:290!null
-                                    ├── key: (287-290)
+                                    ├── columns: a1:288!null a2:289!null a3:290!null a4:291!null
+                                    ├── grouping columns: a1:288!null a2:289!null a3:290!null a4:291!null
+                                    ├── key: (288-291)
                                     └── union-all
-                                         ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
-                                         ├── left columns: a1:430 a2:431 a3:432 a4:433
-                                         ├── right columns: a1:443 a2:444 a3:445 a4:446
+                                         ├── columns: a1:288!null a2:289!null a3:290!null a4:291!null
+                                         ├── left columns: a1:431 a2:432 a3:433 a4:434
+                                         ├── right columns: a1:444 a2:445 a3:446 a4:447
                                          ├── project
-                                         │    ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null
-                                         │    ├── key: (430-433)
+                                         │    ├── columns: a1:431!null a2:432!null a3:433!null a4:434!null
+                                         │    ├── key: (431-434)
                                          │    └── inner-join (hash)
-                                         │         ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null b2:437!null
+                                         │         ├── columns: a1:431!null a2:432!null a3:433!null a4:434!null b2:438!null
                                          │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-                                         │         ├── key: (430,432,433,437)
-                                         │         ├── fd: (431)==(437), (437)==(431)
+                                         │         ├── key: (431,433,434,438)
+                                         │         ├── fd: (432)==(438), (438)==(432)
                                          │         ├── scan a
-                                         │         │    ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null
-                                         │         │    └── key: (430-433)
+                                         │         │    ├── columns: a1:431!null a2:432!null a3:433!null a4:434!null
+                                         │         │    └── key: (431-434)
                                          │         ├── distinct-on
-                                         │         │    ├── columns: b2:437
-                                         │         │    ├── grouping columns: b2:437
-                                         │         │    ├── internal-ordering: +437
-                                         │         │    ├── key: (437)
+                                         │         │    ├── columns: b2:438
+                                         │         │    ├── grouping columns: b2:438
+                                         │         │    ├── internal-ordering: +438
+                                         │         │    ├── key: (438)
                                          │         │    └── scan b@b_b2_idx
-                                         │         │         ├── columns: b2:437
-                                         │         │         └── ordering: +437
+                                         │         │         ├── columns: b2:438
+                                         │         │         └── ordering: +438
                                          │         └── filters
-                                         │              └── a2:431 = b2:437 [outer=(431,437), constraints=(/431: (/NULL - ]; /437: (/NULL - ]), fd=(431)==(437), (437)==(431)]
+                                         │              └── a2:432 = b2:438 [outer=(432,438), constraints=(/432: (/NULL - ]; /438: (/NULL - ]), fd=(432)==(438), (438)==(432)]
                                          └── project
-                                              ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null
-                                              ├── key: (443-446)
+                                              ├── columns: a1:444!null a2:445!null a3:446!null a4:447!null
+                                              ├── key: (444-447)
                                               └── inner-join (hash)
-                                                   ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null b3:451!null
+                                                   ├── columns: a1:444!null a2:445!null a3:446!null a4:447!null b3:452!null
                                                    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-                                                   ├── key: (443,444,446,451)
-                                                   ├── fd: (445)==(451), (451)==(445)
+                                                   ├── key: (444,445,447,452)
+                                                   ├── fd: (446)==(452), (452)==(446)
                                                    ├── scan a
-                                                   │    ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null
-                                                   │    └── key: (443-446)
+                                                   │    ├── columns: a1:444!null a2:445!null a3:446!null a4:447!null
+                                                   │    └── key: (444-447)
                                                    ├── distinct-on
-                                                   │    ├── columns: b3:451
-                                                   │    ├── grouping columns: b3:451
-                                                   │    ├── internal-ordering: +451
-                                                   │    ├── key: (451)
+                                                   │    ├── columns: b3:452
+                                                   │    ├── grouping columns: b3:452
+                                                   │    ├── internal-ordering: +452
+                                                   │    ├── key: (452)
                                                    │    └── scan b@b_b3_idx
-                                                   │         ├── columns: b3:451
-                                                   │         └── ordering: +451
+                                                   │         ├── columns: b3:452
+                                                   │         └── ordering: +452
                                                    └── filters
-                                                        └── a3:445 = b3:451 [outer=(445,451), constraints=(/445: (/NULL - ]; /451: (/NULL - ]), fd=(445)==(451), (451)==(445)]
+                                                        └── a3:446 = b3:452 [outer=(446,452), constraints=(/446: (/NULL - ]; /452: (/NULL - ]), fd=(446)==(452), (452)==(446)]
 
 # More than one disjunction in the filter
 opt expect=SplitDisjunctionOfJoinTerms
@@ -2227,106 +2227,106 @@ project
       ├── key: (1-4)
       └── union-all
            ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-           ├── left columns: a1:14 a2:15 a3:16 a4:17
-           ├── right columns: a1:27 a2:28 a3:29 a4:30
+           ├── left columns: a1:15 a2:16 a3:17 a4:18
+           ├── right columns: a1:28 a2:29 a3:30 a4:31
            ├── project
-           │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-           │    ├── key: (14-17)
+           │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+           │    ├── key: (15-18)
            │    └── inner-join (hash)
-           │         ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null c1:20!null
+           │         ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null c1:21!null
            │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-           │         ├── key: (15-17,20)
-           │         ├── fd: (14)==(20), (20)==(14)
+           │         ├── key: (16-18,21)
+           │         ├── fd: (15)==(21), (21)==(15)
            │         ├── scan a
-           │         │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-           │         │    └── key: (14-17)
+           │         │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+           │         │    └── key: (15-18)
            │         ├── distinct-on
-           │         │    ├── columns: c1:20
-           │         │    ├── grouping columns: c1:20
-           │         │    ├── key: (20)
+           │         │    ├── columns: c1:21
+           │         │    ├── grouping columns: c1:21
+           │         │    ├── key: (21)
            │         │    └── scan c
-           │         │         └── columns: c1:20
+           │         │         └── columns: c1:21
            │         └── filters
-           │              └── a1:14 = c1:20 [outer=(14,20), constraints=(/14: (/NULL - ]; /20: (/NULL - ]), fd=(14)==(20), (20)==(14)]
+           │              └── a1:15 = c1:21 [outer=(15,21), constraints=(/15: (/NULL - ]; /21: (/NULL - ]), fd=(15)==(21), (21)==(15)]
            └── project
-                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                ├── key: (27-30)
+                ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                ├── key: (28-31)
                 └── distinct-on
-                     ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                     ├── grouping columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                     ├── key: (27-30)
+                     ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                     ├── grouping columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                     ├── key: (28-31)
                      └── union-all
-                          ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                          ├── left columns: a1:274 a2:275 a3:276 a4:277
-                          ├── right columns: a1:287 a2:288 a3:289 a4:290
+                          ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                          ├── left columns: a1:275 a2:276 a3:277 a4:278
+                          ├── right columns: a1:288 a2:289 a3:290 a4:291
                           ├── project
-                          │    ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null
-                          │    ├── key: (274-277)
+                          │    ├── columns: a1:275!null a2:276!null a3:277!null a4:278!null
+                          │    ├── key: (275-278)
                           │    └── inner-join (hash)
-                          │         ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null c4:283!null
+                          │         ├── columns: a1:275!null a2:276!null a3:277!null a4:278!null c4:284!null
                           │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-                          │         ├── key: (274-276,283)
-                          │         ├── fd: (277)==(283), (283)==(277)
+                          │         ├── key: (275-277,284)
+                          │         ├── fd: (278)==(284), (284)==(278)
                           │         ├── scan a
-                          │         │    ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null
-                          │         │    └── key: (274-277)
+                          │         │    ├── columns: a1:275!null a2:276!null a3:277!null a4:278!null
+                          │         │    └── key: (275-278)
                           │         ├── distinct-on
-                          │         │    ├── columns: c4:283
-                          │         │    ├── grouping columns: c4:283
-                          │         │    ├── key: (283)
+                          │         │    ├── columns: c4:284
+                          │         │    ├── grouping columns: c4:284
+                          │         │    ├── key: (284)
                           │         │    └── scan c
-                          │         │         └── columns: c4:283
+                          │         │         └── columns: c4:284
                           │         └── filters
-                          │              └── a4:277 = c4:283 [outer=(277,283), constraints=(/277: (/NULL - ]; /283: (/NULL - ]), fd=(277)==(283), (283)==(277)]
+                          │              └── a4:278 = c4:284 [outer=(278,284), constraints=(/278: (/NULL - ]; /284: (/NULL - ]), fd=(278)==(284), (284)==(278)]
                           └── project
-                               ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
-                               ├── key: (287-290)
+                               ├── columns: a1:288!null a2:289!null a3:290!null a4:291!null
+                               ├── key: (288-291)
                                └── distinct-on
-                                    ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
-                                    ├── grouping columns: a1:287!null a2:288!null a3:289!null a4:290!null
-                                    ├── key: (287-290)
+                                    ├── columns: a1:288!null a2:289!null a3:290!null a4:291!null
+                                    ├── grouping columns: a1:288!null a2:289!null a3:290!null a4:291!null
+                                    ├── key: (288-291)
                                     └── union-all
-                                         ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
-                                         ├── left columns: a1:430 a2:431 a3:432 a4:433
-                                         ├── right columns: a1:443 a2:444 a3:445 a4:446
+                                         ├── columns: a1:288!null a2:289!null a3:290!null a4:291!null
+                                         ├── left columns: a1:431 a2:432 a3:433 a4:434
+                                         ├── right columns: a1:444 a2:445 a3:446 a4:447
                                          ├── project
-                                         │    ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null
-                                         │    ├── key: (430-433)
+                                         │    ├── columns: a1:431!null a2:432!null a3:433!null a4:434!null
+                                         │    ├── key: (431-434)
                                          │    └── inner-join (hash)
-                                         │         ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null c2:437!null
+                                         │         ├── columns: a1:431!null a2:432!null a3:433!null a4:434!null c2:438!null
                                          │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-                                         │         ├── key: (430,432,433,437)
-                                         │         ├── fd: (431)==(437), (437)==(431)
+                                         │         ├── key: (431,433,434,438)
+                                         │         ├── fd: (432)==(438), (438)==(432)
                                          │         ├── scan a
-                                         │         │    ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null
-                                         │         │    └── key: (430-433)
+                                         │         │    ├── columns: a1:431!null a2:432!null a3:433!null a4:434!null
+                                         │         │    └── key: (431-434)
                                          │         ├── distinct-on
-                                         │         │    ├── columns: c2:437
-                                         │         │    ├── grouping columns: c2:437
-                                         │         │    ├── key: (437)
+                                         │         │    ├── columns: c2:438
+                                         │         │    ├── grouping columns: c2:438
+                                         │         │    ├── key: (438)
                                          │         │    └── scan c
-                                         │         │         └── columns: c2:437
+                                         │         │         └── columns: c2:438
                                          │         └── filters
-                                         │              └── a2:431 = c2:437 [outer=(431,437), constraints=(/431: (/NULL - ]; /437: (/NULL - ]), fd=(431)==(437), (437)==(431)]
+                                         │              └── a2:432 = c2:438 [outer=(432,438), constraints=(/432: (/NULL - ]; /438: (/NULL - ]), fd=(432)==(438), (438)==(432)]
                                          └── project
-                                              ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null
-                                              ├── key: (443-446)
+                                              ├── columns: a1:444!null a2:445!null a3:446!null a4:447!null
+                                              ├── key: (444-447)
                                               └── inner-join (hash)
-                                                   ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null c3:451!null
+                                                   ├── columns: a1:444!null a2:445!null a3:446!null a4:447!null c3:452!null
                                                    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-                                                   ├── key: (443,444,446,451)
-                                                   ├── fd: (445)==(451), (451)==(445)
+                                                   ├── key: (444,445,447,452)
+                                                   ├── fd: (446)==(452), (452)==(446)
                                                    ├── scan a
-                                                   │    ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null
-                                                   │    └── key: (443-446)
+                                                   │    ├── columns: a1:444!null a2:445!null a3:446!null a4:447!null
+                                                   │    └── key: (444-447)
                                                    ├── distinct-on
-                                                   │    ├── columns: c3:451
-                                                   │    ├── grouping columns: c3:451
-                                                   │    ├── key: (451)
+                                                   │    ├── columns: c3:452
+                                                   │    ├── grouping columns: c3:452
+                                                   │    ├── key: (452)
                                                    │    └── scan c
-                                                   │         └── columns: c3:451
+                                                   │         └── columns: c3:452
                                                    └── filters
-                                                        └── a3:445 = c3:451 [outer=(445,451), constraints=(/445: (/NULL - ]; /451: (/NULL - ]), fd=(445)==(451), (451)==(445)]
+                                                        └── a3:446 = c3:452 [outer=(446,452), constraints=(/446: (/NULL - ]; /452: (/NULL - ]), fd=(446)==(452), (452)==(446)]
 
 # More than one disjunction in the filter
 opt expect=SplitDisjunctionOfJoinTerms
@@ -2341,113 +2341,113 @@ project
       ├── key: (1-4)
       └── union-all
            ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-           ├── left columns: a1:14 a2:15 a3:16 a4:17
-           ├── right columns: a1:27 a2:28 a3:29 a4:30
+           ├── left columns: a1:15 a2:16 a3:17 a4:18
+           ├── right columns: a1:28 a2:29 a3:30 a4:31
            ├── project
-           │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-           │    ├── key: (14-17)
+           │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+           │    ├── key: (15-18)
            │    └── inner-join (hash)
-           │         ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null c2:21!null
+           │         ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null c2:22!null
            │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-           │         ├── key: (15-17,21)
-           │         ├── fd: (14)==(21), (21)==(14)
+           │         ├── key: (16-18,22)
+           │         ├── fd: (15)==(22), (22)==(15)
            │         ├── scan a
-           │         │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-           │         │    └── key: (14-17)
+           │         │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+           │         │    └── key: (15-18)
            │         ├── distinct-on
-           │         │    ├── columns: c2:21
-           │         │    ├── grouping columns: c2:21
-           │         │    ├── key: (21)
+           │         │    ├── columns: c2:22
+           │         │    ├── grouping columns: c2:22
+           │         │    ├── key: (22)
            │         │    └── scan c
-           │         │         └── columns: c2:21
+           │         │         └── columns: c2:22
            │         └── filters
-           │              └── a1:14 = c2:21 [outer=(14,21), constraints=(/14: (/NULL - ]; /21: (/NULL - ]), fd=(14)==(21), (21)==(14)]
+           │              └── a1:15 = c2:22 [outer=(15,22), constraints=(/15: (/NULL - ]; /22: (/NULL - ]), fd=(15)==(22), (22)==(15)]
            └── project
-                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                ├── key: (27-30)
+                ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                ├── key: (28-31)
                 └── distinct-on
-                     ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                     ├── grouping columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                     ├── key: (27-30)
+                     ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                     ├── grouping columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                     ├── key: (28-31)
                      └── union-all
-                          ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                          ├── left columns: a1:274 a2:275 a3:276 a4:277
-                          ├── right columns: a1:287 a2:288 a3:289 a4:290
+                          ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                          ├── left columns: a1:275 a2:276 a3:277 a4:278
+                          ├── right columns: a1:288 a2:289 a3:290 a4:291
                           ├── project
-                          │    ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null
-                          │    ├── key: (274-277)
+                          │    ├── columns: a1:275!null a2:276!null a3:277!null a4:278!null
+                          │    ├── key: (275-278)
                           │    └── inner-join (hash)
-                          │         ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null c4:283!null
+                          │         ├── columns: a1:275!null a2:276!null a3:277!null a4:278!null c4:284!null
                           │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-                          │         ├── key: (274,275,277,283)
-                          │         ├── fd: (276)==(283), (283)==(276)
+                          │         ├── key: (275,276,278,284)
+                          │         ├── fd: (277)==(284), (284)==(277)
                           │         ├── scan a
-                          │         │    ├── columns: a1:274!null a2:275!null a3:276!null a4:277!null
-                          │         │    └── key: (274-277)
+                          │         │    ├── columns: a1:275!null a2:276!null a3:277!null a4:278!null
+                          │         │    └── key: (275-278)
                           │         ├── distinct-on
-                          │         │    ├── columns: c4:283
-                          │         │    ├── grouping columns: c4:283
-                          │         │    ├── key: (283)
+                          │         │    ├── columns: c4:284
+                          │         │    ├── grouping columns: c4:284
+                          │         │    ├── key: (284)
                           │         │    └── scan c
-                          │         │         └── columns: c4:283
+                          │         │         └── columns: c4:284
                           │         └── filters
-                          │              └── a3:276 = c4:283 [outer=(276,283), constraints=(/276: (/NULL - ]; /283: (/NULL - ]), fd=(276)==(283), (283)==(276)]
+                          │              └── a3:277 = c4:284 [outer=(277,284), constraints=(/277: (/NULL - ]; /284: (/NULL - ]), fd=(277)==(284), (284)==(277)]
                           └── project
-                               ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
-                               ├── key: (287-290)
+                               ├── columns: a1:288!null a2:289!null a3:290!null a4:291!null
+                               ├── key: (288-291)
                                └── distinct-on
-                                    ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
-                                    ├── grouping columns: a1:287!null a2:288!null a3:289!null a4:290!null
-                                    ├── key: (287-290)
+                                    ├── columns: a1:288!null a2:289!null a3:290!null a4:291!null
+                                    ├── grouping columns: a1:288!null a2:289!null a3:290!null a4:291!null
+                                    ├── key: (288-291)
                                     └── union-all
-                                         ├── columns: a1:287!null a2:288!null a3:289!null a4:290!null
-                                         ├── left columns: a1:430 a2:431 a3:432 a4:433
-                                         ├── right columns: a1:443 a2:444 a3:445 a4:446
+                                         ├── columns: a1:288!null a2:289!null a3:290!null a4:291!null
+                                         ├── left columns: a1:431 a2:432 a3:433 a4:434
+                                         ├── right columns: a1:444 a2:445 a3:446 a4:447
                                          ├── project
-                                         │    ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null
-                                         │    ├── key: (430-433)
+                                         │    ├── columns: a1:431!null a2:432!null a3:433!null a4:434!null
+                                         │    ├── key: (431-434)
                                          │    └── inner-join (hash)
-                                         │         ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null c1:436!null
+                                         │         ├── columns: a1:431!null a2:432!null a3:433!null a4:434!null c1:437!null
                                          │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-                                         │         ├── key: (430,432,433,436)
-                                         │         ├── fd: (431)==(436), (436)==(431)
+                                         │         ├── key: (431,433,434,437)
+                                         │         ├── fd: (432)==(437), (437)==(432)
                                          │         ├── scan a
-                                         │         │    ├── columns: a1:430!null a2:431!null a3:432!null a4:433!null
-                                         │         │    └── key: (430-433)
+                                         │         │    ├── columns: a1:431!null a2:432!null a3:433!null a4:434!null
+                                         │         │    └── key: (431-434)
                                          │         ├── distinct-on
-                                         │         │    ├── columns: c1:436
-                                         │         │    ├── grouping columns: c1:436
-                                         │         │    ├── key: (436)
+                                         │         │    ├── columns: c1:437
+                                         │         │    ├── grouping columns: c1:437
+                                         │         │    ├── key: (437)
                                          │         │    └── scan c
-                                         │         │         └── columns: c1:436
+                                         │         │         └── columns: c1:437
                                          │         └── filters
-                                         │              └── a2:431 = c1:436 [outer=(431,436), constraints=(/431: (/NULL - ]; /436: (/NULL - ]), fd=(431)==(436), (436)==(431)]
+                                         │              └── a2:432 = c1:437 [outer=(432,437), constraints=(/432: (/NULL - ]; /437: (/NULL - ]), fd=(432)==(437), (437)==(432)]
                                          └── project
-                                              ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null
-                                              ├── key: (443-446)
+                                              ├── columns: a1:444!null a2:445!null a3:446!null a4:447!null
+                                              ├── key: (444-447)
                                               └── inner-join (hash)
-                                                   ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null c4:452!null
+                                                   ├── columns: a1:444!null a2:445!null a3:446!null a4:447!null c4:453!null
                                                    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-                                                   ├── key: (443,444,446,452)
-                                                   ├── fd: (445)==(452), (452)==(445)
+                                                   ├── key: (444,445,447,453)
+                                                   ├── fd: (446)==(453), (453)==(446)
                                                    ├── scan a
-                                                   │    ├── columns: a1:443!null a2:444!null a3:445!null a4:446!null
-                                                   │    └── key: (443-446)
+                                                   │    ├── columns: a1:444!null a2:445!null a3:446!null a4:447!null
+                                                   │    └── key: (444-447)
                                                    ├── distinct-on
-                                                   │    ├── columns: c4:452
-                                                   │    ├── grouping columns: c4:452
-                                                   │    ├── key: (452)
+                                                   │    ├── columns: c4:453
+                                                   │    ├── grouping columns: c4:453
+                                                   │    ├── key: (453)
                                                    │    └── scan c
-                                                   │         └── columns: c4:452
+                                                   │         └── columns: c4:453
                                                    └── filters
-                                                        └── a3:445 = c4:452 [outer=(445,452), constraints=(/445: (/NULL - ]; /452: (/NULL - ]), fd=(445)==(452), (452)==(445)]
+                                                        └── a3:446 = c4:453 [outer=(446,453), constraints=(/446: (/NULL - ]; /453: (/NULL - ]), fd=(446)==(453), (453)==(446)]
 
 # IN subquery
 opt expect=SplitDisjunctionOfJoinTerms
 SELECT a1+a3-a2 FROM a WHERE a1 IN (SELECT b1 FROM b WHERE EXISTS (SELECT 1 FROM c WHERE c2 IS NULL OR c2=b2 OR c2=b3))
 ----
 project
- ├── columns: "?column?":22!null
+ ├── columns: "?column?":24!null
  ├── immutable
  ├── project
  │    ├── columns: a1:1!null a2:2!null a3:3!null
@@ -2470,103 +2470,103 @@ project
  │         │              ├── fd: (11)-->(7-9)
  │         │              ├── union-all
  │         │              │    ├── columns: b1:7 b2:8 b3:9 b.rowid:11!null
- │         │              │    ├── left columns: b1:23 b2:24 b3:25 b.rowid:27
- │         │              │    ├── right columns: b1:37 b2:38 b3:39 b.rowid:41
+ │         │              │    ├── left columns: b1:25 b2:26 b3:27 b.rowid:29
+ │         │              │    ├── right columns: b1:39 b2:40 b3:41 b.rowid:43
  │         │              │    ├── project
- │         │              │    │    ├── columns: b1:23 b2:24 b3:25 b.rowid:27!null
- │         │              │    │    ├── key: (27)
- │         │              │    │    ├── fd: (27)-->(23-25)
+ │         │              │    │    ├── columns: b1:25 b2:26 b3:27 b.rowid:29!null
+ │         │              │    │    ├── key: (29)
+ │         │              │    │    ├── fd: (29)-->(25-27)
  │         │              │    │    └── project
- │         │              │    │         ├── columns: b1:23 b2:24 b3:25 b.rowid:27!null
- │         │              │    │         ├── key: (27)
- │         │              │    │         ├── fd: (27)-->(23-25)
+ │         │              │    │         ├── columns: b1:25 b2:26 b3:27 b.rowid:29!null
+ │         │              │    │         ├── key: (29)
+ │         │              │    │         ├── fd: (29)-->(25-27)
  │         │              │    │         └── inner-join (cross)
- │         │              │    │              ├── columns: b1:23 b2:24 b3:25 b.rowid:27!null c2:31
+ │         │              │    │              ├── columns: b1:25 b2:26 b3:27 b.rowid:29!null c2:33
  │         │              │    │              ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │         │              │    │              ├── key: (27)
- │         │              │    │              ├── fd: ()-->(31), (27)-->(23-25)
+ │         │              │    │              ├── key: (29)
+ │         │              │    │              ├── fd: ()-->(33), (29)-->(25-27)
  │         │              │    │              ├── scan b
- │         │              │    │              │    ├── columns: b1:23 b2:24 b3:25 b.rowid:27!null
- │         │              │    │              │    ├── key: (27)
- │         │              │    │              │    └── fd: (27)-->(23-25)
+ │         │              │    │              │    ├── columns: b1:25 b2:26 b3:27 b.rowid:29!null
+ │         │              │    │              │    ├── key: (29)
+ │         │              │    │              │    └── fd: (29)-->(25-27)
  │         │              │    │              ├── limit
- │         │              │    │              │    ├── columns: c2:31
+ │         │              │    │              │    ├── columns: c2:33
  │         │              │    │              │    ├── cardinality: [0 - 1]
  │         │              │    │              │    ├── key: ()
- │         │              │    │              │    ├── fd: ()-->(31)
+ │         │              │    │              │    ├── fd: ()-->(33)
  │         │              │    │              │    ├── select
- │         │              │    │              │    │    ├── columns: c2:31
- │         │              │    │              │    │    ├── fd: ()-->(31)
+ │         │              │    │              │    │    ├── columns: c2:33
+ │         │              │    │              │    │    ├── fd: ()-->(33)
  │         │              │    │              │    │    ├── limit hint: 1.00
  │         │              │    │              │    │    ├── scan c
- │         │              │    │              │    │    │    ├── columns: c2:31
+ │         │              │    │              │    │    │    ├── columns: c2:33
  │         │              │    │              │    │    │    └── limit hint: 100.00
  │         │              │    │              │    │    └── filters
- │         │              │    │              │    │         └── c2:31 IS NULL [outer=(31), constraints=(/31: [/NULL - /NULL]; tight), fd=()-->(31)]
+ │         │              │    │              │    │         └── c2:33 IS NULL [outer=(33), constraints=(/33: [/NULL - /NULL]; tight), fd=()-->(33)]
  │         │              │    │              │    └── 1
  │         │              │    │              └── filters (true)
  │         │              │    └── project
- │         │              │         ├── columns: b1:37 b2:38 b3:39 b.rowid:41!null
- │         │              │         ├── key: (41)
- │         │              │         ├── fd: (41)-->(37-39)
+ │         │              │         ├── columns: b1:39 b2:40 b3:41 b.rowid:43!null
+ │         │              │         ├── key: (43)
+ │         │              │         ├── fd: (43)-->(39-41)
  │         │              │         └── distinct-on
- │         │              │              ├── columns: b1:37 b2:38 b3:39 b.rowid:41!null
- │         │              │              ├── grouping columns: b.rowid:41!null
- │         │              │              ├── key: (41)
- │         │              │              ├── fd: (41)-->(37-39)
+ │         │              │              ├── columns: b1:39 b2:40 b3:41 b.rowid:43!null
+ │         │              │              ├── grouping columns: b.rowid:43!null
+ │         │              │              ├── key: (43)
+ │         │              │              ├── fd: (43)-->(39-41)
  │         │              │              ├── union-all
- │         │              │              │    ├── columns: b1:37 b2:38 b3:39 b.rowid:41!null
- │         │              │              │    ├── left columns: b1:191 b2:192 b3:193 b.rowid:195
- │         │              │              │    ├── right columns: b1:205 b2:206 b3:207 b.rowid:209
+ │         │              │              │    ├── columns: b1:39 b2:40 b3:41 b.rowid:43!null
+ │         │              │              │    ├── left columns: b1:193 b2:194 b3:195 b.rowid:197
+ │         │              │              │    ├── right columns: b1:207 b2:208 b3:209 b.rowid:211
  │         │              │              │    ├── project
- │         │              │              │    │    ├── columns: b1:191 b2:192 b3:193 b.rowid:195!null
- │         │              │              │    │    ├── key: (195)
- │         │              │              │    │    ├── fd: (195)-->(191-193)
+ │         │              │              │    │    ├── columns: b1:193 b2:194 b3:195 b.rowid:197!null
+ │         │              │              │    │    ├── key: (197)
+ │         │              │              │    │    ├── fd: (197)-->(193-195)
  │         │              │              │    │    └── inner-join (hash)
- │         │              │              │    │         ├── columns: b1:191 b2:192 b3:193!null b.rowid:195!null c2:199!null
+ │         │              │              │    │         ├── columns: b1:193 b2:194 b3:195!null b.rowid:197!null c2:201!null
  │         │              │              │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │         │              │              │    │         ├── key: (195)
- │         │              │              │    │         ├── fd: (195)-->(191-193), (193)==(199), (199)==(193)
+ │         │              │              │    │         ├── key: (197)
+ │         │              │              │    │         ├── fd: (197)-->(193-195), (195)==(201), (201)==(195)
  │         │              │              │    │         ├── scan b
- │         │              │              │    │         │    ├── columns: b1:191 b2:192 b3:193 b.rowid:195!null
- │         │              │              │    │         │    ├── key: (195)
- │         │              │              │    │         │    └── fd: (195)-->(191-193)
+ │         │              │              │    │         │    ├── columns: b1:193 b2:194 b3:195 b.rowid:197!null
+ │         │              │              │    │         │    ├── key: (197)
+ │         │              │              │    │         │    └── fd: (197)-->(193-195)
  │         │              │              │    │         ├── distinct-on
- │         │              │              │    │         │    ├── columns: c2:199
- │         │              │              │    │         │    ├── grouping columns: c2:199
- │         │              │              │    │         │    ├── key: (199)
+ │         │              │              │    │         │    ├── columns: c2:201
+ │         │              │              │    │         │    ├── grouping columns: c2:201
+ │         │              │              │    │         │    ├── key: (201)
  │         │              │              │    │         │    └── scan c
- │         │              │              │    │         │         └── columns: c2:199
+ │         │              │              │    │         │         └── columns: c2:201
  │         │              │              │    │         └── filters
- │         │              │              │    │              └── c2:199 = b3:193 [outer=(193,199), constraints=(/193: (/NULL - ]; /199: (/NULL - ]), fd=(193)==(199), (199)==(193)]
+ │         │              │              │    │              └── c2:201 = b3:195 [outer=(195,201), constraints=(/195: (/NULL - ]; /201: (/NULL - ]), fd=(195)==(201), (201)==(195)]
  │         │              │              │    └── project
- │         │              │              │         ├── columns: b1:205 b2:206 b3:207 b.rowid:209!null
- │         │              │              │         ├── key: (209)
- │         │              │              │         ├── fd: (209)-->(205-207)
+ │         │              │              │         ├── columns: b1:207 b2:208 b3:209 b.rowid:211!null
+ │         │              │              │         ├── key: (211)
+ │         │              │              │         ├── fd: (211)-->(207-209)
  │         │              │              │         └── inner-join (hash)
- │         │              │              │              ├── columns: b1:205 b2:206!null b3:207 b.rowid:209!null c2:213!null
+ │         │              │              │              ├── columns: b1:207 b2:208!null b3:209 b.rowid:211!null c2:215!null
  │         │              │              │              ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │         │              │              │              ├── key: (209)
- │         │              │              │              ├── fd: (209)-->(205-207), (206)==(213), (213)==(206)
+ │         │              │              │              ├── key: (211)
+ │         │              │              │              ├── fd: (211)-->(207-209), (208)==(215), (215)==(208)
  │         │              │              │              ├── scan b
- │         │              │              │              │    ├── columns: b1:205 b2:206 b3:207 b.rowid:209!null
- │         │              │              │              │    ├── key: (209)
- │         │              │              │              │    └── fd: (209)-->(205-207)
+ │         │              │              │              │    ├── columns: b1:207 b2:208 b3:209 b.rowid:211!null
+ │         │              │              │              │    ├── key: (211)
+ │         │              │              │              │    └── fd: (211)-->(207-209)
  │         │              │              │              ├── distinct-on
- │         │              │              │              │    ├── columns: c2:213
- │         │              │              │              │    ├── grouping columns: c2:213
- │         │              │              │              │    ├── key: (213)
+ │         │              │              │              │    ├── columns: c2:215
+ │         │              │              │              │    ├── grouping columns: c2:215
+ │         │              │              │              │    ├── key: (215)
  │         │              │              │              │    └── scan c
- │         │              │              │              │         └── columns: c2:213
+ │         │              │              │              │         └── columns: c2:215
  │         │              │              │              └── filters
- │         │              │              │                   └── c2:213 = b2:206 [outer=(206,213), constraints=(/206: (/NULL - ]; /213: (/NULL - ]), fd=(206)==(213), (213)==(206)]
+ │         │              │              │                   └── c2:215 = b2:208 [outer=(208,215), constraints=(/208: (/NULL - ]; /215: (/NULL - ]), fd=(208)==(215), (215)==(208)]
  │         │              │              └── aggregations
- │         │              │                   ├── const-agg [as=b1:37, outer=(37)]
- │         │              │                   │    └── b1:37
- │         │              │                   ├── const-agg [as=b2:38, outer=(38)]
- │         │              │                   │    └── b2:38
- │         │              │                   └── const-agg [as=b3:39, outer=(39)]
- │         │              │                        └── b3:39
+ │         │              │                   ├── const-agg [as=b1:39, outer=(39)]
+ │         │              │                   │    └── b1:39
+ │         │              │                   ├── const-agg [as=b2:40, outer=(40)]
+ │         │              │                   │    └── b2:40
+ │         │              │                   └── const-agg [as=b3:41, outer=(41)]
+ │         │              │                        └── b3:41
  │         │              └── aggregations
  │         │                   ├── const-agg [as=b1:7, outer=(7)]
  │         │                   │    └── b1:7
@@ -2577,7 +2577,7 @@ project
  │         └── filters
  │              └── a1:1 = b1:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
  └── projections
-      └── (a1:1 + a3:3) - a2:2 [as="?column?":22, outer=(1-3), immutable]
+      └── (a1:1 + a3:3) - a2:2 [as="?column?":24, outer=(1-3), immutable]
 
 # IN subquery, 2 columns
 opt expect=SplitDisjunctionOfJoinTerms
@@ -2585,7 +2585,7 @@ SELECT a1+a3-a2 FROM a WHERE (a1,a2) IN (SELECT b1,b2 FROM b WHERE
                                             EXISTS (SELECT 1 FROM c WHERE c2 IS NULL OR c2=b2 OR c2=b3))
 ----
 project
- ├── columns: "?column?":23!null
+ ├── columns: "?column?":25!null
  ├── immutable
  ├── semi-join (hash)
  │    ├── columns: a1:1!null a2:2!null a3:3!null
@@ -2600,103 +2600,103 @@ project
  │    │         ├── fd: (11)-->(7-9)
  │    │         ├── union-all
  │    │         │    ├── columns: b1:7 b2:8 b3:9 b.rowid:11!null
- │    │         │    ├── left columns: b1:24 b2:25 b3:26 b.rowid:28
- │    │         │    ├── right columns: b1:38 b2:39 b3:40 b.rowid:42
+ │    │         │    ├── left columns: b1:26 b2:27 b3:28 b.rowid:30
+ │    │         │    ├── right columns: b1:40 b2:41 b3:42 b.rowid:44
  │    │         │    ├── project
- │    │         │    │    ├── columns: b1:24 b2:25 b3:26 b.rowid:28!null
- │    │         │    │    ├── key: (28)
- │    │         │    │    ├── fd: (28)-->(24-26)
+ │    │         │    │    ├── columns: b1:26 b2:27 b3:28 b.rowid:30!null
+ │    │         │    │    ├── key: (30)
+ │    │         │    │    ├── fd: (30)-->(26-28)
  │    │         │    │    └── project
- │    │         │    │         ├── columns: b1:24 b2:25 b3:26 b.rowid:28!null
- │    │         │    │         ├── key: (28)
- │    │         │    │         ├── fd: (28)-->(24-26)
+ │    │         │    │         ├── columns: b1:26 b2:27 b3:28 b.rowid:30!null
+ │    │         │    │         ├── key: (30)
+ │    │         │    │         ├── fd: (30)-->(26-28)
  │    │         │    │         └── inner-join (cross)
- │    │         │    │              ├── columns: b1:24 b2:25 b3:26 b.rowid:28!null c2:32
+ │    │         │    │              ├── columns: b1:26 b2:27 b3:28 b.rowid:30!null c2:34
  │    │         │    │              ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │         │    │              ├── key: (28)
- │    │         │    │              ├── fd: ()-->(32), (28)-->(24-26)
+ │    │         │    │              ├── key: (30)
+ │    │         │    │              ├── fd: ()-->(34), (30)-->(26-28)
  │    │         │    │              ├── scan b
- │    │         │    │              │    ├── columns: b1:24 b2:25 b3:26 b.rowid:28!null
- │    │         │    │              │    ├── key: (28)
- │    │         │    │              │    └── fd: (28)-->(24-26)
+ │    │         │    │              │    ├── columns: b1:26 b2:27 b3:28 b.rowid:30!null
+ │    │         │    │              │    ├── key: (30)
+ │    │         │    │              │    └── fd: (30)-->(26-28)
  │    │         │    │              ├── limit
- │    │         │    │              │    ├── columns: c2:32
+ │    │         │    │              │    ├── columns: c2:34
  │    │         │    │              │    ├── cardinality: [0 - 1]
  │    │         │    │              │    ├── key: ()
- │    │         │    │              │    ├── fd: ()-->(32)
+ │    │         │    │              │    ├── fd: ()-->(34)
  │    │         │    │              │    ├── select
- │    │         │    │              │    │    ├── columns: c2:32
- │    │         │    │              │    │    ├── fd: ()-->(32)
+ │    │         │    │              │    │    ├── columns: c2:34
+ │    │         │    │              │    │    ├── fd: ()-->(34)
  │    │         │    │              │    │    ├── limit hint: 1.00
  │    │         │    │              │    │    ├── scan c
- │    │         │    │              │    │    │    ├── columns: c2:32
+ │    │         │    │              │    │    │    ├── columns: c2:34
  │    │         │    │              │    │    │    └── limit hint: 100.00
  │    │         │    │              │    │    └── filters
- │    │         │    │              │    │         └── c2:32 IS NULL [outer=(32), constraints=(/32: [/NULL - /NULL]; tight), fd=()-->(32)]
+ │    │         │    │              │    │         └── c2:34 IS NULL [outer=(34), constraints=(/34: [/NULL - /NULL]; tight), fd=()-->(34)]
  │    │         │    │              │    └── 1
  │    │         │    │              └── filters (true)
  │    │         │    └── project
- │    │         │         ├── columns: b1:38 b2:39 b3:40 b.rowid:42!null
- │    │         │         ├── key: (42)
- │    │         │         ├── fd: (42)-->(38-40)
+ │    │         │         ├── columns: b1:40 b2:41 b3:42 b.rowid:44!null
+ │    │         │         ├── key: (44)
+ │    │         │         ├── fd: (44)-->(40-42)
  │    │         │         └── distinct-on
- │    │         │              ├── columns: b1:38 b2:39 b3:40 b.rowid:42!null
- │    │         │              ├── grouping columns: b.rowid:42!null
- │    │         │              ├── key: (42)
- │    │         │              ├── fd: (42)-->(38-40)
+ │    │         │              ├── columns: b1:40 b2:41 b3:42 b.rowid:44!null
+ │    │         │              ├── grouping columns: b.rowid:44!null
+ │    │         │              ├── key: (44)
+ │    │         │              ├── fd: (44)-->(40-42)
  │    │         │              ├── union-all
- │    │         │              │    ├── columns: b1:38 b2:39 b3:40 b.rowid:42!null
- │    │         │              │    ├── left columns: b1:192 b2:193 b3:194 b.rowid:196
- │    │         │              │    ├── right columns: b1:206 b2:207 b3:208 b.rowid:210
+ │    │         │              │    ├── columns: b1:40 b2:41 b3:42 b.rowid:44!null
+ │    │         │              │    ├── left columns: b1:194 b2:195 b3:196 b.rowid:198
+ │    │         │              │    ├── right columns: b1:208 b2:209 b3:210 b.rowid:212
  │    │         │              │    ├── project
- │    │         │              │    │    ├── columns: b1:192 b2:193 b3:194 b.rowid:196!null
- │    │         │              │    │    ├── key: (196)
- │    │         │              │    │    ├── fd: (196)-->(192-194)
+ │    │         │              │    │    ├── columns: b1:194 b2:195 b3:196 b.rowid:198!null
+ │    │         │              │    │    ├── key: (198)
+ │    │         │              │    │    ├── fd: (198)-->(194-196)
  │    │         │              │    │    └── inner-join (hash)
- │    │         │              │    │         ├── columns: b1:192 b2:193 b3:194!null b.rowid:196!null c2:200!null
+ │    │         │              │    │         ├── columns: b1:194 b2:195 b3:196!null b.rowid:198!null c2:202!null
  │    │         │              │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │         │              │    │         ├── key: (196)
- │    │         │              │    │         ├── fd: (196)-->(192-194), (194)==(200), (200)==(194)
+ │    │         │              │    │         ├── key: (198)
+ │    │         │              │    │         ├── fd: (198)-->(194-196), (196)==(202), (202)==(196)
  │    │         │              │    │         ├── scan b
- │    │         │              │    │         │    ├── columns: b1:192 b2:193 b3:194 b.rowid:196!null
- │    │         │              │    │         │    ├── key: (196)
- │    │         │              │    │         │    └── fd: (196)-->(192-194)
+ │    │         │              │    │         │    ├── columns: b1:194 b2:195 b3:196 b.rowid:198!null
+ │    │         │              │    │         │    ├── key: (198)
+ │    │         │              │    │         │    └── fd: (198)-->(194-196)
  │    │         │              │    │         ├── distinct-on
- │    │         │              │    │         │    ├── columns: c2:200
- │    │         │              │    │         │    ├── grouping columns: c2:200
- │    │         │              │    │         │    ├── key: (200)
+ │    │         │              │    │         │    ├── columns: c2:202
+ │    │         │              │    │         │    ├── grouping columns: c2:202
+ │    │         │              │    │         │    ├── key: (202)
  │    │         │              │    │         │    └── scan c
- │    │         │              │    │         │         └── columns: c2:200
+ │    │         │              │    │         │         └── columns: c2:202
  │    │         │              │    │         └── filters
- │    │         │              │    │              └── c2:200 = b3:194 [outer=(194,200), constraints=(/194: (/NULL - ]; /200: (/NULL - ]), fd=(194)==(200), (200)==(194)]
+ │    │         │              │    │              └── c2:202 = b3:196 [outer=(196,202), constraints=(/196: (/NULL - ]; /202: (/NULL - ]), fd=(196)==(202), (202)==(196)]
  │    │         │              │    └── project
- │    │         │              │         ├── columns: b1:206 b2:207 b3:208 b.rowid:210!null
- │    │         │              │         ├── key: (210)
- │    │         │              │         ├── fd: (210)-->(206-208)
+ │    │         │              │         ├── columns: b1:208 b2:209 b3:210 b.rowid:212!null
+ │    │         │              │         ├── key: (212)
+ │    │         │              │         ├── fd: (212)-->(208-210)
  │    │         │              │         └── inner-join (hash)
- │    │         │              │              ├── columns: b1:206 b2:207!null b3:208 b.rowid:210!null c2:214!null
+ │    │         │              │              ├── columns: b1:208 b2:209!null b3:210 b.rowid:212!null c2:216!null
  │    │         │              │              ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │         │              │              ├── key: (210)
- │    │         │              │              ├── fd: (210)-->(206-208), (207)==(214), (214)==(207)
+ │    │         │              │              ├── key: (212)
+ │    │         │              │              ├── fd: (212)-->(208-210), (209)==(216), (216)==(209)
  │    │         │              │              ├── scan b
- │    │         │              │              │    ├── columns: b1:206 b2:207 b3:208 b.rowid:210!null
- │    │         │              │              │    ├── key: (210)
- │    │         │              │              │    └── fd: (210)-->(206-208)
+ │    │         │              │              │    ├── columns: b1:208 b2:209 b3:210 b.rowid:212!null
+ │    │         │              │              │    ├── key: (212)
+ │    │         │              │              │    └── fd: (212)-->(208-210)
  │    │         │              │              ├── distinct-on
- │    │         │              │              │    ├── columns: c2:214
- │    │         │              │              │    ├── grouping columns: c2:214
- │    │         │              │              │    ├── key: (214)
+ │    │         │              │              │    ├── columns: c2:216
+ │    │         │              │              │    ├── grouping columns: c2:216
+ │    │         │              │              │    ├── key: (216)
  │    │         │              │              │    └── scan c
- │    │         │              │              │         └── columns: c2:214
+ │    │         │              │              │         └── columns: c2:216
  │    │         │              │              └── filters
- │    │         │              │                   └── c2:214 = b2:207 [outer=(207,214), constraints=(/207: (/NULL - ]; /214: (/NULL - ]), fd=(207)==(214), (214)==(207)]
+ │    │         │              │                   └── c2:216 = b2:209 [outer=(209,216), constraints=(/209: (/NULL - ]; /216: (/NULL - ]), fd=(209)==(216), (216)==(209)]
  │    │         │              └── aggregations
- │    │         │                   ├── const-agg [as=b1:38, outer=(38)]
- │    │         │                   │    └── b1:38
- │    │         │                   ├── const-agg [as=b2:39, outer=(39)]
- │    │         │                   │    └── b2:39
- │    │         │                   └── const-agg [as=b3:40, outer=(40)]
- │    │         │                        └── b3:40
+ │    │         │                   ├── const-agg [as=b1:40, outer=(40)]
+ │    │         │                   │    └── b1:40
+ │    │         │                   ├── const-agg [as=b2:41, outer=(41)]
+ │    │         │                   │    └── b2:41
+ │    │         │                   └── const-agg [as=b3:42, outer=(42)]
+ │    │         │                        └── b3:42
  │    │         └── aggregations
  │    │              ├── const-agg [as=b1:7, outer=(7)]
  │    │              │    └── b1:7
@@ -2708,7 +2708,7 @@ project
  │         ├── b1:7 = a1:1 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
  │         └── b2:8 = a2:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
  └── projections
-      └── (a1:1 + a3:3) - a2:2 [as="?column?":23, outer=(1-3), immutable]
+      └── (a1:1 + a3:3) - a2:2 [as="?column?":25, outer=(1-3), immutable]
 
 # ANDed disjuncts
 opt expect=SplitDisjunctionOfJoinTerms
@@ -2780,39 +2780,39 @@ project
       │    │         ├── fd: (1-4,18)-->(14,15)
       │    │         ├── union-all
       │    │         │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:14 b2:15 b.rowid:18!null
-      │    │         │    ├── left columns: a1:80 a2:81 a3:82 a4:83 b1:86 b2:87 b.rowid:90
-      │    │         │    ├── right columns: a1:93 a2:94 a3:95 a4:96 b1:99 b2:100 b.rowid:103
+      │    │         │    ├── left columns: a1:81 a2:82 a3:83 a4:84 b1:87 b2:88 b.rowid:91
+      │    │         │    ├── right columns: a1:94 a2:95 a3:96 a4:97 b1:100 b2:101 b.rowid:104
       │    │         │    ├── inner-join (merge)
-      │    │         │    │    ├── columns: a1:80!null a2:81!null a3:82!null a4:83!null b1:86!null b2:87 b.rowid:90!null
-      │    │         │    │    ├── left ordering: +80
-      │    │         │    │    ├── right ordering: +86
-      │    │         │    │    ├── key: (81-83,90)
-      │    │         │    │    ├── fd: (90)-->(86,87), (80)==(86), (86)==(80)
+      │    │         │    │    ├── columns: a1:81!null a2:82!null a3:83!null a4:84!null b1:87!null b2:88 b.rowid:91!null
+      │    │         │    │    ├── left ordering: +81
+      │    │         │    │    ├── right ordering: +87
+      │    │         │    │    ├── key: (82-84,91)
+      │    │         │    │    ├── fd: (91)-->(87,88), (81)==(87), (87)==(81)
       │    │         │    │    ├── scan a
-      │    │         │    │    │    ├── columns: a1:80!null a2:81!null a3:82!null a4:83!null
-      │    │         │    │    │    ├── key: (80-83)
-      │    │         │    │    │    └── ordering: +80
+      │    │         │    │    │    ├── columns: a1:81!null a2:82!null a3:83!null a4:84!null
+      │    │         │    │    │    ├── key: (81-84)
+      │    │         │    │    │    └── ordering: +81
       │    │         │    │    ├── scan b@b_b1_b2_idx
-      │    │         │    │    │    ├── columns: b1:86 b2:87 b.rowid:90!null
-      │    │         │    │    │    ├── key: (90)
-      │    │         │    │    │    ├── fd: (90)-->(86,87)
-      │    │         │    │    │    └── ordering: +86
+      │    │         │    │    │    ├── columns: b1:87 b2:88 b.rowid:91!null
+      │    │         │    │    │    ├── key: (91)
+      │    │         │    │    │    ├── fd: (91)-->(87,88)
+      │    │         │    │    │    └── ordering: +87
       │    │         │    │    └── filters (true)
       │    │         │    └── inner-join (merge)
-      │    │         │         ├── columns: a1:93!null a2:94!null a3:95!null a4:96!null b1:99 b2:100!null b.rowid:103!null
-      │    │         │         ├── left ordering: +93
-      │    │         │         ├── right ordering: +100
-      │    │         │         ├── key: (94-96,103)
-      │    │         │         ├── fd: (103)-->(99,100), (93)==(100), (100)==(93)
+      │    │         │         ├── columns: a1:94!null a2:95!null a3:96!null a4:97!null b1:100 b2:101!null b.rowid:104!null
+      │    │         │         ├── left ordering: +94
+      │    │         │         ├── right ordering: +101
+      │    │         │         ├── key: (95-97,104)
+      │    │         │         ├── fd: (104)-->(100,101), (94)==(101), (101)==(94)
       │    │         │         ├── scan a
-      │    │         │         │    ├── columns: a1:93!null a2:94!null a3:95!null a4:96!null
-      │    │         │         │    ├── key: (93-96)
-      │    │         │         │    └── ordering: +93
+      │    │         │         │    ├── columns: a1:94!null a2:95!null a3:96!null a4:97!null
+      │    │         │         │    ├── key: (94-97)
+      │    │         │         │    └── ordering: +94
       │    │         │         ├── scan b@b_b2_idx
-      │    │         │         │    ├── columns: b1:99 b2:100 b.rowid:103!null
-      │    │         │         │    ├── key: (103)
-      │    │         │         │    ├── fd: (103)-->(99,100)
-      │    │         │         │    └── ordering: +100
+      │    │         │         │    ├── columns: b1:100 b2:101 b.rowid:104!null
+      │    │         │         │    ├── key: (104)
+      │    │         │         │    ├── fd: (104)-->(100,101)
+      │    │         │         │    └── ordering: +101
       │    │         │         └── filters (true)
       │    │         └── aggregations
       │    │              ├── const-agg [as=b1:14, outer=(14)]
@@ -2908,39 +2908,39 @@ project
                 │         ├── fd: (1-4,11)-->(7,8)
                 │         ├── union-all
                 │         │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7 b2:8 b.rowid:11!null
-                │         │    ├── left columns: a1:22 a2:23 a3:24 a4:25 b1:28 b2:29 b.rowid:32
-                │         │    ├── right columns: a1:35 a2:36 a3:37 a4:38 b1:41 b2:42 b.rowid:45
+                │         │    ├── left columns: a1:24 a2:25 a3:26 a4:27 b1:30 b2:31 b.rowid:34
+                │         │    ├── right columns: a1:37 a2:38 a3:39 a4:40 b1:43 b2:44 b.rowid:47
                 │         │    ├── inner-join (merge)
-                │         │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null b1:28!null b2:29 b.rowid:32!null
-                │         │    │    ├── left ordering: +22
-                │         │    │    ├── right ordering: +28
-                │         │    │    ├── key: (23-25,32)
-                │         │    │    ├── fd: (32)-->(28,29), (22)==(28), (28)==(22)
+                │         │    │    ├── columns: a1:24!null a2:25!null a3:26!null a4:27!null b1:30!null b2:31 b.rowid:34!null
+                │         │    │    ├── left ordering: +24
+                │         │    │    ├── right ordering: +30
+                │         │    │    ├── key: (25-27,34)
+                │         │    │    ├── fd: (34)-->(30,31), (24)==(30), (30)==(24)
                 │         │    │    ├── scan a
-                │         │    │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null
-                │         │    │    │    ├── key: (22-25)
-                │         │    │    │    └── ordering: +22
+                │         │    │    │    ├── columns: a1:24!null a2:25!null a3:26!null a4:27!null
+                │         │    │    │    ├── key: (24-27)
+                │         │    │    │    └── ordering: +24
                 │         │    │    ├── scan b@b_b1_b2_idx
-                │         │    │    │    ├── columns: b1:28 b2:29 b.rowid:32!null
-                │         │    │    │    ├── key: (32)
-                │         │    │    │    ├── fd: (32)-->(28,29)
-                │         │    │    │    └── ordering: +28
+                │         │    │    │    ├── columns: b1:30 b2:31 b.rowid:34!null
+                │         │    │    │    ├── key: (34)
+                │         │    │    │    ├── fd: (34)-->(30,31)
+                │         │    │    │    └── ordering: +30
                 │         │    │    └── filters (true)
                 │         │    └── inner-join (merge)
-                │         │         ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null b1:41 b2:42!null b.rowid:45!null
-                │         │         ├── left ordering: +35
-                │         │         ├── right ordering: +42
-                │         │         ├── key: (36-38,45)
-                │         │         ├── fd: (45)-->(41,42), (35)==(42), (42)==(35)
+                │         │         ├── columns: a1:37!null a2:38!null a3:39!null a4:40!null b1:43 b2:44!null b.rowid:47!null
+                │         │         ├── left ordering: +37
+                │         │         ├── right ordering: +44
+                │         │         ├── key: (38-40,47)
+                │         │         ├── fd: (47)-->(43,44), (37)==(44), (44)==(37)
                 │         │         ├── scan a
-                │         │         │    ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
-                │         │         │    ├── key: (35-38)
-                │         │         │    └── ordering: +35
+                │         │         │    ├── columns: a1:37!null a2:38!null a3:39!null a4:40!null
+                │         │         │    ├── key: (37-40)
+                │         │         │    └── ordering: +37
                 │         │         ├── scan b@b_b2_idx
-                │         │         │    ├── columns: b1:41 b2:42 b.rowid:45!null
-                │         │         │    ├── key: (45)
-                │         │         │    ├── fd: (45)-->(41,42)
-                │         │         │    └── ordering: +42
+                │         │         │    ├── columns: b1:43 b2:44 b.rowid:47!null
+                │         │         │    ├── key: (47)
+                │         │         │    ├── fd: (47)-->(43,44)
+                │         │         │    └── ordering: +44
                 │         │         └── filters (true)
                 │         └── aggregations
                 │              ├── const-agg [as=b1:7, outer=(7)]
@@ -2973,51 +2973,51 @@ project
       │         ├── key: (1-4)
       │         └── union-all
       │              ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-      │              ├── left columns: a1:100 a2:101 a3:102 a4:103
-      │              ├── right columns: a1:113 a2:114 a3:115 a4:116
+      │              ├── left columns: a1:102 a2:103 a3:104 a4:105
+      │              ├── right columns: a1:115 a2:116 a3:117 a4:118
       │              ├── project
-      │              │    ├── columns: a1:100!null a2:101!null a3:102!null a4:103!null
-      │              │    ├── key: (100-103)
+      │              │    ├── columns: a1:102!null a2:103!null a3:104!null a4:105!null
+      │              │    ├── key: (102-105)
       │              │    └── inner-join (merge)
-      │              │         ├── columns: a1:100!null a2:101!null a3:102!null a4:103!null b1:106!null
-      │              │         ├── left ordering: +100
-      │              │         ├── right ordering: +106
-      │              │         ├── key: (101-103,106)
-      │              │         ├── fd: (100)==(106), (106)==(100)
+      │              │         ├── columns: a1:102!null a2:103!null a3:104!null a4:105!null b1:108!null
+      │              │         ├── left ordering: +102
+      │              │         ├── right ordering: +108
+      │              │         ├── key: (103-105,108)
+      │              │         ├── fd: (102)==(108), (108)==(102)
       │              │         ├── scan a
-      │              │         │    ├── columns: a1:100!null a2:101!null a3:102!null a4:103!null
-      │              │         │    ├── key: (100-103)
-      │              │         │    └── ordering: +100
+      │              │         │    ├── columns: a1:102!null a2:103!null a3:104!null a4:105!null
+      │              │         │    ├── key: (102-105)
+      │              │         │    └── ordering: +102
       │              │         ├── distinct-on
-      │              │         │    ├── columns: b1:106
-      │              │         │    ├── grouping columns: b1:106
-      │              │         │    ├── key: (106)
-      │              │         │    ├── ordering: +106
+      │              │         │    ├── columns: b1:108
+      │              │         │    ├── grouping columns: b1:108
+      │              │         │    ├── key: (108)
+      │              │         │    ├── ordering: +108
       │              │         │    └── scan b@b_b1_b2_idx
-      │              │         │         ├── columns: b1:106
-      │              │         │         └── ordering: +106
+      │              │         │         ├── columns: b1:108
+      │              │         │         └── ordering: +108
       │              │         └── filters (true)
       │              └── project
-      │                   ├── columns: a1:113!null a2:114!null a3:115!null a4:116!null
-      │                   ├── key: (113-116)
+      │                   ├── columns: a1:115!null a2:116!null a3:117!null a4:118!null
+      │                   ├── key: (115-118)
       │                   └── inner-join (merge)
-      │                        ├── columns: a1:113!null a2:114!null a3:115!null a4:116!null b2:120!null
-      │                        ├── left ordering: +113
-      │                        ├── right ordering: +120
-      │                        ├── key: (114-116,120)
-      │                        ├── fd: (113)==(120), (120)==(113)
+      │                        ├── columns: a1:115!null a2:116!null a3:117!null a4:118!null b2:122!null
+      │                        ├── left ordering: +115
+      │                        ├── right ordering: +122
+      │                        ├── key: (116-118,122)
+      │                        ├── fd: (115)==(122), (122)==(115)
       │                        ├── scan a
-      │                        │    ├── columns: a1:113!null a2:114!null a3:115!null a4:116!null
-      │                        │    ├── key: (113-116)
-      │                        │    └── ordering: +113
+      │                        │    ├── columns: a1:115!null a2:116!null a3:117!null a4:118!null
+      │                        │    ├── key: (115-118)
+      │                        │    └── ordering: +115
       │                        ├── distinct-on
-      │                        │    ├── columns: b2:120
-      │                        │    ├── grouping columns: b2:120
-      │                        │    ├── key: (120)
-      │                        │    ├── ordering: +120
+      │                        │    ├── columns: b2:122
+      │                        │    ├── grouping columns: b2:122
+      │                        │    ├── key: (122)
+      │                        │    ├── ordering: +122
       │                        │    └── scan b@b_b2_idx
-      │                        │         ├── columns: b2:120
-      │                        │         └── ordering: +120
+      │                        │         ├── columns: b2:122
+      │                        │         └── ordering: +122
       │                        └── filters (true)
       ├── scan c
       │    └── columns: c1:14 c2:15
@@ -3041,114 +3041,114 @@ project
       │         ├── key: (1-4)
       │         └── union-all
       │              ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-      │              ├── left columns: a1:516 a2:517 a3:518 a4:519
-      │              ├── right columns: a1:529 a2:530 a3:531 a4:532
+      │              ├── left columns: a1:518 a2:519 a3:520 a4:521
+      │              ├── right columns: a1:531 a2:532 a3:533 a4:534
       │              ├── project
-      │              │    ├── columns: a1:516!null a2:517!null a3:518!null a4:519!null
-      │              │    ├── key: (516-519)
+      │              │    ├── columns: a1:518!null a2:519!null a3:520!null a4:521!null
+      │              │    ├── key: (518-521)
       │              │    └── inner-join (merge)
-      │              │         ├── columns: a1:516!null a2:517!null a3:518!null a4:519!null b1:522!null
-      │              │         ├── left ordering: +516
-      │              │         ├── right ordering: +522
-      │              │         ├── key: (517-519,522)
-      │              │         ├── fd: (516)==(522), (522)==(516)
+      │              │         ├── columns: a1:518!null a2:519!null a3:520!null a4:521!null b1:524!null
+      │              │         ├── left ordering: +518
+      │              │         ├── right ordering: +524
+      │              │         ├── key: (519-521,524)
+      │              │         ├── fd: (518)==(524), (524)==(518)
       │              │         ├── scan a
-      │              │         │    ├── columns: a1:516!null a2:517!null a3:518!null a4:519!null
-      │              │         │    ├── key: (516-519)
-      │              │         │    └── ordering: +516
+      │              │         │    ├── columns: a1:518!null a2:519!null a3:520!null a4:521!null
+      │              │         │    ├── key: (518-521)
+      │              │         │    └── ordering: +518
       │              │         ├── distinct-on
-      │              │         │    ├── columns: b1:522
-      │              │         │    ├── grouping columns: b1:522
-      │              │         │    ├── key: (522)
-      │              │         │    ├── ordering: +522
+      │              │         │    ├── columns: b1:524
+      │              │         │    ├── grouping columns: b1:524
+      │              │         │    ├── key: (524)
+      │              │         │    ├── ordering: +524
       │              │         │    └── scan b@b_b1_b2_idx
-      │              │         │         ├── columns: b1:522
-      │              │         │         └── ordering: +522
+      │              │         │         ├── columns: b1:524
+      │              │         │         └── ordering: +524
       │              │         └── filters (true)
       │              └── project
-      │                   ├── columns: a1:529!null a2:530!null a3:531!null a4:532!null
-      │                   ├── key: (529-532)
+      │                   ├── columns: a1:531!null a2:532!null a3:533!null a4:534!null
+      │                   ├── key: (531-534)
       │                   └── distinct-on
-      │                        ├── columns: a1:529!null a2:530!null a3:531!null a4:532!null
-      │                        ├── grouping columns: a1:529!null a2:530!null a3:531!null a4:532!null
-      │                        ├── key: (529-532)
+      │                        ├── columns: a1:531!null a2:532!null a3:533!null a4:534!null
+      │                        ├── grouping columns: a1:531!null a2:532!null a3:533!null a4:534!null
+      │                        ├── key: (531-534)
       │                        └── union-all
-      │                             ├── columns: a1:529!null a2:530!null a3:531!null a4:532!null
-      │                             ├── left columns: a1:620 a2:621 a3:622 a4:623
-      │                             ├── right columns: a1:633 a2:634 a3:635 a4:636
+      │                             ├── columns: a1:531!null a2:532!null a3:533!null a4:534!null
+      │                             ├── left columns: a1:622 a2:623 a3:624 a4:625
+      │                             ├── right columns: a1:635 a2:636 a3:637 a4:638
       │                             ├── project
-      │                             │    ├── columns: a1:620!null a2:621!null a3:622!null a4:623!null
-      │                             │    ├── key: (620-623)
+      │                             │    ├── columns: a1:622!null a2:623!null a3:624!null a4:625!null
+      │                             │    ├── key: (622-625)
       │                             │    └── inner-join (hash)
-      │                             │         ├── columns: a1:620!null a2:621!null a3:622!null a4:623!null b4:629!null
+      │                             │         ├── columns: a1:622!null a2:623!null a3:624!null a4:625!null b4:631!null
       │                             │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-      │                             │         ├── key: (621-623,629)
-      │                             │         ├── fd: (620)==(629), (629)==(620)
+      │                             │         ├── key: (623-625,631)
+      │                             │         ├── fd: (622)==(631), (631)==(622)
       │                             │         ├── scan a
-      │                             │         │    ├── columns: a1:620!null a2:621!null a3:622!null a4:623!null
-      │                             │         │    └── key: (620-623)
+      │                             │         │    ├── columns: a1:622!null a2:623!null a3:624!null a4:625!null
+      │                             │         │    └── key: (622-625)
       │                             │         ├── distinct-on
-      │                             │         │    ├── columns: b4:629
-      │                             │         │    ├── grouping columns: b4:629
-      │                             │         │    ├── key: (629)
+      │                             │         │    ├── columns: b4:631
+      │                             │         │    ├── grouping columns: b4:631
+      │                             │         │    ├── key: (631)
       │                             │         │    └── scan b
-      │                             │         │         └── columns: b4:629
+      │                             │         │         └── columns: b4:631
       │                             │         └── filters
-      │                             │              └── a1:620 = b4:629 [outer=(620,629), constraints=(/620: (/NULL - ]; /629: (/NULL - ]), fd=(620)==(629), (629)==(620)]
+      │                             │              └── a1:622 = b4:631 [outer=(622,631), constraints=(/622: (/NULL - ]; /631: (/NULL - ]), fd=(622)==(631), (631)==(622)]
       │                             └── project
-      │                                  ├── columns: a1:633!null a2:634!null a3:635!null a4:636!null
-      │                                  ├── key: (633-636)
+      │                                  ├── columns: a1:635!null a2:636!null a3:637!null a4:638!null
+      │                                  ├── key: (635-638)
       │                                  └── distinct-on
-      │                                       ├── columns: a1:633!null a2:634!null a3:635!null a4:636!null
-      │                                       ├── grouping columns: a1:633!null a2:634!null a3:635!null a4:636!null
-      │                                       ├── key: (633-636)
+      │                                       ├── columns: a1:635!null a2:636!null a3:637!null a4:638!null
+      │                                       ├── grouping columns: a1:635!null a2:636!null a3:637!null a4:638!null
+      │                                       ├── key: (635-638)
       │                                       └── union-all
-      │                                            ├── columns: a1:633!null a2:634!null a3:635!null a4:636!null
-      │                                            ├── left columns: a1:698 a2:699 a3:700 a4:701
-      │                                            ├── right columns: a1:711 a2:712 a3:713 a4:714
+      │                                            ├── columns: a1:635!null a2:636!null a3:637!null a4:638!null
+      │                                            ├── left columns: a1:700 a2:701 a3:702 a4:703
+      │                                            ├── right columns: a1:713 a2:714 a3:715 a4:716
       │                                            ├── project
-      │                                            │    ├── columns: a1:698!null a2:699!null a3:700!null a4:701!null
-      │                                            │    ├── key: (698-701)
+      │                                            │    ├── columns: a1:700!null a2:701!null a3:702!null a4:703!null
+      │                                            │    ├── key: (700-703)
       │                                            │    └── inner-join (merge)
-      │                                            │         ├── columns: a1:698!null a2:699!null a3:700!null a4:701!null b2:705!null
-      │                                            │         ├── left ordering: +698
-      │                                            │         ├── right ordering: +705
-      │                                            │         ├── key: (699-701,705)
-      │                                            │         ├── fd: (698)==(705), (705)==(698)
+      │                                            │         ├── columns: a1:700!null a2:701!null a3:702!null a4:703!null b2:707!null
+      │                                            │         ├── left ordering: +700
+      │                                            │         ├── right ordering: +707
+      │                                            │         ├── key: (701-703,707)
+      │                                            │         ├── fd: (700)==(707), (707)==(700)
       │                                            │         ├── scan a
-      │                                            │         │    ├── columns: a1:698!null a2:699!null a3:700!null a4:701!null
-      │                                            │         │    ├── key: (698-701)
-      │                                            │         │    └── ordering: +698
+      │                                            │         │    ├── columns: a1:700!null a2:701!null a3:702!null a4:703!null
+      │                                            │         │    ├── key: (700-703)
+      │                                            │         │    └── ordering: +700
       │                                            │         ├── distinct-on
-      │                                            │         │    ├── columns: b2:705
-      │                                            │         │    ├── grouping columns: b2:705
-      │                                            │         │    ├── key: (705)
-      │                                            │         │    ├── ordering: +705
+      │                                            │         │    ├── columns: b2:707
+      │                                            │         │    ├── grouping columns: b2:707
+      │                                            │         │    ├── key: (707)
+      │                                            │         │    ├── ordering: +707
       │                                            │         │    └── scan b@b_b2_idx
-      │                                            │         │         ├── columns: b2:705
-      │                                            │         │         └── ordering: +705
+      │                                            │         │         ├── columns: b2:707
+      │                                            │         │         └── ordering: +707
       │                                            │         └── filters (true)
       │                                            └── project
-      │                                                 ├── columns: a1:711!null a2:712!null a3:713!null a4:714!null
-      │                                                 ├── key: (711-714)
+      │                                                 ├── columns: a1:713!null a2:714!null a3:715!null a4:716!null
+      │                                                 ├── key: (713-716)
       │                                                 └── inner-join (merge)
-      │                                                      ├── columns: a1:711!null a2:712!null a3:713!null a4:714!null b3:719!null
-      │                                                      ├── left ordering: +711
-      │                                                      ├── right ordering: +719
-      │                                                      ├── key: (712-714,719)
-      │                                                      ├── fd: (711)==(719), (719)==(711)
+      │                                                      ├── columns: a1:713!null a2:714!null a3:715!null a4:716!null b3:721!null
+      │                                                      ├── left ordering: +713
+      │                                                      ├── right ordering: +721
+      │                                                      ├── key: (714-716,721)
+      │                                                      ├── fd: (713)==(721), (721)==(713)
       │                                                      ├── scan a
-      │                                                      │    ├── columns: a1:711!null a2:712!null a3:713!null a4:714!null
-      │                                                      │    ├── key: (711-714)
-      │                                                      │    └── ordering: +711
+      │                                                      │    ├── columns: a1:713!null a2:714!null a3:715!null a4:716!null
+      │                                                      │    ├── key: (713-716)
+      │                                                      │    └── ordering: +713
       │                                                      ├── distinct-on
-      │                                                      │    ├── columns: b3:719
-      │                                                      │    ├── grouping columns: b3:719
-      │                                                      │    ├── key: (719)
-      │                                                      │    ├── ordering: +719
+      │                                                      │    ├── columns: b3:721
+      │                                                      │    ├── grouping columns: b3:721
+      │                                                      │    ├── key: (721)
+      │                                                      │    ├── ordering: +721
       │                                                      │    └── scan b@b_b3_idx
-      │                                                      │         ├── columns: b3:719
-      │                                                      │         └── ordering: +719
+      │                                                      │         ├── columns: b3:721
+      │                                                      │         └── ordering: +721
       │                                                      └── filters (true)
       ├── scan c
       │    └── columns: c1:14 c2:15 c3:16 c4:17
@@ -3175,39 +3175,39 @@ project
       │         ├── fd: (1-4,11)-->(7-10)
       │         ├── union-all
       │         │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null
-      │         │    ├── left columns: a1:22 a2:23 a3:24 a4:25 b1:28 b2:29 b3:30 b4:31 b.rowid:32
-      │         │    ├── right columns: a1:35 a2:36 a3:37 a4:38 b1:41 b2:42 b3:43 b4:44 b.rowid:45
+      │         │    ├── left columns: a1:23 a2:24 a3:25 a4:26 b1:29 b2:30 b3:31 b4:32 b.rowid:33
+      │         │    ├── right columns: a1:36 a2:37 a3:38 a4:39 b1:42 b2:43 b3:44 b4:45 b.rowid:46
       │         │    ├── inner-join (merge)
-      │         │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null b1:28!null b2:29 b3:30 b4:31 b.rowid:32!null
-      │         │    │    ├── left ordering: +22
-      │         │    │    ├── right ordering: +28
-      │         │    │    ├── key: (23-25,32)
-      │         │    │    ├── fd: (32)-->(28-31), (22)==(28), (28)==(22)
+      │         │    │    ├── columns: a1:23!null a2:24!null a3:25!null a4:26!null b1:29!null b2:30 b3:31 b4:32 b.rowid:33!null
+      │         │    │    ├── left ordering: +23
+      │         │    │    ├── right ordering: +29
+      │         │    │    ├── key: (24-26,33)
+      │         │    │    ├── fd: (33)-->(29-32), (23)==(29), (29)==(23)
       │         │    │    ├── scan a
-      │         │    │    │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null
-      │         │    │    │    ├── key: (22-25)
-      │         │    │    │    └── ordering: +22
+      │         │    │    │    ├── columns: a1:23!null a2:24!null a3:25!null a4:26!null
+      │         │    │    │    ├── key: (23-26)
+      │         │    │    │    └── ordering: +23
       │         │    │    ├── scan b@b_b1_b2_idx
-      │         │    │    │    ├── columns: b1:28!null b2:29 b3:30 b4:31 b.rowid:32!null
-      │         │    │    │    ├── constraint: /28/29/32: [/1 - ]
-      │         │    │    │    ├── key: (32)
-      │         │    │    │    ├── fd: (32)-->(28-31)
-      │         │    │    │    └── ordering: +28
+      │         │    │    │    ├── columns: b1:29!null b2:30 b3:31 b4:32 b.rowid:33!null
+      │         │    │    │    ├── constraint: /29/30/33: [/1 - ]
+      │         │    │    │    ├── key: (33)
+      │         │    │    │    ├── fd: (33)-->(29-32)
+      │         │    │    │    └── ordering: +29
       │         │    │    └── filters (true)
       │         │    └── inner-join (hash)
-      │         │         ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null b1:41!null b2:42!null b3:43 b4:44 b.rowid:45!null
-      │         │         ├── key: (35,37,38,45)
-      │         │         ├── fd: (45)-->(41-44), (36)==(42), (42)==(36)
+      │         │         ├── columns: a1:36!null a2:37!null a3:38!null a4:39!null b1:42!null b2:43!null b3:44 b4:45 b.rowid:46!null
+      │         │         ├── key: (36,38,39,46)
+      │         │         ├── fd: (46)-->(42-45), (37)==(43), (43)==(37)
       │         │         ├── scan a
-      │         │         │    ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
-      │         │         │    └── key: (35-38)
+      │         │         │    ├── columns: a1:36!null a2:37!null a3:38!null a4:39!null
+      │         │         │    └── key: (36-39)
       │         │         ├── scan b@b_b1_b2_idx
-      │         │         │    ├── columns: b1:41!null b2:42 b3:43 b4:44 b.rowid:45!null
-      │         │         │    ├── constraint: /41/42/45: [/1 - ]
-      │         │         │    ├── key: (45)
-      │         │         │    └── fd: (45)-->(41-44)
+      │         │         │    ├── columns: b1:42!null b2:43 b3:44 b4:45 b.rowid:46!null
+      │         │         │    ├── constraint: /42/43/46: [/1 - ]
+      │         │         │    ├── key: (46)
+      │         │         │    └── fd: (46)-->(42-45)
       │         │         └── filters
-      │         │              └── a2:36 = b2:42 [outer=(36,42), constraints=(/36: (/NULL - ]; /42: (/NULL - ]), fd=(36)==(42), (42)==(36)]
+      │         │              └── a2:37 = b2:43 [outer=(37,43), constraints=(/37: (/NULL - ]; /43: (/NULL - ]), fd=(37)==(43), (43)==(37)]
       │         └── aggregations
       │              ├── const-agg [as=b1:7, outer=(7)]
       │              │    └── b1:7
@@ -3249,52 +3249,52 @@ inner-join (hash)
  │         ├── fd: (11)-->(7-10)
  │         ├── union-all
  │         │    ├── columns: b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null
- │         │    ├── left columns: b1:22 b2:23 b3:24 b4:25 b.rowid:26
- │         │    ├── right columns: b1:36 b2:37 b3:38 b4:39 b.rowid:40
+ │         │    ├── left columns: b1:23 b2:24 b3:25 b4:26 b.rowid:27
+ │         │    ├── right columns: b1:37 b2:38 b3:39 b4:40 b.rowid:41
  │         │    ├── project
- │         │    │    ├── columns: b1:22!null b2:23 b3:24 b4:25 b.rowid:26!null
- │         │    │    ├── key: (26)
- │         │    │    ├── fd: (26)-->(22-25)
+ │         │    │    ├── columns: b1:23!null b2:24 b3:25 b4:26 b.rowid:27!null
+ │         │    │    ├── key: (27)
+ │         │    │    ├── fd: (27)-->(23-26)
  │         │    │    └── inner-join (hash)
- │         │    │         ├── columns: b1:22!null b2:23 b3:24 b4:25 b.rowid:26!null c1:29!null
+ │         │    │         ├── columns: b1:23!null b2:24 b3:25 b4:26 b.rowid:27!null c1:30!null
  │         │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │         │    │         ├── key: (26)
- │         │    │         ├── fd: (26)-->(22-25), (22)==(29), (29)==(22)
+ │         │    │         ├── key: (27)
+ │         │    │         ├── fd: (27)-->(23-26), (23)==(30), (30)==(23)
  │         │    │         ├── scan b@b_b1_b2_idx
- │         │    │         │    ├── columns: b1:22!null b2:23 b3:24 b4:25 b.rowid:26!null
- │         │    │         │    ├── constraint: /22/23/26: [/1 - ]
- │         │    │         │    ├── key: (26)
- │         │    │         │    └── fd: (26)-->(22-25)
+ │         │    │         │    ├── columns: b1:23!null b2:24 b3:25 b4:26 b.rowid:27!null
+ │         │    │         │    ├── constraint: /23/24/27: [/1 - ]
+ │         │    │         │    ├── key: (27)
+ │         │    │         │    └── fd: (27)-->(23-26)
  │         │    │         ├── distinct-on
- │         │    │         │    ├── columns: c1:29
- │         │    │         │    ├── grouping columns: c1:29
- │         │    │         │    ├── key: (29)
+ │         │    │         │    ├── columns: c1:30
+ │         │    │         │    ├── grouping columns: c1:30
+ │         │    │         │    ├── key: (30)
  │         │    │         │    └── scan c
- │         │    │         │         └── columns: c1:29
+ │         │    │         │         └── columns: c1:30
  │         │    │         └── filters
- │         │    │              └── c1:29 = b1:22 [outer=(22,29), constraints=(/22: (/NULL - ]; /29: (/NULL - ]), fd=(22)==(29), (29)==(22)]
+ │         │    │              └── c1:30 = b1:23 [outer=(23,30), constraints=(/23: (/NULL - ]; /30: (/NULL - ]), fd=(23)==(30), (30)==(23)]
  │         │    └── project
- │         │         ├── columns: b1:36!null b2:37 b3:38 b4:39 b.rowid:40!null
- │         │         ├── key: (40)
- │         │         ├── fd: (40)-->(36-39)
+ │         │         ├── columns: b1:37!null b2:38 b3:39 b4:40 b.rowid:41!null
+ │         │         ├── key: (41)
+ │         │         ├── fd: (41)-->(37-40)
  │         │         └── inner-join (hash)
- │         │              ├── columns: b1:36!null b2:37!null b3:38 b4:39 b.rowid:40!null c2:44!null
+ │         │              ├── columns: b1:37!null b2:38!null b3:39 b4:40 b.rowid:41!null c2:45!null
  │         │              ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │         │              ├── key: (40)
- │         │              ├── fd: (40)-->(36-39), (37)==(44), (44)==(37)
+ │         │              ├── key: (41)
+ │         │              ├── fd: (41)-->(37-40), (38)==(45), (45)==(38)
  │         │              ├── scan b@b_b1_b2_idx
- │         │              │    ├── columns: b1:36!null b2:37 b3:38 b4:39 b.rowid:40!null
- │         │              │    ├── constraint: /36/37/40: [/1 - ]
- │         │              │    ├── key: (40)
- │         │              │    └── fd: (40)-->(36-39)
+ │         │              │    ├── columns: b1:37!null b2:38 b3:39 b4:40 b.rowid:41!null
+ │         │              │    ├── constraint: /37/38/41: [/1 - ]
+ │         │              │    ├── key: (41)
+ │         │              │    └── fd: (41)-->(37-40)
  │         │              ├── distinct-on
- │         │              │    ├── columns: c2:44
- │         │              │    ├── grouping columns: c2:44
- │         │              │    ├── key: (44)
+ │         │              │    ├── columns: c2:45
+ │         │              │    ├── grouping columns: c2:45
+ │         │              │    ├── key: (45)
  │         │              │    └── scan c
- │         │              │         └── columns: c2:44
+ │         │              │         └── columns: c2:45
  │         │              └── filters
- │         │                   └── c2:44 = b2:37 [outer=(37,44), constraints=(/37: (/NULL - ]; /44: (/NULL - ]), fd=(37)==(44), (44)==(37)]
+ │         │                   └── c2:45 = b2:38 [outer=(38,45), constraints=(/38: (/NULL - ]; /45: (/NULL - ]), fd=(38)==(45), (45)==(38)]
  │         └── aggregations
  │              ├── const-agg [as=b1:7, outer=(7)]
  │              │    └── b1:7
@@ -3331,42 +3331,42 @@ project
       ├── fd: (1)-->(2-5)
       ├── union-all
       │    ├── columns: e1:1!null e2:2!null e3:3!null e4:4!null e5:5
-      │    ├── left columns: e1:14 e2:15 e3:16 e4:17 e5:18
-      │    ├── right columns: e1:27 e2:28 e3:29 e4:30 e5:31
+      │    ├── left columns: e1:15 e2:16 e3:17 e4:18 e5:19
+      │    ├── right columns: e1:28 e2:29 e3:30 e4:31 e5:32
       │    ├── semi-join (lookup f@f_f3_idx)
-      │    │    ├── columns: e1:14!null e2:15!null e3:16!null e4:17!null e5:18!null
-      │    │    ├── key columns: [15] = [23]
-      │    │    ├── key: (14)
-      │    │    ├── fd: ()-->(18), (14)-->(15-17)
+      │    │    ├── columns: e1:15!null e2:16!null e3:17!null e4:18!null e5:19!null
+      │    │    ├── key columns: [16] = [24]
+      │    │    ├── key: (15)
+      │    │    ├── fd: ()-->(19), (15)-->(16-18)
       │    │    ├── index-join e
-      │    │    │    ├── columns: e1:14!null e2:15!null e3:16!null e4:17!null e5:18!null
-      │    │    │    ├── key: (14)
-      │    │    │    ├── fd: ()-->(18), (14)-->(15-17)
+      │    │    │    ├── columns: e1:15!null e2:16!null e3:17!null e4:18!null e5:19!null
+      │    │    │    ├── key: (15)
+      │    │    │    ├── fd: ()-->(19), (15)-->(16-18)
       │    │    │    └── scan e@e_e5_idx
-      │    │    │         ├── columns: e1:14!null e5:18!null
-      │    │    │         ├── constraint: /18/14: [/30 - /30]
-      │    │    │         ├── key: (14)
-      │    │    │         └── fd: ()-->(18)
+      │    │    │         ├── columns: e1:15!null e5:19!null
+      │    │    │         ├── constraint: /19/15: [/30 - /30]
+      │    │    │         ├── key: (15)
+      │    │    │         └── fd: ()-->(19)
       │    │    └── filters (true)
       │    └── semi-join (hash)
-      │         ├── columns: e1:27!null e2:28!null e3:29!null e4:30!null e5:31
-      │         ├── key: (27)
-      │         ├── fd: ()-->(29), (27)-->(28,30,31)
+      │         ├── columns: e1:28!null e2:29!null e3:30!null e4:31!null e5:32
+      │         ├── key: (28)
+      │         ├── fd: ()-->(30), (28)-->(29,31,32)
       │         ├── index-join e
-      │         │    ├── columns: e1:27!null e2:28!null e3:29!null e4:30!null e5:31
-      │         │    ├── key: (27)
-      │         │    ├── fd: ()-->(29), (27)-->(28,30,31)
+      │         │    ├── columns: e1:28!null e2:29!null e3:30!null e4:31!null e5:32
+      │         │    ├── key: (28)
+      │         │    ├── fd: ()-->(30), (28)-->(29,31,32)
       │         │    └── scan e@e_e3_e5_e4_idx
-      │         │         ├── columns: e1:27!null e3:29!null e4:30!null e5:31
-      │         │         ├── constraint: /29/31/30/27: [/10 - /10]
-      │         │         ├── key: (27)
-      │         │         └── fd: ()-->(29), (27)-->(30,31)
+      │         │         ├── columns: e1:28!null e3:30!null e4:31!null e5:32
+      │         │         ├── constraint: /30/32/31/28: [/10 - /10]
+      │         │         ├── key: (28)
+      │         │         └── fd: ()-->(30), (28)-->(31,32)
       │         ├── scan f@f_f2_idx
-      │         │    ├── columns: f2:35!null f3:36
-      │         │    ├── constraint: /35/34: [/20 - /20]
-      │         │    └── fd: ()-->(35)
+      │         │    ├── columns: f2:36!null f3:37
+      │         │    ├── constraint: /36/35: [/20 - /20]
+      │         │    └── fd: ()-->(36)
       │         └── filters
-      │              └── f3:36 = e2:28 [outer=(28,36), constraints=(/28: (/NULL - ]; /36: (/NULL - ]), fd=(28)==(36), (36)==(28)]
+      │              └── f3:37 = e2:29 [outer=(29,37), constraints=(/29: (/NULL - ]; /37: (/NULL - ]), fd=(29)==(37), (37)==(29)]
       └── aggregations
            ├── const-agg [as=e2:2, outer=(2)]
            │    └── e2:2
@@ -3404,53 +3404,53 @@ project
       ├── fd: (1)-->(2-5)
       ├── union-all
       │    ├── columns: e1:1!null e2:2!null e3:3!null e4:4!null e5:5
-      │    ├── left columns: e1:14 e2:15 e3:16 e4:17 e5:18
-      │    ├── right columns: e1:27 e2:28 e3:29 e4:30 e5:31
+      │    ├── left columns: e1:15 e2:16 e3:17 e4:18 e5:19
+      │    ├── right columns: e1:28 e2:29 e3:30 e4:31 e5:32
       │    ├── project
-      │    │    ├── columns: e1:14!null e2:15!null e3:16!null e4:17!null e5:18!null
-      │    │    ├── key: (14)
-      │    │    ├── fd: (14)-->(15-18)
+      │    │    ├── columns: e1:15!null e2:16!null e3:17!null e4:18!null e5:19!null
+      │    │    ├── key: (15)
+      │    │    ├── fd: (15)-->(16-19)
       │    │    └── inner-join (hash)
-      │    │         ├── columns: e1:14!null e2:15!null e3:16!null e4:17!null e5:18!null f3:23!null
+      │    │         ├── columns: e1:15!null e2:16!null e3:17!null e4:18!null e5:19!null f3:24!null
       │    │         ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
-      │    │         ├── key: (14)
-      │    │         ├── fd: (14)-->(15-18), (15)==(23), (23)==(15)
+      │    │         ├── key: (15)
+      │    │         ├── fd: (15)-->(16-19), (16)==(24), (24)==(16)
       │    │         ├── distinct-on
-      │    │         │    ├── columns: f3:23
-      │    │         │    ├── grouping columns: f3:23
-      │    │         │    ├── internal-ordering: +23
-      │    │         │    ├── key: (23)
+      │    │         │    ├── columns: f3:24
+      │    │         │    ├── grouping columns: f3:24
+      │    │         │    ├── internal-ordering: +24
+      │    │         │    ├── key: (24)
       │    │         │    └── scan f@f_f3_idx
-      │    │         │         ├── columns: f3:23
-      │    │         │         └── ordering: +23
+      │    │         │         ├── columns: f3:24
+      │    │         │         └── ordering: +24
       │    │         ├── index-join e
-      │    │         │    ├── columns: e1:14!null e2:15!null e3:16!null e4:17!null e5:18!null
-      │    │         │    ├── key: (14)
-      │    │         │    ├── fd: (14)-->(15-18)
+      │    │         │    ├── columns: e1:15!null e2:16!null e3:17!null e4:18!null e5:19!null
+      │    │         │    ├── key: (15)
+      │    │         │    ├── fd: (15)-->(16-19)
       │    │         │    └── scan e@e_e5_idx
-      │    │         │         ├── columns: e1:14!null e5:18!null
-      │    │         │         ├── constraint: /18/14: [/31 - /39]
-      │    │         │         ├── key: (14)
-      │    │         │         └── fd: (14)-->(18)
+      │    │         │         ├── columns: e1:15!null e5:19!null
+      │    │         │         ├── constraint: /19/15: [/31 - /39]
+      │    │         │         ├── key: (15)
+      │    │         │         └── fd: (15)-->(19)
       │    │         └── filters
-      │    │              └── f3:23 = e2:15 [outer=(15,23), constraints=(/15: (/NULL - ]; /23: (/NULL - ]), fd=(15)==(23), (23)==(15)]
+      │    │              └── f3:24 = e2:16 [outer=(16,24), constraints=(/16: (/NULL - ]; /24: (/NULL - ]), fd=(16)==(24), (24)==(16)]
       │    └── semi-join (hash)
-      │         ├── columns: e1:27!null e2:28!null e3:29!null e4:30!null e5:31
-      │         ├── key: (27)
-      │         ├── fd: (27)-->(28-31)
+      │         ├── columns: e1:28!null e2:29!null e3:30!null e4:31!null e5:32
+      │         ├── key: (28)
+      │         ├── fd: (28)-->(29-32)
       │         ├── index-join e
-      │         │    ├── columns: e1:27!null e2:28!null e3:29!null e4:30!null e5:31
-      │         │    ├── key: (27)
-      │         │    ├── fd: (27)-->(28-31)
+      │         │    ├── columns: e1:28!null e2:29!null e3:30!null e4:31!null e5:32
+      │         │    ├── key: (28)
+      │         │    ├── fd: (28)-->(29-32)
       │         │    └── scan e@e_e3_idx,partial
-      │         │         ├── columns: e1:27!null e3:29!null
-      │         │         ├── key: (27)
-      │         │         └── fd: (27)-->(29)
+      │         │         ├── columns: e1:28!null e3:30!null
+      │         │         ├── key: (28)
+      │         │         └── fd: (28)-->(30)
       │         ├── scan f@f_f2_idx
-      │         │    ├── columns: f2:35!null f3:36
-      │         │    └── constraint: /35/34: [/11 - /19]
+      │         │    ├── columns: f2:36!null f3:37
+      │         │    └── constraint: /36/35: [/11 - /19]
       │         └── filters
-      │              └── f3:36 = e2:28 [outer=(28,36), constraints=(/28: (/NULL - ]; /36: (/NULL - ]), fd=(28)==(36), (36)==(28)]
+      │              └── f3:37 = e2:29 [outer=(29,37), constraints=(/29: (/NULL - ]; /37: (/NULL - ]), fd=(29)==(37), (37)==(29)]
       └── aggregations
            ├── const-agg [as=e2:2, outer=(2)]
            │    └── e2:2
@@ -3473,29 +3473,29 @@ project
  ├── columns: a1:1!null a2:2!null a3:3!null
  └── intersect-all
       ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-      ├── left columns: a1:14 a2:15 a3:16 a4:17
-      ├── right columns: a1:27 a2:28 a3:29 a4:30
+      ├── left columns: a1:15 a2:16 a3:17 a4:18
+      ├── right columns: a1:28 a2:29 a3:30 a4:31
       ├── key: (1-4)
       ├── anti-join (hash)
-      │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-      │    ├── key: (14-17)
+      │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+      │    ├── key: (15-18)
       │    ├── scan a
-      │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-      │    │    └── key: (14-17)
+      │    │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+      │    │    └── key: (15-18)
       │    ├── scan b
-      │    │    └── columns: b2:21
+      │    │    └── columns: b2:22
       │    └── filters
-      │         └── a2:15 = b2:21 [outer=(15,21), constraints=(/15: (/NULL - ]; /21: (/NULL - ]), fd=(15)==(21), (21)==(15)]
+      │         └── a2:16 = b2:22 [outer=(16,22), constraints=(/16: (/NULL - ]; /22: (/NULL - ]), fd=(16)==(22), (22)==(16)]
       └── anti-join (hash)
-           ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-           ├── key: (27-30)
+           ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+           ├── key: (28-31)
            ├── scan a
-           │    ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-           │    └── key: (27-30)
+           │    ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+           │    └── key: (28-31)
            ├── scan b
-           │    └── columns: b3:35
+           │    └── columns: b3:36
            └── filters
-                └── a3:29 = b3:35 [outer=(29,35), constraints=(/29: (/NULL - ]; /35: (/NULL - ]), fd=(29)==(35), (35)==(29)]
+                └── a3:30 = b3:36 [outer=(30,36), constraints=(/30: (/NULL - ]; /36: (/NULL - ]), fd=(30)==(36), (36)==(30)]
 
 opt expect=SplitDisjunctionOfAntiJoinTerms
 SELECT a1,a2,a3 FROM a WHERE NOT EXISTS (SELECT * FROM b WHERE a1 = b1 OR a1 = b2)
@@ -3504,34 +3504,34 @@ project
  ├── columns: a1:1!null a2:2!null a3:3!null
  └── intersect-all
       ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-      ├── left columns: a1:14 a2:15 a3:16 a4:17
-      ├── right columns: a1:27 a2:28 a3:29 a4:30
+      ├── left columns: a1:15 a2:16 a3:17 a4:18
+      ├── right columns: a1:28 a2:29 a3:30 a4:31
       ├── key: (1-4)
       ├── anti-join (merge)
-      │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-      │    ├── left ordering: +14
-      │    ├── right ordering: +20
-      │    ├── key: (14-17)
+      │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+      │    ├── left ordering: +15
+      │    ├── right ordering: +21
+      │    ├── key: (15-18)
       │    ├── scan a
-      │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-      │    │    ├── key: (14-17)
-      │    │    └── ordering: +14
+      │    │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+      │    │    ├── key: (15-18)
+      │    │    └── ordering: +15
       │    ├── scan b@b_b1_b2_idx
-      │    │    ├── columns: b1:20
-      │    │    └── ordering: +20
+      │    │    ├── columns: b1:21
+      │    │    └── ordering: +21
       │    └── filters (true)
       └── anti-join (merge)
-           ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-           ├── left ordering: +27
-           ├── right ordering: +34
-           ├── key: (27-30)
+           ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+           ├── left ordering: +28
+           ├── right ordering: +35
+           ├── key: (28-31)
            ├── scan a
-           │    ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-           │    ├── key: (27-30)
-           │    └── ordering: +27
+           │    ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+           │    ├── key: (28-31)
+           │    └── ordering: +28
            ├── scan b@b_b2_idx
-           │    ├── columns: b2:34
-           │    └── ordering: +34
+           │    ├── columns: b2:35
+           │    └── ordering: +35
            └── filters (true)
 
 # The left side of the join already produces key columns
@@ -3543,68 +3543,68 @@ project
  ├── key: (1-4)
  └── intersect-all
       ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-      ├── left columns: a1:14 a2:15 a3:16 a4:17
-      ├── right columns: a1:27 a2:28 a3:29 a4:30
+      ├── left columns: a1:15 a2:16 a3:17 a4:18
+      ├── right columns: a1:28 a2:29 a3:30 a4:31
       ├── key: (1-4)
       ├── anti-join (merge)
-      │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-      │    ├── left ordering: +14
-      │    ├── right ordering: +20
-      │    ├── key: (14-17)
+      │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+      │    ├── left ordering: +15
+      │    ├── right ordering: +21
+      │    ├── key: (15-18)
       │    ├── scan a
-      │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-      │    │    ├── key: (14-17)
-      │    │    └── ordering: +14
+      │    │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+      │    │    ├── key: (15-18)
+      │    │    └── ordering: +15
       │    ├── scan b@b_b1_b2_idx
-      │    │    ├── columns: b1:20
-      │    │    └── ordering: +20
+      │    │    ├── columns: b1:21
+      │    │    └── ordering: +21
       │    └── filters (true)
       └── project
-           ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-           ├── key: (27-30)
+           ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+           ├── key: (28-31)
            └── intersect-all
-                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                ├── left columns: a1:40 a2:41 a3:42 a4:43
-                ├── right columns: a1:53 a2:54 a3:55 a4:56
-                ├── key: (27-30)
+                ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                ├── left columns: a1:41 a2:42 a3:43 a4:44
+                ├── right columns: a1:54 a2:55 a3:56 a4:57
+                ├── key: (28-31)
                 ├── anti-join (hash)
-                │    ├── columns: a1:40!null a2:41!null a3:42!null a4:43!null
-                │    ├── key: (40-43)
+                │    ├── columns: a1:41!null a2:42!null a3:43!null a4:44!null
+                │    ├── key: (41-44)
                 │    ├── scan a
-                │    │    ├── columns: a1:40!null a2:41!null a3:42!null a4:43!null
-                │    │    └── key: (40-43)
+                │    │    ├── columns: a1:41!null a2:42!null a3:43!null a4:44!null
+                │    │    └── key: (41-44)
                 │    ├── scan b
-                │    │    └── columns: b4:49
+                │    │    └── columns: b4:50
                 │    └── filters
-                │         └── a4:43 = b4:49 [outer=(43,49), constraints=(/43: (/NULL - ]; /49: (/NULL - ]), fd=(43)==(49), (49)==(43)]
+                │         └── a4:44 = b4:50 [outer=(44,50), constraints=(/44: (/NULL - ]; /50: (/NULL - ]), fd=(44)==(50), (50)==(44)]
                 └── project
-                     ├── columns: a1:53!null a2:54!null a3:55!null a4:56!null
-                     ├── key: (53-56)
+                     ├── columns: a1:54!null a2:55!null a3:56!null a4:57!null
+                     ├── key: (54-57)
                      └── intersect-all
-                          ├── columns: a1:53!null a2:54!null a3:55!null a4:56!null
-                          ├── left columns: a1:66 a2:67 a3:68 a4:69
-                          ├── right columns: a1:79 a2:80 a3:81 a4:82
-                          ├── key: (53-56)
+                          ├── columns: a1:54!null a2:55!null a3:56!null a4:57!null
+                          ├── left columns: a1:67 a2:68 a3:69 a4:70
+                          ├── right columns: a1:80 a2:81 a3:82 a4:83
+                          ├── key: (54-57)
                           ├── anti-join (hash)
-                          │    ├── columns: a1:66!null a2:67!null a3:68!null a4:69!null
-                          │    ├── key: (66-69)
+                          │    ├── columns: a1:67!null a2:68!null a3:69!null a4:70!null
+                          │    ├── key: (67-70)
                           │    ├── scan a
-                          │    │    ├── columns: a1:66!null a2:67!null a3:68!null a4:69!null
-                          │    │    └── key: (66-69)
+                          │    │    ├── columns: a1:67!null a2:68!null a3:69!null a4:70!null
+                          │    │    └── key: (67-70)
                           │    ├── scan b
-                          │    │    └── columns: b2:73
+                          │    │    └── columns: b2:74
                           │    └── filters
-                          │         └── a2:67 = b2:73 [outer=(67,73), constraints=(/67: (/NULL - ]; /73: (/NULL - ]), fd=(67)==(73), (73)==(67)]
+                          │         └── a2:68 = b2:74 [outer=(68,74), constraints=(/68: (/NULL - ]; /74: (/NULL - ]), fd=(68)==(74), (74)==(68)]
                           └── anti-join (hash)
-                               ├── columns: a1:79!null a2:80!null a3:81!null a4:82!null
-                               ├── key: (79-82)
+                               ├── columns: a1:80!null a2:81!null a3:82!null a4:83!null
+                               ├── key: (80-83)
                                ├── scan a
-                               │    ├── columns: a1:79!null a2:80!null a3:81!null a4:82!null
-                               │    └── key: (79-82)
+                               │    ├── columns: a1:80!null a2:81!null a3:82!null a4:83!null
+                               │    └── key: (80-83)
                                ├── scan b
-                               │    └── columns: b3:87
+                               │    └── columns: b3:88
                                └── filters
-                                    └── a3:81 = b3:87 [outer=(81,87), constraints=(/81: (/NULL - ]; /87: (/NULL - ]), fd=(81)==(87), (87)==(81)]
+                                    └── a3:82 = b3:88 [outer=(82,88), constraints=(/82: (/NULL - ]; /88: (/NULL - ]), fd=(82)==(88), (88)==(82)]
 
 # More than one disjunction in the filter
 opt expect=SplitDisjunctionOfAntiJoinTerms
@@ -3615,65 +3615,65 @@ project
  ├── key: (1-4)
  └── intersect-all
       ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-      ├── left columns: a1:14 a2:15 a3:16 a4:17
-      ├── right columns: a1:27 a2:28 a3:29 a4:30
+      ├── left columns: a1:15 a2:16 a3:17 a4:18
+      ├── right columns: a1:28 a2:29 a3:30 a4:31
       ├── key: (1-4)
       ├── anti-join (hash)
-      │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-      │    ├── key: (14-17)
+      │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+      │    ├── key: (15-18)
       │    ├── scan a
-      │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-      │    │    └── key: (14-17)
+      │    │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+      │    │    └── key: (15-18)
       │    ├── scan c
-      │    │    └── columns: c1:20
+      │    │    └── columns: c1:21
       │    └── filters
-      │         └── a1:14 = c1:20 [outer=(14,20), constraints=(/14: (/NULL - ]; /20: (/NULL - ]), fd=(14)==(20), (20)==(14)]
+      │         └── a1:15 = c1:21 [outer=(15,21), constraints=(/15: (/NULL - ]; /21: (/NULL - ]), fd=(15)==(21), (21)==(15)]
       └── project
-           ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-           ├── key: (27-30)
+           ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+           ├── key: (28-31)
            └── intersect-all
-                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                ├── left columns: a1:40 a2:41 a3:42 a4:43
-                ├── right columns: a1:53 a2:54 a3:55 a4:56
-                ├── key: (27-30)
+                ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                ├── left columns: a1:41 a2:42 a3:43 a4:44
+                ├── right columns: a1:54 a2:55 a3:56 a4:57
+                ├── key: (28-31)
                 ├── anti-join (hash)
-                │    ├── columns: a1:40!null a2:41!null a3:42!null a4:43!null
-                │    ├── key: (40-43)
+                │    ├── columns: a1:41!null a2:42!null a3:43!null a4:44!null
+                │    ├── key: (41-44)
                 │    ├── scan a
-                │    │    ├── columns: a1:40!null a2:41!null a3:42!null a4:43!null
-                │    │    └── key: (40-43)
+                │    │    ├── columns: a1:41!null a2:42!null a3:43!null a4:44!null
+                │    │    └── key: (41-44)
                 │    ├── scan c
-                │    │    └── columns: c4:49
+                │    │    └── columns: c4:50
                 │    └── filters
-                │         └── a4:43 = c4:49 [outer=(43,49), constraints=(/43: (/NULL - ]; /49: (/NULL - ]), fd=(43)==(49), (49)==(43)]
+                │         └── a4:44 = c4:50 [outer=(44,50), constraints=(/44: (/NULL - ]; /50: (/NULL - ]), fd=(44)==(50), (50)==(44)]
                 └── project
-                     ├── columns: a1:53!null a2:54!null a3:55!null a4:56!null
-                     ├── key: (53-56)
+                     ├── columns: a1:54!null a2:55!null a3:56!null a4:57!null
+                     ├── key: (54-57)
                      └── intersect-all
-                          ├── columns: a1:53!null a2:54!null a3:55!null a4:56!null
-                          ├── left columns: a1:66 a2:67 a3:68 a4:69
-                          ├── right columns: a1:79 a2:80 a3:81 a4:82
-                          ├── key: (53-56)
+                          ├── columns: a1:54!null a2:55!null a3:56!null a4:57!null
+                          ├── left columns: a1:67 a2:68 a3:69 a4:70
+                          ├── right columns: a1:80 a2:81 a3:82 a4:83
+                          ├── key: (54-57)
                           ├── anti-join (hash)
-                          │    ├── columns: a1:66!null a2:67!null a3:68!null a4:69!null
-                          │    ├── key: (66-69)
+                          │    ├── columns: a1:67!null a2:68!null a3:69!null a4:70!null
+                          │    ├── key: (67-70)
                           │    ├── scan a
-                          │    │    ├── columns: a1:66!null a2:67!null a3:68!null a4:69!null
-                          │    │    └── key: (66-69)
+                          │    │    ├── columns: a1:67!null a2:68!null a3:69!null a4:70!null
+                          │    │    └── key: (67-70)
                           │    ├── scan c
-                          │    │    └── columns: c2:73
+                          │    │    └── columns: c2:74
                           │    └── filters
-                          │         └── a2:67 = c2:73 [outer=(67,73), constraints=(/67: (/NULL - ]; /73: (/NULL - ]), fd=(67)==(73), (73)==(67)]
+                          │         └── a2:68 = c2:74 [outer=(68,74), constraints=(/68: (/NULL - ]; /74: (/NULL - ]), fd=(68)==(74), (74)==(68)]
                           └── anti-join (hash)
-                               ├── columns: a1:79!null a2:80!null a3:81!null a4:82!null
-                               ├── key: (79-82)
+                               ├── columns: a1:80!null a2:81!null a3:82!null a4:83!null
+                               ├── key: (80-83)
                                ├── scan a
-                               │    ├── columns: a1:79!null a2:80!null a3:81!null a4:82!null
-                               │    └── key: (79-82)
+                               │    ├── columns: a1:80!null a2:81!null a3:82!null a4:83!null
+                               │    └── key: (80-83)
                                ├── scan c
-                               │    └── columns: c3:87
+                               │    └── columns: c3:88
                                └── filters
-                                    └── a3:81 = c3:87 [outer=(81,87), constraints=(/81: (/NULL - ]; /87: (/NULL - ]), fd=(81)==(87), (87)==(81)]
+                                    └── a3:82 = c3:88 [outer=(82,88), constraints=(/82: (/NULL - ]; /88: (/NULL - ]), fd=(82)==(88), (88)==(82)]
 
 opt expect=SplitDisjunctionOfAntiJoinTerms
 SELECT * FROM a WHERE NOT EXISTS (SELECT * FROM c WHERE a1 = c2 OR a2 = c1 OR a3 = c4 OR a3 = c4)
@@ -3683,65 +3683,65 @@ project
  ├── key: (1-4)
  └── intersect-all
       ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-      ├── left columns: a1:14 a2:15 a3:16 a4:17
-      ├── right columns: a1:27 a2:28 a3:29 a4:30
+      ├── left columns: a1:15 a2:16 a3:17 a4:18
+      ├── right columns: a1:28 a2:29 a3:30 a4:31
       ├── key: (1-4)
       ├── anti-join (hash)
-      │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-      │    ├── key: (14-17)
+      │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+      │    ├── key: (15-18)
       │    ├── scan a
-      │    │    ├── columns: a1:14!null a2:15!null a3:16!null a4:17!null
-      │    │    └── key: (14-17)
+      │    │    ├── columns: a1:15!null a2:16!null a3:17!null a4:18!null
+      │    │    └── key: (15-18)
       │    ├── scan c
-      │    │    └── columns: c2:21
+      │    │    └── columns: c2:22
       │    └── filters
-      │         └── a1:14 = c2:21 [outer=(14,21), constraints=(/14: (/NULL - ]; /21: (/NULL - ]), fd=(14)==(21), (21)==(14)]
+      │         └── a1:15 = c2:22 [outer=(15,22), constraints=(/15: (/NULL - ]; /22: (/NULL - ]), fd=(15)==(22), (22)==(15)]
       └── project
-           ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-           ├── key: (27-30)
+           ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+           ├── key: (28-31)
            └── intersect-all
-                ├── columns: a1:27!null a2:28!null a3:29!null a4:30!null
-                ├── left columns: a1:40 a2:41 a3:42 a4:43
-                ├── right columns: a1:53 a2:54 a3:55 a4:56
-                ├── key: (27-30)
+                ├── columns: a1:28!null a2:29!null a3:30!null a4:31!null
+                ├── left columns: a1:41 a2:42 a3:43 a4:44
+                ├── right columns: a1:54 a2:55 a3:56 a4:57
+                ├── key: (28-31)
                 ├── anti-join (hash)
-                │    ├── columns: a1:40!null a2:41!null a3:42!null a4:43!null
-                │    ├── key: (40-43)
+                │    ├── columns: a1:41!null a2:42!null a3:43!null a4:44!null
+                │    ├── key: (41-44)
                 │    ├── scan a
-                │    │    ├── columns: a1:40!null a2:41!null a3:42!null a4:43!null
-                │    │    └── key: (40-43)
+                │    │    ├── columns: a1:41!null a2:42!null a3:43!null a4:44!null
+                │    │    └── key: (41-44)
                 │    ├── scan c
-                │    │    └── columns: c4:49
+                │    │    └── columns: c4:50
                 │    └── filters
-                │         └── a3:42 = c4:49 [outer=(42,49), constraints=(/42: (/NULL - ]; /49: (/NULL - ]), fd=(42)==(49), (49)==(42)]
+                │         └── a3:43 = c4:50 [outer=(43,50), constraints=(/43: (/NULL - ]; /50: (/NULL - ]), fd=(43)==(50), (50)==(43)]
                 └── project
-                     ├── columns: a1:53!null a2:54!null a3:55!null a4:56!null
-                     ├── key: (53-56)
+                     ├── columns: a1:54!null a2:55!null a3:56!null a4:57!null
+                     ├── key: (54-57)
                      └── intersect-all
-                          ├── columns: a1:53!null a2:54!null a3:55!null a4:56!null
-                          ├── left columns: a1:66 a2:67 a3:68 a4:69
-                          ├── right columns: a1:79 a2:80 a3:81 a4:82
-                          ├── key: (53-56)
+                          ├── columns: a1:54!null a2:55!null a3:56!null a4:57!null
+                          ├── left columns: a1:67 a2:68 a3:69 a4:70
+                          ├── right columns: a1:80 a2:81 a3:82 a4:83
+                          ├── key: (54-57)
                           ├── anti-join (hash)
-                          │    ├── columns: a1:66!null a2:67!null a3:68!null a4:69!null
-                          │    ├── key: (66-69)
+                          │    ├── columns: a1:67!null a2:68!null a3:69!null a4:70!null
+                          │    ├── key: (67-70)
                           │    ├── scan a
-                          │    │    ├── columns: a1:66!null a2:67!null a3:68!null a4:69!null
-                          │    │    └── key: (66-69)
+                          │    │    ├── columns: a1:67!null a2:68!null a3:69!null a4:70!null
+                          │    │    └── key: (67-70)
                           │    ├── scan c
-                          │    │    └── columns: c1:72
+                          │    │    └── columns: c1:73
                           │    └── filters
-                          │         └── a2:67 = c1:72 [outer=(67,72), constraints=(/67: (/NULL - ]; /72: (/NULL - ]), fd=(67)==(72), (72)==(67)]
+                          │         └── a2:68 = c1:73 [outer=(68,73), constraints=(/68: (/NULL - ]; /73: (/NULL - ]), fd=(68)==(73), (73)==(68)]
                           └── anti-join (hash)
-                               ├── columns: a1:79!null a2:80!null a3:81!null a4:82!null
-                               ├── key: (79-82)
+                               ├── columns: a1:80!null a2:81!null a3:82!null a4:83!null
+                               ├── key: (80-83)
                                ├── scan a
-                               │    ├── columns: a1:79!null a2:80!null a3:81!null a4:82!null
-                               │    └── key: (79-82)
+                               │    ├── columns: a1:80!null a2:81!null a3:82!null a4:83!null
+                               │    └── key: (80-83)
                                ├── scan c
-                               │    └── columns: c4:88
+                               │    └── columns: c4:89
                                └── filters
-                                    └── a3:81 = c4:88 [outer=(81,88), constraints=(/81: (/NULL - ]; /88: (/NULL - ]), fd=(81)==(88), (88)==(81)]
+                                    └── a3:82 = c4:89 [outer=(82,89), constraints=(/82: (/NULL - ]; /89: (/NULL - ]), fd=(82)==(89), (89)==(82)]
 
 # Nested NOT EXISTS
 # Not currently supported. Maybe needs better subquery decorrelation?
@@ -3778,34 +3778,34 @@ project
       │    ├── columns: a1:1!null a2:2!null a4:4!null
       │    └── intersect-all
       │         ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-      │         ├── left columns: a1:47 a2:48 a3:49 a4:50
-      │         ├── right columns: a1:60 a2:61 a3:62 a4:63
+      │         ├── left columns: a1:49 a2:50 a3:51 a4:52
+      │         ├── right columns: a1:62 a2:63 a3:64 a4:65
       │         ├── key: (1-4)
       │         ├── anti-join (merge)
-      │         │    ├── columns: a1:47!null a2:48!null a3:49!null a4:50!null
-      │         │    ├── left ordering: +47
-      │         │    ├── right ordering: +53
-      │         │    ├── key: (47-50)
+      │         │    ├── columns: a1:49!null a2:50!null a3:51!null a4:52!null
+      │         │    ├── left ordering: +49
+      │         │    ├── right ordering: +55
+      │         │    ├── key: (49-52)
       │         │    ├── scan a
-      │         │    │    ├── columns: a1:47!null a2:48!null a3:49!null a4:50!null
-      │         │    │    ├── key: (47-50)
-      │         │    │    └── ordering: +47
+      │         │    │    ├── columns: a1:49!null a2:50!null a3:51!null a4:52!null
+      │         │    │    ├── key: (49-52)
+      │         │    │    └── ordering: +49
       │         │    ├── scan b@b_b1_b2_idx
-      │         │    │    ├── columns: b1:53
-      │         │    │    └── ordering: +53
+      │         │    │    ├── columns: b1:55
+      │         │    │    └── ordering: +55
       │         │    └── filters (true)
       │         └── anti-join (merge)
-      │              ├── columns: a1:60!null a2:61!null a3:62!null a4:63!null
-      │              ├── left ordering: +60
-      │              ├── right ordering: +67
-      │              ├── key: (60-63)
+      │              ├── columns: a1:62!null a2:63!null a3:64!null a4:65!null
+      │              ├── left ordering: +62
+      │              ├── right ordering: +69
+      │              ├── key: (62-65)
       │              ├── scan a
-      │              │    ├── columns: a1:60!null a2:61!null a3:62!null a4:63!null
-      │              │    ├── key: (60-63)
-      │              │    └── ordering: +60
+      │              │    ├── columns: a1:62!null a2:63!null a3:64!null a4:65!null
+      │              │    ├── key: (62-65)
+      │              │    └── ordering: +62
       │              ├── scan b@b_b2_idx
-      │              │    ├── columns: b2:67
-      │              │    └── ordering: +67
+      │              │    ├── columns: b2:69
+      │              │    └── ordering: +69
       │              └── filters (true)
       ├── scan c
       │    └── columns: c1:14 c2:15
@@ -3874,36 +3874,36 @@ inner-join (lookup a)
  │    ├── columns: b1:7!null b2:8 b3:9 b4:10
  │    └── intersect-all
  │         ├── columns: b1:7!null b2:8 b3:9 b4:10 b.rowid:11!null
- │         ├── left columns: b1:22 b2:23 b3:24 b4:25 b.rowid:26
- │         ├── right columns: b1:36 b2:37 b3:38 b4:39 b.rowid:40
+ │         ├── left columns: b1:23 b2:24 b3:25 b4:26 b.rowid:27
+ │         ├── right columns: b1:37 b2:38 b3:39 b4:40 b.rowid:41
  │         ├── key: (11)
  │         ├── fd: (11)-->(7-10)
  │         ├── anti-join (hash)
- │         │    ├── columns: b1:22!null b2:23 b3:24 b4:25 b.rowid:26!null
- │         │    ├── key: (26)
- │         │    ├── fd: (26)-->(22-25)
+ │         │    ├── columns: b1:23!null b2:24 b3:25 b4:26 b.rowid:27!null
+ │         │    ├── key: (27)
+ │         │    ├── fd: (27)-->(23-26)
  │         │    ├── scan b@b_b1_b2_idx
- │         │    │    ├── columns: b1:22!null b2:23 b3:24 b4:25 b.rowid:26!null
- │         │    │    ├── constraint: /22/23/26: [/1 - ]
- │         │    │    ├── key: (26)
- │         │    │    └── fd: (26)-->(22-25)
+ │         │    │    ├── columns: b1:23!null b2:24 b3:25 b4:26 b.rowid:27!null
+ │         │    │    ├── constraint: /23/24/27: [/1 - ]
+ │         │    │    ├── key: (27)
+ │         │    │    └── fd: (27)-->(23-26)
  │         │    ├── scan c
- │         │    │    └── columns: c1:29
+ │         │    │    └── columns: c1:30
  │         │    └── filters
- │         │         └── c1:29 = b1:22 [outer=(22,29), constraints=(/22: (/NULL - ]; /29: (/NULL - ]), fd=(22)==(29), (29)==(22)]
+ │         │         └── c1:30 = b1:23 [outer=(23,30), constraints=(/23: (/NULL - ]; /30: (/NULL - ]), fd=(23)==(30), (30)==(23)]
  │         └── anti-join (hash)
- │              ├── columns: b1:36!null b2:37 b3:38 b4:39 b.rowid:40!null
- │              ├── key: (40)
- │              ├── fd: (40)-->(36-39)
+ │              ├── columns: b1:37!null b2:38 b3:39 b4:40 b.rowid:41!null
+ │              ├── key: (41)
+ │              ├── fd: (41)-->(37-40)
  │              ├── scan b@b_b1_b2_idx
- │              │    ├── columns: b1:36!null b2:37 b3:38 b4:39 b.rowid:40!null
- │              │    ├── constraint: /36/37/40: [/1 - ]
- │              │    ├── key: (40)
- │              │    └── fd: (40)-->(36-39)
+ │              │    ├── columns: b1:37!null b2:38 b3:39 b4:40 b.rowid:41!null
+ │              │    ├── constraint: /37/38/41: [/1 - ]
+ │              │    ├── key: (41)
+ │              │    └── fd: (41)-->(37-40)
  │              ├── scan c
- │              │    └── columns: c2:44
+ │              │    └── columns: c2:45
  │              └── filters
- │                   └── c2:44 = b2:37 [outer=(37,44), constraints=(/37: (/NULL - ]; /44: (/NULL - ]), fd=(37)==(44), (44)==(37)]
+ │                   └── c2:45 = b2:38 [outer=(38,45), constraints=(/38: (/NULL - ]; /45: (/NULL - ]), fd=(38)==(45), (45)==(38)]
  └── filters (true)
 
 # We should be able to split the disjunction even though the predicates are
@@ -3990,50 +3990,50 @@ anti-join (cross)
  │         ├── fd: (12)-->(8-10)
  │         ├── union-all
  │         │    ├── columns: b1:8 b2:9 b3:10 b.rowid:12!null
- │         │    ├── left columns: b1:23 b2:24 b3:25 b.rowid:27
- │         │    ├── right columns: b1:37 b2:38 b3:39 b.rowid:41
+ │         │    ├── left columns: b1:25 b2:26 b3:27 b.rowid:29
+ │         │    ├── right columns: b1:39 b2:40 b3:41 b.rowid:43
  │         │    ├── project
- │         │    │    ├── columns: b1:23 b2:24 b3:25 b.rowid:27!null
- │         │    │    ├── key: (27)
- │         │    │    ├── fd: (27)-->(23-25)
+ │         │    │    ├── columns: b1:25 b2:26 b3:27 b.rowid:29!null
+ │         │    │    ├── key: (29)
+ │         │    │    ├── fd: (29)-->(25-27)
  │         │    │    └── inner-join (hash)
- │         │    │         ├── columns: b1:23 b2:24!null b3:25 b.rowid:27!null c2:31!null
+ │         │    │         ├── columns: b1:25 b2:26!null b3:27 b.rowid:29!null c2:33!null
  │         │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │         │    │         ├── key: (27)
- │         │    │         ├── fd: (27)-->(23-25), (24)==(31), (31)==(24)
+ │         │    │         ├── key: (29)
+ │         │    │         ├── fd: (29)-->(25-27), (26)==(33), (33)==(26)
  │         │    │         ├── scan b
- │         │    │         │    ├── columns: b1:23 b2:24 b3:25 b.rowid:27!null
- │         │    │         │    ├── key: (27)
- │         │    │         │    └── fd: (27)-->(23-25)
+ │         │    │         │    ├── columns: b1:25 b2:26 b3:27 b.rowid:29!null
+ │         │    │         │    ├── key: (29)
+ │         │    │         │    └── fd: (29)-->(25-27)
  │         │    │         ├── distinct-on
- │         │    │         │    ├── columns: c2:31
- │         │    │         │    ├── grouping columns: c2:31
- │         │    │         │    ├── key: (31)
+ │         │    │         │    ├── columns: c2:33
+ │         │    │         │    ├── grouping columns: c2:33
+ │         │    │         │    ├── key: (33)
  │         │    │         │    └── scan c
- │         │    │         │         └── columns: c2:31
+ │         │    │         │         └── columns: c2:33
  │         │    │         └── filters
- │         │    │              └── c2:31 = b2:24 [outer=(24,31), constraints=(/24: (/NULL - ]; /31: (/NULL - ]), fd=(24)==(31), (31)==(24)]
+ │         │    │              └── c2:33 = b2:26 [outer=(26,33), constraints=(/26: (/NULL - ]; /33: (/NULL - ]), fd=(26)==(33), (33)==(26)]
  │         │    └── project
- │         │         ├── columns: b1:37 b2:38 b3:39 b.rowid:41!null
- │         │         ├── key: (41)
- │         │         ├── fd: (41)-->(37-39)
+ │         │         ├── columns: b1:39 b2:40 b3:41 b.rowid:43!null
+ │         │         ├── key: (43)
+ │         │         ├── fd: (43)-->(39-41)
  │         │         └── inner-join (hash)
- │         │              ├── columns: b1:37 b2:38 b3:39!null b.rowid:41!null c2:45!null
+ │         │              ├── columns: b1:39 b2:40 b3:41!null b.rowid:43!null c2:47!null
  │         │              ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │         │              ├── key: (41)
- │         │              ├── fd: (41)-->(37-39), (39)==(45), (45)==(39)
+ │         │              ├── key: (43)
+ │         │              ├── fd: (43)-->(39-41), (41)==(47), (47)==(41)
  │         │              ├── scan b
- │         │              │    ├── columns: b1:37 b2:38 b3:39 b.rowid:41!null
- │         │              │    ├── key: (41)
- │         │              │    └── fd: (41)-->(37-39)
+ │         │              │    ├── columns: b1:39 b2:40 b3:41 b.rowid:43!null
+ │         │              │    ├── key: (43)
+ │         │              │    └── fd: (43)-->(39-41)
  │         │              ├── distinct-on
- │         │              │    ├── columns: c2:45
- │         │              │    ├── grouping columns: c2:45
- │         │              │    ├── key: (45)
+ │         │              │    ├── columns: c2:47
+ │         │              │    ├── grouping columns: c2:47
+ │         │              │    ├── key: (47)
  │         │              │    └── scan c
- │         │              │         └── columns: c2:45
+ │         │              │         └── columns: c2:47
  │         │              └── filters
- │         │                   └── c2:45 = b3:39 [outer=(39,45), constraints=(/39: (/NULL - ]; /45: (/NULL - ]), fd=(39)==(45), (45)==(39)]
+ │         │                   └── c2:47 = b3:41 [outer=(41,47), constraints=(/41: (/NULL - ]; /47: (/NULL - ]), fd=(41)==(47), (47)==(41)]
  │         └── aggregations
  │              ├── const-agg [as=b1:8, outer=(8)]
  │              │    └── b1:8
@@ -4054,7 +4054,7 @@ anti-join (cross)
  ├── scan d
  │    └── columns: d1:1 d2:2 d3:3
  ├── project
- │    ├── columns: column23:23
+ │    ├── columns: column24:24
  │    ├── project
  │    │    ├── columns: b1:8 b2:9 b3:10
  │    │    └── distinct-on
@@ -4064,50 +4064,50 @@ anti-join (cross)
  │    │         ├── fd: (12)-->(8-10)
  │    │         ├── union-all
  │    │         │    ├── columns: b1:8 b2:9 b3:10 b.rowid:12!null
- │    │         │    ├── left columns: b1:24 b2:25 b3:26 b.rowid:28
- │    │         │    ├── right columns: b1:38 b2:39 b3:40 b.rowid:42
+ │    │         │    ├── left columns: b1:26 b2:27 b3:28 b.rowid:30
+ │    │         │    ├── right columns: b1:40 b2:41 b3:42 b.rowid:44
  │    │         │    ├── project
- │    │         │    │    ├── columns: b1:24 b2:25 b3:26 b.rowid:28!null
- │    │         │    │    ├── key: (28)
- │    │         │    │    ├── fd: (28)-->(24-26)
+ │    │         │    │    ├── columns: b1:26 b2:27 b3:28 b.rowid:30!null
+ │    │         │    │    ├── key: (30)
+ │    │         │    │    ├── fd: (30)-->(26-28)
  │    │         │    │    └── inner-join (hash)
- │    │         │    │         ├── columns: b1:24 b2:25!null b3:26 b.rowid:28!null c2:32!null
+ │    │         │    │         ├── columns: b1:26 b2:27!null b3:28 b.rowid:30!null c2:34!null
  │    │         │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │         │    │         ├── key: (28)
- │    │         │    │         ├── fd: (28)-->(24-26), (25)==(32), (32)==(25)
+ │    │         │    │         ├── key: (30)
+ │    │         │    │         ├── fd: (30)-->(26-28), (27)==(34), (34)==(27)
  │    │         │    │         ├── scan b
- │    │         │    │         │    ├── columns: b1:24 b2:25 b3:26 b.rowid:28!null
- │    │         │    │         │    ├── key: (28)
- │    │         │    │         │    └── fd: (28)-->(24-26)
+ │    │         │    │         │    ├── columns: b1:26 b2:27 b3:28 b.rowid:30!null
+ │    │         │    │         │    ├── key: (30)
+ │    │         │    │         │    └── fd: (30)-->(26-28)
  │    │         │    │         ├── distinct-on
- │    │         │    │         │    ├── columns: c2:32
- │    │         │    │         │    ├── grouping columns: c2:32
- │    │         │    │         │    ├── key: (32)
+ │    │         │    │         │    ├── columns: c2:34
+ │    │         │    │         │    ├── grouping columns: c2:34
+ │    │         │    │         │    ├── key: (34)
  │    │         │    │         │    └── scan c
- │    │         │    │         │         └── columns: c2:32
+ │    │         │    │         │         └── columns: c2:34
  │    │         │    │         └── filters
- │    │         │    │              └── c2:32 = b2:25 [outer=(25,32), constraints=(/25: (/NULL - ]; /32: (/NULL - ]), fd=(25)==(32), (32)==(25)]
+ │    │         │    │              └── c2:34 = b2:27 [outer=(27,34), constraints=(/27: (/NULL - ]; /34: (/NULL - ]), fd=(27)==(34), (34)==(27)]
  │    │         │    └── project
- │    │         │         ├── columns: b1:38 b2:39 b3:40 b.rowid:42!null
- │    │         │         ├── key: (42)
- │    │         │         ├── fd: (42)-->(38-40)
+ │    │         │         ├── columns: b1:40 b2:41 b3:42 b.rowid:44!null
+ │    │         │         ├── key: (44)
+ │    │         │         ├── fd: (44)-->(40-42)
  │    │         │         └── inner-join (hash)
- │    │         │              ├── columns: b1:38 b2:39 b3:40!null b.rowid:42!null c2:46!null
+ │    │         │              ├── columns: b1:40 b2:41 b3:42!null b.rowid:44!null c2:48!null
  │    │         │              ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │         │              ├── key: (42)
- │    │         │              ├── fd: (42)-->(38-40), (40)==(46), (46)==(40)
+ │    │         │              ├── key: (44)
+ │    │         │              ├── fd: (44)-->(40-42), (42)==(48), (48)==(42)
  │    │         │              ├── scan b
- │    │         │              │    ├── columns: b1:38 b2:39 b3:40 b.rowid:42!null
- │    │         │              │    ├── key: (42)
- │    │         │              │    └── fd: (42)-->(38-40)
+ │    │         │              │    ├── columns: b1:40 b2:41 b3:42 b.rowid:44!null
+ │    │         │              │    ├── key: (44)
+ │    │         │              │    └── fd: (44)-->(40-42)
  │    │         │              ├── distinct-on
- │    │         │              │    ├── columns: c2:46
- │    │         │              │    ├── grouping columns: c2:46
- │    │         │              │    ├── key: (46)
+ │    │         │              │    ├── columns: c2:48
+ │    │         │              │    ├── grouping columns: c2:48
+ │    │         │              │    ├── key: (48)
  │    │         │              │    └── scan c
- │    │         │              │         └── columns: c2:46
+ │    │         │              │         └── columns: c2:48
  │    │         │              └── filters
- │    │         │                   └── c2:46 = b3:40 [outer=(40,46), constraints=(/40: (/NULL - ]; /46: (/NULL - ]), fd=(40)==(46), (46)==(40)]
+ │    │         │                   └── c2:48 = b3:42 [outer=(42,48), constraints=(/42: (/NULL - ]; /48: (/NULL - ]), fd=(42)==(48), (48)==(42)]
  │    │         └── aggregations
  │    │              ├── const-agg [as=b1:8, outer=(8)]
  │    │              │    └── b1:8
@@ -4116,9 +4116,9 @@ anti-join (cross)
  │    │              └── const-agg [as=b3:10, outer=(10)]
  │    │                   └── b3:10
  │    └── projections
- │         └── (b1:8, b2:9) [as=column23:23, outer=(8,9)]
+ │         └── (b1:8, b2:9) [as=column24:24, outer=(8,9)]
  └── filters
-      └── (column23:23 = (d1:1, d3:3)) IS NOT false [outer=(1,3,23), immutable]
+      └── (column24:24 = (d1:1, d3:3)) IS NOT false [outer=(1,3,24), immutable]
 
 # The conjuncts under the top-level disjunct contain no join terms directly,
 # but are nested in another OR. Join terms should still be detected.

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1142,10 +1142,10 @@ WHERE a IN (
 GROUP BY a
 ----
 project
- ├── columns: a:1!null min:10!null
+ ├── columns: a:1!null min:11!null
  ├── cardinality: [0 - 1]
  ├── key: (1)
- ├── fd: (1)-->(10)
+ ├── fd: (1)-->(11)
  ├── inner-join (lookup t112131)
  │    ├── columns: a:1!null b:2!null min:9!null
  │    ├── key columns: [9] = [1]
@@ -1165,7 +1165,7 @@ project
  │    │              └── b:6
  │    └── filters (true)
  └── projections
-      └── b:2 [as=min:10, outer=(2)]
+      └── b:2 [as=min:11, outer=(2)]
 
 # Regression test for #112131. ReplaceMaxWithLimit should project constant
 # grouping columns.
@@ -1177,10 +1177,10 @@ WHERE a IN (
 GROUP BY a
 ----
 project
- ├── columns: a:1!null max:10!null
+ ├── columns: a:1!null max:11!null
  ├── cardinality: [0 - 1]
  ├── key: (1)
- ├── fd: (1)-->(10)
+ ├── fd: (1)-->(11)
  ├── inner-join (lookup t112131)
  │    ├── columns: a:1!null b:2!null max:9!null
  │    ├── key columns: [9] = [1]
@@ -1200,7 +1200,7 @@ project
  │    │              └── b:6
  │    └── filters (true)
  └── projections
-      └── b:2 [as=max:10, outer=(2)]
+      └── b:2 [as=max:11, outer=(2)]
 
 # --------------------------------------------------
 # ReplaceScalarMinMaxWithScalarSubqueries

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -714,20 +714,20 @@ FROM
 INNER JOIN small ON small.n = medium.n
 ----
 project
- ├── columns: n:2!null m:11 n:12!null
- ├── fd: (2)==(12), (12)==(2)
+ ├── columns: n:2!null m:12 n:13!null
+ ├── fd: (2)==(13), (13)==(2)
  └── semi-join (hash)
-      ├── columns: medium.m:1 medium.n:2!null small.m:11 small.n:12!null
-      ├── fd: (2)==(12), (12)==(2)
+      ├── columns: medium.m:1 medium.n:2!null small.m:12 small.n:13!null
+      ├── fd: (2)==(13), (13)==(2)
       ├── inner-join (hash)
-      │    ├── columns: medium.m:1 medium.n:2!null small.m:11 small.n:12!null
-      │    ├── fd: (2)==(12), (12)==(2)
+      │    ├── columns: medium.m:1 medium.n:2!null small.m:12 small.n:13!null
+      │    ├── fd: (2)==(13), (13)==(2)
       │    ├── scan medium
       │    │    └── columns: medium.m:1 medium.n:2
       │    ├── scan small
-      │    │    └── columns: small.m:11 small.n:12
+      │    │    └── columns: small.m:12 small.n:13
       │    └── filters
-      │         └── small.n:12 = medium.n:2 [outer=(2,12), constraints=(/2: (/NULL - ]; /12: (/NULL - ]), fd=(2)==(12), (12)==(2)]
+      │         └── small.n:13 = medium.n:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
       ├── scan large
       │    └── columns: large.m:6
       └── filters
@@ -746,20 +746,20 @@ FROM
 INNER JOIN small ON small.n = medium.n
 ----
 project
- ├── columns: n:2!null m:11 n:12!null
- ├── fd: (2)==(12), (12)==(2)
+ ├── columns: n:2!null m:12 n:13!null
+ ├── fd: (2)==(13), (13)==(2)
  └── anti-join (cross)
-      ├── columns: medium.m:1 medium.n:2!null small.m:11 small.n:12!null
-      ├── fd: (2)==(12), (12)==(2)
+      ├── columns: medium.m:1 medium.n:2!null small.m:12 small.n:13!null
+      ├── fd: (2)==(13), (13)==(2)
       ├── inner-join (hash)
-      │    ├── columns: medium.m:1 medium.n:2!null small.m:11 small.n:12!null
-      │    ├── fd: (2)==(12), (12)==(2)
+      │    ├── columns: medium.m:1 medium.n:2!null small.m:12 small.n:13!null
+      │    ├── fd: (2)==(13), (13)==(2)
       │    ├── scan medium
       │    │    └── columns: medium.m:1 medium.n:2
       │    ├── scan small
-      │    │    └── columns: small.m:11 small.n:12
+      │    │    └── columns: small.m:12 small.n:13
       │    └── filters
-      │         └── small.n:12 = medium.n:2 [outer=(2,12), constraints=(/2: (/NULL - ]; /12: (/NULL - ]), fd=(2)==(12), (12)==(2)]
+      │         └── small.n:13 = medium.n:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
       ├── scan large
       │    └── columns: large.m:6
       └── filters
@@ -1607,30 +1607,30 @@ project
       ├── fd: (4)-->(1-3)
       ├── union-all
       │    ├── columns: a:1 b:2 c:3 rowid:4!null
-      │    ├── left columns: a:12 b:13 c:14 rowid:15
-      │    ├── right columns: a:23 b:24 c:25 rowid:26
+      │    ├── left columns: a:13 b:14 c:15 rowid:16
+      │    ├── right columns: a:24 b:25 c:26 rowid:27
       │    ├── semi-join (lookup def)
-      │    │    ├── columns: a:12 b:13 c:14 rowid:15!null
-      │    │    ├── key columns: [12] = [18]
-      │    │    ├── key: (15)
-      │    │    ├── fd: (15)-->(12-14)
+      │    │    ├── columns: a:13 b:14 c:15 rowid:16!null
+      │    │    ├── key columns: [13] = [19]
+      │    │    ├── key: (16)
+      │    │    ├── fd: (16)-->(13-15)
       │    │    ├── scan abc
-      │    │    │    ├── columns: a:12 b:13 c:14 rowid:15!null
-      │    │    │    ├── key: (15)
-      │    │    │    └── fd: (15)-->(12-14)
+      │    │    │    ├── columns: a:13 b:14 c:15 rowid:16!null
+      │    │    │    ├── key: (16)
+      │    │    │    └── fd: (16)-->(13-15)
       │    │    └── filters (true)
       │    └── semi-join (hash)
-      │         ├── columns: a:23 b:24 c:25 rowid:26!null
-      │         ├── key: (26)
-      │         ├── fd: (26)-->(23-25)
+      │         ├── columns: a:24 b:25 c:26 rowid:27!null
+      │         ├── key: (27)
+      │         ├── fd: (27)-->(24-26)
       │         ├── scan abc
-      │         │    ├── columns: a:23 b:24 c:25 rowid:26!null
-      │         │    ├── key: (26)
-      │         │    └── fd: (26)-->(23-25)
+      │         │    ├── columns: a:24 b:25 c:26 rowid:27!null
+      │         │    ├── key: (27)
+      │         │    └── fd: (27)-->(24-26)
       │         ├── scan def
-      │         │    └── columns: e:30!null
+      │         │    └── columns: e:31!null
       │         └── filters
-      │              └── c:25 = e:30 [outer=(25,30), constraints=(/25: (/NULL - ]; /30: (/NULL - ]), fd=(25)==(30), (30)==(25)]
+      │              └── c:26 = e:31 [outer=(26,31), constraints=(/26: (/NULL - ]; /31: (/NULL - ]), fd=(26)==(31), (31)==(26)]
       └── aggregations
            ├── const-agg [as=a:1, outer=(1)]
            │    └── a:1
@@ -2715,14 +2715,14 @@ SELECT m, n FROM small WHERE EXISTS(SELECT 1 FROM abcd WHERE m = a AND n = c)
 ----
 semi-join (lookup abcd)
  ├── columns: m:1 n:2
- ├── key columns: [16] = [9]
+ ├── key columns: [17] = [9]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── inner-join (lookup abcd@abcd_a_b_idx)
- │    ├── columns: m:1!null n:2 a:13!null abcd.rowid:16!null continuation:19
- │    ├── key columns: [1] = [13]
- │    ├── first join in paired joiner; continuation column: continuation:19
- │    ├── fd: (16)-->(13,19), (1)==(13), (13)==(1)
+ │    ├── columns: m:1!null n:2 a:14!null abcd.rowid:17!null continuation:20
+ │    ├── key columns: [1] = [14]
+ │    ├── first join in paired joiner; continuation column: continuation:20
+ │    ├── fd: (17)-->(14,20), (1)==(14), (14)==(1)
  │    ├── scan small
  │    │    └── columns: m:1 n:2
  │    └── filters (true)
@@ -2747,14 +2747,14 @@ SELECT m, n FROM small WHERE NOT EXISTS(SELECT 1 FROM abcd WHERE m = a AND n = c
 ----
 anti-join (lookup abcd)
  ├── columns: m:1 n:2
- ├── key columns: [16] = [9]
+ ├── key columns: [17] = [9]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── left-join (lookup abcd@abcd_a_b_idx)
- │    ├── columns: m:1 n:2 a:13 abcd.rowid:16 continuation:19
- │    ├── key columns: [1] = [13]
- │    ├── first join in paired joiner; continuation column: continuation:19
- │    ├── fd: (16)-->(13,19)
+ │    ├── columns: m:1 n:2 a:14 abcd.rowid:17 continuation:20
+ │    ├── key columns: [1] = [14]
+ │    ├── first join in paired joiner; continuation column: continuation:20
+ │    ├── fd: (17)-->(14,20)
  │    ├── scan small
  │    │    └── columns: m:1 n:2
  │    └── filters (true)
@@ -2817,15 +2817,15 @@ SELECT m FROM small WHERE EXISTS (SELECT * FROM shard WHERE small.m = shard.a)
 ----
 semi-join (lookup shard@shard_a_idx)
  ├── columns: m:1
- ├── key columns: [14 1] = [9 7]
+ ├── key columns: [15 1] = [9 7]
  ├── project
- │    ├── columns: shard_a_eq:14 m:1
+ │    ├── columns: shard_a_eq:15 m:1
  │    ├── immutable
- │    ├── fd: (1)-->(14)
+ │    ├── fd: (1)-->(15)
  │    ├── scan small
  │    │    └── columns: m:1
  │    └── projections
- │         └── mod(fnv32(crdb_internal.datums_to_bytes(m:1)), 3) [as=shard_a_eq:14, outer=(1), immutable]
+ │         └── mod(fnv32(crdb_internal.datums_to_bytes(m:1)), 3) [as=shard_a_eq:15, outer=(1), immutable]
  └── filters (true)
 
 # Generate an anti lookup join by synthesizing an equality constraint for an
@@ -2835,15 +2835,15 @@ SELECT m FROM small WHERE NOT EXISTS (SELECT * FROM shard WHERE small.m = shard.
 ----
 anti-join (lookup shard@shard_a_idx)
  ├── columns: m:1
- ├── key columns: [14 1] = [9 7]
+ ├── key columns: [15 1] = [9 7]
  ├── project
- │    ├── columns: shard_a_eq:14 m:1
+ │    ├── columns: shard_a_eq:15 m:1
  │    ├── immutable
- │    ├── fd: (1)-->(14)
+ │    ├── fd: (1)-->(15)
  │    ├── scan small
  │    │    └── columns: m:1
  │    └── projections
- │         └── mod(fnv32(crdb_internal.datums_to_bytes(m:1)), 3) [as=shard_a_eq:14, outer=(1), immutable]
+ │         └── mod(fnv32(crdb_internal.datums_to_bytes(m:1)), 3) [as=shard_a_eq:15, outer=(1), immutable]
  └── filters (true)
 
 exec-ddl
@@ -4107,18 +4107,18 @@ SELECT m, n FROM small WHERE EXISTS(SELECT 1 FROM abcd WHERE m = a AND n = c AND
 ----
 semi-join (lookup abcd)
  ├── columns: m:1 n:2
- ├── key columns: [16] = [9]
+ ├── key columns: [17] = [9]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── inner-join (lookup abcd@abcd_a_b_idx)
- │    ├── columns: m:1!null n:2 a:13!null b:14!null abcd.rowid:16!null continuation:19
- │    ├── key columns: [1] = [13]
- │    ├── first join in paired joiner; continuation column: continuation:19
- │    ├── fd: (16)-->(13,14,19), (1)==(13), (13)==(1)
+ │    ├── columns: m:1!null n:2 a:14!null b:15!null abcd.rowid:17!null continuation:20
+ │    ├── key columns: [1] = [14]
+ │    ├── first join in paired joiner; continuation column: continuation:20
+ │    ├── fd: (17)-->(14,15,20), (1)==(14), (14)==(1)
  │    ├── scan small
  │    │    └── columns: m:1 n:2
  │    └── filters
- │         └── a:13 > b:14 [outer=(13,14), constraints=(/13: (/NULL - ]; /14: (/NULL - ])]
+ │         └── a:14 > b:15 [outer=(14,15), constraints=(/14: (/NULL - ]; /15: (/NULL - ])]
  └── filters
       └── n:2 = c:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
 
@@ -4141,18 +4141,18 @@ SELECT m, n FROM small WHERE NOT EXISTS(SELECT 1 FROM abcd WHERE m = a AND n = c
 ----
 anti-join (lookup abcd)
  ├── columns: m:1 n:2
- ├── key columns: [16] = [9]
+ ├── key columns: [17] = [9]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── left-join (lookup abcd@abcd_a_b_idx)
- │    ├── columns: m:1 n:2 a:13 b:14 abcd.rowid:16 continuation:19
- │    ├── key columns: [1] = [13]
- │    ├── first join in paired joiner; continuation column: continuation:19
- │    ├── fd: (16)-->(13,14,19)
+ │    ├── columns: m:1 n:2 a:14 b:15 abcd.rowid:17 continuation:20
+ │    ├── key columns: [1] = [14]
+ │    ├── first join in paired joiner; continuation column: continuation:20
+ │    ├── fd: (17)-->(14,15,20)
  │    ├── scan small
  │    │    └── columns: m:1 n:2
  │    └── filters
- │         └── a:13 > b:14 [outer=(13,14), constraints=(/13: (/NULL - ]; /14: (/NULL - ])]
+ │         └── a:14 > b:15 [outer=(14,15), constraints=(/14: (/NULL - ]; /15: (/NULL - ])]
  └── filters
       └── n:2 = c:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
 
@@ -4411,14 +4411,14 @@ project
  ├── columns: m:1
  └── semi-join (lookup partial_tab)
       ├── columns: m:1 n:2
-      ├── key columns: [12] = [6]
+      ├── key columns: [13] = [6]
       ├── lookup columns are key
       ├── second join in paired joiner
       ├── inner-join (lookup partial_tab@partial_idx,partial)
-      │    ├── columns: m:1 n:2!null k:12!null i:13!null continuation:17
-      │    ├── key columns: [2] = [13]
-      │    ├── first join in paired joiner; continuation column: continuation:17
-      │    ├── fd: (12)-->(13,17), (2)==(13), (13)==(2)
+      │    ├── columns: m:1 n:2!null k:13!null i:14!null continuation:18
+      │    ├── key columns: [2] = [14]
+      │    ├── first join in paired joiner; continuation column: continuation:18
+      │    ├── fd: (13)-->(14,18), (2)==(14), (14)==(2)
       │    ├── scan small
       │    │    └── columns: m:1 n:2
       │    └── filters (true)
@@ -4448,14 +4448,14 @@ project
  ├── columns: m:1
  └── anti-join (lookup partial_tab)
       ├── columns: m:1 n:2
-      ├── key columns: [12] = [6]
+      ├── key columns: [13] = [6]
       ├── lookup columns are key
       ├── second join in paired joiner
       ├── left-join (lookup partial_tab@partial_idx,partial)
-      │    ├── columns: m:1 n:2 k:12 i:13 continuation:17
-      │    ├── key columns: [2] = [13]
-      │    ├── first join in paired joiner; continuation column: continuation:17
-      │    ├── fd: (12)-->(13,17)
+      │    ├── columns: m:1 n:2 k:13 i:14 continuation:18
+      │    ├── key columns: [2] = [14]
+      │    ├── first join in paired joiner; continuation column: continuation:18
+      │    ├── fd: (13)-->(14,18)
       │    ├── scan small
       │    │    └── columns: m:1 n:2
       │    └── filters (true)
@@ -6097,15 +6097,15 @@ SELECT m FROM small WHERE EXISTS (SELECT * FROM virt WHERE virt.l = 1 AND m = vi
 ----
 semi-join (lookup virt@l_v1)
  ├── columns: m:1
- ├── key columns: [16 1] = [13 9]
+ ├── key columns: [17 1] = [13 9]
  ├── immutable
  ├── project
- │    ├── columns: "lookup_join_const_col_@13":16!null m:1
- │    ├── fd: ()-->(16)
+ │    ├── columns: "lookup_join_const_col_@13":17!null m:1
+ │    ├── fd: ()-->(17)
  │    ├── scan small
  │    │    └── columns: m:1
  │    └── projections
- │         └── 1 [as="lookup_join_const_col_@13":16]
+ │         └── 1 [as="lookup_join_const_col_@13":17]
  └── filters (true)
 
 # Semi-join with multiple constant values for the leading lookup column.
@@ -6161,15 +6161,15 @@ SELECT m FROM small WHERE NOT EXISTS (SELECT * FROM virt WHERE virt.l = 1 AND m 
 ----
 anti-join (lookup virt@l_v1)
  ├── columns: m:1
- ├── key columns: [16 1] = [13 9]
+ ├── key columns: [17 1] = [13 9]
  ├── immutable
  ├── project
- │    ├── columns: "lookup_join_const_col_@13":16!null m:1
- │    ├── fd: ()-->(16)
+ │    ├── columns: "lookup_join_const_col_@13":17!null m:1
+ │    ├── fd: ()-->(17)
  │    ├── scan small
  │    │    └── columns: m:1
  │    └── projections
- │         └── 1 [as="lookup_join_const_col_@13":16]
+ │         └── 1 [as="lookup_join_const_col_@13":17]
  └── filters (true)
 
 # Anti-join with multiple constant values for the leading lookup column.
@@ -7614,19 +7614,19 @@ WHERE EXISTS (
 ----
 semi-join (lookup nyc_neighborhoods [as=n])
  ├── columns: gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 boroname:9 geom:10
- ├── key columns: [21] = [14]
+ ├── key columns: [22] = [14]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-10)
  ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
- │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:21!null continuation:28
- │    ├── first join in paired joiner; continuation column: continuation:28
+ │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:22!null continuation:29
+ │    ├── first join in paired joiner; continuation column: continuation:29
  │    ├── inverted-expr
- │    │    └── st_covers(c.geom:10, n.geom:24)
- │    ├── key: (1,21)
- │    ├── fd: (1)-->(2-10), (21)-->(28)
+ │    │    └── st_covers(c.geom:10, n.geom:25)
+ │    ├── key: (1,22)
+ │    ├── fd: (1)-->(2-10), (22)-->(29)
  │    ├── scan nyc_census_blocks [as=c]
  │    │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10
  │    │    ├── key: (1)
@@ -7648,19 +7648,19 @@ WHERE NOT EXISTS (
 ----
 anti-join (lookup nyc_neighborhoods [as=n])
  ├── columns: gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 boroname:9 geom:10
- ├── key columns: [21] = [14]
+ ├── key columns: [22] = [14]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-10)
  ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
- │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:21 continuation:28
- │    ├── first join in paired joiner; continuation column: continuation:28
+ │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:22 continuation:29
+ │    ├── first join in paired joiner; continuation column: continuation:29
  │    ├── inverted-expr
- │    │    └── st_covers(c.geom:10, n.geom:24)
- │    ├── key: (1,21)
- │    ├── fd: (1)-->(2-10), (21)-->(28)
+ │    │    └── st_covers(c.geom:10, n.geom:25)
+ │    ├── key: (1,22)
+ │    ├── fd: (1)-->(2-10), (22)-->(29)
  │    ├── scan nyc_census_blocks [as=c]
  │    │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10
  │    │    ├── key: (1)
@@ -7684,16 +7684,16 @@ project
  ├── immutable
  └── anti-join (lookup nyc_neighborhoods [as=n])
       ├── columns: c.boroname:9 c.geom:10
-      ├── key columns: [22] = [14]
+      ├── key columns: [23] = [14]
       ├── lookup columns are key
       ├── second join in paired joiner
       ├── immutable
       ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx [as=n])
-      │    ├── columns: c.boroname:9 c.geom:10 n.gid:22 continuation:29
-      │    ├── first join in paired joiner; continuation column: continuation:29
+      │    ├── columns: c.boroname:9 c.geom:10 n.gid:23 continuation:30
+      │    ├── first join in paired joiner; continuation column: continuation:30
       │    ├── inverted-expr
-      │    │    └── st_covers(c.geom:10, n.geom:25)
-      │    ├── fd: (22)-->(29)
+      │    │    └── st_covers(c.geom:10, n.geom:26)
+      │    ├── fd: (23)-->(30)
       │    ├── scan nyc_census_blocks [as=c]
       │    │    └── columns: c.boroname:9 c.geom:10
       │    └── filters
@@ -8395,19 +8395,19 @@ WHERE EXISTS (
 ----
 semi-join (lookup json_arr1 [as=t1])
  ├── columns: k:1!null l:2 j:3 a:4
- ├── key columns: [15] = [7]
+ ├── key columns: [16] = [7]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── inner-join (inverted json_arr1@j_idx [as=t1])
- │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:15!null continuation:23
- │    ├── first join in paired joiner; continuation column: continuation:23
+ │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:16!null continuation:24
+ │    ├── first join in paired joiner; continuation column: continuation:24
  │    ├── inverted-expr
- │    │    └── t1.j:17 @> t2.j:3
- │    ├── key: (1,15)
- │    ├── fd: (1)-->(2-4), (15)-->(23)
+ │    │    └── t1.j:18 @> t2.j:3
+ │    ├── key: (1,16)
+ │    ├── fd: (1)-->(2-4), (16)-->(24)
  │    ├── scan json_arr2 [as=t2]
  │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
  │    │    ├── key: (1)
@@ -8425,19 +8425,19 @@ WHERE EXISTS (
 ----
 semi-join (lookup json_arr1 [as=t1])
  ├── columns: k:1!null l:2 j:3 a:4
- ├── key columns: [15] = [7]
+ ├── key columns: [16] = [7]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── inner-join (inverted json_arr1@j_idx [as=t1])
- │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:15!null continuation:23
- │    ├── first join in paired joiner; continuation column: continuation:23
+ │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:16!null continuation:24
+ │    ├── first join in paired joiner; continuation column: continuation:24
  │    ├── inverted-expr
- │    │    └── t1.j:17 <@ t2.j:3
- │    ├── key: (1,15)
- │    ├── fd: (1)-->(2-4), (15)-->(23)
+ │    │    └── t1.j:18 <@ t2.j:3
+ │    ├── key: (1,16)
+ │    ├── fd: (1)-->(2-4), (16)-->(24)
  │    ├── scan json_arr2 [as=t2]
  │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
  │    │    ├── key: (1)
@@ -8455,19 +8455,19 @@ WHERE NOT EXISTS (
 ----
 anti-join (lookup json_arr1 [as=t1])
  ├── columns: k:1!null l:2 j:3 a:4
- ├── key columns: [15] = [7]
+ ├── key columns: [16] = [7]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── left-join (inverted json_arr1@j_idx [as=t1])
- │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:15 continuation:23
- │    ├── first join in paired joiner; continuation column: continuation:23
+ │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:16 continuation:24
+ │    ├── first join in paired joiner; continuation column: continuation:24
  │    ├── inverted-expr
- │    │    └── t1.j:17 @> t2.j:3
- │    ├── key: (1,15)
- │    ├── fd: (1)-->(2-4), (15)-->(23)
+ │    │    └── t1.j:18 @> t2.j:3
+ │    ├── key: (1,16)
+ │    ├── fd: (1)-->(2-4), (16)-->(24)
  │    ├── scan json_arr2 [as=t2]
  │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
  │    │    ├── key: (1)
@@ -8485,19 +8485,19 @@ WHERE NOT EXISTS (
 ----
 anti-join (lookup json_arr1 [as=t1])
  ├── columns: k:1!null l:2 j:3 a:4
- ├── key columns: [15] = [7]
+ ├── key columns: [16] = [7]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── left-join (inverted json_arr1@j_idx [as=t1])
- │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:15 continuation:23
- │    ├── first join in paired joiner; continuation column: continuation:23
+ │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:16 continuation:24
+ │    ├── first join in paired joiner; continuation column: continuation:24
  │    ├── inverted-expr
- │    │    └── t1.j:17 <@ t2.j:3
- │    ├── key: (1,15)
- │    ├── fd: (1)-->(2-4), (15)-->(23)
+ │    │    └── t1.j:18 <@ t2.j:3
+ │    ├── key: (1,16)
+ │    ├── fd: (1)-->(2-4), (16)-->(24)
  │    ├── scan json_arr2 [as=t2]
  │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
  │    │    ├── key: (1)
@@ -9228,18 +9228,18 @@ project
       ├── fd: (1)-->(2-4)
       ├── inner-join (lookup json_arr1 [as=t1])
       │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 i:8!null t1.j:9
-      │    ├── key columns: [22] = [7]
+      │    ├── key columns: [23] = [7]
       │    ├── lookup columns are key
       │    ├── immutable
       │    ├── fd: (1)-->(2-4)
       │    ├── inner-join (inverted json_arr1@j_idx [as=t1])
-      │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:22!null i:23!null
-      │    │    ├── prefix key columns: [21] = [23]
+      │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:23!null i:24!null
+      │    │    ├── prefix key columns: [22] = [24]
       │    │    ├── inverted-expr
-      │    │    │    └── t1.j:24 @> t2.j:3
-      │    │    ├── fd: (1)-->(2-4), (22)-->(23)
+      │    │    │    └── t1.j:25 @> t2.j:3
+      │    │    ├── fd: (1)-->(2-4), (23)-->(24)
       │    │    ├── inner-join (cross)
-      │    │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 "inverted_join_const_col_@8":21!null
+      │    │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 "inverted_join_const_col_@8":22!null
       │    │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
       │    │    │    ├── fd: (1)-->(2-4)
       │    │    │    ├── scan json_arr2 [as=t2]
@@ -9247,7 +9247,7 @@ project
       │    │    │    │    ├── key: (1)
       │    │    │    │    └── fd: (1)-->(2-4)
       │    │    │    ├── values
-      │    │    │    │    ├── columns: "inverted_join_const_col_@8":21!null
+      │    │    │    │    ├── columns: "inverted_join_const_col_@8":22!null
       │    │    │    │    ├── cardinality: [2 - 2]
       │    │    │    │    ├── (3,)
       │    │    │    │    └── (4,)
@@ -9273,20 +9273,20 @@ WHERE EXISTS (
 ----
 semi-join (lookup json_arr1 [as=t1])
  ├── columns: k:1!null l:2 j:3 a:4
- ├── key columns: [21] = [7]
+ ├── key columns: [22] = [7]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── inner-join (inverted json_arr1@j_idx [as=t1])
- │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:21!null i:22!null continuation:35
- │    ├── prefix key columns: [1] = [22]
- │    ├── first join in paired joiner; continuation column: continuation:35
+ │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:22!null i:23!null continuation:36
+ │    ├── prefix key columns: [1] = [23]
+ │    ├── first join in paired joiner; continuation column: continuation:36
  │    ├── inverted-expr
- │    │    └── t1.j:23 @> t2.j:3
- │    ├── key: (21)
- │    ├── fd: (1)-->(2-4), (21)-->(22,35), (1)==(22), (22)==(1)
+ │    │    └── t1.j:24 @> t2.j:3
+ │    ├── key: (22)
+ │    ├── fd: (1)-->(2-4), (22)-->(23,36), (1)==(23), (23)==(1)
  │    ├── scan json_arr2 [as=t2]
  │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
  │    │    ├── key: (1)
@@ -9331,20 +9331,20 @@ WHERE NOT EXISTS (
 ----
 anti-join (lookup json_arr1 [as=t1])
  ├── columns: k:1!null l:2 j:3 a:4
- ├── key columns: [21] = [7]
+ ├── key columns: [22] = [7]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── left-join (inverted json_arr1@j_idx [as=t1])
- │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:21 i:22 continuation:35
- │    ├── prefix key columns: [1] = [22]
- │    ├── first join in paired joiner; continuation column: continuation:35
+ │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4 t1.k:22 i:23 continuation:36
+ │    ├── prefix key columns: [1] = [23]
+ │    ├── first join in paired joiner; continuation column: continuation:36
  │    ├── inverted-expr
- │    │    └── t1.j:23 @> t2.j:3
- │    ├── key: (1,21)
- │    ├── fd: (1)-->(2-4), (21)-->(22,35)
+ │    │    └── t1.j:24 @> t2.j:3
+ │    ├── key: (1,22)
+ │    ├── fd: (1)-->(2-4), (22)-->(23,36)
  │    ├── scan json_arr2 [as=t2]
  │    │    ├── columns: t2.k:1!null l:2 t2.j:3 t2.a:4
  │    │    ├── key: (1)
@@ -9659,19 +9659,19 @@ WHERE EXISTS (
 ----
 semi-join (lookup nyc_neighborhoods [as=n])
  ├── columns: gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 boroname:9 geom:10
- ├── key columns: [23] = [14]
+ ├── key columns: [24] = [14]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-10)
  ├── inner-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
- │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:23!null continuation:32
- │    ├── first join in paired joiner; continuation column: continuation:32
+ │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:24!null continuation:33
+ │    ├── first join in paired joiner; continuation column: continuation:33
  │    ├── inverted-expr
- │    │    └── st_covers(c.geom:10, n.geom:26)
- │    ├── key: (1,23)
- │    ├── fd: (1)-->(2-10), (23)-->(32)
+ │    │    └── st_covers(c.geom:10, n.geom:27)
+ │    ├── key: (1,24)
+ │    ├── fd: (1)-->(2-10), (24)-->(33)
  │    ├── scan nyc_census_blocks [as=c]
  │    │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10
  │    │    ├── key: (1)
@@ -9691,19 +9691,19 @@ WHERE NOT EXISTS (
 ----
 anti-join (lookup nyc_neighborhoods [as=n])
  ├── columns: gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 boroname:9 geom:10
- ├── key columns: [23] = [14]
+ ├── key columns: [24] = [14]
  ├── lookup columns are key
  ├── second join in paired joiner
  ├── immutable
  ├── key: (1)
  ├── fd: (1)-->(2-10)
  ├── left-join (inverted nyc_neighborhoods@nyc_neighborhoods_geo_idx,partial [as=n])
- │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:23 continuation:32
- │    ├── first join in paired joiner; continuation column: continuation:32
+ │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10 n.gid:24 continuation:33
+ │    ├── first join in paired joiner; continuation column: continuation:33
  │    ├── inverted-expr
- │    │    └── st_covers(c.geom:10, n.geom:26)
- │    ├── key: (1,23)
- │    ├── fd: (1)-->(2-10), (23)-->(32)
+ │    │    └── st_covers(c.geom:10, n.geom:27)
+ │    ├── key: (1,24)
+ │    ├── fd: (1)-->(2-10), (24)-->(33)
  │    ├── scan nyc_census_blocks [as=c]
  │    │    ├── columns: c.gid:1!null blkid:2 popn_total:3 popn_white:4 popn_black:5 popn_nativ:6 popn_asian:7 popn_other:8 c.boroname:9 c.geom:10
  │    │    ├── key: (1)
@@ -9859,70 +9859,70 @@ project
       ├── fd: (1)-->(2,3)
       ├── union-all
       │    ├── columns: a:1!null b:2 c:3
-      │    ├── left columns: a:13 b:14 c:15
-      │    ├── right columns: a:25 b:26 c:27
+      │    ├── left columns: a:14 b:15 c:16
+      │    ├── right columns: a:26 b:27 c:28
       │    ├── cardinality: [0 - 2]
       │    ├── ordering: +1
       │    ├── semi-join (lookup pqr@q)
-      │    │    ├── columns: a:13!null b:14 c:15!null
-      │    │    ├── key columns: [14 105] = [19 18]
+      │    │    ├── columns: a:14!null b:15 c:16!null
+      │    │    ├── key columns: [15 106] = [20 19]
       │    │    ├── lookup columns are key
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(13-15)
+      │    │    ├── fd: ()-->(14-16)
       │    │    ├── project
-      │    │    │    ├── columns: "lookup_join_const_col_@18":105!null a:13!null b:14 c:15!null
+      │    │    │    ├── columns: "lookup_join_const_col_@19":106!null a:14!null b:15 c:16!null
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(13-15,105)
+      │    │    │    ├── fd: ()-->(14-16,106)
       │    │    │    ├── index-join zz
-      │    │    │    │    ├── columns: a:13!null b:14 c:15!null
+      │    │    │    │    ├── columns: a:14!null b:15 c:16!null
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(13-15)
+      │    │    │    │    ├── fd: ()-->(14-16)
       │    │    │    │    └── scan zz@idx_c
-      │    │    │    │         ├── columns: a:13!null c:15!null
-      │    │    │    │         ├── constraint: /15: [/0 - /0]
+      │    │    │    │         ├── columns: a:14!null c:16!null
+      │    │    │    │         ├── constraint: /16: [/0 - /0]
       │    │    │    │         ├── cardinality: [0 - 1]
       │    │    │    │         ├── key: ()
-      │    │    │    │         └── fd: ()-->(13,15)
+      │    │    │    │         └── fd: ()-->(14,16)
       │    │    │    └── projections
-      │    │    │         └── 0 [as="lookup_join_const_col_@18":105]
+      │    │    │         └── 0 [as="lookup_join_const_col_@19":106]
       │    │    └── filters (true)
       │    └── project
-      │         ├── columns: a:25!null b:26 c:27
+      │         ├── columns: a:26!null b:27 c:28
       │         ├── cardinality: [0 - 1]
-      │         ├── key: (25)
-      │         ├── fd: (25)-->(26,27), (27)~~>(25,26)
-      │         ├── ordering: +25
+      │         ├── key: (26)
+      │         ├── fd: (26)-->(27,28), (28)~~>(26,27)
+      │         ├── ordering: +26
       │         └── project
-      │              ├── columns: a:25!null b:26!null c:27!null q:31!null r:32!null
+      │              ├── columns: a:26!null b:27!null c:28!null q:32!null r:33!null
       │              ├── cardinality: [0 - 1]
       │              ├── key: ()
-      │              ├── fd: ()-->(25-27,31,32), (27)==(32), (32)==(27), (26)==(31), (31)==(26)
+      │              ├── fd: ()-->(26-28,32,33), (28)==(33), (33)==(28), (27)==(32), (32)==(27)
       │              └── inner-join (lookup zz)
-      │                   ├── columns: a:25!null b:26!null c:27!null p:30!null q:31!null r:32!null
-      │                   ├── key columns: [25] = [25]
+      │                   ├── columns: a:26!null b:27!null c:28!null p:31!null q:32!null r:33!null
+      │                   ├── key columns: [26] = [26]
       │                   ├── lookup columns are key
       │                   ├── cardinality: [0 - 1]
       │                   ├── key: ()
-      │                   ├── fd: ()-->(25-27,30-32), (31)==(26), (27)==(32), (32)==(27), (26)==(31)
+      │                   ├── fd: ()-->(26-28,31-33), (32)==(27), (28)==(33), (33)==(28), (27)==(32)
       │                   ├── inner-join (lookup zz@idx_c)
-      │                   │    ├── columns: a:25!null c:27!null p:30!null q:31 r:32!null
-      │                   │    ├── key columns: [32] = [27]
+      │                   │    ├── columns: a:26!null c:28!null p:31!null q:32 r:33!null
+      │                   │    ├── key columns: [33] = [28]
       │                   │    ├── lookup columns are key
       │                   │    ├── cardinality: [0 - 1]
       │                   │    ├── key: ()
-      │                   │    ├── fd: ()-->(25,27,30-32), (32)==(27), (27)==(32)
+      │                   │    ├── fd: ()-->(26,28,31-33), (33)==(28), (28)==(33)
       │                   │    ├── scan pqr
-      │                   │    │    ├── columns: p:30!null q:31 r:32
-      │                   │    │    ├── constraint: /30: [/0 - /0]
+      │                   │    │    ├── columns: p:31!null q:32 r:33
+      │                   │    │    ├── constraint: /31: [/0 - /0]
       │                   │    │    ├── cardinality: [0 - 1]
       │                   │    │    ├── key: ()
-      │                   │    │    └── fd: ()-->(30-32)
+      │                   │    │    └── fd: ()-->(31-33)
       │                   │    └── filters (true)
       │                   └── filters
-      │                        └── q:31 = b:26 [outer=(26,31), constraints=(/26: (/NULL - ]; /31: (/NULL - ]), fd=(26)==(31), (31)==(26)]
+      │                        └── q:32 = b:27 [outer=(27,32), constraints=(/27: (/NULL - ]; /32: (/NULL - ]), fd=(27)==(32), (32)==(27)]
       └── aggregations
            ├── const-agg [as=b:2, outer=(2)]
            │    └── b:2
@@ -11032,26 +11032,26 @@ anti-join (lookup abc_part)
  │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
- │    │    ├── left columns: def_part.r:14 d:15 e:16 f:17
- │    │    ├── right columns: def_part.r:20 d:21 e:22 f:23
+ │    │    ├── left columns: def_part.r:15 d:16 e:17 f:18
+ │    │    ├── right columns: def_part.r:21 d:22 e:23 f:24
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
  │    │    ├── distribution: east
  │    │    ├── scan def_part
- │    │    │    ├── columns: def_part.r:14!null d:15!null e:16 f:17
- │    │    │    ├── constraint: /14/15: [/'east'/1 - /'east'/1]
+ │    │    │    ├── columns: def_part.r:15!null d:16!null e:17 f:18
+ │    │    │    ├── constraint: /15/16: [/'east'/1 - /'east'/1]
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
- │    │    │    └── fd: ()-->(14-17)
+ │    │    │    └── fd: ()-->(15-18)
  │    │    └── scan def_part
- │    │         ├── columns: def_part.r:20!null d:21!null e:22 f:23
- │    │         ├── constraint: /20/21
+ │    │         ├── columns: def_part.r:21!null d:22!null e:23 f:24
+ │    │         ├── constraint: /21/22
  │    │         │    ├── [/'central'/1 - /'central'/1]
  │    │         │    └── [/'west'/1 - /'west'/1]
  │    │         ├── cardinality: [0 - 1]
  │    │         ├── key: ()
- │    │         └── fd: ()-->(20-23)
+ │    │         └── fd: ()-->(21-24)
  │    └── filters (true)
  └── filters (true)
 
@@ -11083,26 +11083,26 @@ anti-join (lookup abc_part)
  │    ├── distribution: west
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
- │    │    ├── left columns: def_part.r:14 d:15 e:16 f:17
- │    │    ├── right columns: def_part.r:20 d:21 e:22 f:23
+ │    │    ├── left columns: def_part.r:15 d:16 e:17 f:18
+ │    │    ├── right columns: def_part.r:21 d:22 e:23 f:24
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
  │    │    ├── distribution: west
  │    │    ├── scan def_part
- │    │    │    ├── columns: def_part.r:14!null d:15!null e:16 f:17
- │    │    │    ├── constraint: /14/15: [/'west'/1 - /'west'/1]
+ │    │    │    ├── columns: def_part.r:15!null d:16!null e:17 f:18
+ │    │    │    ├── constraint: /15/16: [/'west'/1 - /'west'/1]
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
- │    │    │    └── fd: ()-->(14-17)
+ │    │    │    └── fd: ()-->(15-18)
  │    │    └── scan def_part
- │    │         ├── columns: def_part.r:20!null d:21!null e:22 f:23
- │    │         ├── constraint: /20/21
+ │    │         ├── columns: def_part.r:21!null d:22!null e:23 f:24
+ │    │         ├── constraint: /21/22
  │    │         │    ├── [/'central'/1 - /'central'/1]
  │    │         │    └── [/'east'/1 - /'east'/1]
  │    │         ├── cardinality: [0 - 1]
  │    │         ├── key: ()
- │    │         └── fd: ()-->(20-23)
+ │    │         └── fd: ()-->(21-24)
  │    └── filters (true)
  └── filters (true)
 
@@ -11134,26 +11134,26 @@ anti-join (lookup abc_part@b_idx)
  │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
- │    │    ├── left columns: def_part.r:14 d:15 e:16 f:17
- │    │    ├── right columns: def_part.r:20 d:21 e:22 f:23
+ │    │    ├── left columns: def_part.r:15 d:16 e:17 f:18
+ │    │    ├── right columns: def_part.r:21 d:22 e:23 f:24
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
  │    │    ├── distribution: east
  │    │    ├── scan def_part
- │    │    │    ├── columns: def_part.r:14!null d:15!null e:16 f:17
- │    │    │    ├── constraint: /14/15: [/'east'/10 - /'east'/10]
+ │    │    │    ├── columns: def_part.r:15!null d:16!null e:17 f:18
+ │    │    │    ├── constraint: /15/16: [/'east'/10 - /'east'/10]
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
- │    │    │    └── fd: ()-->(14-17)
+ │    │    │    └── fd: ()-->(15-18)
  │    │    └── scan def_part
- │    │         ├── columns: def_part.r:20!null d:21!null e:22 f:23
- │    │         ├── constraint: /20/21
+ │    │         ├── columns: def_part.r:21!null d:22!null e:23 f:24
+ │    │         ├── constraint: /21/22
  │    │         │    ├── [/'central'/10 - /'central'/10]
  │    │         │    └── [/'west'/10 - /'west'/10]
  │    │         ├── cardinality: [0 - 1]
  │    │         ├── key: ()
- │    │         └── fd: ()-->(20-23)
+ │    │         └── fd: ()-->(21-24)
  │    └── filters (true)
  └── filters (true)
 
@@ -11185,26 +11185,26 @@ anti-join (lookup abc_part)
  │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
- │    │    ├── left columns: def_part.r:14 d:15 e:16 f:17
- │    │    ├── right columns: def_part.r:20 d:21 e:22 f:23
+ │    │    ├── left columns: def_part.r:15 d:16 e:17 f:18
+ │    │    ├── right columns: def_part.r:21 d:22 e:23 f:24
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
  │    │    ├── distribution: east
  │    │    ├── scan def_part
- │    │    │    ├── columns: def_part.r:14!null d:15!null e:16 f:17
- │    │    │    ├── constraint: /14/15: [/'east'/1 - /'east'/1]
+ │    │    │    ├── columns: def_part.r:15!null d:16!null e:17 f:18
+ │    │    │    ├── constraint: /15/16: [/'east'/1 - /'east'/1]
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
- │    │    │    └── fd: ()-->(14-17)
+ │    │    │    └── fd: ()-->(15-18)
  │    │    └── scan def_part
- │    │         ├── columns: def_part.r:20!null d:21!null e:22 f:23
- │    │         ├── constraint: /20/21
+ │    │         ├── columns: def_part.r:21!null d:22!null e:23 f:24
+ │    │         ├── constraint: /21/22
  │    │         │    ├── [/'central'/1 - /'central'/1]
  │    │         │    └── [/'west'/1 - /'west'/1]
  │    │         ├── cardinality: [0 - 1]
  │    │         ├── key: ()
- │    │         └── fd: ()-->(20-23)
+ │    │         └── fd: ()-->(21-24)
  │    └── filters
  │         └── f:4 > b:9 [outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ])]
  └── filters
@@ -11280,26 +11280,26 @@ anti-join (lookup abc_part@c_idx)
  │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
- │    │    ├── left columns: def_part.r:14 d:15 e:16 f:17
- │    │    ├── right columns: def_part.r:20 d:21 e:22 f:23
+ │    │    ├── left columns: def_part.r:15 d:16 e:17 f:18
+ │    │    ├── right columns: def_part.r:21 d:22 e:23 f:24
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
  │    │    ├── distribution: east
  │    │    ├── scan def_part
- │    │    │    ├── columns: def_part.r:14!null d:15!null e:16 f:17
- │    │    │    ├── constraint: /14/15: [/'east'/10 - /'east'/10]
+ │    │    │    ├── columns: def_part.r:15!null d:16!null e:17 f:18
+ │    │    │    ├── constraint: /15/16: [/'east'/10 - /'east'/10]
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
- │    │    │    └── fd: ()-->(14-17)
+ │    │    │    └── fd: ()-->(15-18)
  │    │    └── scan def_part
- │    │         ├── columns: def_part.r:20!null d:21!null e:22 f:23
- │    │         ├── constraint: /20/21
+ │    │         ├── columns: def_part.r:21!null d:22!null e:23 f:24
+ │    │         ├── constraint: /21/22
  │    │         │    ├── [/'central'/10 - /'central'/10]
  │    │         │    └── [/'west'/10 - /'west'/10]
  │    │         ├── cardinality: [0 - 1]
  │    │         ├── key: ()
- │    │         └── fd: ()-->(20-23)
+ │    │         └── fd: ()-->(21-24)
  │    └── filters (true)
  └── filters (true)
 
@@ -11332,26 +11332,26 @@ anti-join (lookup abc_part@c_idx)
  │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
- │    │    ├── left columns: def_part.r:14 d:15 e:16 f:17
- │    │    ├── right columns: def_part.r:20 d:21 e:22 f:23
+ │    │    ├── left columns: def_part.r:15 d:16 e:17 f:18
+ │    │    ├── right columns: def_part.r:21 d:22 e:23 f:24
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
  │    │    ├── distribution: east
  │    │    ├── scan def_part
- │    │    │    ├── columns: def_part.r:14!null d:15!null e:16 f:17
- │    │    │    ├── constraint: /14/15: [/'east'/10 - /'east'/10]
+ │    │    │    ├── columns: def_part.r:15!null d:16!null e:17 f:18
+ │    │    │    ├── constraint: /15/16: [/'east'/10 - /'east'/10]
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
- │    │    │    └── fd: ()-->(14-17)
+ │    │    │    └── fd: ()-->(15-18)
  │    │    └── scan def_part
- │    │         ├── columns: def_part.r:20!null d:21!null e:22 f:23
- │    │         ├── constraint: /20/21
+ │    │         ├── columns: def_part.r:21!null d:22!null e:23 f:24
+ │    │         ├── constraint: /21/22
  │    │         │    ├── [/'central'/10 - /'central'/10]
  │    │         │    └── [/'west'/10 - /'west'/10]
  │    │         ├── cardinality: [0 - 1]
  │    │         ├── key: ()
- │    │         └── fd: ()-->(20-23)
+ │    │         └── fd: ()-->(21-24)
  │    └── filters
  │         └── (e:3 % a:8) = 0 [outer=(3,8), immutable]
  └── filters
@@ -11367,26 +11367,26 @@ anti-join (lookup abc_part@c_b_idx)
  ├── lookup expression
  │    └── filters
  │         ├── r:2 IN ('central', 'west') [outer=(2), constraints=(/2: [/'central' - /'central'] [/'west' - /'west']; tight)]
- │         ├── "lookup_join_const_col_@5":18 = c:5 [outer=(5,18), constraints=(/5: (/NULL - ]; /18: (/NULL - ]), fd=(5)==(18), (18)==(5)]
+ │         ├── "lookup_join_const_col_@5":19 = c:5 [outer=(5,19), constraints=(/5: (/NULL - ]; /19: (/NULL - ]), fd=(5)==(19), (19)==(5)]
  │         └── column1:1 = b:4 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
  ├── lookup columns are key
  ├── cardinality: [0 - 2]
  ├── distribution: east
  ├── anti-join (lookup abc_part@c_b_idx)
- │    ├── columns: column1:1!null "lookup_join_const_col_@5":18!null
+ │    ├── columns: column1:1!null "lookup_join_const_col_@5":19!null
  │    ├── lookup expression
  │    │    └── filters
  │    │         ├── r:2 = 'east' [outer=(2), constraints=(/2: [/'east' - /'east']; tight), fd=()-->(2)]
- │    │         ├── "lookup_join_const_col_@5":18 = c:5 [outer=(5,18), constraints=(/5: (/NULL - ]; /18: (/NULL - ]), fd=(5)==(18), (18)==(5)]
+ │    │         ├── "lookup_join_const_col_@5":19 = c:5 [outer=(5,19), constraints=(/5: (/NULL - ]; /19: (/NULL - ]), fd=(5)==(19), (19)==(5)]
  │    │         └── column1:1 = b:4 [outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
  │    ├── lookup columns are key
  │    ├── cardinality: [0 - 2]
- │    ├── fd: ()-->(18)
+ │    ├── fd: ()-->(19)
  │    ├── distribution: east
  │    ├── project
- │    │    ├── columns: "lookup_join_const_col_@5":18!null column1:1!null
+ │    │    ├── columns: "lookup_join_const_col_@5":19!null column1:1!null
  │    │    ├── cardinality: [2 - 2]
- │    │    ├── fd: ()-->(18)
+ │    │    ├── fd: ()-->(19)
  │    │    ├── distribution: east
  │    │    ├── values
  │    │    │    ├── columns: column1:1!null
@@ -11395,7 +11395,7 @@ anti-join (lookup abc_part@c_b_idx)
  │    │    │    ├── (2,)
  │    │    │    └── (4,)
  │    │    └── projections
- │    │         └── 1 [as="lookup_join_const_col_@5":18]
+ │    │         └── 1 [as="lookup_join_const_col_@5":19]
  │    └── filters (true)
  └── filters (true)
 
@@ -11420,26 +11420,26 @@ semi-join (lookup abc_part)
  ├── distribution: central
  ├── locality-optimized-search
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
- │    ├── left columns: def_part.r:14 d:15 e:16 f:17
- │    ├── right columns: def_part.r:20 d:21 e:22 f:23
+ │    ├── left columns: def_part.r:15 d:16 e:17 f:18
+ │    ├── right columns: def_part.r:21 d:22 e:23 f:24
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
  │    ├── distribution: central
  │    ├── scan def_part
- │    │    ├── columns: def_part.r:14!null d:15!null e:16 f:17
- │    │    ├── constraint: /14/15: [/'central'/1 - /'central'/1]
+ │    │    ├── columns: def_part.r:15!null d:16!null e:17 f:18
+ │    │    ├── constraint: /15/16: [/'central'/1 - /'central'/1]
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
- │    │    └── fd: ()-->(14-17)
+ │    │    └── fd: ()-->(15-18)
  │    └── scan def_part
- │         ├── columns: def_part.r:20!null d:21!null e:22 f:23
- │         ├── constraint: /20/21
+ │         ├── columns: def_part.r:21!null d:22!null e:23 f:24
+ │         ├── constraint: /21/22
  │         │    ├── [/'east'/1 - /'east'/1]
  │         │    └── [/'west'/1 - /'west'/1]
  │         ├── cardinality: [0 - 1]
  │         ├── key: ()
- │         └── fd: ()-->(20-23)
+ │         └── fd: ()-->(21-24)
  └── filters (true)
 
 exec-ddl
@@ -11575,26 +11575,26 @@ semi-join (lookup abc_part)
  ├── distribution: central
  ├── locality-optimized-search
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
- │    ├── left columns: def_part.r:14 d:15 e:16 f:17
- │    ├── right columns: def_part.r:20 d:21 e:22 f:23
+ │    ├── left columns: def_part.r:15 d:16 e:17 f:18
+ │    ├── right columns: def_part.r:21 d:22 e:23 f:24
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
  │    ├── distribution: central
  │    ├── scan def_part
- │    │    ├── columns: def_part.r:14!null d:15!null e:16 f:17
- │    │    ├── constraint: /14/15: [/'central'/1 - /'central'/1]
+ │    │    ├── columns: def_part.r:15!null d:16!null e:17 f:18
+ │    │    ├── constraint: /15/16: [/'central'/1 - /'central'/1]
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
- │    │    └── fd: ()-->(14-17)
+ │    │    └── fd: ()-->(15-18)
  │    └── scan def_part
- │         ├── columns: def_part.r:20!null d:21!null e:22 f:23
- │         ├── constraint: /20/21
+ │         ├── columns: def_part.r:21!null d:22!null e:23 f:24
+ │         ├── constraint: /21/22
  │         │    ├── [/'east'/1 - /'east'/1]
  │         │    └── [/'west'/1 - /'west'/1]
  │         ├── cardinality: [0 - 1]
  │         ├── key: ()
- │         └── fd: ()-->(20-23)
+ │         └── fd: ()-->(21-24)
  └── filters (true)
 
 # Locality optimized semi join, with an extra ON filter.
@@ -11618,26 +11618,26 @@ semi-join (lookup abc_part)
  ├── distribution: west
  ├── locality-optimized-search
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
- │    ├── left columns: def_part.r:14 d:15 e:16 f:17
- │    ├── right columns: def_part.r:20 d:21 e:22 f:23
+ │    ├── left columns: def_part.r:15 d:16 e:17 f:18
+ │    ├── right columns: def_part.r:21 d:22 e:23 f:24
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
  │    ├── distribution: west
  │    ├── scan def_part
- │    │    ├── columns: def_part.r:14!null d:15!null e:16 f:17
- │    │    ├── constraint: /14/15: [/'west'/1 - /'west'/1]
+ │    │    ├── columns: def_part.r:15!null d:16!null e:17 f:18
+ │    │    ├── constraint: /15/16: [/'west'/1 - /'west'/1]
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
- │    │    └── fd: ()-->(14-17)
+ │    │    └── fd: ()-->(15-18)
  │    └── scan def_part
- │         ├── columns: def_part.r:20!null d:21!null e:22 f:23
- │         ├── constraint: /20/21
+ │         ├── columns: def_part.r:21!null d:22!null e:23 f:24
+ │         ├── constraint: /21/22
  │         │    ├── [/'central'/1 - /'central'/1]
  │         │    └── [/'east'/1 - /'east'/1]
  │         ├── cardinality: [0 - 1]
  │         ├── key: ()
- │         └── fd: ()-->(20-23)
+ │         └── fd: ()-->(21-24)
  └── filters
       └── f:4 > b:9 [outer=(4,9), constraints=(/4: (/NULL - ]; /9: (/NULL - ])]
 
@@ -11821,26 +11821,26 @@ semi-join (lookup abc_part@c_idx)
  ├── distribution: east
  ├── locality-optimized-search
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
- │    ├── left columns: def_part.r:14 d:15 e:16 f:17
- │    ├── right columns: def_part.r:20 d:21 e:22 f:23
+ │    ├── left columns: def_part.r:15 d:16 e:17 f:18
+ │    ├── right columns: def_part.r:21 d:22 e:23 f:24
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
  │    ├── distribution: east
  │    ├── scan def_part
- │    │    ├── columns: def_part.r:14!null d:15!null e:16 f:17
- │    │    ├── constraint: /14/15: [/'east'/10 - /'east'/10]
+ │    │    ├── columns: def_part.r:15!null d:16!null e:17 f:18
+ │    │    ├── constraint: /15/16: [/'east'/10 - /'east'/10]
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
- │    │    └── fd: ()-->(14-17)
+ │    │    └── fd: ()-->(15-18)
  │    └── scan def_part
- │         ├── columns: def_part.r:20!null d:21!null e:22 f:23
- │         ├── constraint: /20/21
+ │         ├── columns: def_part.r:21!null d:22!null e:23 f:24
+ │         ├── constraint: /21/22
  │         │    ├── [/'central'/10 - /'central'/10]
  │         │    └── [/'west'/10 - /'west'/10]
  │         ├── cardinality: [0 - 1]
  │         ├── key: ()
- │         └── fd: ()-->(20-23)
+ │         └── fd: ()-->(21-24)
  └── filters (true)
 
 # Optimization does not apply for a semi join that may have more than one
@@ -11864,26 +11864,26 @@ semi-join (lookup abc_part@c_idx)
  ├── distribution: east
  ├── locality-optimized-search
  │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
- │    ├── left columns: def_part.r:14 d:15 e:16 f:17
- │    ├── right columns: def_part.r:20 d:21 e:22 f:23
+ │    ├── left columns: def_part.r:15 d:16 e:17 f:18
+ │    ├── right columns: def_part.r:21 d:22 e:23 f:24
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    ├── fd: ()-->(1-4)
  │    ├── distribution: east
  │    ├── scan def_part
- │    │    ├── columns: def_part.r:14!null d:15!null e:16 f:17
- │    │    ├── constraint: /14/15: [/'east'/10 - /'east'/10]
+ │    │    ├── columns: def_part.r:15!null d:16!null e:17 f:18
+ │    │    ├── constraint: /15/16: [/'east'/10 - /'east'/10]
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
- │    │    └── fd: ()-->(14-17)
+ │    │    └── fd: ()-->(15-18)
  │    └── scan def_part
- │         ├── columns: def_part.r:20!null d:21!null e:22 f:23
- │         ├── constraint: /20/21
+ │         ├── columns: def_part.r:21!null d:22!null e:23 f:24
+ │         ├── constraint: /21/22
  │         │    ├── [/'central'/10 - /'central'/10]
  │         │    └── [/'west'/10 - /'west'/10]
  │         ├── cardinality: [0 - 1]
  │         ├── key: ()
- │         └── fd: ()-->(20-23)
+ │         └── fd: ()-->(21-24)
  └── filters
       └── (e:3 % a:8) = 0 [outer=(3,8), immutable]
 
@@ -11972,26 +11972,26 @@ anti-join (lookup abc_part)
  │    ├── distribution: east
  │    ├── locality-optimized-search
  │    │    ├── columns: def_part.r:1!null d:2!null e:3 f:4
- │    │    ├── left columns: def_part.r:14 d:15 e:16 f:17
- │    │    ├── right columns: def_part.r:20 d:21 e:22 f:23
+ │    │    ├── left columns: def_part.r:15 d:16 e:17 f:18
+ │    │    ├── right columns: def_part.r:21 d:22 e:23 f:24
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1-4)
  │    │    ├── distribution: east
  │    │    ├── scan def_part
- │    │    │    ├── columns: def_part.r:14!null d:15!null e:16 f:17
- │    │    │    ├── constraint: /14/15: [/'east'/1 - /'east'/1]
+ │    │    │    ├── columns: def_part.r:15!null d:16!null e:17 f:18
+ │    │    │    ├── constraint: /15/16: [/'east'/1 - /'east'/1]
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
- │    │    │    └── fd: ()-->(14-17)
+ │    │    │    └── fd: ()-->(15-18)
  │    │    └── scan def_part
- │    │         ├── columns: def_part.r:20!null d:21!null e:22 f:23
- │    │         ├── constraint: /20/21
+ │    │         ├── columns: def_part.r:21!null d:22!null e:23 f:24
+ │    │         ├── constraint: /21/22
  │    │         │    ├── [/'central'/1 - /'central'/1]
  │    │         │    └── [/'west'/1 - /'west'/1]
  │    │         ├── cardinality: [0 - 1]
  │    │         ├── key: ()
- │    │         └── fd: ()-->(20-23)
+ │    │         └── fd: ()-->(21-24)
  │    └── filters (true)
  └── filters (true)
 
@@ -12285,14 +12285,14 @@ SELECT m FROM small WHERE m IN (
 ----
 semi-join (lookup t87306@t87306_a_c_idx)
  ├── columns: m:1
- ├── key columns: [12 1] = [6 8]
+ ├── key columns: [13 1] = [6 8]
  ├── project
- │    ├── columns: "lookup_join_const_col_@6":12!null m:1
- │    ├── fd: ()-->(12)
+ │    ├── columns: "lookup_join_const_col_@6":13!null m:1
+ │    ├── fd: ()-->(13)
  │    ├── scan small
  │    │    └── columns: m:1
  │    └── projections
- │         └── 0 [as="lookup_join_const_col_@6":12]
+ │         └── 0 [as="lookup_join_const_col_@6":13]
  └── filters (true)
 
 # --------------------------------------------------
@@ -12595,46 +12595,46 @@ project
       ├── fd: (1,2)-->(3)
       ├── union-all
       │    ├── columns: a:1!null b:2!null c:3
-      │    ├── left columns: a:12 b:13 c:14
-      │    ├── right columns: a:23 b:24 c:25
+      │    ├── left columns: a:13 b:14 c:15
+      │    ├── right columns: a:24 b:25 c:26
       │    ├── project
-      │    │    ├── columns: a:12!null b:13!null c:14
-      │    │    ├── key: (12,13)
-      │    │    ├── fd: (12,13)-->(14)
+      │    │    ├── columns: a:13!null b:14!null c:15
+      │    │    ├── key: (13,14)
+      │    │    ├── fd: (13,14)-->(15)
       │    │    └── inner-join (merge)
-      │    │         ├── columns: a:12!null b:13!null c:14 x:17!null
-      │    │         ├── left ordering: +12
-      │    │         ├── right ordering: +17
-      │    │         ├── key: (13,17)
-      │    │         ├── fd: (12,13)-->(14), (12)==(17), (17)==(12)
+      │    │         ├── columns: a:13!null b:14!null c:15 x:18!null
+      │    │         ├── left ordering: +13
+      │    │         ├── right ordering: +18
+      │    │         ├── key: (14,18)
+      │    │         ├── fd: (13,14)-->(15), (13)==(18), (18)==(13)
       │    │         ├── scan abc
-      │    │         │    ├── columns: a:12!null b:13!null c:14
-      │    │         │    ├── key: (12,13)
-      │    │         │    ├── fd: (12,13)-->(14)
-      │    │         │    └── ordering: +12
+      │    │         │    ├── columns: a:13!null b:14!null c:15
+      │    │         │    ├── key: (13,14)
+      │    │         │    ├── fd: (13,14)-->(15)
+      │    │         │    └── ordering: +13
       │    │         ├── distinct-on
-      │    │         │    ├── columns: x:17
-      │    │         │    ├── grouping columns: x:17
-      │    │         │    ├── key: (17)
-      │    │         │    ├── ordering: +17
+      │    │         │    ├── columns: x:18
+      │    │         │    ├── grouping columns: x:18
+      │    │         │    ├── key: (18)
+      │    │         │    ├── ordering: +18
       │    │         │    └── scan xyz@xy
-      │    │         │         ├── columns: x:17
-      │    │         │         └── ordering: +17
+      │    │         │         ├── columns: x:18
+      │    │         │         └── ordering: +18
       │    │         └── filters (true)
       │    └── semi-join (merge)
-      │         ├── columns: a:23!null b:24!null c:25
-      │         ├── left ordering: +24
-      │         ├── right ordering: +29
-      │         ├── key: (23,24)
-      │         ├── fd: (23,24)-->(25)
+      │         ├── columns: a:24!null b:25!null c:26
+      │         ├── left ordering: +25
+      │         ├── right ordering: +30
+      │         ├── key: (24,25)
+      │         ├── fd: (24,25)-->(26)
       │         ├── scan abc@bc
-      │         │    ├── columns: a:23!null b:24!null c:25
-      │         │    ├── key: (23,24)
-      │         │    ├── fd: (23,24)-->(25)
-      │         │    └── ordering: +24
+      │         │    ├── columns: a:24!null b:25!null c:26
+      │         │    ├── key: (24,25)
+      │         │    ├── fd: (24,25)-->(26)
+      │         │    └── ordering: +25
       │         ├── scan xyz@yz
-      │         │    ├── columns: y:29
-      │         │    └── ordering: +29
+      │         │    ├── columns: y:30
+      │         │    └── ordering: +30
       │         └── filters (true)
       └── aggregations
            └── const-agg [as=c:3, outer=(3)]
@@ -12655,47 +12655,47 @@ project
       ├── fd: (1,2)-->(3)
       ├── union-all
       │    ├── columns: a:1!null b:2!null c:3
-      │    ├── left columns: a:12 b:13 c:14
-      │    ├── right columns: a:23 b:24 c:25
+      │    ├── left columns: a:13 b:14 c:15
+      │    ├── right columns: a:24 b:25 c:26
       │    ├── project
-      │    │    ├── columns: a:12!null b:13!null c:14
-      │    │    ├── key: (12,13)
-      │    │    ├── fd: (12,13)-->(14)
+      │    │    ├── columns: a:13!null b:14!null c:15
+      │    │    ├── key: (13,14)
+      │    │    ├── fd: (13,14)-->(15)
       │    │    └── inner-join (hash)
-      │    │         ├── columns: a:12!null b:13!null c:14 x:17!null
+      │    │         ├── columns: a:13!null b:14!null c:15 x:18!null
       │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-      │    │         ├── key: (13,17)
-      │    │         ├── fd: (12,13)-->(14), (12)==(17), (17)==(12)
+      │    │         ├── key: (14,18)
+      │    │         ├── fd: (13,14)-->(15), (13)==(18), (18)==(13)
       │    │         ├── scan abc@bc
-      │    │         │    ├── columns: a:12!null b:13!null c:14
-      │    │         │    ├── constraint: /13/14/12: [ - /0]
-      │    │         │    ├── key: (12,13)
-      │    │         │    └── fd: (12,13)-->(14)
+      │    │         │    ├── columns: a:13!null b:14!null c:15
+      │    │         │    ├── constraint: /14/15/13: [ - /0]
+      │    │         │    ├── key: (13,14)
+      │    │         │    └── fd: (13,14)-->(15)
       │    │         ├── distinct-on
-      │    │         │    ├── columns: x:17
-      │    │         │    ├── grouping columns: x:17
-      │    │         │    ├── key: (17)
+      │    │         │    ├── columns: x:18
+      │    │         │    ├── grouping columns: x:18
+      │    │         │    ├── key: (18)
       │    │         │    └── scan xyz@yz
-      │    │         │         ├── columns: x:17 y:18!null
-      │    │         │         └── constraint: /18/19/20: [/2 - ]
+      │    │         │         ├── columns: x:18 y:19!null
+      │    │         │         └── constraint: /19/20/21: [/2 - ]
       │    │         └── filters
-      │    │              └── a:12 = x:17 [outer=(12,17), constraints=(/12: (/NULL - ]; /17: (/NULL - ]), fd=(12)==(17), (17)==(12)]
+      │    │              └── a:13 = x:18 [outer=(13,18), constraints=(/13: (/NULL - ]; /18: (/NULL - ]), fd=(13)==(18), (18)==(13)]
       │    └── semi-join (merge)
-      │         ├── columns: a:23!null b:24!null c:25
-      │         ├── left ordering: +24
-      │         ├── right ordering: +29
-      │         ├── key: (23,24)
-      │         ├── fd: (23,24)-->(25)
+      │         ├── columns: a:24!null b:25!null c:26
+      │         ├── left ordering: +25
+      │         ├── right ordering: +30
+      │         ├── key: (24,25)
+      │         ├── fd: (24,25)-->(26)
       │         ├── scan abc@bc
-      │         │    ├── columns: a:23!null b:24!null c:25
-      │         │    ├── constraint: /24/25/23: [ - /0]
-      │         │    ├── key: (23,24)
-      │         │    ├── fd: (23,24)-->(25)
-      │         │    └── ordering: +24
+      │         │    ├── columns: a:24!null b:25!null c:26
+      │         │    ├── constraint: /25/26/24: [ - /0]
+      │         │    ├── key: (24,25)
+      │         │    ├── fd: (24,25)-->(26)
+      │         │    └── ordering: +25
       │         ├── scan xyz@yz
-      │         │    ├── columns: y:29!null
-      │         │    ├── constraint: /29/30/31: [/2 - ]
-      │         │    └── ordering: +29
+      │         │    ├── columns: y:30!null
+      │         │    ├── constraint: /30/31/32: [/2 - ]
+      │         │    └── ordering: +30
       │         └── filters (true)
       └── aggregations
            └── const-agg [as=c:3, outer=(3)]
@@ -12718,47 +12718,47 @@ project
            ├── fd: (1,2)-->(3)
            ├── union-all
            │    ├── columns: a:1!null b:2!null c:3
-           │    ├── left columns: a:12 b:13 c:14
-           │    ├── right columns: a:23 b:24 c:25
+           │    ├── left columns: a:13 b:14 c:15
+           │    ├── right columns: a:24 b:25 c:26
            │    ├── project
-           │    │    ├── columns: a:12!null b:13!null c:14
-           │    │    ├── key: (12,13)
-           │    │    ├── fd: (12,13)-->(14)
+           │    │    ├── columns: a:13!null b:14!null c:15
+           │    │    ├── key: (13,14)
+           │    │    ├── fd: (13,14)-->(15)
            │    │    └── inner-join (hash)
-           │    │         ├── columns: a:12!null b:13!null c:14 x:17!null
+           │    │         ├── columns: a:13!null b:14!null c:15 x:18!null
            │    │         ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-           │    │         ├── key: (13,17)
-           │    │         ├── fd: (12,13)-->(14), (12)==(17), (17)==(12)
+           │    │         ├── key: (14,18)
+           │    │         ├── fd: (13,14)-->(15), (13)==(18), (18)==(13)
            │    │         ├── scan abc@bc
-           │    │         │    ├── columns: a:12!null b:13!null c:14
-           │    │         │    ├── constraint: /13/14/12: [ - /0]
-           │    │         │    ├── key: (12,13)
-           │    │         │    └── fd: (12,13)-->(14)
+           │    │         │    ├── columns: a:13!null b:14!null c:15
+           │    │         │    ├── constraint: /14/15/13: [ - /0]
+           │    │         │    ├── key: (13,14)
+           │    │         │    └── fd: (13,14)-->(15)
            │    │         ├── distinct-on
-           │    │         │    ├── columns: x:17
-           │    │         │    ├── grouping columns: x:17
-           │    │         │    ├── key: (17)
+           │    │         │    ├── columns: x:18
+           │    │         │    ├── grouping columns: x:18
+           │    │         │    ├── key: (18)
            │    │         │    └── scan xyz@yz
-           │    │         │         ├── columns: x:17 y:18!null
-           │    │         │         └── constraint: /18/19/20: [/2 - ]
+           │    │         │         ├── columns: x:18 y:19!null
+           │    │         │         └── constraint: /19/20/21: [/2 - ]
            │    │         └── filters
-           │    │              └── a:12 = x:17 [outer=(12,17), constraints=(/12: (/NULL - ]; /17: (/NULL - ]), fd=(12)==(17), (17)==(12)]
+           │    │              └── a:13 = x:18 [outer=(13,18), constraints=(/13: (/NULL - ]; /18: (/NULL - ]), fd=(13)==(18), (18)==(13)]
            │    └── semi-join (merge)
-           │         ├── columns: a:23!null b:24!null c:25
-           │         ├── left ordering: +24
-           │         ├── right ordering: +29
-           │         ├── key: (23,24)
-           │         ├── fd: (23,24)-->(25)
+           │         ├── columns: a:24!null b:25!null c:26
+           │         ├── left ordering: +25
+           │         ├── right ordering: +30
+           │         ├── key: (24,25)
+           │         ├── fd: (24,25)-->(26)
            │         ├── scan abc@bc
-           │         │    ├── columns: a:23!null b:24!null c:25
-           │         │    ├── constraint: /24/25/23: [ - /0]
-           │         │    ├── key: (23,24)
-           │         │    ├── fd: (23,24)-->(25)
-           │         │    └── ordering: +24
+           │         │    ├── columns: a:24!null b:25!null c:26
+           │         │    ├── constraint: /25/26/24: [ - /0]
+           │         │    ├── key: (24,25)
+           │         │    ├── fd: (24,25)-->(26)
+           │         │    └── ordering: +25
            │         ├── scan xyz@yz
-           │         │    ├── columns: y:29!null
-           │         │    ├── constraint: /29/30/31: [/2 - ]
-           │         │    └── ordering: +29
+           │         │    ├── columns: y:30!null
+           │         │    ├── constraint: /30/31/32: [/2 - ]
+           │         │    └── ordering: +30
            │         └── filters (true)
            └── aggregations
                 └── const-agg [as=c:3, outer=(3)]
@@ -12790,39 +12790,39 @@ project
  ├── fd: (1,2)-->(3)
  └── intersect-all
       ├── columns: a:1!null b:2!null c:3
-      ├── left columns: a:12 b:13 c:14
-      ├── right columns: a:23 b:24 c:25
+      ├── left columns: a:13 b:14 c:15
+      ├── right columns: a:24 b:25 c:26
       ├── key: (1,2)
       ├── fd: (1,2)-->(3)
       ├── anti-join (merge)
-      │    ├── columns: a:12!null b:13!null c:14
-      │    ├── left ordering: +12
-      │    ├── right ordering: +17
-      │    ├── key: (12,13)
-      │    ├── fd: (12,13)-->(14)
+      │    ├── columns: a:13!null b:14!null c:15
+      │    ├── left ordering: +13
+      │    ├── right ordering: +18
+      │    ├── key: (13,14)
+      │    ├── fd: (13,14)-->(15)
       │    ├── scan abc
-      │    │    ├── columns: a:12!null b:13!null c:14
-      │    │    ├── key: (12,13)
-      │    │    ├── fd: (12,13)-->(14)
-      │    │    └── ordering: +12
+      │    │    ├── columns: a:13!null b:14!null c:15
+      │    │    ├── key: (13,14)
+      │    │    ├── fd: (13,14)-->(15)
+      │    │    └── ordering: +13
       │    ├── scan xyz@xy
-      │    │    ├── columns: x:17
-      │    │    └── ordering: +17
+      │    │    ├── columns: x:18
+      │    │    └── ordering: +18
       │    └── filters (true)
       └── anti-join (merge)
-           ├── columns: a:23!null b:24!null c:25
-           ├── left ordering: +24
-           ├── right ordering: +29
-           ├── key: (23,24)
-           ├── fd: (23,24)-->(25)
+           ├── columns: a:24!null b:25!null c:26
+           ├── left ordering: +25
+           ├── right ordering: +30
+           ├── key: (24,25)
+           ├── fd: (24,25)-->(26)
            ├── scan abc@bc
-           │    ├── columns: a:23!null b:24!null c:25
-           │    ├── key: (23,24)
-           │    ├── fd: (23,24)-->(25)
-           │    └── ordering: +24
+           │    ├── columns: a:24!null b:25!null c:26
+           │    ├── key: (24,25)
+           │    ├── fd: (24,25)-->(26)
+           │    └── ordering: +25
            ├── scan xyz@yz
-           │    ├── columns: y:29
-           │    └── ordering: +29
+           │    ├── columns: y:30
+           │    └── ordering: +30
            └── filters (true)
 
 # Antijoin with constraints
@@ -12835,40 +12835,40 @@ project
  ├── fd: (1,2)-->(3)
  └── intersect-all
       ├── columns: a:1!null b:2!null c:3
-      ├── left columns: a:12 b:13 c:14
-      ├── right columns: a:23 b:24 c:25
+      ├── left columns: a:13 b:14 c:15
+      ├── right columns: a:24 b:25 c:26
       ├── key: (1,2)
       ├── fd: (1,2)-->(3)
       ├── anti-join (hash)
-      │    ├── columns: a:12!null b:13!null c:14
-      │    ├── key: (12,13)
-      │    ├── fd: (12,13)-->(14)
+      │    ├── columns: a:13!null b:14!null c:15
+      │    ├── key: (13,14)
+      │    ├── fd: (13,14)-->(15)
       │    ├── scan abc@bc
-      │    │    ├── columns: a:12!null b:13!null c:14
-      │    │    ├── constraint: /13/14/12: [ - /0]
-      │    │    ├── key: (12,13)
-      │    │    └── fd: (12,13)-->(14)
+      │    │    ├── columns: a:13!null b:14!null c:15
+      │    │    ├── constraint: /14/15/13: [ - /0]
+      │    │    ├── key: (13,14)
+      │    │    └── fd: (13,14)-->(15)
       │    ├── scan xyz@yz
-      │    │    ├── columns: x:17 y:18!null
-      │    │    └── constraint: /18/19/20: [/2 - ]
+      │    │    ├── columns: x:18 y:19!null
+      │    │    └── constraint: /19/20/21: [/2 - ]
       │    └── filters
-      │         └── a:12 = x:17 [outer=(12,17), constraints=(/12: (/NULL - ]; /17: (/NULL - ]), fd=(12)==(17), (17)==(12)]
+      │         └── a:13 = x:18 [outer=(13,18), constraints=(/13: (/NULL - ]; /18: (/NULL - ]), fd=(13)==(18), (18)==(13)]
       └── anti-join (merge)
-           ├── columns: a:23!null b:24!null c:25
-           ├── left ordering: +24
-           ├── right ordering: +29
-           ├── key: (23,24)
-           ├── fd: (23,24)-->(25)
+           ├── columns: a:24!null b:25!null c:26
+           ├── left ordering: +25
+           ├── right ordering: +30
+           ├── key: (24,25)
+           ├── fd: (24,25)-->(26)
            ├── scan abc@bc
-           │    ├── columns: a:23!null b:24!null c:25
-           │    ├── constraint: /24/25/23: [ - /0]
-           │    ├── key: (23,24)
-           │    ├── fd: (23,24)-->(25)
-           │    └── ordering: +24
+           │    ├── columns: a:24!null b:25!null c:26
+           │    ├── constraint: /25/26/24: [ - /0]
+           │    ├── key: (24,25)
+           │    ├── fd: (24,25)-->(26)
+           │    └── ordering: +25
            ├── scan xyz@yz
-           │    ├── columns: y:29!null
-           │    ├── constraint: /29/30/31: [/2 - ]
-           │    └── ordering: +29
+           │    ├── columns: y:30!null
+           │    ├── constraint: /30/31/32: [/2 - ]
+           │    └── ordering: +30
            └── filters (true)
 
 # Regression for #79886
@@ -13750,49 +13750,49 @@ limit
  ├── distribution: east
  ├── locality-optimized-search
  │    ├── columns: c_id:1!null c_p_id:2 c.crdb_region:3!null
- │    ├── left columns: c_id:36 c_p_id:37 c.crdb_region:38
- │    ├── right columns: c_id:41 c_p_id:42 c.crdb_region:43
+ │    ├── left columns: c_id:37 c_p_id:38 c.crdb_region:39
+ │    ├── right columns: c_id:42 c_p_id:43 c.crdb_region:44
  │    ├── key: (1)
  │    ├── fd: (1)-->(2,3)
  │    ├── limit hint: 1.00
  │    ├── distribution: east
  │    ├── semi-join (lookup parent@id2_idx [as=p])
- │    │    ├── columns: c_id:36!null c_p_id:37 c.crdb_region:38!null
+ │    │    ├── columns: c_id:37!null c_p_id:38 c.crdb_region:39!null
  │    │    ├── lookup expression
  │    │    │    └── filters
- │    │    │         ├── p.crdb_region:49 = 'east' [outer=(49), constraints=(/49: [/'east' - /'east']; tight), fd=()-->(49)]
- │    │    │         └── c_p_id:37 = id2:47 [outer=(37,47), constraints=(/37: (/NULL - ]; /47: (/NULL - ]), fd=(37)==(47), (47)==(37)]
+ │    │    │         ├── p.crdb_region:50 = 'east' [outer=(50), constraints=(/50: [/'east' - /'east']; tight), fd=()-->(50)]
+ │    │    │         └── c_p_id:38 = id2:48 [outer=(38,48), constraints=(/38: (/NULL - ]; /48: (/NULL - ]), fd=(38)==(48), (48)==(38)]
  │    │    ├── remote lookup expression
  │    │    │    └── filters
- │    │    │         ├── p.crdb_region:49 IN ('central', 'west') [outer=(49), constraints=(/49: [/'central' - /'central'] [/'west' - /'west']; tight)]
- │    │    │         └── c_p_id:37 = id2:47 [outer=(37,47), constraints=(/37: (/NULL - ]; /47: (/NULL - ]), fd=(37)==(47), (47)==(37)]
+ │    │    │         ├── p.crdb_region:50 IN ('central', 'west') [outer=(50), constraints=(/50: [/'central' - /'central'] [/'west' - /'west']; tight)]
+ │    │    │         └── c_p_id:38 = id2:48 [outer=(38,48), constraints=(/38: (/NULL - ]; /48: (/NULL - ]), fd=(38)==(48), (48)==(38)]
  │    │    ├── lookup columns are key
- │    │    ├── key: (36)
- │    │    ├── fd: ()-->(38), (36)-->(37)
+ │    │    ├── key: (37)
+ │    │    ├── fd: ()-->(39), (37)-->(38)
  │    │    ├── limit hint: 1.00
  │    │    ├── scan child [as=c]
- │    │    │    ├── columns: c_id:36!null c_p_id:37 c.crdb_region:38!null
- │    │    │    ├── constraint: /38/36: [/'east' - /'east']
- │    │    │    ├── key: (36)
- │    │    │    └── fd: ()-->(38), (36)-->(37)
+ │    │    │    ├── columns: c_id:37!null c_p_id:38 c.crdb_region:39!null
+ │    │    │    ├── constraint: /39/37: [/'east' - /'east']
+ │    │    │    ├── key: (37)
+ │    │    │    └── fd: ()-->(39), (37)-->(38)
  │    │    └── filters (true)
  │    └── semi-join (lookup parent@id2_idx [as=p])
- │         ├── columns: c_id:41!null c_p_id:42 c.crdb_region:43!null
+ │         ├── columns: c_id:42!null c_p_id:43 c.crdb_region:44!null
  │         ├── lookup expression
  │         │    └── filters
- │         │         ├── p.crdb_region:55 IN ('central', 'east', 'west') [outer=(55), constraints=(/55: [/'central' - /'central'] [/'east' - /'east'] [/'west' - /'west']; tight)]
- │         │         └── c_p_id:42 = id2:53 [outer=(42,53), constraints=(/42: (/NULL - ]; /53: (/NULL - ]), fd=(42)==(53), (53)==(42)]
+ │         │         ├── p.crdb_region:56 IN ('central', 'east', 'west') [outer=(56), constraints=(/56: [/'central' - /'central'] [/'east' - /'east'] [/'west' - /'west']; tight)]
+ │         │         └── c_p_id:43 = id2:54 [outer=(43,54), constraints=(/43: (/NULL - ]; /54: (/NULL - ]), fd=(43)==(54), (54)==(43)]
  │         ├── lookup columns are key
- │         ├── key: (41)
- │         ├── fd: (41)-->(42,43)
+ │         ├── key: (42)
+ │         ├── fd: (42)-->(43,44)
  │         ├── limit hint: 1.00
  │         ├── scan child [as=c]
- │         │    ├── columns: c_id:41!null c_p_id:42 c.crdb_region:43!null
- │         │    ├── constraint: /43/41
+ │         │    ├── columns: c_id:42!null c_p_id:43 c.crdb_region:44!null
+ │         │    ├── constraint: /44/42
  │         │    │    ├── [/'central' - /'central']
  │         │    │    └── [/'west' - /'west']
- │         │    ├── key: (41)
- │         │    └── fd: (41)-->(42,43)
+ │         │    ├── key: (42)
+ │         │    └── fd: (42)-->(43,44)
  │         └── filters (true)
  └── 1
 
@@ -14024,40 +14024,40 @@ limit
  ├── distribution: east
  ├── locality-optimized-search
  │    ├── columns: c_id:1!null c_p_id:2 v:3!null crdb_region:4!null
- │    ├── left columns: c_id:12 c_p_id:13 v:14 crdb_region:15
- │    ├── right columns: c_id:18 c_p_id:19 v:20 crdb_region:21
+ │    ├── left columns: c_id:13 c_p_id:14 v:15 crdb_region:16
+ │    ├── right columns: c_id:19 c_p_id:20 v:21 crdb_region:22
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    ├── limit hint: 1.00
  │    ├── distribution: east
  │    ├── semi-join (lookup parent2@id2_idx [as=p])
- │    │    ├── columns: c_id:12!null c_p_id:13 v:14!null crdb_region:15!null
- │    │    ├── key columns: [13] = [25]
+ │    │    ├── columns: c_id:13!null c_p_id:14 v:15!null crdb_region:16!null
+ │    │    ├── key columns: [14] = [26]
  │    │    ├── lookup columns are key
- │    │    ├── key: (12)
- │    │    ├── fd: ()-->(15), (12)-->(13,14)
+ │    │    ├── key: (13)
+ │    │    ├── fd: ()-->(16), (13)-->(14,15)
  │    │    ├── limit hint: 1.00
  │    │    ├── scan child2 [as=c]
- │    │    │    ├── columns: c_id:12!null c_p_id:13 v:14!null crdb_region:15!null
- │    │    │    ├── constraint: /15/12: [/'east' - /'east']
- │    │    │    ├── key: (12)
- │    │    │    ├── fd: ()-->(15), (12)-->(13,14)
+ │    │    │    ├── columns: c_id:13!null c_p_id:14 v:15!null crdb_region:16!null
+ │    │    │    ├── constraint: /16/13: [/'east' - /'east']
+ │    │    │    ├── key: (13)
+ │    │    │    ├── fd: ()-->(16), (13)-->(14,15)
  │    │    │    └── limit hint: 10.00
  │    │    └── filters (true)
  │    └── semi-join (lookup parent2@id2_idx [as=p])
- │         ├── columns: c_id:18!null c_p_id:19 v:20!null crdb_region:21!null
- │         ├── key columns: [19] = [30]
+ │         ├── columns: c_id:19!null c_p_id:20 v:21!null crdb_region:22!null
+ │         ├── key columns: [20] = [31]
  │         ├── lookup columns are key
- │         ├── key: (18)
- │         ├── fd: (18)-->(19-21)
+ │         ├── key: (19)
+ │         ├── fd: (19)-->(20-22)
  │         ├── limit hint: 1.00
  │         ├── scan child2 [as=c]
- │         │    ├── columns: c_id:18!null c_p_id:19 v:20!null crdb_region:21!null
- │         │    ├── constraint: /21/18
+ │         │    ├── columns: c_id:19!null c_p_id:20 v:21!null crdb_region:22!null
+ │         │    ├── constraint: /22/19
  │         │    │    ├── [/'central' - /'central']
  │         │    │    └── [/'west' - /'west']
- │         │    ├── key: (18)
- │         │    ├── fd: (18)-->(19-21)
+ │         │    ├── key: (19)
+ │         │    ├── fd: (19)-->(20-22)
  │         │    └── limit hint: 20.00
  │         └── filters (true)
  └── 1
@@ -14118,19 +14118,19 @@ distribute
       ├── fd: ()-->(1-4)
       ├── semi-join (lookup parent2 [as=p])
       │    ├── columns: c_id:1!null c_p_id:2 v:3!null crdb_region:4!null
-      │    ├── key columns: [12] = [7]
+      │    ├── key columns: [13] = [7]
       │    ├── lookup columns are key
       │    ├── second join in paired joiner
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-4)
       │    ├── limit hint: 1.00
       │    ├── inner-join (lookup parent2@id2_idx [as=p])
-      │    │    ├── columns: c_id:1!null c_p_id:2!null v:3!null crdb_region:4!null p_id:12!null id2:13!null continuation:17
-      │    │    ├── key columns: [2] = [13]
+      │    │    ├── columns: c_id:1!null c_p_id:2!null v:3!null crdb_region:4!null p_id:13!null id2:14!null continuation:18
+      │    │    ├── key columns: [2] = [14]
       │    │    ├── lookup columns are key
-      │    │    ├── first join in paired joiner; continuation column: continuation:17
+      │    │    ├── first join in paired joiner; continuation column: continuation:18
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-4), (12)-->(13,17), (13)-->(12), (2)==(13), (13)==(2)
+      │    │    ├── fd: (1)-->(2-4), (13)-->(14,18), (14)-->(13), (2)==(14), (14)==(2)
       │    │    ├── limit hint: 100.00
       │    │    ├── scan child2 [as=c]
       │    │    │    ├── columns: c_id:1!null c_p_id:2 v:3!null crdb_region:4!null
@@ -14230,39 +14230,39 @@ limit
  │              ├── distribution: east
  │              ├── locality-optimized-search
  │              │    ├── columns: c_id:1!null c_p_id:2!null v:3!null crdb_region:4!null p_id:7!null id2:8!null
- │              │    ├── left columns: c_id:18 c_p_id:19 v:20 crdb_region:21 p_id:30 id2:31
- │              │    ├── right columns: c_id:24 c_p_id:25 v:26 crdb_region:27 p_id:35 id2:36
+ │              │    ├── left columns: c_id:19 c_p_id:20 v:21 crdb_region:22 p_id:31 id2:32
+ │              │    ├── right columns: c_id:25 c_p_id:26 v:27 crdb_region:28 p_id:36 id2:37
  │              │    ├── key: (1)
  │              │    ├── fd: (1)-->(2-4), (7)-->(8), (8)-->(7), (2)==(8), (8)==(2)
  │              │    ├── limit hint: 100.00
  │              │    ├── distribution: east
  │              │    ├── inner-join (lookup parent2@id2_idx [as=p])
- │              │    │    ├── columns: c_id:18!null c_p_id:19!null v:20!null crdb_region:21!null p_id:30!null id2:31!null
- │              │    │    ├── key columns: [19] = [31]
+ │              │    │    ├── columns: c_id:19!null c_p_id:20!null v:21!null crdb_region:22!null p_id:31!null id2:32!null
+ │              │    │    ├── key columns: [20] = [32]
  │              │    │    ├── lookup columns are key
- │              │    │    ├── key: (18)
- │              │    │    ├── fd: ()-->(21), (18)-->(19,20), (30)-->(31), (31)-->(30), (19)==(31), (31)==(19)
+ │              │    │    ├── key: (19)
+ │              │    │    ├── fd: ()-->(22), (19)-->(20,21), (31)-->(32), (32)-->(31), (20)==(32), (32)==(20)
  │              │    │    ├── limit hint: 100.00
  │              │    │    ├── scan child2 [as=c]
- │              │    │    │    ├── columns: c_id:18!null c_p_id:19 v:20!null crdb_region:21!null
- │              │    │    │    ├── constraint: /21/18: [/'east' - /'east']
- │              │    │    │    ├── key: (18)
- │              │    │    │    └── fd: ()-->(21), (18)-->(19,20)
+ │              │    │    │    ├── columns: c_id:19!null c_p_id:20 v:21!null crdb_region:22!null
+ │              │    │    │    ├── constraint: /22/19: [/'east' - /'east']
+ │              │    │    │    ├── key: (19)
+ │              │    │    │    └── fd: ()-->(22), (19)-->(20,21)
  │              │    │    └── filters (true)
  │              │    └── inner-join (lookup parent2@id2_idx [as=p])
- │              │         ├── columns: c_id:24!null c_p_id:25!null v:26!null crdb_region:27!null p_id:35!null id2:36!null
- │              │         ├── key columns: [25] = [36]
+ │              │         ├── columns: c_id:25!null c_p_id:26!null v:27!null crdb_region:28!null p_id:36!null id2:37!null
+ │              │         ├── key columns: [26] = [37]
  │              │         ├── lookup columns are key
- │              │         ├── key: (24)
- │              │         ├── fd: (24)-->(25-27), (35)-->(36), (36)-->(35), (25)==(36), (36)==(25)
+ │              │         ├── key: (25)
+ │              │         ├── fd: (25)-->(26-28), (36)-->(37), (37)-->(36), (26)==(37), (37)==(26)
  │              │         ├── limit hint: 100.00
  │              │         ├── scan child2 [as=c]
- │              │         │    ├── columns: c_id:24!null c_p_id:25 v:26!null crdb_region:27!null
- │              │         │    ├── constraint: /27/24
+ │              │         │    ├── columns: c_id:25!null c_p_id:26 v:27!null crdb_region:28!null
+ │              │         │    ├── constraint: /28/25
  │              │         │    │    ├── [/'central' - /'central']
  │              │         │    │    └── [/'west' - /'west']
- │              │         │    ├── key: (24)
- │              │         │    └── fd: (24)-->(25-27)
+ │              │         │    ├── key: (25)
+ │              │         │    └── fd: (25)-->(26-28)
  │              │         └── filters (true)
  │              └── filters
  │                   └── c_id:1 > id3:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ])]

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -2387,13 +2387,13 @@ Joins Considered: 26
 Final Plan
 ================================================================================
 inner-join (hash)
- ├── columns: a:1!null b:2 c:3 d:4 b:7!null x:8!null d:15!null z:16!null
- ├── key: (7,15)
- ├── fd: (1)-->(2-4), (7)-->(8), (1)==(8,16), (8)==(1,16), (15)-->(16), (16)==(1,8)
+ ├── columns: a:1!null b:2 c:3 d:4 b:7!null x:8!null d:16!null z:17!null
+ ├── key: (7,16)
+ ├── fd: (1)-->(2-4), (7)-->(8), (1)==(8,17), (8)==(1,17), (16)-->(17), (17)==(1,8)
  ├── scan dz
- │    ├── columns: dz.d:15!null z:16
- │    ├── key: (15)
- │    └── fd: (15)-->(16)
+ │    ├── columns: dz.d:16!null z:17
+ │    ├── key: (16)
+ │    └── fd: (16)-->(17)
  ├── project
  │    ├── columns: a:1!null abc.b:2 abc.c:3 abc.d:4 bx.b:7!null x:8!null
  │    ├── key: (7)
@@ -2429,7 +2429,7 @@ inner-join (hash)
  │         └── filters
  │              └── a:1 = x:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
  └── filters
-      └── a:1 = z:16 [outer=(1,16), constraints=(/1: (/NULL - ]; /16: (/NULL - ]), fd=(1)==(16), (16)==(1)]
+      └── a:1 = z:17 [outer=(1,17), constraints=(/1: (/NULL - ]; /17: (/NULL - ]), fd=(1)==(17), (17)==(1)]
 
 
 # Special case for reordering inner-joins and left-joins: One inner-join

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -968,23 +968,23 @@ project
       ├── distribution: east
       ├── locality-optimized-search
       │    ├── columns: a:11!null
-      │    ├── left columns: a:19
-      │    ├── right columns: a:27
+      │    ├── left columns: a:20
+      │    ├── right columns: a:28
       │    ├── cardinality: [0 - 3]
       │    ├── key: (11)
       │    ├── distribution: east
       │    ├── scan abc_part@b_idx
-      │    │    ├── columns: a:19!null
-      │    │    ├── constraint: /17/20: [/'east' - /'east']
+      │    │    ├── columns: a:20!null
+      │    │    ├── constraint: /18/21: [/'east' - /'east']
       │    │    ├── limit: 3
-      │    │    └── key: (19)
+      │    │    └── key: (20)
       │    └── scan abc_part@b_idx
-      │         ├── columns: a:27!null
-      │         ├── constraint: /25/28
+      │         ├── columns: a:28!null
+      │         ├── constraint: /26/29
       │         │    ├── [/'central' - /'central']
       │         │    └── [/'west' - /'west']
       │         ├── limit: 3
-      │         └── key: (27)
+      │         └── key: (28)
       └── filters (true)
 
 # Correlated semijoin with LIMIT in outer query block should not enable
@@ -1034,27 +1034,27 @@ distribute
                 └── coalesce [subquery]
                      ├── subquery
                      │    └── project
-                     │         ├── columns: column18:18!null
+                     │         ├── columns: column19:19!null
                      │         ├── cardinality: [0 - 1]
                      │         ├── key: ()
-                     │         ├── fd: ()-->(18)
+                     │         ├── fd: ()-->(19)
                      │         ├── distribution: east
                      │         ├── locality-optimized-search
                      │         │    ├── cardinality: [0 - 1]
                      │         │    ├── key: ()
                      │         │    ├── distribution: east
                      │         │    ├── scan abc_part@b_idx
-                     │         │    │    ├── constraint: /19/22: [/'east' - /'east']
+                     │         │    │    ├── constraint: /20/23: [/'east' - /'east']
                      │         │    │    ├── limit: 1
                      │         │    │    └── key: ()
                      │         │    └── scan abc_part@b_idx
-                     │         │         ├── constraint: /27/30
+                     │         │         ├── constraint: /28/31
                      │         │         │    ├── [/'central' - /'central']
                      │         │         │    └── [/'west' - /'west']
                      │         │         ├── limit: 1
                      │         │         └── key: ()
                      │         └── projections
-                     │              └── true [as=column18:18]
+                     │              └── true [as=column19:19]
                      └── false
 
 # Partitioning without CHECK constraints

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -10319,68 +10319,68 @@ project
       ├── fd: (1)-->(2,3)
       ├── union-all
       │    ├── columns: d.k:1!null d.u:2 d.v:3
-      │    ├── left columns: d.k:13 d.u:14 d.v:15
-      │    ├── right columns: d.k:19 d.u:20 d.v:21
+      │    ├── left columns: d.k:14 d.u:15 d.v:16
+      │    ├── right columns: d.k:20 d.u:21 d.v:22
       │    ├── ordering: +1
       │    ├── index-join d
-      │    │    ├── columns: d.k:13!null d.u:14!null d.v:15
-      │    │    ├── key: (13)
-      │    │    ├── fd: ()-->(14), (13)-->(15)
-      │    │    ├── ordering: +13 opt(14) [actual: +13]
+      │    │    ├── columns: d.k:14!null d.u:15!null d.v:16
+      │    │    ├── key: (14)
+      │    │    ├── fd: ()-->(15), (14)-->(16)
+      │    │    ├── ordering: +14 opt(15) [actual: +14]
       │    │    └── select
-      │    │         ├── columns: d.k:13!null d.u:14!null
-      │    │         ├── key: (13)
-      │    │         ├── fd: ()-->(14)
-      │    │         ├── ordering: +13 opt(14) [actual: +13]
+      │    │         ├── columns: d.k:14!null d.u:15!null
+      │    │         ├── key: (14)
+      │    │         ├── fd: ()-->(15)
+      │    │         ├── ordering: +14 opt(15) [actual: +14]
       │    │         ├── scan d@u
-      │    │         │    ├── columns: d.k:13!null d.u:14!null
-      │    │         │    ├── constraint: /14/13: [/1 - /1]
-      │    │         │    ├── key: (13)
-      │    │         │    ├── fd: ()-->(14)
-      │    │         │    └── ordering: +13 opt(14) [actual: +13]
+      │    │         │    ├── columns: d.k:14!null d.u:15!null
+      │    │         │    ├── constraint: /15/14: [/1 - /1]
+      │    │         │    ├── key: (14)
+      │    │         │    ├── fd: ()-->(15)
+      │    │         │    └── ordering: +14 opt(15) [actual: +14]
       │    │         └── filters
       │    │              └── coalesce [subquery]
       │    │                   ├── subquery
       │    │                   │    └── project
-      │    │                   │         ├── columns: column12:12!null
+      │    │                   │         ├── columns: column13:13!null
       │    │                   │         ├── cardinality: [0 - 1]
       │    │                   │         ├── key: ()
-      │    │                   │         ├── fd: ()-->(12)
+      │    │                   │         ├── fd: ()-->(13)
       │    │                   │         ├── scan a
       │    │                   │         │    ├── limit: 1
       │    │                   │         │    └── key: ()
       │    │                   │         └── projections
-      │    │                   │              └── true [as=column12:12]
+      │    │                   │              └── true [as=column13:13]
       │    │                   └── false
       │    └── index-join d
-      │         ├── columns: d.k:19!null d.u:20 d.v:21!null
-      │         ├── key: (19)
-      │         ├── fd: ()-->(21), (19)-->(20)
-      │         ├── ordering: +19 opt(21) [actual: +19]
+      │         ├── columns: d.k:20!null d.u:21 d.v:22!null
+      │         ├── key: (20)
+      │         ├── fd: ()-->(22), (20)-->(21)
+      │         ├── ordering: +20 opt(22) [actual: +20]
       │         └── select
-      │              ├── columns: d.k:19!null d.v:21!null
-      │              ├── key: (19)
-      │              ├── fd: ()-->(21)
-      │              ├── ordering: +19 opt(21) [actual: +19]
+      │              ├── columns: d.k:20!null d.v:22!null
+      │              ├── key: (20)
+      │              ├── fd: ()-->(22)
+      │              ├── ordering: +20 opt(22) [actual: +20]
       │              ├── scan d@v
-      │              │    ├── columns: d.k:19!null d.v:21!null
-      │              │    ├── constraint: /21/19: [/1 - /1]
-      │              │    ├── key: (19)
-      │              │    ├── fd: ()-->(21)
-      │              │    └── ordering: +19 opt(21) [actual: +19]
+      │              │    ├── columns: d.k:20!null d.v:22!null
+      │              │    ├── constraint: /22/20: [/1 - /1]
+      │              │    ├── key: (20)
+      │              │    ├── fd: ()-->(22)
+      │              │    └── ordering: +20 opt(22) [actual: +20]
       │              └── filters
       │                   └── coalesce [subquery]
       │                        ├── subquery
       │                        │    └── project
-      │                        │         ├── columns: column12:12!null
+      │                        │         ├── columns: column13:13!null
       │                        │         ├── cardinality: [0 - 1]
       │                        │         ├── key: ()
-      │                        │         ├── fd: ()-->(12)
+      │                        │         ├── fd: ()-->(13)
       │                        │         ├── scan a
       │                        │         │    ├── limit: 1
       │                        │         │    └── key: ()
       │                        │         └── projections
-      │                        │              └── true [as=column12:12]
+      │                        │              └── true [as=column13:13]
       │                        └── false
       └── aggregations
            ├── const-agg [as=d.u:2, outer=(2)]
@@ -10408,31 +10408,31 @@ project
       │    ├── fd: (1)-->(2,3)
       │    ├── union-all
       │    │    ├── columns: d.k:1!null d.u:2 d.v:3
-      │    │    ├── left columns: d.k:12 d.u:13 d.v:14
-      │    │    ├── right columns: d.k:18 d.u:19 d.v:20
+      │    │    ├── left columns: d.k:13 d.u:14 d.v:15
+      │    │    ├── right columns: d.k:19 d.u:20 d.v:21
       │    │    ├── ordering: +1
       │    │    ├── index-join d
-      │    │    │    ├── columns: d.k:12!null d.u:13!null d.v:14
-      │    │    │    ├── key: (12)
-      │    │    │    ├── fd: ()-->(13), (12)-->(14)
-      │    │    │    ├── ordering: +12 opt(13) [actual: +12]
+      │    │    │    ├── columns: d.k:13!null d.u:14!null d.v:15
+      │    │    │    ├── key: (13)
+      │    │    │    ├── fd: ()-->(14), (13)-->(15)
+      │    │    │    ├── ordering: +13 opt(14) [actual: +13]
       │    │    │    └── scan d@u
-      │    │    │         ├── columns: d.k:12!null d.u:13!null
-      │    │    │         ├── constraint: /13/12: [/1 - /1]
-      │    │    │         ├── key: (12)
-      │    │    │         ├── fd: ()-->(13)
-      │    │    │         └── ordering: +12 opt(13) [actual: +12]
+      │    │    │         ├── columns: d.k:13!null d.u:14!null
+      │    │    │         ├── constraint: /14/13: [/1 - /1]
+      │    │    │         ├── key: (13)
+      │    │    │         ├── fd: ()-->(14)
+      │    │    │         └── ordering: +13 opt(14) [actual: +13]
       │    │    └── index-join d
-      │    │         ├── columns: d.k:18!null d.u:19 d.v:20!null
-      │    │         ├── key: (18)
-      │    │         ├── fd: ()-->(20), (18)-->(19)
-      │    │         ├── ordering: +18 opt(20) [actual: +18]
+      │    │         ├── columns: d.k:19!null d.u:20 d.v:21!null
+      │    │         ├── key: (19)
+      │    │         ├── fd: ()-->(21), (19)-->(20)
+      │    │         ├── ordering: +19 opt(21) [actual: +19]
       │    │         └── scan d@v
-      │    │              ├── columns: d.k:18!null d.v:20!null
-      │    │              ├── constraint: /20/18: [/1 - /1]
-      │    │              ├── key: (18)
-      │    │              ├── fd: ()-->(20)
-      │    │              └── ordering: +18 opt(20) [actual: +18]
+      │    │              ├── columns: d.k:19!null d.v:21!null
+      │    │              ├── constraint: /21/19: [/1 - /1]
+      │    │              ├── key: (19)
+      │    │              ├── fd: ()-->(21)
+      │    │              └── ordering: +19 opt(21) [actual: +19]
       │    └── aggregations
       │         ├── const-agg [as=d.u:2, outer=(2)]
       │         │    └── d.u:2
@@ -10460,31 +10460,31 @@ project
       │    ├── fd: (1)-->(2-4)
       │    ├── union-all
       │    │    ├── columns: d.k:1!null d.u:2 d.v:3 w:4
-      │    │    ├── left columns: d.k:12 d.u:13 d.v:14 w:15
-      │    │    ├── right columns: d.k:18 d.u:19 d.v:20 w:21
+      │    │    ├── left columns: d.k:13 d.u:14 d.v:15 w:16
+      │    │    ├── right columns: d.k:19 d.u:20 d.v:21 w:22
       │    │    ├── ordering: +1
       │    │    ├── index-join d
-      │    │    │    ├── columns: d.k:12!null d.u:13!null d.v:14 w:15
-      │    │    │    ├── key: (12)
-      │    │    │    ├── fd: ()-->(13), (12)-->(14,15)
-      │    │    │    ├── ordering: +12 opt(13) [actual: +12]
+      │    │    │    ├── columns: d.k:13!null d.u:14!null d.v:15 w:16
+      │    │    │    ├── key: (13)
+      │    │    │    ├── fd: ()-->(14), (13)-->(15,16)
+      │    │    │    ├── ordering: +13 opt(14) [actual: +13]
       │    │    │    └── scan d@u
-      │    │    │         ├── columns: d.k:12!null d.u:13!null
-      │    │    │         ├── constraint: /13/12: [/1 - /1]
-      │    │    │         ├── key: (12)
-      │    │    │         ├── fd: ()-->(13)
-      │    │    │         └── ordering: +12 opt(13) [actual: +12]
+      │    │    │         ├── columns: d.k:13!null d.u:14!null
+      │    │    │         ├── constraint: /14/13: [/1 - /1]
+      │    │    │         ├── key: (13)
+      │    │    │         ├── fd: ()-->(14)
+      │    │    │         └── ordering: +13 opt(14) [actual: +13]
       │    │    └── index-join d
-      │    │         ├── columns: d.k:18!null d.u:19 d.v:20!null w:21
-      │    │         ├── key: (18)
-      │    │         ├── fd: ()-->(20), (18)-->(19,21)
-      │    │         ├── ordering: +18 opt(20) [actual: +18]
+      │    │         ├── columns: d.k:19!null d.u:20 d.v:21!null w:22
+      │    │         ├── key: (19)
+      │    │         ├── fd: ()-->(21), (19)-->(20,22)
+      │    │         ├── ordering: +19 opt(21) [actual: +19]
       │    │         └── scan d@v
-      │    │              ├── columns: d.k:18!null d.v:20!null
-      │    │              ├── constraint: /20/18: [/1 - /1]
-      │    │              ├── key: (18)
-      │    │              ├── fd: ()-->(20)
-      │    │              └── ordering: +18 opt(20) [actual: +18]
+      │    │              ├── columns: d.k:19!null d.v:21!null
+      │    │              ├── constraint: /21/19: [/1 - /1]
+      │    │              ├── key: (19)
+      │    │              ├── fd: ()-->(21)
+      │    │              └── ordering: +19 opt(21) [actual: +19]
       │    └── aggregations
       │         ├── const-agg [as=d.u:2, outer=(2)]
       │         │    └── d.u:2
@@ -11850,68 +11850,68 @@ project
       ├── fd: (1)-->(2,3)
       ├── union-all
       │    ├── columns: d.k:1!null d.u:2 d.v:3
-      │    ├── left columns: d.k:13 d.u:14 d.v:15
-      │    ├── right columns: d.k:19 d.u:20 d.v:21
+      │    ├── left columns: d.k:14 d.u:15 d.v:16
+      │    ├── right columns: d.k:20 d.u:21 d.v:22
       │    ├── ordering: +1
       │    ├── index-join d
-      │    │    ├── columns: d.k:13!null d.u:14!null d.v:15
-      │    │    ├── key: (13)
-      │    │    ├── fd: ()-->(14), (13)-->(15)
-      │    │    ├── ordering: +13 opt(14) [actual: +13]
+      │    │    ├── columns: d.k:14!null d.u:15!null d.v:16
+      │    │    ├── key: (14)
+      │    │    ├── fd: ()-->(15), (14)-->(16)
+      │    │    ├── ordering: +14 opt(15) [actual: +14]
       │    │    └── select
-      │    │         ├── columns: d.k:13!null d.u:14!null
-      │    │         ├── key: (13)
-      │    │         ├── fd: ()-->(14)
-      │    │         ├── ordering: +13 opt(14) [actual: +13]
+      │    │         ├── columns: d.k:14!null d.u:15!null
+      │    │         ├── key: (14)
+      │    │         ├── fd: ()-->(15)
+      │    │         ├── ordering: +14 opt(15) [actual: +14]
       │    │         ├── scan d@u
-      │    │         │    ├── columns: d.k:13!null d.u:14!null
-      │    │         │    ├── constraint: /14/13: [/1 - /1]
-      │    │         │    ├── key: (13)
-      │    │         │    ├── fd: ()-->(14)
-      │    │         │    └── ordering: +13 opt(14) [actual: +13]
+      │    │         │    ├── columns: d.k:14!null d.u:15!null
+      │    │         │    ├── constraint: /15/14: [/1 - /1]
+      │    │         │    ├── key: (14)
+      │    │         │    ├── fd: ()-->(15)
+      │    │         │    └── ordering: +14 opt(15) [actual: +14]
       │    │         └── filters
       │    │              └── coalesce [subquery]
       │    │                   ├── subquery
       │    │                   │    └── project
-      │    │                   │         ├── columns: column12:12!null
+      │    │                   │         ├── columns: column13:13!null
       │    │                   │         ├── cardinality: [0 - 1]
       │    │                   │         ├── key: ()
-      │    │                   │         ├── fd: ()-->(12)
+      │    │                   │         ├── fd: ()-->(13)
       │    │                   │         ├── scan a
       │    │                   │         │    ├── limit: 1
       │    │                   │         │    └── key: ()
       │    │                   │         └── projections
-      │    │                   │              └── true [as=column12:12]
+      │    │                   │              └── true [as=column13:13]
       │    │                   └── false
       │    └── index-join d
-      │         ├── columns: d.k:19!null d.u:20 d.v:21!null
-      │         ├── key: (19)
-      │         ├── fd: ()-->(21), (19)-->(20)
-      │         ├── ordering: +19 opt(21) [actual: +19]
+      │         ├── columns: d.k:20!null d.u:21 d.v:22!null
+      │         ├── key: (20)
+      │         ├── fd: ()-->(22), (20)-->(21)
+      │         ├── ordering: +20 opt(22) [actual: +20]
       │         └── select
-      │              ├── columns: d.k:19!null d.v:21!null
-      │              ├── key: (19)
-      │              ├── fd: ()-->(21)
-      │              ├── ordering: +19 opt(21) [actual: +19]
+      │              ├── columns: d.k:20!null d.v:22!null
+      │              ├── key: (20)
+      │              ├── fd: ()-->(22)
+      │              ├── ordering: +20 opt(22) [actual: +20]
       │              ├── scan d@v
-      │              │    ├── columns: d.k:19!null d.v:21!null
-      │              │    ├── constraint: /21/19: [/1 - /1]
-      │              │    ├── key: (19)
-      │              │    ├── fd: ()-->(21)
-      │              │    └── ordering: +19 opt(21) [actual: +19]
+      │              │    ├── columns: d.k:20!null d.v:22!null
+      │              │    ├── constraint: /22/20: [/1 - /1]
+      │              │    ├── key: (20)
+      │              │    ├── fd: ()-->(22)
+      │              │    └── ordering: +20 opt(22) [actual: +20]
       │              └── filters
       │                   └── coalesce [subquery]
       │                        ├── subquery
       │                        │    └── project
-      │                        │         ├── columns: column12:12!null
+      │                        │         ├── columns: column13:13!null
       │                        │         ├── cardinality: [0 - 1]
       │                        │         ├── key: ()
-      │                        │         ├── fd: ()-->(12)
+      │                        │         ├── fd: ()-->(13)
       │                        │         ├── scan a
       │                        │         │    ├── limit: 1
       │                        │         │    └── key: ()
       │                        │         └── projections
-      │                        │              └── true [as=column12:12]
+      │                        │              └── true [as=column13:13]
       │                        └── false
       └── aggregations
            ├── const-agg [as=d.u:2, outer=(2)]
@@ -11936,31 +11936,31 @@ semi-join (lookup a@u)
  │         ├── fd: (1)-->(2,3)
  │         ├── union-all
  │         │    ├── columns: d.k:1!null d.u:2 d.v:3
- │         │    ├── left columns: d.k:12 d.u:13 d.v:14
- │         │    ├── right columns: d.k:18 d.u:19 d.v:20
+ │         │    ├── left columns: d.k:13 d.u:14 d.v:15
+ │         │    ├── right columns: d.k:19 d.u:20 d.v:21
  │         │    ├── ordering: +1
  │         │    ├── index-join d
- │         │    │    ├── columns: d.k:12!null d.u:13!null d.v:14
- │         │    │    ├── key: (12)
- │         │    │    ├── fd: ()-->(13), (12)-->(14)
- │         │    │    ├── ordering: +12 opt(13) [actual: +12]
+ │         │    │    ├── columns: d.k:13!null d.u:14!null d.v:15
+ │         │    │    ├── key: (13)
+ │         │    │    ├── fd: ()-->(14), (13)-->(15)
+ │         │    │    ├── ordering: +13 opt(14) [actual: +13]
  │         │    │    └── scan d@u
- │         │    │         ├── columns: d.k:12!null d.u:13!null
- │         │    │         ├── constraint: /13/12: [/1 - /1]
- │         │    │         ├── key: (12)
- │         │    │         ├── fd: ()-->(13)
- │         │    │         └── ordering: +12 opt(13) [actual: +12]
+ │         │    │         ├── columns: d.k:13!null d.u:14!null
+ │         │    │         ├── constraint: /14/13: [/1 - /1]
+ │         │    │         ├── key: (13)
+ │         │    │         ├── fd: ()-->(14)
+ │         │    │         └── ordering: +13 opt(14) [actual: +13]
  │         │    └── index-join d
- │         │         ├── columns: d.k:18!null d.u:19 d.v:20!null
- │         │         ├── key: (18)
- │         │         ├── fd: ()-->(20), (18)-->(19)
- │         │         ├── ordering: +18 opt(20) [actual: +18]
+ │         │         ├── columns: d.k:19!null d.u:20 d.v:21!null
+ │         │         ├── key: (19)
+ │         │         ├── fd: ()-->(21), (19)-->(20)
+ │         │         ├── ordering: +19 opt(21) [actual: +19]
  │         │         └── scan d@v
- │         │              ├── columns: d.k:18!null d.v:20!null
- │         │              ├── constraint: /20/18: [/1 - /1]
- │         │              ├── key: (18)
- │         │              ├── fd: ()-->(20)
- │         │              └── ordering: +18 opt(20) [actual: +18]
+ │         │              ├── columns: d.k:19!null d.v:21!null
+ │         │              ├── constraint: /21/19: [/1 - /1]
+ │         │              ├── key: (19)
+ │         │              ├── fd: ()-->(21)
+ │         │              └── ordering: +19 opt(21) [actual: +19]
  │         └── aggregations
  │              ├── const-agg [as=d.u:2, outer=(2)]
  │              │    └── d.u:2
@@ -11987,31 +11987,31 @@ project
       │         ├── fd: (1)-->(2-4)
       │         ├── union-all
       │         │    ├── columns: d.k:1!null d.u:2 d.v:3 w:4
-      │         │    ├── left columns: d.k:12 d.u:13 d.v:14 w:15
-      │         │    ├── right columns: d.k:18 d.u:19 d.v:20 w:21
+      │         │    ├── left columns: d.k:13 d.u:14 d.v:15 w:16
+      │         │    ├── right columns: d.k:19 d.u:20 d.v:21 w:22
       │         │    ├── ordering: +1
       │         │    ├── index-join d
-      │         │    │    ├── columns: d.k:12!null d.u:13!null d.v:14 w:15
-      │         │    │    ├── key: (12)
-      │         │    │    ├── fd: ()-->(13), (12)-->(14,15)
-      │         │    │    ├── ordering: +12 opt(13) [actual: +12]
+      │         │    │    ├── columns: d.k:13!null d.u:14!null d.v:15 w:16
+      │         │    │    ├── key: (13)
+      │         │    │    ├── fd: ()-->(14), (13)-->(15,16)
+      │         │    │    ├── ordering: +13 opt(14) [actual: +13]
       │         │    │    └── scan d@u
-      │         │    │         ├── columns: d.k:12!null d.u:13!null
-      │         │    │         ├── constraint: /13/12: [/1 - /1]
-      │         │    │         ├── key: (12)
-      │         │    │         ├── fd: ()-->(13)
-      │         │    │         └── ordering: +12 opt(13) [actual: +12]
+      │         │    │         ├── columns: d.k:13!null d.u:14!null
+      │         │    │         ├── constraint: /14/13: [/1 - /1]
+      │         │    │         ├── key: (13)
+      │         │    │         ├── fd: ()-->(14)
+      │         │    │         └── ordering: +13 opt(14) [actual: +13]
       │         │    └── index-join d
-      │         │         ├── columns: d.k:18!null d.u:19 d.v:20!null w:21
-      │         │         ├── key: (18)
-      │         │         ├── fd: ()-->(20), (18)-->(19,21)
-      │         │         ├── ordering: +18 opt(20) [actual: +18]
+      │         │         ├── columns: d.k:19!null d.u:20 d.v:21!null w:22
+      │         │         ├── key: (19)
+      │         │         ├── fd: ()-->(21), (19)-->(20,22)
+      │         │         ├── ordering: +19 opt(21) [actual: +19]
       │         │         └── scan d@v
-      │         │              ├── columns: d.k:18!null d.v:20!null
-      │         │              ├── constraint: /20/18: [/1 - /1]
-      │         │              ├── key: (18)
-      │         │              ├── fd: ()-->(20)
-      │         │              └── ordering: +18 opt(20) [actual: +18]
+      │         │              ├── columns: d.k:19!null d.v:21!null
+      │         │              ├── constraint: /21/19: [/1 - /1]
+      │         │              ├── key: (19)
+      │         │              ├── fd: ()-->(21)
+      │         │              └── ordering: +19 opt(21) [actual: +19]
       │         └── aggregations
       │              ├── const-agg [as=d.u:2, outer=(2)]
       │              │    └── d.u:2


### PR DESCRIPTION
#### opt/execbuilder: return error from `colOrdMap.Set`

Release note: None

#### opt/execbuilder: return error from `colOrdMap.CopyFrom`

Release note: None

#### opt/execbuilder: reduce memory footprint of `colOrdMap`

This commit reduces the memory footprint of `colOrdMap`s by storing
ordinals in a slice of `int32` instead of a slice of `int`. For complex
queries with many relational expressions and columns, this speeds up the
execbuilder phase. Benchmarks show a reduction in latency of up to ~12%.

Release note: None
