### PR TITLE
workload/schemachange: fix DROP SCHEMA under legacy schema changer

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1281,6 +1281,34 @@ SELECT EXISTS(
 `, tableName.String(), columnName)
 }
 
+func (og *operationGenerator) schemaContainsTypesWithCrossSchemaReferences(
+	ctx context.Context, tx pgx.Tx, schemaName string,
+) (bool, error) {
+	ctes := []CTE{
+		{"descriptors", descJSONQuery},
+		{"functions", functionDescsQuery},
+		{"types", enumDescsQuery},
+		{"referenced_descriptor_ids", `
+				SELECT json_array_elements(descriptor->'referencingDescriptorIds')::INT8 AS id FROM types WHERE schema_id = $1::REGNAMESPACE::INT8
+			UNION ALL
+				SELECT (ref->'id')::INT8 AS id FROM (SELECT json_array_elements(descriptor->'dependedOnBy') AS ref from functions WHERE schema_id = $1::REGNAMESPACE::INT8)
+		`},
+	}
+
+	_, err := Collect(ctx, og, tx, pgx.RowToMap, With(ctes, `SELECT * FROM types WHERE schema_id = $1::REGNAMESPACE::INT8`), schemaName)
+	if err != nil {
+		return false, err
+	}
+
+	result, err := Collect(ctx, og, tx, pgx.RowToMap, With(ctes, `
+		SELECT $1::REGNAMESPACE::INT8 AS this_schema_id, * FROM descriptors d
+		WHERE schema_id != $1::REGNAMESPACE::INT8
+		AND EXISTS(SELECT * FROM referenced_descriptor_ids WHERE id = d.id)
+		AND (NOT descriptor ? 'table')
+	`), schemaName)
+	return len(result) > 0, err
+}
+
 // enumMemberPresent determines whether val is a member of the enum.
 // This includes non-public members.
 func (og *operationGenerator) enumMemberPresent(

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3869,10 +3869,18 @@ func (og *operationGenerator) dropSchema(ctx context.Context, tx pgx.Tx) (*opStm
 	if err != nil {
 		return nil, err
 	}
+	crossReferences := false
+	if schemaExists {
+		crossReferences, err = og.schemaContainsTypesWithCrossSchemaReferences(ctx, tx, schemaName)
+		if err != nil {
+			return nil, err
+		}
+	}
 	stmt := makeOpStmt(OpStmtDDL)
 	stmt.expectedExecErrors.addAll(codesWithConditions{
 		{pgcode.UndefinedSchema, !schemaExists},
 		{pgcode.InvalidSchemaName, schemaName == catconstants.PublicSchemaName},
+		{pgcode.FeatureNotSupported, crossReferences && !og.useDeclarativeSchemaChanger},
 	})
 
 	stmt.sql = fmt.Sprintf(`DROP SCHEMA "%s" CASCADE`, schemaName)

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -201,8 +201,9 @@ func (s *schemaChange) Ops(
 		return workload.QueryLoad{}, err
 	}
 	stdoutLog := makeAtomicLog(os.Stdout)
-	// Use NewPseudoRand here because we want to print out the global seed used by the workload.
-	// Using NewTestRand() here would only let us see the per-test seed that is derived from the global seed.
+	// Use NewPseudoRand here because we want to print out the global seed used by
+	// the workload. Using NewTestRand() here would only let us see the per-test
+	// seed that is derived from the global seed.
 	_, seed := randutil.NewPseudoRand()
 	stdoutLog.printLn(fmt.Sprintf("using random seed: %d", seed))
 	// A separate weighting is constructed of only schema changes supported by the


### PR DESCRIPTION
The legacy schemachanger does not support CASCADE well.

This brings back the check that was deleted in
15cea91, but only uses it for the
legacy schema changer.

fixes https://github.com/cockroachdb/cockroach/issues/119148
Release note: None