### PR TITLE
kv: disable LongLatchHoldThreshold in TestConcurrencyManagerBasic

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -33,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/lockspanset"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanlatch"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -712,6 +714,9 @@ func newCluster() *cluster {
 }
 
 func newClusterWithSettings(st *clustersettings.Settings) *cluster {
+	// Set the latch manager's long latch threshold to infinity to disable
+	// logging, which could cause a test to erroneously fail.
+	spanlatch.LongLatchHoldThreshold.Override(context.Background(), &st.SV, math.MaxInt64)
 	manual := timeutil.NewManualTime(timeutil.Unix(123, 0))
 	return &cluster{
 		nodeDesc:  &roachpb.NodeDescriptor{NodeID: 1},

--- a/pkg/kv/kvserver/spanlatch/settings.go
+++ b/pkg/kv/kvserver/spanlatch/settings.go
@@ -20,10 +20,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 )
 
-var longLatchHoldDuration = settings.RegisterDurationSetting(
+// LongLatchHoldThreshold controls when we will log latch holds.
+var LongLatchHoldThreshold = settings.RegisterDurationSetting(
 	settings.SystemOnly,
 	"kv.concurrency.long_latch_hold_duration",
-	"duration threshold for logging long latch holding",
+	"the threshold for logging long latch holds",
 	3*time.Second,
 	settings.NonNegativeDuration,
 )


### PR DESCRIPTION
Fixes #119162.

Release note: None