### PR TITLE
admission,kvadmission: scope admission.kv.bulk_only.enabled to store …

### DIFF
--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -52,12 +52,13 @@ var KVAdmissionControlEnabled = settings.RegisterBoolSetting(
 	true).WithPublic()
 
 // KVBulkOnlyAdmissionControlEnabled controls whether user (normal and above
-// priority) work is subject to admission control. If it is set to true, then
-// user work will not be throttled by admission control but bulk work still will
-// be. This setting is a preferable alternative to completely disabling
-// admission control. It can be used reactively in cases where index backfill,
-// schema modifications or other bulk operations are causing high latency due to
-// io_overload on nodes.
+// priority) work is subject to store admission control. If it is set to true,
+// then user work will not be throttled by store admission control but bulk
+// work still will be. This setting is a preferable alternative to completely
+// disabling admission control. It can be used reactively in cases where index
+// backfill, schema modifications or other bulk operations are causing high
+// latency due to overload on stores.
+//
 // TODO(baptist): Find a better solution to this in v23.1.
 var KVBulkOnlyAdmissionControlEnabled = settings.RegisterBoolSetting(
 	settings.SystemOnly,


### PR DESCRIPTION
…admission only

This was originally meant to work around the fact that follower work at low priority (bulk work) was consuming store admission tokens without waiting (because of the lack of replication AC, which was introduced later in v23.2), which harmed locally evaluated normal priority work. This setting allowed the normal priority work to bypass AC. However, it was scoped too broadly, and allowed such normal priority work to also bypass the CPU admission control queue.

This change narrows the scope, so locally proposed normal priority work can bypass store admission and still be subject to CPU admission. It addresses production incidents we have observed where a cluster is running with this enabled and inadvertently causes SQL read requests to bypass AC and result in very high runnable goroutine counts, which then cause node liveness failures. See
https://github.com/cockroachlabs/support/issues/2812#issuecomment-1939771613

Epic: none

Release note (ops change): admission.kv.bulk_only.enabled, when set to true, only skips store admission control for normal priority work, and continues to subject the work to CPU admission control.