### PR TITLE
sessiondatapb: correctly propagate streamer_enabled to remote nodes

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -834,7 +834,7 @@ func applyInternalExecutorSessionExceptions(sd *sessiondata.SessionData) {
 	// At the moment, we disable the usage of the Streamer API in the internal
 	// executor to avoid possible concurrency with the "outer" query (which
 	// might be using the RootTxn).
-	sd.LocalOnlySessionData.StreamerEnabled = false
+	sd.SessionData.StreamerEnabled = false
 	// If the internal executor creates a new transaction, then it runs in
 	// SERIALIZABLE. If it's used in an existing transaction, then it inherits the
 	// isolation level of the existing transaction.

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -367,8 +367,7 @@ message LocalOnlySessionData {
   // Execution of these deallocated prepared statements will fail until they are
   // prepared again.
   int64 prepared_statements_cache_size = 97;
-  // StreamerEnabled controls whether the Streamer API can be used.
-  bool streamer_enabled = 98;
+  reserved 98;
   // DisableDropVirtualCluster causes errors when the client
   // attempts to drop virtual clusters or tenant records.
   bool disable_drop_virtual_cluster = 99;

--- a/pkg/sql/sessiondatapb/session_data.proto
+++ b/pkg/sql/sessiondatapb/session_data.proto
@@ -142,6 +142,8 @@ message SessionData {
   // could be adopted by any node in the cluster (not necessarily the gateway)
   // and so we will need this information available on all nodes.
   int64 distsql_plan_gateway_bias = 31;
+  // StreamerEnabled controls whether the Streamer API can be used.
+  bool streamer_enabled = 32;
 }
 
 // DataConversionConfig contains the parameters that influence the output


### PR DESCRIPTION
`streamer_enabled` session variable determines whether the Streamer API should be used for a particular DistSQL flow, and previously we incorrectly stored it in the local-only session data that doesn't get sent to remote nodes. As a result, remote nodes would get the Go default value `false` for this parameter, so we would end up using the Streamer API on the gateway and non-streamer on remote nodes within the same flow. This is now fixed (in backwards-compatible way - older binaries will keep the incorrect old behavior and newer binaries will respect the session variable).

This bug was introduced about a year ago in ed3f640510fa2d993f9cf4508cd0f8b9c53733d5 (before that change we consulted the cluster setting).

Informs: #118542.

Epic: None

Release note: None