### PR TITLE
sql: prevent illegal concurrency with internal executor in some cases

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1032,6 +1032,13 @@ func (ie *InternalExecutor) execInternal(
 
 	applyInternalExecutorSessionExceptions(sd)
 	applyOverrides(sessionDataOverride, sd)
+	if !rw.async() && (txn != nil && txn.Type() == kv.RootTxn) {
+		// If the "outer" query uses the RootTxn and the sync result channel is
+		// requested, then we must disable DistSQL to ensure that the "inner"
+		// query doesn't use the LeafTxn (which could result in illegal
+		// concurrency).
+		sd.DistSQLMode = sessiondatapb.DistSQLOff
+	}
 	sd.Internal = true
 	if sd.User().Undefined() {
 		return nil, errors.AssertionFailedf("no user specified for internal query")

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -831,10 +831,6 @@ func applyInternalExecutorSessionExceptions(sd *sessiondata.SessionData) {
 	// DisableBuffering is not supported by the InternalExecutor
 	// which uses streamingCommandResults.
 	sd.LocalOnlySessionData.AvoidBuffering = false
-	// At the moment, we disable the usage of the Streamer API in the internal
-	// executor to avoid possible concurrency with the "outer" query (which
-	// might be using the RootTxn).
-	sd.SessionData.StreamerEnabled = false
 	// If the internal executor creates a new transaction, then it runs in
 	// SERIALIZABLE. If it's used in an existing transaction, then it inherits the
 	// isolation level of the existing transaction.
@@ -1034,10 +1030,11 @@ func (ie *InternalExecutor) execInternal(
 	applyOverrides(sessionDataOverride, sd)
 	if !rw.async() && (txn != nil && txn.Type() == kv.RootTxn) {
 		// If the "outer" query uses the RootTxn and the sync result channel is
-		// requested, then we must disable DistSQL to ensure that the "inner"
-		// query doesn't use the LeafTxn (which could result in illegal
-		// concurrency).
+		// requested, then we must disable both DistSQL and Streamer to ensure
+		// that the "inner" query doesn't use the LeafTxn (which could result in
+		// illegal concurrency).
 		sd.DistSQLMode = sessiondatapb.DistSQLOff
+		sd.StreamerEnabled = false
 	}
 	sd.Internal = true
 	if sd.User().Undefined() {


### PR DESCRIPTION
Previously, it was possible for some methods of the internal executor result in illegal concurrency. In particular, `QueryIterator{Ex}` methods allow for the result of the internal query to be consumed in "streaming" fashion but we must do so without any concurrency, and it's achieved by using "sync" result channel (which synchronizes the reader ("outer" query) and the writer (InternalExecutor)). However, previously the internal query could result in illegal concurrency on its own - if it happens to use DistSQL. During 23.1 time frame we started populating the SessionData with proper session defaults in some cases and completed this work in 23.2; as a result, the internally-executed queries can now use DistSQL, but we must disable it in this "sync" mode, when the root txn is specified, which is what this commit does.

We already made a similar change to disable the Streamer some time ago for the same reason in ed3f640.

I spent quite a few hours to come up with a reproduction but didn't succeed, so there is no regression test in this commit.

Fixes: #118542.

Release note (bug fix): Previously, CockroachDB could encounter an internal error "attempting to append refresh spans after the tracked timestamp has moved forward" in some cases when using virtual tables (like `crdb_internal.system_jobs`, etc), and this has now been fixed. The bug was introduced in 23.1 version.