### PR TITLE
release-23.2: sql: prevent illegal concurrency with internal executor in some cases

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1012,6 +1012,13 @@ func (ie *InternalExecutor) execInternal(
 
 	applyInternalExecutorSessionExceptions(sd)
 	applyOverrides(sessionDataOverride, sd)
+	if !rw.async() && (txn != nil && txn.Type() == kv.RootTxn) {
+		// If the "outer" query uses the RootTxn and the sync result channel is
+		// requested, then we must disable DistSQL to ensure that the "inner"
+		// query doesn't use the LeafTxn (which could result in illegal
+		// concurrency).
+		sd.DistSQLMode = sessiondatapb.DistSQLOff
+	}
 	sd.Internal = true
 	if sd.User().Undefined() {
 		return nil, errors.AssertionFailedf("no user specified for internal query")


### PR DESCRIPTION
Backport 1/2 commits from #119176.

/cc @cockroachdb/release

---

Previously, it was possible for some methods of the internal executor result in illegal concurrency. In particular, `QueryIterator{Ex}` methods allow for the result of the internal query to be consumed in "streaming" fashion but we must do so without any concurrency, and it's achieved by using "sync" result channel (which synchronizes the reader ("outer" query) and the writer (InternalExecutor)). However, previously the internal query could result in illegal concurrency on its own - if it happens to use DistSQL. During 23.1 time frame we started populating the SessionData with proper session defaults in some cases and completed this work in 23.2; as a result, the internally-executed queries can now use DistSQL, but we must disable it in this "sync" mode, when the root txn is specified, which is what this commit does.

We already made a similar change to disable the Streamer some time ago for the same reason in ed3f640.

I spent quite a few hours to come up with a reproduction but didn't succeed, so there is no regression test in this commit.

Fixes: #118542.

Release note (bug fix): Previously, CockroachDB could encounter an internal error "attempting to append refresh spans after the tracked timestamp has moved forward" in some cases when using virtual tables (like `crdb_internal.system_jobs`, etc), and this has now been fixed. The bug was introduced in 23.1 version.

Release justification: bug fix.