### PR TITLE
cli,jobs: provide debug tool to clean up abandoned rows

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "convert_url.go",
         "debug.go",
         "debug_check_store.go",
+        "debug_job_cleanup.go",
         "debug_job_trace.go",
         "debug_list_files.go",
         "debug_logconfig.go",

--- a/pkg/cli/clisqlclient/api.go
+++ b/pkg/cli/clisqlclient/api.go
@@ -29,6 +29,10 @@ type Conn interface {
 	// Exec executes a statement.
 	Exec(ctx context.Context, query string, args ...interface{}) error
 
+	// ExecWithRowsAffected is like Exec but returns the number of
+	// affected rows.
+	ExecWithRowsAffected(ctx context.Context, query string, args ...interface{}) (int64, error)
+
 	// Query returns one or more SQL statements and returns the
 	// corresponding result set(s).
 	Query(ctx context.Context, query string, args ...interface{}) (Rows, error)
@@ -199,6 +203,7 @@ type TxBoundConn interface {
 type DriverConn interface {
 	Query(ctx context.Context, query string, args ...interface{}) (driver.Rows, error)
 	Exec(ctx context.Context, query string, args ...interface{}) error
+	ExecWithRowsAffected(ctx context.Context, query string, args ...interface{}) (int64, error)
 	CopyFrom(ctx context.Context, reader io.Reader, query string) (int64, error)
 	CopyTo(ctx context.Context, w io.Writer, query string) error
 }
@@ -218,6 +223,12 @@ func (d *driverConnAdapter) Query(
 
 func (d *driverConnAdapter) Exec(ctx context.Context, query string, args ...interface{}) error {
 	return d.c.Exec(ctx, query, args...)
+}
+
+func (d *driverConnAdapter) ExecWithRowsAffected(
+	ctx context.Context, query string, args ...interface{},
+) (int64, error) {
+	return d.c.ExecWithRowsAffected(ctx, query, args...)
 }
 
 func (d *driverConnAdapter) CopyFrom(

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1456,6 +1456,13 @@ func init() {
 	DebugCmd.AddCommand(debugStatementBundleCmd)
 
 	DebugCmd.AddCommand(debugJobTraceFromClusterCmd)
+	DebugCmd.AddCommand(debugJobCleanupInfoRows)
+	f = debugJobCleanupInfoRows.PersistentFlags()
+	f.IntVar(&jobCleanupInfoRowOpts.PageSize, "page-size", jobCleanupInfoRowOpts.PageSize,
+		"number of deletes to perform per query",
+	)
+	f.DurationVar(&jobCleanupInfoRowOpts.Age, "age", jobCleanupInfoRowOpts.Age,
+		"minimum age of job_info rows to delete; rows younger than this will not be deleted")
 
 	f = debugSyncBenchCmd.Flags()
 	f.IntVarP(&syncBenchOpts.Concurrency, "concurrency", "c", syncBenchOpts.Concurrency,

--- a/pkg/cli/debug_job_cleanup.go
+++ b/pkg/cli/debug_job_cleanup.go
@@ -1,0 +1,72 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cli/clierrorplus"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+var debugJobCleanupInfoRows = &cobra.Command{
+	Use:   "job-cleanup-job-info",
+	Short: "cleans up system.job_info rows with no related system.jobs entry",
+	RunE:  clierrorplus.MaybeDecorateError(runDebugJobInfoCleanup),
+}
+
+var jobCleanupInfoRowOpts = struct {
+	PageSize int
+	Age      time.Duration
+}{
+	PageSize: 500,
+	Age:      12 * time.Hour,
+}
+
+func runDebugJobInfoCleanup(_ *cobra.Command, args []string) (resErr error) {
+	ctx := context.Background()
+	sqlConn, err := makeSQLClient(ctx, "cockroach debug job-cleanup-job-info", useSystemDb)
+	if err != nil {
+		return errors.Wrap(err, "could not establish connection to cluster")
+	}
+	defer func() { resErr = errors.CombineErrors(resErr, sqlConn.Close()) }()
+
+	totalDeleted := 0
+	defer func() {
+		if totalDeleted > 0 {
+			telemetry.Inc(jobs.AbandonedInfoRowsFound)
+		}
+	}()
+
+	for {
+		rowsAffected, err := sqlConn.ExecWithRowsAffected(ctx,
+			jobs.AbandonedJobInfoRowsCleanupQuery,
+			timeutil.Now().Add(-1*jobCleanupInfoRowOpts.Age),
+			jobCleanupInfoRowOpts.PageSize)
+		if err != nil {
+			return err
+		}
+		if rowsAffected == 0 {
+			break
+		}
+		fmt.Printf("deleted %d system.job_info rows\n", rowsAffected)
+		totalDeleted += int(rowsAffected)
+	}
+
+	fmt.Printf("%d total rows deleted\n", totalDeleted)
+	return nil
+}

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -608,6 +608,7 @@ func init() {
 
 	clientCmds := []*cobra.Command{
 		debugJobTraceFromClusterCmd,
+		debugJobCleanupInfoRows,
 		debugGossipValuesCmd,
 		debugTimeSeriesDumpCmd,
 		debugZipCmd,
@@ -728,6 +729,7 @@ func init() {
 		sqlShellCmd,
 		demoCmd,
 		debugJobTraceFromClusterCmd,
+		debugJobCleanupInfoRows,
 		doctorExamineClusterCmd,
 		doctorExamineFallbackClusterCmd,
 		doctorRecreateClusterCmd,

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -339,6 +339,11 @@ func getJobTelemetryMetricsArray() [jobspb.NumJobTypes]*JobTelemetryMetrics {
 	return metrics
 }
 
-// TelemetryMetrics contains telemetry metrics for different
-// job types.
-var TelemetryMetrics = getJobTelemetryMetricsArray()
+var (
+	// TelemetryMetrics contains telemetry metrics for different
+	// job types.
+	TelemetryMetrics = getJobTelemetryMetricsArray()
+	// AbandonedInfoRowsFound is how many times our cleanup
+	// routine found abandoned rows.
+	AbandonedInfoRowsFound = telemetry.GetCounterOnce("job.registry.cleanup_found_abandoned_rows")
+)

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1153,6 +1153,15 @@ func (r *Registry) cleanupOldJobs(ctx context.Context, olderThan time.Time) erro
 	}
 }
 
+// AbandonedJobInfoRowsCleanupQuery is used by the CLI command
+// job-cleanup-job-info to delete jobs that were abandoned because of
+// previous CRDB bugs. It is exposed here for testing.
+const AbandonedJobInfoRowsCleanupQuery = `
+	DELETE
+FROM system.job_info
+WHERE written < $1 AND job_id NOT IN (SELECT id FROM system.jobs)
+LIMIT $2`
+
 // The ordering is important as we keep track of the maximum ID we've seen.
 const expiredJobsQueryWithJobInfoTable = `
 WITH


### PR DESCRIPTION
We recently fixed a bug that could have resulted in job_info rows. This is a CLI tool to help with cleanup of those rows in any cluster where we happen to find them.

Epic: None

Release note: None