### PR TITLE
roachtest: small fixes for weekly test run

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
@@ -28,9 +28,6 @@ source $root/build/teamcity/util/roachtest_util.sh
 # NB(2): We specify --zones below so that nodes are created in us-central1-b
 # by default. This reserves us-east1-b (the roachprod default zone) for use
 # by manually created clusters.
-#
-# NB(3): If you make changes here, you should probably make the same change in
-# build/teamcity-weekly-roachtest.sh
 timeout -s INT $((7800*60)) build/teamcity-roachtest-invoke.sh \
   --suite weekly \
   --cluster-id "${TC_BUILD_ID}" \
@@ -38,5 +35,6 @@ timeout -s INT $((7800*60)) build/teamcity-roachtest-invoke.sh \
   --artifacts=/artifacts \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --parallelism 5 \
+  --cpu-quota 500 \
   --metamorphic-encryption-probability=0.5 \
   --slack-token="${SLACK_TOKEN}"

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -664,8 +664,12 @@ func (r *testRunner) runWorker(
 			}
 		}
 
-		//  TODO(babusrithar): remove this once we see enough data in nightly runs. This is a temp logic to test spot VMs.
-		if roachtestflags.Cloud == spec.GCE && testToRun.spec.Benchmark && rand.Float64() <= 0.5 {
+		//  TODO(babusrithar): remove this once we see enough data in
+		//  nightly runs. This is a temp logic to test spot VMs.
+		if roachtestflags.Cloud == spec.GCE &&
+			testToRun.spec.Benchmark &&
+			!testToRun.spec.Suites.Contains(registry.Weekly) &&
+			rand.Float64() <= 0.5 {
 			l.PrintfCtx(ctx, "using spot VMs to run test %s", testToRun.spec.Name)
 			testToRun.spec.Cluster.UseSpotVMs = true
 		}


### PR DESCRIPTION
**roachtest: don't use spot VMs in weekly test runs**
Many of the weekly tests take several hours or days to finish. It's
wasteful to run a test for several hours only to give up due to
preemption. Since the running time is so long, it's also unlikely
these tests will ever run to completion.

Epic: none

Release note: None

**build: increase cpu-quota for roachtest weekly runner**
With the addition of the `multi-region/mixed-version` weekly
roachtest, the default `cpu-quota` (300) is no longer sufficient. We
increase it to 500, which should be enough for our current usage.

Epic: none

Release note: None