### PR TITLE
kv: [DNM] approximate MVCCStats during splits (prototype 3)

### DIFF
--- a/pkg/kv/kvserver/batcheval/result/metrics.go
+++ b/pkg/kv/kvserver/batcheval/result/metrics.go
@@ -13,14 +13,18 @@ package result
 // Metrics tracks various counters related to command applications and
 // their outcomes.
 type Metrics struct {
-	LeaseRequestSuccess  int // lease request evaluated successfully
-	LeaseRequestError    int // lease request error at evaluation time
-	LeaseTransferSuccess int // lease transfer evaluated successfully
-	LeaseTransferError   int // lease transfer error at evaluation time
-	ResolveCommit        int // intent commit evaluated successfully
-	ResolveAbort         int // non-poisoning intent abort evaluated successfully
-	ResolvePoison        int // poisoning intent abort evaluated successfully
-	AddSSTableAsWrites   int // AddSSTable requests with IngestAsWrites set
+	LeaseRequestSuccess      int // lease request evaluated successfully
+	LeaseRequestError        int // lease request error at evaluation time
+	LeaseTransferSuccess     int // lease transfer evaluated successfully
+	LeaseTransferError       int // lease transfer error at evaluation time
+	ResolveCommit            int // intent commit evaluated successfully
+	ResolveAbort             int // non-poisoning intent abort evaluated successfully
+	ResolvePoison            int // poisoning intent abort evaluated successfully
+	AddSSTableAsWrites       int // AddSSTable requests with IngestAsWrites set
+	SplitDiscrepancyKeyCount int
+	SplitDiscrepancyKeyBytes int
+	SplitDiscrepancyValCount int
+	SplitDiscrepancyValBytes int
 }
 
 // Add absorbs the supplied Metrics into the receiver.
@@ -33,4 +37,8 @@ func (mt *Metrics) Add(o Metrics) {
 	mt.ResolveAbort += o.ResolveAbort
 	mt.ResolvePoison += o.ResolvePoison
 	mt.AddSSTableAsWrites += o.AddSSTableAsWrites
+	mt.SplitDiscrepancyKeyCount += o.SplitDiscrepancyKeyCount
+	mt.SplitDiscrepancyKeyBytes += o.SplitDiscrepancyKeyBytes
+	mt.SplitDiscrepancyValCount += o.SplitDiscrepancyValCount
+	mt.SplitDiscrepancyValBytes += o.SplitDiscrepancyValBytes
 }

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -113,6 +113,21 @@ func MakeReplicatedKeySpans(d *roachpb.RangeDescriptor) []roachpb.Span {
 	})
 }
 
+func MakeReplicatedKeySpansUserOnly(d *roachpb.RangeDescriptor) []roachpb.Span {
+	return Select(d.RangeID, SelectOpts{
+		ReplicatedBySpan:      d.RSpan(),
+		ReplicatedSpansFilter: ReplicatedSpansUserOnly,
+	})
+}
+
+func MakeReplicatedKeySpansExcludingUser(d *roachpb.RangeDescriptor) []roachpb.Span {
+	return Select(d.RangeID, SelectOpts{
+		ReplicatedBySpan:      d.RSpan(),
+		ReplicatedByRangeID:   true,
+		ReplicatedSpansFilter: ReplicatedSpansExcludeUser,
+	})
+}
+
 // MakeReplicatedKeySpanSet is similar to MakeReplicatedKeySpans, except it
 // creates a SpanSet instead of a slice of spans. Note that lock table spans
 // are skipped.

--- a/pkg/kv/kvserver/rditer/stats.go
+++ b/pkg/kv/kvserver/rditer/stats.go
@@ -27,6 +27,20 @@ func ComputeStatsForRange(
 		ctx, d, reader, nowNanos, storage.ComputeStatsVisitors{})
 }
 
+func ComputeStatsForUserOnlyRange(
+	ctx context.Context, d *roachpb.RangeDescriptor, reader storage.Reader, nowNanos int64,
+) (enginepb.MVCCStats, error) {
+	return ComputeStatsForUserOnlyRangeWithVisitors(
+		ctx, d, reader, nowNanos, storage.ComputeStatsVisitors{})
+}
+
+func ComputeStatsExcludingUserForRange(
+	ctx context.Context, d *roachpb.RangeDescriptor, reader storage.Reader, nowNanos int64,
+) (enginepb.MVCCStats, error) {
+	return ComputeStatsExcludingUserRangeWithVisitors(
+		ctx, d, reader, nowNanos, storage.ComputeStatsVisitors{})
+}
+
 // ComputeStatsForRangeWithVisitors is like ComputeStatsForRange but also
 // calls the given callbacks for every key.
 func ComputeStatsForRangeWithVisitors(
@@ -36,8 +50,38 @@ func ComputeStatsForRangeWithVisitors(
 	nowNanos int64,
 	visitors storage.ComputeStatsVisitors,
 ) (enginepb.MVCCStats, error) {
+	return computeStatsForSpansWithVisitors(ctx, MakeReplicatedKeySpans(d), reader, nowNanos, visitors)
+}
+
+func ComputeStatsForUserOnlyRangeWithVisitors(
+	ctx context.Context,
+	d *roachpb.RangeDescriptor,
+	reader storage.Reader,
+	nowNanos int64,
+	visitors storage.ComputeStatsVisitors,
+) (enginepb.MVCCStats, error) {
+	return computeStatsForSpansWithVisitors(ctx, MakeReplicatedKeySpansUserOnly(d), reader, nowNanos, visitors)
+}
+
+func ComputeStatsExcludingUserRangeWithVisitors(
+	ctx context.Context,
+	d *roachpb.RangeDescriptor,
+	reader storage.Reader,
+	nowNanos int64,
+	visitors storage.ComputeStatsVisitors,
+) (enginepb.MVCCStats, error) {
+	return computeStatsForSpansWithVisitors(ctx, MakeReplicatedKeySpansExcludingUser(d), reader, nowNanos, visitors)
+}
+
+func computeStatsForSpansWithVisitors(
+	ctx context.Context,
+	spans []roachpb.Span,
+	reader storage.Reader,
+	nowNanos int64,
+	visitors storage.ComputeStatsVisitors,
+) (enginepb.MVCCStats, error) {
 	var ms enginepb.MVCCStats
-	for _, keySpan := range MakeReplicatedKeySpans(d) {
+	for _, keySpan := range spans {
 		msDelta, err := storage.ComputeStatsWithVisitors(
 			ctx, reader, keySpan.Key, keySpan.EndKey, nowNanos, visitors)
 		if err != nil {

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -130,6 +130,9 @@ message SplitTrigger {
   RangeDescriptor right_desc = 2 [(gogoproto.nullable) = false];
 
   reserved 3, 4;
+
+  storage.enginepb.MVCCStats pre_split_left_stats = 5 [(gogoproto.nullable) = false];
+  storage.enginepb.MVCCStats pre_split_total_stats = 6 [(gogoproto.nullable) = false];
 }
 
 // A MergeTrigger is run after a successful commit of an AdminMerge


### PR DESCRIPTION
Instead of computing accurate MVCCStats for the LHS and RHS of a split while holding latches, compute only the user-data LHS stats in AdminSplit and pass it to the splitTrigger. In the splitTrigger, compute the non-user LHS stats, add those to the passed in user-data LHS stats, and use the combined stats to derive the RHS stats. This produces inaccurate stats because it doesn't account for writes to the LHS concurrent with the split.

In addition, export stats in the discrepancy between the total stats pre- (in AdminSplit) and post- (in splitTrigger) split. If there is a big discrepancy, we can fall back to computing accurate stats. Otherwise, we can distribute the discrepancy based on the pre-split distribution of stats between the LHS and RHS.

Do not merge, this is an experiment.