### PR TITLE
tenantcapabilities: make shared service imply all capabilities

### DIFF
--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
@@ -416,7 +416,13 @@ func (a *Authorizer) getMode(
 					tid)
 				selectedMode = authorizerModeV222
 			}
-
+			// Shared service tenants in UA implicitly have all capabilities. If/when
+			// we offer shared service for truly _multi-tenant_ deployments and wish to
+			// restrict some of those tenants, we can add another service mode that is
+			// similar to shared but adds restriction to only granted capabilities.
+			if entry.ServiceMode == mtinfopb.ServiceModeShared {
+				selectedMode = authorizerModeAllowAll
+			}
 		}
 	}
 	return entry, selectedMode

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/authorizer_enabled
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/authorizer_enabled
@@ -100,7 +100,7 @@ has-capability-for-batch ten=10 cmds=(Scan)
 ----
 ok
 
-# Set the service state to externa and make sure we can send a batch.
+# Set the service state to shared and make sure we can send a batch.
 upsert ten=10 can_admin_scatter=false can_admin_split=false can_view_node_info=false can_view_tsdb_metrics=false service=shared
 ----
 ok
@@ -108,3 +108,16 @@ ok
 has-capability-for-batch ten=10 cmds=(Scan)
 ----
 ok
+
+has-capability-for-batch ten=10 cmds=(AdminScatter, Scan)
+----
+ok
+
+# Set the service state to external and make sure we are restricted again.
+upsert ten=10 can_admin_scatter=false can_admin_split=false can_view_node_info=false can_view_tsdb_metrics=false service=external
+----
+ok
+
+has-capability-for-batch ten=10 cmds=(AdminScatter, Scan)
+----
+client tenant does not have capability "can_admin_scatter" (*kvpb.AdminScatterRequest)

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiestestutils/testutils.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiestestutils/testutils.go
@@ -162,7 +162,7 @@ func GetServiceState(t *testing.T, d *datadriven.TestData) mtinfopb.TenantServic
 		}
 		return serviceState
 	}
-	return mtinfopb.ServiceModeShared
+	return mtinfopb.ServiceModeExternal
 }
 
 // AlteredCapabilitiesString pretty-prints all altered capability


### PR DESCRIPTION
If/when we decide we to support truly _multi_ tenant clusters using shared service, we may then wish to restrict the capabilities of some tenants. For now however the only users of shared service are UA app tenants who are granted all capabilities via intitialization steps. This change makes that implicit, removing the initialization steps. If we later decide we want some shared service tenants to be restricted we can always add a second service more that indicates shared-but-with-restrictions.

Release note: none.
Epic: none.