### PR TITLE
storage: add Engine.NewReader method

### DIFF
--- a/pkg/kv/kvserver/batcheval/lock_test.go
+++ b/pkg/kv/kvserver/batcheval/lock_test.go
@@ -205,7 +205,7 @@ func TestTxnBoundReplicatedLockTableView(t *testing.T) {
 	err = storage.MVCCAcquireLock(ctx, engine, &txn1, lock.Shared, keyB, nil, 0)
 	require.NoError(t, err)
 
-	reader := engine.NewReadOnly(storage.StandardDurability)
+	reader := engine.NewReader(storage.StandardDurability)
 	defer reader.Close()
 
 	txn1LTView := newTxnBoundReplicatedLockTableView(reader, &txn1)

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -459,7 +459,7 @@ func LoadTerm(
 		return kvpb.RaftTerm(entry.Term), nil
 	}
 
-	reader := eng.NewReadOnly(storage.StandardDurability)
+	reader := eng.NewReader(storage.StandardDurability)
 	defer reader.Close()
 
 	if err := raftlog.Visit(ctx, reader, rangeID, index, index+1, func(ent raftpb.Entry) error {
@@ -592,7 +592,7 @@ func LoadEntries(
 		return nil
 	}
 
-	reader := eng.NewReadOnly(storage.StandardDurability)
+	reader := eng.NewReader(storage.StandardDurability)
 	defer reader.Close()
 	if err := raftlog.Visit(ctx, reader, rangeID, expectedIndex, hi, scanFunc); err != nil {
 		return nil, 0, 0, err

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -1384,7 +1384,7 @@ func BenchmarkNodeLivenessScanStorage(b *testing.B) {
 			ScanStats: ss,
 		}
 		scanRes, err := storage.MVCCScan(
-			ctx, eng.NewReadOnly(storage.StandardDurability), keys.NodeLivenessPrefix,
+			ctx, eng.NewReader(storage.StandardDurability), keys.NodeLivenessPrefix,
 			keys.NodeLivenessKeyMax, hlc.MaxTimestamp, opts)
 		if err != nil {
 			b.Fatal(err.Error())

--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -451,7 +451,7 @@ func (t *raftLogTruncator) durabilityAdvanced(ctx context.Context) {
 	// Sort it for deterministic testing output.
 	sort.Sort(rangesByRangeID(ranges))
 	// Create an engine Reader to provide a safe lower bound on what is durable.
-	reader := t.store.getEngine().NewReadOnly(storage.GuaranteedDurability)
+	reader := t.store.getEngine().NewReader(storage.GuaranteedDurability)
 	defer reader.Close()
 	shouldQuiesce := t.stopper.ShouldQuiesce()
 	quiesced := false

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -336,8 +336,8 @@ func TestIterateMVCCReplicaKeySpansSpansSet(t *testing.T) {
 	// fragmented.
 	//
 	get := func(t *testing.T, useSpanSet, reverse bool) ([]storage.MVCCKey, []storage.MVCCRangeKey) {
-		readWriter := eng.NewReadOnly(storage.StandardDurability)
-		defer readWriter.Close()
+		reader := eng.NewReader(storage.StandardDurability)
+		defer reader.Close()
 		if useSpanSet {
 			var spans spanset.SpanSet
 			spans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{
@@ -352,12 +352,12 @@ func TestIterateMVCCReplicaKeySpansSpansSet(t *testing.T) {
 				Key:    desc.StartKey.AsRawKey(),
 				EndKey: desc.EndKey.AsRawKey(),
 			}, hlc.Timestamp{WallTime: 42})
-			readWriter = spanset.NewReadWriterAt(readWriter, &spans, hlc.Timestamp{WallTime: 42})
+			reader = spanset.NewReader(reader, &spans, hlc.Timestamp{WallTime: 42})
 		}
 		var rangeStart roachpb.Key
 		var actualKeys []storage.MVCCKey
 		var actualRanges []storage.MVCCRangeKey
-		err := IterateMVCCReplicaKeySpans(context.Background(), &desc, readWriter, IterateOptions{
+		err := IterateMVCCReplicaKeySpans(context.Background(), &desc, reader, IterateOptions{
 			CombineRangesAndPoints: false,
 			Reverse:                reverse,
 		}, func(iter storage.MVCCIterator, span roachpb.Span, keyType storage.IterKeyType) error {

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -749,6 +749,14 @@ func makeSpanSetReadWriterAt(rw storage.ReadWriter, spans *SpanSet, ts hlc.Times
 	}
 }
 
+// NewReader returns a storage.Reader that asserts access of the underlying
+// Reader against the given SpanSet at a given timestamp. If zero timestamp is
+// provided, accesses are considered non-MVCC.
+func NewReader(r storage.Reader, spans *SpanSet, ts hlc.Timestamp) storage.Reader {
+	spans = addLockTableSpans(spans)
+	return spanSetReader{r: r, spans: spans, ts: ts}
+}
+
 // NewReadWriterAt returns a storage.ReadWriter that asserts access of the
 // underlying ReadWriter against the given SpanSet at a given timestamp.
 // If zero timestamp is provided, accesses are considered non-MVCC.

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -2106,12 +2106,12 @@ func BenchmarkMVCCScannerWithIntentsAndVersions(b *testing.B) {
 		require.NoError(b, eng.IngestLocalFiles(ctx, []string{sstFileName}))
 	}
 	for i := 0; i < b.N; i++ {
-		rw := eng.NewReadOnly(StandardDurability)
+		ro := eng.NewReader(StandardDurability)
 		ts := hlc.Timestamp{WallTime: int64(numVersions) + 5}
 		startKey := makeKey(nil, 0)
 		endKey := makeKey(nil, totalNumKeys+1)
 		iter, err := newMVCCIterator(
-			ctx, rw, ts, false, false, IterOptions{
+			ctx, ro, ts, false, false, IterOptions{
 				KeyTypes:   IterKeyTypePointsAndRanges,
 				LowerBound: startKey,
 				UpperBound: endKey,
@@ -2134,6 +2134,6 @@ func BenchmarkMVCCScannerWithIntentsAndVersions(b *testing.B) {
 			fmt.Printf("stats: %s\n", stats.Stats.String())
 		}
 		iter.Close()
-		rw.Close()
+		ro.Close()
 	}
 }

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -954,6 +954,14 @@ type Engine interface {
 	// this engine. Batched engines accumulate all mutations and apply
 	// them atomically on a call to Commit().
 	NewBatch() Batch
+	// NewReader returns a new instance of a Reader that wraps this engine, and
+	// with the given durability requirement. This wrapper caches iterators to
+	// avoid the overhead of creating multiple iterators for batched reads.
+	//
+	// All iterators created from a read-only engine are guaranteed to provide a
+	// consistent snapshot of the underlying engine. See the comment on the
+	// Reader interface and the Reader.ConsistentIterators method.
+	NewReader(durability DurabilityRequirement) Reader
 	// NewReadOnly returns a new instance of a ReadWriter that wraps this
 	// engine, and with the given durability requirement. This wrapper panics
 	// when unexpected operations (e.g., write operations) are executed on it
@@ -963,6 +971,9 @@ type Engine interface {
 	// All iterators created from a read-only engine are guaranteed to provide a
 	// consistent snapshot of the underlying engine. See the comment on the
 	// Reader interface and the Reader.ConsistentIterators method.
+	//
+	// TODO(sumeer,jackson): Remove this method and force the caller to operate
+	// explicitly with a separate WriteBatch and Reader.
 	NewReadOnly(durability DurabilityRequirement) ReadWriter
 	// NewUnindexedBatch returns a new instance of a batched engine which wraps
 	// this engine. It is unindexed, in that writes to the batch are not

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -799,7 +799,7 @@ func TestEngineScan1(t *testing.T) {
 	}
 
 	// Test iterator stats.
-	ro := engine.NewReadOnly(StandardDurability)
+	ro := engine.NewReader(StandardDurability)
 	iter, err := ro.NewMVCCIterator(context.Background(), MVCCKeyIterKind, IterOptions{LowerBound: roachpb.Key("cat"), UpperBound: roachpb.Key("server")})
 	require.NoError(t, err)
 	iter.SeekGE(MVCCKey{Key: roachpb.Key("cat")})
@@ -1950,6 +1950,11 @@ func TestEngineIteratorVisibility(t *testing.T) {
 			expectConsistent: true,
 			canWrite:         true,
 			readOwnWrites:    false,
+		},
+		"Reader": {
+			makeReader:       func(e Engine) Reader { return e.NewReader(StandardDurability) },
+			expectConsistent: true,
+			canWrite:         false,
 		},
 		"ReadOnly": {
 			makeReader:       func(e Engine) Reader { return e.NewReadOnly(StandardDurability) },

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -2571,8 +2571,8 @@ func (e *evalCtx) newReader() storage.Reader {
 	switch mvccHistoriesReader {
 	case "engine":
 		return noopCloseReader{e.engine}
-	case "readonly":
-		return e.engine.NewReadOnly(storage.StandardDurability)
+	case "reader", "readOnly":
+		return e.engine.NewReader(storage.StandardDurability)
 	case "batch":
 		return e.engine.NewBatch()
 	case "snapshot":

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2233,6 +2233,11 @@ func (p *Pebble) NewBatch() Batch {
 	return newPebbleBatch(p.db, p.db.NewIndexedBatch(), p.settings, p, p)
 }
 
+// NewReader implements the Engine interface.
+func (p *Pebble) NewReader(durability DurabilityRequirement) Reader {
+	return newPebbleReadOnly(p, durability)
+}
+
 // NewReadOnly implements the Engine interface.
 func (p *Pebble) NewReadOnly(durability DurabilityRequirement) ReadWriter {
 	return newPebbleReadOnly(p, durability)

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -81,7 +81,7 @@ func TestMVCCScanWithManyVersionsAndSeparatedIntents(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	reader := eng.NewReadOnly(StandardDurability)
+	reader := eng.NewReader(StandardDurability)
 	defer reader.Close()
 	iter, err := reader.NewMVCCIterator(context.Background(), MVCCKeyAndIntentsIterKind, IterOptions{LowerBound: keys[0], UpperBound: roachpb.Key("d")})
 	require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestMVCCScanWithLargeKeyValue(t *testing.T) {
 	require.NoError(t, eng.PutMVCC(MVCCKey{Key: keys[3], Timestamp: hlc.Timestamp{WallTime: 1}},
 		MVCCValue{Value: roachpb.MakeValueFromBytes(largeValue)}))
 
-	reader := eng.NewReadOnly(StandardDurability)
+	reader := eng.NewReader(StandardDurability)
 	defer reader.Close()
 	iter, err := reader.NewMVCCIterator(context.Background(), MVCCKeyAndIntentsIterKind, IterOptions{LowerBound: keys[0], UpperBound: roachpb.Key("e")})
 	require.NoError(t, err)

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -304,9 +304,9 @@ func TestPebbleIterConsistency(t *testing.T) {
 	require.NoError(t, eng.PutMVCC(k1, v1))
 
 	var (
-		roEngine  = eng.NewReadOnly(StandardDurability)
+		roEngine  = eng.NewReader(StandardDurability)
 		batch     = eng.NewBatch()
-		roEngine2 = eng.NewReadOnly(StandardDurability)
+		roEngine2 = eng.NewReader(StandardDurability)
 		batch2    = eng.NewBatch()
 	)
 	defer roEngine.Close()
@@ -988,11 +988,11 @@ func TestPebbleFlushCallbackAndDurabilityRequirement(t *testing.T) {
 	eng.RegisterFlushCompletedCallback(func() {
 		atomic.AddInt32(&cbCount, 1)
 	})
-	roStandard := eng.NewReadOnly(StandardDurability)
+	roStandard := eng.NewReader(StandardDurability)
 	defer roStandard.Close()
-	roGuaranteed := eng.NewReadOnly(GuaranteedDurability)
+	roGuaranteed := eng.NewReader(GuaranteedDurability)
 	defer roGuaranteed.Close()
-	roGuaranteedPinned := eng.NewReadOnly(GuaranteedDurability)
+	roGuaranteedPinned := eng.NewReader(GuaranteedDurability)
 	defer roGuaranteedPinned.Close()
 	require.NoError(t, roGuaranteedPinned.PinEngineStateForIterators(UnknownReadCategory))
 	// Returns the value found or nil.
@@ -1029,7 +1029,7 @@ func TestPebbleFlushCallbackAndDurabilityRequirement(t *testing.T) {
 	})
 	// Write is visible to new guaranteed reader. We need to use a new reader
 	// due to iterator caching.
-	roGuaranteed2 := eng.NewReadOnly(GuaranteedDurability)
+	roGuaranteed2 := eng.NewReader(GuaranteedDurability)
 	defer roGuaranteed2.Close()
 	require.Equal(t, v.Value.RawBytes, checkGetAndIter(roGuaranteed2))
 }
@@ -1062,7 +1062,7 @@ func TestPebbleReaderMultipleIterators(t *testing.T) {
 	require.NoError(t, eng.PutMVCC(b1, v2))
 	require.NoError(t, eng.PutMVCC(c1, v3))
 
-	readOnly := eng.NewReadOnly(StandardDurability)
+	readOnly := eng.NewReader(StandardDurability)
 	defer readOnly.Close()
 	require.NoError(t, readOnly.PinEngineStateForIterators(UnknownReadCategory))
 


### PR DESCRIPTION
Add a NewReader method that returns a storage.Reader rather than a storage.ReadWriter. Eventually, we'd like to remove Engine.NewReadOnly in favor of explicitly propagating both a Reader and a WriteBatch.

Epic: none
Release note: none