### PR TITLE
colenc,rowenc: miscellaneous cleanup

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_scan_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan_test.go
@@ -239,7 +239,7 @@ func makeRowKey(t *testing.T, id int, columnFamily uint32) roachpb.Key {
 
 	var err error
 	key := keys.SystemSQLCodec.IndexPrefix(1, 1)
-	key, _, err = rowenc.EncodeColumns(
+	key, err = rowenc.EncodeColumns(
 		[]descpb.ColumnID{0}, nil /* directions */, colMap,
 		[]tree.Datum{tree.NewDInt(tree.DInt(id))}, key)
 	require.NoError(t, err)

--- a/pkg/sql/colenc/encode.go
+++ b/pkg/sql/colenc/encode.go
@@ -349,7 +349,6 @@ func (b *BatchEncoder) encodePK(ctx context.Context, ind catalog.Index) error {
 			}
 
 			col := fetchedCols[idx]
-			typ := col.GetType()
 			vec := vecs[idx]
 			nulls := vec.Nulls()
 			lastColIDs := b.lastColIDs
@@ -372,7 +371,7 @@ func (b *BatchEncoder) encodePK(ctx context.Context, ind catalog.Index) error {
 				colIDDelta := valueside.MakeColumnIDDelta(lastColIDs[row], colID)
 				lastColIDs[row] = colID
 				var err error
-				values[row], err = valuesideEncodeCol(values[row], typ, colIDDelta, vec, row+b.start)
+				values[row], err = valuesideEncodeCol(values[row], colIDDelta, vec, row+b.start)
 				if err != nil {
 					return err
 				}
@@ -426,7 +425,7 @@ func (b *BatchEncoder) encodeSecondaryIndex(ctx context.Context, ind catalog.Ind
 	kys := b.keys
 
 	// Encode key suffix columns and save the results in extraKeys.
-	_, err = encodeColumns(ind.IndexDesc().KeySuffixColumnIDs, nil /*directions*/, b.colMap, b.start, b.end, b.b.ColVecs(), b.extraKeys)
+	err = encodeColumns(ind.IndexDesc().KeySuffixColumnIDs, nil /*directions*/, b.colMap, b.start, b.end, b.b.ColVecs(), b.extraKeys)
 	if err != nil {
 		return err
 	}
@@ -601,7 +600,7 @@ func (b *BatchEncoder) writeColumnValues(
 			}
 			colIDDelta := valueside.MakeColumnIDDelta(lastColIDs[row], col.ColID)
 			lastColIDs[row] = col.ColID
-			values[row], err = valuesideEncodeCol(values[row], vec.Type(), colIDDelta, vec, row+b.start)
+			values[row], err = valuesideEncodeCol(values[row], colIDDelta, vec, row+b.start)
 			if err != nil {
 				return err
 			}
@@ -619,32 +618,26 @@ func encodeColumns[T []byte | roachpb.Key](
 	start, end int,
 	vecs []coldata.Vec,
 	keys []T,
-) (*coldata.Nulls, error) {
-	var nulls coldata.Nulls
+) error {
 	var err error
 	for colIdx, id := range columnIDs {
 		var vec coldata.Vec
-		var typ *types.T
 		i, ok := colMap.Get(id)
 		if ok {
 			vec = vecs[i]
-			typ = vec.Type()
-			if vec.Nulls().MaybeHasNulls() {
-				nulls = nulls.Or(*vec.Nulls())
-			}
 		}
 		dir := encoding.Ascending
 		if directions != nil {
 			dir, err = directions.Get(colIdx)
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
-		if err := encodeKeys(keys, typ, dir, vec, start, end); err != nil {
-			return nil, err
+		if err = encodeKeys(keys, dir, vec, start, end); err != nil {
+			return err
 		}
 	}
-	return &nulls, nil
+	return nil
 }
 
 func (b *BatchEncoder) initFamily(familyIndex, familyID int) {

--- a/pkg/sql/colenc/inverted.go
+++ b/pkg/sql/colenc/inverted.go
@@ -116,7 +116,7 @@ func (b *BatchEncoder) encodeInvertedIndexPrefixKeys(
 		colIDs := index.IndexDesc().KeyColumnIDs[:numColumns-1]
 		dirs := index.IndexDesc().KeyColumnDirections
 
-		_, err = encodeColumns(colIDs, dirs, b.colMap, b.start, b.end, b.b.ColVecs(), kys)
+		err = encodeColumns(colIDs, dirs, b.colMap, b.start, b.end, b.b.ColVecs(), kys)
 		if err != nil {
 			return nil, err
 		}
@@ -152,7 +152,7 @@ func writeColumnValueOneRow(
 		}
 		colIDDelta := valueside.MakeColumnIDDelta(lastColID, col.ColID)
 		lastColID = col.ColID
-		value, err = valuesideEncodeCol(value, vec.Type(), colIDDelta, vec, row)
+		value, err = valuesideEncodeCol(value, colIDDelta, vec, row)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/colenc/value.go
+++ b/pkg/sql/colenc/value.go
@@ -22,12 +22,12 @@ import (
 
 // valuesideEncodeCol is the vector version of valueside.Encode.
 func valuesideEncodeCol(
-	appendTo []byte, typ *types.T, colID valueside.ColumnIDDelta, vec coldata.Vec, row int,
+	appendTo []byte, colID valueside.ColumnIDDelta, vec coldata.Vec, row int,
 ) ([]byte, error) {
 	if vec.Nulls().NullAt(row) {
 		return encoding.EncodeNullValue(appendTo, uint32(colID)), nil
 	}
-	switch typ.Family() {
+	switch typ := vec.Type(); typ.Family() {
 	case types.BoolFamily:
 		bs := vec.Bool()
 		return encoding.EncodeBoolValue(appendTo, uint32(colID), bs[row]), nil

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -650,7 +650,7 @@ func EncodeInvertedIndexPrefixKeys(
 		// efficient.
 		keyPrefix = growKey(keyPrefix, len(keyPrefix))
 
-		keyPrefix, _, err = EncodeColumns(colIDs, dirs, colMap, values, keyPrefix)
+		keyPrefix, err = EncodeColumns(colIDs, dirs, colMap, values, keyPrefix)
 		if err != nil {
 			return nil, err
 		}
@@ -1326,7 +1326,7 @@ func EncodeSecondaryIndex(
 
 	// Add the extra columns - they are encoded in ascending order which is done
 	// by passing nil for the encoding directions.
-	extraKey, _, err := EncodeColumns(
+	extraKey, err := EncodeColumns(
 		secondaryIndex.IndexDesc().KeySuffixColumnIDs,
 		nil, /* directions */
 		colMap,
@@ -1656,24 +1656,21 @@ func EncodeColumns(
 	colMap catalog.TableColMap,
 	values []tree.Datum,
 	keyPrefix []byte,
-) (key []byte, containsNull bool, err error) {
+) (key []byte, err error) {
 	key = keyPrefix
 	for colIdx, id := range columnIDs {
 		val := findColumnValue(id, colMap, values)
-		if val == tree.DNull {
-			containsNull = true
-		}
 
 		dir, err := directions.Get(colIdx)
 		if err != nil {
-			return nil, false, err
+			return nil, err
 		}
 
 		if key, err = keyside.Encode(key, val, dir); err != nil {
-			return nil, false, err
+			return nil, err
 		}
 	}
-	return key, containsNull, nil
+	return key, nil
 }
 
 // growKey returns a new key with  the same contents as the given key and with

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1965,7 +1965,7 @@ func init() {
 func makeBenchRowKey(b *testing.B, buf []byte, id int, columnFamily uint32) roachpb.Key {
 	var err error
 	buf = append(buf, benchRowPrefix...)
-	buf, _, err = rowenc.EncodeColumns(
+	buf, err = rowenc.EncodeColumns(
 		[]descpb.ColumnID{0}, nil /* directions */, benchRowColMap,
 		[]tree.Datum{tree.NewDInt(tree.DInt(id))}, buf)
 	if err != nil {

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -3013,7 +3013,7 @@ func toKey(s string, sqlCodec keys.SQLCodec) roachpb.Key {
 		var colMap catalog.TableColMap
 		colMap.Set(0, 0)
 		key := sqlCodec.IndexPrefix(1, 1)
-		key, _, err = rowenc.EncodeColumns([]descpb.ColumnID{0}, nil /* directions */, colMap, []tree.Datum{tree.NewDString(pk)}, key)
+		key, err = rowenc.EncodeColumns([]descpb.ColumnID{0}, nil /* directions */, colMap, []tree.Datum{tree.NewDString(pk)}, key)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This commit removes redundant type argument from a few functions as well as fixes a hypothetical bug that could lead to a nil pointer error (namely, in `encodeKeys` we can have `vec` argument be `nil` which means that all values are NULL, and previously we didn't short-circuit the execution of this method - as a result we could access `typ` later which is also `nil`). This change matches what we do in `keyside.Encode`.

Additionally it removes `containsNull` return parameter since it's not used anywhere and was being populated incorrectly in the vectorized case when `vec` is `nil`.

Epic: None

Release note: None