### PR TITLE
kvserver,sql,lease: migrate some tests to `heavy`

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -357,10 +357,9 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":kvserver"],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {
+        "test.Pool": "heavy",
+    },
     shard_count = 48,
     tags = ["cpu:2"],
     deps = [

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -223,10 +223,8 @@ func TestReplicateQueueRebalanceMultiStore(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			if testCase.storesPerNode > 1 {
 				// 8 stores with active rebalancing can lead to failed heartbeats due
-				// to overload. Skip under stress and remote  execution when running
-				// the multi-store variant.
+				// to overload. Skip under stress when running the multi-store variant.
 				skip.UnderStress(t)
-				skip.UnderRemoteExecutionWithIssue(t, 118347)
 			}
 			// Set up a test cluster with multiple stores per node if needed.
 			args := base.TestClusterArgs{

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -740,10 +740,9 @@ go_test(
         "//pkg/sql/vtable:pg_catalog.go",
     ],
     embed = [":sql"],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {
+        "test.Pool": "heavy",
+    },
     shard_count = 16,
     deps = [
         "//pkg/base",

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -86,10 +86,9 @@ go_test(
         "main_test.go",
     ],
     embed = [":lease"],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {
+        "test.Pool": "heavy",
+    },
     shard_count = 4,
     deps = [
         "//pkg/base",

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1851,8 +1851,6 @@ func TestLeaseRenewedPeriodically(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
 	defer log.Scope(testingT).Close(testingT)
 
-	skip.UnderRemoteExecutionWithIssue(testingT, 117929, "prone to stalling for some reason")
-
 	ctx := context.Background()
 
 	var mu syncutil.Mutex

--- a/pkg/sql/mem_limit_test.go
+++ b/pkg/sql/mem_limit_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -156,8 +155,6 @@ func TestMemoryLimit(t *testing.T) {
 func TestStreamerTightBudget(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	skip.UnderRemoteExecutionWithIssue(t, 118004, "sporadic max memory usage assertion failures")
 
 	// Start a cluster with large --max-sql-memory parameter so that the
 	// Streamer isn't hitting the root budget exceeded error.


### PR DESCRIPTION
Also, un-skip a few tests that have been skipped under remote execution
due apparently to excess load.

Epic: CRDB-8308
Release note: None