### PR TITLE
roachtest: require libGEOS in tests that run schemachange

### DIFF
--- a/build/teamcity/cockroach/ci/tests/local_roachtest_fips_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_fips_impl.sh
@@ -11,12 +11,19 @@ fi
 
 export CROSSLINUX_CONFIG="crosslinuxfips"
 
+BAZEL_BIN=$(bazel info bazel-bin --config=$CROSSLINUX_CONFIG --config=ci)
+
 bazel build --config=$CROSSLINUX_CONFIG --config=ci //pkg/cmd/cockroach-short \
       //pkg/cmd/roachtest \
       //pkg/cmd/roachprod \
       //pkg/cmd/workload
 
-BAZEL_BIN=$(bazel info bazel-bin --config=$CROSSLINUX_CONFIG --config=ci)
+bazel build --config=$CROSSLINUX_CONFIG --config=ci --config=force_build_cdeps //c-deps:libgeos
+
+mkdir -p lib
+cp $BAZEL_BIN/c-deps/libgeos_foreign/lib/libgeos.so lib/libgeos.so
+cp $BAZEL_BIN/c-deps/libgeos_foreign/lib/libgeos_c.so lib/libgeos_c.so
+chmod a+w lib/libgeos.so lib/libgeos_c.so
 
 # if there are any local clusters on this host, stop them before we
 # attempt to run acceptance tests. While this is generally not the

--- a/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
@@ -8,12 +8,19 @@ else
   export CROSSLINUX_CONFIG="crosslinux"
 fi
 
+BAZEL_BIN=$(bazel info bazel-bin --config=$CROSSLINUX_CONFIG --config=ci)
+
 bazel build --config=$CROSSLINUX_CONFIG --config=ci //pkg/cmd/cockroach-short \
       //pkg/cmd/roachtest \
       //pkg/cmd/roachprod \
       //pkg/cmd/workload
 
-BAZEL_BIN=$(bazel info bazel-bin --config=$CROSSLINUX_CONFIG --config=ci)
+bazel build --config=$CROSSLINUX_CONFIG --config=ci --config=force_build_cdeps //c-deps:libgeos
+
+mkdir -p lib
+cp $BAZEL_BIN/c-deps/libgeos_foreign/lib/libgeos.so lib/libgeos.so
+cp $BAZEL_BIN/c-deps/libgeos_foreign/lib/libgeos_c.so lib/libgeos_c.so
+chmod a+w lib/libgeos.so lib/libgeos_c.so
 
 # if there are any local clusters on this host, stop them before we
 # attempt to run acceptance tests. While this is generally not the

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -33,6 +33,7 @@ func registerAcceptance(r registry.Registry) {
 		encryptionSupport registry.EncryptionSupport
 		defaultLeases     bool
 		requiresLicense   bool
+		nativeLibs        []string
 		disallowLocal     bool
 	}{
 		registry.OwnerKV: {
@@ -83,6 +84,7 @@ func registerAcceptance(r registry.Registry) {
 				fn:            runVersionUpgrade,
 				timeout:       2 * time.Hour, // actually lower in local runs; see `runVersionUpgrade`
 				defaultLeases: true,
+				nativeLibs:    registry.LibGEOS,
 			},
 		},
 		registry.OwnerDisasterRecovery: {
@@ -145,6 +147,9 @@ func registerAcceptance(r registry.Registry) {
 			}
 			if tc.disallowLocal {
 				testSpec.CompatibleClouds = testSpec.CompatibleClouds.NoLocal()
+			}
+			if len(tc.nativeLibs) > 0 {
+				testSpec.NativeLibs = tc.nativeLibs
 			}
 			testSpec.Run = func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				tc.fn(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -79,6 +79,7 @@ func registerBackupRestoreRoundTrip(r registry.Registry) {
 			Cluster:           r.MakeClusterSpec(4),
 			EncryptionSupport: registry.EncryptionMetamorphic,
 			RequiresLicense:   true,
+			NativeLibs:        registry.LibGEOS,
 			CompatibleClouds:  registry.OnlyGCE,
 			Suites:            registry.Suites(registry.Nightly),
 			Skip:              sp.skip,

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2471,6 +2471,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 		Cluster:           r.MakeClusterSpec(5),
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		RequiresLicense:   true,
+		NativeLibs:        registry.LibGEOS,
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
The schemachange workload started performing statements that might require libGEOS to be present in the cluster. Several tests invoke that workload without indicating that they need lib GEOS. In this commit, we update tests in this situation.

Fixes: #119123
Fixes: #119125

Release note: None