### PR TITLE
release-23.1.15-rc: server, ui: set `HttpOnly: true` and `Secure` flags on cookies

### DIFF
--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -362,6 +362,7 @@ func TestServerControllerDefaultHTTPTenant(t *testing.T) {
 	for _, c := range resp.Cookies() {
 		if c.Name == server.TenantSelectCookieName {
 			tenantCookie = c.Value
+			require.True(t, c.Secure)
 		}
 	}
 	require.Equal(t, "hello", tenantCookie)
@@ -579,6 +580,7 @@ func TestServerControllerLoginLogout(t *testing.T) {
 	for i, c := range resp.Cookies() {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
+		require.True(t, c.Secure)
 		if c.Name == "session" {
 			require.True(t, c.HttpOnly)
 		}
@@ -603,6 +605,7 @@ func TestServerControllerLoginLogout(t *testing.T) {
 	for i, c := range resp.Cookies() {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
+		require.True(t, c.Secure)
 		if c.Name == "session" {
 			require.True(t, c.HttpOnly)
 		}
@@ -633,6 +636,7 @@ func TestServerControllerLoginLogout(t *testing.T) {
 	for i, c := range resp.Cookies() {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
+		require.True(t, c.Secure)
 		if c.Name == "session" {
 			require.True(t, c.HttpOnly)
 		}

--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -579,6 +579,9 @@ func TestServerControllerLoginLogout(t *testing.T) {
 	for i, c := range resp.Cookies() {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
+		if c.Name == "session" {
+			require.True(t, c.HttpOnly)
+		}
 	}
 	require.ElementsMatch(t, []string{"session", "tenant"}, cookieNames)
 	require.ElementsMatch(t, []string{"", ""}, cookieValues)
@@ -600,6 +603,9 @@ func TestServerControllerLoginLogout(t *testing.T) {
 	for i, c := range resp.Cookies() {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
+		if c.Name == "session" {
+			require.True(t, c.HttpOnly)
+		}
 	}
 	require.ElementsMatch(t, []string{"session", "tenant"}, cookieNames)
 	require.ElementsMatch(t, []string{"", ""}, cookieValues)
@@ -627,6 +633,9 @@ func TestServerControllerLoginLogout(t *testing.T) {
 	for i, c := range resp.Cookies() {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
+		if c.Name == "session" {
+			require.True(t, c.HttpOnly)
+		}
 	}
 	require.ElementsMatch(t, []string{"session", "tenant"}, cookieNames)
 	require.ElementsMatch(t, []string{"", ""}, cookieValues)

--- a/pkg/ccl/serverccl/tenant_vars_test.go
+++ b/pkg/ccl/serverccl/tenant_vars_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net/http"
+	"net/url"
 	"os"
 	"testing"
 
@@ -62,13 +63,16 @@ func TestTenantVars(t *testing.T) {
 		}
 
 		startNowNanos := timeutil.Now().UnixNano()
-		url := tenant.AdminURL() + "/_status/load"
+		urlParsed, err := url.Parse(tenant.AdminURL())
+		require.NoError(t, err)
+		urlParsed.Path = urlParsed.Path + "/_status/load"
+		urlString := urlParsed.String()
 		client := http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			},
 		}
-		resp, err := client.Get(url)
+		resp, err := client.Get(urlString)
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		require.Equal(t, 200, resp.StatusCode,
@@ -115,7 +119,7 @@ func TestTenantVars(t *testing.T) {
 
 		require.LessOrEqual(t, 0., uptimeSeconds)
 
-		resp, err = client.Get(url)
+		resp, err = client.Get(urlString)
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		require.Equal(t, 200, resp.StatusCode,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1128,6 +1128,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		&systemServerWrapper{server: lateBoundServer},
 		systemTenantNameContainer,
 		pgPreServer.SendRoutingError,
+		cfg.BaseConfig.DisableTLSForHTTP,
 	)
 	drain.serverCtl = sc
 

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -85,6 +85,8 @@ type serverController struct {
 	// orchestrator is the orchestration method to use.
 	orchestrator serverOrchestrator
 
+	disableTLSForHTTP bool
+
 	mu struct {
 		syncutil.Mutex
 
@@ -111,6 +113,7 @@ func newServerController(
 	systemServer onDemandServer,
 	systemTenantNameContainer *roachpb.TenantNameContainer,
 	sendSQLRoutingError func(ctx context.Context, conn net.Conn, tenantName roachpb.TenantName),
+	disableTLSForHTTP bool,
 ) *serverController {
 	c := &serverController{
 		AmbientContext:      ambientCtx,
@@ -121,6 +124,7 @@ func newServerController(
 		stopper:             parentStopper,
 		tenantServerCreator: tenantServerCreator,
 		sendSQLRoutingError: sendSQLRoutingError,
+		disableTLSForHTTP:   disableTLSForHTTP,
 	}
 	c.orchestrator = newServerOrchestrator(parentStopper, c)
 	c.mu.servers = map[roachpb.TenantName]serverState{

--- a/pkg/server/server_controller_http.go
+++ b/pkg/server/server_controller_http.go
@@ -213,7 +213,7 @@ func (c *serverController) attemptLoginToAllTenants() http.Handler {
 				Name:     SessionCookieName,
 				Value:    sessionsStr,
 				Path:     "/",
-				HttpOnly: false,
+				HttpOnly: true,
 			}
 			http.SetCookie(w, &cookie)
 			// The tenant cookie needs to be set at some point in order for
@@ -331,7 +331,7 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 			Name:     SessionCookieName,
 			Value:    "",
 			Path:     "/",
-			HttpOnly: false,
+			HttpOnly: true,
 			Expires:  timeutil.Unix(0, 0),
 		}
 		http.SetCookie(w, &cookie)

--- a/pkg/server/server_controller_http.go
+++ b/pkg/server/server_controller_http.go
@@ -81,6 +81,7 @@ func (c *serverController) httpMux(w http.ResponseWriter, r *http.Request) {
 			Value:    "",
 			Path:     "/",
 			HttpOnly: true,
+			Secure:   !c.disableTLSForHTTP,
 			Expires:  timeutil.Unix(0, 0),
 		})
 		http.SetCookie(w, &http.Cookie{
@@ -88,6 +89,7 @@ func (c *serverController) httpMux(w http.ResponseWriter, r *http.Request) {
 			Value:    "",
 			Path:     "/",
 			HttpOnly: false,
+			Secure:   !c.disableTLSForHTTP,
 			Expires:  timeutil.Unix(0, 0),
 		})
 		// Fall back to serving requests from the default tenant. This helps us serve
@@ -214,6 +216,7 @@ func (c *serverController) attemptLoginToAllTenants() http.Handler {
 				Value:    sessionsStr,
 				Path:     "/",
 				HttpOnly: true,
+				Secure:   !c.disableTLSForHTTP,
 			}
 			http.SetCookie(w, &cookie)
 			// The tenant cookie needs to be set at some point in order for
@@ -235,6 +238,7 @@ func (c *serverController) attemptLoginToAllTenants() http.Handler {
 				Value:    tenantSelection,
 				Path:     "/",
 				HttpOnly: false,
+				Secure:   !c.disableTLSForHTTP,
 			}
 			http.SetCookie(w, &cookie)
 			if r.Header.Get(AcceptHeader) == JSONContentType {
@@ -332,6 +336,7 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 			Value:    "",
 			Path:     "/",
 			HttpOnly: true,
+			Secure:   !c.disableTLSForHTTP,
 			Expires:  timeutil.Unix(0, 0),
 		}
 		http.SetCookie(w, &cookie)
@@ -340,6 +345,7 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 			Value:    "",
 			Path:     "/",
 			HttpOnly: false,
+			Secure:   !c.disableTLSForHTTP,
 			Expires:  timeutil.Unix(0, 0),
 		}
 		http.SetCookie(w, &cookie)

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -13,7 +13,9 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/NYTimes/gziphandler"
 	"github.com/cockroachdb/cmux"
@@ -28,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -109,6 +112,56 @@ func (s *httpServer) handleHealth(healthHandler http.Handler) {
 	s.mux.Handle(healthPath, healthHandler)
 }
 
+const virtualClustersPath = "/virtual_clusters"
+
+// virtualClustersResp is the response returned by the virtual clusters
+// endpoint that contains a list of active tenant sessions in the
+// current session cookie. This allows the DB Console to populate a
+// dropdown allowing the user to select a cluster.
+type virtualClustersResp struct {
+	// VirtualClusters is a list of virtual cluster names.
+	VirtualClusters []string `json:"virtual_clusters"`
+}
+
+// virtualClustersHandler parses the session cookie from the request
+// and returns a JSON body with the list of cluster names contained
+// within the session. If the session does not contain any cluster
+// names, it returns an empty list. If the cookie is missing, it
+// returns 200 OK with an empty request body.
+var virtualClustersHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	sessionCookie, err := req.Cookie(SessionCookieName)
+	if err != nil {
+		if errors.Is(err, http.ErrNoCookie) {
+			w.Header().Add("Content-Type", "application/json")
+			if _, err := w.Write([]byte(`{"virtual_clusters":[]}`)); err != nil {
+				log.Errorf(req.Context(), "unable to write virtual clusters response: %s", err.Error())
+			}
+			return
+		}
+		http.Error(w, "unable to decode session cookie", http.StatusInternalServerError)
+		return
+	}
+	sessionsAndClusters := strings.Split(sessionCookie.Value, ",")
+	resp := &virtualClustersResp{
+		VirtualClusters: make([]string, 0),
+	}
+	for i, c := range sessionsAndClusters {
+		if i%2 == 1 {
+			resp.VirtualClusters = append(resp.VirtualClusters, c)
+		}
+	}
+
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, "unable to marshal virtual clusterse JSON", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Add("Content-Type", "application/json")
+	if _, err := w.Write(respBytes); err != nil {
+		log.Errorf(req.Context(), "unable to write virtual clusters response: %s", err.Error())
+	}
+})
+
 func (s *httpServer) setupRoutes(
 	ctx context.Context,
 	authnServer *authenticationServer,
@@ -167,6 +220,7 @@ func (s *httpServer) setupRoutes(
 	// The /login endpoint is, by definition, available pre-authentication.
 	s.mux.Handle(loginPath, handleRequestsUnauthenticated)
 	s.mux.Handle(logoutPath, authenticatedHandler)
+	s.mux.Handle(virtualClustersPath, virtualClustersHandler)
 	// The login path for 'cockroach demo', if we're currently running
 	// that.
 	if s.cfg.EnableDemoLoginEndpoint {

--- a/pkg/server/server_http_test.go
+++ b/pkg/server/server_http_test.go
@@ -12,10 +12,14 @@ package server
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -83,4 +87,103 @@ func TestHSTS(t *testing.T) {
 		defer resp.Body.Close()
 		require.Empty(t, resp.Header.Get(hstsHeaderKey))
 	}
+}
+
+func TestVirtualClustersSingleTenant(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	httpClient, err := s.GetUnauthenticatedHTTPClient()
+	require.NoError(t, err)
+	defer httpClient.CloseIdleConnections()
+
+	secureClient, err := s.GetAuthenticatedHTTPClient(false, serverutils.SingleTenantSession)
+	require.NoError(t, err)
+	defer secureClient.CloseIdleConnections()
+
+	adminURLHTTPS := s.AdminURL()
+	adminURLHTTP := strings.Replace(adminURLHTTPS, "https", "http", 1)
+
+	resp, err := httpClient.Get(adminURLHTTP + "/virtual_clusters")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	read, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "application/json", resp.Header.Get("content-type"))
+	require.Equal(t, `{"virtual_clusters":[]}`, string(read))
+
+	resp, err = secureClient.Get(adminURLHTTPS + "/virtual_clusters")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	read, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "application/json", resp.Header.Get("content-type"))
+	require.Equal(t, `{"virtual_clusters":[]}`, string(read))
+}
+
+func TestVirtualClustersMultiTenant(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	appServer, _, err := s.StartSharedProcessTenant(ctx,
+		base.TestSharedProcessTenantArgs{
+			TenantName: roachpb.TenantName("test-tenant"),
+		})
+	require.NoError(t, err)
+
+	httpClient, err := appServer.GetUnauthenticatedHTTPClient()
+	require.NoError(t, err)
+	defer httpClient.CloseIdleConnections()
+
+	secureClient, err := appServer.GetAuthenticatedHTTPClient(false, serverutils.MultiTenantSession)
+	require.NoError(t, err)
+	defer secureClient.CloseIdleConnections()
+
+	adminURLHTTPS, err := url.Parse(appServer.AdminURL())
+	require.NoError(t, err)
+	adminURLHTTPS.Scheme = "http"
+	adminURLHTTPS.Path = adminURLHTTPS.Path + "/virtual_clusters"
+
+	resp, err := httpClient.Get(adminURLHTTPS.String())
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	read, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "application/json", resp.Header.Get("content-type"))
+	require.Equal(t, `{"virtual_clusters":[]}`, string(read))
+
+	adminURLHTTPS.Scheme = "https"
+	resp, err = secureClient.Get(adminURLHTTPS.String())
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	read, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "application/json", resp.Header.Get("content-type"))
+	require.Equal(t, `{"virtual_clusters":["test-tenant"]}`, string(read))
+
+	secureClient.Jar.SetCookies(adminURLHTTPS, []*http.Cookie{
+		{
+			Name: "session",
+			Value: createAggregatedSessionCookieValue([]sessionCookieValue{
+				{"system", "session=abcd1234"},
+				{"app", "session=efgh5678"},
+			}),
+		},
+	})
+
+	adminURLHTTPS.Scheme = "https"
+	resp, err = secureClient.Get(adminURLHTTPS.String())
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	read, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "application/json", resp.Header.Get("content-type"))
+	require.Equal(t, `{"virtual_clusters":["system","app"]}`, string(read))
 }

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -938,6 +938,7 @@ func (ts *TestServer) StartSharedProcessTenant(
 	hts := &httpTestServer{}
 	hts.t.authentication = sqlServerWrapper.authentication
 	hts.t.sqlServer = sqlServer
+	hts.t.tenantName = args.TenantName
 	testTenant := &TestTenant{
 		sql:            sqlServer,
 		Cfg:            sqlServer.cfg,

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -49,6 +49,10 @@ stubComponentInModule("src/views/insights/schemaInsightsPage", "default");
 stubComponentInModule("src/views/schedules/schedulesPage", "default");
 stubComponentInModule("src/views/schedules/scheduleDetails", "default");
 stubComponentInModule("src/views/tracez_v2/snapshotPage", "default");
+stubComponentInModule(
+  "src/views/app/components/tenantDropdown/tenantDropdown",
+  "default",
+);
 
 import React from "react";
 import { Action, Store } from "redux";

--- a/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
@@ -28,7 +28,7 @@ import { util as clusterUiUtil } from "@cockroachlabs/cluster-ui";
 const { isForbiddenRequestError } = clusterUiUtil;
 
 import { PayloadAction, WithRequest } from "src/interfaces/action";
-import { maybeClearTenantCookie } from "./cookies";
+import { clearTenantCookie } from "./cookies";
 
 export interface WithPaginationRequest {
   page_size: number;
@@ -320,7 +320,10 @@ export class CachedDataReducer<
             // codes.  However, at the moment that's all that the underlying
             // timeoutFetch offers.  Major changes to this plumbing are warranted.
             if (error.message === "Unauthorized") {
-              maybeClearTenantCookie();
+              // Clearing the tenant cookie is necessary when we force a login
+              // because otherwise the DB routing will continue routing to that
+              // specific tenant.
+              clearTenantCookie();
               // TODO(couchand): This is an unpleasant dependency snuck in here...
               const { location } = createHashHistory();
               if (

--- a/pkg/ui/workspaces/db-console/src/redux/cookies.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cookies.spec.ts
@@ -1,0 +1,55 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import {
+  getAllCookies,
+  getCookieValue,
+  clearTenantCookie,
+  setCookie,
+} from "./cookies";
+
+describe("Cookies", () => {
+  beforeEach(() => {
+    Object.defineProperty(window.document, "cookie", {
+      writable: true,
+      value: "tenant=system;someother=cookie;another=cookievalue",
+    });
+  });
+  afterEach(() => {
+    Object.defineProperty(window.document, "cookie", {
+      writable: true,
+      value: "",
+    });
+  });
+  it("should return a map of cookie keys mapped to their values", () => {
+    const result = getAllCookies();
+    const expected = new Map();
+    expected.set("tenant", "system");
+    expected.set("someother", "cookie");
+    expected.set("another", "cookievalue");
+    expect(result).toEqual(expected);
+  });
+  it("should return a cookie value by key or return null", () => {
+    const result = getCookieValue("tenant");
+    const expected = "system";
+    expect(result).toEqual(expected);
+    const result2 = getCookieValue("unknown");
+    expect(result2).toBeNull();
+  });
+  it("should clear the tenant cookie", () => {
+    clearTenantCookie();
+    const tenantCookie = getCookieValue("tenant");
+    expect(tenantCookie).toBeNull();
+  });
+  it("should set a cookie given a key and value", () => {
+    setCookie("foo", "bar");
+    const result = getCookieValue("foo");
+    expect(result).toEqual("bar");
+  });
+});

--- a/pkg/ui/workspaces/db-console/src/redux/cookies.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cookies.ts
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export const MULTITENANT_SESSION_COOKIE_NAME = "session";
 export const SYSTEM_TENANT_NAME = "system";
 
 export const getAllCookies = (): Map<string, string> => {
@@ -27,28 +26,8 @@ export const getCookieValue = (cookieName: string): string => {
   return cookies.get(cookieName) || null;
 };
 
-// selectTenantsFromMultitenantSessionCookie formats the session
-// cookie value and returns only the tenant names.
-export const selectTenantsFromMultitenantSessionCookie = (): string[] => {
-  const cookies = getAllCookies();
-  const sessionsStr = cookies.get(MULTITENANT_SESSION_COOKIE_NAME);
-  return sessionsStr
-    ? sessionsStr
-        .replace(/["]/g, "")
-        .split(/[,]/g)
-        .filter((_, idx) => idx % 2 == 1)
-    : [];
-};
-
-// maybeClearTenantCookie clears the tenant cookie if there are multiple tenants
-// found in the multitenant-session cookie.
-export const maybeClearTenantCookie = () => {
-  const tenants = selectTenantsFromMultitenantSessionCookie();
-  // If in multi-tenant environment, we need to clear the tenant cookie so that
-  // we can do a multi-tenant logout.
-  if (tenants.length > 1) {
-    setCookie("tenant", "");
-  }
+export const clearTenantCookie = () => {
+  setCookie("tenant", "");
 };
 
 export const setCookie = (

--- a/pkg/ui/workspaces/db-console/src/redux/login.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/login.ts
@@ -20,7 +20,7 @@ import { cockroach } from "src/js/protos";
 import { getDataFromServer } from "src/util/dataFromServer";
 
 import UserLoginRequest = cockroach.server.serverpb.UserLoginRequest;
-import { maybeClearTenantCookie } from "./cookies";
+import { clearTenantCookie } from "./cookies";
 
 const dataFromServer = getDataFromServer();
 
@@ -217,7 +217,9 @@ export function doLogout(): ThunkAction<
 > {
   return dispatch => {
     dispatch(logoutBeginAction);
-    maybeClearTenantCookie();
+    // Clearing the tenant cookie on logout is necessary in order to
+    // avoid routing login requests to that specific tenant.
+    clearTenantCookie();
     // Make request to log out, reloading the page whether it succeeds or not.
     // If there was a successful log out but the network dropped the response somehow,
     // you'll get the login page on reload. If The logout actually didn't work, you'll

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.spec.tsx
@@ -7,39 +7,56 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import {
-  selectTenantsFromMultitenantSessionCookie,
-  getCookieValue,
-} from "src/redux/cookies";
+import { getCookieValue } from "src/redux/cookies";
 import React from "react";
 import TenantDropdown from "./tenantDropdown";
 import { shallow } from "enzyme";
+import fetchMock from "fetch-mock";
 
 jest.mock("src/redux/cookies", () => ({
-  selectTenantsFromMultitenantSessionCookie: jest.fn(),
   getCookieValue: jest.fn(),
 }));
 
 describe("TenantDropdown", () => {
+  beforeEach(() => {});
+
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
   it("returns null if there's no current virtual cluster", () => {
-    (
-      selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
-        typeof selectTenantsFromMultitenantSessionCookie
-      >
-    ).mockReturnValueOnce([]);
+    fetchMock.mock({
+      matcher: `virtual_clusters`,
+      method: "GET",
+      response: () => {
+        return {
+          body: JSON.stringify({
+            virtual_clusters: [],
+          }),
+        };
+      },
+    });
+
     (
       getCookieValue as jest.MockedFn<typeof getCookieValue>
     ).mockReturnValueOnce(null);
     const wrapper = shallow(<TenantDropdown />);
     expect(wrapper.isEmptyRender());
   });
-  // Mutli-tenant scenarios
+  // Multi-tenant scenarios
   it("returns null if there are no virtual clusters or less than 2 in the session cookie", () => {
-    (
-      selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
-        typeof selectTenantsFromMultitenantSessionCookie
-      >
-    ).mockReturnValueOnce(["system"]);
+    fetchMock.mock({
+      matcher: `virtual_clusters`,
+      method: "GET",
+      response: () => {
+        return {
+          body: JSON.stringify({
+            virtual_clusters: ["system"],
+          }),
+        };
+      },
+    });
+
     (
       getCookieValue as jest.MockedFn<typeof getCookieValue>
     ).mockReturnValueOnce("system");
@@ -47,11 +64,18 @@ describe("TenantDropdown", () => {
     expect(wrapper.isEmptyRender());
   });
   it("returns a dropdown list of tenant options if there are multiple virtual clusters in the session cookie", () => {
-    (
-      selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
-        typeof selectTenantsFromMultitenantSessionCookie
-      >
-    ).mockReturnValueOnce(["system", "app"]);
+    fetchMock.mock({
+      matcher: `virtual_clusters`,
+      method: "GET",
+      response: () => {
+        return {
+          body: JSON.stringify({
+            virtual_clusters: ["system", "app"],
+          }),
+        };
+      },
+    });
+
     (
       getCookieValue as jest.MockedFn<typeof getCookieValue>
     ).mockReturnValueOnce("system");
@@ -61,11 +85,18 @@ describe("TenantDropdown", () => {
     ).toEqual(1);
   });
   it("returns a dropdown if the there is a single virtual cluster option but isn't system", () => {
-    (
-      selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
-        typeof selectTenantsFromMultitenantSessionCookie
-      >
-    ).mockReturnValueOnce(["app"]);
+    fetchMock.mock({
+      matcher: `virtual_clusters`,
+      method: "GET",
+      response: () => {
+        return {
+          body: JSON.stringify({
+            virtual_clusters: ["app"],
+          }),
+        };
+      },
+    });
+
     (
       getCookieValue as jest.MockedFn<typeof getCookieValue>
     ).mockReturnValueOnce("app");


### PR DESCRIPTION
### server, ui: session cookie is HttpOnly 

This change removes the ability of the DB Console JS code to read
the `session` cookie from the browser by setting the `HttpOnly` flag
to `true`.

This change requires a modification of how the `TenantDropdown`
components works since it relied on reading the `session` cookie and
extracting the list of logged-in tenants from it.

Instead of reading the cookie, the component now relies on a server-
side endpoint to "read back" the list of tenants in the session. You
might ask why this is necessary because we could return the list of
valid tenants on `/login` success and have them available outright.
There is a reason why that's not sufficient.

When you are logged in to multiple tenants with a valid session, you
can switch between them in the dropdown switcher. This switch occurs
without a subsequent call to `/login`, and will just set the `tenant`
cookie to the new tenant name and issue a full refresh to the browser
which will re-render everything. In this case, the `TenantDropdown`
component gets fully re-rendered but no longer has access to the
state it was initialized with containing all the valid tenants. This
necessitates adding an endpoint that the component can use to populate
itself directly whenever it's rendered.

Epic: None
Fixes: [CRDB-36034](https://cockroachlabs.atlassian.net/browse/CRDB-36034)

Release note (security update): DB Console `session` cookie is now
marked `HttpOnly` to prevent it from being read by any Javascript
code.

----

### server: set Secure on cookies if cluster is secure 

Cookie `Secure` setting is based on `disableTLSForHTTP` passed down
from the server.

Part of [CRDB-36034](https://cockroachlabs.atlassian.net/browse/CRDB-36034)
Epic: None

Release note (security update): DB Console cookies are marked `Secure`
for the browser when the cluster is running in secure mode.

----

Release justification: high-priority need for fix