### PR TITLE
roachtest: use http url in follower-reads test

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -684,7 +684,9 @@ func verifySQLLatency(
 	if err != nil {
 		t.Fatal(err)
 	}
-	url := "https://" + adminURLs[0] + "/ts/query"
+	// follower-reads/mixed-version runs on insecure mode, so we need http.
+	// Tests that do run on secure mode will redirect to https.
+	url := "http://" + adminURLs[0] + "/ts/query"
 	var sources []string
 	for i := range liveNodes {
 		sources = append(sources, strconv.Itoa(i))


### PR DESCRIPTION
`verifySQLLatency` was using `https` which will error out if the client expects `http`. The mixed-version tests are running on insecure mode and use `http` while other tests use `https` and will redirect `http` to it.

Release note: none
Epic: none
Fixes: #119245