### PR TITLE
schemachanger: Fix concurrent DML failure when dropping a column with depended on by indexes/constraints

### DIFF
--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -392,6 +392,14 @@ func TestAlterTableDMLInjection(t *testing.T) {
 			skipIssue:    97813,
 		},
 		{
+			desc: "drop column with check constraint",
+			setup: []string{
+				"ALTER TABLE tbl ADD COLUMN i INT NOT NULL DEFAULT 1",
+				"ALTER TABLE tbl ADD CONSTRAINT check_i CHECK (i > 0)",
+			},
+			schemaChange: "ALTER TABLE tbl DROP COLUMN i",
+		},
+		{
 			desc:         "create expression index",
 			schemaChange: "CREATE INDEX idx ON tbl ((val + 1))",
 		},

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -221,16 +221,33 @@ type SetAddedColumnType struct {
 	ColumnType scpb.ColumnType
 }
 
-// MakeWriteOnlyColumnPublic moves a new column from its mutation to public.
-type MakeWriteOnlyColumnPublic struct {
+// MakeWriteOnlyColumnPublicButInaccessible moves a new column from its mutation
+// to public but still inaccessible.
+type MakeWriteOnlyColumnPublicButInaccessible struct {
 	immediateMutationOp
 	TableID  descpb.ID
 	ColumnID descpb.ColumnID
 }
 
-// MakePublicColumnWriteOnly zeros out the column and adds
+// MakePublicButInaccessibleColumnPublic moves a public but inaccessible
+// column to fully public.
+type MakePublicButInaccessibleColumnPublic struct {
+	immediateMutationOp
+	TableID  descpb.ID
+	ColumnID descpb.ColumnID
+}
+
+// MakePublicColumnPublicButInaccessible makes a public inaccessible (but still
+// public).
+type MakePublicColumnPublicButInaccessible struct {
+	immediateMutationOp
+	TableID  descpb.ID
+	ColumnID descpb.ColumnID
+}
+
+// MakePublicButInaccessibleColumnWriteOnly zeros out the column and adds
 // a column drop mutation in WRITE_ONLY for it.
-type MakePublicColumnWriteOnly struct {
+type MakePublicButInaccessibleColumnWriteOnly struct {
 	immediateMutationOp
 	TableID  descpb.ID
 	ColumnID descpb.ColumnID

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -47,8 +47,10 @@ type ImmediateMutationVisitor interface {
 	MakeIndexAbsent(context.Context, MakeIndexAbsent) error
 	MakeAbsentColumnDeleteOnly(context.Context, MakeAbsentColumnDeleteOnly) error
 	SetAddedColumnType(context.Context, SetAddedColumnType) error
-	MakeWriteOnlyColumnPublic(context.Context, MakeWriteOnlyColumnPublic) error
-	MakePublicColumnWriteOnly(context.Context, MakePublicColumnWriteOnly) error
+	MakeWriteOnlyColumnPublicButInaccessible(context.Context, MakeWriteOnlyColumnPublicButInaccessible) error
+	MakePublicButInaccessibleColumnPublic(context.Context, MakePublicButInaccessibleColumnPublic) error
+	MakePublicColumnPublicButInaccessible(context.Context, MakePublicColumnPublicButInaccessible) error
+	MakePublicButInaccessibleColumnWriteOnly(context.Context, MakePublicButInaccessibleColumnWriteOnly) error
 	MakeWriteOnlyColumnDeleteOnly(context.Context, MakeWriteOnlyColumnDeleteOnly) error
 	RemoveDroppedColumnType(context.Context, RemoveDroppedColumnType) error
 	MakeDeleteOnlyColumnAbsent(context.Context, MakeDeleteOnlyColumnAbsent) error
@@ -257,13 +259,23 @@ func (op SetAddedColumnType) Visit(ctx context.Context, v ImmediateMutationVisit
 }
 
 // Visit is part of the ImmediateMutationOp interface.
-func (op MakeWriteOnlyColumnPublic) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
-	return v.MakeWriteOnlyColumnPublic(ctx, op)
+func (op MakeWriteOnlyColumnPublicButInaccessible) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.MakeWriteOnlyColumnPublicButInaccessible(ctx, op)
 }
 
 // Visit is part of the ImmediateMutationOp interface.
-func (op MakePublicColumnWriteOnly) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
-	return v.MakePublicColumnWriteOnly(ctx, op)
+func (op MakePublicButInaccessibleColumnPublic) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.MakePublicButInaccessibleColumnPublic(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op MakePublicColumnPublicButInaccessible) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.MakePublicColumnPublicButInaccessible(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op MakePublicButInaccessibleColumnWriteOnly) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.MakePublicButInaccessibleColumnWriteOnly(ctx, op)
 }
 
 // Visit is part of the ImmediateMutationOp interface.

--- a/pkg/sql/schemachanger/scpb/scpb.proto
+++ b/pkg/sql/schemachanger/scpb/scpb.proto
@@ -67,10 +67,16 @@ enum Status {
   TRANSIENT_VALIDATED = 20;
   TRANSIENT_PUBLIC = 21;
   TRANSIENT_DROPPED = 22;
+  TRANSIENT_PUBLIC_BUT_INACCESSIBLE = 24;
 
   // When a basic descriptor (the object element) is first created before all
   // the other dependent elements become public.
   DESCRIPTOR_ADDED = 23;
+
+  // Public_But_Inaccessible is used for column element. It is a status where
+  // the column is public but inaccessible. This is the last status before
+  // transitioning into Public status.
+  PUBLIC_BUT_INACCESSIBLE = 25;
 }
 
 // TargetMetadata refers to the metadata for individual elements, where

--- a/pkg/sql/schemachanger/scpb/transient.go
+++ b/pkg/sql/schemachanger/scpb/transient.go
@@ -30,14 +30,15 @@ func GetNonTransientEquivalent(s Status) (Status, bool) {
 }
 
 var transientEquivalent = map[Status]Status{
-	Status_DELETE_ONLY:   Status_TRANSIENT_DELETE_ONLY,
-	Status_WRITE_ONLY:    Status_TRANSIENT_WRITE_ONLY,
-	Status_ABSENT:        Status_TRANSIENT_ABSENT,
-	Status_PUBLIC:        Status_TRANSIENT_PUBLIC,
-	Status_BACKFILL_ONLY: Status_TRANSIENT_BACKFILL_ONLY,
-	Status_BACKFILLED:    Status_TRANSIENT_BACKFILLED,
-	Status_MERGE_ONLY:    Status_TRANSIENT_MERGE_ONLY,
-	Status_MERGED:        Status_TRANSIENT_MERGED,
-	Status_VALIDATED:     Status_TRANSIENT_VALIDATED,
-	Status_DROPPED:       Status_TRANSIENT_DROPPED,
+	Status_DELETE_ONLY:             Status_TRANSIENT_DELETE_ONLY,
+	Status_WRITE_ONLY:              Status_TRANSIENT_WRITE_ONLY,
+	Status_ABSENT:                  Status_TRANSIENT_ABSENT,
+	Status_PUBLIC:                  Status_TRANSIENT_PUBLIC,
+	Status_BACKFILL_ONLY:           Status_TRANSIENT_BACKFILL_ONLY,
+	Status_BACKFILLED:              Status_TRANSIENT_BACKFILLED,
+	Status_MERGE_ONLY:              Status_TRANSIENT_MERGE_ONLY,
+	Status_MERGED:                  Status_TRANSIENT_MERGED,
+	Status_VALIDATED:               Status_TRANSIENT_VALIDATED,
+	Status_DROPPED:                 Status_TRANSIENT_DROPPED,
+	Status_PUBLIC_BUT_INACCESSIBLE: Status_TRANSIENT_PUBLIC_BUT_INACCESSIBLE,
 }

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_column.go
@@ -22,10 +22,10 @@ import (
 func init() {
 
 	registerDepRuleForDrop(
-		"column no longer public before dependents",
+		"column no longer accessible before dependents",
 		scgraph.Precedence,
 		"column", "dependent",
-		scpb.Status_WRITE_ONLY, scpb.Status_ABSENT,
+		scpb.Status_PUBLIC_BUT_INACCESSIBLE, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.Column)(nil)),


### PR DESCRIPTION
This PR is a partial work to address a few concurrent DML failures with ongoing schema changes. The main theme of those failures involves dropping a column with dependent hash-sharded index, or expression index, or constraint, as reported in #111608, #111619, and #118314.

Our proposed solution is to introduce a new status for column element in the DSC so that the transition becomes

ABSENT <--> DELETE_ONLY <--> WRITE_ONLY <--> PUBLIC_BUT_INACCESSIBLE <--> PUBLIC

where the column stays in that newly introduced PUBLIC_BUT_INACCESSIBLE state until we hit NonRevertible phase where no thing could fail, at which time we can transition the column to non-public and eventually absent. It gives us two desirable effects with this approach:
    1. the column is still public for the optimizer so that the current DML failure, which mostly revolves around a column is no longer public, can be solved;
    2. the column is inaccessible for the user so it cannot be referenced in user queries, creating an effect of a dropped (or a dropping) column.