### PR TITLE
changefeedccl: re-enable pulsar sink in unit tests

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -881,7 +881,7 @@ func randomSinkTypeWithOptions(options feedTestOptions) string {
 		"pubsub":       1,
 		"sinkless":     2,
 		"cloudstorage": 0,
-		"pulsar":       0,
+		"pulsar":       1,
 	}
 	if options.externalIODir != "" {
 		sinkWeights["cloudstorage"] = 3
@@ -1247,6 +1247,7 @@ func verifyLogsWithEmittedBytesAndMessages(
 		var emittedBytes int64 = 0
 		var emittedMessages int64 = 0
 		for _, msg := range emittedBytesLogs {
+			t.Logf("read message %v", msg)
 			if msg.JobId != int64(jobID) {
 				continue
 			}


### PR DESCRIPTION
### changefeedccl: re-enable pulsar sink in unit tests
In https://github.com/cockroachdb/cockroach/pull/118975, unit tests were changed so the pulsar sink is not used.
This is because certain unit tests were failing with the pulsar sink.

This change fixes a bug which caused those unit tests to fail.
A metrics callback was not being called, which caused tests
related to telemetry and metrics to fail. This change fixes
the code to call this callback.

Release note: None
Epic: None

---

### do not merge: force pulsar sink in failing tests in CI
This change will not be merged. It forces the pulsar sink to be used
in tests.

Release note: None
