### PR TITLE
workflows: adjust shutdown logic

### DIFF
--- a/build/github/run-bazel.sh
+++ b/build/github/run-bazel.sh
@@ -1,11 +1,17 @@
+#!/usr/bin/env bash
+
 # Any arguments passed to this script will be directly passed to Bazel. In
 # addition to just calling Bazel, this script has the property that the Bazel
 # server will be killed if we receive an interrupt.
 
-bazel_shutdown() {
-    bazel shutdown
+kill_bazel() {
+    PIDS=$(ps -ef | grep bazel | grep -v run-bazel.sh | grep -v grep | awk '{print $2}')
+    for PID in $PIDS
+    do
+        kill -KILL $PID
+    done
 }
 
-trap bazel_shutdown EXIT
+trap kill_bazel INT TERM
 
 bazel "$@"


### PR DESCRIPTION
This script was flawed in a couple ways:
1. `bazel shutdown` is too nice for what we need to do as it waits for
   running builds to complete before the exit actually occurs.
2. We used `EXIT` which runs unconditionally on process exit.

Instead we `killall bazel` if we receive a `SIGINT` or `SIGTERM`.

Epic: [CRDB-8308](https://cockroachlabs.atlassian.net/browse/CRDB-8308)
Release note: None