### PR TITLE
execstats: fix possible race

### DIFF
--- a/pkg/sql/colfetcher/colbatch_direct_scan.go
+++ b/pkg/sql/colfetcher/colbatch_direct_scan.go
@@ -59,7 +59,7 @@ func (s *ColBatchDirectScan) Init(ctx context.Context) {
 	}
 	s.Ctx, s.tracingSpan = execinfra.ProcessorSpan(
 		s.Ctx, s.flowCtx, "colbatchdirectscan", s.processorID,
-		&s.contentionEventsListener, &s.scanStatsListener, &s.tenantConsumptionListener,
+		&s.ContentionEventsListener, &s.ScanStatsListener, &s.TenantConsumptionListener,
 	)
 	firstBatchLimit := cFetcherFirstBatchLimit(s.limitHint, s.spec.MaxKeysPerRow)
 	err := s.fetcher.SetupNextFetch(

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -109,11 +109,11 @@ type ColIndexJoin struct {
 
 	// tracingSpan is created when the stats should be collected for the query
 	// execution, and it will be finished when closing the operator.
-	tracingSpan               *tracing.Span
-	contentionEventsListener  execstats.ContentionEventsListener
-	scanStatsListener         execstats.ScanStatsListener
-	tenantConsumptionListener execstats.TenantConsumptionListener
-	mu                        struct {
+	tracingSpan *tracing.Span
+	execstats.ContentionEventsListener
+	execstats.ScanStatsListener
+	execstats.TenantConsumptionListener
+	mu struct {
 		syncutil.Mutex
 		// rowsRead contains the number of total rows this ColIndexJoin has
 		// returned so far.
@@ -142,7 +142,7 @@ func (s *ColIndexJoin) Init(ctx context.Context) {
 	}
 	s.Ctx, s.tracingSpan = execinfra.ProcessorSpan(
 		s.Ctx, s.flowCtx, "colindexjoin", s.processorID,
-		&s.contentionEventsListener, &s.scanStatsListener, &s.tenantConsumptionListener,
+		&s.ContentionEventsListener, &s.ScanStatsListener, &s.TenantConsumptionListener,
 	)
 	s.Input.Init(s.Ctx)
 }
@@ -415,21 +415,6 @@ func (s *ColIndexJoin) GetBatchRequestsIssued() int64 {
 // GetKVCPUTime is part of the colexecop.KVReader interface.
 func (s *ColIndexJoin) GetKVCPUTime() time.Duration {
 	return s.cf.cpuStopWatch.Elapsed()
-}
-
-// GetContentionTime is part of the colexecop.KVReader interface.
-func (s *ColIndexJoin) GetContentionTime() time.Duration {
-	return s.contentionEventsListener.CumulativeContentionTime
-}
-
-// GetScanStats is part of the colexecop.KVReader interface.
-func (s *ColIndexJoin) GetScanStats() execstats.ScanStats {
-	return s.scanStatsListener.ScanStats
-}
-
-// GetConsumedRU is part of the colexecop.KVReader interface.
-func (s *ColIndexJoin) GetConsumedRU() uint64 {
-	return s.tenantConsumptionListener.ConsumedRU
 }
 
 // UsedStreamer is part of the colexecop.KVReader interface.

--- a/pkg/sql/execstats/BUILD.bazel
+++ b/pkg/sql/execstats/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/optional",
         "//pkg/util/protoutil",
+        "//pkg/util/syncutil",
         "//pkg/util/tracing",
         "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/execstats/stats.go
+++ b/pkg/sql/execstats/stats.go
@@ -12,12 +12,14 @@ package execstats
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/optional"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
@@ -32,7 +34,7 @@ func ShouldCollectStats(ctx context.Context, collectStats bool) bool {
 // ContentionEventsListener calculates the cumulative contention time across all
 // kvpb.ContentionEvents seen by the listener.
 type ContentionEventsListener struct {
-	CumulativeContentionTime time.Duration
+	cumulativeContentionTime int64 // atomic
 }
 
 var _ tracing.EventListener = &ContentionEventsListener{}
@@ -43,14 +45,23 @@ func (c *ContentionEventsListener) Notify(event tracing.Structured) tracing.Even
 	if !ok {
 		return tracing.EventNotConsumed
 	}
-	c.CumulativeContentionTime += ce.Duration
+	atomic.AddInt64(&c.cumulativeContentionTime, int64(ce.Duration))
 	return tracing.EventConsumed
+}
+
+// GetContentionTime returns the cumulative contention time this listener has
+// seen so far.
+func (c *ContentionEventsListener) GetContentionTime() time.Duration {
+	return time.Duration(atomic.LoadInt64(&c.cumulativeContentionTime))
 }
 
 // ScanStatsListener aggregates all kvpb.ScanStats objects into a single
 // ScanStats object.
 type ScanStatsListener struct {
-	ScanStats
+	mu struct {
+		syncutil.Mutex
+		ScanStats
+	}
 }
 
 var _ tracing.EventListener = &ScanStatsListener{}
@@ -61,32 +72,41 @@ func (l *ScanStatsListener) Notify(event tracing.Structured) tracing.EventConsum
 	if !ok {
 		return tracing.EventNotConsumed
 	}
-	l.ScanStats.NumInterfaceSteps += ss.NumInterfaceSteps
-	l.ScanStats.NumInternalSteps += ss.NumInternalSteps
-	l.ScanStats.NumInterfaceSeeks += ss.NumInterfaceSeeks
-	l.ScanStats.NumInternalSeeks += ss.NumInternalSeeks
-	l.ScanStats.BlockBytes += ss.BlockBytes
-	l.ScanStats.BlockBytesInCache += ss.BlockBytesInCache
-	l.ScanStats.KeyBytes += ss.KeyBytes
-	l.ScanStats.ValueBytes += ss.ValueBytes
-	l.ScanStats.PointCount += ss.PointCount
-	l.ScanStats.PointsCoveredByRangeTombstones += ss.PointsCoveredByRangeTombstones
-	l.ScanStats.RangeKeyCount += ss.RangeKeyCount
-	l.ScanStats.RangeKeyContainedPoints += ss.RangeKeyContainedPoints
-	l.ScanStats.RangeKeySkippedPoints += ss.RangeKeySkippedPoints
-	l.ScanStats.SeparatedPointCount += ss.SeparatedPointCount
-	l.ScanStats.SeparatedPointValueBytes += ss.SeparatedPointValueBytes
-	l.ScanStats.SeparatedPointValueBytesFetched += ss.SeparatedPointValueBytesFetched
-	l.ScanStats.NumGets += ss.NumGets
-	l.ScanStats.NumScans += ss.NumScans
-	l.ScanStats.NumReverseScans += ss.NumReverseScans
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.mu.ScanStats.numInterfaceSteps += ss.NumInterfaceSteps
+	l.mu.ScanStats.numInternalSteps += ss.NumInternalSteps
+	l.mu.ScanStats.numInterfaceSeeks += ss.NumInterfaceSeeks
+	l.mu.ScanStats.numInternalSeeks += ss.NumInternalSeeks
+	l.mu.ScanStats.blockBytes += ss.BlockBytes
+	l.mu.ScanStats.blockBytesInCache += ss.BlockBytesInCache
+	l.mu.ScanStats.keyBytes += ss.KeyBytes
+	l.mu.ScanStats.valueBytes += ss.ValueBytes
+	l.mu.ScanStats.pointCount += ss.PointCount
+	l.mu.ScanStats.pointsCoveredByRangeTombstones += ss.PointsCoveredByRangeTombstones
+	l.mu.ScanStats.rangeKeyCount += ss.RangeKeyCount
+	l.mu.ScanStats.rangeKeyContainedPoints += ss.RangeKeyContainedPoints
+	l.mu.ScanStats.rangeKeySkippedPoints += ss.RangeKeySkippedPoints
+	l.mu.ScanStats.separatedPointCount += ss.SeparatedPointCount
+	l.mu.ScanStats.separatedPointValueBytes += ss.SeparatedPointValueBytes
+	l.mu.ScanStats.separatedPointValueBytesFetched += ss.SeparatedPointValueBytesFetched
+	l.mu.ScanStats.numGets += ss.NumGets
+	l.mu.ScanStats.numScans += ss.NumScans
+	l.mu.ScanStats.numReverseScans += ss.NumReverseScans
 	return tracing.EventConsumed
+}
+
+// GetScanStats returns all ScanStats the listener has accumulated so far.
+func (l *ScanStatsListener) GetScanStats() ScanStats {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.mu.ScanStats
 }
 
 // TenantConsumptionListener aggregates consumed RUs from all
 // kvpb.TenantConsumption events seen by the listener.
 type TenantConsumptionListener struct {
-	ConsumedRU uint64
+	consumedRU uint64 // atomic
 }
 
 var _ tracing.EventListener = &TenantConsumptionListener{}
@@ -99,8 +119,13 @@ func (l *TenantConsumptionListener) Notify(
 	if !ok {
 		return tracing.EventNotConsumed
 	}
-	l.ConsumedRU += uint64(tc.RU)
+	atomic.AddUint64(&l.consumedRU, uint64(tc.RU))
 	return tracing.EventConsumed
+}
+
+// GetConsumedRU returns all consumed RUs that this listener has seen so far.
+func (l *TenantConsumptionListener) GetConsumedRU() uint64 {
+	return atomic.LoadUint64(&l.consumedRU)
 }
 
 // ScanStats contains statistics on the internal MVCC operators used to satisfy
@@ -109,51 +134,51 @@ func (l *TenantConsumptionListener) Notify(
 // TODO(sql-observability): include other fields that are in roachpb.ScanStats,
 // here and in execinfrapb.KVStats.
 type ScanStats struct {
-	// NumInterfaceSteps is the number of times the MVCC step function was called
+	// numInterfaceSteps is the number of times the MVCC step function was called
 	// to satisfy a scan.
-	NumInterfaceSteps uint64
-	// NumInternalSteps is the number of times that MVCC step was invoked
+	numInterfaceSteps uint64
+	// numInternalSteps is the number of times that MVCC step was invoked
 	// internally, including to step over internal, uncompacted Pebble versions.
-	NumInternalSteps uint64
-	// NumInterfaceSeeks is the number of times the MVCC seek function was called
+	numInternalSteps uint64
+	// numInterfaceSeeks is the number of times the MVCC seek function was called
 	// to satisfy a scan.
-	NumInterfaceSeeks uint64
-	// NumInternalSeeks is the number of times that MVCC seek was invoked
+	numInterfaceSeeks uint64
+	// numInternalSeeks is the number of times that MVCC seek was invoked
 	// internally, including to step over internal, uncompacted Pebble versions.
-	NumInternalSeeks                uint64
-	BlockBytes                      uint64
-	BlockBytesInCache               uint64
-	KeyBytes                        uint64
-	ValueBytes                      uint64
-	PointCount                      uint64
-	PointsCoveredByRangeTombstones  uint64
-	RangeKeyCount                   uint64
-	RangeKeyContainedPoints         uint64
-	RangeKeySkippedPoints           uint64
-	SeparatedPointCount             uint64
-	SeparatedPointValueBytes        uint64
-	SeparatedPointValueBytesFetched uint64
-	NumGets                         uint64
-	NumScans                        uint64
-	NumReverseScans                 uint64
+	numInternalSeeks                uint64
+	blockBytes                      uint64
+	blockBytesInCache               uint64
+	keyBytes                        uint64
+	valueBytes                      uint64
+	pointCount                      uint64
+	pointsCoveredByRangeTombstones  uint64
+	rangeKeyCount                   uint64
+	rangeKeyContainedPoints         uint64
+	rangeKeySkippedPoints           uint64
+	separatedPointCount             uint64
+	separatedPointValueBytes        uint64
+	separatedPointValueBytesFetched uint64
+	numGets                         uint64
+	numScans                        uint64
+	numReverseScans                 uint64
 }
 
 // PopulateKVMVCCStats adds data from the input ScanStats to the input KVStats.
 func PopulateKVMVCCStats(kvStats *execinfrapb.KVStats, ss *ScanStats) {
-	kvStats.NumInterfaceSteps = optional.MakeUint(ss.NumInterfaceSteps)
-	kvStats.NumInternalSteps = optional.MakeUint(ss.NumInternalSteps)
-	kvStats.NumInterfaceSeeks = optional.MakeUint(ss.NumInterfaceSeeks)
-	kvStats.NumInternalSeeks = optional.MakeUint(ss.NumInternalSeeks)
-	kvStats.BlockBytes = optional.MakeUint(ss.BlockBytes)
-	kvStats.BlockBytesInCache = optional.MakeUint(ss.BlockBytesInCache)
-	kvStats.KeyBytes = optional.MakeUint(ss.KeyBytes)
-	kvStats.ValueBytes = optional.MakeUint(ss.ValueBytes)
-	kvStats.PointCount = optional.MakeUint(ss.PointCount)
-	kvStats.PointsCoveredByRangeTombstones = optional.MakeUint(ss.PointsCoveredByRangeTombstones)
-	kvStats.RangeKeyCount = optional.MakeUint(ss.RangeKeyCount)
-	kvStats.RangeKeyContainedPoints = optional.MakeUint(ss.RangeKeyContainedPoints)
-	kvStats.RangeKeySkippedPoints = optional.MakeUint(ss.RangeKeySkippedPoints)
-	kvStats.NumGets = optional.MakeUint(ss.NumGets)
-	kvStats.NumScans = optional.MakeUint(ss.NumScans)
-	kvStats.NumReverseScans = optional.MakeUint(ss.NumReverseScans)
+	kvStats.NumInterfaceSteps = optional.MakeUint(ss.numInterfaceSteps)
+	kvStats.NumInternalSteps = optional.MakeUint(ss.numInternalSteps)
+	kvStats.NumInterfaceSeeks = optional.MakeUint(ss.numInterfaceSeeks)
+	kvStats.NumInternalSeeks = optional.MakeUint(ss.numInternalSeeks)
+	kvStats.BlockBytes = optional.MakeUint(ss.blockBytes)
+	kvStats.BlockBytesInCache = optional.MakeUint(ss.blockBytesInCache)
+	kvStats.KeyBytes = optional.MakeUint(ss.keyBytes)
+	kvStats.ValueBytes = optional.MakeUint(ss.valueBytes)
+	kvStats.PointCount = optional.MakeUint(ss.pointCount)
+	kvStats.PointsCoveredByRangeTombstones = optional.MakeUint(ss.pointsCoveredByRangeTombstones)
+	kvStats.RangeKeyCount = optional.MakeUint(ss.rangeKeyCount)
+	kvStats.RangeKeyContainedPoints = optional.MakeUint(ss.rangeKeyContainedPoints)
+	kvStats.RangeKeySkippedPoints = optional.MakeUint(ss.rangeKeySkippedPoints)
+	kvStats.NumGets = optional.MakeUint(ss.numGets)
+	kvStats.NumScans = optional.MakeUint(ss.numScans)
+	kvStats.NumReverseScans = optional.MakeUint(ss.numReverseScans)
 }

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -262,15 +262,15 @@ func (p *planNodeToRowSource) trailingMetaCallback() []execinfrapb.ProducerMetad
 // execStatsForTrace implements ProcessorBase.ExecStatsForTrace.
 func (p *planNodeToRowSource) execStatsForTrace() *execinfrapb.ComponentStats {
 	// Propagate contention time and RUs from IO requests.
-	if p.contentionEventsListener.CumulativeContentionTime == 0 && p.tenantConsumptionListener.ConsumedRU == 0 {
+	if p.contentionEventsListener.GetContentionTime() == 0 && p.tenantConsumptionListener.GetConsumedRU() == 0 {
 		return nil
 	}
 	return &execinfrapb.ComponentStats{
 		KV: execinfrapb.KVStats{
-			ContentionTime: optional.MakeTimeValue(p.contentionEventsListener.CumulativeContentionTime),
+			ContentionTime: optional.MakeTimeValue(p.contentionEventsListener.GetContentionTime()),
 		},
 		Exec: execinfrapb.ExecStats{
-			ConsumedRU: optional.MakeUint(p.tenantConsumptionListener.ConsumedRU),
+			ConsumedRU: optional.MakeUint(p.tenantConsumptionListener.GetConsumedRU()),
 		},
 	}
 }

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -774,7 +774,7 @@ func (ij *invertedJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 			KVPairsRead:         optional.MakeUint(uint64(ij.fetcher.GetKVPairsRead())),
 			TuplesRead:          fis.NumTuples,
 			KVTime:              fis.WaitTime,
-			ContentionTime:      optional.MakeTimeValue(ij.contentionEventsListener.CumulativeContentionTime),
+			ContentionTime:      optional.MakeTimeValue(ij.contentionEventsListener.GetContentionTime()),
 			BatchRequestsIssued: optional.MakeUint(uint64(ij.fetcher.GetBatchRequestsIssued())),
 			KVCPUTime:           optional.MakeTimeValue(fis.kvCPUTime),
 		},
@@ -784,8 +784,9 @@ func (ij *invertedJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 		},
 		Output: ij.OutputHelper.Stats(),
 	}
-	ret.Exec.ConsumedRU = optional.MakeUint(ij.tenantConsumptionListener.ConsumedRU)
-	execstats.PopulateKVMVCCStats(&ret.KV, &ij.scanStatsListener.ScanStats)
+	ret.Exec.ConsumedRU = optional.MakeUint(ij.tenantConsumptionListener.GetConsumedRU())
+	scanStats := ij.scanStatsListener.GetScanStats()
+	execstats.PopulateKVMVCCStats(&ret.KV, &scanStats)
 	return &ret
 }
 

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -1245,7 +1245,7 @@ func (jr *joinReader) execStatsForTrace() *execinfrapb.ComponentStats {
 			KVPairsRead:         optional.MakeUint(uint64(jr.fetcher.GetKVPairsRead())),
 			TuplesRead:          fis.NumTuples,
 			KVTime:              fis.WaitTime,
-			ContentionTime:      optional.MakeTimeValue(jr.contentionEventsListener.CumulativeContentionTime),
+			ContentionTime:      optional.MakeTimeValue(jr.contentionEventsListener.GetContentionTime()),
 			BatchRequestsIssued: optional.MakeUint(uint64(jr.fetcher.GetBatchRequestsIssued())),
 			KVCPUTime:           optional.MakeTimeValue(fis.kvCPUTime),
 			UsedStreamer:        jr.usesStreamer,
@@ -1264,8 +1264,9 @@ func (jr *joinReader) execStatsForTrace() *execinfrapb.ComponentStats {
 			ret.Exec.MaxAllocatedDisk.Add(jr.streamerInfo.diskMonitor.MaximumBytes())
 		}
 	}
-	ret.Exec.ConsumedRU = optional.MakeUint(jr.tenantConsumptionListener.ConsumedRU)
-	execstats.PopulateKVMVCCStats(&ret.KV, &jr.scanStatsListener.ScanStats)
+	ret.Exec.ConsumedRU = optional.MakeUint(jr.tenantConsumptionListener.GetConsumedRU())
+	scanStats := jr.scanStatsListener.GetScanStats()
+	execstats.PopulateKVMVCCStats(&ret.KV, &scanStats)
 	return ret
 }
 

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -317,14 +317,15 @@ func (tr *tableReader) execStatsForTrace() *execinfrapb.ComponentStats {
 			KVPairsRead:         optional.MakeUint(uint64(tr.fetcher.GetKVPairsRead())),
 			TuplesRead:          is.NumTuples,
 			KVTime:              is.WaitTime,
-			ContentionTime:      optional.MakeTimeValue(tr.contentionEventsListener.CumulativeContentionTime),
+			ContentionTime:      optional.MakeTimeValue(tr.contentionEventsListener.GetContentionTime()),
 			BatchRequestsIssued: optional.MakeUint(uint64(tr.fetcher.GetBatchRequestsIssued())),
 			KVCPUTime:           optional.MakeTimeValue(is.kvCPUTime),
 		},
 		Output: tr.OutputHelper.Stats(),
 	}
-	ret.Exec.ConsumedRU = optional.MakeUint(tr.tenantConsumptionListener.ConsumedRU)
-	execstats.PopulateKVMVCCStats(&ret.KV, &tr.scanStatsListener.ScanStats)
+	ret.Exec.ConsumedRU = optional.MakeUint(tr.tenantConsumptionListener.GetConsumedRU())
+	scanStats := tr.scanStatsListener.GetScanStats()
+	execstats.PopulateKVMVCCStats(&ret.KV, &scanStats)
 	return ret
 }
 

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -852,10 +852,11 @@ func (z *zigzagJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 	kvStats := execinfrapb.KVStats{
 		BytesRead:           optional.MakeUint(uint64(z.getBytesRead())),
 		KVPairsRead:         optional.MakeUint(uint64(z.getKVPairsRead())),
-		ContentionTime:      optional.MakeTimeValue(z.contentionEventsListener.CumulativeContentionTime),
+		ContentionTime:      optional.MakeTimeValue(z.contentionEventsListener.GetContentionTime()),
 		BatchRequestsIssued: optional.MakeUint(uint64(z.getBatchRequestsIssued())),
 	}
-	execstats.PopulateKVMVCCStats(&kvStats, &z.scanStatsListener.ScanStats)
+	scanStats := z.scanStatsListener.GetScanStats()
+	execstats.PopulateKVMVCCStats(&kvStats, &scanStats)
 	for i := range z.infos {
 		fis, ok := getFetcherInputStats(z.infos[i].fetcher)
 		if !ok {
@@ -869,7 +870,7 @@ func (z *zigzagJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 		KV:     kvStats,
 		Output: z.OutputHelper.Stats(),
 	}
-	ret.Exec.ConsumedRU = optional.MakeUint(z.tenantConsumptionListener.ConsumedRU)
+	ret.Exec.ConsumedRU = optional.MakeUint(z.tenantConsumptionListener.GetConsumedRU())
 	return ret
 }
 


### PR DESCRIPTION
This commit fixes possible races that can occur when accessing the accumulated stats. In particular, when using the Streamer API it is possible that the Streamer will have KV requests outstanding (which might add to exec stats) at the time when the exec stats are read (for example, this is possible when the execution of the flow with the Streamer encountered an error outside of Streamer). This problem is now fixed by adding synchronization to all three stats listeners (for two via atomic operations and for scan stats - via a mutex).

Additionally, this commit does a minor cleanup to unexport fields of `execstats.ScanStats` as well as remove some redundant method definitions by embedding the stats listeners.

Fixes: #119201.

Release note: None