### PR TITLE
server, ui: set `HttpOnly: true` and `Secure` flags on cookies

### DIFF
--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -558,6 +558,9 @@ func TestServerControllerLoginLogout(t *testing.T) {
 	for i, c := range resp.Cookies() {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
+		if c.Name == "session" {
+			require.True(t, c.HttpOnly)
+		}
 	}
 	require.ElementsMatch(t, []string{"session", "tenant"}, cookieNames)
 	require.ElementsMatch(t, []string{"", ""}, cookieValues)
@@ -582,6 +585,9 @@ func TestServerControllerLoginLogout(t *testing.T) {
 	for i, c := range resp.Cookies() {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
+		if c.Name == "session" {
+			require.True(t, c.HttpOnly)
+		}
 	}
 	require.ElementsMatch(t, []string{"session", "tenant"}, cookieNames)
 	require.ElementsMatch(t, []string{"", ""}, cookieValues)
@@ -607,6 +613,9 @@ func TestServerControllerLoginLogout(t *testing.T) {
 	for i, c := range resp.Cookies() {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
+		if c.Name == "session" {
+			require.True(t, c.HttpOnly)
+		}
 	}
 	require.ElementsMatch(t, []string{"session", "tenant"}, cookieNames)
 	require.ElementsMatch(t, []string{"", ""}, cookieValues)

--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -338,6 +338,7 @@ func TestServerControllerDefaultHTTPTenant(t *testing.T) {
 	for _, c := range resp.Cookies() {
 		if c.Name == authserver.TenantSelectCookieName {
 			tenantCookie = c.Value
+			require.True(t, c.Secure)
 		}
 	}
 	require.Equal(t, "hello", tenantCookie)
@@ -558,6 +559,7 @@ func TestServerControllerLoginLogout(t *testing.T) {
 	for i, c := range resp.Cookies() {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
+		require.True(t, c.Secure)
 		if c.Name == "session" {
 			require.True(t, c.HttpOnly)
 		}
@@ -585,6 +587,7 @@ func TestServerControllerLoginLogout(t *testing.T) {
 	for i, c := range resp.Cookies() {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
+		require.True(t, c.Secure)
 		if c.Name == "session" {
 			require.True(t, c.HttpOnly)
 		}
@@ -613,6 +616,7 @@ func TestServerControllerLoginLogout(t *testing.T) {
 	for i, c := range resp.Cookies() {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
+		require.True(t, c.Secure)
 		if c.Name == "session" {
 			require.True(t, c.HttpOnly)
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1229,6 +1229,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		pgPreServer.SendRoutingError,
 		tenantCapabilitiesWatcher,
 		cfg.DisableSQLServer,
+		cfg.BaseConfig.DisableTLSForHTTP,
 	)
 	drain.serverCtl = sc
 

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -93,6 +93,8 @@ type serverController struct {
 
 	watcher *tenantcapabilitieswatcher.Watcher
 
+	disableTLSForHTTP bool
+
 	mu struct {
 		syncutil.RWMutex
 
@@ -128,6 +130,7 @@ func newServerController(
 	sendSQLRoutingError func(ctx context.Context, conn net.Conn, tenantName roachpb.TenantName),
 	watcher *tenantcapabilitieswatcher.Watcher,
 	disableSQLServer bool,
+	disableTLSForHTTP bool,
 ) *serverController {
 	c := &serverController{
 		AmbientContext:      ambientCtx,
@@ -141,6 +144,7 @@ func newServerController(
 		tenantWaiter:        singleflight.NewGroup("tenant server poller", "poll"),
 		drainCh:             make(chan struct{}),
 		disableSQLServer:    disableSQLServer,
+		disableTLSForHTTP:   disableTLSForHTTP,
 	}
 	c.orchestrator = newServerOrchestrator(parentStopper, c)
 	c.mu.servers = map[roachpb.TenantName]serverState{

--- a/pkg/server/server_controller_http.go
+++ b/pkg/server/server_controller_http.go
@@ -235,7 +235,7 @@ func (c *serverController) attemptLoginToAllTenants() http.Handler {
 				Name:     authserver.SessionCookieName,
 				Value:    sessionsStr,
 				Path:     "/",
-				HttpOnly: false,
+				HttpOnly: true,
 			}
 			http.SetCookie(w, &cookie)
 			// The tenant cookie needs to be set at some point in order for
@@ -353,7 +353,7 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 			Name:     authserver.SessionCookieName,
 			Value:    "",
 			Path:     "/",
-			HttpOnly: false,
+			HttpOnly: true,
 			Expires:  timeutil.Unix(0, 0),
 		}
 		http.SetCookie(w, &cookie)

--- a/pkg/server/server_controller_http.go
+++ b/pkg/server/server_controller_http.go
@@ -103,6 +103,7 @@ func (c *serverController) httpMux(w http.ResponseWriter, r *http.Request) {
 			Value:    "",
 			Path:     "/",
 			HttpOnly: true,
+			Secure:   !c.disableTLSForHTTP,
 			Expires:  timeutil.Unix(0, 0),
 		})
 		http.SetCookie(w, &http.Cookie{
@@ -110,6 +111,7 @@ func (c *serverController) httpMux(w http.ResponseWriter, r *http.Request) {
 			Value:    "",
 			Path:     "/",
 			HttpOnly: false,
+			Secure:   !c.disableTLSForHTTP,
 			Expires:  timeutil.Unix(0, 0),
 		})
 		// Fall back to serving requests from the default tenant. This helps us serve
@@ -236,6 +238,7 @@ func (c *serverController) attemptLoginToAllTenants() http.Handler {
 				Value:    sessionsStr,
 				Path:     "/",
 				HttpOnly: true,
+				Secure:   !c.disableTLSForHTTP,
 			}
 			http.SetCookie(w, &cookie)
 			// The tenant cookie needs to be set at some point in order for
@@ -257,6 +260,7 @@ func (c *serverController) attemptLoginToAllTenants() http.Handler {
 				Value:    tenantSelection,
 				Path:     "/",
 				HttpOnly: false,
+				Secure:   !c.disableTLSForHTTP,
 			}
 			http.SetCookie(w, &cookie)
 			if r.Header.Get(AcceptHeader) == JSONContentType {
@@ -354,6 +358,7 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 			Value:    "",
 			Path:     "/",
 			HttpOnly: true,
+			Secure:   !c.disableTLSForHTTP,
 			Expires:  timeutil.Unix(0, 0),
 		}
 		http.SetCookie(w, &cookie)
@@ -362,6 +367,7 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 			Value:    "",
 			Path:     "/",
 			HttpOnly: false,
+			Secure:   !c.disableTLSForHTTP,
 			Expires:  timeutil.Unix(0, 0),
 		}
 		http.SetCookie(w, &cookie)

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -49,6 +49,10 @@ stubComponentInModule("src/views/insights/schemaInsightsPage", "default");
 stubComponentInModule("src/views/schedules/schedulesPage", "default");
 stubComponentInModule("src/views/schedules/scheduleDetails", "default");
 stubComponentInModule("src/views/tracez_v2/snapshotPage", "default");
+stubComponentInModule(
+  "src/views/app/components/tenantDropdown/tenantDropdown",
+  "default",
+);
 
 import React from "react";
 import { Action, Store } from "redux";

--- a/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
@@ -28,7 +28,7 @@ import { util as clusterUiUtil } from "@cockroachlabs/cluster-ui";
 const { isForbiddenRequestError } = clusterUiUtil;
 
 import { PayloadAction, WithRequest } from "src/interfaces/action";
-import { maybeClearTenantCookie } from "./cookies";
+import { clearTenantCookie } from "./cookies";
 
 export interface WithPaginationRequest {
   page_size: number;
@@ -323,7 +323,10 @@ export class CachedDataReducer<
             // codes.  However, at the moment that's all that the underlying
             // timeoutFetch offers.  Major changes to this plumbing are warranted.
             if (error.message === "Unauthorized") {
-              maybeClearTenantCookie();
+              // Clearing the tenant cookie is necessary when we force a login
+              // because otherwise the DB routing will continue routing to that
+              // specific tenant.
+              clearTenantCookie();
               // TODO(couchand): This is an unpleasant dependency snuck in here...
               const { location } = createHashHistory();
               if (

--- a/pkg/ui/workspaces/db-console/src/redux/cookies.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cookies.spec.ts
@@ -10,8 +10,7 @@
 import {
   getAllCookies,
   getCookieValue,
-  selectTenantsFromMultitenantSessionCookie,
-  maybeClearTenantCookie,
+  clearTenantCookie,
   setCookie,
 } from "./cookies";
 
@@ -19,7 +18,7 @@ describe("Cookies", () => {
   beforeEach(() => {
     Object.defineProperty(window.document, "cookie", {
       writable: true,
-      value: "tenant=system;session=abc123,system,def456,demoapp",
+      value: "tenant=system;someother=cookie;another=cookievalue",
     });
   });
   afterEach(() => {
@@ -32,7 +31,8 @@ describe("Cookies", () => {
     const result = getAllCookies();
     const expected = new Map();
     expected.set("tenant", "system");
-    expected.set("session", "abc123,system,def456,demoapp");
+    expected.set("someother", "cookie");
+    expected.set("another", "cookievalue");
     expect(result).toEqual(expected);
   });
   it("should return a cookie value by key or return null", () => {
@@ -42,19 +42,8 @@ describe("Cookies", () => {
     const result2 = getCookieValue("unknown");
     expect(result2).toBeNull();
   });
-  it("should give a string array of tenants from the session cookie or an empty array", () => {
-    const result = selectTenantsFromMultitenantSessionCookie();
-    const expected = ["system", "demoapp"];
-    expect(result).toEqual(expected);
-    Object.defineProperty(window.document, "cookie", {
-      writable: true,
-      value: "",
-    });
-    const result2 = selectTenantsFromMultitenantSessionCookie();
-    expect(result2).toEqual([]);
-  });
-  it("should clear the tenant cookie if in a multitenant cluster", () => {
-    maybeClearTenantCookie();
+  it("should clear the tenant cookie", () => {
+    clearTenantCookie();
     const tenantCookie = getCookieValue("tenant");
     expect(tenantCookie).toBeNull();
   });

--- a/pkg/ui/workspaces/db-console/src/redux/cookies.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cookies.ts
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export const MULTITENANT_SESSION_COOKIE_NAME = "session";
 export const SYSTEM_TENANT_NAME = "system";
 
 export const getAllCookies = (): Map<string, string> => {
@@ -27,28 +26,8 @@ export const getCookieValue = (cookieName: string): string => {
   return cookies.get(cookieName) || null;
 };
 
-// selectTenantsFromMultitenantSessionCookie formats the session
-// cookie value and returns only the tenant names.
-export const selectTenantsFromMultitenantSessionCookie = (): string[] => {
-  const cookies = getAllCookies();
-  const sessionsStr = cookies.get(MULTITENANT_SESSION_COOKIE_NAME);
-  return sessionsStr
-    ? sessionsStr
-        .replace(/["]/g, "")
-        .split(/[,]/g)
-        .filter((_, idx) => idx % 2 === 1)
-    : [];
-};
-
-// maybeClearTenantCookie clears the tenant cookie if there are multiple tenants
-// found in the multitenant-session cookie.
-export const maybeClearTenantCookie = () => {
-  const tenants = selectTenantsFromMultitenantSessionCookie();
-  // If in multi-tenant environment, we need to clear the tenant cookie so that
-  // we can do a multi-tenant logout.
-  if (tenants.length > 1) {
-    setCookie("tenant", "");
-  }
+export const clearTenantCookie = () => {
+  setCookie("tenant", "");
 };
 
 export const setCookie = (

--- a/pkg/ui/workspaces/db-console/src/redux/login.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/login.ts
@@ -20,7 +20,7 @@ import { cockroach } from "src/js/protos";
 import { getDataFromServer } from "src/util/dataFromServer";
 
 import UserLoginRequest = cockroach.server.serverpb.UserLoginRequest;
-import { maybeClearTenantCookie } from "./cookies";
+import { clearTenantCookie } from "./cookies";
 
 const dataFromServer = getDataFromServer();
 
@@ -217,7 +217,9 @@ export function doLogout(): ThunkAction<
 > {
   return dispatch => {
     dispatch(logoutBeginAction);
-    maybeClearTenantCookie();
+    // Clearing the tenant cookie on logout is necessary in order to
+    // avoid routing login requests to that specific tenant.
+    clearTenantCookie();
     // Make request to log out, reloading the page whether it succeeds or not.
     // If there was a successful log out but the network dropped the response somehow,
     // you'll get the login page on reload. If The logout actually didn't work, you'll

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.spec.tsx
@@ -7,39 +7,56 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import {
-  selectTenantsFromMultitenantSessionCookie,
-  getCookieValue,
-} from "src/redux/cookies";
+import { getCookieValue } from "src/redux/cookies";
 import React from "react";
 import TenantDropdown from "./tenantDropdown";
 import { shallow } from "enzyme";
+import fetchMock from "fetch-mock";
 
 jest.mock("src/redux/cookies", () => ({
-  selectTenantsFromMultitenantSessionCookie: jest.fn(),
   getCookieValue: jest.fn(),
 }));
 
 describe("TenantDropdown", () => {
+  beforeEach(() => {});
+
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
   it("returns null if there's no current virtual cluster", () => {
-    (
-      selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
-        typeof selectTenantsFromMultitenantSessionCookie
-      >
-    ).mockReturnValueOnce([]);
+    fetchMock.mock({
+      matcher: `virtual_clusters`,
+      method: "GET",
+      response: () => {
+        return {
+          body: JSON.stringify({
+            virtual_clusters: [],
+          }),
+        };
+      },
+    });
+
     (
       getCookieValue as jest.MockedFn<typeof getCookieValue>
     ).mockReturnValueOnce(null);
     const wrapper = shallow(<TenantDropdown />);
     expect(wrapper.isEmptyRender());
   });
-  // Mutli-tenant scenarios
+  // Multi-tenant scenarios
   it("returns null if there are no virtual clusters or less than 2 in the session cookie", () => {
-    (
-      selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
-        typeof selectTenantsFromMultitenantSessionCookie
-      >
-    ).mockReturnValueOnce(["system"]);
+    fetchMock.mock({
+      matcher: `virtual_clusters`,
+      method: "GET",
+      response: () => {
+        return {
+          body: JSON.stringify({
+            virtual_clusters: ["system"],
+          }),
+        };
+      },
+    });
+
     (
       getCookieValue as jest.MockedFn<typeof getCookieValue>
     ).mockReturnValueOnce("system");
@@ -47,11 +64,18 @@ describe("TenantDropdown", () => {
     expect(wrapper.isEmptyRender());
   });
   it("returns a dropdown list of tenant options if there are multiple virtual clusters in the session cookie", () => {
-    (
-      selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
-        typeof selectTenantsFromMultitenantSessionCookie
-      >
-    ).mockReturnValueOnce(["system", "app"]);
+    fetchMock.mock({
+      matcher: `virtual_clusters`,
+      method: "GET",
+      response: () => {
+        return {
+          body: JSON.stringify({
+            virtual_clusters: ["system", "app"],
+          }),
+        };
+      },
+    });
+
     (
       getCookieValue as jest.MockedFn<typeof getCookieValue>
     ).mockReturnValueOnce("system");
@@ -61,11 +85,18 @@ describe("TenantDropdown", () => {
     ).toEqual(1);
   });
   it("returns a dropdown if the there is a single virtual cluster option but isn't system", () => {
-    (
-      selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
-        typeof selectTenantsFromMultitenantSessionCookie
-      >
-    ).mockReturnValueOnce(["app"]);
+    fetchMock.mock({
+      matcher: `virtual_clusters`,
+      method: "GET",
+      response: () => {
+        return {
+          body: JSON.stringify({
+            virtual_clusters: ["app"],
+          }),
+        };
+      },
+    });
+
     (
       getCookieValue as jest.MockedFn<typeof getCookieValue>
     ).mockReturnValueOnce("app");


### PR DESCRIPTION
### server, ui: session cookie is HttpOnly 

This change removes the ability of the DB Console JS code to read
the `session` cookie from the browser by setting the `HttpOnly` flag
to `true`.

This change requires a modification of how the `TenantDropdown`
components works since it relied on reading the `session` cookie and
extracting the list of logged-in tenants from it.

Instead of reading the cookie, the component now relies on a server-
side endpoint to "read back" the list of tenants in the session. You
might ask why this is necessary because we could return the list of
valid tenants on `/login` success and have them available outright.
There is a reason why that's not sufficient.

When you are logged in to multiple tenants with a valid session, you
can switch between them in the dropdown switcher. This switch occurs
without a subsequent call to `/login`, and will just set the `tenant`
cookie to the new tenant name and issue a full refresh to the browser
which will re-render everything. In this case, the `TenantDropdown`
component gets fully re-rendered but no longer has access to the
state it was initialized with containing all the valid tenants. This
necessitates adding an endpoint that the component can use to populate
itself directly whenever it's rendered.

Epic: None
Fixes: [CRDB-36034](https://cockroachlabs.atlassian.net/browse/CRDB-36034)

Release note (security update): DB Console `session` cookie is now
marked `HttpOnly` to prevent it from being read by any Javascript
code.

----

### server: set Secure on cookies if cluster is secure 

Cookie `Secure` setting is based on `disableTLSForHTTP` passed down
from the server.

Part of [CRDB-36034](https://cockroachlabs.atlassian.net/browse/CRDB-36034)
Epic: None

Release note (security update): DB Console cookies are marked `Secure`
for the browser when the cluster is running in secure mode.
