### PR TITLE
sql: remove DistSQL version compatibility check

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -997,7 +997,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		),
 		DistSQLPlanner: sql.NewDistSQLPlanner(
 			ctx,
-			execinfra.Version,
 			cfg.Settings,
 			cfg.nodeIDContainer.SQLInstanceID(),
 			cfg.rpcContext,

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -314,7 +314,7 @@ func startConnExecutor(
 		},
 		Codec: keys.SystemSQLCodec,
 		DistSQLPlanner: NewDistSQLPlanner(
-			ctx, execinfra.Version, st, 1, /* sqlInstanceID */
+			ctx, st, 1, /* sqlInstanceID */
 			nil, /* rpcCtx */
 			distsql.NewServer(
 				ctx,

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -188,14 +188,6 @@ func (ds *ServerImpl) setDraining(drain bool) error {
 	return nil
 }
 
-// FlowVerIsCompatible checks a flow's version is compatible with this node's
-// DistSQL version.
-func FlowVerIsCompatible(
-	flowVer, minAcceptedVersion, serverVersion execinfrapb.DistSQLVersion,
-) bool {
-	return flowVer >= minAcceptedVersion && flowVer <= serverVersion
-}
-
 // setupFlow creates a Flow.
 //
 // Args:
@@ -244,7 +236,7 @@ func (ds *ServerImpl) setupFlow(
 		}
 	}()
 
-	if !FlowVerIsCompatible(req.Version, execinfra.MinAcceptedVersion, execinfra.Version) {
+	if req.Version < execinfra.MinAcceptedVersion || req.Version > execinfra.Version {
 		err := errors.Errorf(
 			"version mismatch in flow request: %d; this node accepts %d through %d",
 			req.Version, execinfra.MinAcceptedVersion, execinfra.Version,

--- a/pkg/sql/execinfrapb/api.proto
+++ b/pkg/sql/execinfrapb/api.proto
@@ -126,11 +126,7 @@ message ConsumerHandshake {
   // dealine, this stream will be disconnected by the server-side.
   optional google.protobuf.Timestamp consumer_schedule_deadline = 2 [(gogoproto.stdtime) = true];
 
-  // The server's DistSQL version range.
-  optional uint32 version = 3 [(gogoproto.nullable) = false,
-    (gogoproto.casttype) = "DistSQLVersion"];
-  optional uint32 min_accepted_version = 4 [(gogoproto.nullable) = false,
-    (gogoproto.casttype) = "DistSQLVersion"];
+  reserved 3, 4;
 }
 
 // CancelDeadFlowsRequest is a request to cancel some flows that are running on

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -365,6 +365,8 @@ message RemoteProducerMetadata {
 //
 // For the meaning of the fields, see the corresponding constants in
 // distsqlrun/server.go.
+// TODO(yuzefovich): propagating version information is no longer needed once
+// compatibility with 23.2 is unnecessary.
 message DistSQLVersionGossipInfo {
   optional uint32 version = 1 [(gogoproto.nullable) = false,
     (gogoproto.casttype) = "DistSQLVersion"];

--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -585,8 +584,6 @@ func (fr *FlowRegistry) ConnectInboundStream(
 			Handshake: &execinfrapb.ConsumerHandshake{
 				ConsumerScheduled:        false,
 				ConsumerScheduleDeadline: &deadline,
-				Version:                  execinfra.Version,
-				MinAcceptedVersion:       execinfra.MinAcceptedVersion,
 			},
 		}); err != nil {
 			return nil, nil, nil, err
@@ -617,9 +614,7 @@ func (fr *FlowRegistry) ConnectInboundStream(
 	// Don't mark s as connected until after the handshake succeeds.
 	handshakeErr := stream.Send(&execinfrapb.ConsumerSignal{
 		Handshake: &execinfrapb.ConsumerHandshake{
-			ConsumerScheduled:  true,
-			Version:            execinfra.Version,
-			MinAcceptedVersion: execinfra.MinAcceptedVersion,
+			ConsumerScheduled: true,
 		},
 	})
 

--- a/pkg/sql/nodestatus_string.go
+++ b/pkg/sql/nodestatus_string.go
@@ -10,7 +10,6 @@ func _() {
 	var x [1]struct{}
 	_ = x[NodeOK-0]
 	_ = x[NodeUnhealthy-1]
-	_ = x[NodeDistSQLVersionIncompatible-2]
 }
 
 func (i NodeStatus) String() string {
@@ -19,8 +18,6 @@ func (i NodeStatus) String() string {
 		return "NodeOK"
 	case NodeUnhealthy:
 		return "NodeUnhealthy"
-	case NodeDistSQLVersionIncompatible:
-		return "NodeDistSQLVersionIncompatible"
 	default:
 		return "NodeStatus(" + strconv.FormatInt(int64(i), 10) + ")"
 	}


### PR DESCRIPTION
**execinfrapb: remove versions from ConsumerHandshake**

This information was never actually used - we make the final decision of whether a particular DistSQL server gets any part of the plan during the physical planning on the gateway (i.e. it should be up to the gateway to know which servers are of compatible version, and right now it's all of them).

Release note: None

**sql: remove DistSQL version compatibility check**

We will never bump the DistSQL version in backwards-incompatible way, so we can remove this check.

Informs: #98550.
Epic: None

Release note: None