### PR TITLE
restore: re-run downloads until poller is done

### DIFF
--- a/pkg/ccl/backupccl/restore_online_test.go
+++ b/pkg/ccl/backupccl/restore_online_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/nodelocal"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -28,8 +27,6 @@ func TestOnlineRestoreBasic(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	defer nodelocal.ReplaceNodeLocalForTesting(t.TempDir())()
-
-	skip.WithIssue(t, 119197)
 
 	const numAccounts = 1000
 	_, sqlDB, dir, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, base.TestClusterArgs{

--- a/pkg/server/span_download.go
+++ b/pkg/server/span_download.go
@@ -119,6 +119,7 @@ func sendDownloadSpans(ctx context.Context, spans roachpb.Spans, out chan roachp
 			return ctx.Err()
 		}
 	}
+	log.Infof(ctx, "all %d download spans enqueued", len(spans))
 	return nil
 }
 
@@ -132,6 +133,7 @@ func downloadSpans(ctx context.Context, eng storage.Engine, spans chan roachpb.S
 				return err
 			}
 		}
+		log.Infof(ctx, "finished downloading %d spans", len(spans))
 		return nil
 	})
 }


### PR DESCRIPTION
Previously the download pass would only run once, since the API contract of Download() is that when it completes there are not external files in its span.

However if somehow there is still an external file in the span, for example if it was added while Download() was running, then the poller may keep observing non-zero extenral files and keep the job running, even though there is no longer a download task running that will change that, causing it to hang forever.

This changes the download task to keep running repeatedly as long as the poller is observing that there is something to download, so that if there are still external files after a pass completes for the reasons described above, they will be downloaded on in a subsequent pass.

Release note: none.
Epic: none.