### PR TITLE
stream ingestion: add logging around processor error propogation

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -259,6 +259,9 @@ func ingestWithRetries(
 		if i := r.CurrentAttempt(); i > 5 {
 			status := redact.Sprintf("retrying after error on attempt %d: %s", i, err)
 			updateRunningStatus(ctx, ingestionJob, jobspb.ReplicationError, status)
+		} else {
+			// At least log the retryable error if we're not updating the status.
+			log.Infof(ctx, "hit retryable error %s", err)
 		}
 		newReplicatedTime := loadReplicatedTime(ctx, execCtx.ExecCfg().InternalDB, ingestionJob)
 		if lastReplicatedTime.Less(newReplicatedTime) {


### PR DESCRIPTION
This patch adds more logging around stream ingestion processor error propogation. Specifically, this patch adds logging to the error sent to the processorBase's `MoveToDraining()` function and around all errors retried by the job coordinator.

Informs #119060

Release note: none