### PR TITLE
changefeedccl: random changefeed frontier placement

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -117,6 +117,7 @@ go_library(
         "//pkg/sql/sem/volatility",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
+        "//pkg/sql/sqlliveness",
         "//pkg/sql/syntheticprivilege",
         "//pkg/sql/types",
         "//pkg/util",

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -509,7 +509,10 @@ func makePlan(
 		switch s := frontierPlacementStrategy.Get(sv); frontierPlacementType(s) {
 		case frontierOnRandomNode:
 			settings := execCtx.ExecCfg().Settings
-			if !settings.Version.IsActive(ctx, clusterversion.V24_1) {
+			if details.SinkURI == "" {
+				log.VInfof(ctx, 2, "random frontier placement not available for core changefeed, using gateway instance %d",
+					frontierSQLInstance)
+			} else if !settings.Version.IsActive(ctx, clusterversion.V24_1) {
 				log.Warningf(ctx,
 					"random frontier placement requested with upgrade in progress, using gateway instance %d",
 					frontierSQLInstance)

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -354,6 +355,24 @@ var RangeDistributionStrategy = settings.RegisterEnumSetting(
 	},
 	settings.WithPublic)
 
+type frontierPlacementType int64
+
+const (
+	frontierOnGateway    frontierPlacementType = 0
+	frontierOnRandomNode frontierPlacementType = 1
+)
+
+var frontierPlacementStrategy = settings.RegisterEnumSetting(
+	settings.ApplicationLevel,
+	"changefeed.default_frontier_placement_strategy",
+	"controls where the changefeed frontier is placed",
+	util.ConstantWithMetamorphicTestChoice("changefeed.default_frontier_placement_strategy",
+		"random", "gateway").(string),
+	map[int64]string{
+		int64(defaultDistribution):        "gateway",
+		int64(balancedSimpleDistribution): "random",
+	})
+
 func makePlan(
 	execCtx sql.JobExecContext,
 	jobID jobspb.JobID,
@@ -485,11 +504,33 @@ func makePlan(
 			aggregatorCorePlacement[i].Core.ChangeAggregator = aggregatorSpecs[i]
 		}
 
+		frontierSQLInstance := dsp.GatewayID()
+		switch s := frontierPlacementStrategy.Get(sv); frontierPlacementType(s) {
+		case frontierOnRandomNode:
+			rng, _ := randutil.NewPseudoRand()
+			all, err := dsp.GetAllInstancesByLocality(ctx, locFilter)
+			if len(all) == 0 || err != nil {
+				// Rather unlikely anything else is
+				// going to succeed if we've hit this
+				// case.
+				log.Warningf(ctx,
+					"random frontier placement requested, but no GetAllInstancesByLocality failed to return nodes (err: %s), using gateway instance %d",
+					err.Error(), frontierSQLInstance)
+			} else {
+				frontierSQLInstance = all[rng.Intn(len(all))].InstanceID
+				log.VInfof(ctx, 2, "placing frontier on randomly chosen instance instance %d", frontierSQLInstance)
+			}
+		case frontierOnGateway:
+			log.VInfof(ctx, 2, "placing frontier on gateway instance %d", frontierSQLInstance)
+		default:
+			log.Warningf(ctx, "unknown frontier placement strategy: %d, using gateway instance %d", s, frontierSQLInstance)
+		}
+
 		p := planCtx.NewPhysicalPlan()
 		p.AddNoInputStage(aggregatorCorePlacement, execinfrapb.PostProcessSpec{}, changefeedResultTypes, execinfrapb.Ordering{})
 		p.AddSingleGroupStage(
 			ctx,
-			dsp.GatewayID(),
+			frontierSQLInstance,
 			execinfrapb.ProcessorCoreUnion{ChangeFrontier: &changeFrontierSpec},
 			execinfrapb.PostProcessSpec{},
 			changefeedResultTypes,

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1234,7 +1234,7 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 	cf.js = newJobState(nil, cf.flowCtx.Cfg.Settings, cf.metrics, timeutil.DefaultTimeSource{})
 
 	if cf.spec.JobID != 0 {
-		job, err := cf.flowCtx.Cfg.JobRegistry.LoadClaimedJob(ctx, cf.spec.JobID)
+		job, err := cf.flowCtx.Cfg.JobRegistry.LoadJob(ctx, cf.spec.JobID)
 		if err != nil {
 			cf.MoveToDraining(err)
 			return

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
@@ -1234,10 +1235,20 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 	cf.js = newJobState(nil, cf.flowCtx.Cfg.Settings, cf.metrics, timeutil.DefaultTimeSource{})
 
 	if cf.spec.JobID != 0 {
-		job, err := cf.flowCtx.Cfg.JobRegistry.LoadJob(ctx, cf.spec.JobID)
-		if err != nil {
-			cf.MoveToDraining(err)
-			return
+		var job *jobs.Job
+		if len(cf.spec.SessionID) > 0 {
+			sessionID := sqlliveness.SessionID(cf.spec.SessionID)
+			job, err = cf.flowCtx.Cfg.JobRegistry.LoadClaimedJob(ctx, cf.spec.JobID, sessionID)
+			if err != nil {
+				cf.MoveToDraining(err)
+				return
+			}
+		} else {
+			job, err = cf.flowCtx.Cfg.JobRegistry.LoadAdoptedJob(ctx, cf.spec.JobID)
+			if err != nil {
+				cf.MoveToDraining(err)
+				return
+			}
 		}
 		cf.js.job = job
 		if changefeedbase.FrontierCheckpointFrequency.Get(&cf.flowCtx.Cfg.Settings.SV) == 0 {

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1352,7 +1352,7 @@ func reconcileJobStateWithLocalState(
 ) error {
 	// Re-load the job in order to update our progress object, which may have
 	// been updated by the changeFrontier processor since the flow started.
-	reloadedJob, reloadErr := execCfg.JobRegistry.LoadClaimedJob(ctx, jobID)
+	reloadedJob, reloadErr := execCfg.JobRegistry.LoadAdoptedJob(ctx, jobID)
 	if reloadErr != nil {
 		log.Warningf(ctx, `CHANGEFEED job %d could not reload job progress (%s); `+
 			`job should be retried later`, jobID, reloadErr)

--- a/pkg/ccl/streamingccl/streamingest/ingest_span_configs.go
+++ b/pkg/ccl/streamingccl/streamingest/ingest_span_configs.go
@@ -80,6 +80,7 @@ func makeSpanConfigIngestor(
 	ctx context.Context,
 	execCfg *sql.ExecutorConfig,
 	ingestionJob *jobs.Job,
+	session sqlliveness.Session,
 	sourceTenantID roachpb.TenantID,
 	stopperCh chan struct{},
 ) (*spanConfigIngestor, error) {
@@ -109,7 +110,7 @@ func makeSpanConfigIngestor(
 	return &spanConfigIngestor{
 		accessor:                 execCfg.SpanConfigKVAccessor,
 		settings:                 execCfg.Settings,
-		session:                  ingestionJob.Session(),
+		session:                  session,
 		client:                   client,
 		rekeyer:                  rekeyer,
 		stopperCh:                stopperCh,

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_dist.go
@@ -187,7 +187,17 @@ func startDistIngestion(
 		if err != nil {
 			return err
 		}
-		ingestor, err := makeSpanConfigIngestor(ctx, execCtx.ExecCfg(), ingestionJob, sourceTenantID, spanConfigIngestStopper)
+		session, err := execCtx.ExecCfg().SQLLiveness.Session(ctx)
+		if err != nil {
+			return err
+		}
+		if session.ID() != ingestionJob.SessionID() {
+			return errors.Newf("session ID mismatch (%s != %s) when starting span config ingestion",
+				session.ID(),
+				ingestionJob.SessionID(),
+			)
+		}
+		ingestor, err := makeSpanConfigIngestor(ctx, execCtx.ExecCfg(), ingestionJob, session, sourceTenantID, spanConfigIngestStopper)
 		if err != nil {
 			return err
 		}

--- a/pkg/jobs/job_info_storage.go
+++ b/pkg/jobs/job_info_storage.go
@@ -63,13 +63,13 @@ func (i *InfoStorage) checkClaimSession(ctx context.Context) error {
 
 	if row == nil {
 		return errors.Errorf(
-			"expected session %q for job ID %d but found none", i.j.Session().ID(), i.j.ID())
+			"expected session %q for job ID %d but found none", i.j.SessionID(), i.j.ID())
 	}
 
 	storedSession := []byte(*row[0].(*tree.DBytes))
-	if !bytes.Equal(storedSession, i.j.Session().ID().UnsafeBytes()) {
+	if !bytes.Equal(storedSession, i.j.SessionID().UnsafeBytes()) {
 		return errors.Errorf(
-			"expected session %q but found %q", i.j.Session().ID(), sqlliveness.SessionID(storedSession))
+			"expected session %q but found %q", i.j.SessionID(), sqlliveness.SessionID(storedSession))
 	}
 	i.claimChecked = true
 
@@ -152,7 +152,7 @@ func (i InfoStorage) doWrite(
 
 	j := i.j
 
-	if j.Session() != nil {
+	if !j.SessionID().IsEmpty() {
 		if err := i.checkClaimSession(ctx); err != nil {
 			return err
 		}

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -131,17 +131,17 @@ WHERE id = $1
 	if progress, err = UnmarshalProgress(row[2]); err != nil {
 		return err
 	}
-	if j.session != nil {
+	if !j.sessionID.IsEmpty() {
 		if row[3] == tree.DNull {
 			return errors.Errorf(
 				"with status %q: expected session %q but found NULL",
-				status, j.session.ID())
+				status, j.sessionID)
 		}
 		storedSession := []byte(*row[3].(*tree.DBytes))
-		if !bytes.Equal(storedSession, j.session.ID().UnsafeBytes()) {
+		if !bytes.Equal(storedSession, j.sessionID.UnsafeBytes()) {
 			return errors.Errorf(
 				"with status %q: expected session %q but found %q",
-				status, j.session.ID(), sqlliveness.SessionID(storedSession))
+				status, j.sessionID, sqlliveness.SessionID(storedSession))
 		}
 	} else {
 		log.VInfof(ctx, 1, "job %d: update called with no session ID", j.ID())

--- a/pkg/sql/execinfrapb/processors_changefeeds.proto
+++ b/pkg/sql/execinfrapb/processors_changefeeds.proto
@@ -84,4 +84,11 @@ message ChangeFrontierSpec {
   // User who initiated the changefeed. This is used to check access privileges
   // when using FileTable ExternalStorage.
   optional string user_proto = 4 [(gogoproto.nullable) = false, (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/security/username.SQLUsernameProto"];
+
+  // SessionID is the ID of the session that has claimed the active
+  // changefeed job identified by JobID.
+  optional bytes session_id = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.customname) = "SessionID"
+  ];
 }

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1299,7 +1299,7 @@ func ingestWithRetry(
 
 		// Re-load the job in order to update our progress object, which
 		// may have been updated since the flow started.
-		reloadedJob, reloadErr := execCtx.ExecCfg().JobRegistry.LoadClaimedJob(ctx, job.ID())
+		reloadedJob, reloadErr := execCtx.ExecCfg().JobRegistry.LoadAdoptedJob(ctx, job.ID())
 		if reloadErr != nil {
 			if ctx.Err() != nil {
 				return res, ctx.Err()

--- a/pkg/sql/sqlliveness/sqlliveness.go
+++ b/pkg/sql/sqlliveness/sqlliveness.go
@@ -78,6 +78,11 @@ func (s SessionID) String() string {
 	return hex.EncodeToString(encoding.UnsafeConvertStringToBytes(string(s)))
 }
 
+// IsEmpty returns true if the session ID is zero-valued.
+func (s SessionID) IsEmpty() bool {
+	return s == ""
+}
+
 // SafeValue implements the redact.SafeValue interface.
 func (s SessionID) SafeValue() {}
 


### PR DESCRIPTION
By default, CHANGEFEED jobs are adopted by the SQL instance that ran the SQL statement.

Further, we places the change frontier processor on the job coordinator node in part so that we could be 
sure that we were only updating the job record from the node that had the job claim.

However, this historically has caused hot-spots on nodes that found themselves as the coordinators
of a large number of changefeed jobs since the change aggregator does do a non-trivial amount of work.

Here, we randomly distribute the change aggregator to one of the eligible nodes.

To guard against concurrent job progress updates, we pass the claim session ID through the processor spec
so that we can still check the session on any update.

Release note: None
Epic: None