### PR TITLE
roachtest/cdc: skip cdc/initial-scan-only/parquet/metamorphic

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1167,6 +1167,7 @@ func registerCDC(r registry.Registry) {
 	})
 	r.Add(registry.TestSpec{
 		Name:             "cdc/initial-scan-only/parquet/metamorphic",
+		Skip:             "#119295",
 		Owner:            registry.OwnerCDC,
 		Benchmark:        true,
 		Cluster:          r.MakeClusterSpec(4, spec.CPU(16), spec.Arch(vm.ArchAMD64)),


### PR DESCRIPTION
This patch skips cdc/initial-scan-only/parquet/metamorphic for now. I can't
reproduce this issue locally and still investigating why TeamCity couldn't fetch
the files from cloud storage. It seems unlikely to get the fix in before the
weekend, so skipping for now.

Part of: https://github.com/cockroachdb/cockroach/issues/119295
Release note: none
