### PR TITLE
streamingccl: redact raw postgres url in a few log lines and errors

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/streamingccl",
+        "//pkg/cloud",
         "//pkg/cloud/externalconn",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//pkg/ccl/streamingccl/streamclient",
         "//pkg/ccl/streamingccl/streamproducer",
         "//pkg/ccl/utilccl",
-        "//pkg/cloud",
         "//pkg/cloud/externalconn",
         "//pkg/cloud/externalconn/connectionpb",
         "//pkg/jobs",

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/replicationtestutils"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/replicationutils"
+	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamclient"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -1046,7 +1047,7 @@ func TestTenantStreamingShowTenant(t *testing.T) {
 	require.Equal(t, "replicating", status)
 	require.Equal(t, "none", serviceMode)
 	require.Equal(t, "source", source)
-	expectedURI, err := redactSourceURI(c.SrcURL.String())
+	expectedURI, err := streamclient.RedactSourceURI(c.SrcURL.String())
 	require.NoError(t, err)
 	require.Equal(t, expectedURI, sourceUri)
 	require.Equal(t, ingestionJobID, jobId)

--- a/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/revertccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/replicationutils"
+	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamclient"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -96,7 +97,7 @@ func getReplicationStatsAndStatus(
 			errors.Newf("job with id %d is not a stream ingestion job", job.ID())
 	}
 
-	details.StreamAddress, err = redactSourceURI(details.StreamAddress)
+	details.StreamAddress, err = streamclient.RedactSourceURI(details.StreamAddress)
 	if err != nil {
 		return nil, jobspb.ReplicationError.String(), err
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -259,6 +259,9 @@ func ingestWithRetries(
 		if i := r.CurrentAttempt(); i > 5 {
 			status := redact.Sprintf("retrying after error on attempt %d: %s", i, err)
 			updateRunningStatus(ctx, ingestionJob, jobspb.ReplicationError, status)
+		} else {
+			// At least log the retryable error if we're not updating the status.
+			log.Infof(ctx, "hit retryable error %s", err)
 		}
 		newReplicatedTime := loadReplicatedTime(ctx, execCtx.ExecCfg().InternalDB, ingestionJob)
 		if lastReplicatedTime.Less(newReplicatedTime) {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamclient"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
-	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -44,7 +43,7 @@ var CannotSetExpirationWindowErr = errors.New("cannot specify EXPIRATION WINDOW 
 func streamIngestionJobDescription(
 	p sql.PlanHookState, sourceAddr string, streamIngestion *tree.CreateTenantFromReplication,
 ) (string, error) {
-	redactedSourceAddr, err := redactSourceURI(sourceAddr)
+	redactedSourceAddr, err := streamclient.RedactSourceURI(sourceAddr)
 	if err != nil {
 		return "", err
 	}
@@ -58,10 +57,6 @@ func streamIngestionJobDescription(
 	}
 	ann := p.ExtendedEvalContext().Annotations
 	return tree.AsStringWithFQNames(redactedCreateStmt, ann), nil
-}
-
-func redactSourceURI(addr string) (string, error) {
-	return cloud.SanitizeExternalStorageURI(addr, streamclient.RedactableURLParameters)
 }
 
 func ingestionTypeCheck(


### PR DESCRIPTION
We should never log or return a raw postgres url as it may contain sensitive
information.

Epic: none

Release note: none