### PR TITLE
jobs: don't log stack trace for cancelled jobs

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1572,7 +1572,8 @@ func (r *Registry) stepThroughStateMachine(
 	payload := job.Payload()
 	jobType := payload.Type()
 	if jobErr != nil {
-		if pgerror.HasCandidateCode(jobErr) {
+		isExpectedError := pgerror.HasCandidateCode(jobErr) || HasErrJobCanceled(jobErr)
+		if isExpectedError {
 			log.Infof(ctx, "%s job %d: stepping through state %s with error: %v", jobType, job.ID(), status, jobErr)
 		} else {
 			log.Errorf(ctx, "%s job %d: stepping through state %s with unexpected error: %+v", jobType, job.ID(), status, jobErr)


### PR DESCRIPTION
This prevents logging a large stack trace for cancelled jobs.

Release note: None
Epic: none