### PR TITLE
roachtest: use non root authentication by default

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -984,6 +984,7 @@ var pgurlCmd = &cobra.Command{
 			Secure:             secure,
 			VirtualClusterName: virtualClusterName,
 			SQLInstance:        sqlInstance,
+			Auth:               install.AuthRootCert,
 		})
 		if err != nil {
 			return err

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2701,7 +2701,7 @@ func (c *clusterImpl) ConnE(
 	urls, err := c.ExternalPGUrl(ctx, l, c.Node(node), roachprod.PGURLOptions{
 		VirtualClusterName: connOptions.TenantName,
 		SQLInstance:        connOptions.SQLInstance,
-		Auth:               install.AuthRootCert,
+		Auth:               connOptions.AuthMode,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2701,6 +2701,7 @@ func (c *clusterImpl) ConnE(
 	urls, err := c.ExternalPGUrl(ctx, l, c.Node(node), roachprod.PGURLOptions{
 		VirtualClusterName: connOptions.TenantName,
 		SQLInstance:        connOptions.SQLInstance,
+		Auth:               install.AuthRootCert,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1349,19 +1349,28 @@ func (c *clusterImpl) FetchDebugZip(
 		// assumption that a down node will refuse the connection, so it won't
 		// waste our time.
 		for _, node := range nodes {
+			// `cockroach debug zip` does not support non root authentication.
+			nodePgUrl, err := c.InternalPGUrl(ctx, l, c.Node(node), roachprod.PGURLOptions{Auth: install.AuthRootCert})
+			if err != nil {
+				l.Printf("cluster.FetchDebugZip failed to retrieve PGUrl on node %d: %v", test.DefaultCockroachPath, node, err)
+				continue
+			}
+
 			// `cockroach debug zip` is noisy. Suppress the output unless it fails.
 			//
-			// Ignore the files in the the log directory; we pull the logs separately anyway
+			// Ignore the files in the log directory; we pull the logs separately anyway
 			// so this would only cause duplication.
 			excludeFiles := "*.log,*.txt,*.pprof"
+
 			cmd := roachtestutil.NewCommand("%s debug zip", test.DefaultCockroachPath).
 				Option("include-range-info").
 				Flag("exclude-files", fmt.Sprintf("'%s'", excludeFiles)).
-				Flag("url", fmt.Sprintf("{pgurl:%d}", node)).
+				Flag("url", nodePgUrl[0]).
 				MaybeFlag(c.IsSecure(), "certs-dir", install.CockroachNodeCertsDir).
+				MaybeFlag(c.IsSecure(), "certs-dir", "certs").
 				Arg(zipName).
 				String()
-			if err := c.RunE(ctx, option.WithNodes(c.Node(node)), cmd); err != nil {
+			if err = c.RunE(ctx, option.WithNodes(c.Node(node)), cmd); err != nil {
 				l.Printf("%s debug zip failed on node %d: %v", test.DefaultCockroachPath, node, err)
 				continue
 			}

--- a/pkg/cmd/roachtest/option/connection_options.go
+++ b/pkg/cmd/roachtest/option/connection_options.go
@@ -13,6 +13,8 @@ package option
 import (
 	"fmt"
 	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 )
 
 type ConnOption struct {
@@ -20,6 +22,7 @@ type ConnOption struct {
 	DBName      string
 	TenantName  string
 	SQLInstance int
+	AuthMode    install.PGAuthMode
 	Options     map[string]string
 }
 
@@ -61,5 +64,11 @@ func ConnectTimeout(t time.Duration) func(*ConnOption) {
 func DBName(dbName string) func(*ConnOption) {
 	return func(option *ConnOption) {
 		option.DBName = dbName
+	}
+}
+
+func AuthMode(authMode install.PGAuthMode) func(*ConnOption) {
+	return func(option *ConnOption) {
+		option.AuthMode = authMode
 	}
 }

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -632,7 +632,8 @@ func runBackupMVCCRangeTombstones(
 	t.Status("starting csv servers")
 	c.Run(ctx, option.WithNodes(c.All()), `./cockroach workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 
-	conn := c.Conn(ctx, t.L(), 1, option.TenantName(config.tenantName))
+	// c2c tests still use the old multitenant API, which does not support non root authentication
+	conn := c.Conn(ctx, t.L(), 1, option.TenantName(config.tenantName), option.AuthMode(install.AuthRootCert))
 
 	// Configure cluster.
 	t.Status("configuring cluster")

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1806,11 +1806,11 @@ func copyPGCertsAndMakeURL(
 	if err != nil {
 		return "", err
 	}
-	sslClientCert, err := os.ReadFile(filepath.Join(tmpDir, "client.root.crt"))
+	sslClientCert, err := os.ReadFile(filepath.Join(tmpDir, fmt.Sprintf("client.%s.crt", install.DefaultUser)))
 	if err != nil {
 		return "", err
 	}
-	sslClientKey, err := os.ReadFile(filepath.Join(tmpDir, "client.root.key"))
+	sslClientKey, err := os.ReadFile(filepath.Join(tmpDir, fmt.Sprintf("client.%s.key", install.DefaultUser)))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -355,7 +355,7 @@ func registerImportDecommissioned(r registry.Registry) {
 		// Decommission a node.
 		nodeToDecommission := 2
 		t.Status(fmt.Sprintf("decommissioning node %d", nodeToDecommission))
-		c.Run(ctx, option.WithNodes(c.Node(nodeToDecommission)), `./cockroach node decommission --self --wait=all --url={pgurl:2}`)
+		c.Run(ctx, option.WithNodes(c.Node(nodeToDecommission)), fmt.Sprintf(`./cockroach node decommission --self --wait=all --port={pgport:%d} --certs-dir=%s`, nodeToDecommission, install.CockroachNodeCertsDir))
 
 		// Wait for a bit for node liveness leases to expire.
 		time.Sleep(10 * time.Second)

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -118,7 +118,8 @@ func registerKV(r registry.Registry) {
 			}
 		}
 		if opts.sharedProcessMT {
-			createInMemoryTenant(ctx, t, c, appTenantName, c.Range(1, nodes), true /* secure */)
+			startOpts = option.DefaultStartSharedVirtualClusterOpts(appTenantName)
+			c.StartServiceForVirtualCluster(ctx, t.L(), c.Range(1, nodes), startOpts, install.MakeClusterSettings(), c.Range(1, nodes))
 		}
 
 		t.Status("running workload")

--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -199,7 +199,7 @@ func runMultiTenantDistSQL(
 		if bundle {
 			// Open bundle and verify its contents
 			sqlConnCtx := clisqlclient.Context{}
-			pgURL, err := c.ExternalPGUrl(ctx, t.L(), c.Node(1), roachprod.PGURLOptions{VirtualClusterName: tenantName, Auth: install.AuthRootCert})
+			pgURL, err := c.ExternalPGUrl(ctx, t.L(), c.Node(1), roachprod.PGURLOptions{VirtualClusterName: tenantName})
 			require.NoError(t, err)
 			conn := sqlConnCtx.MakeSQLConn(io.Discard, io.Discard, pgURL[0])
 			bundles, err := clisqlclient.StmtDiagListBundles(ctx, conn)

--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -199,7 +199,7 @@ func runMultiTenantDistSQL(
 		if bundle {
 			// Open bundle and verify its contents
 			sqlConnCtx := clisqlclient.Context{}
-			pgURL, err := c.ExternalPGUrl(ctx, t.L(), c.Node(1), roachprod.PGURLOptions{VirtualClusterName: tenantName})
+			pgURL, err := c.ExternalPGUrl(ctx, t.L(), c.Node(1), roachprod.PGURLOptions{VirtualClusterName: tenantName, Auth: install.AuthRootCert})
 			require.NoError(t, err)
 			conn := sqlConnCtx.MakeSQLConn(io.Discard, io.Discard, pgURL[0])
 			bundles, err := clisqlclient.StmtDiagListBundles(ctx, conn)

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -202,7 +202,7 @@ func (tn *tenantNode) start(ctx context.Context, t test.Test, c cluster.Cluster,
 		extraArgs...,
 	)
 
-	externalUrls, err := c.ExternalPGUrl(ctx, t.L(), c.Node(tn.node), roachprod.PGURLOptions{})
+	externalUrls, err := c.ExternalPGUrl(ctx, t.L(), c.Node(tn.node), roachprod.PGURLOptions{Auth: install.AuthRootCert})
 	require.NoError(t, err)
 	u, err := url.Parse(externalUrls[0])
 	require.NoError(t, err)
@@ -217,7 +217,9 @@ func (tn *tenantNode) start(ctx context.Context, t test.Test, c cluster.Cluster,
 	// (i.e. to run workload on the tenant).
 	secureUrls, err := roachprod.PgURL(ctx, t.L(), c.MakeNodes(c.Node(tn.node)), install.CockroachNodeCertsDir, roachprod.PGURLOptions{
 		External: false,
-		Secure:   true})
+		Secure:   true,
+		Auth:     install.AuthRootCert,
+	})
 	require.NoError(t, err)
 	u, err = url.Parse(strings.Trim(secureUrls[0], "'"))
 	require.NoError(t, err)

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -202,6 +202,8 @@ func (tn *tenantNode) start(ctx context.Context, t test.Test, c cluster.Cluster,
 		extraArgs...,
 	)
 
+	// The old multitenant API does not create a default admin user for virtual clusters, so root
+	// authentication is used instead.
 	externalUrls, err := c.ExternalPGUrl(ctx, t.L(), c.Node(tn.node), roachprod.PGURLOptions{Auth: install.AuthRootCert})
 	require.NoError(t, err)
 	u, err := url.Parse(externalUrls[0])
@@ -215,6 +217,9 @@ func (tn *tenantNode) start(ctx context.Context, t test.Test, c cluster.Cluster,
 	// pgURL has full paths to local certs embedded, i.e.
 	// /tmp/roachtest-certs3630333874/certs, on the cluster we want just certs
 	// (i.e. to run workload on the tenant).
+	//
+	// The old multitenant API does not create a default admin user for virtual clusters, so root
+	// authentication is used instead.
 	secureUrls, err := roachprod.PgURL(ctx, t.L(), c.MakeNodes(c.Node(tn.node)), install.CockroachNodeCertsDir, roachprod.PGURLOptions{
 		External: false,
 		Secure:   true,
@@ -374,7 +379,9 @@ func startInMemoryTenant(
 	var tenantConn *gosql.DB
 	testutils.SucceedsSoon(t, func() error {
 		var err error
-		tenantConn, err = c.ConnE(ctx, t.L(), nodes.RandNode()[0], option.TenantName(tenantName))
+		// The old multitenant API does not create a default admin user for virtual clusters, so root
+		// authentication is used instead.
+		tenantConn, err = c.ConnE(ctx, t.L(), nodes.RandNode()[0], option.TenantName(tenantName), option.AuthMode(install.AuthRootCert))
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -298,12 +298,10 @@ func startTenantServer(
 
 // createTenantAdminRole creates a role that can be used to log into a secure cluster's db console.
 func createTenantAdminRole(t test.Test, tenantName string, tenantSQL *sqlutils.SQLRunner) {
-	username := "secure"
-	password := "roach"
-	tenantSQL.Exec(t, fmt.Sprintf(`CREATE ROLE %s WITH LOGIN PASSWORD '%s'`, username, password))
-	tenantSQL.Exec(t, fmt.Sprintf(`GRANT ADMIN TO %s`, username))
+	tenantSQL.Exec(t, fmt.Sprintf(`CREATE ROLE IF NOT EXISTS %s WITH LOGIN PASSWORD '%s'`, install.DefaultUser, install.DefaultPassword))
+	tenantSQL.Exec(t, fmt.Sprintf(`GRANT ADMIN TO %s`, install.DefaultUser))
 	t.L().Printf(`Log into %s db console with username "%s" and password "%s"`,
-		tenantName, username, password)
+		tenantName, install.DefaultUser, install.DefaultPassword)
 }
 
 const appTenantName = "app"

--- a/pkg/cmd/roachtest/tests/network_logging.go
+++ b/pkg/cmd/roachtest/tests/network_logging.go
@@ -82,7 +82,8 @@ func registerNetworkLogging(r registry.Registry) {
 			install.CockroachNodeCertsDir, /* certsDir */
 			roachprod.PGURLOptions{
 				External: false,
-				Secure:   true})
+				Secure:   true,
+			})
 		require.NoError(t, err)
 		workloadPGURLs := make([]string, len(secureUrls))
 		for i, url := range secureUrls {

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -1455,7 +1455,9 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 
 	var db *gosql.DB
 	if b.SharedProcessMT {
-		db = createInMemoryTenantWithConn(ctx, t, c, appTenantName, roachNodes, false /* secure */)
+		startOpts = option.DefaultStartSharedVirtualClusterOpts(appTenantName)
+		c.StartServiceForVirtualCluster(ctx, t.L(), roachNodes, startOpts, settings, roachNodes)
+		db = c.Conn(ctx, t.L(), 1, option.TenantName(appTenantName))
 	} else {
 		db = c.Conn(ctx, t.L(), 1)
 	}

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -512,7 +512,9 @@ func runTPCHVec(ctx context.Context, t test.Test, c cluster.Cluster, testCase tp
 		if _, err := singleTenantConn.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false;"); err != nil {
 			t.Fatal(err)
 		}
-		conn = createInMemoryTenantWithConn(ctx, t, c, appTenantName, c.All(), c.IsSecure() /* secure */)
+		startOpts := option.DefaultStartSharedVirtualClusterOpts(appTenantName)
+		c.StartServiceForVirtualCluster(ctx, t.L(), c.All(), startOpts, install.MakeClusterSettings(), c.All())
+		conn = c.Conn(ctx, t.L(), c.All().RandNode()[0], option.TenantName(appTenantName))
 	} else {
 		conn = c.Conn(ctx, t.L(), 1)
 		disableMergeQueue = true

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2580,7 +2580,7 @@ func (c *SyncedCluster) pgurls(
 		if err != nil {
 			return nil, err
 		}
-		m[node] = c.NodeURL(host, desc.Port, virtualClusterName, desc.ServiceMode, AuthRootCert)
+		m[node] = c.NodeURL(host, desc.Port, virtualClusterName, desc.ServiceMode, AuthUserCert)
 	}
 	return m, nil
 }

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -500,22 +500,21 @@ func (c *SyncedCluster) CertsDir(node Node) string {
 type PGAuthMode int
 
 const (
-	// AuthRootCert authenticates using the root user and root cert + root client certs.
-	// Root authentication skips verification paths and is not reflective of how real
-	// users authenticate.
-	// TODO(darrylwong): Minimize the amount of root user authentication used.
-	AuthRootCert PGAuthMode = iota
+	// AuthUserCert authenticates using the default user and password, as well
+	// as the root cert and client certs. This uses sslmode=verify-full and will
+	// verify that the certificate is valid. This is the preferred mode of
+	// authentication.
+	AuthUserCert PGAuthMode = iota
 	// AuthUserPassword authenticates using the default user and password. Since
 	// no certs are specified, sslmode is set to allow. Note this form of auth
 	// only works if sslmode=allow is an option, i.e. cockroach sql.
 	// AuthUserCert should be used instead most of the time, except when
 	// certificates don't exist.
 	AuthUserPassword
-	// AuthUserCert authenticates using the default user and password, as well
-	// as the root cert and client certs. This uses sslmode=verify-full and will
-	// verify that the certificate is valid. This is the preferred mode of
-	// authentication.
-	AuthUserCert
+	// AuthRootCert authenticates using the root user and root cert + root client certs.
+	// Root authentication skips verification paths and is not reflective of how real
+	// users authenticate.
+	AuthRootCert
 
 	DefaultUser     = "roachprod"
 	DefaultPassword = "cockroachdb"
@@ -534,8 +533,6 @@ func (c *SyncedCluster) NodeURL(
 	v := url.Values{}
 	if c.Secure {
 		user := DefaultUser
-		// TODO(DarrylWong): Support authentication for multitenant,
-		// since they do not use roach:system.
 		password := DefaultPassword
 
 		switch auth {


### PR DESCRIPTION
This PR attempts to minimize the usage of root user authentication in roachtests, as the root user skips certain authentication paths. 

This is done through changing the default mode of authentication to `AuthUserCert` instead of `AuthRootCert`. This establishes non root user auth as the preferred default for roachtests and forces tests to explicitly opt into root auth. Relevant roachtest/roachprod helpers such as `c.Conn` and `{pgurl}` will now default to using the `DefaultUser` instead of root.

The majority of tests should now be authenticating with a non root user. The exceptions are:
1. Tests that run in insecure mode. 
3. `multitenant` tests that use the old API. The old API does not create a default admin user for the tenant or copy certs to the tenant. While the `c2c` tests have helpers that do this, it would be easier/better to just switch the problematic tests to the new API than to try and reuse the c2c API. I did this for a few of the trivial switches, i.e `kv0/enc=false/nodes=3/cpu=32/mt-shared-process`.
4. Roachprod cluster setup that cannot use a non root user, i.e. the command to create the default non root user.

Release note: none
Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/63145