### PR TITLE
backupccl_test: migrate to `heavy` remote execution pool

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -205,10 +205,9 @@ go_test(
     ],
     data = glob(["testdata/**"]) + ["//c-deps:libgeos"],
     embed = [":backupccl"],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {
+        "test.Pool": "heavy",
+    },
     shard_count = 48,
     tags = ["ccl_test"],
     deps = [


### PR DESCRIPTION
`TestBackupDBWithViewOnAdjacentDBRange` in this package is routinely flaking only in remote execution. Trying this to see if it helps.

Epic: CRDB-8308
Release note: None