### PR TITLE
workflows: for `acceptance`, only upload artifacts if job failed

### DIFF
--- a/.github/workflows/experimental-github-actions-testing.yml
+++ b/.github/workflows/experimental-github-actions-testing.yml
@@ -82,6 +82,7 @@ jobs:
         run: ./build/github/summarize-build.sh bes.bin
         if: always()
       - uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
         with:
           name: acceptance artifacts
           path: artifacts


### PR DESCRIPTION
Epic: CRDB-8308
Release note: None