### PR TITLE
backupccl: deflake TestDataDriven_column_families

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/column-families
+++ b/pkg/ccl/backupccl/testdata/backup-restore/column-families
@@ -47,10 +47,11 @@ RESTORE cfs FROM LATEST IN 'nodelocal://1/foo' WITH into_db='r1';
 ----
 
 query-sql
-SELECT start_key FROM [SHOW RANGES FROM TABLE orig.cfs]
+SELECT start_pretty from crdb_internal.ranges
+ WHERE start_key >= crdb_internal.index_span('orig.cfs'::regclass::oid::int, 1)[1]
+   AND start_key <= crdb_internal.index_span('orig.cfs'::regclass::oid::int, 1)[2];
 ----
-…/<TableMin>
-…/1/0
-…/1/1
-…/1/2
-…/1/3
+/Table/109/1/0
+/Table/109/1/1
+/Table/109/1/2
+/Table/109/1/3


### PR DESCRIPTION
Sometimes, this test runs fast enough that the split at the start of our table hasn't actually been put in place yet. Here, I change the assertion to just look for the splits we manually put into place.

If this doesn't work, we should just remove the assertion completely, since the assertion this test used to actually care about was on the _restored_ table, but that assertion was removed because it was invalidated by other changes to how we split on restore.

Fixes #119287

Release note: none