### PR TITLE
kv: verify roachpb.Value checksums when building snapshots

### DIFF
--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -556,15 +556,24 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 			}
 
 			timingTag.start("sst")
+			verifyCheckSum := snapshotChecksumVerification.Get(&s.ClusterSettings().SV)
 			// All batch operations are guaranteed to be point key or range key puts.
 			for batchReader.Next() {
+				// TODO(lyang24): maybe avoid decoding engine key twice.
+				// msstw calls (i.e. PutInternalPointKey) can use the decoded engine key here as input.
+				ek, err := batchReader.EngineKey()
+				if err != nil {
+					return noSnap, err
+				}
+				// Verify value checksum to catch data corruption.
+				if verifyCheckSum {
+					if err = ek.Verify(batchReader.Value()); err != nil {
+						return noSnap, errors.Wrap(err, "verifying value checksum")
+					}
+				}
 				switch batchReader.KeyKind() {
 				case pebble.InternalKeyKindSet, pebble.InternalKeyKindSetWithDelete:
-					key, err := batchReader.EngineKey()
-					if err != nil {
-						return noSnap, err
-					}
-					if err := msstw.Put(ctx, key, batchReader.Value()); err != nil {
+					if err := msstw.Put(ctx, ek, batchReader.Value()); err != nil {
 						return noSnap, errors.Wrapf(err, "writing sst for raft snapshot")
 					}
 				case pebble.InternalKeyKindDelete, pebble.InternalKeyKindDeleteSized:
@@ -607,10 +616,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 						}
 					}
 				case pebble.InternalKeyKindRangeKeySet:
-					start, err := batchReader.EngineKey()
-					if err != nil {
-						return noSnap, err
-					}
+					start := ek
 					end, err := batchReader.EngineEndKey()
 					if err != nil {
 						return noSnap, err
@@ -1658,6 +1664,15 @@ var snapshotSSTWriteSyncRate = settings.RegisterByteSizeSetting(
 	"threshold after which snapshot SST writes must fsync",
 	kvserverbase.BulkIOWriteBurst,
 	settings.PositiveInt,
+)
+
+// snapshotChecksumVerification enables/disables value checksums verification
+// when receiving snapshots.
+var snapshotChecksumVerification = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.snapshot_receiver.checksum_verification.enabled",
+	"verify value checksums on receiving a raft snapshot",
+	true,
 )
 
 // SendEmptySnapshot creates an OutgoingSnapshot for the input range


### PR DESCRIPTION
This commit verify record checksum verification when processing raft snapshot records. This process prevents data corruption spread via snapshot process. Cluster setting snapshotChecksumVerification is introduced to act as a safeguard knob to turn on/off the verifcation.

Fixes: https://github.com/cockroachdb/cockroach/issues/110572

Release note: None