### PR TITLE
kvcoord: add `Transport.Reset()`

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -216,6 +216,10 @@ func (l *simpleTransportAdapter) MoveToFront(replica roachpb.ReplicaDescriptor) 
 	return false
 }
 
+func (l *simpleTransportAdapter) Reset() {
+	l.nextReplicaIdx = 0
+}
+
 func (l *simpleTransportAdapter) Release() {}
 
 func makeGossip(t *testing.T, stopper *stop.Stopper, rpcContext *rpc.Context) *gossip.Gossip {

--- a/pkg/kv/kvclient/kvcoord/mocks_generated_test.go
+++ b/pkg/kv/kvclient/kvcoord/mocks_generated_test.go
@@ -106,6 +106,18 @@ func (mr *MockTransportMockRecorder) Release() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Release", reflect.TypeOf((*MockTransport)(nil).Release))
 }
 
+// Reset mocks base method.
+func (m *MockTransport) Reset() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Reset")
+}
+
+// Reset indicates an expected call of Reset.
+func (mr *MockTransportMockRecorder) Reset() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockTransport)(nil).Reset))
+}
+
 // SendNext mocks base method.
 func (m *MockTransport) SendNext(arg0 context.Context, arg1 *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
 	m.ctrl.T.Helper()

--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -193,6 +193,10 @@ func (*firstNErrorTransport) MoveToFront(roachpb.ReplicaDescriptor) bool {
 	return true
 }
 
+func (f *firstNErrorTransport) Reset() {
+	f.numSent = 0
+}
+
 // TestComplexScenarios verifies various complex success/failure scenarios by
 // mocking sendOne.
 func TestComplexScenarios(t *testing.T) {

--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -85,6 +85,11 @@ type Transport interface {
 	// transport.
 	MoveToFront(roachpb.ReplicaDescriptor) bool
 
+	// Reset moves back to the first replica in the transport, according to the
+	// current ordering. This may not be the same replica as MoveToFront if it was
+	// called prior, which places the replica at the next rather than first index.
+	Reset()
+
 	// Release releases any resources held by this Transport.
 	Release()
 }
@@ -283,6 +288,10 @@ func (gt *grpcTransport) MoveToFront(replica roachpb.ReplicaDescriptor) bool {
 	return false
 }
 
+func (gt *grpcTransport) Reset() {
+	gt.nextReplicaIdx = 0
+}
+
 // splitHealthy splits the grpcTransport's replica slice into healthy replica
 // and unhealthy replica, based on their connection state. Healthy replicas will
 // be rearranged first in the replicas slice, and unhealthy replicas will be
@@ -393,5 +402,7 @@ func (s *senderTransport) SkipReplica() {
 func (s *senderTransport) MoveToFront(replica roachpb.ReplicaDescriptor) bool {
 	return true
 }
+
+func (s *senderTransport) Reset() {}
 
 func (s *senderTransport) Release() {}

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -106,6 +106,50 @@ func TestTransportMoveToFront(t *testing.T) {
 	require.Equal(t, 1, gt.nextReplicaIdx)
 }
 
+func TestTransportReset(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	rd1 := roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 1, ReplicaID: 1}
+	rd2 := roachpb.ReplicaDescriptor{NodeID: 2, StoreID: 2, ReplicaID: 2}
+	rd3 := roachpb.ReplicaDescriptor{NodeID: 3, StoreID: 3, ReplicaID: 3}
+	gt := grpcTransport{replicas: []roachpb.ReplicaDescriptor{rd1, rd2, rd3}}
+
+	// Reset should be a noop when positioned at start.
+	require.Equal(t, rd1, gt.NextReplica())
+	gt.Reset()
+	require.Equal(t, rd1, gt.NextReplica())
+
+	// Reset should move back to front when in the middle.
+	gt.SkipReplica()
+	require.Equal(t, rd2, gt.NextReplica())
+	gt.Reset()
+	require.Equal(t, rd1, gt.NextReplica())
+
+	// Reset should move back to front when exhausted.
+	gt.SkipReplica()
+	gt.SkipReplica()
+	gt.SkipReplica()
+	require.True(t, gt.IsExhausted())
+	gt.Reset()
+	require.False(t, gt.IsExhausted())
+	require.Equal(t, rd1, gt.NextReplica())
+
+	// MoveToFront will reorder replicas by moving the replica to the next index.
+	// Reset moves to the start of the modified ordering.
+	gt.SkipReplica()
+	gt.SkipReplica()
+	require.True(t, gt.MoveToFront(rd1))
+	gt.Reset()
+	require.Equal(t, rd2, gt.NextReplica())
+	gt.SkipReplica()
+	require.Equal(t, rd1, gt.NextReplica())
+	gt.SkipReplica()
+	require.Equal(t, rd3, gt.NextReplica())
+	gt.SkipReplica()
+	require.True(t, gt.IsExhausted())
+}
+
 // TestSpanImport tests that the gRPC transport ingests trace information that
 // came from gRPC responses (via tracingpb.RecordedSpan on the batch responses).
 func TestSpanImport(t *testing.T) {


### PR DESCRIPTION
Extracted from #118943.

---

This resets the transport back to the first replica in the list.

Epic: none
Release note: None