### PR TITLE
util/circuit: allow nil event handler

### DIFF
--- a/pkg/jobs/joberror/errors_test.go
+++ b/pkg/jobs/joberror/errors_test.go
@@ -25,7 +25,6 @@ func TestErrBreakerOpenIsRetriable(t *testing.T) {
 		AsyncProbe: func(_ func(error), done func()) {
 			done() // never untrip
 		},
-		EventHandler: &circuit.EventLogger{Log: func(redact.StringBuilder) {}},
 	})
 	br.Report(errors.New("test error"))
 	require.False(t, IsPermanentBulkJobError(br.Signal().Err()))

--- a/pkg/rpc/peer.go
+++ b/pkg/rpc/peer.go
@@ -185,9 +185,6 @@ func (rpcCtx *Context) newPeer(k peerKey) *peer {
 				p.launch(ctx, report, done)
 			})
 		},
-		// Use a noop EventHandler; we do our own logging in the probe since we'll
-		// have better information.
-		EventHandler: &circuit.EventLogger{Log: func(buf redact.StringBuilder) {}},
 	})
 	p.b = b
 	c := newConnectionToNodeID(k, b.Signal)

--- a/pkg/util/circuit/circuitbreaker_test.go
+++ b/pkg/util/circuit/circuitbreaker_test.go
@@ -438,7 +438,6 @@ func BenchmarkBreaker_Signal(b *testing.B) {
 		AsyncProbe: func(_ func(error), done func()) {
 			done() // never untrip
 		},
-		EventHandler: &EventLogger{Log: func(redact.StringBuilder) {}},
 	})
 
 	// The point of this benchmark is to verify the absence of allocations when

--- a/pkg/util/circuit/options.go
+++ b/pkg/util/circuit/options.go
@@ -42,7 +42,8 @@ type Options struct {
 	AsyncProbe func(report func(error), done func())
 
 	// EventHandler receives events from the Breaker. For an implementation that
-	// performs unstructured logging, see EventLogger.
+	// performs unstructured logging, see EventLogger. Can be nil if no event
+	// handler is needed.
 	EventHandler EventHandler
 
 	// signalInterceptor gets to see and change the return value of the Signal


### PR DESCRIPTION
Extracted from #118943.

---

Users may not need an event handler, allow it to be unset.

Epic: none
Release note: None