### PR TITLE
kvserver: add `Replica.GetMutexForTesting()`

### DIFF
--- a/pkg/kv/kvserver/kvserverbase/stores.go
+++ b/pkg/kv/kvserver/kvserverbase/stores.go
@@ -42,6 +42,7 @@ type Store interface {
 
 	// GetReplicaMutexForTesting returns the mutex of the replica with the given
 	// range ID, or nil if no replica was found. This is used for testing.
+	// Returns a syncutil.RWMutex rather than ReplicaMutex to avoid import cycles.
 	GetReplicaMutexForTesting(rangeID roachpb.RangeID) *syncutil.RWMutex
 }
 

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2464,3 +2464,8 @@ func (r *Replica) ReadProtectedTimestampsForTesting(ctx context.Context) (err er
 	ts, err = r.readProtectedTimestampsRLocked(ctx)
 	return err
 }
+
+// GetMutexForTesting returns the replica's mutex, for use in tests.
+func (r *Replica) GetMutexForTesting() *ReplicaMutex {
+	return &r.mu.ReplicaMutex
+}

--- a/pkg/kv/kvserver/stores_base.go
+++ b/pkg/kv/kvserver/stores_base.go
@@ -99,7 +99,7 @@ func (s *baseStore) SetQueueActive(active bool, queue string) error {
 func (s *baseStore) GetReplicaMutexForTesting(rangeID roachpb.RangeID) *syncutil.RWMutex {
 	store := (*Store)(s)
 	if repl := store.GetReplicaIfExists(rangeID); repl != nil {
-		return (*syncutil.RWMutex)(&repl.mu.ReplicaMutex)
+		return (*syncutil.RWMutex)(repl.GetMutexForTesting())
 	}
 	return nil
 }


### PR DESCRIPTION
Extracted from #118943.

---

This allows testing replica stalls and deadlocks from outside of the kvserver package.

Epic: none
Release note: None