### PR TITLE
jobs: reduce round trips for control queries

### DIFF
--- a/pkg/bench/rttanalysis/jobs_test.go
+++ b/pkg/bench/rttanalysis/jobs_test.go
@@ -45,14 +45,51 @@ func init() {
 		fmt.Sprintf("INSERT INTO system.job_info(job_id, info_key, value) (SELECT id, 'legacy_payload', '\\x%s' FROM generate_series(1000, 3000) as id)",
 			hex.EncodeToString(payloadBytes)),
 		"INSERT INTO system.jobs(id, status, created, job_type) (SELECT id, 'succeeded', now(), 'IMPORT' FROM generate_series(1000, 3000) as id)",
+
+		// Job 3001 is a RUNNING job. We've marked it as
+		// claimed and added run stats that likely prevent it
+		// from being meaninfully used during the duration of
+		// the test.
+		fmt.Sprintf("INSERT INTO system.job_info(job_id, info_key, value) VALUES (3001, 'legacy_progress', '\\x%s')", hex.EncodeToString(progressBytes)),
+		fmt.Sprintf("INSERT INTO system.job_info(job_id, info_key, value) VALUES (3001, 'legacy_payload', '\\x%s')", hex.EncodeToString(payloadBytes)),
+		`INSERT INTO system.jobs(id, status, created, last_run, num_runs, job_type, claim_instance_id, claim_session_id) VALUES (3001, 'running', now(), now(), 200, 'IMPORT',
+(SELECT id FROM system.sql_instances WHERE session_id IS NOT NULL ORDER BY id LIMIT 1),
+(SELECT session_id FROM system.sql_instances WHERE session_id IS NOT NULL ORDER BY id LIMIT 1))`,
+
+		// Job 3002 is a PAUSED job.
+		fmt.Sprintf("INSERT INTO system.job_info(job_id, info_key, value) VALUES (3002, 'legacy_progress', '\\x%s')", hex.EncodeToString(progressBytes)),
+		fmt.Sprintf("INSERT INTO system.job_info(job_id, info_key, value) VALUES (3002, 'legacy_payload', '\\x%s')", hex.EncodeToString(payloadBytes)),
+		`INSERT INTO system.jobs(id, status, created, last_run, num_runs, job_type, claim_instance_id, claim_session_id) VALUES (3002, 'paused', now(), now(), 200, 'IMPORT',
+(SELECT id FROM system.sql_instances WHERE session_id IS NOT NULL ORDER BY id LIMIT 1),
+(SELECT session_id FROM system.sql_instances WHERE session_id IS NOT NULL ORDER BY id LIMIT 1))`,
 	}
+
+	cleanupQuery := "DELETE FROM system.jobs WHERE id >= 1000 AND id <= 4000; DELETE FROM system.job_info WHERE job_id >= 1000 AND job_id <= 4000"
 
 	reg.Register("Jobs", []RoundTripBenchTestCase{
 		{
 			SetupEx: setupQueries,
-			Reset:   "DELETE FROM system.jobs WHERE id >= 1000 AND id <= 3000; DELETE FROM system.job_info WHERE job_id >= 1000 AND job_id <= 3000",
+			Reset:   cleanupQuery,
 			Name:    "show job",
 			Stmt:    "SHOW JOB 2000",
+		},
+		{
+			SetupEx: setupQueries,
+			Reset:   cleanupQuery,
+			Name:    "pause job",
+			Stmt:    "PAUSE JOB 3001",
+		},
+		{
+			SetupEx: setupQueries,
+			Reset:   cleanupQuery,
+			Name:    "cancel job",
+			Stmt:    "CANCEL JOB 3001",
+		},
+		{
+			SetupEx: setupQueries,
+			Reset:   cleanupQuery,
+			Name:    "resume job",
+			Stmt:    "RESUME JOB 3002",
 		},
 	})
 }

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -61,9 +61,9 @@ exp,benchmark
 23,Grant/grant_all_on_3_tables
 19,GrantRole/grant_1_role
 25,GrantRole/grant_2_roles
-9,Jobs/cancel_job
-11,Jobs/pause_job
-11,Jobs/resume_job
+6,Jobs/cancel_job
+8,Jobs/pause_job
+8,Jobs/resume_job
 3,Jobs/show_job
 3,ORMQueries/activerecord_type_introspection_query
 0,ORMQueries/asyncpg_types

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -63,7 +63,7 @@ exp,benchmark
 25,GrantRole/grant_2_roles
 6,Jobs/cancel_job
 8,Jobs/pause_job
-8,Jobs/resume_job
+6,Jobs/resume_job
 3,Jobs/show_job
 3,ORMQueries/activerecord_type_introspection_query
 0,ORMQueries/asyncpg_types

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -61,6 +61,9 @@ exp,benchmark
 23,Grant/grant_all_on_3_tables
 19,GrantRole/grant_1_role
 25,GrantRole/grant_2_roles
+9,Jobs/cancel_job
+11,Jobs/pause_job
+11,Jobs/resume_job
 3,Jobs/show_job
 3,ORMQueries/activerecord_type_introspection_query
 0,ORMQueries/asyncpg_types

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1212,10 +1212,10 @@ func (b *changefeedResumer) handleChangefeedError(
 		const errorFmt = "job failed (%v) but is being paused because of %s=%s"
 		errorMessage := fmt.Sprintf(errorFmt, changefeedErr,
 			changefeedbase.OptOnError, changefeedbase.OptOnErrorPause)
-		return b.job.NoTxn().PauseRequestedWithFunc(ctx, func(ctx context.Context,
-			planHookState interface{}, txn isql.Txn, progress *jobspb.Progress) error {
+		return b.job.NoTxn().PauseRequestedWithFunc(ctx, func(ctx context.Context, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 			// directly update running status to avoid the running/reverted job status check
-			progress.RunningStatus = errorMessage
+			md.Progress.RunningStatus = errorMessage
+			ju.UpdateProgress(md.Progress)
 			log.Warningf(ctx, errorFmt, changefeedErr, changefeedbase.OptOnError, changefeedbase.OptOnErrorPause)
 			return nil
 		}, errorMessage)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3312,10 +3312,10 @@ func TestChangefeedJobControl(t *testing.T) {
 			waitForJobStatus(userDB, t, currentFeed.JobID(), "running")
 		})
 		asUser(t, f, `userWithSomeGrants`, func(userDB *sqlutils.SQLRunner) {
-			userDB.ExpectErr(t, "pq: user userwithsomegrants does not have CHANGEFEED privilege on relation table_b", "PAUSE job $1", currentFeed.JobID())
+			userDB.ExpectErr(t, "user userwithsomegrants does not have CHANGEFEED privilege on relation table_b", "PAUSE job $1", currentFeed.JobID())
 		})
 		asUser(t, f, `regularUser`, func(userDB *sqlutils.SQLRunner) {
-			userDB.ExpectErr(t, "pq: user regularuser does not have CHANGEFEED privilege on relation (table_a|table_b)", "PAUSE job $1", currentFeed.JobID())
+			userDB.ExpectErr(t, "user regularuser does not have CHANGEFEED privilege on relation (table_a|table_b)", "PAUSE job $1", currentFeed.JobID())
 		})
 		closeCf()
 
@@ -3329,10 +3329,10 @@ func TestChangefeedJobControl(t *testing.T) {
 			waitForJobStatus(userDB, t, currentFeed.JobID(), "paused")
 		})
 		asUser(t, f, `userWithAllGrants`, func(userDB *sqlutils.SQLRunner) {
-			userDB.ExpectErr(t, "pq: only admins can control jobs owned by other admins", "PAUSE job $1", currentFeed.JobID())
+			userDB.ExpectErr(t, "only admins can control jobs owned by other admins", "PAUSE job $1", currentFeed.JobID())
 		})
 		asUser(t, f, `jobController`, func(userDB *sqlutils.SQLRunner) {
-			userDB.ExpectErr(t, "pq: only admins can control jobs owned by other admins", "PAUSE job $1", currentFeed.JobID())
+			userDB.ExpectErr(t, "only admins can control jobs owned by other admins", "PAUSE job $1", currentFeed.JobID())
 		})
 		closeCf()
 	}

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -262,7 +262,7 @@ func (r *Registry) resumeJob(
 		return nil
 	}
 
-	resumer, err := r.createResumer(job, r.settings)
+	resumer, err := r.createResumer(job)
 	if err != nil {
 		return err
 	}

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -19,9 +19,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// OnPauseRequestFunc forwards the definition for use in tests.
-type OnPauseRequestFunc = onPauseRequestFunc
-
 func (r *Registry) CancelRequested(ctx context.Context, txn isql.Txn, id jobspb.JobID) error {
 	return r.cancelRequested(ctx, txn, id)
 }

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -375,22 +374,7 @@ func (u Updater) paused(ctx context.Context, fn func(context.Context, isql.Txn) 
 // resumes it.
 func (u Updater) Unpaused(ctx context.Context) error {
 	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
-		if md.Status == StatusRunning || md.Status == StatusReverting {
-			// Already resumed - do nothing.
-			return nil
-		}
-		if md.Status != StatusPaused {
-			return fmt.Errorf("job with status %s cannot be resumed", md.Status)
-		}
-		// We use the absence of error to determine what state we should
-		// resume into.
-		if md.Payload.FinalResumeError == nil {
-			ju.UpdateStatus(StatusRunning)
-		} else {
-			ju.UpdateStatus(StatusReverting)
-		}
-		ju.UpdatePayload(md.Payload)
-		return nil
+		return ju.Unpaused(ctx, md)
 	})
 }
 
@@ -412,26 +396,7 @@ func (u Updater) CancelRequested(ctx context.Context) error {
 // StatusReverting.
 func (u Updater) CancelRequestedWithReason(ctx context.Context, reason error) error {
 	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
-		if md.Payload.Noncancelable {
-			return errors.Newf("job %d: not cancelable", md.ID)
-		}
-		if md.Status == StatusCancelRequested || md.Status == StatusCanceled {
-			return nil
-		}
-		if md.Status != StatusPending && md.Status != StatusRunning && md.Status != StatusPaused {
-			return fmt.Errorf("job with status %s cannot be requested to be canceled", md.Status)
-		}
-		if md.Status == StatusPaused && md.Payload.FinalResumeError != nil {
-			decodedErr := errors.DecodeError(ctx, *md.Payload.FinalResumeError)
-			return errors.Wrapf(decodedErr, "job %d is paused and has non-nil FinalResumeError "+
-				"hence cannot be canceled and should be reverted", md.ID)
-		}
-		if !errors.Is(reason, errJobCanceled) {
-			md.Payload.Error = reason.Error()
-			ju.UpdatePayload(md.Payload)
-		}
-		ju.UpdateStatus(StatusCancelRequested)
-		return nil
+		return ju.CancelRequestedWithReason(ctx, md, reason)
 	})
 }
 
@@ -440,6 +405,41 @@ func (u Updater) CancelRequestedWithReason(ctx context.Context, reason error) er
 type onPauseRequestFunc func(
 	ctx context.Context, planHookState interface{}, txn isql.Txn, progress *jobspb.Progress,
 ) error
+
+func (u Updater) RunPauseRequestFunc(
+	ctx context.Context, fn onPauseRequestFunc, md JobMetadata,
+) error {
+	execCtx, cleanup := u.j.registry.execCtx(ctx, "pause request", md.Payload.UsernameProto.Decode())
+	defer cleanup()
+
+	return fn(ctx, execCtx, u.txn, md.Progress)
+}
+
+func (u Updater) PauseRequestFuncForPayload(payload *jobspb.Payload) (onPauseRequestFunc, error) {
+	c, err := u.j.registry.resumerConstructorForPayload(payload)
+	if err != nil {
+		return nil, err
+	}
+	resumer := c(u.j, u.j.registry.settings)
+
+	var fn onPauseRequestFunc
+	if pr, ok := resumer.(PauseRequester); ok {
+		fn = pr.OnPauseRequest
+	}
+	return fn, nil
+}
+
+// PauseRequested is like PausedRequestedWithFunc but uses the default
+// implementation of OnPauseRequested if the underlying job is a
+// PauseRequester.
+func (u Updater) PauseRequested(ctx context.Context, reason string) error {
+	payload := u.j.Payload()
+	fn, err := u.PauseRequestFuncForPayload(&payload)
+	if err != nil {
+		return err
+	}
+	return u.PauseRequestedWithFunc(ctx, fn, reason)
+}
 
 // PauseRequestedWithFunc sets the status of the tracked job to pause-requested.
 // It does not directly pause the job; it expects the node that runs the job will
@@ -451,41 +451,8 @@ func (u Updater) PauseRequestedWithFunc(
 	ctx context.Context, fn onPauseRequestFunc, reason string,
 ) error {
 	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
-		if md.Status == StatusPauseRequested || md.Status == StatusPaused {
-			return nil
-		}
-		if md.Status != StatusPending && md.Status != StatusRunning && md.Status != StatusReverting {
-			return fmt.Errorf("job with status %s cannot be requested to be paused", md.Status)
-		}
-		if fn != nil {
-			execCtx, cleanup := u.j.registry.execCtx(ctx, "pause request", md.Payload.UsernameProto.Decode())
-			defer cleanup()
-			if err := fn(ctx, execCtx, txn, md.Progress); err != nil {
-				return err
-			}
-			ju.UpdateProgress(md.Progress)
-		}
-		ju.UpdateStatus(StatusPauseRequested)
-		md.Payload.PauseReason = reason
-		ju.UpdatePayload(md.Payload)
-		log.Infof(ctx, "job %d: pause requested recorded with reason %s", md.ID, reason)
-		return nil
+		return ju.PauseRequestedWithFunc(ctx, txn, md, fn, reason)
 	})
-}
-
-// PauseRequested is like PausedRequestedWithFunc but uses the default
-// implementation of OnPauseRequested if the underlying job is a
-// PauseRequester.
-func (u Updater) PauseRequested(ctx context.Context, reason string) error {
-	resumer, err := u.j.registry.createResumer(u.j, u.j.registry.settings)
-	if err != nil {
-		return err
-	}
-	var fn onPauseRequestFunc
-	if pr, ok := resumer.(PauseRequester); ok {
-		fn = pr.OnPauseRequest
-	}
-	return u.PauseRequestedWithFunc(ctx, fn, reason)
 }
 
 // reverted sets the status of the tracked job to reverted.

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1541,7 +1541,7 @@ func TestJobLifecycle(t *testing.T) {
 			}, registry.MakeJobID(), txn)
 			return errors.New("boom")
 		}))
-		if err := job.Started(ctx); !testutils.IsError(err, "not found in system.jobs table") {
+		if err := job.Started(ctx); !testutils.IsError(err, "does not exist") {
 			t.Fatalf("unexpected error %v", err)
 		}
 	})

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -170,7 +170,6 @@ type registryTestSuite struct {
 	failOrCancelCh      chan error
 	resumeCheckCh       chan struct{}
 	failOrCancelCheckCh chan struct{}
-	onPauseRequest      jobs.OnPauseRequestFunc
 
 	// beforeUpdate is invoked in the BeforeUpdate testing knob if non-nil.
 	beforeUpdate func(orig, updated jobs.JobMetadata) error
@@ -185,12 +184,6 @@ type registryTestSuite struct {
 
 	// controls whether job resumers will ask for a real tracing span.
 	traceRealSpan bool
-}
-
-func noopPauseRequestFunc(
-	ctx context.Context, planHookState interface{}, txn isql.Txn, progress *jobspb.Progress,
-) error {
-	return nil
 }
 
 var _ jobs.TraceableJob = (*jobstest.FakeResumer)(nil)
@@ -244,7 +237,6 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 	rts.failOrCancelCh = make(chan error)
 	rts.resumeCheckCh = make(chan struct{})
 	rts.failOrCancelCheckCh = make(chan struct{})
-	rts.onPauseRequest = noopPauseRequestFunc
 
 	jobs.RegisterConstructor(jobspb.TypeImport, func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
 		return jobstest.FakeResumer{
@@ -324,9 +316,6 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 				}()
 				rts.mu.a.Success = true
 				return rts.successErr
-			},
-			PauseRequest: func(ctx context.Context, execCfg interface{}, txn isql.Txn, progress *jobspb.Progress) error {
-				return rts.onPauseRequest(ctx, execCfg, txn, progress)
 			},
 		}
 	}, jobs.UsesTenantCostControl)
@@ -897,74 +886,6 @@ func TestRegistryLifecycle(t *testing.T) {
 		close(rts.failOrCancelCh)
 		rts.mu.e.OnFailOrCancelExit = true
 		rts.check(t, jobs.StatusFailed)
-	})
-
-	t.Run("OnPauseRequest", func(t *testing.T) {
-		rts := registryTestSuite{}
-		rts.setUp(t)
-		defer rts.tearDown()
-		madeUpSpans := []roachpb.Span{
-			{Key: roachpb.Key("foo")},
-		}
-		rts.onPauseRequest = func(ctx context.Context, planHookState interface{}, txn isql.Txn, progress *jobspb.Progress) error {
-			progress.GetImport().SpanProgress = madeUpSpans
-			return nil
-		}
-
-		job, err := jobs.TestingCreateAndStartJob(rts.ctx, rts.registry, rts.idb(), rts.mockJob)
-		require.NoError(t, err)
-		rts.job = job
-
-		rts.resumeCheckCh <- struct{}{}
-		rts.mu.e.ResumeStart = true
-		rts.check(t, jobs.StatusRunning)
-
-		// Request that the job is paused.
-		pauseErrCh := make(chan error)
-		go func() {
-			_, err := rts.outerDB.Exec("PAUSE JOB $1", job.ID())
-			pauseErrCh <- err
-		}()
-
-		// Ensure that the pause went off without a problem.
-		require.NoError(t, <-pauseErrCh)
-		rts.check(t, jobs.StatusPaused)
-		{
-			// Make sure the side-effects of our pause function occurred.
-			j, err := rts.registry.LoadJob(rts.ctx, job.ID())
-			require.NoError(t, err)
-			progress := j.Progress()
-			require.Equal(t, madeUpSpans, progress.GetImport().SpanProgress)
-		}
-	})
-	t.Run("OnPauseRequest failure does not pause", func(t *testing.T) {
-		rts := registryTestSuite{}
-		rts.setUp(t)
-		defer rts.tearDown()
-
-		rts.onPauseRequest = func(ctx context.Context, planHookState interface{}, txn isql.Txn, progress *jobspb.Progress) error {
-			return errors.New("boom")
-		}
-
-		job, err := jobs.TestingCreateAndStartJob(rts.ctx, rts.registry, rts.idb(), rts.mockJob)
-		require.NoError(t, err)
-		rts.job = job
-
-		// Allow the job to start.
-		rts.resumeCheckCh <- struct{}{}
-		rts.mu.e.ResumeStart = true
-		rts.check(t, jobs.StatusRunning)
-
-		// Request that the job is paused and ensure that the pause hit the error
-		// and failed to pause.
-		_, err = rts.outerDB.Exec("PAUSE JOB $1", job.ID())
-		require.Regexp(t, "boom", err)
-
-		// Allow the job to complete.
-		rts.resumeCh <- nil
-		rts.mu.e.Success = true
-		rts.mu.e.ResumeExit++
-		rts.check(t, jobs.StatusSucceeded)
 	})
 	t.Run("dump traces on pause-unpause-success", func(t *testing.T) {
 		ctx := context.Background()

--- a/pkg/jobs/jobstest/BUILD.bazel
+++ b/pkg/jobs/jobstest/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/scheduledjobs",
         "//pkg/sql/catalog/systemschema",
-        "//pkg/sql/isql",
         "//pkg/sql/sem/tree",
         "//pkg/testutils",
         "//pkg/util/log",

--- a/pkg/jobs/jobstest/resumer.go
+++ b/pkg/jobs/jobstest/resumer.go
@@ -10,19 +10,13 @@
 
 package jobstest
 
-import (
-	"context"
-
-	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/sql/isql"
-)
+import "context"
 
 // FakeResumer calls optional callbacks during the job lifecycle.
 type FakeResumer struct {
 	OnResume      func(context.Context) error
 	FailOrCancel  func(context.Context) error
 	Success       func() error
-	PauseRequest  func(ctx context.Context, planHookState interface{}, txn isql.Txn, progress *jobspb.Progress) error
 	TraceRealSpan bool
 }
 
@@ -55,13 +49,4 @@ func (d FakeResumer) OnFailOrCancel(ctx context.Context, _ interface{}, _ error)
 
 func (d FakeResumer) CollectProfile(_ context.Context, _ interface{}) error {
 	return nil
-}
-
-func (d FakeResumer) OnPauseRequest(
-	ctx context.Context, execCtx interface{}, txn isql.Txn, details *jobspb.Progress,
-) error {
-	if d.PauseRequest == nil {
-		return nil
-	}
-	return d.PauseRequest(ctx, execCtx, txn, details)
 }

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -70,7 +70,7 @@ func (u Updater) update(ctx context.Context, updateFn UpdateFn) (retErr error) {
 	var runStats *RunStats
 	j := u.j
 	defer func() {
-		if retErr != nil {
+		if retErr != nil && !HasJobNotFoundError(retErr) {
 			retErr = errors.Wrapf(retErr, "job %d", j.id)
 			return
 		}
@@ -120,7 +120,7 @@ WHERE id = $1
 		return err
 	}
 	if row == nil {
-		return errors.Errorf("not found in system.jobs table")
+		return &JobNotFoundError{jobID: j.ID()}
 	}
 
 	if status, err = unmarshalStatus(row[0]); err != nil {
@@ -168,7 +168,10 @@ WHERE id = $1
 		},
 	}
 
-	var ju JobUpdater
+	ju := JobUpdater{
+		PauseRequestFunc:       u.PauseRequestFuncForPayload,
+		PauseRequestFuncRunner: u.RunPauseRequestFunc,
+	}
 	if err := updateFn(u.txn, md, &ju); err != nil {
 		return err
 	}
@@ -294,6 +297,9 @@ func (md *JobMetadata) CheckRunningOrReverting() error {
 // JobUpdater accumulates changes to job metadata that are to be persisted.
 type JobUpdater struct {
 	md JobMetadata
+
+	PauseRequestFunc       func(*jobspb.Payload) (onPauseRequestFunc, error)
+	PauseRequestFuncRunner func(context.Context, onPauseRequestFunc, JobMetadata) error
 }
 
 // UpdateStatus sets a new status (to be persisted).
@@ -340,6 +346,86 @@ func (ju *JobUpdater) UpdateHighwaterProgressed(highWater hlc.Timestamp, md JobM
 		HighWater: &highWater,
 	}
 	ju.UpdateProgress(md.Progress)
+	return nil
+}
+
+func (ju *JobUpdater) PauseRequested(
+	ctx context.Context, txn isql.Txn, md JobMetadata, reason string,
+) error {
+	fn, err := ju.PauseRequestFunc(md.Payload)
+	if err != nil {
+		return err
+	}
+	return ju.PauseRequestedWithFunc(ctx, txn, md, fn, reason)
+}
+
+func (ju *JobUpdater) PauseRequestedWithFunc(
+	ctx context.Context, txn isql.Txn, md JobMetadata, fn onPauseRequestFunc, reason string,
+) error {
+	if md.Status == StatusPauseRequested || md.Status == StatusPaused {
+		return nil
+	}
+	if md.Status != StatusPending && md.Status != StatusRunning && md.Status != StatusReverting {
+		return fmt.Errorf("job with status %s cannot be requested to be paused", md.Status)
+	}
+	if fn != nil {
+		if err := ju.PauseRequestFuncRunner(ctx, fn, md); err != nil {
+			return err
+		}
+		ju.UpdateProgress(md.Progress)
+	}
+	ju.UpdateStatus(StatusPauseRequested)
+	md.Payload.PauseReason = reason
+	ju.UpdatePayload(md.Payload)
+	log.Infof(ctx, "job %d: pause requested recorded with reason %s", md.ID, reason)
+	return nil
+}
+
+func (ju *JobUpdater) Unpaused(_ context.Context, md JobMetadata) error {
+	if md.Status == StatusRunning || md.Status == StatusReverting {
+		// Already resumed - do nothing.
+		return nil
+	}
+	if md.Status != StatusPaused {
+		return fmt.Errorf("job with status %s cannot be resumed", md.Status)
+	}
+	// We use the absence of error to determine what state we should
+	// resume into.
+	if md.Payload.FinalResumeError == nil {
+		ju.UpdateStatus(StatusRunning)
+	} else {
+		ju.UpdateStatus(StatusReverting)
+	}
+	ju.UpdatePayload(md.Payload)
+	return nil
+}
+
+func (ju *JobUpdater) CancelRequested(ctx context.Context, md JobMetadata) error {
+	return ju.CancelRequestedWithReason(ctx, md, errJobCanceled)
+}
+
+func (ju *JobUpdater) CancelRequestedWithReason(
+	ctx context.Context, md JobMetadata, reason error,
+) error {
+	if md.Payload.Noncancelable {
+		return errors.Newf("job %d: not cancelable", md.ID)
+	}
+	if md.Status == StatusCancelRequested || md.Status == StatusCanceled {
+		return nil
+	}
+	if md.Status != StatusPending && md.Status != StatusRunning && md.Status != StatusPaused {
+		return fmt.Errorf("job with status %s cannot be requested to be canceled", md.Status)
+	}
+	if md.Status == StatusPaused && md.Payload.FinalResumeError != nil {
+		decodedErr := errors.DecodeError(ctx, *md.Payload.FinalResumeError)
+		return errors.Wrapf(decodedErr, "job %d is paused and has non-nil FinalResumeError "+
+			"hence cannot be canceled and should be reverted", md.ID)
+	}
+	if !errors.Is(reason, errJobCanceled) {
+		md.Payload.Error = reason.Error()
+		ju.UpdatePayload(md.Payload)
+	}
+	ju.UpdateStatus(StatusCancelRequested)
 	return nil
 }
 

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -396,7 +396,6 @@ func (ju *JobUpdater) Unpaused(_ context.Context, md JobMetadata) error {
 	} else {
 		ju.UpdateStatus(StatusReverting)
 	}
-	ju.UpdatePayload(md.Payload)
 	return nil
 }
 

--- a/pkg/sql/job_exec_context.go
+++ b/pkg/sql/job_exec_context.go
@@ -76,7 +76,7 @@ func (e *plannerJobExecContext) SpanStatsConsumer() keyvisualizer.SpanStatsConsu
 }
 
 // JobExecContext provides the execution environment for a job. It is what is
-// passed to the Resume/OnFailOrCancel/OnPauseRequested methods of a jobs's
+// passed to the Resume/OnFailOrCancel methods of a jobs's
 // Resumer to give that resumer access to things like ExecutorCfg, LeaseMgr,
 // etc -- the kinds of things that would usually be on planner or similar during
 // a non-job SQL statement's execution. Unlike a planner however, or planner-ish

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -162,7 +162,7 @@ SELECT job_id FROM [SHOW JOBS] WHERE user_name = 'root' AND job_type = 'SCHEMA C
 
 user testuser
 
-statement error pq: only admins can control jobs owned by other admins
+statement error only admins can control jobs owned by other admins
 PAUSE JOB (SELECT $job_id)
 
 user root
@@ -177,13 +177,13 @@ SELECT job_id FROM [SHOW JOBS] WHERE user_name = 'testuser2' AND job_type = 'SCH
 user testuser
 
 # testuser should no longer have the ability to control jobs.
-statement error pq: user testuser does not have privileges for job
+statement error user testuser does not have privileges for job
 PAUSE JOB (SELECT $job_id)
 
-statement error pq: user testuser does not have privileges for job
+statement error user testuser does not have privileges for job
 CANCEL JOB (SELECT $job_id)
 
-statement error pq: user testuser does not have privileges for job
+statement error user testuser does not have privileges for job
 RESUME JOB (SELECT $job_id)
 
 user root


### PR DESCRIPTION
The APIs provided by the job system makes it very easy for calling code
to inadvertently do a good deal of extra work.

This small PR addresses one such example. The control operations were
all loading the job record twice.

In the newly added rttanalysis test for these operations, a bit of code-re-arrangement gets
a nice reduction in the number of KV batches sent for these queries:

Before:

```
+9,Jobs/cancel_job
+11,Jobs/pause_job
+11,Jobs/resume_job
```

After:

```
+6,Jobs/cancel_job
+8,Jobs/pause_job
+6,Jobs/resume_job
```

Epic: None