### PR TITLE
batcheval: add LAI and closed timestamp to `LeaseInfoResponse`

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -1695,6 +1695,14 @@ message LeaseInfoResponse{
   // still not evaluated by the node it was sent to if that node's replica is a
   // learner or the node doesn't have a replica at all.
   int32 evaluated_by = 4 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.StoreID"];
+  // lease_applied_index contains the replica's current lease applied index.
+  // This is not guaranteed to be consistent with other fields as they are read
+  // in separate critical sections.
+  uint64 lease_applied_index = 5  [(gogoproto.casttype) = "LeaseAppliedIndex"];
+  // closed_timestamp contains the replica's current closed timestamp. This is
+  // not guaranteed to be consistent with other fields as they are read in
+  // separate critical sections.
+  util.hlc.Timestamp closed_timestamp = 6 [(gogoproto.nullable) = false];
 }
 
 // A RequestLeaseResponse is the response to a RequestLease() or TransferLease()

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -110,6 +110,7 @@ go_test(
         "cmd_export_test.go",
         "cmd_get_test.go",
         "cmd_is_span_empty_test.go",
+        "cmd_lease_info_test.go",
         "cmd_lease_test.go",
         "cmd_push_txn_test.go",
         "cmd_query_intent_test.go",

--- a/pkg/kv/kvserver/batcheval/cmd_lease_info.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_info.go
@@ -53,6 +53,8 @@ func LeaseInfo(
 	} else {
 		reply.Lease = lease
 	}
+	reply.ClosedTimestamp = cArgs.EvalCtx.GetCurrentClosedTimestamp(ctx)
+	reply.LeaseAppliedIndex = cArgs.EvalCtx.GetLeaseAppliedIndex()
 	reply.EvaluatedBy = cArgs.EvalCtx.StoreID()
 	return result.Result{}, nil
 }

--- a/pkg/kv/kvserver/batcheval/cmd_lease_info_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_info_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package batcheval_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeaseInfo(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	clock := hlc.NewClockForTesting(timeutil.NewManualTime(timeutil.Now()))
+	engine := storage.NewDefaultInMemForTesting()
+	defer engine.Close()
+
+	now := clock.Now()
+
+	const id = 1
+	lease := roachpb.Lease{
+		Start:    now.UnsafeToClockTimestamp(),
+		Sequence: 1,
+		Epoch:    1,
+		Replica:  roachpb.ReplicaDescriptor{NodeID: id, StoreID: id, ReplicaID: id},
+	}
+	lai := kvpb.LeaseAppliedIndex(7)
+	closedTS := hlc.MinTimestamp
+
+	// Test both with and without a tentative lease request.
+	testutils.RunTrueAndFalse(t, "leaseReq", func(t *testing.T, leaseReq bool) {
+		var nextLease roachpb.Lease
+		if leaseReq {
+			nextLease = lease
+			nextLease.Sequence += 1
+			nextLease.Start.Logical += 1
+		}
+
+		evalCtx := (&batcheval.MockEvalCtx{
+			Clock:             clock,
+			Lease:             lease,
+			NextLease:         nextLease,
+			LeaseAppliedIndex: lai,
+			ClosedTimestamp:   closedTS,
+			StoreID:           id,
+		}).EvalContext()
+
+		resp := kvpb.LeaseInfoResponse{}
+		res, err := batcheval.LeaseInfo(ctx, engine, batcheval.CommandArgs{
+			EvalCtx: evalCtx,
+			Header: kvpb.Header{
+				Timestamp: clock.Now(),
+			},
+			Args: &kvpb.LeaseInfoRequest{},
+		}, &resp)
+		require.NoError(t, err)
+
+		expect := kvpb.LeaseInfoResponse{
+			Lease:             lease,
+			LeaseAppliedIndex: lai,
+			ClosedTimestamp:   closedTS,
+			EvaluatedBy:       id,
+		}
+		if leaseReq {
+			expect.Lease = nextLease
+			expect.CurrentLease = &lease
+		}
+
+		require.Equal(t, result.Result{}, res)
+		require.Equal(t, expect, resp)
+	})
+}

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -180,6 +180,8 @@ type MockEvalCtx struct {
 	CanCreateTxnRecordFn func() (bool, kvpb.TransactionAbortedReason)
 	MinTxnCommitTSFn     func() hlc.Timestamp
 	Lease                roachpb.Lease
+	NextLease            roachpb.Lease
+	LeaseAppliedIndex    kvpb.LeaseAppliedIndex
 	CurrentReadSummary   rspb.ReadSummary
 	ClosedTimestamp      hlc.Timestamp
 	RevokedLeaseSeq      roachpb.LeaseSequence
@@ -240,7 +242,7 @@ func (m *mockEvalCtxImpl) GetTerm(kvpb.RaftIndex) (kvpb.RaftTerm, error) {
 	return m.Term, nil
 }
 func (m *mockEvalCtxImpl) GetLeaseAppliedIndex() kvpb.LeaseAppliedIndex {
-	panic("unimplemented")
+	return m.LeaseAppliedIndex
 }
 func (m *mockEvalCtxImpl) Desc() *roachpb.RangeDescriptor {
 	return m.MockEvalCtx.Desc
@@ -283,7 +285,7 @@ func (m *mockEvalCtxImpl) GetLastReplicaGCTimestamp(context.Context) (hlc.Timest
 	panic("unimplemented")
 }
 func (m *mockEvalCtxImpl) GetLease() (roachpb.Lease, roachpb.Lease) {
-	return m.Lease, roachpb.Lease{}
+	return m.Lease, m.NextLease
 }
 func (m *mockEvalCtxImpl) GetRangeInfo(ctx context.Context) roachpb.RangeInfo {
 	return roachpb.RangeInfo{Desc: *m.Desc(), Lease: m.Lease}


### PR DESCRIPTION
This may be useful to DistSender circuit breaker probes, to determine the replica's closed timestamp for follower reads with a tripped circuit breaker.

Touches #118943.
Epic: none
Release note: None
