### PR TITLE
roachprod: create load balancer (gcloud)

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -365,7 +365,7 @@ func initFlags() {
 		cmd.Flags().StringVarP(&config.Binary,
 			"binary", "b", config.Binary, "the remote cockroach binary to use")
 	}
-	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, stopInstanceCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd, jaegerStartCmd, grafanaAnnotationCmd} {
+	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd, stopInstanceCmd, loadBalanceCmd, sqlCmd, pgurlCmd, adminurlCmd, runCmd, jaegerStartCmd, grafanaAnnotationCmd} {
 		cmd.Flags().BoolVar(&secure,
 			"secure", false, "use a secure cluster")
 	}

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -369,7 +369,7 @@ func initFlags() {
 		cmd.Flags().BoolVar(&secure,
 			"secure", false, "use a secure cluster")
 	}
-	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, adminurlCmd, stopInstanceCmd, jaegerStartCmd} {
+	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd, adminurlCmd, stopInstanceCmd, loadBalanceCmd, jaegerStartCmd} {
 		cmd.Flags().StringVar(&virtualClusterName,
 			"cluster", "", "specific virtual cluster to connect to")
 		cmd.Flags().IntVar(&sqlInstance,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -468,6 +468,30 @@ destroyed:
 	}),
 }
 
+var loadBalanceCmd = &cobra.Command{
+	Use:   "load-balance <cluster> [virtual-cluster-name]",
+	Short: "create a load balancer for a cluster",
+	Long: `Create a load balancer for a specific service (port), system by default, for the given cluster.
+
+The load balancer is created using the cloud provider's load balancer service.
+Currently only Google Cloud is supported, and the cluster must have been created
+with the --gce-managed flag. On Google Cloud a load balancer consists of various
+components that include backend services, health checks and forwarding rules.
+These resources will automatically be destroyed when the cluster is destroyed.
+`,
+
+	Args: cobra.RangeArgs(1, 2),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		serviceName := install.SystemInterfaceName
+		if len(args) == 2 {
+			serviceName = args[1]
+		}
+		return roachprod.CreateLoadBalancer(context.Background(), config.Logger,
+			args[0], secure, serviceName, sqlInstance,
+		)
+	}),
+}
+
 const tagHelp = `
 The --tag flag can be used to to associate a tag with the process. This tag can
 then be used to restrict the processes which are operated on by the status and
@@ -552,7 +576,7 @@ SIGHUP), unless you also configure --max-wait.
 }
 
 var startInstanceCmd = &cobra.Command{
-	Use:   "start-sql <name> --storage-cluster <storage-cluster> [--external-cluster <virtual-cluster-nodes]",
+	Use:   "start-sql <name> --storage-cluster <storage-cluster> [--external-cluster <virtual-cluster-nodes>]",
 	Short: "start the SQL/HTTP service for a virtual cluster as a separate process",
 	Long: `Start SQL/HTTP instances for a virtual cluster as separate processes.
 
@@ -1526,6 +1550,7 @@ func main() {
 		resetCmd,
 		destroyCmd,
 		extendCmd,
+		loadBalanceCmd,
 		listCmd,
 		syncCmd,
 		gcCmd,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -469,7 +469,7 @@ destroyed:
 }
 
 var loadBalanceCmd = &cobra.Command{
-	Use:   "load-balance <cluster> [virtual-cluster-name]",
+	Use:   "load-balance <cluster>",
 	Short: "create a load balancer for a cluster",
 	Long: `Create a load balancer for a specific service (port), system by default, for the given cluster.
 
@@ -480,14 +480,10 @@ components that include backend services, health checks and forwarding rules.
 These resources will automatically be destroyed when the cluster is destroyed.
 `,
 
-	Args: cobra.RangeArgs(1, 2),
+	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		serviceName := install.SystemInterfaceName
-		if len(args) == 2 {
-			serviceName = args[1]
-		}
 		return roachprod.CreateLoadBalancer(context.Background(), config.Logger,
-			args[0], secure, serviceName, sqlInstance,
+			args[0], secure, virtualClusterName, sqlInstance,
 		)
 	}),
 }

--- a/pkg/roachprod/BUILD.bazel
+++ b/pkg/roachprod/BUILD.bazel
@@ -32,5 +32,6 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@org_golang_x_sys//unix",
     ],
 )

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -2463,7 +2463,22 @@ func CreateLoadBalancer(
 	}
 
 	// Create a load balancer for the service's port.
-	return vm.FanOut(c.VMs, func(provider vm.Provider, vms vm.List) error {
-		return provider.CreateLoadBalancer(l, vms, port)
+	err = vm.FanOut(c.VMs, func(provider vm.Provider, vms vm.List) error {
+		createErr := provider.CreateLoadBalancer(l, vms, port)
+		if createErr != nil {
+			l.Errorf("Cleaning up partially-created load balancer (prev err: %s)", createErr)
+			cleanupErr := provider.DeleteLoadBalancer(l, vms, port)
+			if cleanupErr != nil {
+				l.Errorf("Error while cleaning up partially-created load balancer: %s", cleanupErr)
+			} else {
+				l.Printf("Cleaned up partially-created load balancer")
+			}
+			return errors.CombineErrors(createErr, cleanupErr)
+		}
+		return nil
 	})
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -2422,3 +2422,48 @@ func createAttachMountVolumes(
 	}
 	return nil
 }
+
+// CreateLoadBalancer creates a load balancer for the SQL service on the given
+// cluster. Currently only supports GCE.
+func CreateLoadBalancer(
+	ctx context.Context,
+	l *logger.Logger,
+	clusterName string,
+	secure bool,
+	virtualClusterName string,
+	sqlInstance int,
+) error {
+	if err := LoadClusters(); err != nil {
+		return err
+	}
+	c, err := newCluster(l, clusterName, install.SecureOption(secure))
+	if err != nil {
+		return err
+	}
+
+	// Find the SQL ports for the service on all nodes.
+	services, err := c.DiscoverServices(
+		ctx, virtualClusterName, install.ServiceTypeSQL,
+		install.ServiceNodePredicate(c.TargetNodes()...), install.ServiceInstancePredicate(sqlInstance),
+	)
+	if err != nil {
+		return err
+	}
+	if len(services) == 0 {
+		return errors.Errorf("%s SQL service not found on cluster %s, start a service first.", virtualClusterName, clusterName)
+	}
+
+	// Confirm that the service has the same port on all nodes.
+	port := services[0].Port
+	for _, service := range services[1:] {
+		if port != service.Port {
+			return errors.Errorf("service %s must share the same port on all nodes, different ports found %d and %d",
+				virtualClusterName, port, service.Port)
+		}
+	}
+
+	// Create a load balancer for the service's port.
+	return vm.FanOut(c.VMs, func(provider vm.Provider, vms vm.List) error {
+		return provider.CreateLoadBalancer(l, vms, port)
+	})
+}

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1614,3 +1614,7 @@ func (p *Provider) DeleteVolumeSnapshots(l *logger.Logger, snapshots ...vm.Volum
 func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
 	panic("unimplemented")
 }
+
+func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
+	panic("unimplemented")
+}

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1618,3 +1618,8 @@ func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
 func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
 	panic("unimplemented")
 }
+
+func (p *Provider) ListLoadBalancers(*logger.Logger, vm.List) ([]vm.ServiceAddress, error) {
+	// This Provider has no concept of load balancers yet, return an empty list.
+	return nil, nil
+}

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1610,3 +1610,7 @@ func (p *Provider) ListVolumeSnapshots(
 func (p *Provider) DeleteVolumeSnapshots(l *logger.Logger, snapshots ...vm.VolumeSnapshot) error {
 	panic("unimplemented")
 }
+
+func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
+	panic("unimplemented")
+}

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -143,6 +143,10 @@ func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) error {
 	panic("unimplemented")
 }
 
+func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
+	panic("unimplemented")
+}
+
 // New constructs a new Provider instance.
 func New() *Provider {
 	p := &Provider{}

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -151,6 +151,11 @@ func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
 	panic("unimplemented")
 }
 
+func (p *Provider) ListLoadBalancers(*logger.Logger, vm.List) ([]vm.ServiceAddress, error) {
+	// This Provider has no concept of load balancers yet, return an empty list.
+	return nil, nil
+}
+
 // New constructs a new Provider instance.
 func New() *Provider {
 	p := &Provider{}

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -147,6 +147,10 @@ func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
 	panic("unimplemented")
 }
 
+func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
+	panic("unimplemented")
+}
+
 // New constructs a new Provider instance.
 func New() *Provider {
 	p := &Provider{}

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -74,6 +74,10 @@ func (p *provider) AttachVolume(*logger.Logger, vm.Volume, *vm.VM) (string, erro
 	return "", errors.Newf("%s", p.unimplemented)
 }
 
+func (p *provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
+	return nil
+}
+
 // CleanSSH implements vm.Provider and is a no-op.
 func (p *provider) CleanSSH(l *logger.Logger) error {
 	return nil

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -78,6 +78,10 @@ func (p *provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
 	return nil
 }
 
+func (p *provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
+	return nil
+}
+
 // CleanSSH implements vm.Provider and is a no-op.
 func (p *provider) CleanSSH(l *logger.Logger) error {
 	return nil

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -82,6 +82,10 @@ func (p *provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
 	return nil
 }
 
+func (p *provider) ListLoadBalancers(*logger.Logger, vm.List) ([]vm.ServiceAddress, error) {
+	return nil, nil
+}
+
 // CleanSSH implements vm.Provider and is a no-op.
 func (p *provider) CleanSSH(l *logger.Logger) error {
 	return nil

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1542,6 +1542,131 @@ func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names
 	return propagateDiskLabels(l, project, labelsJoined, zoneToHostNames, len(vms[0].LocalDisks) != 0)
 }
 
+// loadBalancerResourceName returns the name of a load balancer resource. The
+// port is used instead of a service name in order to be able to identify
+// different parts of the name, since we have limited delimiter options.
+func loadBalancerResourceName(clusterName string, port int, resourceType string) string {
+	return fmt.Sprintf("%s-%d-%s-roachprod", clusterName, port, resourceType)
+}
+
+// CreateLoadBalancer creates a load balancer for the given cluster, derived
+// from the VM list, and port. The cluster has to be part of a managed instance
+// group. Additionally, a health check is created for the given port. A proxy is
+// used to support global load balancing. The different parts of the load
+// balancer are created sequentially, as they depend on each other.
+func (p *Provider) CreateLoadBalancer(_ *logger.Logger, vms vm.List, port int) error {
+	if err := checkSDKVersion("450.0.0" /* minVersion */, "required by load balancers"); err != nil {
+		return err
+	}
+	if !isManaged(vms) {
+		return errors.New("load balancer creation is only supported for managed instance groups")
+	}
+	project := vms[0].Project
+	clusterName, err := vms[0].ClusterName()
+	if err != nil {
+		return err
+	}
+	groups, err := listManagedInstanceGroups(project, instanceGroupName(clusterName))
+	if err != nil {
+		return err
+	}
+	if len(groups) == 0 {
+		return errors.Errorf("no managed instance groups found for cluster %s", clusterName)
+	}
+
+	healthCheckName := loadBalancerResourceName(clusterName, port, "health-check")
+	args := []string{"compute", "health-checks", "create", "tcp",
+		healthCheckName,
+		"--project", project,
+		"--port", strconv.Itoa(port),
+	}
+	cmd := exec.Command("gcloud", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+	}
+
+	loadBalancerName := loadBalancerResourceName(clusterName, port, "load-balancer")
+	args = []string{"compute", "backend-services", "create", loadBalancerName,
+		"--project", project,
+		"--load-balancing-scheme", "EXTERNAL_MANAGED",
+		"--global-health-checks",
+		"--global",
+		"--protocol", "TCP",
+		"--health-checks", healthCheckName,
+		"--timeout", "5m",
+		"--port-name", "cockroach",
+	}
+	cmd = exec.Command("gcloud", args...)
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+	}
+
+	// Add the instance group to the backend service. This has to be done
+	// sequentially, and for each zone, because gcloud does not allow adding
+	// multiple instance groups in parallel.
+	for _, group := range groups {
+		args = []string{"compute", "backend-services", "add-backend", loadBalancerName,
+			"--project", project,
+			"--global",
+			"--instance-group", group.Name,
+			"--instance-group-zone", group.Zone,
+			"--balancing-mode", "UTILIZATION",
+			"--max-utilization", "0.8",
+		}
+		cmd = exec.Command("gcloud", args...)
+		output, err = cmd.CombinedOutput()
+		if err != nil {
+			return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+		}
+	}
+
+	proxyName := loadBalancerResourceName(clusterName, port, "proxy")
+	args = []string{"compute", "target-tcp-proxies", "create", proxyName,
+		"--project", project,
+		"--backend-service", loadBalancerName,
+		"--proxy-header", "NONE",
+	}
+	cmd = exec.Command("gcloud", args...)
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+	}
+
+	args = []string{"compute", "forwarding-rules", "create",
+		loadBalancerResourceName(clusterName, port, "forwarding-rule"),
+		"--project", project,
+		"--global",
+		"--target-tcp-proxy", proxyName,
+		"--ports", strconv.Itoa(port),
+	}
+	cmd = exec.Command("gcloud", args...)
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", args, output)
+	}
+
+	// Named ports can be set in parallel for all instance groups.
+	var g errgroup.Group
+	for _, group := range groups {
+		groupArgs := []string{"compute", "instance-groups", "set-named-ports", group.Name,
+			"--project", project,
+			"--zone", group.Zone,
+			"--named-ports", "cockroach:" + strconv.Itoa(port),
+		}
+		g.Go(func() error {
+			cmd := exec.Command("gcloud", groupArgs...)
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", groupArgs, output)
+			}
+			return nil
+		})
+	}
+	return g.Wait()
+}
+
 // Given a machine type, return the allowed number (> 0) of local SSDs, sorted in ascending order.
 // N.B. Only n1, n2, n2d and c2 instances are supported since we don't typically use other instance types.
 // Consult https://cloud.google.com/compute/docs/disks/#local_ssd_machine_type_restrictions for other types of instances.

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -196,6 +196,10 @@ func (p *Provider) RemoveLabels(l *logger.Logger, vms vm.List, labels []string) 
 	return nil
 }
 
+func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
+	return nil
+}
+
 // Create just creates fake host-info entries in the local filesystem
 func (p *Provider) Create(
 	l *logger.Logger, names []string, opts vm.CreateOpts, unusedProviderOpts vm.ProviderOpts,

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -200,6 +200,10 @@ func (p *Provider) CreateLoadBalancer(*logger.Logger, vm.List, int) error {
 	return nil
 }
 
+func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
+	return nil
+}
+
 // Create just creates fake host-info entries in the local filesystem
 func (p *Provider) Create(
 	l *logger.Logger, names []string, opts vm.CreateOpts, unusedProviderOpts vm.ProviderOpts,

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -204,6 +204,10 @@ func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
 	return nil
 }
 
+func (p *Provider) ListLoadBalancers(*logger.Logger, vm.List) ([]vm.ServiceAddress, error) {
+	return nil, nil
+}
+
 // Create just creates fake host-info entries in the local filesystem
 func (p *Provider) Create(
 	l *logger.Logger, names []string, opts vm.CreateOpts, unusedProviderOpts vm.ProviderOpts,

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -486,6 +486,10 @@ type Provider interface {
 	// GetPreemptedSpotVMs returns a list of Spot VMs that were preempted since the time specified.
 	// Returns nil, nil when SupportsSpotVMs() is false.
 	GetPreemptedSpotVMs(l *logger.Logger, vms List, since time.Time) ([]PreemptedVM, error)
+
+	// CreateLoadBalancer creates a load balancer, for a specific port, that
+	// delegates to the given cluster.
+	CreateLoadBalancer(l *logger.Logger, vms List, port int) error
 }
 
 // DeleteCluster is an optional capability for a Provider which can

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -426,6 +426,12 @@ type PreemptedVM struct {
 	PreemptedAt time.Time
 }
 
+// ServiceAddress stores the IP and port of a service.
+type ServiceAddress struct {
+	IP   string
+	Port int
+}
+
 // A Provider is a source of virtual machines running on some hosting platform.
 type Provider interface {
 	CreateProviderOpts() ProviderOpts
@@ -493,6 +499,10 @@ type Provider interface {
 
 	// DeleteLoadBalancer deletes a load balancers created for a specific port.
 	DeleteLoadBalancer(l *logger.Logger, vms List, port int) error
+
+	// ListLoadBalancers returns a list of load balancer IPs and ports that are currently
+	// routing to services for the given VMs.
+	ListLoadBalancers(l *logger.Logger, vms List) ([]ServiceAddress, error)
 }
 
 // DeleteCluster is an optional capability for a Provider which can

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -490,6 +490,9 @@ type Provider interface {
 	// CreateLoadBalancer creates a load balancer, for a specific port, that
 	// delegates to the given cluster.
 	CreateLoadBalancer(l *logger.Logger, vms List, port int) error
+
+	// DeleteLoadBalancer deletes a load balancers created for a specific port.
+	DeleteLoadBalancer(l *logger.Logger, vms List, port int) error
 }
 
 // DeleteCluster is an optional capability for a Provider which can


### PR DESCRIPTION
Previously, we did not support load balancers and workloads usually connected to
a single node with fallback support to other nodes. This change adds the ability
to create a load balancer for a managed cluster (only supports GCE currently).

A load balancer can be created for each service (virtual cluster). Load
balancers are discerned by the port they serve. A simple health check is also
added to monitor the connectivity on these ports. Currently, the load balancers
will be set to use utilisation as a metric for load balancing. But if required
we can switch this to something else.

Load balancers consist of various components in Google Cloud that work together
to achieve load balancing. The main parts require an instance group that becomes
part of a backend service. Forwarding rules are then set up to configure the
correct ports and policies.

See: #119009
Epic: CRDB-33832

Release Note: None
