### PR TITLE
sql: check for stats job in transaction that creates stats job

### DIFF
--- a/pkg/jobs/utils.go
+++ b/pkg/jobs/utils.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -28,11 +27,7 @@ import (
 // the ID specified by ignoreJobID as well as any jobs created after it, if
 // the passed ID is not InvalidJobID.
 func RunningJobExists(
-	ctx context.Context,
-	ignoreJobID jobspb.JobID,
-	txn isql.Txn,
-	cv clusterversion.Handle,
-	jobTypes ...jobspb.Type,
+	ctx context.Context, ignoreJobID jobspb.JobID, txn isql.Txn, jobTypes ...jobspb.Type,
 ) (exists bool, retErr error) {
 	var typeStrs string
 	switch len(jobTypes) {

--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -182,7 +182,7 @@ func (m *Manager) createAndStartJobIfNoneExists(ctx context.Context) (bool, erro
 
 	var job *jobs.Job
 	if err := m.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		exists, err := jobs.RunningJobExists(ctx, jobspb.InvalidJobID, txn, m.settings.Version,
+		exists, err := jobs.RunningJobExists(ctx, jobspb.InvalidJobID, txn,
 			jobspb.TypeAutoSpanConfigReconciliation)
 		if err != nil {
 			return err

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -129,21 +129,22 @@ func (n *createStatsNode) runJob(ctx context.Context) error {
 		return err
 	}
 
-	if n.Name == jobspb.AutoStatsName {
-		// Don't start the job if there is already a CREATE STATISTICS job running.
-		// (To handle race conditions we check this again after the job starts,
-		// but this check is used to prevent creating a large number of jobs that
-		// immediately fail).
-		if err := checkRunningJobs(ctx, nil /* job */, n.p); err != nil {
-			return err
-		}
-	} else {
+	if n.Name != jobspb.AutoStatsName {
 		telemetry.Inc(sqltelemetry.CreateStatisticsUseCounter)
 	}
 
 	var job *jobs.StartableJob
 	jobID := n.p.ExecCfg().JobRegistry.MakeJobID()
 	if err := n.p.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) (err error) {
+		if n.Name == jobspb.AutoStatsName {
+			// Don't start the job if there is already a CREATE STATISTICS job running.
+			// (To handle race conditions we check this again after the job starts,
+			// but this check is used to prevent creating a large number of jobs that
+			// immediately fail).
+			if err := checkRunningJobsInTxn(ctx, jobspb.InvalidJobID, txn); err != nil {
+				return err
+			}
+		}
 		return n.p.ExecCfg().JobRegistry.CreateStartableJobWithTxn(ctx, &job, jobID, txn, *record)
 	}); err != nil {
 		if job != nil {
@@ -743,13 +744,21 @@ func checkRunningJobs(ctx context.Context, job *jobs.Job, p JobExecContext) erro
 	if job != nil {
 		jobID = job.ID()
 	}
-	var exists bool
-	if err := p.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) (err error) {
-		exists, err = jobs.RunningJobExists(ctx, jobID, txn, p.ExecCfg().Settings.Version,
-			jobspb.TypeCreateStats, jobspb.TypeAutoCreateStats,
-		)
-		return err
-	}); err != nil {
+	return p.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) (err error) {
+		return checkRunningJobsInTxn(ctx, jobID, txn)
+	})
+}
+
+// checkRunningJobsInTxn checks whether there are any other CreateStats jobs in
+// the pending, running, or paused status that started earlier than this one. If
+// there are, checkRunningJobsInTxn returns an error. If jobID is
+// jobspb.InvalidJobID, checkRunningJobsInTxn just checks if there are any pending,
+// running, or paused CreateStats jobs.
+func checkRunningJobsInTxn(ctx context.Context, jobID jobspb.JobID, txn isql.Txn) error {
+	exists, err := jobs.RunningJobExists(ctx, jobID, txn,
+		jobspb.TypeCreateStats, jobspb.TypeAutoCreateStats,
+	)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Previously, we would check for existing stats job and then create a stats job in two different transactions. This would create a small race where sometimes we would create a duplicate job. A follow up check in the resumer protects against that race.

Here, we've moved the query to check for existing jobs into the same transaction that creates the job. In ad-hoc experiments locally this reduces the number of concurrent creation errors returned by stats jobs themselves to 0 in a 3-node demo cluster.

I don't _think_ this should increase job system contention since if the job exists we won't lock any rows for writing. And if the job doesn't exist the row we are writing can't be involved in any other transactions. But, if I'm mistaken about that, perhaps we can lower the priority of this transaction.

Issue #108435 proposes a more complete solution, but this is a relatively small change.

Epic: None
Release note: None
