### PR TITLE
db-console: add lease queue metrics to queue dashboard 

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
@@ -49,6 +49,11 @@ export default function (props: GraphDashboardProps) {
           nonNegativeRate
         />
         <Metric
+          name="cr.store.queue.lease.process.failure"
+          title="Lease"
+          nonNegativeRate
+        />
+        <Metric
           name="cr.store.queue.split.process.failure"
           title="Split"
           nonNegativeRate
@@ -101,6 +106,11 @@ export default function (props: GraphDashboardProps) {
         <Metric
           name="cr.store.queue.replicate.processingnanos"
           title="Replication"
+          nonNegativeRate
+        />
+        <Metric
+          name="cr.store.queue.lease.processingnanos"
+          title="Lease"
           nonNegativeRate
         />
         <Metric
@@ -213,6 +223,31 @@ export default function (props: GraphDashboardProps) {
         <Metric
           name="cr.store.queue.replicate.purgatory"
           title="Replicas in Purgatory"
+          downsampleMax
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Lease Queue"
+      sources={storeSources}
+      tenantSource={tenantSource}
+      showMetricsInTooltip={true}
+    >
+      <Axis units={AxisUnits.Count} label="actions">
+        <Metric
+          name="cr.store.queue.lease.process.success"
+          title="Successful Actions / sec"
+          nonNegativeRate
+        />
+        <Metric
+          name="cr.store.queue.lease.pending"
+          title="Pending Actions"
+          downsampleMax
+        />
+        <Metric
+          name="cr.store.queue.lease.purgatory"
+          title="Replicas in  Purgatory"
           downsampleMax
         />
       </Axis>


### PR DESCRIPTION
First commit from #118976.

Add the lease queue processing failures (`queue.lease.process.failure`)
and processing time (`queue.lease.processingnanos`) to the respective
charts on the queue dashboard. Also, add a new `Lease Queue` chart below the
replication queue, tracking the successful actions(/s), pending actions
and replicas in purgatory.

Resolves: https://github.com/cockroachdb/cockroach/issues/118967
Release note (ui change): The queue dashboard will now display lease
queue metrics, similar to the other replica queues.

![image](https://github.com/cockroachdb/cockroach/assets/39606633/10b95b94-c409-4c25-982b-d8aca1e7c0c1)
![image](https://github.com/cockroachdb/cockroach/assets/39606633/4230865f-84eb-46cd-9bdf-3d530a6858ff)
![image](https://github.com/cockroachdb/cockroach/assets/39606633/c9f7467a-6f80-4a1b-b234-d587d6777ff8)


Part of: #118966
Release note: None
