### PR TITLE
asim: store initial state string as opposed to state

### DIFF
--- a/pkg/kv/kvserver/asim/tests/output.go
+++ b/pkg/kv/kvserver/asim/tests/output.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/gen"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/history"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/scheduled"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
 )
 
 // OutputFlags sets flags for what to output in tests. If you want to add a flag
@@ -66,16 +66,17 @@ func (o OutputFlags) Has(f OutputFlags) bool {
 }
 
 type testResult struct {
-	seed          int64
-	failed        bool
-	reason        string
-	clusterGen    gen.ClusterGen
-	rangeGen      gen.RangeGen
-	loadGen       gen.LoadGen
-	eventGen      gen.EventGen
-	initialTime   time.Time
-	initialState  state.State
-	eventExecutor scheduled.EventExecutor
+	seed            int64
+	failed          bool
+	reason          string
+	clusterGen      gen.ClusterGen
+	rangeGen        gen.RangeGen
+	loadGen         gen.LoadGen
+	eventGen        gen.EventGen
+	initialTime     time.Time
+	initialStateStr string
+	eventExecutor   scheduled.EventExecutor
+	history         history.History
 }
 
 type testResultsReport struct {
@@ -159,10 +160,10 @@ func (tr testResultsReport) String() string {
 		}
 		if failed || tr.flags.Has(OutputInitialState) {
 			buf.WriteString(fmt.Sprintf("initial state at %s:\n", output.initialTime.Format("2006-01-02 15:04:05")))
-			buf.WriteString(fmt.Sprintf("\t%v\n", output.initialState.PrettyPrint()))
+			buf.WriteString(fmt.Sprintf("\t%v\n", output.initialStateStr))
 		}
 		if failed || tr.flags.Has(OutputTopology) {
-			topology := output.initialState.Topology()
+			topology := output.history.S.Topology()
 			buf.WriteString(fmt.Sprintf("topology:\n%s", topology.String()))
 		}
 		if failed || tr.flags.Has(OutputEvents) {

--- a/pkg/kv/kvserver/asim/tests/rand_framework.go
+++ b/pkg/kv/kvserver/asim/tests/rand_framework.go
@@ -124,21 +124,22 @@ func (f randTestingFramework) runRandTest() testResult {
 	staticEvents := f.getStaticEvents(cluster, staticSettings)
 	seed := f.s.randSource.Int63()
 	simulator := gen.GenerateSimulation(f.s.duration, cluster, ranges, load, staticSettings, staticEvents, seed)
-	initialState, initialTime := simulator.State(), simulator.Curr()
+	initialStateStr, initialTime := simulator.State().PrettyPrint(), simulator.Curr()
 	simulator.RunSim(ctx)
 	history := simulator.History()
 	failed, reason := checkAssertions(ctx, history, f.s.assertions)
 	return testResult{
-		seed:          seed,
-		failed:        failed,
-		reason:        reason,
-		clusterGen:    cluster,
-		rangeGen:      ranges,
-		loadGen:       load,
-		eventGen:      staticEvents,
-		initialState:  initialState,
-		initialTime:   initialTime,
-		eventExecutor: simulator.EventExecutor(),
+		seed:            seed,
+		failed:          failed,
+		reason:          reason,
+		clusterGen:      cluster,
+		rangeGen:        ranges,
+		loadGen:         load,
+		eventGen:        staticEvents,
+		initialStateStr: initialStateStr,
+		initialTime:     initialTime,
+		history:         history,
+		eventExecutor:   simulator.EventExecutor(),
 	}
 }
 

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_event
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_event
@@ -32,7 +32,7 @@ configurations generated using seed 7894140303635748408
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=12, number of assertion events=12
 initial state at 2022-03-21 11:00:00:
-	stores(28)=[s1n1=(replicas(0)),s2n2=(replicas(0)),s3n3=(replicas(0)),s4n4=(replicas(1)),s5n5=(replicas(0)),s6n6=(replicas(0)),s7n7=(replicas(0)),s8n8=(replicas(0)),s9n9=(replicas(0)),s10n10=(replicas(0)),s11n11=(replicas(0)),s12n12=(replicas(0)),s13n13=(replicas(0)),s14n14=(replicas(0)),s15n15=(replicas(0)),s16n16=(replicas(0)),s17n17=(replicas(1)),s18n18=(replicas(0)),s19n19=(replicas(0)),s20n20=(replicas(0)),s21n21=(replicas(0)),s22n22=(replicas(1)),s23n23=(replicas(0)),s24n24=(replicas(0)),s25n25=(replicas(1)),s26n26=(replicas(1)),s27n27=(replicas(0)),s28n28=(replicas(0))]
+	stores(28)=[s1n1=(replicas(1)),s2n2=(replicas(1)),s3n3=(replicas(1)),s4n4=(replicas(0)),s5n5=(replicas(0)),s6n6=(replicas(0)),s7n7=(replicas(0)),s8n8=(replicas(0)),s9n9=(replicas(0)),s10n10=(replicas(0)),s11n11=(replicas(0)),s12n12=(replicas(0)),s13n13=(replicas(0)),s14n14=(replicas(0)),s15n15=(replicas(0)),s16n16=(replicas(0)),s17n17=(replicas(0)),s18n18=(replicas(0)),s19n19=(replicas(0)),s20n20=(replicas(0)),s21n21=(replicas(0)),s22n22=(replicas(0)),s23n23=(replicas(0)),s24n24=(replicas(0)),s25n25=(replicas(0)),s26n26=(replicas(0)),s27n27=(replicas(0)),s28n28=(replicas(0))]
 topology:
 EU
   EU_1

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/rand_ranges
@@ -178,7 +178,7 @@ configurations generated using seed 2643318057788968173
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0
 initial state at 2022-03-21 11:00:00:
-	stores(15)=[s1n1=(replicas(65)),s2n2=(replicas(64)),s3n3=(replicas(66)),s4n4=(replicas(63)),s5n5=(replicas(63)),s6n6=(replicas(63)),s7n7=(replicas(63)),s8n8=(replicas(62)),s9n9=(replicas(64)),s10n10=(replicas(64)),s11n11=(replicas(62)),s12n12=(replicas(63)),s13n13=(replicas(63)),s14n14=(replicas(64)),s15n15=(replicas(64))]
+	stores(15)=[s1n1=(replicas(64)),s2n2=(replicas(51)),s3n3=(replicas(12)),s4n4=(replicas(25)),s5n5=(replicas(115)),s6n6=(replicas(90)),s7n7=(replicas(114)),s8n8=(replicas(25)),s9n9=(replicas(26)),s10n10=(replicas(64)),s11n11=(replicas(0)),s12n12=(replicas(114)),s13n13=(replicas(103)),s14n14=(replicas(51)),s15n15=(replicas(90))]
 topology:
 US
   US_1

--- a/pkg/kv/kvserver/asim/tests/testdata/rand/weighted_rand
+++ b/pkg/kv/kvserver/asim/tests/testdata/rand/weighted_rand
@@ -73,7 +73,7 @@ configurations generated using seed 5571782338101878760
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0
 initial state at 2022-03-21 11:00:00:
-	stores(6)=[s1n1=(replicas(132)),s2n1=(replicas(130)),s3n2=(replicas(131)),s4n2=(replicas(437)),s5n3=(replicas(428)),s6n3=(replicas(431))]
+	stores(6)=[s1n1=(replicas(22)),s2n1=(replicas(23)),s3n2=(replicas(23)),s4n2=(replicas(529)),s5n3=(replicas(563)),s6n3=(replicas(529))]
 sample1: pass
 ----------------------------------
 sample2: start running
@@ -83,7 +83,7 @@ configurations generated using seed 4299969443970870044
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0
 initial state at 2022-03-21 11:00:00:
-	stores(6)=[s1n1=(replicas(140)),s2n1=(replicas(136)),s3n2=(replicas(139)),s4n2=(replicas(169)),s5n3=(replicas(142)),s6n3=(replicas(171))]
+	stores(6)=[s1n1=(replicas(53)),s2n1=(replicas(52)),s3n2=(replicas(52)),s4n2=(replicas(299)),s5n3=(replicas(142)),s6n3=(replicas(299))]
 sample2: pass
 ----------------------------------
 sample3: start running
@@ -93,6 +93,6 @@ configurations generated using seed 4157513341729910236
 	basic load with rw_ratio=0.00, rate=0.00, skewed_access=false, min_block_size=1, max_block_size=1, min_key=1, max_key=200000
 	number of mutation events=0, number of assertion events=0
 initial state at 2022-03-21 11:00:00:
-	stores(6)=[s1n1=(replicas(180)),s2n1=(replicas(181)),s3n2=(replicas(183)),s4n2=(replicas(386)),s5n3=(replicas(247)),s6n3=(replicas(386))]
+	stores(6)=[s1n1=(replicas(91)),s2n1=(replicas(91)),s3n2=(replicas(92)),s4n2=(replicas(521)),s5n3=(replicas(247)),s6n3=(replicas(521))]
 sample3: pass
 ----------------------------------


### PR DESCRIPTION
The datadriven test result would store the initial simulator state of each sample, however this initial state would be a reference pointing to the final simulator state.

Store a serialized string format of the initial state instead.

Epic: None
Release note: None
