### PR TITLE
bincheck: do not use `uname -o`

### DIFF
--- a/build/release/bincheck/bincheck
+++ b/build/release/bincheck/bincheck
@@ -57,7 +57,7 @@ EOF
 diff -u expected actual
 
 # Verify libgeos functionality on all platforms except MacOS ARM64 and Windows
-if [[ $(uname -om) == "Darwin arm64" || $(uname -o) == "Msys" ]]; then
+if [[ $(uname -sm) == "Darwin arm64" || $(uname -s) == "MINGW64_NT"* ]]; then
   echo "Skipping libgeos tests"
 else
   echo "Testing libgeos functionality"


### PR DESCRIPTION
Previously, the bincheck script used `uname -om` to identify the OS. The `-o` options is not supported on the GitHub runners for darwin-amd64.

This PR stops using `-o` to fix the issue.

Epic: none
Release note: None