### PR TITLE
awsdms: don't use secure roachprod cluster

### DIFF
--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -562,7 +562,8 @@ func setupAWSDMS(
 func setupCockroachDBCluster(ctx context.Context, t test.Test, c cluster.Cluster) func() error {
 	return func() error {
 		t.L().Printf("setting up cockroach")
-		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
+		settings := install.MakeClusterSettings(install.SecureOption(false))
+		c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.All())
 
 		db := c.Conn(ctx, t.L(), 1)
 		for _, stmt := range []string{


### PR DESCRIPTION
With a change to MakeClusterSettings, roachprod clusers were set to be in secure mode by default. We don't need this for our test so we will be going back to the default behavior so we can use sslmode None for the dms endpoint settings.

Fixes: #119051
Release note: None