### PR TITLE
workflows: update_releases.yaml - bump Node.js from 16 to 20

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -29,11 +29,11 @@ jobs:
     name: Update pkg/testutils/release/cockroach_releases.yaml on ${{ matrix.branch }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: "${{ matrix.branch }}"
       - name: Mount bazel cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "~/.cache/bazel"
           key: bazel
@@ -43,7 +43,7 @@ jobs:
           $(bazel info bazel-bin)/pkg/cmd/release/release_/release update-releases-file
           git diff
       - name: Update pkg/testutils/release/cockroach_releases.yaml on ${{ matrix.branch }}
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           base: "${{ matrix.branch }}"
           branch: 'crdb-releases-yaml-update-${{ matrix.branch }}'

--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 on:
+  # TODO(celia) -- REMOVE THIS ONCE FIX IS VERIFIED --- NO NOT MERGE !!!!
+  pull_request:
+    branches:
+      - master
   schedule:
      - cron: 0 0 * * *
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
Node.js 16 actions are deprecated. Bumping action versions to bump Node.js from 16 to 20.

Fixes: https://github.com/cockroachdb/cockroach/actions/runs/7977572065

Release note: None
Epic: None