### PR TITLE
kv: increment txn.restarts.writetooold on WriteTooOld error

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -837,6 +837,13 @@ func (tc *TxnCoordSender) handleRetryableErrLocked(ctx context.Context, pErr *kv
 		}
 
 	case *kvpb.WriteTooOldError:
+		tc.metrics.RestartsWriteTooOld.Inc()
+		// Also increment the deprecated "txn.restarts.writetoooldmulti" metric.
+		// We preserve this for one release to avoid confusion in mixed-version
+		// clusters.
+		// TODO(nvanbenschoten): remove this when compatibility with v23.2 is no
+		// longer needed. At the same time, also remove the corresponding metric
+		// from the "Transaction Restarts" graph in the SQL Dashboard.
 		tc.metrics.RestartsWriteTooOldMulti.Inc()
 
 	case *kvpb.ReadWithinUncertaintyIntervalError:


### PR DESCRIPTION
WriteTooOld errors were previously counted in either the `txn.restarts.writetooold` metric or the `txn.restarts.writetoooldmulti` metric, depending on when in the lifecycle of a transaction they were thrown. Now that WriteTooOld errors are rarely (never?) deferred, we would like to consolidate these metrics to avoid confusion.

As a first step, we now increment `txn.restarts.writetooold` in both cases. In the next release, we can remove the `txn.restarts.writetoooldmulti` metric and its presence in the "Transaction Restarts" graph in the SQL Dashboard.

Release note (ui change): The "Write Too Old" metric in the "Transaction Restarts" graph under the SQL Dashboard now includes all restarts previously categorized as "Write Too Old (multiple)". The former is a now a superset of the latter. The "Write Too Old (multiple)" metric will be removed in a future release.