### PR TITLE
ui: remove "Push Failure" and "Unknown" from "Transaction Restarts" graph

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -525,16 +525,6 @@ export default function (props: GraphDashboardProps) {
           title="Aborted"
           nonNegativeRate
         />
-        <Metric
-          name="cr.node.txn.restarts.txnpush"
-          title="Push Failure"
-          nonNegativeRate
-        />
-        <Metric
-          name="cr.node.txn.restarts.unknown"
-          title="Unknown"
-          nonNegativeRate
-        />
       </Axis>
     </LineGraph>,
 


### PR DESCRIPTION
These two metrics are always 0 in practice, so this commit removes them from the "Transaction Restarts" graph in the SQL Dashboard to avoid confusion and concern.

We could also consider removing the metrics entirely, but it's nice to have them for debugging. Users don't need to see them though.

Epic: None
Release note: None