### PR TITLE
workflows: add docker test to GitHub actions CI

### DIFF
--- a/.github/workflows/experimental-github-actions-testing.yml
+++ b/.github/workflows/experimental-github-actions-testing.yml
@@ -106,3 +106,19 @@ jobs:
       - name: clean up
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
+  docker_image_amd64:
+    runs-on: [self-hosted, basic_runner_group]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: ./build/github/get-engflow-keys.sh
+      - run: ./build/github/prepare-summarize-build.sh
+      - name: run docker tests
+        run: ./build/github/docker-image.sh amd64
+      - name: upload build results
+        run: ./build/github/summarize-build.sh bes.bin
+        if: always()
+      - name: clean up
+        run: ./build/github/cleanup-engflow-keys.sh
+        if: always()

--- a/build/github/docker-image.sh
+++ b/build/github/docker-image.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# The first and only parameter is the name of the architecture the image is being built for,
+# either amd64 or arm64.
+case $1 in
+    amd64)
+        CROSSCONFIG=crosslinux
+        ARCHIVEDIR=archived_cdep_libgeos_linux
+    ;;
+    arm64)
+        CROSSCONFIG=crosslinuxarm
+        ARCHIVEDIR=archived_cdep_libgeos_linuxarm
+    ;;
+    *)
+        echo 'expected one argument, either amd64 or arm64'
+    ;;
+esac
+
+build_arch=${1:-amd64}
+
+bazel build //pkg/cmd/cockroach //c-deps:libgeos --config $CROSSCONFIG --jobs 100 $(./build/github/engflow-args.sh)
+cp _bazel/bin/pkg/cmd/cockroach/cockroach_/cockroach build/deploy
+cp _bazel/cockroach/external/$ARCHIVEDIR/lib/libgeos.so build/deploy
+cp _bazel/cockroach/external/$ARCHIVEDIR/lib/libgeos_c.so build/deploy
+
+cp -r licenses build/deploy/
+
+chmod 755 build/deploy/cockroach
+
+docker_image_tar_name="cockroach-docker-image.tar"
+
+docker_tag="cockroachdb/cockroach-ci"
+
+# We have to always pull here because this runner may have been used to build
+# a different architecture's docker image. If that's the case, the cache will
+# return the cached version of the UBI base image (which will be for the wrong
+# architecture), then build will use it and fail because it's for the wrong
+# architecture. The cache is really stupid, in other words.
+docker build \
+  --no-cache \
+  --platform=linux/${build_arch} \
+  --tag="$docker_tag" \
+  --memory 30g \
+  --memory-swap -1 \
+  --pull \
+  build/deploy
+
+bazel test \
+  //pkg/testutils/docker:docker_test \
+  --config=crosslinux \
+  --test_timeout=3000 \
+  --remote_download_minimal \
+  --jobs 100 $(./build/github/engflow-args.sh) --build_event_binary_file=bes.bin


### PR DESCRIPTION
The arm64 tests are still disabled in TC CI, so I haven't added them
here.

Epic: CRDB-8308
Release note: None