### PR TITLE
sql: initialize the cluster version early

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -368,8 +368,8 @@ func runMultiTenantUpgrade(
 			withResults([][]string{{"true"}}))
 
 	t.Status("restarting the tenant 14 server to check it works after a restart")
-	tenant13.stop(ctx, t, c)
-	tenant13.start(ctx, t, c, currentBinary)
+	tenant14.stop(ctx, t, c)
+	tenant14.start(ctx, t, c, currentBinary)
 
 	t.Status("verifying the post-upgrade tenant works and has the proper version")
 	verifySQL(t, tenant14.pgURL,
@@ -377,6 +377,19 @@ func runMultiTenantUpgrade(
 			withResults([][]string{{"1", "bar"}}),
 		mkStmt("SELECT version = crdb_internal.node_executable_version() FROM [SHOW CLUSTER SETTING version]").
 			withResults([][]string{{"true"}}))
+
+	t.Status("restarting the tenant 14 server to check it works with preserve downgrade option as an override")
+	runner.Exec(
+		t,
+		`ALTER TENANT [14] SET CLUSTER SETTING cluster.preserve_downgrade_option = crdb_internal.node_executable_version()`)
+	tenant14.stop(ctx, t, c)
+	tenant14.start(ctx, t, c, currentBinary)
+
+	t.Status("restarting the tenant 13 server to check it works with preserve downgrade option in the tenant")
+	verifySQL(t, tenant13.pgURL,
+		mkStmt("SET CLUSTER SETTING cluster.preserve_downgrade_option = crdb_internal.node_executable_version()"))
+	tenant13.stop(ctx, t, c)
+	tenant13.start(ctx, t, c, currentBinary)
 }
 
 type sqlVerificationStmt struct {


### PR DESCRIPTION
In secondary tenants, we previously did not initialize the cluster version until we received it via the initial rangefeed scan in the settings watcher.

The cluster.preserve_downgrade_option is almost surely going to arrive in our initial scan before the version setting. The setter for that option has validation that requires the cluster version setting is initialized. Similarly, if cluster.preserve_downgrade_option is set via an override that validation will be hit before the cluster version is initialized)

Here, we read the setting directly from storage before starting the settings watcher to initialize the setting.

Fixes #119431

Release note: None