### PR TITLE
gossip: delay and batch gossip info propagation

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -123,6 +123,11 @@ const (
 	// we didn't need to tighten the last time we checked.
 	gossipTightenInterval = time.Second
 
+	// gossipPropagateInfosDelay is the delay between gossiping updated infos to
+	// peers. By delaying gossip requests and responses, we more effectively batch
+	// info updates and bound the amount of time we spend computing info deltas.
+	gossipPropagateInfosDelay = 10 * time.Millisecond
+
 	unknownNodeID roachpb.NodeID = 0
 )
 

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -196,6 +196,12 @@ func (s *server) Gossip(stream Gossip_GossipServer) error {
 		case err := <-errCh:
 			return err
 		case <-ready:
+			// Wait out the gossipPropagateInfosDelay to accumulate more infos.
+			select {
+			case <-time.After(gossipPropagateInfosDelay):
+			case <-s.stopper.ShouldQuiesce():
+				return nil
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #119420.

This commit addresses #119420 by delaying gossiping updated infos to peers by up to 10ms. In doing so, we more effectively batch info updates and bound the amount of time we spend computing info deltas.

With a maxHops = 5, a gossipPropagateInfosDelay of 10ms means that we will be delaying the propagation of info updates by up to 50ms. This should be a reasonable delay for most use cases, given the benefit of this change.

TODO: run some tests.

Release note (performance improvement): gossip info propagation is now delayed by up to 10ms in order to promote more batching of gossip updates. The effect of this is TBD.