### PR TITLE
release-23.1: roachtest: Fix npgsql test

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -790,4 +790,5 @@ var npgsqlIgnoreList = blocklist{
 	`Npgsql.Tests.TransactionTests(NonMultiplexing).CommitAsync(Prepared)`:                                 "flaky",
 	`Npgsql.Tests.TransactionTests(NonMultiplexing).Rollback(Prepared)`:                                    "flaky",
 	`Npgsql.Tests.TransactionTests(NonMultiplexing).RollbackAsync(NotPrepared)`:                            "flaky",
+	`Npgsql.Tests.CommandTests(Multiplexing).Batched_big_statements_do_not_deadlock`:                       "flaky",
 }


### PR DESCRIPTION
One more npgsql test is flaking on 23.1 due to
https://github.com/cockroachdb/cockroach/issues/108414. Marking it as a flake to resolve the failure.

Fixes https://github.com/cockroachdb/cockroach/issues/119240
Epic: none
Release note: None
Release justication: Low risk test only change