### PR TITLE
server: don't initialize bogus cluster version

### DIFF
--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/clientsecopts"
@@ -189,21 +188,6 @@ func makeSharedProcessTenantServerConfig(
 	stopper *stop.Stopper,
 	nodeMetricsRecorder *status.MetricsRecorder,
 ) (baseCfg BaseConfig, sqlCfg SQLConfig, err error) {
-	// We need a value in the version setting prior to the update
-	// coming from the system.settings table. This value must be valid
-	// and compatible with the state of the tenant's keyspace.
-	//
-	// Since we don't know at which binary version the tenant
-	// keyspace was initialized, we must be conservative and
-	// assume it was created a long time ago; and that we may
-	// have to run all known migrations since then. So initialize
-	// the version setting to the minimum supported version.
-	if err := clusterversion.Initialize(
-		ctx, st.Version.MinSupportedVersion(), &st.SV,
-	); err != nil {
-		return BaseConfig{}, SQLConfig{}, err
-	}
-
 	tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV))
 
 	// Define a tenant store. This will be used to write the


### PR DESCRIPTION
We initialize this from SQL directly. Removing this means you can't use the cluster version before it is initialized during server startup.

Release note: None
Epic: none