### PR TITLE
roachtest: restore max disk mem default

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -377,11 +377,8 @@ func registerRestore(r registry.Registry) {
 				workload:          tpceRestore{customers: 2000000},
 				numBackupsInChain: 400,
 			}),
-			timeout: 30 * time.Hour,
-			suites:  registry.Suites(registry.Weekly),
-			extraArgs: []string{
-				"--max-disk-temp-storage", "128GiB",
-			},
+			timeout:                30 * time.Hour,
+			suites:                 registry.Suites(registry.Weekly),
 			restoreUptoIncremental: 400,
 		},
 		{
@@ -393,11 +390,8 @@ func registerRestore(r registry.Registry) {
 				cloud:             spec.GCE,
 				numBackupsInChain: 400,
 			}),
-			timeout: 30 * time.Hour,
-			suites:  registry.Suites(registry.Weekly),
-			extraArgs: []string{
-				"--max-disk-temp-storage", "128GiB",
-			},
+			timeout:                30 * time.Hour,
+			suites:                 registry.Suites(registry.Weekly),
 			restoreUptoIncremental: 400,
 			skip:                   "a recent gcp pricing policy makes this test very expensive. unskip after #111371 is addressed",
 		},


### PR DESCRIPTION
We set this before discovering the impact of a non-standard cluster setting. Let's see if this test passes in the nightlies with the default restored.

Epic: none
Release note: None