### PR TITLE
pkg/sql: reset the tenant global metrics exporter timer after fetching stats

### DIFF
--- a/pkg/sql/mvcc_statistics_update_job.go
+++ b/pkg/sql/mvcc_statistics_update_job.go
@@ -31,8 +31,8 @@ import (
 )
 
 // TenantGlobalMetricsExporterInterval is the interval at which an external
-// tenant's process in the cluster will update the global metrics. This is
-// exported for testing purposes.
+// tenant's process in the cluster will update the global metrics, and is
+// measured from the *last update*. This is exported for testing purposes.
 var TenantGlobalMetricsExporterInterval = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"tenant_global_metrics_exporter_interval",
@@ -143,10 +143,10 @@ func (j *mvccStatisticsUpdateJob) runTenantGlobalMetricsExporter(
 			return ctx.Err()
 		case <-timer.C:
 			timer.Read = true
-			timer.Reset(TenantGlobalMetricsExporterInterval.Get(&execCtx.ExecCfg().Settings.SV))
 			if err := runTask(); err != nil {
 				log.Errorf(ctx, "mvcc statistics update job error: %v", err)
 			}
+			timer.Reset(TenantGlobalMetricsExporterInterval.Get(&execCtx.ExecCfg().Settings.SV))
 		}
 	}
 }


### PR DESCRIPTION
Previously, we reset the timer for the tenant global metrics exporter before
fetching the stats for tenant spans. This means that if fetching took more
than a minute, we will almost always be fetching the stats. In theory, if
this became an issue, we can increase the interval via an override within the
host. To add on, this likely won't be an issue on Serverless clusters to begin
with. For completeness purposes, this commit updates the code such that we
only reset the timer after fetching the stats. This avoids needing to deal
with custom overrides when it is a problem.

Release note: None