### PR TITLE
roachtest: bump online restore IO specs

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -190,6 +190,9 @@ func getAWSOpts(
 	}
 	if ebsThroughput != 0 {
 		opts.DefaultEBSVolume.Disk.Throughput = ebsThroughput
+		if opts.DefaultEBSVolume.Disk.IOPs < opts.DefaultEBSVolume.Disk.Throughput*4 {
+			opts.DefaultEBSVolume.Disk.IOPs = opts.DefaultEBSVolume.Disk.Throughput * 6
+		}
 	}
 	if localSSD {
 		opts.SSDMachineType = machineType

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -69,7 +69,7 @@ func registerOnlineRestore(r registry.Registry) {
 		},
 		{
 			// 400GB tpce Online Restore
-			hardware:               makeHardwareSpecs(hardwareSpecs{ebsThroughput: 250 /* MB/s */, workloadNode: true}),
+			hardware:               makeHardwareSpecs(hardwareSpecs{ebsThroughput: 1000 /* MB/s */, workloadNode: true}),
 			backup:                 makeRestoringBackupSpecs(backupSpecs{nonRevisionHistory: true, version: "v23.1.11"}),
 			timeout:                1 * time.Hour,
 			suites:                 registry.Suites(registry.Nightly),
@@ -78,7 +78,7 @@ func registerOnlineRestore(r registry.Registry) {
 		{
 			// 8TB tpce Online Restore
 			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 10, volumeSize: 2000,
-				ebsThroughput: 250 /* MB/s */, workloadNode: true}),
+				ebsThroughput: 1000 /* MB/s */, workloadNode: true}),
 			backup: makeRestoringBackupSpecs(backupSpecs{
 				nonRevisionHistory: true,
 				version:            "v23.1.11",

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -149,6 +149,10 @@ func (d *ebsDisk) Set(s string) error {
 			// 125MB/s is base throughput for gp3.
 			d.Throughput = 125
 		}
+
+		if d.IOPs < d.Throughput*4 {
+			d.IOPs = d.Throughput * 6
+		}
 	case "io1", "io2":
 		if d.IOPs == 0 {
 			return errors.AssertionFailedf("Iops required for %s disk", d.VolumeType)


### PR DESCRIPTION
Release note: none.
Epic: none.