### PR TITLE
release-23.1: catalog: remove the chart catalog

### DIFF
--- a/pkg/server/server_import_ts_test.go
+++ b/pkg/server/server_import_ts_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/ts"
@@ -79,7 +80,11 @@ func TestServerWithTimeseriesImport(t *testing.T) {
 }
 
 func dumpTSNonempty(t *testing.T, cc *grpc.ClientConn, dest string) (bytes int64) {
-	c, err := tspb.NewTimeSeriesClient(cc).DumpRaw(context.Background(), &tspb.DumpRequest{})
+	names, err := serverpb.GetInternalTimeseriesNamesFromServer(context.Background(), cc)
+	require.NoError(t, err)
+	c, err := tspb.NewTimeSeriesClient(cc).DumpRaw(context.Background(), &tspb.DumpRequest{
+		Names: names,
+	})
 	require.NoError(t, err)
 
 	f, err := os.Create(dest)

--- a/pkg/server/serverpb/BUILD.bazel
+++ b/pkg/server/serverpb/BUILD.bazel
@@ -105,6 +105,9 @@ go_library(
     deps = [
         "//pkg/roachpb",
         "//pkg/util/errorutil",
+        "//pkg/util/metric",
+        "@com_github_prometheus_client_model//go",
+        "@org_golang_google_grpc//:go_default_library",
     ],
 )
 

--- a/pkg/server/serverpb/admin.go
+++ b/pkg/server/serverpb/admin.go
@@ -10,7 +10,14 @@
 
 package serverpb
 
-import context "context"
+import (
+	context "context"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"google.golang.org/grpc"
+)
 
 // Add adds values from ots to ts.
 func (ts *TableStatsResponse) Add(ots *TableStatsResponse) {
@@ -62,4 +69,44 @@ type TenantAdminServer interface {
 // healthcheck.
 func (r *RecoveryVerifyResponse_UnavailableRanges) Empty() bool {
 	return len(r.Ranges) == 0 && len(r.Error) == 0
+}
+
+// GetInternalTimeseriesNamesFromServer is a helper that uses the provided
+// ClientConn to query the AllMetricMetadata endpoint, and returns the set of
+// all possible internal metric names as a sorted slice.
+//
+// This is *not* the list of timeseries names. Instead, it is that list but
+// adding `cr.node.` and `cr.store.` prefixes (both copies are emitted, since we
+// can't tell what the true prefix for each metric is). Additionally, for histograms
+// we generate the names for the quantiles that are exported (internal TSDB does
+// not support full histograms).
+func GetInternalTimeseriesNamesFromServer(
+	ctx context.Context, conn *grpc.ClientConn,
+) ([]string, error) {
+	c := NewAdminClient(conn)
+	resp, err := c.AllMetricMetadata(ctx, &MetricMetadataRequest{})
+	if err != nil {
+		return nil, err
+	}
+	var sl []string
+	for name, meta := range resp.Metadata {
+		if meta.MetricType == io_prometheus_client.MetricType_HISTOGRAM {
+			// See usage of RecordHistogramQuantiles in pkg/server/status/recorder.go.
+			for _, q := range metric.RecordHistogramQuantiles {
+				sl = append(sl, name+q.Suffix)
+			}
+			sl = append(sl, name+"-avg")
+			sl = append(sl, name+"-count")
+		} else {
+			sl = append(sl, name)
+		}
+	}
+	out := make([]string, 0, 2*len(sl))
+	for _, prefix := range []string{"cr.node.", "cr.store."} {
+		for _, name := range sl {
+			out = append(out, prefix+name)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #99788.

/cc @cockroachdb/release

**NB: This commit has been altered to reduce the overall # of changes, to
make it more backport friendly. Original commit message is contained
below, although the kept changes solely aim to ensure that the list of
metrics contained within `tsdump` are sourced dynamically, instead of
from a static chart catalog.**


---

Roughly the following, all in the same commit (sorry - discovered what needed to be done as I went, if reviewers find it hard to grok I can try to chop it into commits):

- tsdump: simplify code a bit
- tsdump: query AllMetricMetadata endpoint to get all timeseries names
  (rather than filling it server-side in the TSDB, which doesn't
  really have access to it now)
- tsdump: return error instead of filling in metric names
- serverpb: add GetInternalTimeSeriesNamesFromServer, this is code that
  essentially lived in `catalog`, but with some cleanups.
  We need this to go from "metric name" to "actual name the TSDB stores this
  under in KV" because that's what `tsdump` operates on.
- catalog: return a flat mock stub in GenerateCatalog
- catalog: pretty much delete everything else, including that
  list of metrics that needed to be manually adjusted every time
  a metric was added or removed.

A 23.1 cli will fail to fetch the timeseries from a 23.2+ host, but the error
message is informative and I don't think additional complexity to smoothen
mixed-version deploys is warranted. A 23.2+ cli will work fine with older
releases.

Closes https://github.com/cockroachdb/cockroach/issues/99791.

Tidy up a few issues that had to do with auto-generating Grafana dashboards
from the catalog:

Closes https://github.com/cockroachdb/cockroach/issues/54178.
Closes https://github.com/cockroachdb/cockroach/issues/78232.
Closes https://github.com/cockroachdb/cockroach/issues/81035.

Epic: none
Release note: None
Release justification: necessary improvement to observability with respect to the `tsdump` tool, which currently omits important histogram metrics without these changes.