### PR TITLE
restore: use copy-compactions in online restore

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3416,6 +3416,7 @@ Support status: [reserved](#support-status)
 | ----- | ---- | ----- | ----------- | -------------- |
 | node_id | [string](#cockroach.server.serverpb.DownloadSpanRequest-string) |  |  | [reserved](#support-status) |
 | spans | [cockroach.roachpb.Span](#cockroach.server.serverpb.DownloadSpanRequest-cockroach.roachpb.Span) | repeated |  | [reserved](#support-status) |
+| via_backing_file_download | [bool](#cockroach.server.serverpb.DownloadSpanRequest-bool) |  |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -603,6 +603,7 @@ message EngineStatsResponse {
 message DownloadSpanRequest {
   string node_id = 1 [(gogoproto.customname) = "NodeID"];
   repeated roachpb.Span spans = 2 [(gogoproto.nullable) = false];
+  bool via_backing_file_download = 3;
 }
 
 message DownloadSpanResponse {

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1101,8 +1101,10 @@ type Engine interface {
 	GetStoreID() (int32, error)
 
 	// Download informs the engine to download remote files corresponding to the
-	// given span.
-	Download(ctx context.Context, span roachpb.Span) error
+	// given span. The parameter copy controls how it is downloaded -- i.e. if it
+	// just copies the backing bytes to a local file of if it rewrites the file
+	// key-by-key to a new file.
+	Download(ctx context.Context, span roachpb.Span, copy bool) error
 }
 
 // Batch is the interface for batch specific operations.


### PR DESCRIPTION
Release note: none.
Epic: none.