### PR TITLE
kv: don't log on lease extension while draining

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -378,7 +378,7 @@ func (r *Replica) leasePostApplyLocked(
 		// Log lease acquisitions loudly when verbose logging is enabled or when the
 		// new leaseholder is draining, in which case it should be shedding leases.
 		// Otherwise, log a trace event.
-		if log.V(1) || r.store.IsDraining() {
+		if log.V(1) || (leaseChangingHands && r.store.IsDraining()) {
 			log.Infof(ctx, "new range lease %s following %s", newLease, prevLease)
 		} else {
 			log.Eventf(ctx, "new range lease %s following %s", newLease, prevLease)


### PR DESCRIPTION
Fixes #119451.

This commit updates the logging in `Replica.leasePostApplyLocked` to not log on expiration-based lease extensions while the new leaseholder's store is draining. We now only log when a draining store receives a new lease.

Release note: None