### PR TITLE
telemetry: don't resample transaction for telemetry on restart

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2038,11 +2038,6 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent, pay
 		ex.state.mu.Lock()
 		defer ex.state.mu.Unlock()
 		ex.state.mu.stmtCount = 0
-		isTracing := ex.planner.ExtendedEvalContext().Tracing.Enabled()
-		ex.extraTxnState.shouldLogToTelemetry, ex.extraTxnState.telemetrySkippedTxns =
-			ex.server.TelemetryLoggingMetrics.shouldEmitTransactionLog(isTracing,
-				ex.executorType == executorTypeInternal,
-				ex.applicationName.Load().(string))
 	}
 
 	// NOTE: on txnRestart we don't need to muck with the savepoints stack. It's either a

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3233,12 +3233,6 @@ func (ex *connExecutor) recordTransactionStart(txnID uuid.UUID) {
 		TxnFingerprintID: appstatspb.InvalidTransactionFingerprintID,
 	})
 
-	isTracing := ex.planner.ExtendedEvalContext().Tracing.Enabled()
-	ex.extraTxnState.shouldLogToTelemetry, ex.extraTxnState.telemetrySkippedTxns =
-		ex.server.TelemetryLoggingMetrics.shouldEmitTransactionLog(isTracing,
-			ex.executorType == executorTypeInternal,
-			ex.applicationName.Load().(string))
-
 	ex.state.mu.RLock()
 	txnStart := ex.state.mu.txnStart
 	ex.state.mu.RUnlock()
@@ -3270,6 +3264,13 @@ func (ex *connExecutor) recordTransactionStart(txnID uuid.UUID) {
 	ex.extraTxnState.txnFinishClosure.txnStartTime = txnStart
 	ex.extraTxnState.txnFinishClosure.implicit = ex.implicitTxn()
 	ex.extraTxnState.shouldExecuteOnTxnRestart = true
+
+	// Determine telemetry logging.
+	isTracing := ex.planner.ExtendedEvalContext().Tracing.Enabled()
+	ex.extraTxnState.shouldLogToTelemetry, ex.extraTxnState.telemetrySkippedTxns =
+		ex.server.TelemetryLoggingMetrics.shouldEmitTransactionLog(isTracing,
+			ex.executorType == executorTypeInternal,
+			ex.applicationName.Load().(string))
 
 	ex.statsCollector.StartTransaction()
 

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -113,8 +113,8 @@ const (
 // TELEMETRY. Currently the criteria is if the statement is not of type DML and is
 // not BEGIN or COMMIT.
 func shouldForceLogStatement(ast tree.Statement) bool {
-	switch ast.StatementTag() {
-	case "BEGIN", "COMMIT":
+	switch ast.(type) {
+	case *tree.BeginTransaction, *tree.CommitTransaction:
 		return false
 	default:
 		return ast.StatementType() != tree.TypeDML

--- a/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
+++ b/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
@@ -286,10 +286,9 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 
 subtest end
 
-subtest txn_retry_is_sampled
+subtest no_sampling_reset_on_txn_retry
 
-# If a transaction restarts, we should redo the sampling logic. This test ensures
-# that even if the first attempt of a txn is not sampled, a retry may be sampled.
+# This test ensures that if a transaction is retried, the sampling decision is not reset.
 
 exec-sql
 CREATE SEQUENCE seq START WITH 1
@@ -298,7 +297,7 @@ CREATE SEQUENCE seq START WITH 1
 reset-last-sampled
 ----
 
-# Execute a query at time=1 so that the first attempt of the next txn is not sampled.
+# Execute a query at time=1 so that the the next txn executed at time=1 is not sampled.
 spy-sql unixSecs=1
 SELECT 1, 2, 3
 ----
@@ -331,15 +330,59 @@ SELECT 1, 2, 3
 	"User": "root"
 }
 
-# The stub time will only be advanced in the retry.
-# Note that the crdb_internal.force_retry will always appear in the logs due to
-# it not being a DML statement.
+# This transaction will not be sampled due to not enough time having elapsed. Its
+# retries should also not be sampled, even though the stub time will be advanced
+# for the retries such that enough time has elapsed for sampling to be enabled,
+# the sampling decision should not be reset and should use the sampling decision
+# initially set for this transaction.
 spy-sql unixSecs=1 restartUnixSecs=2
 BEGIN;
 SELECT 'hello';
 SELECT CASE nextval('seq') WHEN 1 THEN crdb_internal.force_retry('1s') ELSE 2 END;
 COMMIT;
 ----
+
+
+# This is the reverse scenario to the above. We will execute a txn at time=2 so that it
+# is sampled (enough time elapsed). On its retry, we will not advance the stub time so that
+# the retry also runs at t=2. The retry should be sampled even though not enough time has
+# elapsed due to it being a retry of asampled txn.
+spy-sql unixSecs=2 restartUnixSecs=2
+BEGIN;
+SELECT 'hello';
+SELECT CASE nextval('seq') WHEN 3 THEN crdb_internal.force_retry('1s') ELSE 2 END;
+COMMIT;
+----
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"EventType": "sampled_query",
+	"NumRows": 1,
+	"OutputRowsEstimate": 1,
+	"PlanGist": "AgICAgYC",
+	"SkippedQueries": 7,
+	"Statement": "SELECT ‹'hello'›",
+	"StatementFingerprintID": 15578946620736494000,
+	"StmtPosInTxn": 1,
+	"Tag": "SELECT",
+	"User": "root"
+}
+{
+	"ApplicationName": "telemetry-logging-datadriven",
+	"Database": "defaultdb",
+	"Distribution": "local",
+	"ErrorText": "crdb_internal.force_retry(): TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()",
+	"EventType": "sampled_query",
+	"OutputRowsEstimate": 1,
+	"PlanGist": "AgICAgYC",
+	"SQLSTATE": "40001",
+	"Statement": "SELECT CASE nextval(‹'seq'›) WHEN ‹3› THEN crdb_internal.force_retry(‹'00:00:01'›) ELSE ‹2› END",
+	"StatementFingerprintID": 17115235937825139000,
+	"StmtPosInTxn": 2,
+	"Tag": "SELECT",
+	"User": "root"
+}
 {
 	"ApplicationName": "telemetry-logging-datadriven",
 	"Database": "defaultdb",
@@ -349,7 +392,6 @@ COMMIT;
 	"NumRows": 1,
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
-	"SkippedQueries": 3,
 	"Statement": "SELECT ‹'hello'›",
 	"StatementFingerprintID": 15578946620736494000,
 	"StmtPosInTxn": 1,
@@ -365,7 +407,7 @@ COMMIT;
 	"NumRows": 1,
 	"OutputRowsEstimate": 1,
 	"PlanGist": "AgICAgYC",
-	"Statement": "SELECT CASE nextval(‹'seq'›) WHEN ‹1› THEN crdb_internal.force_retry(‹'00:00:01'›) ELSE ‹2› END",
+	"Statement": "SELECT CASE nextval(‹'seq'›) WHEN ‹3› THEN crdb_internal.force_retry(‹'00:00:01'›) ELSE ‹2› END",
 	"StatementFingerprintID": 9891387630896048000,
 	"StmtPosInTxn": 2,
 	"Tag": "SELECT",

--- a/pkg/util/log/eventpb/eventpbgen/gen.go
+++ b/pkg/util/log/eventpb/eventpbgen/gen.go
@@ -84,7 +84,7 @@ type fieldInfo struct {
 	Inherited           bool
 	IsEnum              bool
 	AllowZeroValue      bool
-	Nullable            bool
+	NotNullable         bool
 }
 
 var (
@@ -464,7 +464,7 @@ func readInput(
 					MixedRedactable:     mixed,
 					IsEnum:              isEnum,
 					AllowZeroValue:      allowZeroValue,
-					Nullable:            !notNullable,
+					NotNullable:         notNullable,
 				}
 				curMsg.Fields = append(curMsg.Fields, fi)
 				curMsg.AllFields = append(curMsg.AllFields, fi)
@@ -718,7 +718,7 @@ func (m *{{.GoType}}) AppendJSONFields(printComma bool, b redact.RedactableBytes
      }
    }
    {{- else if eq .FieldType "nestedMessage"}}
-   {{ if .Nullable -}}
+   {{ if not .NotNullable -}}
    if m.{{.FieldName}} != nil {
    {{- end }}
      if printComma { b = append(b, ',')}; printComma = true
@@ -726,7 +726,7 @@ func (m *{{.GoType}}) AppendJSONFields(printComma bool, b redact.RedactableBytes
      b = append(b, '{')
      printComma, b = m.{{.FieldName}}.AppendJSONFields(false, b)
      b = append(b, '}')
-   {{ if .Nullable -}}
+   {{ if not .NotNullable -}}
    }
    {{- end }}
    {{- else}}


### PR DESCRIPTION
### telemetry: don't resample transaction for telemetry on restart

We will only attempt to sample the transaction once at the
start of its execution.

Additional changes:
- Move the sampling decision for transactions to be closer to section
updating `extraTxnState`
- Use the concrete statement types in `shouldForceLogStatement` to
prevent force logging on BEGIN and COMMIT statements.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/119284

Release note: None

### eventpbgen: rename Nullable property to NotNullable

Let's rename the `Nullable` field to `NotNullable` for the
`fieldInfo` struct used in generating json encoding functions
for protobuf definitons. Note this field currently only applies to
`nestedMessage` types.

Epic: none

Release note: None