### PR TITLE
storage: ratchet pebble on fence version

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -399,6 +399,16 @@ func (k Key) Version() roachpb.Version {
 	return maybeApplyDevOffset(k, version)
 }
 
+// FenceVersion is the fence version -- the internal immediately prior -- for
+// the named version, if it is Internal.
+func (k Key) FenceVersion() roachpb.Version {
+	v := k.Version()
+	if v.Internal > 0 {
+		v.Internal -= 1
+	}
+	return v
+}
+
 // IsFinal returns true if the key corresponds to a final version (as opposed to
 // a transitional internal version during upgrade).
 func (k Key) IsFinal() bool {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2477,14 +2477,10 @@ func (p *Pebble) CreateCheckpoint(dir string, spans []roachpb.Span) error {
 // map the persisted cluster version to the corresponding format major version,
 // ratcheting Pebble's format major version if necessary.
 //
-// Note that when introducing a new Pebble format version that relies on _all_
-// engines in a cluster being at the same, newer format major version, two
-// cluster versions should be used. The first is used to enable the feature in
-// Pebble, and should control the version ratchet below. The second is used as a
-// feature flag. The use of two cluster versions relies on a guarantee provided
-// by the migration framework (see pkg/migration) that if a node is at a version
-// X+1, it is guaranteed that all nodes have already ratcheted their store
-// version to the version X that enabled the feature at the Pebble level.
+// The pebble versions are advanced when nodes enter the "fence" version for the
+// named cluster version, if there is one, so that if *any* node moves into the
+// named version, it can be assumed all *nodes* have ratcheted to the pebble
+// version associated with it, since they did so during the fence version.
 var pebbleFormatVersionMap = map[clusterversion.Key]pebble.FormatMajorVersion{
 	clusterversion.V23_1: pebble.FormatFlushableIngest,
 	clusterversion.V23_2_PebbleFormatDeleteSizedAndObsolete: pebble.FormatDeleteSizedAndObsolete,
@@ -2510,7 +2506,7 @@ func pebbleFormatVersion(clusterVersion roachpb.Version) pebble.FormatMajorVersi
 	// pebbleFormatVersionKeys are sorted in descending order; find the first one
 	// that is not newer than clusterVersion.
 	for _, k := range pebbleFormatVersionKeys {
-		if clusterVersion.AtLeast(k.Version()) {
+		if clusterVersion.AtLeast(k.FenceVersion()) {
 			return pebbleFormatVersionMap[k]
 		}
 	}


### PR DESCRIPTION
The cluster version upgrade system operates by asking all nodes to write their version twice: once with a 'fence' version, then it runs the upgrade function if any, then again with the actual version that indicates the function completed.

When a cluster asks a node to write this version, in both cases, part of that write call includes pebble checking if the version being written should trigger a ratchet of the pebble format version. Today, pebble is instructed to do this based on a mapping of cluster versions to pebble versions, specifically from the non-fence cluster versions. This, however, means that one node may not have done the update write yet, and changed its format version, even when another has, and thus IsActive of that version is true on that node. This is normally not an issue for code that is checking if the upgrade ran as usually the upgrade function is run _before_ sending the instruction to write the second version to any node.

This changes the mapping of cluster version to pebble version so that the first of the two versions for each named cluster version, ie. the fence version, is the one that causes the pebble version to be updated. This brings the pebble behavior change in line with other upgrades, that perform their upgrade work -- the change from before to after condition -- before writing the 'real' cluster version which is associated with that work and considered an indication of it being done.

This means that a caller wishing to check if the cluster is using a format version can do e.g. `IsActive(V24_1)` using the alias for latest version as is preferred for new behavior gates, as well as `IsActive(VPebbleBumped)`, whereas previously they would have needed to explicitly mint an extra version both to check directly in the latter case but also to ensure that the latest alias in the former case didn't just point ot their bump version. But with this change the bump version is a reliable indicator of the pebble version being advanced, so no extra versions are required for either gate check.

Release note: none.
Epic: none.