### PR TITLE
opt: add back the fix for trivial constrained scans

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_foreign_key_lookup_join
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_foreign_key_lookup_join
@@ -167,7 +167,7 @@ vectorized: true
     └── • scan
           missing stats
           table: child_rbr@child_rbr_pkey
-          spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
+          spans: FULL SCAN
 
 query IIIIITI
 SELECT *
@@ -200,7 +200,7 @@ vectorized: true
         └── • scan
               missing stats
               table: child_rbr@child_rbr_pkey
-              spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
+              spans: FULL SCAN
 
 query IIIIITI rowsort
 SELECT *

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -1983,7 +1983,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES 
 │                   └── • scan
 │                         missing stats
 │                         table: regional_by_row_table_virt@regional_by_row_table_virt_pkey
-│                         spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
+│                         spans: FULL SCAN (SOFT LIMIT)
 │
 └── • constraint-check
     │
@@ -2162,7 +2162,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b)
 │                   └── • scan
 │                         missing stats
 │                         table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
-│                         spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
+│                         spans: FULL SCAN (SOFT LIMIT)
 │
 └── • constraint-check
     │
@@ -2182,7 +2182,7 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b)
                     └── • scan
                           missing stats
                           table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
-                          spans: [/'ap-southeast-2' - /'ap-southeast-2'] [/'ca-central-1' - /'us-east-1']
+                          spans: FULL SCAN (SOFT LIMIT)
 
 query T retry
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b) VALUES (1, 1, 1)] OFFSET 2

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -2704,23 +2704,23 @@ project
       │    │    ├── limit hint: 3.00
       │    │    ├── union-all
       │    │    │    ├── columns: a:2!null rowid:7!null
-      │    │    │    ├── left columns: a:48 rowid:53
-      │    │    │    ├── right columns: a:57 rowid:62
+      │    │    │    ├── left columns: a:30 rowid:35
+      │    │    │    ├── right columns: a:39 rowid:44
       │    │    │    ├── ordering: +2
       │    │    │    ├── limit hint: 3.00
       │    │    │    ├── scan regional@partial_a,partial
-      │    │    │    │    ├── columns: a:48!null rowid:53!null
-      │    │    │    │    ├── constraint: /47/48: [/'east' - /'east']
-      │    │    │    │    ├── key: (53)
-      │    │    │    │    ├── fd: (53)-->(48), (48)-->(53)
-      │    │    │    │    ├── ordering: +48
+      │    │    │    │    ├── columns: a:30!null rowid:35!null
+      │    │    │    │    ├── constraint: /29/30: [/'east' - /'east']
+      │    │    │    │    ├── key: (35)
+      │    │    │    │    ├── fd: (35)-->(30), (30)-->(35)
+      │    │    │    │    ├── ordering: +30
       │    │    │    │    └── limit hint: 3.00
       │    │    │    └── scan regional@partial_a,partial
-      │    │    │         ├── columns: a:57!null rowid:62!null
-      │    │    │         ├── constraint: /56/57: [/'west' - /'west']
-      │    │    │         ├── key: (62)
-      │    │    │         ├── fd: (62)-->(57), (57)-->(62)
-      │    │    │         ├── ordering: +57
+      │    │    │         ├── columns: a:39!null rowid:44!null
+      │    │    │         ├── constraint: /38/39: [/'west' - /'west']
+      │    │    │         ├── key: (44)
+      │    │    │         ├── fd: (44)-->(39), (39)-->(44)
+      │    │    │         ├── ordering: +39
       │    │    │         └── limit hint: 3.00
       │    │    └── aggregations
       │    │         └── count-rows [as=count_rows:10]

--- a/pkg/sql/opt/xform/testdata/rules/insert
+++ b/pkg/sql/opt/xform/testdata/rules/insert
@@ -175,17 +175,15 @@ insert t
       │         ├── columns: t.k:26!null t.r:27!null t.a:28!null t.b:29 t.c:30
       │         ├── key: (26)
       │         ├── fd: ()-->(28), (26)-->(27,29,30)
-      │         ├── index-join t
+      │         ├── scan t
       │         │    ├── columns: t.k:26!null t.r:27!null t.a:28 t.b:29 t.c:30
+      │         │    ├── check constraint expressions
+      │         │    │    └── t.r:27 IN ('east', 'west') [outer=(27), constraints=(/27: [/'east' - /'east'] [/'west' - /'west']; tight)]
+      │         │    ├── computed column expressions
+      │         │    │    └── t.b:29
+      │         │    │         └── t.k:26 % 9
       │         │    ├── key: (26)
-      │         │    ├── fd: (26)-->(27-30)
-      │         │    └── scan t@t_r_c_idx
-      │         │         ├── columns: t.k:26!null t.r:27!null t.c:30
-      │         │         ├── constraint: /27/30/26
-      │         │         │    ├── [/'east' - /'east']
-      │         │         │    └── [/'west' - /'west']
-      │         │         ├── key: (26)
-      │         │         └── fd: (26)-->(27,30)
+      │         │    └── fd: (26)-->(27-30)
       │         └── filters
       │              └── t.a:28 = 10 [outer=(28), constraints=(/28: [/10 - /10]; tight), fd=()-->(28)]
       └── fast-path-unique-checks-item: t(c)
@@ -525,19 +523,15 @@ insert t
       │         ├── key: (22)
       │         └── fd: ()-->(24), (22)-->(23,25)
       ├── fast-path-unique-checks-item: t(b)
-      │    └── select
+      │    └── index-join t
       │         ├── columns: t.k:38!null t.r:39!null t.a:40 t.b:41!null
       │         ├── key: (38)
       │         ├── fd: ()-->(41), (38)-->(39,40)
-      │         ├── scan t@t_r_a_b_idx
-      │         │    ├── columns: t.k:38!null t.r:39!null t.a:40 t.b:41
-      │         │    ├── constraint: /39/40/41/38
-      │         │    │    ├── [/'east' - /'east']
-      │         │    │    └── [/'west' - /'west']
-      │         │    ├── key: (38)
-      │         │    └── fd: (38)-->(39-41)
-      │         └── filters
-      │              └── t.b:41 = 2 [outer=(41), constraints=(/41: [/2 - /2]; tight), fd=()-->(41)]
+      │         └── scan t@t_b_a_idx
+      │              ├── columns: t.k:38!null t.a:40 t.b:41!null
+      │              ├── constraint: /41/40/38: [/2 - /2]
+      │              ├── key: (38)
+      │              └── fd: ()-->(41), (38)-->(40)
       ├── fast-path-unique-checks-item: t(r,a,b)
       │    └── scan t@t_r_a_b_idx
       │         ├── columns: t.k:54!null t.r:55!null t.a:56!null t.b:57!null

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -13050,7 +13050,6 @@ explain
            │    │    │    ├── columns: u85353.a:6 u85353.b:7
            │    │    │    └── scan u85353@b_idx
            │    │    │         ├── columns: u85353.b:7 u85353.rowid:10!null
-           │    │    │         ├── constraint: /9/7/10: [/0 - /7]
            │    │    │         ├── flags: force-index=b_idx
            │    │    │         ├── key: (10)
            │    │    │         └── fd: (10)-->(7)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -133,6 +133,15 @@ CREATE TABLE virtual (
 )
 ----
 
+exec-ddl
+CREATE TABLE singleton_check(
+  singleton BOOL DEFAULT TRUE,
+  count INT NOT NULL,
+  PRIMARY KEY (singleton),
+  CHECK (singleton)
+)
+----
+
 # --------------------------------------------------
 # GeneratePartialIndexScans
 # --------------------------------------------------
@@ -2609,7 +2618,8 @@ project
       ├── fd: ()-->(3)
       ├── scan t114250
       │    ├── columns: x:1!null z:3!null
-      │    └── constraint: /1/2: [/1 - /4]
+      │    └── check constraint expressions
+      │         └── (x:1 > 0) AND (x:1 < 5) [outer=(1), constraints=(/1: [/1 - /4]; tight)]
       └── filters
            └── z:3 = 5 [outer=(3), constraints=(/3: [/5 - /5]; tight), fd=()-->(3)]
 
@@ -2649,6 +2659,21 @@ project
       ├── constraint: /4/1: [/true - /true]
       └── key: (1)
 
+# Regression test for #114470 - allow a non-selective constraint for singleton
+# tables.
+#
+# This is a simplified version of an internal query performed on the
+# system.span_count table, which is vulnerable to the small increase in latency
+# caused by performing a KV Scan instead of a Get.
+opt expect=GenerateConstrainedScans
+SELECT * FROM singleton_check WHERE singleton;
+----
+scan singleton_check
+ ├── columns: singleton:1!null count:2!null
+ ├── constraint: /1: [/true - /true]
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ └── fd: ()-->(1,2)
 
 # --------------------------------------------------
 # GenerateInvertedIndexScans


### PR DESCRIPTION
This commit recovers the improvement which was made in #114332 and reverted in #114744. Constrained scans are no longer generated when the constraint is implied by the table's check constraints, except for singleton tables (which are statically guaranteed to have one row).

This omission is necessary because a "trivial" constraint for a singleton table allows the scan to use a KV Get request instead of a Scan, which allows for some low-level optimizations. Preventing this optimization regresses performance of an internal query on the `system.span_count` table, which led to the failures seen in #114470.

There is no release note, since the release note from #114332 still applies.

Fixes #114470

Release note: None