### PR TITLE
ui: add charts on gc assist metric

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -139,6 +139,23 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="GC Assist Time"
+      sources={nodeSources}
+      tenantSource={tenantSource}
+      tooltip={`Estimated total CPU time user goroutines spent performing GC tasks on processors
+        ${tooltipSelection}.`}
+      showMetricsInTooltip={true}
+    >
+      <Axis units={AxisUnits.Duration} label="gc assist time">
+        <Metric
+          name="cr.node.sys.gc.assist.ns"
+          title="GC Assist Time"
+          nonNegativeRate
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="CPU Time"
       sources={nodeSources}
       tenantSource={tenantSource}


### PR DESCRIPTION
This commit adds a line chart contains gc assist duration on the runtime page. The goal is to present the estimated time user go routines spend on assisting gc tasks.

Informs: https://github.com/cockroachdb/cockroach/pull/118875

Release note: None

gc assist on crdb single node with kv workload gcttl=5s for database in (kv, system)
![image](https://github.com/cockroachdb/cockroach/assets/20375035/b88882d0-8390-4fe4-8343-eb2a7497bc9f)
