### PR TITLE
roachtest: make validation of workload voluntary

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -317,7 +317,7 @@ func initBinariesAndLibraries() {
 	cockroachEAPath := roachtestflags.CockroachEAPath
 	workloadPath := roachtestflags.WorkloadPath
 	cockroach[defaultArch], _ = resolveBinary("cockroach", cockroachPath, defaultArch, true, false)
-	workload[defaultArch], _ = resolveBinary("workload", workloadPath, defaultArch, true, false)
+	workload[defaultArch], _ = resolveBinary("workload", workloadPath, defaultArch, false, false)
 	cockroachEA[defaultArch], err = resolveBinary("cockroach-ea", cockroachEAPath, defaultArch, false, true)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "WARN: unable to find %q for %q: %s\n", "cockroach-ea", defaultArch, err)

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -135,6 +135,9 @@ type TestSpec struct {
 	// If one is not specified, the default behavior is to upload
 	// a binary with the crdb_test flag randomly enabled or disabled.
 	CockroachBinary ClusterCockroachBinary
+
+	// RequiresDeprecatedWorkload, if true, will validate that `workload` exists.
+	RequiresDeprecatedWorkload bool
 }
 
 // PostValidation is a type of post-validation that runs after a test completes.

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -688,6 +688,11 @@ func (r *testRunner) runWorker(
 			return err
 		}
 
+		if testToRun.spec.RequiresDeprecatedWorkload && workload[arch] == "" {
+			fmt.Fprintf(os.Stderr, "ERROR: unable to find required workload binary for %q", arch)
+			os.Exit(1)
+		}
+
 		var clusterCreateErr error
 		var vmCreateOpts *vm.CreateOpts
 

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
@@ -140,5 +140,6 @@ func registerElasticIO(r registry.Registry) {
 			})
 			m.Wait()
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }

--- a/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
@@ -101,5 +101,6 @@ func registerMultiStoreOverload(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runKV(ctx, t, c)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }

--- a/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
@@ -162,16 +162,17 @@ func registerTPCCOverload(r registry.Registry) {
 		name := fmt.Sprintf("admission-control/tpcc-olap/nodes=%d/cpu=%d/w=%d/c=%d",
 			s.Nodes, s.CPUs, s.Warehouses, s.Concurrency)
 		r.Add(registry.TestSpec{
-			Name:              name,
-			Owner:             registry.OwnerAdmissionControl,
-			Benchmark:         true,
-			CompatibleClouds:  registry.AllExceptAWS,
-			Suites:            registry.Suites(registry.Weekly),
-			Cluster:           r.MakeClusterSpec(s.Nodes+1, spec.CPU(s.CPUs)),
-			Run:               s.run,
-			EncryptionSupport: registry.EncryptionMetamorphic,
-			Leases:            registry.MetamorphicLeases,
-			Timeout:           20 * time.Minute,
+			Name:                       name,
+			Owner:                      registry.OwnerAdmissionControl,
+			Benchmark:                  true,
+			CompatibleClouds:           registry.AllExceptAWS,
+			Suites:                     registry.Suites(registry.Weekly),
+			Cluster:                    r.MakeClusterSpec(s.Nodes+1, spec.CPU(s.CPUs)),
+			Run:                        s.run,
+			EncryptionSupport:          registry.EncryptionMetamorphic,
+			Leases:                     registry.MetamorphicLeases,
+			Timeout:                    20 * time.Minute,
+			RequiresDeprecatedWorkload: true,
 		})
 	}
 }
@@ -210,5 +211,6 @@ func registerTPCCSevereOverload(r registry.Registry) {
 			t.Status("running workload (fails in ~3-4 hours)")
 			c.Run(ctx, option.WithNodes(c.Node(workloadNode)), "./cockroach workload run tpcc --ramp=6h --tolerate-errors --warehouses=10000 '{pgurl:1-6}'")
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }

--- a/pkg/cmd/roachtest/tests/allocation_bench.go
+++ b/pkg/cmd/roachtest/tests/allocation_bench.go
@@ -267,6 +267,7 @@ func registerAllocationBenchSpec(r registry.Registry, allocSpec allocationBenchS
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runAllocationBench(ctx, t, c, allocSpec)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/alterpk.go
+++ b/pkg/cmd/roachtest/tests/alterpk.go
@@ -180,11 +180,12 @@ func registerAlterPK(r registry.Registry) {
 		Owner: registry.OwnerSQLFoundations,
 		// Use a 4 node cluster -- 3 nodes will run cockroach, and the last will be the
 		// workload driver node.
-		Cluster:          r.MakeClusterSpec(4),
-		Leases:           registry.MetamorphicLeases,
-		CompatibleClouds: registry.AllExceptAWS,
-		Suites:           registry.Suites(registry.Nightly),
-		Run:              runAlterPKBank,
+		Cluster:                    r.MakeClusterSpec(4),
+		Leases:                     registry.MetamorphicLeases,
+		CompatibleClouds:           registry.AllExceptAWS,
+		Suites:                     registry.Suites(registry.Nightly),
+		Run:                        runAlterPKBank,
+		RequiresDeprecatedWorkload: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:  "alterpk-tpcc-250",
@@ -198,6 +199,7 @@ func registerAlterPK(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runAlterPKTPCC(ctx, t, c, 250 /* warehouses */, true /* expensiveChecks */)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:  "alterpk-tpcc-500",
@@ -211,5 +213,6 @@ func registerAlterPK(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runAlterPKTPCC(ctx, t, c, 500 /* warehouses */, false /* expensiveChecks */)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -234,6 +234,7 @@ func registerBackupNodeShutdown(r registry.Registry) {
 
 			jobSurvivesNodeShutdown(ctx, t, c, nodeToShutdown, startBackup)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:              fmt.Sprintf("backup/nodeShutdown/coordinator/%s", backupNodeRestartSpec),
@@ -258,6 +259,7 @@ func registerBackupNodeShutdown(r registry.Registry) {
 
 			jobSurvivesNodeShutdown(ctx, t, c, nodeToShutdown, startBackup)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 
 }
@@ -356,6 +358,7 @@ func registerBackup(r registry.Registry) {
 			})
 			m.Wait()
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 
 	for _, item := range []struct {
@@ -444,6 +447,7 @@ func registerBackup(r registry.Registry) {
 
 				m.Wait()
 			},
+			RequiresDeprecatedWorkload: true,
 		})
 	}
 	KMSSpec := r.MakeClusterSpec(3)
@@ -567,6 +571,7 @@ func registerBackup(r registry.Registry) {
 				})
 				m.Wait()
 			},
+			RequiresDeprecatedWorkload: true,
 		})
 	}
 
@@ -585,6 +590,7 @@ func registerBackup(r registry.Registry) {
 			}
 			runBackupMVCCRangeTombstones(ctx, t, c, mvccRangeTombstoneConfig{})
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1025,17 +1025,18 @@ func c2cRegisterWrapper(
 	}
 
 	r.Add(registry.TestSpec{
-		Name:             sp.name,
-		Owner:            registry.OwnerDisasterRecovery,
-		Benchmark:        sp.benchmark,
-		Cluster:          r.MakeClusterSpec(sp.dstNodes+sp.srcNodes+1, clusterOps...),
-		Leases:           registry.MetamorphicLeases,
-		Timeout:          sp.timeout,
-		Skip:             sp.skip,
-		CompatibleClouds: sp.clouds,
-		Suites:           sp.suites,
-		RequiresLicense:  true,
-		Run:              run,
+		Name:                       sp.name,
+		Owner:                      registry.OwnerDisasterRecovery,
+		Benchmark:                  sp.benchmark,
+		Cluster:                    r.MakeClusterSpec(sp.dstNodes+sp.srcNodes+1, clusterOps...),
+		Leases:                     registry.MetamorphicLeases,
+		Timeout:                    sp.timeout,
+		Skip:                       sp.skip,
+		CompatibleClouds:           sp.clouds,
+		Suites:                     sp.suites,
+		RequiresLicense:            true,
+		Run:                        run,
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/connection_latency.go
+++ b/pkg/cmd/roachtest/tests/connection_latency.go
@@ -123,6 +123,7 @@ func registerConnectionLatencyTest(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numNodes, 1, false /*password*/)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 
 	geoZones := []string{regionUsEast, regionUsWest, regionEuWest}
@@ -141,6 +142,7 @@ func registerConnectionLatencyTest(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numMultiRegionNodes, numZones, false /*password*/)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 
 	r.Add(registry.TestSpec{
@@ -153,5 +155,6 @@ func registerConnectionLatencyTest(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runConnectionLatencyTest(ctx, t, c, numMultiRegionNodes, numZones, true /*password*/)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }

--- a/pkg/cmd/roachtest/tests/copy.go
+++ b/pkg/cmd/roachtest/tests/copy.go
@@ -204,6 +204,7 @@ func registerCopy(r registry.Registry) {
 				}
 				runCopy(ctx, t, c, tc.rows, tc.txn)
 			},
+			RequiresDeprecatedWorkload: true,
 		})
 	}
 }

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -56,6 +56,7 @@ func registerDecommission(r registry.Registry) {
 				}
 				runDecommission(ctx, t, c, numNodes, duration)
 			},
+			RequiresDeprecatedWorkload: true,
 		})
 	}
 	{
@@ -71,6 +72,7 @@ func registerDecommission(r registry.Registry) {
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDrainAndDecommission(ctx, t, c, numNodes, duration)
 			},
+			RequiresDeprecatedWorkload: true,
 		})
 	}
 	{
@@ -85,6 +87,7 @@ func registerDecommission(r registry.Registry) {
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDecommissionDrains(ctx, t, c)
 			},
+			RequiresDeprecatedWorkload: true,
 		})
 	}
 	{
@@ -100,6 +103,7 @@ func registerDecommission(r registry.Registry) {
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDecommissionRandomized(ctx, t, c)
 			},
+			RequiresDeprecatedWorkload: true,
 		})
 	}
 	{
@@ -113,6 +117,7 @@ func registerDecommission(r registry.Registry) {
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDecommissionMixedVersions(ctx, t, c, t.BuildVersion())
 			},
+			RequiresDeprecatedWorkload: true,
 		})
 	}
 	{
@@ -127,6 +132,7 @@ func registerDecommission(r registry.Registry) {
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDecommissionSlow(ctx, t, c)
 			},
+			RequiresDeprecatedWorkload: true,
 		})
 	}
 }

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -307,6 +307,7 @@ func registerDecommissionBenchSpec(r registry.Registry, benchSpec decommissionBe
 				runDecommissionBench(ctx, t, c, benchSpec, timeout)
 			}
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/drop.go
+++ b/pkg/cmd/roachtest/tests/drop.go
@@ -177,5 +177,6 @@ func registerDrop(r registry.Registry) {
 			}
 			runDrop(ctx, t, c, warehouses, numNodes)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }

--- a/pkg/cmd/roachtest/tests/hotspotsplits.go
+++ b/pkg/cmd/roachtest/tests/hotspotsplits.go
@@ -108,5 +108,6 @@ func registerHotSpotSplits(r registry.Registry) {
 			}
 			runHotSpot(ctx, t, c, minutes, concurrency)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -103,6 +103,7 @@ func registerImportNodeShutdown(r registry.Registry) {
 
 			jobSurvivesNodeShutdown(ctx, t, c, nodeToShutdown, startImport)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:             "import/nodeShutdown/coordinator",
@@ -122,6 +123,7 @@ func registerImportNodeShutdown(r registry.Registry) {
 
 			jobSurvivesNodeShutdown(ctx, t, c, nodeToShutdown, startImport)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 
@@ -183,6 +185,7 @@ func registerImportTPCC(r registry.Registry) {
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runImportTPCC(ctx, t, c, testName, timeout, warehouses)
 			},
+			RequiresDeprecatedWorkload: true,
 		})
 	}
 	const geoWarehouses = 4000
@@ -200,6 +203,7 @@ func registerImportTPCC(r registry.Registry) {
 			runImportTPCC(ctx, t, c, fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses),
 				5*time.Hour, geoWarehouses)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 
@@ -365,12 +369,13 @@ func registerImportDecommissioned(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:             "import/decommissioned",
-		Owner:            registry.OwnerSQLQueries,
-		Cluster:          r.MakeClusterSpec(4),
-		CompatibleClouds: registry.AllExceptAWS,
-		Suites:           registry.Suites(registry.Nightly),
-		Leases:           registry.MetamorphicLeases,
-		Run:              runImportDecommissioned,
+		Name:                       "import/decommissioned",
+		Owner:                      registry.OwnerSQLQueries,
+		Cluster:                    r.MakeClusterSpec(4),
+		CompatibleClouds:           registry.AllExceptAWS,
+		Suites:                     registry.Suites(registry.Nightly),
+		Leases:                     registry.MetamorphicLeases,
+		Run:                        runImportDecommissioned,
+		RequiresDeprecatedWorkload: true,
 	})
 }

--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -45,6 +45,7 @@ func registerImportCancellation(r registry.Registry) {
 			}
 			runImportCancellation(ctx, t, c)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/indexes.go
+++ b/pkg/cmd/roachtest/tests/indexes.go
@@ -141,6 +141,7 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 			})
 			m.Wait()
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/inverted_index.go
+++ b/pkg/cmd/roachtest/tests/inverted_index.go
@@ -34,6 +34,7 @@ func registerSchemaChangeInvertedIndex(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSchemaChangeInvertedIndex(ctx, t, c)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -342,9 +342,10 @@ func registerKV(r registry.Registry) {
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runKV(ctx, t, c, opts)
 			},
-			CompatibleClouds:  clouds,
-			Suites:            suites,
-			EncryptionSupport: encryption,
+			CompatibleClouds:           clouds,
+			Suites:                     suites,
+			EncryptionSupport:          encryption,
+			RequiresDeprecatedWorkload: true,
 		})
 	}
 }

--- a/pkg/cmd/roachtest/tests/kvbench.go
+++ b/pkg/cmd/roachtest/tests/kvbench.go
@@ -100,6 +100,7 @@ func registerKVBenchSpec(r registry.Registry, b kvBenchSpec) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runKVBench(ctx, t, c, b)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/ledger.go
+++ b/pkg/cmd/roachtest/tests/ledger.go
@@ -58,5 +58,6 @@ func registerLedger(r registry.Registry) {
 			})
 			m.Wait()
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2541,6 +2541,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 			}
 			mvt.Run()
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -79,6 +79,7 @@ func registerCDCMixedVersions(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCMixedVersions(ctx, t, c)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -44,6 +44,7 @@ func registerSchemaChangeMixedVersions(r registry.Registry) {
 			}
 			runSchemaChangeMixedVersions(ctx, t, c, maxOps, concurrency)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/multitenant_shared_process.go
+++ b/pkg/cmd/roachtest/tests/multitenant_shared_process.go
@@ -60,5 +60,6 @@ func registerMultiTenantSharedProcess(r registry.Registry) {
 				tpccWarehouses, crdbNodes, appTenantName)
 			c.Run(ctx, option.WithNodes(workloadNode), runCmd)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -163,6 +163,7 @@ func registerMultiTenantTPCH(r registry.Registry) {
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runMultiTenantTPCH(ctx, t, c, enableDirectScans, sharedProcess)
 				},
+				RequiresDeprecatedWorkload: true,
 			})
 		}
 	}

--- a/pkg/cmd/roachtest/tests/queue.go
+++ b/pkg/cmd/roachtest/tests/queue.go
@@ -38,6 +38,7 @@ func registerQueue(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runQueue(ctx, t, c)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/roachmart.go
+++ b/pkg/cmd/roachtest/tests/roachmart.go
@@ -81,6 +81,7 @@ func registerRoachmart(r registry.Registry) {
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runRoachmart(ctx, t, c, v)
 			},
+			RequiresDeprecatedWorkload: true,
 		})
 	}
 }

--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -81,6 +81,7 @@ func registerSchemaChangeDuringKV(r registry.Registry) {
 			})
 			m.Wait()
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 
@@ -336,6 +337,7 @@ func makeIndexAddTpccTest(
 				SetupType: usingImport,
 			})
 		},
+		RequiresDeprecatedWorkload: true,
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -53,6 +53,7 @@ func registerSchemaChangeRandomLoad(r registry.Registry) {
 			}
 			runSchemaChangeRandomLoad(ctx, t, c, maxOps, concurrency)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -194,6 +194,7 @@ func registerLoadSplits(r registry.Registry) {
 					waitDuration: 10 * time.Minute,
 				}})
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/uniform/nodes=%d/obj=cpu", numRoachNodes),
@@ -216,6 +217,7 @@ func registerLoadSplits(r registry.Registry) {
 					waitDuration: 10 * time.Minute,
 				}})
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/sequential/nodes=%d", numRoachNodes),
@@ -240,6 +242,7 @@ func registerLoadSplits(r registry.Registry) {
 					waitDuration: 60 * time.Second,
 				}})
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/sequential/nodes=%d/obj=cpu", numRoachNodes),
@@ -267,6 +270,7 @@ func registerLoadSplits(r registry.Registry) {
 					waitDuration: 60 * time.Second,
 				}})
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/spanning/nodes=%d", numRoachNodes),
@@ -288,6 +292,7 @@ func registerLoadSplits(r registry.Registry) {
 					waitDuration: 60 * time.Second,
 				}})
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/spanning/nodes=%d/obj=cpu", numRoachNodes),
@@ -318,6 +323,7 @@ func registerLoadSplits(r registry.Registry) {
 					waitDuration: 10 * time.Minute,
 				}})
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/ycsb/a/nodes=%d/obj=cpu", numRoachNodes),
@@ -343,6 +349,7 @@ func registerLoadSplits(r registry.Registry) {
 					waitDuration: 10 * time.Minute,
 				}})
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/ycsb/b/nodes=%d/obj=cpu", numRoachNodes),
@@ -367,6 +374,7 @@ func registerLoadSplits(r registry.Registry) {
 					waitDuration: 10 * time.Minute,
 				}})
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/ycsb/d/nodes=%d/obj=cpu", numRoachNodes),
@@ -392,6 +400,7 @@ func registerLoadSplits(r registry.Registry) {
 					waitDuration: 10 * time.Minute,
 				}})
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("splits/load/ycsb/e/nodes=%d/obj=cpu", numRoachNodes),
@@ -416,6 +425,7 @@ func registerLoadSplits(r registry.Registry) {
 					waitDuration: 10 * time.Minute,
 				}})
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -213,6 +213,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHConcurrency(ctx, t, c, false /* disableStreamer */)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 
 	r.Add(registry.TestSpec{
@@ -226,5 +227,6 @@ func registerTPCHConcurrency(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHConcurrency(ctx, t, c, true /* disableStreamer */)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -173,6 +173,7 @@ func registerTPCHBenchSpec(r registry.Registry, b tpchBenchSpec) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHBench(ctx, t, c, b)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -571,6 +571,7 @@ func registerTPCHVec(r registry.Registry) {
 				false,                    /* sharedProcessMT */
 			))
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 
 	r.Add(registry.TestSpec{
@@ -598,6 +599,7 @@ func registerTPCHVec(r registry.Registry) {
 				false,                              /* sharedProcessMT */
 			))
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 
 	r.Add(registry.TestSpec{
@@ -614,6 +616,7 @@ func registerTPCHVec(r registry.Registry) {
 				false, /* sharedProcessMT */
 			))
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 
 	r.Add(registry.TestSpec{
@@ -630,6 +633,7 @@ func registerTPCHVec(r registry.Registry) {
 				true, /* sharedProcessMT */
 			))
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 
 	r.Add(registry.TestSpec{
@@ -662,5 +666,6 @@ func registerTPCHVec(r registry.Registry) {
 			)
 			runTPCHVec(ctx, t, c, benchTest)
 		},
+		RequiresDeprecatedWorkload: true,
 	})
 }

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -117,8 +117,9 @@ func registerYCSB(r registry.Registry) {
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runYCSB(ctx, t, c, wl, cpus, false /* readCommitted */, false /* rangeTombstone */)
 				},
-				CompatibleClouds: registry.AllClouds,
-				Suites:           registry.Suites(registry.Nightly),
+				RequiresDeprecatedWorkload: true,
+				CompatibleClouds:           registry.AllClouds,
+				Suites:                     registry.Suites(registry.Nightly),
 			})
 
 			if wl == "A" {
@@ -130,8 +131,9 @@ func registerYCSB(r registry.Registry) {
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, false /* readCommitted */, false /* rangeTombstone */)
 					},
-					CompatibleClouds: registry.AllExceptAWS,
-					Suites:           registry.Suites(registry.Nightly),
+					RequiresDeprecatedWorkload: true,
+					CompatibleClouds:           registry.AllExceptAWS,
+					Suites:                     registry.Suites(registry.Nightly),
 				})
 			}
 
@@ -144,8 +146,9 @@ func registerYCSB(r registry.Registry) {
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, true /* readCommitted */, false /* rangeTombstone */)
 					},
-					CompatibleClouds: registry.AllClouds,
-					Suites:           registry.Suites(registry.Nightly),
+					RequiresDeprecatedWorkload: true,
+					CompatibleClouds:           registry.AllClouds,
+					Suites:                     registry.Suites(registry.Nightly),
 				})
 			}
 
@@ -158,8 +161,9 @@ func registerYCSB(r registry.Registry) {
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, false /* readCommitted */, true /* rangeTombstone */)
 					},
-					CompatibleClouds: registry.AllClouds,
-					Suites:           registry.Suites(registry.Nightly),
+					RequiresDeprecatedWorkload: true,
+					CompatibleClouds:           registry.AllClouds,
+					Suites:                     registry.Suites(registry.Nightly),
 				})
 			}
 		}


### PR DESCRIPTION
Similar to https://github.com/cockroachdb/cockroach/pull/115947 but now with also opting in many tests that were easily identified by grep as needing the old binary into validating it.