### PR TITLE
sql/stmtdiagnostics: deflake TestDiagnosticsRequest

### DIFF
--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -82,7 +82,15 @@ func TestDiagnosticsRequest(t *testing.T) {
 		require.False(t, diagnosticsID.Valid) // diagnosticsID should be NULL
 	}
 	checkCompleted := func(reqID int64) {
-		completed, diagnosticsID := isCompleted(reqID)
+		var completed bool
+		var diagnosticsID gosql.NullInt64
+		testutils.SucceedsSoon(t, func() error {
+			completed, diagnosticsID = isCompleted(reqID)
+			if !completed {
+				return errors.New("request not completed")
+			}
+			return nil
+		})
 		require.True(t, completed)
 		require.True(t, diagnosticsID.Valid)
 	}


### PR DESCRIPTION
This commit adds a `SucceedsSoon` wrapper around the query to check for completion of the statement bundle request, since it might take some time to complete.

Fixes #118524

Release note: None