### PR TITLE
release-23.1: changefeedccl: fix bug in AllRangeSpans

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -10,11 +10,14 @@ package kvfeed
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/schemafeed"
@@ -26,13 +29,17 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -456,6 +463,68 @@ func (f rawEventFeed) run(
 		}
 	}
 	return nil
+}
+
+// TestDistSenderAllRangeSpans tests (*distserver).AllRangeSpans.
+func TestDistSenderAllRangeSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const nodes = 1
+	// desctestutils.TestingGetPublicTableDescriptor relies on system DB.
+	args := base.TestClusterArgs{
+		ServerArgsPerNode: map[int]base.TestServerArgs{},
+		ServerArgs: base.TestServerArgs{
+			DisableDefaultTestTenant: true,
+		},
+	}
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, nodes, args)
+	defer tc.Stopper().Stop(ctx)
+
+	node := tc.Server(0)
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	distSender := node.DistSenderI().(*kvcoord.DistSender)
+
+	// Use manual merging/splitting only.
+	tc.ToggleReplicateQueues(false)
+
+	mergeRange := func(key interface{}) {
+		err := node.DB().AdminMerge(ctx, key)
+		if err != nil {
+			if !strings.Contains(err.Error(), "cannot merge final range") {
+				t.Fatal(err)
+			}
+		}
+	}
+	getTableSpan := func(tableName string) roachpb.Span {
+		desc := desctestutils.TestingGetPublicTableDescriptor(
+			node.DB(), node.Codec(), "defaultdb", "a")
+		return desc.PrimaryIndexSpan(node.Codec())
+	}
+	getTableDesc := func(tableName string) catalog.TableDescriptor {
+		return desctestutils.TestingGetPublicTableDescriptor(
+			node.DB(), node.Codec(), "defaultdb", "a")
+	}
+
+	// Regression test for the issue in #117286.
+	t.Run("returned range does not exceed input span boundaries", func(t *testing.T) {
+		// Merge 3 tables into one range.
+		sqlDB.Exec(t, "create table a (i int primary key)")
+		sqlDB.Exec(t, "create table b (j int primary key)")
+		sqlDB.Exec(t, "create table c (k int primary key)")
+		mergeRange(getTableSpan("a").Key)
+		mergeRange(getTableSpan("b").Key)
+
+		bTableID := getTableDesc("b").GetID()
+		rangeSpans, err := AllRangeSpans(ctx, distSender, []roachpb.Span{getTableSpan("b")})
+		require.NoError(t, err)
+
+		// Assert that the returned range is trimmed, so it only contains spans from "b" and not the entire
+		// range containing "a" and "c".
+		require.Equal(t, 1, len(rangeSpans), fmt.Sprintf("%v", rangeSpans))
+		require.Equal(t, fmt.Sprintf("/Table/%d/{1-2}", bTableID), rangeSpans[0].String())
+	})
 }
 
 var _ schemafeed.SchemaFeed = (*rawTableFeed)(nil)


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/117286

---

Previously, the method `AllRangeSpans` would sometimes return a list of spans containing keys outside of the input list of spans. This is seen in #117270, where the input span `/Table/104/1{-/2}` gets expanded to `/Table/{65-104/1/1}, /Table/104/1/{1-2}`. The reason this occurs is because the start key of table 104 is in the middle of a range. `AllRangeSpans` would use the start key of the range in the output span.

This change modifies the above behavior by making sure the output list of spans is trimmed such that it contains no keys outside of the input list of spans.

Release note: None
Informs: #117270
Informs: https://github.com/cockroachlabs/support/issues/2819
Epic: None

Release justification: Important bug fix. Had significant time to bake in master branch.