### PR TITLE
cli: add encode-uri command

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -270,6 +270,7 @@ func init() {
 		DebugCmd,
 		sqlfmtCmd,
 		workloadCmd,
+		encodeURICmd,
 	)
 }
 

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1222,6 +1222,7 @@ Available Commands:
   debug             debugging commands
   sqlfmt            format SQL statements
   workload          generators for data and query loads
+  encode-uri        encode a CRDB connection URL
   help              Help about any command
 
 Flags:


### PR DESCRIPTION
We expect that users may find distributing certs to all of their nodes for use in PCR a burden. To address this, we previously added support for "sslinline" URLs where the certs could be provided directly in the URL. However, such URLs are difficult to create. This command helps users create them more easily for example:

    ./cockroach encode-uri demo:demo20498@127.0.0.1:26257 --inline --ca-cert ~/.cockroach-demo/ca.crt

Epic: none

Release note (cli change): A new encode-uri utility has been added to make generating connection strings for use with physical replication easier.