### PR TITLE
release 23.2: kvcoord: fix bug in distsender.AllRangeSpans

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -183,6 +183,7 @@ go_test(
     srcs = [
         "alter_changefeed_test.go",
         "avro_test.go",
+        "changefeed_dist_test.go",
         "changefeed_test.go",
         "csv_test.go",
         "encoder_test.go",

--- a/pkg/ccl/changefeedccl/changefeed_dist_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist_test.go
@@ -1,0 +1,96 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDistSenderAllRangeSpans tests (*distserver).AllRangeSpans.
+func TestDistSenderAllRangeSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const nodes = 1
+	args := base.TestClusterArgs{
+		ServerArgsPerNode: map[int]base.TestServerArgs{},
+		ServerArgs: base.TestServerArgs{
+			DefaultTestTenant: base.TestTenantProbabilisticOnly,
+		},
+	}
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, nodes, args)
+	defer tc.Stopper().Stop(ctx)
+
+	node := tc.Server(0).ApplicationLayer()
+	systemLayer := tc.Server(0).SystemLayer()
+	sqlDB := sqlutils.MakeSQLRunner(node.SQLConn(t))
+	distSender := node.DistSenderI().(*kvcoord.DistSender)
+
+	tenantPrefix := ""
+	if tc.StartedDefaultTestTenant() {
+		tenantPrefix = "/Tenant/10"
+	}
+
+	// Use manual merging/splitting only.
+	tc.ToggleReplicateQueues(false)
+
+	mergeRange := func(key interface{}) {
+		err := systemLayer.DB().AdminMerge(ctx, key)
+		if err != nil {
+			if !strings.Contains(err.Error(), "cannot merge final range") {
+				t.Fatal(err)
+			}
+		}
+	}
+	getTableSpan := func(tableName string) roachpb.Span {
+		desc := desctestutils.TestingGetPublicTableDescriptor(
+			node.DB(), node.Codec(), "defaultdb", "a")
+		return desc.PrimaryIndexSpan(node.Codec())
+	}
+	getTableDesc := func(tableName string) catalog.TableDescriptor {
+		return desctestutils.TestingGetPublicTableDescriptor(
+			node.DB(), node.Codec(), "defaultdb", "a")
+	}
+
+	// Regression test for the issue in #117286.
+	t.Run("returned range does not exceed input span boundaries", func(t *testing.T) {
+		// Merge 3 tables into one range.
+		sqlDB.Exec(t, "create table a (i int primary key)")
+		sqlDB.Exec(t, "create table b (j int primary key)")
+		sqlDB.Exec(t, "create table c (k int primary key)")
+		mergeRange(getTableSpan("a").Key)
+		mergeRange(getTableSpan("b").Key)
+
+		bTableID := getTableDesc("b").GetID()
+		rangeSpans, _, err := distSender.AllRangeSpans(ctx, []roachpb.Span{getTableSpan("b")})
+		require.NoError(t, err)
+
+		// Assert that the returned range is trimmed, so it only contains spans from "b" and not the entire
+		// range containing "a" and "c".
+		require.Equal(t, 1, len(rangeSpans), fmt.Sprintf("%v", rangeSpans))
+		require.Equal(t, fmt.Sprintf("%s/Table/%d/{1-2}", tenantPrefix, bTableID), rangeSpans[0].String())
+	})
+
+}

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2803,8 +2803,11 @@ func (ds *DistSender) maybeIncrementErrCounters(br *kvpb.BatchResponse, err erro
 	}
 }
 
-// AllRangeSpans returns the list of all ranges that cover input spans along with the
-// nodeCountHint indicating the number of nodes that host those ranges.
+// AllRangeSpans returns a list of spans equivalent to the input list of spans
+// where each returned span represents all the keys in a range.
+//
+// For example, if the input span is {1-8} and the ranges are
+// {0-2}{2-4}{4-6}{6-8}{8-10}, then the output is {1-2}{2-4}{4-6}{6-8}{8-9}.
 func (ds *DistSender) AllRangeSpans(
 	ctx context.Context, spans []roachpb.Span,
 ) (_ []roachpb.Span, nodeCountHint int, _ error) {
@@ -2822,8 +2825,19 @@ func (ds *DistSender) AllRangeSpans(
 			if !it.Valid() {
 				return nil, 0, it.Error()
 			}
+
+			// If the range boundaries are outside the original span, trim
+			// the range.
+			startKey := it.Desc().StartKey
+			if startKey.Compare(rSpan.Key) == -1 {
+				startKey = rSpan.Key
+			}
+			endKey := it.Desc().EndKey
+			if endKey.Compare(rSpan.EndKey) == 1 {
+				endKey = rSpan.EndKey
+			}
 			ranges = append(ranges, roachpb.Span{
-				Key: it.Desc().StartKey.AsRawKey(), EndKey: it.Desc().EndKey.AsRawKey(),
+				Key: startKey.AsRawKey(), EndKey: endKey.AsRawKey(),
 			})
 			for _, r := range it.Desc().InternalReplicas {
 				replicas.Set(int(r.NodeID), 0)


### PR DESCRIPTION
backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/117286

---
kvcoord: fix bug in distsender.AllRangeSpans #119529

Previously, the method `distsender.AllRangeSpans` would sometimes return a list of spans containing keys outside of the input list of spans. This is seen in #117270, where the input span `/Table/104/1{-/2}` gets expanded to `/Table/{65-104/1/1}, /Table/104/1/{1-2}`. The reason this occurs is because the start key of table 104 is in the middle of a range. `distsender.AllRangeSpans` would use the start key of the range in the output span.

This change modifies the above behavior by making sure the output list of spans is trimmed such that it contains no keys outside of the input list of spans.

Release note: None
Fixes: #117270
Epic: None

Release justification: Important bug fix. Had significant time to bake in master branch.