### PR TITLE
roachtest: fail tests if monitor encounters an error

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -171,10 +171,7 @@ func (g *githubIssues) createPostRequest(
 	issueClusterName := ""
 	errWithOwnership := failuresSpecifyOwner(failures)
 	switch {
-	case errWithOwnership != nil:
-		handleErrorWithOwnership(*errWithOwnership)
-
-	// The following error come from various entrypoints in roachprod,
+	// The following errors come from various entrypoints in roachprod,
 	// but we know that they should be handled by TestEng whenever they
 	// happen during a test.
 	case failuresContainsError(failures, rperrors.ErrSSH255):
@@ -189,6 +186,8 @@ func (g *githubIssues) createPostRequest(
 			registry.WithTitleOverride("dns_problem"),
 			registry.InfraFlake,
 		))
+	case errWithOwnership != nil:
+		handleErrorWithOwnership(*errWithOwnership)
 	}
 
 	// Issues posted from roachtest are identifiable as such, and they are also release blockers

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -297,18 +297,7 @@ func TestCreatePostRequest(t *testing.T) {
 				"coverageBuild":    "true",
 			}),
 		},
-		// 9. Verify preemption failure are routed to test-eng and marked as infra-flake,
-		// even if the first failure is another handled error.
-		{
-			nonReleaseBlocker:     true,
-			failures:              []failure{createFailure(gce.ErrDNSOperation), createFailure(vmPreemptionError("my_VM"))},
-			expectedPost:          true,
-			expectedName:          "vm_preemption",
-			expectedTeam:          "@cockroachdb/test-eng",
-			expectedMessagePrefix: testName + " failed",
-			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
-		},
-		// 10. Verify preemption failure are routed to test-eng and marked as infra-flake, when the
+		// 9. Verify preemption failure are routed to test-eng and marked as infra-flake, when the
 		// first failure is a non-handled error.
 		{
 			nonReleaseBlocker:     true,
@@ -319,7 +308,7 @@ func TestCreatePostRequest(t *testing.T) {
 			expectedMessagePrefix: testName + " failed",
 			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
 		},
-		// 11. Verify preemption failure are routed to test-eng and marked as infra-flake, when the only error is
+		// 10. Verify preemption failure are routed to test-eng and marked as infra-flake, when the only error is
 		// preemption failure
 		{
 			nonReleaseBlocker: true,
@@ -329,6 +318,21 @@ func TestCreatePostRequest(t *testing.T) {
 			expectedPost:          true,
 			expectedTeam:          "@cockroachdb/test-eng",
 			expectedName:          "vm_preemption",
+			expectedMessagePrefix: testName + " failed",
+			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
+		},
+		// 11. Errors with ownership that happen as a result of roachprod
+		// errors are ignored -- roachprod errors are routed directly to
+		// test-eng.
+		{
+			nonReleaseBlocker: true,
+			failures: []failure{
+				createFailure(gce.ErrDNSOperation),
+				createFailure(registry.ErrorWithOwner(registry.OwnerSQLFoundations, errors.New("oops"))),
+			},
+			expectedPost:          true,
+			expectedTeam:          "@cockroachdb/test-eng",
+			expectedName:          "dns_problem",
 			expectedMessagePrefix: testName + " failed",
 			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
 		},

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -445,6 +445,12 @@ func (t *testImpl) suppressFailures() {
 	t.mu.failuresSuppressed = true
 }
 
+func (t *testImpl) resetFailures() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.mu.failures = nil
+}
+
 // We take the "squashed" error that contains information of all the errors for each failure.
 func formatFailure(b *strings.Builder, reportFailures ...failure) {
 	for i, failure := range reportFailures {

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1016,6 +1016,14 @@ func (r *testRunner) runTest(
 				preemptedVMNames := getPreemptedVMNames(ctx, c, l)
 				if preemptedVMNames != "" {
 					failureMsg = fmt.Sprintf("VMs preempted during the test run : %s\n\n**Other Failure**\n%s", preemptedVMNames, failureMsg)
+					// Reset failures in the test so that the VM preemption
+					// error is the one that is taken into account when
+					// reporting the failure. Note any other failures that
+					// happened during the test will be present in the
+					// `failureMsg` used when reporting the issue. In addition,
+					// `failure_N.log` files should also already exist at this
+					// point.
+					t.resetFailures()
 					t.Error(vmPreemptionError(preemptedVMNames))
 				}
 				output := fmt.Sprintf("%s\ntest artifacts and logs in: %s", failureMsg, t.ArtifactsDir())

--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -441,7 +441,7 @@ func runLoadSplits(ctx context.Context, t test.Test, c cluster.Cluster, params s
 	)
 	c.Start(ctx, t.L(), startOpts, settings, crdbNodes)
 
-	m := c.NewMonitor(ctx, c.All())
+	m := c.NewMonitor(ctx, crdbNodes)
 	m.Go(func(ctx context.Context) error {
 		db := c.Conn(ctx, t.L(), 1)
 		defer db.Close()


### PR DESCRIPTION
This commit updates the roachprod and roachtest monitors to 1) send an
event when the monitor is abruptly terminated (i.e., reader stream
sees an EOF when the associated context is *not* canceled); and 2)
return any errors encountered by the roachprod monitor in roachtest,
causing the currently running test to fail. The error has TestEng
ownership so that teams are not be pinged on these kinds of flakes.

The main purpose of this change is for the monitor to fail in
situations where the monitored node is preempted by the cloud
provider. Previously, these events would be ignored, leading to a test
timeout, wasting resources and leading to confusing test failures
being reported on GitHub.

Fixes: #118563.

Release note: None