### PR TITLE
opt/execbuilder: fix EXPORT when input expression has hidden columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/export
+++ b/pkg/sql/logictest/testdata/logic_test/export
@@ -13,3 +13,16 @@ query T noticetrace
 WITH cte AS (EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM t) SELECT filename FROM cte;
 ----
 NOTICE: EXPORT is not the recommended way to move data out of CockroachDB and may be deprecated in the future. Please consider exporting data with changefeeds instead: https://www.cockroachlabs.com/docs/stable/export-data-with-changefeeds
+
+# Regression test for #115290. Correctly handle the case where the Export's
+# input expression has NOT NULL columns that are not part of the presentation of
+# the expression.
+statement ok
+CREATE TABLE t115290 (
+  id INT PRIMARY KEY,
+  a INT NOT NULL,
+  b INT
+);
+
+statement ok
+EXPORT INTO PARQUET 'nodelocal://1/export1/' FROM SELECT b FROM t115290 ORDER BY a;


### PR DESCRIPTION
#### opt/execbuilder: fix EXPORT when input expression has hidden columns

Fixes #115290

Release note (bug fix): A bug has been fixed that caused internal errors
when executing EXPORT statement.

#### opt/execbuilder: remove getNodeColumnOrdinalSet

This simple function was only used in one place, so it has been inlined
and removed.

Release note: None
