### PR TITLE
json: avoid interface boxing when decoding keys

### DIFF
--- a/pkg/util/json/encode.go
+++ b/pkg/util/json/encode.go
@@ -262,17 +262,14 @@ func decodeJSONObject(containerHeader uint32, b []byte) ([]byte, JSON, error) {
 	result := make(jsonObject, length)
 	// Decode the keys.
 	for i := 0; i < length; i++ {
-		var nextJSON JSON
-		b, nextJSON, err = decodeJSONValue(keyJEntries[i], b)
-		if err != nil {
-			return b, nil, err
-		}
-		if key, ok := nextJSON.(jsonString); ok {
-			result[i].k = key
-		} else {
+		e := keyJEntries[i]
+		if e.typCode != stringTag {
 			return b, nil, errors.AssertionFailedf(
-				"key encoded as non-string: %T", nextJSON)
+				"key encoded as non-string: %d", errors.Safe(e.typCode))
 		}
+		// Inline string decoding from decodeJSONValue. This avoids the cost to pass
+		// through a JSON interface.
+		b, result[i].k = b[e.length:], jsonString(b[:e.length])
 	}
 
 	// Decode the values.


### PR DESCRIPTION
This commit avoids interface boxing when decoding keys in JSON objects. Instead of parsing the keys using decodeJSONValue and then downcasting to a jsonString, we parse the keys directly as jsonStrings.

This will reduce the number of heap allocations during JSON parsing and reduce the resulting GC pressure.

```
name           old time/op    new time/op    delta
DecodeJSON-10    1.78µs ± 1%    1.42µs ± 1%  -20.66%  (p=0.000 n=9+9)

name           old alloc/op   new alloc/op   delta
DecodeJSON-10    1.87kB ± 0%    1.58kB ± 0%  -15.38%  (p=0.000 n=10+10)

name           old allocs/op  new allocs/op  delta
DecodeJSON-10      80.0 ± 0%      62.0 ± 0%  -22.50%  (p=0.000 n=10+10)
```

In a recent escalation, this was partly responsible for the largest source of heap allocations:
```
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                       79456794626 73.70% |   github.com/cockroachdb/cockroach/pkg/util/json.decodeJSONObject github.com/cockroachdb/cockroach/pkg/util/json/encode.go:266
                                       27477584514 25.49% |   github.com/cockroachdb/cockroach/pkg/util/json.decodeJSONObject github.com/cockroachdb/cockroach/pkg/util/json/encode.go:281
                                         872112155  0.81% |   github.com/cockroachdb/cockroach/pkg/util/json.decodeJSONArray github.com/cockroachdb/cockroach/pkg/util/json/encode.go:225
107806491295 10.99% 10.99% 107806491295 10.99%                | github.com/cockroachdb/cockroach/pkg/util/json.decodeJSONValue github.com/cockroachdb/cockroach/pkg/util/json/encode.go:307
----------------------------------------------------------+-------------
```

Epic: None
Release note: None