### PR TITLE
release-23.1: roachprod: create admin user and backup schedule for virtual clusters

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -201,13 +201,6 @@ func initFlags() {
 		"init-target", startOpts.InitTarget, "node on which to run initialization")
 	startCmd.Flags().IntVar(&startOpts.StoreCount,
 		"store-count", startOpts.StoreCount, "number of stores to start each node with")
-	startCmd.Flags().BoolVar(&startOpts.ScheduleBackups,
-		"schedule-backups", startOpts.ScheduleBackups,
-		"create a cluster backup schedule once the cluster has started (by default, "+
-			"full backup hourly and incremental every 15 minutes)")
-	startCmd.Flags().StringVar(&startOpts.ScheduleBackupArgs, "schedule-backup-args", "",
-		`Recurrence and scheduled backup options specification.
-Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS first_run = 'now'"`)
 
 	startInstanceCmd.Flags().StringVarP(&storageCluster, "storage-cluster", "S", "", "storage cluster")
 	_ = startInstanceCmd.MarkFlagRequired("storage-cluster")
@@ -322,6 +315,13 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 	}
 
 	for _, cmd := range []*cobra.Command{startCmd, startInstanceCmd} {
+		cmd.Flags().BoolVar(&startOpts.ScheduleBackups,
+			"schedule-backups", startOpts.ScheduleBackups,
+			"create a cluster backup schedule once the cluster has started (by default, "+
+				"full backup hourly and incremental every 15 minutes)")
+		cmd.Flags().StringVar(&startOpts.ScheduleBackupArgs,
+			"schedule-backup-args", startOpts.ScheduleBackupArgs,
+			"Recurrence and scheduled backup options specification")
 		cmd.Flags().Int64Var(&startOpts.NumFilesLimit, "num-files-limit", startOpts.NumFilesLimit,
 			"limit the number of files that can be created by the cockroach process")
 		cmd.Flags().IntVar(&startOpts.SQLPort,

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2921,8 +2921,8 @@ func (c *SyncedCluster) ParallelE(
 // to maintain parity with auto-init behavior of `roachprod start` (when
 // --skip-init) is not specified.
 func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger, node Node) error {
-	if res, err := c.initializeCluster(ctx, l, node); err != nil || (res != nil && res.Err != nil) {
-		return errors.WithDetail(errors.CombineErrors(err, res.Err), "install.Init() failed: unable to initialize cluster.")
+	if err := c.initializeCluster(ctx, l, node); err != nil {
+		return errors.WithDetail(err, "install.Init() failed: unable to initialize cluster.")
 	}
 
 	if err := c.setClusterSettings(ctx, l, node, ""); err != nil {

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -984,9 +984,6 @@ func (c *SyncedCluster) createAdminUserForSecureCluster(
 	// TODO(renato): use the same combination once we're able to select
 	// the virtual cluster we are connecting to in the console.
 	var password = startOpts.VirtualClusterName
-	if startOpts.VirtualClusterName == "" {
-		password = SystemInterfaceName
-	}
 
 	stmts := strings.Join([]string{
 		fmt.Sprintf("CREATE USER IF NOT EXISTS %s WITH LOGIN PASSWORD '%s'", username, password),
@@ -1001,9 +998,6 @@ func (c *SyncedCluster) createAdminUserForSecureCluster(
 	if err := retryOpts.Do(ctx, func(ctx context.Context) error {
 		// We use the first node in the virtual cluster to create the user.
 		firstNode := c.TargetNodes()[0]
-		if startOpts.VirtualClusterName == "" {
-			startOpts.VirtualClusterName = SystemInterfaceName
-		}
 		results, err := c.ExecSQL(
 			ctx, l, Nodes{firstNode}, startOpts.VirtualClusterName, startOpts.SQLInstance, []string{
 				"-e", stmts,

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -661,6 +661,10 @@ func Extend(l *logger.Logger, clusterName string, lifetime time.Duration) error 
 	return nil
 }
 
+// Default scheduled backup runs a full backup every hour and an incremental
+// every 15 minutes.
+const DefaultBackupSchedule = `RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS first_run = 'now'`
+
 // DefaultStartOpts returns a StartOpts populated with default values.
 func DefaultStartOpts() install.StartOpts {
 	return install.StartOpts{
@@ -670,7 +674,7 @@ func DefaultStartOpts() install.StartOpts {
 		StoreCount:         1,
 		VirtualClusterID:   2,
 		ScheduleBackups:    false,
-		ScheduleBackupArgs: "",
+		ScheduleBackupArgs: DefaultBackupSchedule,
 		InitTarget:         1,
 		// TODO(renato): change the defaults below to `0` (i.e., pick a
 		// random available port) once #111052 is addressed.

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -674,7 +674,9 @@ func DefaultStartOpts() install.StartOpts {
 		InitTarget:         1,
 		// TODO(renato): change the defaults below to `0` (i.e., pick a
 		// random available port) once #111052 is addressed.
-		SQLPort:     config.DefaultSQLPort,
+		SQLPort:            config.DefaultSQLPort,
+		VirtualClusterName: install.SystemInterfaceName,
+		// TODO(DarrylWong): revert back to 0 once #117125 is addressed.
 		AdminUIPort: config.DefaultAdminUIPort,
 	}
 }


### PR DESCRIPTION
Backport 3/4 commits from #118851.

/cc @cockroachdb/release

Release justification: test only changes.

---

This commit updates `roachprod start{-sql}` and unifies the set of
steps performed on the cluster regardless of whether we are starting
the system tenant for the first time or creating a new tenant.

Specifically, tenants will also have an admin user configured and a
default backup schedule is created when `--schedule-backups` is passed.

Epic: none

Release note: None
