### PR TITLE
release-23.1: add more observability to restore span processing

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -276,6 +276,7 @@ func (rd *restoreDataProcessor) openSSTs(
 		readAsOfIter := storage.NewReadAsOfIterator(iter, rd.spec.RestoreTime)
 
 		cleanup := func() {
+			log.VInfof(ctx, 1, "finished with and closing %d files in span [%s-%s)", len(entry.Files), entry.Span.Key, entry.Span.EndKey)
 			readAsOfIter.Close()
 
 			for _, dir := range dirsToSend {
@@ -295,7 +296,7 @@ func (rd *restoreDataProcessor) openSSTs(
 		return mSST, nil
 	}
 
-	log.VEventf(ctx, 1 /* level */, "ingesting span [%s-%s)", entry.Span.Key, entry.Span.EndKey)
+	log.VEventf(ctx, 1, "ingesting %d files in span [%s-%s)", len(entry.Files), entry.Span.Key, entry.Span.EndKey)
 
 	storeFiles := make([]storageccl.StoreFile, 0, len(entry.Files))
 	for _, file := range entry.Files {

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/pprofutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	gogotypes "github.com/gogo/protobuf/types"
@@ -353,6 +354,8 @@ func (rd *restoreDataProcessor) runRestoreWorkers(
 				ctx := logtags.AddTag(ctx, "restore-span", fmt.Sprintf("%s", hex.EncodeToString(entry.Span.Key)))
 				ctx, undo := pprofutil.SetProfilerLabelsFromCtxTags(ctx)
 				defer undo()
+				ctx, sp := tracing.ChildSpan(ctx, "restore.processRestoreSpanEntry")
+				defer sp.Finish()
 
 				sstIter, err := rd.openSSTs(ctx, entry)
 				if err != nil {


### PR DESCRIPTION
see commits.

This might not merge but is intended to be run, at least in custom build form, in a production cluster so it should be reviewed as if it will merge. If it does merge, it would be forward-ported to master and backported to 23.2, but this isn't the priority right now.
