### PR TITLE
sql/rowenc: introduce NullEncDatum

### DIFF
--- a/pkg/sql/rowenc/encoded_datum.go
+++ b/pkg/sql/rowenc/encoded_datum.go
@@ -197,6 +197,11 @@ func DatumToEncDatum(ctyp *types.T, d tree.Datum) EncDatum {
 	return EncDatum{Datum: d}
 }
 
+// NullEncDatum initializes an EncDatum with the NULL value.
+func NullEncDatum() EncDatum {
+	return EncDatum{Datum: tree.DNull}
+}
+
 // UnsetDatum ensures subsequent IsUnset() calls return false.
 func (ed *EncDatum) UnsetDatum() {
 	ed.encoded = nil

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
@@ -60,11 +59,11 @@ func (jb *joinerBase) init(
 
 	jb.emptyLeft = make(rowenc.EncDatumRow, len(leftTypes))
 	for i := range jb.emptyLeft {
-		jb.emptyLeft[i] = rowenc.DatumToEncDatum(leftTypes[i], tree.DNull)
+		jb.emptyLeft[i] = rowenc.NullEncDatum()
 	}
 	jb.emptyRight = make(rowenc.EncDatumRow, len(rightTypes))
 	for i := range jb.emptyRight {
-		jb.emptyRight[i] = rowenc.DatumToEncDatum(rightTypes[i], tree.DNull)
+		jb.emptyRight[i] = rowenc.NullEncDatum()
 	}
 
 	rowSize := len(leftTypes) + len(rightTypes)

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -368,7 +368,7 @@ func (s *samplerProcessor) mainLoop(
 	outRow := make(rowenc.EncDatumRow, len(s.outTypes))
 	// Emit the sampled rows.
 	for i := range outRow {
-		outRow[i] = rowenc.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		outRow[i] = rowenc.NullEncDatum()
 	}
 	// Reuse the numRows column for the capacity of the sample reservoir.
 	outRow[s.numRowsCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(s.sr.Cap()))}
@@ -381,7 +381,7 @@ func (s *samplerProcessor) mainLoop(
 	}
 	// Emit the inverted sample rows.
 	for i := range outRow {
-		outRow[i] = rowenc.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		outRow[i] = rowenc.NullEncDatum()
 	}
 	for col, invSr := range s.invSr {
 		// Reuse the numRows column for the capacity of the sample reservoir.
@@ -402,7 +402,7 @@ func (s *samplerProcessor) mainLoop(
 
 	// Emit the sketch rows.
 	for i := range outRow {
-		outRow[i] = rowenc.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		outRow[i] = rowenc.NullEncDatum()
 	}
 	for i, si := range s.sketches {
 		outRow[s.sketchIdxCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(i))}
@@ -413,7 +413,7 @@ func (s *samplerProcessor) mainLoop(
 
 	// Emit the inverted sketch rows.
 	for i := range outRow {
-		outRow[i] = rowenc.DatumToEncDatum(s.outTypes[i], tree.DNull)
+		outRow[i] = rowenc.NullEncDatum()
 	}
 	for col, invSketch := range s.invSketch {
 		outRow[s.invColIdxCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(col))}


### PR DESCRIPTION
This commit introduces the `NullEncDatum` function which is a fast-path
version of `DatumToEncDatum` when the datum to encode is a constant
`tree.DNull`. This eliminates unnecessary overhead that constitutes an
appreciable % of total CPU time in some workloads (most notably those
with joins of tables with many columns and using the row-by-row
execution engine).

Epic: None

Release note: None
