### PR TITLE
json: implement Format on jsonEncoded, fused with decoding

### DIFF
--- a/pkg/util/json/BUILD.bazel
+++ b/pkg/util/json/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "contains_testers.go",
         "encode.go",
         "encoded.go",
+        "encoded_format.go",
         "iterator.go",
         "jentry.go",
         "json.go",

--- a/pkg/util/json/encode.go
+++ b/pkg/util/json/encode.go
@@ -284,10 +284,10 @@ func decodeJSONObject(containerHeader uint32, b []byte) ([]byte, JSON, error) {
 	return b, result, nil
 }
 
-func decodeJSONNumber(b []byte) ([]byte, JSON, error) {
+func decodeJSONNumber(b []byte) ([]byte, jsonNumber, error) {
 	b, d, err := encoding.DecodeUntaggedDecimalValue(b)
 	if err != nil {
-		return b, nil, err
+		return b, jsonNumber{}, err
 	}
 	return b, jsonNumber(d), nil
 }

--- a/pkg/util/json/encode_test.go
+++ b/pkg/util/json/encode_test.go
@@ -31,21 +31,34 @@ var rewriteResultsInTestfiles = flag.Bool(
 )
 
 func assertEncodeRoundTrip(t *testing.T, j JSON) {
-	encoded, err := EncodeJSON(nil, j)
+	beforeStr := j.String()
+	encoding, err := EncodeJSON(nil, j)
 	if err != nil {
 		t.Fatal(j, err)
 	}
-	_, decoded, err := DecodeJSON(encoded)
+	encoded, err := newEncodedFromRoot(encoding)
 	if err != nil {
 		t.Fatal(j, err)
 	}
+	encodedStr := encoded.String()
+	_, decoded, err := DecodeJSON(encoding)
+	if err != nil {
+		t.Fatal(j, err)
+	}
+	afterStr := decoded.String()
 
 	c, err := j.Compare(decoded)
 	if err != nil {
 		t.Fatal(j, err)
 	}
 	if c != 0 {
-		t.Fatalf("expected %s, got %s (encoding %v)", j, decoded, encoded)
+		t.Fatalf("expected %s, got %s (encoding %v)", j, decoded, encoding)
+	}
+	if beforeStr != encodedStr {
+		t.Fatalf("expected %s, got %s (encoding %v)", beforeStr, encodedStr, encoding)
+	}
+	if beforeStr != afterStr {
+		t.Fatalf("expected %s, got %s (encoding %v)", beforeStr, afterStr, encoding)
 	}
 }
 

--- a/pkg/util/json/encode_test.go
+++ b/pkg/util/json/encode_test.go
@@ -278,3 +278,29 @@ func BenchmarkDecodeJSON(b *testing.B) {
 		_, _, _ = DecodeJSON(bytes)
 	}
 }
+
+func BenchmarkFormatJSON(b *testing.B) {
+	j := parseJSON(b, sampleJSON)
+
+	b.Run("decoded", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = j.String()
+		}
+	})
+
+	b.Run("encoded", func(b *testing.B) {
+		encoding, err := EncodeJSON(nil, j)
+		if err != nil {
+			b.Fatal(err)
+		}
+		encoded, err := newEncodedFromRoot(encoding)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = encoded.String()
+		}
+	})
+}

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -12,7 +12,6 @@ package json
 
 import (
 	"bytes"
-	"fmt"
 	"sort"
 	"strconv"
 	"unsafe"
@@ -695,15 +694,6 @@ func (j *jsonEncoded) FetchValKeyOrIdx(key string) (JSON, error) {
 		return j.FetchValIdx(idx)
 	}
 	return nil, nil
-}
-
-func (j *jsonEncoded) Format(buf *bytes.Buffer) {
-	decoded, err := j.decode()
-	if err != nil {
-		fmt.Fprintf(buf, `<corrupt JSON data: %s>`, err.Error())
-	} else {
-		decoded.Format(buf)
-	}
 }
 
 // RemoveIndex implements the JSON interface.

--- a/pkg/util/json/encoded_format.go
+++ b/pkg/util/json/encoded_format.go
@@ -1,0 +1,226 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package json
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/errors"
+)
+
+func (j *jsonEncoded) Format(buf *bytes.Buffer) {
+	// We don't know exactly how big the JSON string will be when decoded and
+	// formatted, but we can make a reasonable guess based on the size of the
+	// encoded data. This can avoid some buffer reallocations in the common case.
+	buf.Grow(len(j.value))
+	preLen := buf.Len()
+	err := j.format(buf)
+	if err != nil {
+		buf.Truncate(preLen)
+		fmt.Fprintf(buf, `<corrupt JSON data: %s>`, err.Error())
+	}
+}
+
+func (j *jsonEncoded) format(buf *bytes.Buffer) error {
+	switch j.typ {
+	case NumberJSONType:
+		_, d, err := decodeJSONNumber(j.value)
+		if err != nil {
+			return err
+		}
+		d.Format(buf)
+	case StringJSONType:
+		s := unsafeJSONString(j.value)
+		s.Format(buf)
+	case TrueJSONType:
+		TrueJSONValue.Format(buf)
+	case FalseJSONType:
+		FalseJSONValue.Format(buf)
+	case NullJSONType:
+		NullJSONValue.Format(buf)
+	default:
+		_, err := formatEncodedJSON(buf, j.value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func formatEncodedJSON(buf *bytes.Buffer, b []byte) ([]byte, error) {
+	b, containerHeader, err := encoding.DecodeUint32Ascending(b)
+	if err != nil {
+		return nil, err
+	}
+	switch containerHeader & containerHeaderTypeMask {
+	case scalarContainerTag:
+		var entry jEntry
+		var err error
+		b, entry, err = decodeJEntry(b, 0)
+		if err != nil {
+			return nil, err
+		}
+		return formatEncodedJSONValue(buf, entry, b)
+	case arrayContainerTag:
+		return formatEncodedJSONArray(buf, containerHeader, b)
+	case objectContainerTag:
+		return formatEncodedJSONObject(buf, containerHeader, b)
+	default:
+		return nil, errors.AssertionFailedf(
+			"error decoding JSON value, header: %x", errors.Safe(containerHeader))
+	}
+}
+
+func formatEncodedJSONArray(buf *bytes.Buffer, containerHeader uint32, b []byte) ([]byte, error) {
+	length := int(containerHeader & containerHeaderLenMask)
+
+	// There are `length` JEntries in the array.
+	entOff, valOff := uint32(0), uint32(0)
+	entB, valB := b, b
+	// Skip past the JEntries to find the first value, permitting parallel
+	// iteration through the JEntries and values below.
+	var err error
+	for i := 0; i < length; i++ {
+		// Decode and ignore.
+		var ent jEntry
+		valB, ent, err = decodeJEntry(valB, valOff)
+		if err != nil {
+			return nil, err
+		}
+		valOff += ent.length
+	}
+
+	buf.WriteByte('[')
+	for i := 0; i < length; i++ {
+		if i != 0 {
+			buf.WriteString(", ")
+		}
+		var ent jEntry
+		var err error
+		entB, ent, err = decodeJEntry(entB, entOff)
+		if err != nil {
+			return nil, err
+		}
+		entOff += ent.length
+		valB, err = formatEncodedJSONValue(buf, ent, valB)
+		if err != nil {
+			return nil, err
+		}
+	}
+	buf.WriteByte(']')
+	return valB, nil
+}
+
+func formatEncodedJSONObject(buf *bytes.Buffer, containerHeader uint32, b []byte) ([]byte, error) {
+	length := int(containerHeader & containerHeaderLenMask)
+
+	// There are `length` key JEntries and then `length` value JEntries in the
+	// object.
+	keyOff, valOff := uint32(0), uint32(0)
+	keyEntB, valEntB := b, b
+	// Skip past the key JEntries to find the first value JEntry, permitting
+	// parallel iteration through the key JEntries, value JEntries, keys, and
+	// values below.
+	var err error
+	for i := 0; i < length; i++ {
+		// Decode (and ignore) key JEntry.
+		var keyEnt jEntry
+		valEntB, keyEnt, err = decodeJEntry(valEntB, valOff)
+		if err != nil {
+			return nil, err
+		}
+		if keyEnt.typCode != stringTag {
+			return nil, errors.AssertionFailedf(
+				"key encoded as non-string: %d", errors.Safe(keyEnt.typCode))
+		}
+		valOff += keyEnt.length
+	}
+	// Skip past the value JEntries to find the first key.
+	valEntsSize := jEntrySize * length
+	if len(valEntB) < valEntsSize {
+		return nil, errors.AssertionFailedf("insufficient data to skip JSON object value JEntries")
+	}
+	keyB := valEntB[valEntsSize:]
+	// Skip past the keys to find the first value.
+	if len(keyB) < int(valOff) {
+		return nil, errors.AssertionFailedf("insufficient data to skip JSON object keys")
+	}
+	valB := keyB[valOff:]
+
+	// Iterate through the keys and values in parallel, formatting them.
+	buf.WriteByte('{')
+	for i := 0; i < length; i++ {
+		if i != 0 {
+			buf.WriteString(", ")
+		}
+		// Decode key JEntry i.
+		var keyEnt jEntry
+		keyEntB, keyEnt, err = decodeJEntry(keyEntB, keyOff)
+		if err != nil {
+			return nil, err
+		}
+		keyOff += keyEnt.length
+		// Decode value JEntry i.
+		var valEnt jEntry
+		valEntB, valEnt, err = decodeJEntry(valEntB, valOff)
+		if err != nil {
+			return nil, err
+		}
+		valOff += valEnt.length
+		// Decode and format key i.
+		keyS := unsafeJSONString(keyB[:keyEnt.length])
+		keyS.Format(buf)
+		keyB = keyB[keyEnt.length:]
+		buf.WriteString(": ")
+		// Decode and format value i.
+		valB, err = formatEncodedJSONValue(buf, valEnt, valB)
+		if err != nil {
+			return nil, err
+		}
+	}
+	buf.WriteByte('}')
+	return valB, nil
+}
+
+func formatEncodedJSONValue(buf *bytes.Buffer, e jEntry, b []byte) ([]byte, error) {
+	switch e.typCode {
+	case trueTag:
+		TrueJSONValue.Format(buf)
+	case falseTag:
+		FalseJSONValue.Format(buf)
+	case nullTag:
+		NullJSONValue.Format(buf)
+	case stringTag:
+		s := unsafeJSONString(b[:e.length])
+		s.Format(buf)
+		b = b[e.length:]
+	case numberTag:
+		var d jsonNumber
+		var err error
+		b, d, err = decodeJSONNumber(b)
+		if err != nil {
+			return nil, err
+		}
+		d.Format(buf)
+	case containerTag:
+		return formatEncodedJSON(buf, b)
+	default:
+		return nil, errors.AssertionFailedf(
+			"error decoding JSON value, unexpected type code: %d", errors.Safe(e.typCode))
+	}
+	return b, nil
+}
+
+func unsafeJSONString(b []byte) jsonString {
+	return jsonString(encoding.UnsafeConvertBytesToString(b))
+}

--- a/pkg/util/json/jentry.go
+++ b/pkg/util/json/jentry.go
@@ -23,6 +23,8 @@ const jEntryIsOffFlag = 0x80000000
 const jEntryTypeMask = 0x70000000
 const jEntryOffLenMask = 0x0FFFFFFF
 
+const jEntrySize = 4
+
 // jEntry is a header for a particular JSON value. See the JSONB encoding RFC
 // for an explanation of its purpose and format:
 // https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20171005_jsonb_encoding.md

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -782,6 +782,7 @@ const hexAlphabet = "0123456789abcdef"
 // encodeJSONString writes a string literal to buf as a JSON string.
 // Cribbed from https://github.com/golang/go/blob/7badae85f20f1bce4cc344f9202447618d45d414/src/encoding/json/encode.go.
 func encodeJSONString(buf *bytes.Buffer, s string) {
+	buf.Grow(len(s) + 2)
 	buf.WriteByte('"')
 	start := 0
 	for i := 0; i < len(s); {

--- a/pkg/util/json/random.go
+++ b/pkg/util/json/random.go
@@ -306,7 +306,7 @@ func (j *errJSON) Format(buf *bytes.Buffer) {
 		t.Format(buf)
 		if j.injectErr() {
 			// Drop terminating quote.
-			buf.Truncate(1)
+			buf.Truncate(buf.Len() - 1)
 		}
 	case jsonNumber:
 		if j.injectErr() {


### PR DESCRIPTION
Fixes #119542.

This commit implement `Format` directly on the `jsonEncoded` type, writing into the `*bytes.Buffer` at the same time as decoding. It replaces an implementation which decoded the full JSON object first into an intermediate JSON tree and then formatted that JSON tree into a `*bytes.Buffer` before discarding it.

As a result, this avoids the cost of constructing the intermediate JSON objects. It also avoids needing to pass through `jsonString` objects, which previously caused `[]byte->string` re-allocations and memcpys.

The improvement on the new `FormatJSON` benchmark is as follows:
```
name                   old time/op    new time/op    delta
FormatJSON/encoded-10    2.29µs ± 1%    0.95µs ± 1%  -58.55%  (p=0.000 n=10+9)

name                   old alloc/op   new alloc/op   delta
FormatJSON/encoded-10    2.98kB ± 0%    0.85kB ± 0%  -71.51%  (p=0.000 n=10+10)

name                   old allocs/op  new allocs/op  delta
FormatJSON/encoded-10      68.0 ± 0%       3.0 ± 0%  -95.59%  (p=0.000 n=10+10)
```

The test coverage here is pretty good, as indicated by code coverage and by the failures I encountered in `TestJSONRoundTrip` while making this change.

Release note: None