### PR TITLE
obs: replace runtime.ReadMemStats with runtime/metrics

### DIFF
--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -13,8 +13,6 @@ package server
 import (
 	"context"
 	"os"
-	"runtime"
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -148,10 +146,6 @@ func startSampleEnvironment(
 	return cfg.stopper.RunAsyncTaskEx(ctx,
 		stop.TaskOpts{TaskName: "mem-logger", SpanOpt: stop.SterileRootSpan},
 		func(ctx context.Context) {
-			var goMemStats atomic.Value // *status.GoMemStats
-			goMemStats.Store(&status.GoMemStats{})
-			var collectingMemStats int32 // atomic, 1 when stats call is ongoing
-
 			var timer timeutil.Timer
 			defer timer.Stop()
 			timer.Reset(cfg.minSampleInterval)
@@ -164,40 +158,8 @@ func startSampleEnvironment(
 					timer.Read = true
 					timer.Reset(cfg.minSampleInterval)
 
-					// We read the heap stats on another goroutine and give up after 1s.
-					// This is necessary because as of Go 1.12, runtime.ReadMemStats()
-					// "stops the world" and that requires first waiting for any current GC
-					// run to finish. With a large heap and under extreme conditions, a
-					// single GC run may take longer than the default sampling period of
-					// 10s. Under normal operations and with more recent versions of Go,
-					// this hasn't been observed to be a problem.
-					statsCollected := make(chan struct{})
-					if atomic.CompareAndSwapInt32(&collectingMemStats, 0, 1) {
-						if err := cfg.stopper.RunAsyncTaskEx(ctx,
-							stop.TaskOpts{TaskName: "get-mem-stats"},
-							func(ctx context.Context) {
-								var ms status.GoMemStats
-								runtime.ReadMemStats(&ms.MemStats)
-								ms.Collected = timeutil.Now()
-								log.VEventf(ctx, 2, "memstats: %+v", ms)
-
-								goMemStats.Store(&ms)
-								atomic.StoreInt32(&collectingMemStats, 0)
-								close(statsCollected)
-							}); err != nil {
-							close(statsCollected)
-						}
-					}
-
-					select {
-					case <-statsCollected:
-						// Good; we managed to read the Go memory stats quickly enough.
-					case <-time.After(time.Second):
-					}
-
-					curStats := goMemStats.Load().(*status.GoMemStats)
 					cgoStats := status.GetCGoMemStats(ctx)
-					cfg.runtime.SampleEnvironment(ctx, curStats, cgoStats)
+					cfg.runtime.SampleEnvironment(ctx, cgoStats)
 
 					if goroutineDumper != nil {
 						goroutineDumper.MaybeDump(ctx, cfg.st, cfg.runtime.Goroutines.Value())
@@ -206,7 +168,7 @@ func startSampleEnvironment(
 						heapProfiler.MaybeTakeProfile(ctx, cfg.runtime.GoAllocBytes.Value())
 						memMonitoringProfiler.MaybeTakeMemoryMonitoringDump(ctx, cfg.runtime.GoAllocBytes.Value(), cfg.rootMemMonitor, cfg.st)
 						nonGoAllocProfiler.MaybeTakeProfile(ctx, cfg.runtime.CgoTotalBytes.Value())
-						statsProfiler.MaybeTakeProfile(ctx, cfg.runtime.RSSBytes.Value(), curStats, cgoStats)
+						statsProfiler.MaybeTakeProfile(ctx, cfg.runtime.RSSBytes.Value(), cgoStats)
 					}
 					if queryProfiler != nil {
 						queryProfiler.MaybeDumpQueries(ctx, cfg.sessionRegistry, cfg.st)

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -69,7 +69,6 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/syncutil",
         "//pkg/util/system",
-        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",

--- a/pkg/util/log/eventpb/health_events.proto
+++ b/pkg/util/log/eventpb/health_events.proto
@@ -39,7 +39,7 @@ message RuntimeStats {
   // The total memory allocated by Go but not released. Expressed as bytes.
   uint64 go_total_bytes = 6 [(gogoproto.jsontag) = ",omitempty"];
   // The staleness of the Go memory statistics. Expressed in seconds.
-  float go_stats_staleness = 7 [(gogoproto.jsontag) = ",omitempty"];
+  float go_stats_staleness = 7 [(gogoproto.jsontag) = ",omitempty", deprecated=true];
   // The amount of heap fragmentation. Expressed as bytes.
   uint64 heap_fragment_bytes = 8 [(gogoproto.jsontag) = ",omitempty"];
   // The amount of heap reserved. Expressed as bytes.


### PR DESCRIPTION
This commit replaces Memstats collection with go runtime metrics. The latter
approach do not require stw to collect memory stats.

A subtle change to be noted: statsProfiler still call runtime.ReadMemStats on
spot when it determines memory stats should be saved. The previous behavior was
to save with the Memstats that was refreshed periodically.

Fixes: https://github.com/cockroachdb/cockroach/issues/119461

Release note: None


Testing:
Single node kv workload side by side comparison
left=this commit and right=master
memory
<img width="960" alt="image" src="https://github.com/cockroachdb/cockroach/assets/20375035/40b5c5c5-e04b-45fa-bdd4-ae6d6234614b">
gc pause time
<img width="964" alt="image" src="https://github.com/cockroachdb/cockroach/assets/20375035/ecebcefd-bbaa-49e5-b03f-39340cdb3ebd">
