### PR TITLE
bench,jobs: add more jobs rttanalysis tests

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/security/username",
         "//pkg/server",
+        "//pkg/server/serverpb",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/bench/rttanalysis/rtt_analysis_bench.go
+++ b/pkg/bench/rttanalysis/rtt_analysis_bench.go
@@ -45,6 +45,7 @@ type RoundTripBenchTestCase struct {
 	// creating the table.
 	SetupEx   []string
 	Stmt      string
+	StmtArgs  []interface{}
 	Reset     string
 	SkipIssue int
 }
@@ -163,7 +164,7 @@ func executeRoundTripTest(b testingB, tc RoundTripBenchTestCase, cc ClusterConst
 		}
 
 		b.StartTimer()
-		sql.Exec(b, tc.Stmt)
+		sql.Exec(b, tc.Stmt, tc.StmtArgs...)
 		b.StopTimer()
 		var ok bool
 

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -62,9 +62,15 @@ exp,benchmark
 19,GrantRole/grant_1_role
 25,GrantRole/grant_2_roles
 6,Jobs/cancel_job
+8,Jobs/crdb_internal.system_jobs
 8,Jobs/pause_job
 6,Jobs/resume_job
+8,Jobs/jobs_page_default
+8,Jobs/jobs_page_latest_50
+8,Jobs/jobs_page_type_filtered
+8,Jobs/jobs_page_type_filtered_no_matches
 3,Jobs/show_job
+8,Jobs/show_jobs
 3,ORMQueries/activerecord_type_introspection_query
 0,ORMQueries/asyncpg_types
 0,ORMQueries/column_descriptions_json_agg


### PR DESCRIPTION
This adds the statements used to drive the DB Console jobs page.

Epic: none
Release note: None