### PR TITLE
release-23.1: pkg/cloud: add metrics readers/writers/listings/conn reuse/tls

### DIFF
--- a/pkg/cloud/cloud_io.go
+++ b/pkg/cloud/cloud_io.go
@@ -73,6 +73,12 @@ var HTTPRetryOptions = retry.Options{
 	Multiplier:     4,
 }
 
+var httpMetrics = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"cloudstorage.http.detailed_metrics.enabled",
+	"enabled collection of detailed metrics on cloud http requests",
+	true)
+
 // MakeHTTPClient makes an http client configured with the common settings used
 // for interacting with cloud storage (timeouts, retries, CA certs, etc).
 func MakeHTTPClient(settings *cluster.Settings) (*http.Client, error) {

--- a/pkg/cloud/external_storage.go
+++ b/pkg/cloud/external_storage.go
@@ -154,7 +154,7 @@ type ExternalStorageContext struct {
 	DB                isql.DB
 	Options           []ExternalStorageOption
 	Limiters          Limiters
-	MetricsRecorder   MetricsRecorder
+	MetricsRecorder   *Metrics
 }
 
 // ExternalStorageOptions holds dependencies and values that can be

--- a/pkg/cloud/externalconn/connection_storage.go
+++ b/pkg/cloud/externalconn/connection_storage.go
@@ -92,7 +92,7 @@ func makeExternalConnectionStorage(
 		uri.Path = path.Join(uri.Path, cfg.Path)
 		return cloud.ExternalStorageFromURI(ctx, uri.String(), args.IOConf, args.Settings,
 			args.BlobClientFactory, username.MakeSQLUsernameFromPreNormalizedString(cfg.User),
-			args.DB, args.Limiters, args.MetricsRecorder.Metrics(), args.Options...)
+			args.DB, args.Limiters, args.MetricsRecorder, args.Options...)
 	default:
 		return nil, errors.Newf("cannot connect to %T; unsupported resource for an ExternalStorage connection", d)
 	}

--- a/pkg/cloud/impl_registry.go
+++ b/pkg/cloud/impl_registry.go
@@ -348,6 +348,9 @@ func (e *esWrapper) ReadFileAt(
 }
 
 func (e *esWrapper) List(ctx context.Context, prefix, delimiter string, fn ListingFn) error {
+	if e.metrics != nil {
+		e.metrics.Listings.Inc(1)
+	}
 	return e.ExternalStorage.List(ctx, prefix, delimiter, fn)
 }
 

--- a/pkg/cloud/impl_registry.go
+++ b/pkg/cloud/impl_registry.go
@@ -348,10 +348,15 @@ func (e *esWrapper) ReadFileAt(
 }
 
 func (e *esWrapper) List(ctx context.Context, prefix, delimiter string, fn ListingFn) error {
+	countingFn := fn
 	if e.metrics != nil {
 		e.metrics.Listings.Inc(1)
+		countingFn = func(s string) error {
+			e.metrics.ListingResults.Inc(1)
+			return fn(s)
+		}
 	}
-	return e.ExternalStorage.List(ctx, prefix, delimiter, fn)
+	return e.ExternalStorage.List(ctx, prefix, delimiter, countingFn)
 }
 
 func (e *esWrapper) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {

--- a/pkg/cloud/metrics.go
+++ b/pkg/cloud/metrics.go
@@ -33,6 +33,8 @@ type Metrics struct {
 	Writers *metric.Counter
 	// WriteBytes counts the bytes written to cloud storage.
 	WriteBytes *metric.Counter
+	// Listings counts the listing calls made to cloud storage.
+	Listings *metric.Counter
 }
 
 // MakeMetrics returns a new instance of Metrics.
@@ -65,11 +67,19 @@ func MakeMetrics() metric.Struct {
 		Unit:        metric.Unit_BYTES,
 		MetricType:  io_prometheus_client.MetricType_COUNTER,
 	}
+	listings := metric.Metadata{
+		Name:        "cloud.listings",
+		Help:        "Listing operations by all cloud operations",
+		Measurement: "Listing",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_COUNTER,
+	}
 	return &Metrics{
 		Readers:    metric.NewCounter(cloudReaders),
 		ReadBytes:  metric.NewCounter(cloudReadBytes),
 		Writers:    metric.NewCounter(cloudWriters),
 		WriteBytes: metric.NewCounter(cloudWriteBytes),
+		Listings:   metric.NewCounter(listings),
 	}
 }
 

--- a/pkg/cloud/metrics.go
+++ b/pkg/cloud/metrics.go
@@ -35,6 +35,8 @@ type Metrics struct {
 	WriteBytes *metric.Counter
 	// Listings counts the listing calls made to cloud storage.
 	Listings *metric.Counter
+	// ListingResults counts the listing results from cloud storage.
+	ListingResults *metric.Counter
 }
 
 // MakeMetrics returns a new instance of Metrics.
@@ -74,12 +76,20 @@ func MakeMetrics() metric.Struct {
 		Unit:        metric.Unit_COUNT,
 		MetricType:  io_prometheus_client.MetricType_COUNTER,
 	}
+	listingResults := metric.Metadata{
+		Name:        "cloud.listing_results",
+		Help:        "Listing results by all cloud operations",
+		Measurement: "Listing",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_COUNTER,
+	}
 	return &Metrics{
-		Readers:    metric.NewCounter(cloudReaders),
-		ReadBytes:  metric.NewCounter(cloudReadBytes),
-		Writers:    metric.NewCounter(cloudWriters),
-		WriteBytes: metric.NewCounter(cloudWriteBytes),
-		Listings:   metric.NewCounter(listings),
+		Readers:        metric.NewCounter(cloudReaders),
+		ReadBytes:      metric.NewCounter(cloudReadBytes),
+		Writers:        metric.NewCounter(cloudWriters),
+		WriteBytes:     metric.NewCounter(cloudWriteBytes),
+		Listings:       metric.NewCounter(listings),
+		ListingResults: metric.NewCounter(listingResults),
 	}
 }
 

--- a/pkg/cloud/metrics.go
+++ b/pkg/cloud/metrics.go
@@ -37,6 +37,9 @@ type Metrics struct {
 	Listings *metric.Counter
 	// ListingResults counts the listing results from cloud storage.
 	ListingResults *metric.Counter
+	// ConnsOpened, ConnsReused and TLSHandhakes track connection http info for cloud
+	// storage when collecting this info is enabled.
+	ConnsOpened, ConnsReused, TLSHandhakes *metric.Counter
 }
 
 // MakeMetrics returns a new instance of Metrics.
@@ -83,6 +86,27 @@ func MakeMetrics() metric.Struct {
 		Unit:        metric.Unit_COUNT,
 		MetricType:  io_prometheus_client.MetricType_COUNTER,
 	}
+	connsOpened := metric.Metadata{
+		Name:        "cloud.conns_opened",
+		Help:        "HTTP connections opened by cloud operations",
+		Measurement: "Connections",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_COUNTER,
+	}
+	connsReused := metric.Metadata{
+		Name:        "cloud.conns_reused",
+		Help:        "HTTP connections reused by cloud operations",
+		Measurement: "Connections",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_COUNTER,
+	}
+	tlsHandhakes := metric.Metadata{
+		Name:        "cloud.tls_handshakes",
+		Help:        "TLS handshakes done by cloud operations",
+		Measurement: "Connections",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_COUNTER,
+	}
 	return &Metrics{
 		Readers:        metric.NewCounter(cloudReaders),
 		ReadBytes:      metric.NewCounter(cloudReadBytes),
@@ -90,6 +114,9 @@ func MakeMetrics() metric.Struct {
 		WriteBytes:     metric.NewCounter(cloudWriteBytes),
 		Listings:       metric.NewCounter(listings),
 		ListingResults: metric.NewCounter(listingResults),
+		ConnsOpened:    metric.NewCounter(connsOpened),
+		ConnsReused:    metric.NewCounter(connsReused),
+		TLSHandhakes:   metric.NewCounter(tlsHandhakes),
 	}
 }
 

--- a/pkg/cloud/metrics.go
+++ b/pkg/cloud/metrics.go
@@ -29,6 +29,8 @@ type Metrics struct {
 	Readers *metric.Counter
 	// ReadBytes counts the bytes read from cloud storage.
 	ReadBytes *metric.Counter
+	// Writers counts the cloud storage writers opened.
+	Writers *metric.Counter
 	// WriteBytes counts the bytes written to cloud storage.
 	WriteBytes *metric.Counter
 }
@@ -49,6 +51,13 @@ func MakeMetrics() metric.Struct {
 		Unit:        metric.Unit_BYTES,
 		MetricType:  io_prometheus_client.MetricType_COUNTER,
 	}
+	cloudWriters := metric.Metadata{
+		Name:        "cloud.writers_opened",
+		Help:        "Writers opened by all cloud operations",
+		Measurement: "Files",
+		Unit:        metric.Unit_COUNT,
+		MetricType:  io_prometheus_client.MetricType_COUNTER,
+	}
 	cloudWriteBytes := metric.Metadata{
 		Name:        "cloud.write_bytes",
 		Help:        "Bytes written by all cloud operations",
@@ -59,6 +68,7 @@ func MakeMetrics() metric.Struct {
 	return &Metrics{
 		Readers:    metric.NewCounter(cloudReaders),
 		ReadBytes:  metric.NewCounter(cloudReadBytes),
+		Writers:    metric.NewCounter(cloudWriters),
 		WriteBytes: metric.NewCounter(cloudWriteBytes),
 	}
 }
@@ -87,6 +97,7 @@ func (m *Metrics) Writer(_ context.Context, _ ExternalStorage, w io.WriteCloser)
 	if m == nil {
 		return w
 	}
+	m.Writers.Inc(1)
 	return &metricsWriter{
 		w: w,
 		m: m,

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3907,6 +3907,14 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Connections",
+				Metrics: []string{
+					"cloud.conns_opened",
+					"cloud.conns_reused",
+					"cloud.tls_handshakes",
+				},
+			},
+			{
 				Title: "Listing",
 				Metrics: []string{
 					"cloud.listings",

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3893,10 +3893,16 @@ var charts = []sectionDescription{
 		Organization: [][]string{{Jobs, "External Storage"}},
 		Charts: []chartDescription{
 			{
-				Title: "External Storage",
+				Title: "Transfer",
 				Metrics: []string{
 					"cloud.read_bytes",
 					"cloud.write_bytes",
+				},
+			},
+			{
+				Title: "Activity",
+				Metrics: []string{
+					"cloud.cloud.readers_opened",
 				},
 			},
 		},

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3902,7 +3902,8 @@ var charts = []sectionDescription{
 			{
 				Title: "Activity",
 				Metrics: []string{
-					"cloud.cloud.readers_opened",
+					"cloud.readers_opened",
+					"cloud.writers_opened",
 				},
 			},
 		},

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3910,6 +3910,7 @@ var charts = []sectionDescription{
 				Title: "Listing",
 				Metrics: []string{
 					"cloud.listings",
+					"cloud.listing_results",
 				},
 			},
 		},

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3907,6 +3907,13 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Open Files",
+				Metrics: []string{
+					"cloud.open_readers",
+					"cloud.open_writers",
+				},
+			},
+			{
 				Title: "Connections",
 				Metrics: []string{
 					"cloud.conns_opened",

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3906,6 +3906,12 @@ var charts = []sectionDescription{
 					"cloud.writers_opened",
 				},
 			},
+			{
+				Title: "Listing",
+				Metrics: []string{
+					"cloud.listings",
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Backport:
  * 6/6 commits from "pkg/cloud: add metrics for readers/writers/listings/conn reuse/tls" (#115517)
  * 1/1 commits from "cloud: add gauges for open cloud readers and writers" (#119571)

Please see individual PRs for details.

/cc @cockroachdb/release


Release justification: low-risk high impact observability improvement.