### PR TITLE
storage: fix TestMVCCHistories

### DIFF
--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -2579,10 +2579,10 @@ func (e *evalCtx) getTxn(opt optArg) *roachpb.Transaction {
 // newReader returns a new (metamorphic) reader for use by a single command. The
 // caller must call Close on the reader when done.
 func (e *evalCtx) newReader() storage.Reader {
-	switch mvccHistoriesReader {
+	switch strings.ToLower(mvccHistoriesReader) {
 	case "engine":
 		return noopCloseReader{e.engine}
-	case "reader", "readOnly":
+	case "reader", "readonly":
 		return e.engine.NewReader(storage.StandardDurability)
 	case "batch":
 		return e.engine.NewBatch()


### PR DESCRIPTION
In #119219, I accidentally changed the capitalization of "readonly" when parsing MVCC history tests. Revert it to "readonly," and lowercase the incoming string to be accepting of capaitalization mistakes within the test files themselves.

Fix #119568.

Epic: none
Release note: none