### PR TITLE
concurrency: remove the concept of distinguished waiters 

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -120,9 +120,6 @@ func (s waitingState) SafeFormat(w redact.SafePrinter, _ rune) {
 	switch s.kind {
 	case waitFor, waitForDistinguished:
 		distinguished := redact.SafeString("")
-		if s.kind == waitForDistinguished {
-			distinguished = " (distinguished)"
-		}
 		target := redact.SafeString("holding lock")
 		if !s.held {
 			target = "running request"
@@ -1906,9 +1903,6 @@ func (kl *keyLocks) safeFormat(sb *redact.StringBuilder, txnStatusCache *txnStat
 				sb.Printf("%v\n", redact.Safe(g.txn.ID))
 			}
 		}
-	}
-	if kl.distinguishedWaiter != nil {
-		sb.Printf("   distinguished req: %d\n", redact.Safe(kl.distinguishedWaiter.seqNum))
 	}
 }
 

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -572,7 +572,7 @@ func TestLockTableBasic(t *testing.T) {
 				}
 				var typeStr string
 				switch state.kind {
-				case waitFor, waitForDistinguished:
+				case waitFor:
 					typeStr = "waitFor"
 				case waitElsewhere:
 					typeStr = "waitElsewhere"
@@ -1160,7 +1160,7 @@ func doWork(ctx context.Context, item *workItem, e *workloadExecutor) error {
 					if item.request.Txn == nil {
 						return errors.Errorf("non-transactional request cannot waitSelf")
 					}
-				case waitForDistinguished, waitFor, waitElsewhere:
+				case waitFor, waitElsewhere:
 					if item.request.Txn != nil {
 						var aborted bool
 						aborted, err = e.waitingFor(item.request.Txn.ID, lastID, state.txn.ID)

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -572,9 +572,7 @@ func TestLockTableBasic(t *testing.T) {
 				}
 				var typeStr string
 				switch state.kind {
-				case waitForDistinguished:
-					typeStr = "waitForDistinguished"
-				case waitFor:
+				case waitFor, waitForDistinguished:
 					typeStr = "waitFor"
 				case waitElsewhere:
 					typeStr = "waitElsewhere"

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -149,7 +149,7 @@ func (w *lockTableWaiterImpl) WaitOn(
 			log.VEventf(ctx, 3, "lock wait-queue event: %s", state)
 			tracer.notify(ctx, state)
 			switch state.kind {
-			case waitFor, waitForDistinguished:
+			case waitFor:
 				// waitFor indicates that the request is waiting on another
 				// transaction. This transaction may be the lock holder of a
 				// conflicting lock or the head of a lock-wait queue that the
@@ -304,11 +304,10 @@ func (w *lockTableWaiterImpl) WaitOn(
 			}
 
 		case <-timerC:
-			// If the request was in the waitFor or waitForDistinguished states
-			// and did not observe any update to its state for the entire delay,
-			// it should push. It may be the case that the transaction is part
-			// of a dependency cycle or that the lock holder's coordinator node
-			// has crashed.
+			// If the request was in the waitFor state and did not observe any update
+			// to its state for the entire delay, it should push. It may be the case
+			// that the transaction is part of a dependency cycle or that the lock
+			// holder's coordinator node has crashed.
 			timerC = nil
 			if timer != nil {
 				timer.Read = true
@@ -1129,7 +1128,7 @@ func (tag *contentionTag) notify(ctx context.Context, s waitingState) *kvpb.Cont
 	// on a different key than we were previously. If we're now waiting on a
 	// different key, we'll return an event corresponding to the previous key.
 	switch s.kind {
-	case waitFor, waitForDistinguished, waitSelf, waitElsewhere:
+	case waitFor, waitSelf, waitElsewhere:
 		// If we're tracking an event and see a different txn/key, the event is
 		// done and we initialize the new event tracking the new txn/key.
 		//

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter_test.go
@@ -170,10 +170,6 @@ func TestLockTableWaiterWithTxn(t *testing.T) {
 			testWaitPush(t, waitFor, makeReq, expPushTS())
 		})
 
-		t.Run("waitForDistinguished", func(t *testing.T) {
-			testWaitPush(t, waitForDistinguished, makeReq, expPushTS())
-		})
-
 		t.Run("waitElsewhere", func(t *testing.T) {
 			testWaitPush(t, waitElsewhere, makeReq, expPushTS())
 		})
@@ -246,10 +242,6 @@ func TestLockTableWaiterWithNonTxn(t *testing.T) {
 	t.Run("state", func(t *testing.T) {
 		t.Run("waitFor", func(t *testing.T) {
 			testWaitPush(t, waitFor, makeReq, reqHeaderTS)
-		})
-
-		t.Run("waitForDistinguished", func(t *testing.T) {
-			testWaitPush(t, waitForDistinguished, makeReq, reqHeaderTS)
 		})
 
 		t.Run("waitElsewhere", func(t *testing.T) {
@@ -465,10 +457,6 @@ func TestLockTableWaiterWithErrorWaitPolicy(t *testing.T) {
 			testErrorWaitPush(t, waitFor, makeHighPriReq, expPushTS, reasonWaitPolicy)
 		})
 
-		t.Run("waitForDistinguished", func(t *testing.T) {
-			testErrorWaitPush(t, waitForDistinguished, makeReq, expPushTS, reasonWaitPolicy)
-		})
-
 		t.Run("waitElsewhere", func(t *testing.T) {
 			testErrorWaitPush(t, waitElsewhere, makeReq, expPushTS, reasonWaitPolicy)
 		})
@@ -635,10 +623,6 @@ func TestLockTableWaiterWithLockTimeout(t *testing.T) {
 		t.Run("state", func(t *testing.T) {
 			t.Run("waitFor", func(t *testing.T) {
 				testWaitPushWithTimeout(t, waitFor, makeReq)
-			})
-
-			t.Run("waitForDistinguished", func(t *testing.T) {
-				testWaitPushWithTimeout(t, waitForDistinguished, makeReq)
 			})
 
 			t.Run("waitElsewhere", func(t *testing.T) {
@@ -818,7 +802,7 @@ func TestLockTableWaiterIntentResolverError(t *testing.T) {
 		pusheeTxn := makeTxnProto("pushee")
 		lockHeld := sync
 		g.state = waitingState{
-			kind:          waitForDistinguished,
+			kind:          waitFor,
 			txn:           &pusheeTxn.TxnMeta,
 			key:           keyA,
 			held:          lockHeld,
@@ -1009,7 +993,7 @@ func TestContentionEventTracer(t *testing.T) {
 		events = append(events, ev)
 	})
 	h.notify(ctx, waitingState{
-		kind: waitForDistinguished,
+		kind: waitFor,
 		key:  roachpb.Key("a"),
 		txn:  &txn1.TxnMeta,
 	})
@@ -1066,7 +1050,7 @@ func TestContentionEventTracer(t *testing.T) {
 	// emit an event.
 	manual.Advance(12)
 	h.notify(ctx, waitingState{
-		kind: waitForDistinguished,
+		kind: waitFor,
 		key:  roachpb.Key("b"),
 		txn:  &txn2.TxnMeta,
 	})

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -113,7 +113,7 @@ sequence req=req3
 [2] sequence req3: acquiring latches
 [2] sequence req3: scanning lock table for conflicting locks
 [2] sequence req3: waiting in lock wait-queues
-[2] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[2] sequence req3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [2] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [2] sequence req3: pushing timestamp of txn 00000002 above 14.000000000,1
 [2] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -200,7 +200,7 @@ sequence req=req5
 [2] sequence req5: acquiring latches
 [2] sequence req5: scanning lock table for conflicting locks
 [2] sequence req5: waiting in lock wait-queues
-[2] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[2] sequence req5: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [2] sequence req5: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [2] sequence req5: pushing timestamp of txn 00000002 above 14.000000000,1
 [2] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -261,7 +261,7 @@ finish req=req6
 [-] finish req6: finishing request
 [4] sequence req7: scanning lock table for conflicting locks
 [4] sequence req7: waiting in lock wait-queues
-[4] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req7: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req7: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req7: pushing txn 00000002 to abort
 [4] sequence req7: blocked on select in concurrency_test.(*cluster).PushTransaction

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -63,7 +63,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -75,7 +75,6 @@ num=10
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 1, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 1
  lock: "b"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "c"
@@ -174,7 +173,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req1: pushing txn 00000002 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -352,7 +351,7 @@ sequence req=req1
 [4] sequence req1: acquiring latches
 [4] sequence req1: scanning lock table for conflicting locks
 [4] sequence req1: waiting in lock wait-queues
-[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -364,7 +363,6 @@ num=4
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 3, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 3
  lock: "b"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
  lock: "g"
@@ -467,7 +465,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req1: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req1: pushing txn 00000003 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -479,7 +477,6 @@ num=3
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 5
  lock: "d"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
@@ -538,7 +535,6 @@ num=5
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 5
  lock: "d"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
@@ -559,7 +555,7 @@ sequence req=req2
 [6] sequence req2: acquiring latches
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: waiting in lock wait-queues
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000003 above 11.000000000,1
 [6] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -571,14 +567,12 @@ num=5
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 8, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 8
  lock: "b"
   holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 5
  lock: "d"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
@@ -597,13 +591,13 @@ on-txn-updated txn=txn3 status=aborted
 ----
 [-] update txn: aborting txn3
 [3] sequence req1: resolving intent ‹"c"› for txn 00000003 with ABORTED status
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000005 holding lock @ key ‹"e"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req1: lock wait-queue event: wait for txn 00000005 holding lock @ key ‹"e"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req1: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"c"› for 123.000s
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req1: pushing txn 00000005 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req2: resolving intent ‹"a"› for txn 00000003 with ABORTED status
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000004 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"a"› for 123.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000004 above 11.000000000,1
@@ -616,7 +610,6 @@ num=4
   holder: txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 8, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 8
  lock: "c"
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
@@ -628,7 +621,6 @@ num=4
   holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 5
 
 debug-advance-clock ts=123
 ----
@@ -660,7 +652,6 @@ num=3
   holder: txn: 00000005-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 5
 
 finish req=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_wait_policy_error
@@ -77,7 +77,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = true
 [3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [3] sequence req1: resolving intent ‹"a"› for txn 00000002 with ABORTED status

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -42,7 +42,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -54,7 +54,6 @@ num=1
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 1, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 1
 
 debug-advance-clock ts=123
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -111,7 +111,7 @@ sequence req=req1r
 [4] sequence req1r: acquiring latches
 [4] sequence req1r: scanning lock table for conflicting locks
 [4] sequence req1r: waiting in lock wait-queues
-[4] sequence req1r: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req1r: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req1r: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req1r: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1r: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -122,7 +122,7 @@ sequence req=req2r
 [5] sequence req2r: acquiring latches
 [5] sequence req2r: scanning lock table for conflicting locks
 [5] sequence req2r: waiting in lock wait-queues
-[5] sequence req2r: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 0, queuedReaders: 1)
+[5] sequence req2r: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 0, queuedReaders: 1)
 [5] sequence req2r: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req2r: pushing timestamp of txn 00000003 above 10.000000000,1
 [5] sequence req2r: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -135,7 +135,7 @@ sequence req=req3r
 [6] sequence req3r: acquiring latches
 [6] sequence req3r: scanning lock table for conflicting locks
 [6] sequence req3r: waiting in lock wait-queues
-[6] sequence req3r: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req3r: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req3r: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req3r: pushing timestamp of txn 00000001 above 10.000000000,1
 [6] sequence req3r: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -148,17 +148,14 @@ num=3
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 6, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 6
  lock: "b"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 4, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 4
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 5, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 5
 
 # Break the deadlock by aborting txn1.
 on-txn-updated txn=txn1 status=aborted
@@ -325,7 +322,7 @@ sequence req=req4w
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
-[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req4w: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req4w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4w: pushing txn 00000001 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -336,7 +333,7 @@ sequence req=req1w2
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
-[5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
+[5] sequence req1w2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
 [5] sequence req1w2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req1w2: pushing txn 00000002 to abort
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -347,7 +344,7 @@ sequence req=req2w2
 [6] sequence req2w2: acquiring latches
 [6] sequence req2w2: scanning lock table for conflicting locks
 [6] sequence req2w2: waiting in lock wait-queues
-[6] sequence req2w2: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
+[6] sequence req2w2: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
 [6] sequence req2w2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req2w2: pushing txn 00000003 to abort
 [6] sequence req2w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -374,17 +371,14 @@ num=3
    queued locking requests:
     active: true req: 10, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
     active: true req: 13, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 10
  lock: "b"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 11, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 11
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 12, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 12
 
 # Break the deadlock by aborting txn1.
 on-txn-updated txn=txn1 status=aborted
@@ -400,7 +394,7 @@ on-txn-updated txn=txn1 status=aborted
 [5] sequence req1w2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [7] sequence req3w2: resolving intent ‹"a"› for txn 00000001 with ABORTED status
-[7] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
+[7] sequence req3w2: lock wait-queue event: wait for txn 00000004 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
 [7] sequence req3w2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [7] sequence req3w2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [7] sequence req3w2: pushing txn 00000004 to detect request deadlock
@@ -554,7 +548,7 @@ sequence req=req4w
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
-[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req4w: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req4w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4w: pushing txn 00000002 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -563,7 +557,7 @@ on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [4] sequence req4w: resolving intent ‹"b"› for txn 00000002 with COMMITTED status
-[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req4w: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req4w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [4] sequence req4w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4w: pushing txn 00000003 to abort
@@ -581,7 +575,6 @@ num=3
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 17, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
-   distinguished req: 17
 
 # --------------------------------
 # Setup complete, test starts here
@@ -601,7 +594,7 @@ sequence req=req1w2
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
-[5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key ‹"b"› (queuedLockingRequests: 2, queuedReaders: 0)
+[5] sequence req1w2: lock wait-queue event: wait for txn 00000004 running request @ key ‹"b"› (queuedLockingRequests: 2, queuedReaders: 0)
 [5] sequence req1w2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req1w2: pushing txn 00000004 to detect request deadlock
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -614,7 +607,7 @@ sequence req=req3w2
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
-[6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[6] sequence req3w2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [6] sequence req3w2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req3w2: pushing txn 00000001 to abort
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -627,17 +620,14 @@ num=3
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 19, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 19
  lock: "b"
    queued locking requests:
     active: false req: 17, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
     active: true req: 18, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 18
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 17, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
-   distinguished req: 17
 
 # Break the deadlock by aborting txn4.
 on-txn-updated txn=txn4 status=aborted
@@ -790,7 +780,7 @@ sequence req=req4w
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: waiting in lock wait-queues
-[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req4w: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req4w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4w: pushing txn 00000002 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -799,7 +789,7 @@ on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [4] sequence req4w: resolving intent ‹"b"› for txn 00000002 with COMMITTED status
-[4] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req4w: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req4w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [4] sequence req4w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4w: pushing txn 00000003 to abort
@@ -817,7 +807,6 @@ num=3
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 23, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
-   distinguished req: 23
 
 # --------------------------------
 # Setup complete, test starts here
@@ -837,7 +826,7 @@ sequence req=req1w2
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: waiting in lock wait-queues
-[5] sequence req1w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key ‹"b"› (queuedLockingRequests: 2, queuedReaders: 0)
+[5] sequence req1w2: lock wait-queue event: wait for txn 00000004 running request @ key ‹"b"› (queuedLockingRequests: 2, queuedReaders: 0)
 [5] sequence req1w2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req1w2: pushing txn 00000004 to detect request deadlock
 [5] sequence req1w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -850,7 +839,7 @@ sequence req=req3w2
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
-[6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[6] sequence req3w2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [6] sequence req3w2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req3w2: pushing txn 00000001 to abort
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -863,17 +852,14 @@ num=3
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 25, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 25
  lock: "b"
    queued locking requests:
     active: false req: 23, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
     active: true req: 24, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 24
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 23, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
-   distinguished req: 23
 
 # Break the deadlock by aborting txn1.
 on-txn-updated txn=txn1 status=aborted
@@ -1038,7 +1024,7 @@ sequence req=req5w
 [4] sequence req5w: acquiring latches
 [4] sequence req5w: scanning lock table for conflicting locks
 [4] sequence req5w: waiting in lock wait-queues
-[4] sequence req5w: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req5w: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req5w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req5w: pushing txn 00000002 to abort
 [4] sequence req5w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1049,7 +1035,7 @@ sequence req=req4w
 [5] sequence req4w: acquiring latches
 [5] sequence req4w: scanning lock table for conflicting locks
 [5] sequence req4w: waiting in lock wait-queues
-[5] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[5] sequence req4w: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [5] sequence req4w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req4w: pushing txn 00000001 to abort
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1068,13 +1054,13 @@ on-txn-updated txn=txn2 status=committed
 ----
 [-] update txn: committing txn2
 [4] sequence req5w: resolving intent ‹"b"› for txn 00000002 with COMMITTED status
-[4] sequence req5w: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req5w: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req5w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [4] sequence req5w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req5w: pushing txn 00000003 to abort
 [4] sequence req5w: blocked on select in concurrency_test.(*cluster).PushTransaction
 [5] sequence req4w: resolving intent ‹"b"› for txn 00000002 with COMMITTED status
-[5] sequence req4w: lock wait-queue event: wait for (distinguished) txn 00000005 running request @ key ‹"b"› (queuedLockingRequests: 2, queuedReaders: 0)
+[5] sequence req4w: lock wait-queue event: wait for txn 00000005 running request @ key ‹"b"› (queuedLockingRequests: 2, queuedReaders: 0)
 [5] sequence req4w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [5] sequence req4w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req4w: pushing txn 00000005 to detect request deadlock
@@ -1090,12 +1076,10 @@ num=3
    queued locking requests:
     active: false req: 29, strength: Intent, txn: 00000005-0000-0000-0000-000000000000
     active: true req: 30, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
-   distinguished req: 30
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 29, strength: Intent, txn: 00000005-0000-0000-0000-000000000000
-   distinguished req: 29
 
 # --------------------------------
 # Setup complete, test starts here
@@ -1113,7 +1097,7 @@ sequence req=req3w2
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: waiting in lock wait-queues
-[6] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
+[6] sequence req3w2: lock wait-queue event: wait for txn 00000004 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
 [6] sequence req3w2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req3w2: pushing txn 00000004 to detect request deadlock
 [6] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1126,17 +1110,14 @@ num=3
    queued locking requests:
     active: false req: 30, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
     active: true req: 31, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 31
  lock: "b"
    queued locking requests:
     active: false req: 29, strength: Intent, txn: 00000005-0000-0000-0000-000000000000
     active: true req: 30, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
-   distinguished req: 30
  lock: "c"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 29, strength: Intent, txn: 00000005-0000-0000-0000-000000000000
-   distinguished req: 29
 
 # Break the deadlock by aborting txn4.
 on-txn-updated txn=txn4 status=aborted

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
@@ -146,7 +146,7 @@ sequence req=req4
 [5] sequence req4: acquiring latches
 [5] sequence req4: scanning lock table for conflicting locks
 [5] sequence req4: waiting in lock wait-queues
-[5] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[5] sequence req4: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [5] sequence req4: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req4: pushing timestamp of txn 00000003 above 10.000000000,0
 [5] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -164,7 +164,6 @@ num=1
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    waiting readers:
     req: 3, txn: 00000004-0000-0000-0000-000000000000
-   distinguished req: 3
 
 sequence req=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -37,7 +37,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 12.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
@@ -269,7 +269,7 @@ sequence req=req5
 [7] sequence req5: acquiring latches
 [7] sequence req5: scanning lock table for conflicting locks
 [7] sequence req5: waiting in lock wait-queues
-[7] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"kSSINormal1"› (queuedLockingRequests: 0, queuedReaders: 1)
+[7] sequence req5: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"kSSINormal1"› (queuedLockingRequests: 0, queuedReaders: 1)
 [7] sequence req5: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [7] sequence req5: pushing timestamp of txn 00000001 above 10.000000000,1
 [7] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -299,7 +299,7 @@ sequence req=req6
 [8] sequence req6: acquiring latches
 [8] sequence req6: scanning lock table for conflicting locks
 [8] sequence req6: waiting in lock wait-queues
-[8] sequence req6: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"kSSINormal2"› (queuedLockingRequests: 0, queuedReaders: 1)
+[8] sequence req6: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"kSSINormal2"› (queuedLockingRequests: 0, queuedReaders: 1)
 [8] sequence req6: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [8] sequence req6: pushing timestamp of txn 00000001 above 11.000000000,1
 [8] sequence req6: pusher pushed pushee to 11.000000000,2
@@ -336,7 +336,7 @@ sequence req=req7
 [9] sequence req7: acquiring latches
 [9] sequence req7: scanning lock table for conflicting locks
 [9] sequence req7: waiting in lock wait-queues
-[9] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"kSSINormal3"› (queuedLockingRequests: 0, queuedReaders: 1)
+[9] sequence req7: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"kSSINormal3"› (queuedLockingRequests: 0, queuedReaders: 1)
 [9] sequence req7: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [9] sequence req7: pushing timestamp of txn 00000001 above 12.000000000,1
 [9] sequence req7: pusher pushed pushee to 12.000000000,2
@@ -369,7 +369,7 @@ sequence req=req8
 [10] sequence req8: acquiring latches
 [10] sequence req8: scanning lock table for conflicting locks
 [10] sequence req8: waiting in lock wait-queues
-[10] sequence req8: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"kSSINormal4"› (queuedLockingRequests: 0, queuedReaders: 1)
+[10] sequence req8: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"kSSINormal4"› (queuedLockingRequests: 0, queuedReaders: 1)
 [10] sequence req8: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [10] sequence req8: pushing timestamp of txn 00000001 above 13.000000000,1
 [10] sequence req8: pusher pushed pushee to 13.000000000,2
@@ -432,7 +432,7 @@ sequence req=req9
 [11] sequence req9: acquiring latches
 [11] sequence req9: scanning lock table for conflicting locks
 [11] sequence req9: waiting in lock wait-queues
-[11] sequence req9: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"kSSIHigh1"› (queuedLockingRequests: 0, queuedReaders: 1)
+[11] sequence req9: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"kSSIHigh1"› (queuedLockingRequests: 0, queuedReaders: 1)
 [11] sequence req9: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [11] sequence req9: pushing timestamp of txn 00000002 above 10.000000000,1
 [11] sequence req9: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -455,7 +455,7 @@ sequence req=req10
 [12] sequence req10: acquiring latches
 [12] sequence req10: scanning lock table for conflicting locks
 [12] sequence req10: waiting in lock wait-queues
-[12] sequence req10: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"kSSIHigh2"› (queuedLockingRequests: 0, queuedReaders: 1)
+[12] sequence req10: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"kSSIHigh2"› (queuedLockingRequests: 0, queuedReaders: 1)
 [12] sequence req10: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [12] sequence req10: pushing timestamp of txn 00000002 above 11.000000000,1
 [12] sequence req10: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -478,7 +478,7 @@ sequence req=req11
 [13] sequence req11: acquiring latches
 [13] sequence req11: scanning lock table for conflicting locks
 [13] sequence req11: waiting in lock wait-queues
-[13] sequence req11: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"kSSIHigh3"› (queuedLockingRequests: 0, queuedReaders: 1)
+[13] sequence req11: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"kSSIHigh3"› (queuedLockingRequests: 0, queuedReaders: 1)
 [13] sequence req11: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [13] sequence req11: pushing timestamp of txn 00000002 above 12.000000000,1
 [13] sequence req11: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -520,7 +520,7 @@ sequence req=req12
 [14] sequence req12: acquiring latches
 [14] sequence req12: scanning lock table for conflicting locks
 [14] sequence req12: waiting in lock wait-queues
-[14] sequence req12: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"kSSIHigh4"› (queuedLockingRequests: 0, queuedReaders: 1)
+[14] sequence req12: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"kSSIHigh4"› (queuedLockingRequests: 0, queuedReaders: 1)
 [14] sequence req12: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [14] sequence req12: pushing timestamp of txn 00000002 above 13.000000000,1
 [14] sequence req12: pusher pushed pushee to 13.000000000,2
@@ -584,7 +584,7 @@ sequence req=req13
 [15] sequence req13: acquiring latches
 [15] sequence req13: scanning lock table for conflicting locks
 [15] sequence req13: waiting in lock wait-queues
-[15] sequence req13: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"kRCNormal1"› (queuedLockingRequests: 0, queuedReaders: 1)
+[15] sequence req13: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"kRCNormal1"› (queuedLockingRequests: 0, queuedReaders: 1)
 [15] sequence req13: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [15] sequence req13: pushing timestamp of txn 00000003 above 10.000000000,1
 [15] sequence req13: pusher pushed pushee to 10.000000000,2
@@ -616,7 +616,7 @@ sequence req=req14
 [16] sequence req14: acquiring latches
 [16] sequence req14: scanning lock table for conflicting locks
 [16] sequence req14: waiting in lock wait-queues
-[16] sequence req14: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"kRCNormal2"› (queuedLockingRequests: 0, queuedReaders: 1)
+[16] sequence req14: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"kRCNormal2"› (queuedLockingRequests: 0, queuedReaders: 1)
 [16] sequence req14: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [16] sequence req14: pushing timestamp of txn 00000003 above 11.000000000,1
 [16] sequence req14: pusher pushed pushee to 11.000000000,2
@@ -648,7 +648,7 @@ sequence req=req15
 [17] sequence req15: acquiring latches
 [17] sequence req15: scanning lock table for conflicting locks
 [17] sequence req15: waiting in lock wait-queues
-[17] sequence req15: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"kRCNormal3"› (queuedLockingRequests: 0, queuedReaders: 1)
+[17] sequence req15: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"kRCNormal3"› (queuedLockingRequests: 0, queuedReaders: 1)
 [17] sequence req15: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [17] sequence req15: pushing timestamp of txn 00000003 above 12.000000000,1
 [17] sequence req15: pusher pushed pushee to 12.000000000,2
@@ -680,7 +680,7 @@ sequence req=req16
 [18] sequence req16: acquiring latches
 [18] sequence req16: scanning lock table for conflicting locks
 [18] sequence req16: waiting in lock wait-queues
-[18] sequence req16: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"kRCNormal4"› (queuedLockingRequests: 0, queuedReaders: 1)
+[18] sequence req16: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"kRCNormal4"› (queuedLockingRequests: 0, queuedReaders: 1)
 [18] sequence req16: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [18] sequence req16: pushing timestamp of txn 00000003 above 13.000000000,1
 [18] sequence req16: pusher pushed pushee to 13.000000000,2
@@ -724,7 +724,7 @@ sequence req=req17
 [19] sequence req17: acquiring latches
 [19] sequence req17: scanning lock table for conflicting locks
 [19] sequence req17: waiting in lock wait-queues
-[19] sequence req17: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key ‹"kRCHigh1"› (queuedLockingRequests: 0, queuedReaders: 1)
+[19] sequence req17: lock wait-queue event: wait for txn 00000004 holding lock @ key ‹"kRCHigh1"› (queuedLockingRequests: 0, queuedReaders: 1)
 [19] sequence req17: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [19] sequence req17: pushing timestamp of txn 00000004 above 10.000000000,1
 [19] sequence req17: pusher pushed pushee to 10.000000000,2
@@ -756,7 +756,7 @@ sequence req=req18
 [20] sequence req18: acquiring latches
 [20] sequence req18: scanning lock table for conflicting locks
 [20] sequence req18: waiting in lock wait-queues
-[20] sequence req18: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key ‹"kRCHigh2"› (queuedLockingRequests: 0, queuedReaders: 1)
+[20] sequence req18: lock wait-queue event: wait for txn 00000004 holding lock @ key ‹"kRCHigh2"› (queuedLockingRequests: 0, queuedReaders: 1)
 [20] sequence req18: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [20] sequence req18: pushing timestamp of txn 00000004 above 11.000000000,1
 [20] sequence req18: pusher pushed pushee to 11.000000000,2
@@ -788,7 +788,7 @@ sequence req=req19
 [21] sequence req19: acquiring latches
 [21] sequence req19: scanning lock table for conflicting locks
 [21] sequence req19: waiting in lock wait-queues
-[21] sequence req19: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key ‹"kRCHigh3"› (queuedLockingRequests: 0, queuedReaders: 1)
+[21] sequence req19: lock wait-queue event: wait for txn 00000004 holding lock @ key ‹"kRCHigh3"› (queuedLockingRequests: 0, queuedReaders: 1)
 [21] sequence req19: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [21] sequence req19: pushing timestamp of txn 00000004 above 12.000000000,1
 [21] sequence req19: pusher pushed pushee to 12.000000000,2
@@ -820,7 +820,7 @@ sequence req=req20
 [22] sequence req20: acquiring latches
 [22] sequence req20: scanning lock table for conflicting locks
 [22] sequence req20: waiting in lock wait-queues
-[22] sequence req20: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key ‹"kRCHigh4"› (queuedLockingRequests: 0, queuedReaders: 1)
+[22] sequence req20: lock wait-queue event: wait for txn 00000004 holding lock @ key ‹"kRCHigh4"› (queuedLockingRequests: 0, queuedReaders: 1)
 [22] sequence req20: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [22] sequence req20: pushing timestamp of txn 00000004 above 13.000000000,1
 [22] sequence req20: pusher pushed pushee to 13.000000000,2

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
@@ -70,7 +70,7 @@ sequence req=req3
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: waiting in lock wait-queues
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k2"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k2"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000001 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -84,7 +84,6 @@ num=3
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 3
  lock: "k3"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -103,7 +102,7 @@ sequence req=reqTimeout1
 [4] sequence reqTimeout1: acquiring latches
 [4] sequence reqTimeout1: scanning lock table for conflicting locks
 [4] sequence reqTimeout1: waiting in lock wait-queues
-[4] sequence reqTimeout1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence reqTimeout1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence reqTimeout1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = true, priority enforcement = false, wait policy error = false
 [4] sequence reqTimeout1: pushing timestamp of txn 00000001 above 12.000000000,1
 [4] sequence reqTimeout1: pushee not abandoned
@@ -119,7 +118,7 @@ on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
 [3] sequence req3: resolving intent ‹"k2"› for txn 00000001 with COMMITTED status
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k3"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k3"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k2"› for 0.000s
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000002 to abort
@@ -146,7 +145,6 @@ num=2
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 3
 
 # -------------------------------------------------------------
 # Read-write request with lock timeout hits reservation
@@ -164,7 +162,7 @@ sequence req=reqTimeout2
 [6] sequence reqTimeout2: acquiring latches
 [6] sequence reqTimeout2: scanning lock table for conflicting locks
 [6] sequence reqTimeout2: waiting in lock wait-queues
-[6] sequence reqTimeout2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"k2"› (queuedLockingRequests: 2, queuedReaders: 0)
+[6] sequence reqTimeout2: lock wait-queue event: wait for txn 00000003 running request @ key ‹"k2"› (queuedLockingRequests: 2, queuedReaders: 0)
 [6] sequence reqTimeout2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = true, priority enforcement = false, wait policy error = false
 [6] sequence reqTimeout2: pushing txn 00000003 to abort
 [6] sequence reqTimeout2: pushee not abandoned
@@ -198,7 +196,7 @@ sequence req=reqTimeout3
 [9] sequence reqTimeout3: acquiring latches
 [9] sequence reqTimeout3: scanning lock table for conflicting locks
 [9] sequence reqTimeout3: waiting in lock wait-queues
-[9] sequence reqTimeout3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k4"› (queuedLockingRequests: 0, queuedReaders: 1)
+[9] sequence reqTimeout3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k4"› (queuedLockingRequests: 0, queuedReaders: 1)
 [9] sequence reqTimeout3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = true, priority enforcement = false, wait policy error = false
 [9] sequence reqTimeout3: pushing timestamp of txn 00000002 above 12.000000000,1
 [9] sequence reqTimeout3: pushee not abandoned
@@ -215,7 +213,6 @@ num=3
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 3
  lock: "k4"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout_v23_1
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout_v23_1
@@ -70,7 +70,7 @@ sequence req=req3
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: waiting in lock wait-queues
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k2"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k2"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000001 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -84,7 +84,6 @@ num=3
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 3
  lock: "k3"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -103,7 +102,7 @@ sequence req=reqTimeout1
 [4] sequence reqTimeout1: acquiring latches
 [4] sequence reqTimeout1: scanning lock table for conflicting locks
 [4] sequence reqTimeout1: waiting in lock wait-queues
-[4] sequence reqTimeout1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence reqTimeout1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence reqTimeout1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = true, priority enforcement = false, wait policy error = false
 [4] sequence reqTimeout1: pushing txn 00000001 to check if abandoned
 [4] sequence reqTimeout1: pushee not abandoned
@@ -119,7 +118,7 @@ on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
 [3] sequence req3: resolving intent ‹"k2"› for txn 00000001 with COMMITTED status
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k3"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k3"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k2"› for 0.000s
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000002 to abort
@@ -146,7 +145,6 @@ num=2
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 3
 
 # -------------------------------------------------------------
 # Read-write request with lock timeout hits reservation
@@ -164,7 +162,7 @@ sequence req=reqTimeout2
 [6] sequence reqTimeout2: acquiring latches
 [6] sequence reqTimeout2: scanning lock table for conflicting locks
 [6] sequence reqTimeout2: waiting in lock wait-queues
-[6] sequence reqTimeout2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"k2"› (queuedLockingRequests: 2, queuedReaders: 0)
+[6] sequence reqTimeout2: lock wait-queue event: wait for txn 00000003 running request @ key ‹"k2"› (queuedLockingRequests: 2, queuedReaders: 0)
 [6] sequence reqTimeout2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = true, priority enforcement = false, wait policy error = false
 [6] sequence reqTimeout2: pushing txn 00000003 to check if abandoned
 [6] sequence reqTimeout2: pushee not abandoned
@@ -198,7 +196,7 @@ sequence req=reqTimeout3
 [9] sequence reqTimeout3: acquiring latches
 [9] sequence reqTimeout3: scanning lock table for conflicting locks
 [9] sequence reqTimeout3: waiting in lock wait-queues
-[9] sequence reqTimeout3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k4"› (queuedLockingRequests: 0, queuedReaders: 1)
+[9] sequence reqTimeout3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k4"› (queuedLockingRequests: 0, queuedReaders: 1)
 [9] sequence reqTimeout3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = true, priority enforcement = false, wait policy error = false
 [9] sequence reqTimeout3: pushing txn 00000002 to check if abandoned
 [9] sequence reqTimeout3: pushee not abandoned
@@ -215,7 +213,6 @@ num=3
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 3
  lock: "k4"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
@@ -89,7 +89,7 @@ sequence req=req3 eval-kind=pess-after-opt
 [4] sequence req3: optimistic failed, so waiting for latches
 [4] sequence req3: scanning lock table for conflicting locks
 [4] sequence req3: waiting in lock wait-queues
-[4] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"d"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req3: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"d"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req3: pushing timestamp of txn 00000001 above 12.000000000,1
 [4] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
@@ -137,7 +137,7 @@ sequence req=req4
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: waiting in lock wait-queues
-[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"kLow1"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req4: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"kLow1"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req4: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4: pushing timestamp of txn 00000001 above 10.000000000,1
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -209,7 +209,7 @@ sequence req=req6
 [6] sequence req6: acquiring latches
 [6] sequence req6: scanning lock table for conflicting locks
 [6] sequence req6: waiting in lock wait-queues
-[6] sequence req6: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"kLow2"› (queuedLockingRequests: 1, queuedReaders: 0)
+[6] sequence req6: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"kLow2"› (queuedLockingRequests: 1, queuedReaders: 0)
 [6] sequence req6: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req6: pushing txn 00000001 to abort
 [6] sequence req6: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -231,7 +231,7 @@ sequence req=req7
 [7] sequence req7: pushing txn 00000001 to abort
 [7] sequence req7: pusher aborted pushee
 [7] sequence req7: resolving intent ‹"kLow2"› for txn 00000001 with ABORTED status
-[7] sequence req7: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key ‹"kLow2"› (queuedLockingRequests: 2, queuedReaders: 0)
+[7] sequence req7: lock wait-queue event: wait for txn 00000004 running request @ key ‹"kLow2"› (queuedLockingRequests: 2, queuedReaders: 0)
 [7] sequence req7: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kLow2"› for 0.000s
 [7] sequence req7: pushing after 0s for: deadlock/liveness detection = false, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [7] sequence req7: pushing txn 00000004 to detect request deadlock
@@ -285,7 +285,7 @@ sequence req=req8
 [8] sequence req8: acquiring latches
 [8] sequence req8: scanning lock table for conflicting locks
 [8] sequence req8: waiting in lock wait-queues
-[8] sequence req8: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"kNormal1"› (queuedLockingRequests: 0, queuedReaders: 1)
+[8] sequence req8: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"kNormal1"› (queuedLockingRequests: 0, queuedReaders: 1)
 [8] sequence req8: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [8] sequence req8: pushing timestamp of txn 00000002 above 10.000000000,1
 [8] sequence req8: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -355,7 +355,7 @@ sequence req=req10
 [10] sequence req10: acquiring latches
 [10] sequence req10: scanning lock table for conflicting locks
 [10] sequence req10: waiting in lock wait-queues
-[10] sequence req10: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"kNormal2"› (queuedLockingRequests: 1, queuedReaders: 0)
+[10] sequence req10: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"kNormal2"› (queuedLockingRequests: 1, queuedReaders: 0)
 [10] sequence req10: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [10] sequence req10: pushing txn 00000002 to abort
 [10] sequence req10: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -377,7 +377,7 @@ sequence req=req11
 [11] sequence req11: pushing txn 00000002 to abort
 [11] sequence req11: pusher aborted pushee
 [11] sequence req11: resolving intent ‹"kNormal2"› for txn 00000002 with ABORTED status
-[11] sequence req11: lock wait-queue event: wait for (distinguished) txn 00000007 running request @ key ‹"kNormal2"› (queuedLockingRequests: 2, queuedReaders: 0)
+[11] sequence req11: lock wait-queue event: wait for txn 00000007 running request @ key ‹"kNormal2"› (queuedLockingRequests: 2, queuedReaders: 0)
 [11] sequence req11: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kNormal2"› for 0.000s
 [11] sequence req11: pushing after 0s for: deadlock/liveness detection = false, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [11] sequence req11: pushing txn 00000007 to detect request deadlock
@@ -429,7 +429,7 @@ sequence req=req12
 [12] sequence req12: acquiring latches
 [12] sequence req12: scanning lock table for conflicting locks
 [12] sequence req12: waiting in lock wait-queues
-[12] sequence req12: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"kHigh1"› (queuedLockingRequests: 0, queuedReaders: 1)
+[12] sequence req12: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"kHigh1"› (queuedLockingRequests: 0, queuedReaders: 1)
 [12] sequence req12: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [12] sequence req12: pushing timestamp of txn 00000003 above 10.000000000,1
 [12] sequence req12: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -501,7 +501,7 @@ sequence req=req14
 [14] sequence req14: acquiring latches
 [14] sequence req14: scanning lock table for conflicting locks
 [14] sequence req14: waiting in lock wait-queues
-[14] sequence req14: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"kHigh2"› (queuedLockingRequests: 1, queuedReaders: 0)
+[14] sequence req14: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"kHigh2"› (queuedLockingRequests: 1, queuedReaders: 0)
 [14] sequence req14: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [14] sequence req14: pushing txn 00000003 to abort
 [14] sequence req14: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -527,7 +527,7 @@ on-txn-updated txn=txnHighPushee status=committed
 [14] sequence req14: scanning lock table for conflicting locks
 [14] sequence req14: sequencing complete, returned guard
 [15] sequence req15: resolving intent ‹"kHigh2"› for txn 00000003 with COMMITTED status
-[15] sequence req15: lock wait-queue event: wait for (distinguished) txn 00000008 running request @ key ‹"kHigh2"› (queuedLockingRequests: 2, queuedReaders: 0)
+[15] sequence req15: lock wait-queue event: wait for txn 00000008 running request @ key ‹"kHigh2"› (queuedLockingRequests: 2, queuedReaders: 0)
 [15] sequence req15: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kHigh2"› for 0.000s
 [15] sequence req15: pushing after 0s for: deadlock/liveness detection = false, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [15] sequence req15: pushing txn 00000008 to detect request deadlock

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
@@ -50,7 +50,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[2] sequence req2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [2] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [2] sequence req2: pushing txn 00000001 to abort
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -94,7 +94,6 @@ num=1
     active: true req: 2, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
     active: true req: 4, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
-   distinguished req: 2
 
 # -------------------------------------------------------------
 # Read-only request runs into long lock wait-queue. Waits for
@@ -127,7 +126,7 @@ on-txn-updated txn=txn1 status=committed
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
 [3] sequence req3: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 running request @ key ‹"k"› (queuedLockingRequests: 3, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for txn 00000002 running request @ key ‹"k"› (queuedLockingRequests: 3, queuedReaders: 0)
 [3] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000002 to detect request deadlock
@@ -152,7 +151,7 @@ finish req=req5r
 on-lock-acquired req=req2 key=k
 ----
 [-] acquire lock: txn 00000002 @ ‹k›
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k"› (queuedLockingRequests: 2, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k"› (queuedLockingRequests: 2, queuedReaders: 0)
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -173,7 +172,6 @@ num=1
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
     active: true req: 4, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
-   distinguished req: 3
 
 # -------------------------------------------------------------
 # Read-write request runs into long lock wait-queue. Instead of
@@ -207,7 +205,7 @@ on-txn-updated txn=txn2 status=aborted
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: sequencing complete, returned guard
 [4] sequence req4: resolving intent ‹"k"› for txn 00000002 with ABORTED status
-[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"k"› (queuedLockingRequests: 2, queuedReaders: 0)
+[4] sequence req4: lock wait-queue event: wait for txn 00000003 running request @ key ‹"k"› (queuedLockingRequests: 2, queuedReaders: 0)
 [4] sequence req4: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [4] sequence req4: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4: pushing txn 00000003 to detect request deadlock

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -93,7 +93,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[2] sequence req2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [2] sequence req2: pushing after 1h0m0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -104,7 +104,6 @@ num=2
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 2
  lock: "k2"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -174,7 +173,7 @@ sequence req=req2
 [7] sequence req2: acquiring latches
 [7] sequence req2: scanning lock table for conflicting locks
 [7] sequence req2: waiting in lock wait-queues
-[7] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[7] sequence req2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [7] sequence req2: pushing after 1h0m0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [7] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -289,7 +288,7 @@ sequence req=req3
 [13] sequence req3: acquiring latches
 [13] sequence req3: scanning lock table for conflicting locks
 [13] sequence req3: waiting in lock wait-queues
-[13] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[13] sequence req3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [13] sequence req3: pushing after 1h0m0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [13] sequence req3: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -402,7 +401,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[2] sequence req2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [2] sequence req2: pushing after 1h0m0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -413,7 +412,6 @@ num=1
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 6
 
 on-split
 ----
@@ -447,7 +445,7 @@ sequence req=req2
 [4] sequence req2: acquiring latches
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: waiting in lock wait-queues
-[4] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req2: pushing after 1h0m0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -574,7 +572,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[2] sequence req2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [2] sequence req2: pushing after 1h0m0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -592,7 +590,6 @@ num=1
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 8, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 8
 
 on-merge
 ----
@@ -667,7 +664,7 @@ sequence req=req2
 [8] sequence req2: acquiring latches
 [8] sequence req2: scanning lock table for conflicting locks
 [8] sequence req2: waiting in lock wait-queues
-[8] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[8] sequence req2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [8] sequence req2: pushing after 1h0m0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [8] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -780,7 +777,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[2] sequence req2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [2] sequence req2: pushing after 1h0m0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [2] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -791,7 +788,6 @@ num=1
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 12, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 12
 
 on-snapshot-applied
 ----
@@ -825,7 +821,7 @@ sequence req=req2
 [4] sequence req2: acquiring latches
 [4] sequence req2: scanning lock table for conflicting locks
 [4] sequence req2: waiting in lock wait-queues
-[4] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req2: pushing after 1h0m0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/refresh
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/refresh
@@ -42,7 +42,7 @@ sequence req=reqNormalPriNoWait
 [2] sequence reqNormalPriNoWait: acquiring latches
 [2] sequence reqNormalPriNoWait: scanning lock table for conflicting locks
 [2] sequence reqNormalPriNoWait: waiting in lock wait-queues
-[2] sequence reqNormalPriNoWait: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[2] sequence reqNormalPriNoWait: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [2] sequence reqNormalPriNoWait: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = true
 [2] sequence reqNormalPriNoWait: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence reqNormalPriNoWait: pushee not abandoned
@@ -71,7 +71,7 @@ sequence req=reqHighPriNoWait
 [3] sequence reqHighPriNoWait: acquiring latches
 [3] sequence reqHighPriNoWait: scanning lock table for conflicting locks
 [3] sequence reqHighPriNoWait: waiting in lock wait-queues
-[3] sequence reqHighPriNoWait: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence reqHighPriNoWait: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence reqHighPriNoWait: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = true
 [3] sequence reqHighPriNoWait: pushing timestamp of txn 00000001 above 11.000000000,1
 [3] sequence reqHighPriNoWait: pusher pushed pushee to 11.000000000,2

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/replicated
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/replicated
@@ -95,7 +95,7 @@ sequence req=req3
 [5] sequence req3: acquiring latches
 [5] sequence req3: scanning lock table for conflicting locks
 [5] sequence req3: waiting in lock wait-queues
-[5] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[5] sequence req3: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [5] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req3: pushing txn 00000001 to abort
 [5] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -104,7 +104,7 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [5] sequence req3: resolving intent ‹"a"› for txn 00000001 with ABORTED status
-[5] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[5] sequence req3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [5] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [5] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req3: pushing txn 00000002 to abort
@@ -187,7 +187,7 @@ sequence req=req5
 [4] sequence req5: acquiring latches
 [4] sequence req5: scanning lock table for conflicting locks
 [4] sequence req5: waiting in lock wait-queues
-[4] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req5: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req5: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req5: pushing txn 00000003 to abort
 [4] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -216,7 +216,6 @@ num=1
    queued locking requests:
     active: true req: 5, strength: Shared, txn: 00000004-0000-0000-0000-000000000000
     active: true req: 6, strength: Shared, txn: 00000005-0000-0000-0000-000000000000
-   distinguished req: 5
 
 # Abort the exclusive lock holder; both the shared locking requests should be
 # able to proceed.

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
@@ -75,7 +75,7 @@ sequence req=req2
 [3] sequence req2: acquiring latches
 [3] sequence req2: scanning lock table for conflicting locks
 [3] sequence req2: waiting in lock wait-queues
-[3] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req2: pushing txn 00000002 to abort
 [3] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -92,7 +92,7 @@ sequence req=req1
 [4] sequence req1: acquiring latches
 [4] sequence req1: scanning lock table for conflicting locks
 [4] sequence req1: waiting in lock wait-queues
-[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: pusher pushed pushee to 10.000000000,2
@@ -137,7 +137,7 @@ sequence req=req2
 [6] sequence req2: acquiring latches
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: waiting in lock wait-queues
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req2: pushing txn 00000002 to abort
 [6] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -238,7 +238,7 @@ sequence req=req1
 [4] sequence req1: acquiring latches
 [4] sequence req1: scanning lock table for conflicting locks
 [4] sequence req1: waiting in lock wait-queues
-[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: pusher pushed pushee to 10.000000000,2
@@ -312,17 +312,17 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 11.000000000,1
 [3] sequence req1: pusher pushed pushee to 11.000000000,2
 [3] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,7}
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 11.000000000,1
 [3] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,9}
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 11.000000000,1
@@ -425,7 +425,7 @@ sequence req=req2
 [3] sequence req2: acquiring latches
 [3] sequence req2: scanning lock table for conflicting locks
 [3] sequence req2: waiting in lock wait-queues
-[3] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req2: pushing txn 00000002 to abort
 [3] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -442,12 +442,12 @@ sequence req=req1
 [4] sequence req1: acquiring latches
 [4] sequence req1: scanning lock table for conflicting locks
 [4] sequence req1: waiting in lock wait-queues
-[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: pusher pushed pushee to 10.000000000,2
 [4] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,14}
-[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
@@ -457,37 +457,37 @@ sequence req=req1
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"c"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,18}
-[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"d"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"d"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"d"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,20}
-[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"e"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"e"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"d"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"e"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,22}
-[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"f"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"f"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"e"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"f"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,24}
-[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"g"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"g"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"f"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"g"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,26}
-[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"h"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"h"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"g"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"h"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,28}
-[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"i"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"i"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"h"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"i"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,30}
-[4] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"j"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"j"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"i"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
@@ -522,7 +522,7 @@ sequence req=req2
 [6] sequence req2: acquiring latches
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: waiting in lock wait-queues
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req2: pushing txn 00000002 to abort
 [6] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
@@ -42,7 +42,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [3] sequence req1: pusher pushed pushee to 10.000000000,2
@@ -154,7 +154,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 11.000000000,1
 [3] sequence req1: pusher pushed pushee to 11.000000000,2
@@ -226,46 +226,46 @@ sequence req=req2
 [6] sequence req2: acquiring latches
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: waiting in lock wait-queues
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,5}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"c"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,7}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"d"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"d"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"d"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,9}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"e"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"e"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"d"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"e"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,11}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"f"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"f"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"e"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"f"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,13}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"g"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"g"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"f"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"g"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,15}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"h"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"h"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"g"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"h"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,17}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"i"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"i"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"h"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"i"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,19}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"j"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"j"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"i"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
@@ -325,7 +325,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [3] sequence req1: pusher pushed pushee to 10.000000000,2
@@ -397,46 +397,46 @@ sequence req=req2
 [6] sequence req2: acquiring latches
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: waiting in lock wait-queues
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,25}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"c"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,27}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"d"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"d"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"d"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,29}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"e"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"e"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"d"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"e"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,31}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"f"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"f"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"e"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"f"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,33}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"g"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"g"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"f"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"g"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,35}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"h"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"h"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"g"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"h"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,37}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"i"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"i"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"h"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"i"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,39}
-[6] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"j"› (queuedLockingRequests: 0, queuedReaders: 1)
+[6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"j"› (queuedLockingRequests: 0, queuedReaders: 1)
 [6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"i"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks
@@ -124,7 +124,7 @@ sequence req=req5
 [5] sequence req5: acquiring latches
 [5] sequence req5: scanning lock table for conflicting locks
 [5] sequence req5: waiting in lock wait-queues
-[5] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[5] sequence req5: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [5] sequence req5: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req5: pushing txn 00000001 to abort
 [5] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -135,7 +135,7 @@ on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
 [5] sequence req5: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
-[5] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[5] sequence req5: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [5] sequence req5: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [5] sequence req5: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req5: pushing txn 00000002 to abort
@@ -147,7 +147,7 @@ on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
 [5] sequence req5: resolving intent ‹"a"› for txn 00000002 with ABORTED status
-[5] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[5] sequence req5: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [5] sequence req5: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [5] sequence req5: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req5: pushing txn 00000003 to abort
@@ -168,14 +168,13 @@ num=1
            txn: 00000004-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 5, strength: Exclusive, txn: 00000005-0000-0000-0000-000000000000
-   distinguished req: 5
 
 # Unlock the key entirely, ensure req5 can proceed.
 on-txn-updated txn=txn3 status=committed
 ----
 [-] update txn: committing txn3
 [5] sequence req5: resolving intent ‹"a"› for txn 00000003 with COMMITTED status
-[5] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000004 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[5] sequence req5: lock wait-queue event: wait for txn 00000004 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [5] sequence req5: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [5] sequence req5: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req5: pushing txn 00000004 to abort
@@ -272,7 +271,7 @@ sequence req=req8
 [10] sequence req8: acquiring latches
 [10] sequence req8: scanning lock table for conflicting locks
 [10] sequence req8: waiting in lock wait-queues
-[10] sequence req8: lock wait-queue event: wait for (distinguished) txn 00000006 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
+[10] sequence req8: lock wait-queue event: wait for txn 00000006 holding lock @ key ‹"a"› (queuedLockingRequests: 0, queuedReaders: 1)
 [10] sequence req8: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [10] sequence req8: pushing timestamp of txn 00000006 above 11.000000000,1
 [10] sequence req8: pusher pushed pushee to 11.000000000,2
@@ -325,7 +324,7 @@ sequence req=req9
 [13] sequence req9: acquiring latches
 [13] sequence req9: scanning lock table for conflicting locks
 [13] sequence req9: waiting in lock wait-queues
-[13] sequence req9: lock wait-queue event: wait for (distinguished) txn 00000006 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[13] sequence req9: lock wait-queue event: wait for txn 00000006 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [13] sequence req9: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [13] sequence req9: pushing txn 00000006 to abort
 [13] sequence req9: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -337,7 +336,6 @@ num=1
   holder: txn: 00000006-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 9, strength: Shared, txn: 00000008-0000-0000-0000-000000000000
-   distinguished req: 9
 
 # Note that txn7 is read-committed, so it can push the timestamp of intents as
 # if it was high priority.
@@ -497,7 +495,7 @@ sequence req=req16
 [6] sequence req16: acquiring latches
 [6] sequence req16: scanning lock table for conflicting locks
 [6] sequence req16: waiting in lock wait-queues
-[6] sequence req16: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[6] sequence req16: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [6] sequence req16: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req16: pushing txn 00000001 to abort
 [6] sequence req16: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -522,7 +520,6 @@ num=1
    queued locking requests:
     active: true req: 16, strength: Exclusive, txn: 00000003-0000-0000-0000-000000000000
     active: true req: 17, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
-   distinguished req: 16
 
 # Now, test non-transactional write requests. Note that we test these last
 # because non-transactional requests race with conflicting requests, which means
@@ -554,14 +551,13 @@ num=1
     active: true req: 16, strength: Exclusive, txn: 00000003-0000-0000-0000-000000000000
     active: true req: 17, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
     active: true req: 18, strength: Intent, txn: none
-   distinguished req: 16
 
 # Cleanup by releasing the shared locks and finishing the waiting requests.
 on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [6] sequence req16: resolving intent ‹"a"› for txn 00000001 with ABORTED status
-[6] sequence req16: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 3, queuedReaders: 0)
+[6] sequence req16: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 3, queuedReaders: 0)
 [6] sequence req16: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [6] sequence req16: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req16: pushing txn 00000002 to abort
@@ -589,7 +585,7 @@ on-txn-updated txn=txn2 status=aborted
 [6] sequence req16: scanning lock table for conflicting locks
 [6] sequence req16: sequencing complete, returned guard
 [7] sequence req17: resolving intent ‹"a"› for txn 00000002 with ABORTED status
-[7] sequence req17: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"a"› (queuedLockingRequests: 3, queuedReaders: 0)
+[7] sequence req17: lock wait-queue event: wait for txn 00000003 running request @ key ‹"a"› (queuedLockingRequests: 3, queuedReaders: 0)
 [7] sequence req17: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [7] sequence req17: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [7] sequence req17: pushing txn 00000003 to detect request deadlock
@@ -608,7 +604,7 @@ finish req=req16
 [7] sequence req17: acquiring latches
 [7] sequence req17: scanning lock table for conflicting locks
 [7] sequence req17: sequencing complete, returned guard
-[8] sequence req18: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
+[8] sequence req18: lock wait-queue event: wait for txn 00000004 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
 [8] sequence req18: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [8] sequence req18: not pushing
 [8] sequence req18: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
@@ -664,7 +660,7 @@ sequence req=req20
 [2] sequence req20: acquiring latches
 [2] sequence req20: scanning lock table for conflicting locks
 [2] sequence req20: waiting in lock wait-queues
-[2] sequence req20: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[2] sequence req20: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [2] sequence req20: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [2] sequence req20: pushing txn 00000001 to abort
 [2] sequence req20: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -740,7 +736,6 @@ num=1
     active: true req: 22, strength: Shared, txn: none
     active: true req: 23, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
     active: true req: 24, strength: Shared, txn: 00000005-0000-0000-0000-000000000000
-   distinguished req: 20
 
 on-txn-updated txn=txn1 status=committed
 ----
@@ -764,7 +759,7 @@ on-txn-updated txn=txn1 status=committed
 [4] sequence req22: scanning lock table for conflicting locks
 [4] sequence req22: sequencing complete, returned guard
 [5] sequence req23: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
-[5] sequence req23: lock wait-queue event: wait for (distinguished) txn 00000002 running request @ key ‹"a"› (queuedLockingRequests: 5, queuedReaders: 0)
+[5] sequence req23: lock wait-queue event: wait for txn 00000002 running request @ key ‹"a"› (queuedLockingRequests: 5, queuedReaders: 0)
 [5] sequence req23: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [5] sequence req23: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req23: pushing txn 00000002 to detect request deadlock
@@ -790,12 +785,11 @@ num=1
     active: false req: 21, strength: Shared, txn: 00000003-0000-0000-0000-000000000000
     active: true req: 23, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
     active: true req: 24, strength: Shared, txn: 00000005-0000-0000-0000-000000000000
-   distinguished req: 23
 
 finish req=req20
 ----
 [-] finish req20: finishing request
-[5] sequence req23: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"a"› (queuedLockingRequests: 3, queuedReaders: 0)
+[5] sequence req23: lock wait-queue event: wait for txn 00000003 running request @ key ‹"a"› (queuedLockingRequests: 3, queuedReaders: 0)
 [5] sequence req23: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [5] sequence req23: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req23: pushing txn 00000003 to detect request deadlock
@@ -820,7 +814,6 @@ num=1
     active: false req: 21, strength: Shared, txn: 00000003-0000-0000-0000-000000000000
     active: true req: 23, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
     active: true req: 24, strength: Shared, txn: 00000005-0000-0000-0000-000000000000
-   distinguished req: 23
 
 finish req=req21
 ----
@@ -830,7 +823,7 @@ finish req=req21
 [5] sequence req23: acquiring latches
 [5] sequence req23: scanning lock table for conflicting locks
 [5] sequence req23: sequencing complete, returned guard
-[6] sequence req24: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
+[6] sequence req24: lock wait-queue event: wait for txn 00000004 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
 [6] sequence req24: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [6] sequence req24: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req24: pushing txn 00000004 to detect request deadlock
@@ -843,7 +836,6 @@ num=1
    queued locking requests:
     active: false req: 23, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
     active: true req: 24, strength: Shared, txn: 00000005-0000-0000-0000-000000000000
-   distinguished req: 24
 
 finish req=req23
 ----
@@ -897,7 +889,7 @@ sequence req=req26
 [2] sequence req26: acquiring latches
 [2] sequence req26: scanning lock table for conflicting locks
 [2] sequence req26: waiting in lock wait-queues
-[2] sequence req26: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[2] sequence req26: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [2] sequence req26: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [2] sequence req26: pushing txn 00000001 to abort
 [2] sequence req26: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -927,7 +919,6 @@ num=1
    queued locking requests:
     active: true req: 26, strength: Exclusive, txn: 00000002-0000-0000-0000-000000000000
     active: true req: 27, strength: Shared, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 26
 
 on-txn-updated txn=txn1 status=aborted
 ----
@@ -939,7 +930,7 @@ on-txn-updated txn=txn1 status=aborted
 [2] sequence req26: scanning lock table for conflicting locks
 [2] sequence req26: sequencing complete, returned guard
 [3] sequence req27: resolving intent ‹"a"› for txn 00000001 with ABORTED status
-[3] sequence req27: lock wait-queue event: wait for (distinguished) txn 00000002 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
+[3] sequence req27: lock wait-queue event: wait for txn 00000002 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
 [3] sequence req27: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [3] sequence req27: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req27: pushing txn 00000002 to detect request deadlock
@@ -1015,7 +1006,7 @@ sequence req=req30
 [3] sequence req30: acquiring latches
 [3] sequence req30: scanning lock table for conflicting locks
 [3] sequence req30: waiting in lock wait-queues
-[3] sequence req30: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req30: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req30: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req30: pushing txn 00000002 to abort
 [3] sequence req30: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1031,7 +1022,7 @@ sequence req=req31
 [4] sequence req31: acquiring latches
 [4] sequence req31: scanning lock table for conflicting locks
 [4] sequence req31: waiting in lock wait-queues
-[4] sequence req31: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req31: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req31: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req31: pushing txn 00000001 to abort
 [4] sequence req31: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1044,12 +1035,10 @@ num=2
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 31, strength: Exclusive, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 31
  lock: "b"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 30, strength: Exclusive, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 30
 
 # Break the deadlock by aborting txn1.
 on-txn-updated txn=txn1 status=aborted
@@ -1131,7 +1120,7 @@ sequence req=req3
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: waiting in lock wait-queues
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1147,7 +1136,7 @@ sequence req=req4
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: waiting in lock wait-queues
-[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req4: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req4: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4: pushing txn 00000001 to abort
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1160,12 +1149,10 @@ num=2
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 35, strength: Shared, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 35
  lock: "b"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 34, strength: Shared, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 34
 
 # Break the deadlock by aborting txn1.
 on-txn-updated txn=txn1 status=aborted
@@ -1278,7 +1265,7 @@ sequence req=req4
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: waiting in lock wait-queues
-[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req4: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"b"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req4: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4: pushing txn 00000003 to abort
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1293,7 +1280,6 @@ num=2
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 39, strength: Shared, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 39
 
 # Setup complete.
 
@@ -1307,7 +1293,7 @@ sequence req=req5
 [5] sequence req5: acquiring latches
 [5] sequence req5: scanning lock table for conflicting locks
 [5] sequence req5: waiting in lock wait-queues
-[5] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[5] sequence req5: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [5] sequence req5: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req5: pushing txn 00000001 to abort
 [5] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1317,7 +1303,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [4] sequence req4: dependency cycle detected 00000002->00000003->00000002
 [5] sequence req5: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
-[5] sequence req5: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
+[5] sequence req5: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
 [5] sequence req5: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
 [5] sequence req5: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req5: pushing txn 00000002 to abort

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -39,7 +39,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -105,7 +105,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 135.000000000,0
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -180,7 +180,7 @@ sequence req=req1
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: waiting in lock wait-queues
-[3] sequence req1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[3] sequence req1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000001 above 15.000000000,1
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
@@ -49,7 +49,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[2] sequence req2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [2] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [2] sequence req2: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -61,7 +61,6 @@ num=1
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 2, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 2
 
 # --------------------------------
 # Setup complete, test starts here
@@ -168,7 +167,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[2] sequence req2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [2] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [2] sequence req2: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -180,7 +179,6 @@ num=1
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 5, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 5
 
 # --------------------------------
 # Setup complete, test starts here
@@ -296,7 +294,7 @@ sequence req=req2
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: waiting in lock wait-queues
-[2] sequence req2: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[2] sequence req2: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [2] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [2] sequence req2: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -308,7 +306,6 @@ num=1
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 8, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 8
 
 # --------------------------------
 # Setup complete, test starts here
@@ -353,7 +350,7 @@ sequence req=req4
 [3] sequence req4: acquiring latches
 [3] sequence req4: scanning lock table for conflicting locks
 [3] sequence req4: waiting in lock wait-queues
-[3] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req4: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req4: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req4: pushing txn 00000001 to abort
 [3] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -384,7 +381,6 @@ num=1
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 9, strength: Intent, txn: none
-   distinguished req: 9
 
 # Finish off txn1. Not needed once we can get rid of req4.
 on-txn-updated txn=txn1 status=committed

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
@@ -60,7 +60,7 @@ sequence req=reqWaiter
 [4] sequence reqWaiter: acquiring latches
 [4] sequence reqWaiter: scanning lock table for conflicting locks
 [4] sequence reqWaiter: waiting in lock wait-queues
-[4] sequence reqWaiter: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence reqWaiter: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence reqWaiter: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence reqWaiter: pushing txn 00000001 to abort
 [4] sequence reqWaiter: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -72,7 +72,6 @@ num=1
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 2
 
 sequence req=reqSecondLock
 ----
@@ -202,7 +201,7 @@ sequence req=reqTwoKeyWaiter
 [10] sequence reqTwoKeyWaiter: acquiring latches
 [10] sequence reqTwoKeyWaiter: scanning lock table for conflicting locks
 [10] sequence reqTwoKeyWaiter: waiting in lock wait-queues
-[10] sequence reqTwoKeyWaiter: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"k1"› (queuedLockingRequests: 0, queuedReaders: 1)
+[10] sequence reqTwoKeyWaiter: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"k1"› (queuedLockingRequests: 0, queuedReaders: 1)
 [10] sequence reqTwoKeyWaiter: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [10] sequence reqTwoKeyWaiter: pushing timestamp of txn 00000003 above 20.000000000,1
 [10] sequence reqTwoKeyWaiter: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -214,7 +213,6 @@ num=2
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 5, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 5
  lock: "k2"
   holder: txn: 00000003-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
 
@@ -246,7 +244,6 @@ num=1
    waiting readers:
     req: 6, txn: 00000002-0000-0000-0000-000000000000
     req: 5, txn: 00000002-0000-0000-0000-000000000000
-   distinguished req: 5
 
 # Before #99635 was fixed, reqTwoKeyWaiter would move on to waiting on key k2
 # and get stuck in lockTableWaiterImpl.WaitOn. Even after it resolved the intent

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -70,7 +70,7 @@ sequence req=req3
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: waiting in lock wait-queues
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k2"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k2"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000001 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -84,7 +84,6 @@ num=3
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 3
  lock: "k3"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -103,7 +102,7 @@ sequence req=reqNoWait1
 [4] sequence reqNoWait1: acquiring latches
 [4] sequence reqNoWait1: scanning lock table for conflicting locks
 [4] sequence reqNoWait1: waiting in lock wait-queues
-[4] sequence reqNoWait1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence reqNoWait1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence reqNoWait1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = true
 [4] sequence reqNoWait1: pushing timestamp of txn 00000001 above 12.000000000,1
 [4] sequence reqNoWait1: pushee not abandoned
@@ -122,7 +121,7 @@ on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
 [3] sequence req3: resolving intent ‹"k2"› for txn 00000001 with COMMITTED status
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k3"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k3"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k2"› for 123.000s
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000002 to abort
@@ -149,7 +148,6 @@ num=2
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 3
 
 # -------------------------------------------------------------
 # Read-write request with WaitPolicy_Error hits reservation
@@ -167,7 +165,7 @@ sequence req=reqNoWait2
 [6] sequence reqNoWait2: acquiring latches
 [6] sequence reqNoWait2: scanning lock table for conflicting locks
 [6] sequence reqNoWait2: waiting in lock wait-queues
-[6] sequence reqNoWait2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"k2"› (queuedLockingRequests: 2, queuedReaders: 0)
+[6] sequence reqNoWait2: lock wait-queue event: wait for txn 00000003 running request @ key ‹"k2"› (queuedLockingRequests: 2, queuedReaders: 0)
 [6] sequence reqNoWait2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = true
 [6] sequence reqNoWait2: pushing txn 00000003 to abort
 [6] sequence reqNoWait2: pushee not abandoned
@@ -201,7 +199,7 @@ sequence req=reqNoWait3
 [9] sequence reqNoWait3: acquiring latches
 [9] sequence reqNoWait3: scanning lock table for conflicting locks
 [9] sequence reqNoWait3: waiting in lock wait-queues
-[9] sequence reqNoWait3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k4"› (queuedLockingRequests: 0, queuedReaders: 1)
+[9] sequence reqNoWait3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k4"› (queuedLockingRequests: 0, queuedReaders: 1)
 [9] sequence reqNoWait3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = true
 [9] sequence reqNoWait3: pushing timestamp of txn 00000002 above 12.000000000,1
 [9] sequence reqNoWait3: pushee not abandoned
@@ -218,7 +216,6 @@ num=3
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 3
  lock: "k4"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error_v23_1
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error_v23_1
@@ -70,7 +70,7 @@ sequence req=req3
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: waiting in lock wait-queues
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k2"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k2"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000001 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -84,7 +84,6 @@ num=3
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 3
  lock: "k3"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -103,7 +102,7 @@ sequence req=reqNoWait1
 [4] sequence reqNoWait1: acquiring latches
 [4] sequence reqNoWait1: scanning lock table for conflicting locks
 [4] sequence reqNoWait1: waiting in lock wait-queues
-[4] sequence reqNoWait1: lock wait-queue event: wait for (distinguished) txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
+[4] sequence reqNoWait1: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k"› (queuedLockingRequests: 0, queuedReaders: 1)
 [4] sequence reqNoWait1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = true
 [4] sequence reqNoWait1: pushing txn 00000001 to check if abandoned
 [4] sequence reqNoWait1: pushee not abandoned
@@ -122,7 +121,7 @@ on-txn-updated txn=txn1 status=committed
 ----
 [-] update txn: committing txn1
 [3] sequence req3: resolving intent ‹"k2"› for txn 00000001 with COMMITTED status
-[3] sequence req3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k3"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k3"› (queuedLockingRequests: 1, queuedReaders: 0)
 [3] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k2"› for 123.000s
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000002 to abort
@@ -149,7 +148,6 @@ num=2
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 3
 
 # -------------------------------------------------------------
 # Read-write request with WaitPolicy_Error hits reservation
@@ -167,7 +165,7 @@ sequence req=reqNoWait2
 [6] sequence reqNoWait2: acquiring latches
 [6] sequence reqNoWait2: scanning lock table for conflicting locks
 [6] sequence reqNoWait2: waiting in lock wait-queues
-[6] sequence reqNoWait2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"k2"› (queuedLockingRequests: 2, queuedReaders: 0)
+[6] sequence reqNoWait2: lock wait-queue event: wait for txn 00000003 running request @ key ‹"k2"› (queuedLockingRequests: 2, queuedReaders: 0)
 [6] sequence reqNoWait2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = true
 [6] sequence reqNoWait2: pushing txn 00000003 to check if abandoned
 [6] sequence reqNoWait2: pushee not abandoned
@@ -201,7 +199,7 @@ sequence req=reqNoWait3
 [9] sequence reqNoWait3: acquiring latches
 [9] sequence reqNoWait3: scanning lock table for conflicting locks
 [9] sequence reqNoWait3: waiting in lock wait-queues
-[9] sequence reqNoWait3: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k4"› (queuedLockingRequests: 0, queuedReaders: 1)
+[9] sequence reqNoWait3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k4"› (queuedLockingRequests: 0, queuedReaders: 1)
 [9] sequence reqNoWait3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = true
 [9] sequence reqNoWait3: pushing txn 00000002 to check if abandoned
 [9] sequence reqNoWait3: pushee not abandoned
@@ -218,7 +216,6 @@ num=3
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
-   distinguished req: 3
  lock: "k4"
   holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
@@ -88,7 +88,7 @@ sequence req=req4
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: waiting in lock wait-queues
-[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key ‹"k4"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req4: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"k4"› (queuedLockingRequests: 1, queuedReaders: 0)
 [4] sequence req4: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4: pushing txn 00000003 to abort
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
@@ -47,7 +47,7 @@ sequence req=reqTxn1
 [2] sequence reqTxn1: acquiring latches
 [2] sequence reqTxn1: scanning lock table for conflicting locks
 [2] sequence reqTxn1: waiting in lock wait-queues
-[2] sequence reqTxn1: lock wait-queue event: wait for (distinguished) txn 00000002 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
+[2] sequence reqTxn1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k"› (queuedLockingRequests: 1, queuedReaders: 0)
 [2] sequence reqTxn1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [2] sequence reqTxn1: pushing txn 00000002 to abort
 [2] sequence reqTxn1: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -87,7 +87,7 @@ on-txn-updated txn=txnOld status=committed
 [2] sequence reqTxn1: scanning lock table for conflicting locks
 [2] sequence reqTxn1: sequencing complete, returned guard
 [3] sequence reqTxnMiddle: resolving intent ‹"k"› for txn 00000002 with COMMITTED status
-[3] sequence reqTxnMiddle: lock wait-queue event: wait for (distinguished) txn 00000001 running request @ key ‹"k"› (queuedLockingRequests: 3, queuedReaders: 0)
+[3] sequence reqTxnMiddle: lock wait-queue event: wait for txn 00000001 running request @ key ‹"k"› (queuedLockingRequests: 3, queuedReaders: 0)
 [3] sequence reqTxnMiddle: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
 [3] sequence reqTxnMiddle: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence reqTxnMiddle: pushing txn 00000001 to detect request deadlock
@@ -105,7 +105,6 @@ num=1
     active: false req: 2, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
     active: true req: 3, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
     active: true req: 4, strength: Intent, txn: 00000001-0000-0000-0000-000000000000
-   distinguished req: 3
 
 
 # This is the interesting step - we see reqTxn2 announce that it conflicted with
@@ -121,7 +120,7 @@ finish req=reqTxn1
 [3] sequence reqTxnMiddle: acquiring latches
 [3] sequence reqTxnMiddle: scanning lock table for conflicting locks
 [3] sequence reqTxnMiddle: sequencing complete, returned guard
-[4] sequence reqTxn2: lock wait-queue event: wait for (distinguished) txn 00000003 running request @ key ‹"k"› (queuedLockingRequests: 2, queuedReaders: 0)
+[4] sequence reqTxn2: lock wait-queue event: wait for txn 00000003 running request @ key ‹"k"› (queuedLockingRequests: 2, queuedReaders: 0)
 [4] sequence reqTxn2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [4] sequence reqTxn2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence reqTxn2: pushing txn 00000003 to detect request deadlock

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
@@ -118,7 +118,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 1)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 3
 
 # However, unreplicated lock acquisition with the same ignored sequence number
 # (8) will result in the list of sequence numbers getting pruned.
@@ -132,7 +131,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 1)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 3
 
 # ------------------------------------------------------------------------------
 # Ensure ignoring a range of sequence numbers works as expected.
@@ -151,7 +149,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 11)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 3
 
 # ------------------------------------------------------------------------------
 # Ensure acquiring a replicated lock at a higher epoch than the one with which
@@ -173,4 +170,3 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 3

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/add_discovered
@@ -71,7 +71,6 @@ num=1
    queued locking requests:
     active: false req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 3
 
 # When uncontented=false one or more active waiters marks the lock as contented.
 query span=a,c
@@ -89,7 +88,7 @@ new: state=doneWaiting
 
 guard-state r=req3
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=false guard-strength=Intent
+new: state=waitFor txn=txn2 key="a" held=false guard-strength=Intent
 
 # --------------------------------
 # Setup complete, test starts here
@@ -109,7 +108,7 @@ start-waiting: true
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn3 key="a" held=true guard-strength=Intent
+new: state=waitFor txn=txn3 key="a" held=true guard-strength=Intent
 
 guard-state r=req3
 ----
@@ -122,7 +121,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 2
 
 release txn=txn3 span=a
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/basic
@@ -122,7 +122,7 @@ start-waiting: true
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Exclusive
+new: state=waitFor txn=txn1 key="b" held=true guard-strength=Exclusive
 
 # 3s passes while req4 is waiting on locks on b,c
 time-tick s=3
@@ -145,7 +145,7 @@ num=3
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn1 key="c" held=true guard-strength=Exclusive
+new: state=waitFor txn=txn1 key="c" held=true guard-strength=Exclusive
 
 # 1s passes while req4 continues to wait on c (and only has reservation on b)
 time-tick s=1
@@ -247,7 +247,7 @@ time-tick s=2
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn3 key="a" held=true guard-strength=Exclusive
+new: state=waitFor txn=txn3 key="a" held=true guard-strength=Exclusive
 
 print
 ----
@@ -256,7 +256,6 @@ num=5
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
    queued locking requests:
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
  lock: "b"
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
@@ -393,7 +392,6 @@ num=5
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
    queued locking requests:
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
  lock: "b"
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
@@ -441,12 +439,10 @@ num=5
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
    queued locking requests:
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
  lock: "b"
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 6
  lock: "c"
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
@@ -552,7 +548,7 @@ topklocksbywaitduration:
 
 guard-state r=req6
 ----
-new: state=waitForDistinguished txn=txn2 key="b" held=false guard-strength=Intent
+new: state=waitFor txn=txn2 key="b" held=false guard-strength=Intent
 
 # 250ms passes between req6 and req7
 time-tick ms=250
@@ -586,7 +582,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn2 key="c" held=false guard-strength=Intent
+new: state=waitFor txn=txn2 key="c" held=false guard-strength=Intent
 
 print
 ----
@@ -595,17 +591,14 @@ num=5
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
    queued locking requests:
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
  lock: "b"
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 6
  lock: "c"
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
@@ -739,12 +732,10 @@ num=5
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 6
  lock: "c"
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
@@ -752,11 +743,11 @@ num=5
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn3 key="f" held=true guard-strength=None
+new: state=waitFor txn=txn3 key="f" held=true guard-strength=None
 
 guard-state r=req6
 ----
-old: state=waitForDistinguished txn=txn2 key="b" held=false guard-strength=Intent
+old: state=waitFor txn=txn2 key="b" held=false guard-strength=Intent
 
 print
 ----
@@ -768,19 +759,16 @@ num=5
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 6
  lock: "c"
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "f"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 6.000000000,0, info: repl [Intent]
    waiting readers:
     req: 4, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
 
 metrics
 ----
@@ -910,12 +898,10 @@ num=4
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 6
  lock: "c"
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -953,12 +939,10 @@ num=4
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 6
  lock: "c"
    queued locking requests:
     active: false req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -972,22 +956,20 @@ num=4
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 6
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 
 guard-state r=req6
 ----
-new: state=waitForDistinguished txn=txn2 key="b" held=true guard-strength=Intent
+new: state=waitFor txn=txn2 key="b" held=true guard-strength=Intent
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn2 key="c" held=true guard-strength=Intent
+new: state=waitFor txn=txn2 key="c" held=true guard-strength=Intent
 
 print
 ----
@@ -999,12 +981,10 @@ num=4
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 6
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -1110,12 +1090,10 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 6
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 7
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -1146,7 +1124,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 6
  lock: "c"
    queued locking requests:
     active: false req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
@@ -1159,7 +1136,7 @@ new: state=doneWaiting
 
 guard-state r=req6
 ----
-old: state=waitForDistinguished txn=txn2 key="b" held=true guard-strength=Intent
+old: state=waitFor txn=txn2 key="b" held=true guard-strength=Intent
 
 print
 ----
@@ -1168,7 +1145,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent]
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 6
  lock: "c"
    queued locking requests:
     active: false req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
@@ -1421,7 +1397,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn1 key="c" held=false guard-strength=Intent
+new: state=waitFor txn=txn1 key="c" held=false guard-strength=Intent
 
 scan r=req6
 ----
@@ -1467,7 +1443,7 @@ start-waiting: true
 
 guard-state r=req8
 ----
-new: state=waitForDistinguished txn=txn1 key="e" held=true guard-strength=Intent
+new: state=waitFor txn=txn1 key="e" held=true guard-strength=Intent
 
 dequeue r=req8
 ----
@@ -1698,7 +1674,7 @@ start-waiting: true
 
 guard-state r=req10
 ----
-new: state=waitForDistinguished txn=txn1 key="c" held=true guard-strength=Exclusive
+new: state=waitFor txn=txn1 key="c" held=true guard-strength=Exclusive
 
 new-request r=req11 txn=txn3 ts=6 spans=intent@c
 ----
@@ -1731,7 +1707,6 @@ num=1
     active: true req: 10, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 10
 
 metrics
 ----
@@ -1830,7 +1805,6 @@ num=1
     active: false req: 10, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 11
 
 guard-state r=req10
 ----
@@ -1838,7 +1812,7 @@ new: state=doneWaiting
 
 guard-state r=req11
 ----
-new: state=waitForDistinguished txn=txn2 key="c" held=false guard-strength=Intent
+new: state=waitFor txn=txn2 key="c" held=false guard-strength=Intent
 
 guard-state r=req12
 ----
@@ -1856,7 +1830,6 @@ num=1
     active: false req: 10, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 11
 
 metrics
 ----
@@ -1953,11 +1926,10 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 11
 
 guard-state r=req11
 ----
-new: state=waitForDistinguished txn=txn2 key="c" held=true guard-strength=Intent
+new: state=waitFor txn=txn2 key="c" held=true guard-strength=Intent
 
 # Since req10 that is also txn2 has acquired the lock, req12 does not need to wait here anymore.
 guard-state r=req12
@@ -1971,7 +1943,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 11
 
 metrics
 ----
@@ -2069,7 +2040,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 11
 
 acquire r=req12 k=c durability=r strength=intent
 ----
@@ -2078,7 +2048,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 11
 
 dequeue r=req12
 ----
@@ -2087,11 +2056,10 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,12, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 11, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 11
 
 guard-state r=req11
 ----
-old: state=waitForDistinguished txn=txn2 key="c" held=true guard-strength=Intent
+old: state=waitFor txn=txn2 key="c" held=true guard-strength=Intent
 
 release txn=txn2 span=b,d
 ----
@@ -2406,12 +2374,10 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 9.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 18, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 18
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 9.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 19
 
 metrics
 ----
@@ -2515,7 +2481,6 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 9.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 19
 
 guard-state r=req18
 ----
@@ -2532,7 +2497,6 @@ num=2
    queued locking requests:
     active: true req: 18, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 19
 
 metrics
 ----
@@ -2732,7 +2696,6 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 22, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 22
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -2840,7 +2803,6 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 22, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 22
  lock: "d"
    queued locking requests:
     active: false req: 23, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear
@@ -81,7 +81,7 @@ start-waiting: true
 
 guard-state r=req3
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=None
 
 # Similarly, a non-transactional write at a arrives and blocks.
 
@@ -107,7 +107,7 @@ start-waiting: true
 
 guard-state r=req5
 ----
-new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Intent
+new: state=waitFor txn=txn1 key="b" held=true guard-strength=Intent
 
 print
 ----
@@ -118,12 +118,10 @@ num=3
     req: 3, txn: none
    queued locking requests:
     active: true req: 4, strength: Intent, txn: none
-   distinguished req: 3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 5
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,1, info: repl [Intent]
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_finalized_txn_locks
@@ -158,7 +158,6 @@ num=5
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 1
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
@@ -183,7 +182,7 @@ start-waiting: true
 
 guard-state r=req1
 ----
-new: state=waitForDistinguished txn=txn4 key="c" held=true guard-strength=Exclusive
+new: state=waitFor txn=txn4 key="c" held=true guard-strength=Exclusive
 
 print
 ----
@@ -200,7 +199,6 @@ num=5
   holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 1
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
@@ -425,7 +423,6 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 5
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
@@ -444,7 +441,7 @@ new: state=waitFor txn=txn2 key="a" held=true guard-strength=Exclusive
 
 guard-state r=req5
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Exclusive
+new: state=waitFor txn=txn2 key="a" held=true guard-strength=Exclusive
 
 print
 ----
@@ -454,7 +451,6 @@ num=2
    queued locking requests:
     active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 6, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 5
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: aborted]
    queued locking requests:
@@ -467,7 +463,6 @@ num=2
    queued locking requests:
     active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 6, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 6
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent] [holder finalized: aborted]
    queued locking requests:
@@ -475,7 +470,7 @@ num=2
 
 guard-state r=req6
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=false guard-strength=Exclusive
+new: state=waitFor txn=txn1 key="a" held=false guard-strength=Exclusive
 
 guard-state r=req5
 ----
@@ -490,7 +485,6 @@ num=2
    queued locking requests:
     active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 6, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 6
  lock: "b"
    queued locking requests:
     active: false req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
@@ -552,7 +546,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Exclusive
+new: state=waitFor txn=txn2 key="a" held=true guard-strength=Exclusive
 
 print
 ----
@@ -561,7 +555,6 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 7
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
@@ -668,7 +661,7 @@ start-waiting: true
 
 guard-state r=req9
 ----
-new: state=waitForDistinguished txn=txn4 key="c" held=true guard-strength=None
+new: state=waitFor txn=txn4 key="c" held=true guard-strength=None
 
 print
 ----
@@ -681,7 +674,6 @@ num=4
   holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    waiting readers:
     req: 9, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 9
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000004 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
 
@@ -1032,7 +1024,6 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000007 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
-   distinguished req: 16
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
@@ -1047,7 +1038,7 @@ start-waiting: true
 
 guard-state r=req17
 ----
-new: state=waitForDistinguished txn=txn8 key="b" held=true guard-strength=Exclusive
+new: state=waitFor txn=txn8 key="b" held=true guard-strength=Exclusive
 
 # Now that req17 is able to wait on lock "b", and claim the lock on "a", it should
 # no longer be the distinguished waiter on lock "a" anymore.
@@ -1062,7 +1053,6 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
-   distinguished req: 16
 
 new-request r=req18 txn=txn8 ts=11,0 spans=exclusive@a
 ----
@@ -1080,9 +1070,7 @@ num=2
    queued locking requests:
     active: false req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
     active: true req: 17, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000008
-   distinguished req: 17
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000008 epoch: 0, iso: Serializable, ts: 11.000000000,1, info: repl [Intent]
    queued locking requests:
     active: true req: 16, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000005
-   distinguished req: 16

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/disable
@@ -83,7 +83,7 @@ start-waiting: true
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Exclusive
+new: state=waitFor txn=txn2 key="a" held=true guard-strength=Exclusive
 
 release txn=txn2 span=a
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/discovered_locks_consults_txn_cache
@@ -114,7 +114,7 @@ start-waiting: true
 
 guard-state r=req1
 ----
-new: state=waitForDistinguished txn=txn4 key="d" held=true guard-strength=Intent
+new: state=waitFor txn=txn4 key="d" held=true guard-strength=Intent
 
 dequeue r=req1
 ----
@@ -202,7 +202,7 @@ start-waiting: true
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn7 key="g" held=true guard-strength=None
+new: state=waitFor txn=txn7 key="g" held=true guard-strength=None
 
 dequeue r=req2
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/dup_access
@@ -45,7 +45,7 @@ start-waiting: true
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Intent
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
 
 print
 ----
@@ -54,7 +54,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 2
 
 release txn=txn1 span=a
 ----
@@ -126,7 +125,7 @@ start-waiting: true
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Intent
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
 
 new-request r=req5 txn=txn3 ts=10 spans=intent@b+intent@c+none@b
 ----
@@ -137,7 +136,7 @@ start-waiting: true
 
 guard-state r=req5
 ----
-new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Intent
+new: state=waitFor txn=txn1 key="b" held=true guard-strength=Intent
 
 print
 ----
@@ -146,12 +145,10 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 5
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -164,7 +161,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
  lock: "b"
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
@@ -173,7 +169,7 @@ num=3
 
 guard-state r=req5
 ----
-new: state=waitForDistinguished txn=txn1 key="c" held=true guard-strength=Intent
+new: state=waitFor txn=txn1 key="c" held=true guard-strength=Intent
 
 print
 ----
@@ -182,7 +178,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
  lock: "b"
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
@@ -190,7 +185,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 5
 
 # req4 breaks the reservation of req4 at "b".
 
@@ -207,7 +201,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 5
 
 guard-state r=req4
 ----
@@ -227,7 +220,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 5
 
 query span=a,d
 ----
@@ -271,7 +263,6 @@ num=3
    queued locking requests:
     active: false req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 5
  lock: "c"
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
@@ -351,7 +342,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Exclusive
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Exclusive
 
 new-request r=req8 txn=none ts=10 spans=intent@b+intent@c+none@b
 ----
@@ -362,7 +353,7 @@ start-waiting: true
 
 guard-state r=req8
 ----
-new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Intent
+new: state=waitFor txn=txn1 key="b" held=true guard-strength=Intent
 
 # req9 is just to prevent the lock for "b" from being gc'd and then a new one
 # created when req7 acquires "b", which due to the old snapshot held by req8
@@ -385,13 +376,11 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 7
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 8, strength: Intent, txn: none
     active: true req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 8
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -404,7 +393,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 7
  lock: "b"
    queued locking requests:
     active: false req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
@@ -413,7 +401,7 @@ num=3
 
 guard-state r=req8
 ----
-new: state=waitForDistinguished txn=txn1 key="c" held=true guard-strength=Intent
+new: state=waitFor txn=txn1 key="c" held=true guard-strength=Intent
 
 print
 ----
@@ -422,7 +410,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 7
  lock: "b"
    queued locking requests:
     active: false req: 9, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
@@ -430,7 +417,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 8, strength: Intent, txn: none
-   distinguished req: 8
 
 # req7 is doneWaiting and proceeds to acquire the lock at "b".
 
@@ -447,7 +433,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 8, strength: Intent, txn: none
-   distinguished req: 8
 
 guard-state r=req7
 ----
@@ -467,7 +452,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 8, strength: Intent, txn: none
-   distinguished req: 8
 
 scan r=req7
 ----
@@ -485,7 +469,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 8, strength: Intent, txn: none
-   distinguished req: 8
 
 # req8 encounters the lock held by req7 at "b" when looking at it for its read access.
 release txn=txn1 span=c
@@ -499,7 +482,7 @@ num=2
 
 guard-state r=req8
 ----
-new: state=waitForDistinguished txn=txn2 key="b" held=true guard-strength=None
+new: state=waitFor txn=txn2 key="b" held=true guard-strength=None
 
 print
 ----
@@ -511,7 +494,6 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 8, txn: none
-   distinguished req: 8
 
 dequeue r=req7
 ----
@@ -520,7 +502,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 8, txn: none
-   distinguished req: 8
 
 dequeue r=req8
 ----
@@ -576,7 +557,7 @@ start-waiting: true
 
 guard-state r=req11
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Exclusive
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Exclusive
 
 new-request r=req12 txn=txn3 ts=10 spans=intent@b+none@b
 ----
@@ -587,7 +568,7 @@ start-waiting: true
 
 guard-state r=req12
 ----
-new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Intent
+new: state=waitFor txn=txn1 key="b" held=true guard-strength=Intent
 
 print
 ----
@@ -596,12 +577,10 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 11, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 11
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 12
 
 # req12 reserves "b".
 
@@ -612,7 +591,6 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 11, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 11
  lock: "b"
    queued locking requests:
     active: false req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
@@ -672,7 +650,7 @@ start-waiting: true
 
 guard-state r=req12
 ----
-new: state=waitForDistinguished txn=txn2 key="b" held=true guard-strength=Intent
+new: state=waitFor txn=txn2 key="b" held=true guard-strength=Intent
 
 dequeue r=req11
 ----
@@ -681,7 +659,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 12, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 12
 
 dequeue r=req12
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/isolation_level
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/isolation_level
@@ -125,7 +125,7 @@ start-waiting: true
 
 guard-state r=req6
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=None
+new: state=waitFor txn=txn2 key="a" held=true guard-strength=None
 
 scan r=req7
 ----
@@ -133,7 +133,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn2 key="b" held=true guard-strength=None
+new: state=waitFor txn=txn2 key="b" held=true guard-strength=None
 
 # ------------------------------------------------------------------------------
 # Test that exclusive locks held by {RC,snapshot} transactions do not block

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_changes
@@ -69,7 +69,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 8.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 2)]
    queued locking requests:
     active: true req: 1, strength: Intent, txn: none
-   distinguished req: 1
 
 dequeue r=reqContend
 ----
@@ -124,7 +123,7 @@ start-waiting: true
 
 guard-state r=req5
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=None
 
 print
 ----
@@ -133,7 +132,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 8.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 2, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 2
 
 new-txn txn=txn1 ts=14 epoch=2 seq=1
 ----
@@ -148,11 +146,10 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 8.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 2, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 2
 
 guard-state r=req5
 ----
-old: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
+old: state=waitFor txn=txn1 key="a" held=true guard-strength=None
 
 acquire r=req6 k=a durability=r strength=intent
 ----
@@ -180,7 +177,7 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=None
 
 add-discovered r=req7 k=a txn=txn1
 ----
@@ -189,11 +186,10 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 14.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 3, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 3
 
 guard-state r=req7
 ----
-old: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
+old: state=waitFor txn=txn1 key="a" held=true guard-strength=None
 
 # ------------------------------------------------------------------------------
 # Try to re-acquire an unreplicated lock that is already held at a higher epoch.
@@ -209,7 +205,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 2, iso: Serializable, ts: 14.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 3, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 3
 
 new-txn txn=txn1 ts=14 epoch=1 seq=1
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_dropped
@@ -60,7 +60,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 2)]
    waiting readers:
     req: 1, txn: none
-   distinguished req: 1
 
 acquire r=req1 k=a durability=r strength=intent
 ----
@@ -101,7 +100,6 @@ num=1
     req: 1, txn: none
    queued locking requests:
     active: true req: 2, strength: Intent, txn: none
-   distinguished req: 1
 
 acquire r=req1 k=a durability=r strength=intent
 ----
@@ -112,11 +110,10 @@ num=1
     req: 1, txn: none
    queued locking requests:
     active: true req: 2, strength: Intent, txn: none
-   distinguished req: 1
 
 guard-state r=reqContendReader
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=None
 
 guard-state r=reqContendWriter
 ----
@@ -167,7 +164,7 @@ start-waiting: true
 
 guard-state r=req3
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=None
 
 acquire r=req2 k=b durability=r strength=intent
 ----
@@ -176,7 +173,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 2)]
    waiting readers:
     req: 3, txn: none
-   distinguished req: 3
 
 release txn=txn1 span=a
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_promotion
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/lock_promotion
@@ -101,7 +101,6 @@ num=1
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 4
 
 # For good measure, create a new request from txn3 that comes after req5, and
 # ensure it sorts after req5 in the wait queue.
@@ -122,7 +121,6 @@ num=1
     active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 6, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 4
 
 # ------------------------------------------------------------------------------
 # Ensure a request trying to promote from Exclusive -> Intent does not conflict
@@ -147,4 +145,3 @@ num=1
     active: false req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 6, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 4

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_active_waiter
@@ -87,7 +87,6 @@ num=3
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 2
 
 scan r=req1
 ----
@@ -95,7 +94,7 @@ start-waiting: true
 
 guard-state r=req1
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Intent
+new: state=waitFor txn=txn2 key="a" held=true guard-strength=Intent
 
 print
 ----
@@ -104,7 +103,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
     active: true req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 1
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
  lock: "c"
@@ -112,7 +110,6 @@ num=3
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 2
 
 # req1 waits at "c" but not as distinguished waiter.
 release txn=txn2 span=a
@@ -128,7 +125,6 @@ num=3
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 2
 
 guard-state r=req1
 ----
@@ -147,7 +143,6 @@ num=3
    queued locking requests:
     active: true req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 2
 
 # req1 waits at "b" as reader.
 
@@ -166,7 +161,7 @@ num=3
 
 guard-state r=req1
 ----
-new: state=waitForDistinguished txn=txn2 key="b" held=true guard-strength=None
+new: state=waitFor txn=txn2 key="b" held=true guard-strength=None
 
 guard-state r=req2
 ----
@@ -182,7 +177,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    waiting readers:
     req: 1, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 1
  lock: "c"
    queued locking requests:
     active: false req: 1, strength: Intent, txn: 00000000-0000-0000-0000-000000000001

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/non_txn_write
@@ -93,17 +93,14 @@ num=3
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 4, strength: Intent, txn: none
-   distinguished req: 2
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 5
 
 # The locks at a, b, c are released. The non-transactional request waits behind
 # the reservation holder at a.
@@ -115,7 +112,6 @@ num=3
    queued locking requests:
     active: false req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 4, strength: Intent, txn: none
-   distinguished req: 4
  lock: "b"
    queued locking requests:
     active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
@@ -133,7 +129,7 @@ new: state=doneWaiting
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=false guard-strength=Intent
+new: state=waitFor txn=txn2 key="a" held=false guard-strength=Intent
 
 guard-state r=req5
 ----
@@ -156,7 +152,6 @@ num=3
     active: false req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 4, strength: Intent, txn: none
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 4
  lock: "b"
    queued locking requests:
     active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
@@ -183,7 +178,7 @@ num=3
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn3 key="b" held=false guard-strength=Intent
+new: state=waitFor txn=txn3 key="b" held=false guard-strength=Intent
 
 guard-state r=req6
 ----
@@ -199,7 +194,6 @@ num=3
    queued locking requests:
     active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 4, strength: Intent, txn: none
-   distinguished req: 4
  lock: "c"
    queued locking requests:
     active: false req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
@@ -263,7 +257,7 @@ start-waiting: true
 
 guard-state r=req4
 ----
-new: state=waitForDistinguished txn=txn2 key="c" held=true guard-strength=Intent
+new: state=waitFor txn=txn2 key="c" held=true guard-strength=Intent
 
 guard-state r=req5
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/query
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/query
@@ -138,14 +138,12 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,2, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
  lock: "e"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 4
 
 query span=a,/Max max-bytes=100
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/queue_length_exceeded
@@ -45,7 +45,6 @@ num=1
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 2
 
 # ---------------------------------------------------------------------------------
 # Read requests do not observe a queue length limit, because they don't wait in the
@@ -74,7 +73,6 @@ num=1
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 2
 
 # ---------------------------------------------------------------------------------
 # Write requests with a large enough MaxLockWaitQueueLength do not throw an error.
@@ -102,7 +100,6 @@ num=1
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 2
 
 # ---------------------------------------------------------------------------------
 # Write requests with a sufficiently low MaxLockWaitQueueLength throw an error.
@@ -130,7 +127,6 @@ num=1
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 2
 
 # ---------------------------------------------------------------------------------
 # Same as previous two cases, but for non-transactional writes.
@@ -155,7 +151,6 @@ num=1
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 2
 
 new-request r=req8 txn=none ts=10 spans=intent@a max-lock-wait-queue-length=2
 ----
@@ -176,7 +171,6 @@ num=1
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 2
 
 # ------------------------------------------------------------------------------
 # Write requests that are already waiting in a lock's wait queue should not
@@ -203,7 +197,6 @@ num=2
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 2
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
 
@@ -219,7 +212,7 @@ start-waiting: true
 
 guard-state r=req10
 ----
-new: state=waitForDistinguished txn=txn6 key="b" held=true guard-strength=Intent
+new: state=waitFor txn=txn6 key="b" held=true guard-strength=Intent
 
 print
 ----
@@ -229,12 +222,10 @@ num=2
    queued locking requests:
     active: true req: 2, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 2
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000006 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 10, strength: Intent, txn: 00000000-0000-0000-0000-000000000007
-   distinguished req: 10
 
 # Re-scan.
 scan r=req10
@@ -243,4 +234,4 @@ start-waiting: true
 
 guard-state r=req10
 ----
-new: state=waitForDistinguished txn=txn6 key="b" held=true guard-strength=Intent
+new: state=waitFor txn=txn6 key="b" held=true guard-strength=Intent

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/replicated_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/replicated_locks
@@ -89,7 +89,6 @@ num=3
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
@@ -106,7 +105,6 @@ num=3
    queued locking requests:
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: repl [Exclusive]
    queued locking requests:
@@ -155,7 +153,6 @@ num=3
     active: false req: 1, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 3, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent, Exclusive]
    queued locking requests:
@@ -228,12 +225,10 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive], unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 6, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 6
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 7
 
 acquire r=req8 k=b durability=r strength=shared
 ----
@@ -242,12 +237,10 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Exclusive], unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 6, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 6
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: repl [Shared], unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 7
 
 
 # Test the other way around. A replicated lock is held first, followed by
@@ -702,7 +695,6 @@ num=2
     req: 29, txn: 00000000-0000-0000-0000-000000000003
    queued locking requests:
     active: false req: 24, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 29
 
 
 # ------------------------------------------------------------------------------
@@ -820,7 +812,6 @@ num=1
    queued locking requests:
     active: false req: 32, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 37, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 37
 
 # 3d. Lock discovery; strength = Shared.
 new-request r=req38 txn=txn2 ts=10 spans=intent@a
@@ -843,7 +834,6 @@ num=1
     active: false req: 32, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 37, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 38, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 37
 
 # ------------------------------------------------------------------------------
 # Test the case where both an unreplicated exclusive lock and an intent exists
@@ -892,7 +882,6 @@ num=1
    queued locking requests:
     active: false req: 41, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 40, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 40
 
 # Ensure non-locking readers at various timestamps -- below the exclusive lock
 # (10), at the exclusive lock (10), between exclusive and intent (20),
@@ -945,4 +934,3 @@ num=1
    queued locking requests:
     active: false req: 41, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 40, strength: Intent, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 40

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/resolve_pushed_txn_locks
@@ -102,17 +102,14 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 3, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 4, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 4
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 5, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 5
 
 pushed-txn-updated txn=txn2 status=pending ts=11,1
 ----
@@ -130,12 +127,10 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    waiting readers:
     req: 4, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 4
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 5, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 5
 
 guard-state r=req1
 ----
@@ -143,11 +138,11 @@ new: state=doneWaiting
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn2 key="b" held=true guard-strength=None
+new: state=waitFor txn=txn2 key="b" held=true guard-strength=None
 
 guard-state r=req3
 ----
-new: state=waitForDistinguished txn=txn2 key="c" held=true guard-strength=None
+new: state=waitFor txn=txn2 key="c" held=true guard-strength=None
 
 guard-state r=req4
 ----
@@ -167,7 +162,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    waiting readers:
     req: 5, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 5
 
 update txn=txn2 ts=11,1 epoch=0 span=c
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/shared_locks
@@ -109,7 +109,6 @@ num=1
    queued locking requests:
     active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 5
 
 # ------------------------------------------------------------------------------
 # Ensure requests with locking strength shared actively wait if there are active
@@ -134,7 +133,6 @@ num=1
     active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000004
     active: true req: 7, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 5
 
 # However, if the shared lock is held by the transaction itself, it doesn't need
 # to actively wait.
@@ -156,7 +154,6 @@ num=1
     active: true req: 5, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000004
     active: true req: 7, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 5
 
 # ------------------------------------------------------------------------------
 # Ensure a key is locked with SHARED locking strength until the all
@@ -233,7 +230,6 @@ num=1
            txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 12, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 12
 
 # Start releasing the shared locks, one by one.
 
@@ -245,7 +241,6 @@ num=1
            txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 12, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 12
 
 release txn=txn2 span=a
 ----
@@ -254,7 +249,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 12, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 12
 
 # Now that all shared locks have been released, the exclusive locking request is
 # free to proceed.
@@ -309,7 +303,6 @@ num=1
     active: true req: 13, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 14, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 15, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 13
 
 release txn=txn4 span=a
 ----
@@ -381,7 +374,6 @@ num=1
     active: true req: 18, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 20, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 17
 
 # Setup complete. Release the exclusive lock and ensure only req17 and req18
 # establish a joint claim. In particular, req20 should be sitting tight.
@@ -394,7 +386,6 @@ num=1
     active: false req: 18, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 20, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 19
 
 # Ensure nothing changes with req20 once req18 acquires the lock. This is
 # because they belong to different transactions (txn1 and txn2, respectively).
@@ -407,7 +398,6 @@ num=1
     active: false req: 17, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 20, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 19
 
 # However, once req17 acquires the shared lock, req20 should be allowed to
 # proceed -- this is because they both belong to the same transaction (txn1).
@@ -419,7 +409,6 @@ num=1
            txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 19
 
 # req20 should be able to come back around and acquire a shared lock for itself.
 # This doesn't change anything though, as the lock was already held by txn1.
@@ -431,7 +420,6 @@ num=1
            txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 19, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 19
 
 
 # ------------------------------------------------------------------------------
@@ -521,7 +509,6 @@ num=1
     active: true req: 26, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 27, strength: Intent, txn: none
     active: true req: 28, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 22
 
 # We're done setting up. Let's release the lock.
 
@@ -534,7 +521,6 @@ num=1
     active: false req: 26, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 27, strength: Intent, txn: none
     active: true req: 28, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 27
 
 # ------------------------------------------------------------------------------
 # Ensure a shared lock request doesn't need to wait if its transaction already
@@ -581,7 +567,6 @@ num=1
    queued locking requests:
     active: true req: 30, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 31, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 30
 
 # Shared lock request from txn5 (which already holds the lock on key "a")
 new-request r=req32 txn=txn5 ts=10 spans=shared@a
@@ -599,7 +584,6 @@ num=1
    queued locking requests:
     active: true req: 30, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 31, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 30
 
 # ------------------------------------------------------------------------------
 # Add a test where one of the waiters to be released is already an inactive
@@ -615,7 +599,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000005 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0), (str: Shared seq: 0)]
    queued locking requests:
     active: true req: 30, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 30
 
 release txn=txn5 span=a
 ----
@@ -656,7 +639,6 @@ num=1
    queued locking requests:
     active: false req: 30, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 34, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 34
 
 release txn=txn5 span=a
 ----
@@ -728,7 +710,6 @@ num=1
     active: true req: 37, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 38, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 39, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 36
 
 # Release the lock. Only req36 should be allowed to proceed.
 release txn=txn5 span=a
@@ -740,7 +721,6 @@ num=1
     active: true req: 37, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 38, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 39, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 37
 
 # ------------------------------------------------------------------------------
 # Ensure that if a exclusive locking request (req36) exits the lock table
@@ -757,7 +737,6 @@ num=1
     active: false req: 37, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: false req: 38, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 39, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 39
 
 # ------------------------------------------------------------------------------
 # Same set up as above, but this time, have the exclusive locking request
@@ -813,7 +792,6 @@ num=1
     active: true req: 41, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 42, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 43, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 41
 
 # Release the lock. Only req41 should be allowed to proceed.
 release txn=txn5 span=a
@@ -824,7 +802,6 @@ num=1
     active: false req: 41, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 42, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 43, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 42
 
 # This time, we'll actually let the exclusive locking request (req41) acquire
 # the lock. Nothing should change with req42 and req43 -- they should sit tight.
@@ -836,7 +813,6 @@ num=1
    queued locking requests:
     active: true req: 42, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 43, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 42
 
 # ------------------------------------------------------------------------------
 # A few more tests of requests exiting the lock table without acquiring locks.
@@ -861,7 +837,6 @@ num=1
     active: false req: 42, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: false req: 43, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 44, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 44
 
 # Have req42 exit the lock table without acquiring its shared lock. Nothing
 # should change with req44.
@@ -872,7 +847,6 @@ num=1
    queued locking requests:
     active: false req: 43, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 44, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 44
 
 # However, once req43 exits without acquiring its shared lock, req44 should be
 # allowed to proceed.
@@ -932,7 +906,6 @@ num=1
    queued locking requests:
     active: true req: 45, strength: Shared, txn: 00000000-0000-0000-0000-000000000001
     active: true req: 46, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 46
 
 # ------------------------------------------------------------------------------
 # Test for lock promotion. When a lock is held with strength Shared, we do not
@@ -995,7 +968,6 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 50, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 50
 
 new-request r=req52 txn=txn3 ts=10 spans=exclusive@a+exclusive@b
 ----
@@ -1018,13 +990,11 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 52, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 52
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 50, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 53, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 50
 
 new-request r=req54 txn=txn3 ts=10 spans=exclusive@b
 ----
@@ -1051,7 +1021,6 @@ num=2
    queued locking requests:
     active: true req: 50, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 53, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 50
 
 scan r=req52
 ----
@@ -1069,7 +1038,6 @@ num=2
     active: true req: 50, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 52, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 53, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 50
 
 # ------------------------------------------------------------------------------
 # Sub-test for lock promotion. When an initial call to ScanAndEnqueue returns an
@@ -1233,7 +1201,6 @@ num=1
     active: true req: 61, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 62, strength: Shared, txn: none
     active: true req: 63, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 60
 
 update txn=txn1 ts=11,0 epoch=0 span=a
 ----
@@ -1244,7 +1211,6 @@ num=1
     active: false req: 60, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: false req: 61, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 63, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 63
 
 # ------------------------------------------------------------------------------
 # Test when a locking request drops out of a wait queue and makes other actively
@@ -1300,7 +1266,6 @@ num=1
     active: true req: 67, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 68, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 69, strength: Shared, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 67
 
 dequeue r=req67
 ----
@@ -1387,7 +1352,6 @@ num=1
     active: true req: 72, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 73, strength: Shared, txn: none
     active: true req: 74, strength: Intent, txn: none
-   distinguished req: 70
 
 release txn=txn2 span=a
 ----
@@ -1399,7 +1363,6 @@ num=1
     active: true req: 72, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 73, strength: Shared, txn: none
     active: true req: 74, strength: Intent, txn: none
-   distinguished req: 72
 
 dequeue r=req70
 ----
@@ -1408,7 +1371,6 @@ num=1
    queued locking requests:
     active: false req: 72, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 74, strength: Intent, txn: none
-   distinguished req: 74
 
 # ------------------------------------------------------------------------------
 # Ensure when a lock is acquired, and we release other locking requests from the
@@ -1468,12 +1430,10 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 77, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 77
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 78, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 78
 
 release txn=txn3 span=a
 ----
@@ -1485,7 +1445,6 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 78, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 78
 
 scan r=req77
 ----
@@ -1502,7 +1461,6 @@ num=2
    queued locking requests:
     active: false req: 77, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 78, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 78
 
 new-request r=req79 txn=txn4 ts=10 spans=shared@b
 ----
@@ -1523,7 +1481,6 @@ num=2
     active: false req: 77, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 78, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 79, strength: Shared, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 78
 
 # The shared lock acquisition by request 77 should remove request 78 from the
 # wait queue as they both belong to txn 2. Request 78 will detect it's trying to
@@ -1603,11 +1560,10 @@ num=2
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 82, strength: Exclusive, txn: none
-   distinguished req: 82
 
 guard-state r=req82
 ----
-new: state=waitForDistinguished txn=txn3 key="b" held=true guard-strength=Exclusive
+new: state=waitFor txn=txn3 key="b" held=true guard-strength=Exclusive
 
 new-request r=req83 txn=none ts=10 spans=shared@a
 ----
@@ -1648,12 +1604,10 @@ num=2
     active: true req: 84, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 85, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 86, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 83
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 82, strength: Exclusive, txn: none
-   distinguished req: 82
 
 pushed-txn-updated txn=txn1 status=aborted
 ----
@@ -1669,12 +1623,10 @@ num=2
     active: true req: 84, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 85, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 86, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 83
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 82, strength: Exclusive, txn: none
-   distinguished req: 82
 
 scan r=req82
 ----
@@ -1689,9 +1641,7 @@ num=2
     active: false req: 84, strength: Shared, txn: 00000000-0000-0000-0000-000000000002
     active: false req: 85, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 86, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000004
-   distinguished req: 86
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000003 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 82, strength: Exclusive, txn: none
-   distinguished req: 82

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/size_limit_exceeded
@@ -71,7 +71,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 2, strength: Intent, txn: none
-   distinguished req: 2
 
 dequeue r=reqContend
 ----
@@ -115,7 +114,6 @@ num=3
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 4, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 3
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
  lock: "c"
@@ -135,7 +133,7 @@ num=3
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn1 key="b" held=true guard-strength=Intent
+new: state=waitFor txn=txn1 key="b" held=true guard-strength=Intent
 
 guard-state r=req3
 ----
@@ -152,7 +150,6 @@ num=3
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
 
@@ -202,12 +199,10 @@ num=4
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 6, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 3
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 7
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: repl [Intent]
    queued locking requests:
@@ -256,4 +251,4 @@ start-waiting: true
 
 guard-state r=req7
 ----
-new: state=waitForDistinguished txn=txn1 key="d" held=true guard-strength=Intent
+new: state=waitFor txn=txn1 key="d" held=true guard-strength=Intent

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
@@ -235,7 +235,6 @@ num=7
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 7
 
 # ---------------------------------------------------------------------------------
 # req8 will scan the lock table with a Skip wait policy. It will not need to wait.
@@ -382,7 +381,6 @@ num=7
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 7
 
 # ---------------------------------------------------------------------------------
 # req9 is the same as req8, except is has a timestamp equal to txn1's to
@@ -456,7 +454,6 @@ num=7
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 0)]
    queued locking requests:
     active: true req: 7, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000001
-   distinguished req: 7
 
 # ---------------------------------------------------------------------------------
 # Ensure the case where a locking skip locked request finds another request from

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/update
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/update
@@ -63,7 +63,7 @@ start-waiting: true
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=None
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=None
 
 scan r=req3
 ----
@@ -100,7 +100,6 @@ num=1
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, strength: Intent, txn: none
-   distinguished req: 2
 
 metrics
 ----
@@ -206,7 +205,6 @@ num=1
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, strength: Intent, txn: none
-   distinguished req: 2
 
 # -------------------------------------------------------------
 # Update lock timestamp to 13,1 - the transactional read at
@@ -224,7 +222,6 @@ num=1
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, strength: Intent, txn: none
-   distinguished req: 4
 
 guard-state r=req2
 ----
@@ -244,7 +241,6 @@ num=1
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, strength: Intent, txn: none
-   distinguished req: 4
 
 # -------------------------------------------------------------
 # Update lock timestamp to 10,1 - noop since lock is already at
@@ -261,7 +257,6 @@ num=1
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, strength: Intent, txn: none
-   distinguished req: 4
 
 # -------------------------------------------------------------
 # Update lock timestamp to 15,1 - nothing moves
@@ -277,7 +272,6 @@ num=1
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, strength: Intent, txn: none
-   distinguished req: 4
 
 # -------------------------------------------------------------
 # Update lock timestamp to 17,1 - the transactional read at
@@ -293,7 +287,6 @@ num=1
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, strength: Intent, txn: none
-   distinguished req: 3
 
 guard-state r=req4
 ----
@@ -311,7 +304,6 @@ num=1
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, strength: Intent, txn: none
-   distinguished req: 3
 
 # -------------------------------------------------------------
 # Update lock timestamp to 19,1 - nothing moves
@@ -325,7 +317,6 @@ num=1
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, strength: Intent, txn: none
-   distinguished req: 3
 
 # -------------------------------------------------------------
 # Update lock epoch to 1 - the lock is dropped and the transactional
@@ -341,7 +332,6 @@ num=1
    queued locking requests:
     active: false req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 5, strength: Intent, txn: none
-   distinguished req: 5
 
 guard-state r=req3
 ----
@@ -353,7 +343,7 @@ start-waiting: false
 
 guard-state r=req5
 ----
-new: state=waitForDistinguished txn=txn3 key="a" held=false guard-strength=Intent
+new: state=waitFor txn=txn3 key="a" held=false guard-strength=Intent
 
 dequeue r=req3
 ----
@@ -532,7 +522,6 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: repl [Intent], unrepl [(str: Exclusive seq: 10)]
    waiting readers:
     req: 2, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 2
 
 new-request r=req7 txn=txn3 ts=10 spans=shared@a
 ----
@@ -550,7 +539,6 @@ num=1
     req: 2, txn: 00000000-0000-0000-0000-000000000002
    queued locking requests:
     active: true req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 2
 
 update txn=txn1 ts=11,0 epoch=0 span=a
 ----
@@ -559,4 +547,3 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 11.000000000,0, info: unrepl [(str: Exclusive seq: 10)]
    queued locking requests:
     active: true req: 3, strength: Shared, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 3

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/wait_self
@@ -59,7 +59,7 @@ start-waiting: true
 
 guard-state r=req2
 ----
-new: state=waitForDistinguished txn=txn1 key="a" held=true guard-strength=Exclusive
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Exclusive
 
 guard-state r=req3
 ----
@@ -78,7 +78,6 @@ num=1
     active: true req: 2, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 2
 
 release txn=txn1 span=a
 ----
@@ -88,7 +87,6 @@ num=1
     active: false req: 2, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 3
 
 guard-state r=req2
 ----
@@ -96,7 +94,7 @@ new: state=doneWaiting
 
 guard-state r=req3
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=false guard-strength=Intent
+new: state=waitFor txn=txn2 key="a" held=false guard-strength=Intent
 
 guard-state r=req4
 ----
@@ -110,7 +108,6 @@ num=1
     active: false req: 2, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
     active: true req: 4, strength: Exclusive, txn: 00000000-0000-0000-0000-000000000002
-   distinguished req: 3
 
 # Stays in waitSelf state if scans again.
 scan r=req4
@@ -133,11 +130,10 @@ num=1
   holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
-   distinguished req: 3
 
 guard-state r=req3
 ----
-new: state=waitForDistinguished txn=txn2 key="a" held=true guard-strength=Intent
+new: state=waitFor txn=txn2 key="a" held=true guard-strength=Intent
 
 guard-state r=req4
 ----


### PR DESCRIPTION
Now that https://github.com/cockroachdb/cockroach/pull/119581 has
landed, we no longer distinguish (no pun intended) between liveness
pushes and deadlock detection pushes. This obviates the need for the
concept of distinguished waiters. Removing them also serves as a nice
cleanup, and gets us a step closer to things like generalized lock
promotion.

Informs https://github.com/cockroachdb/cockroach/issues/110435

Release note: None