### PR TITLE
roachtest/cdc: fix cdc/kafka-topics flakes

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1607,7 +1607,7 @@ func registerCDC(r registry.Registry) {
 			defer ct.Close()
 
 			// Run minimal level of tpcc workload and changefeed.
-			ct.runTPCCWorkload(tpccArgs{warehouses: 1, duration: "30s"})
+			ct.runTPCCWorkload(tpccArgs{warehouses: 1, duration: "5m"})
 
 			kafka, cleanup := setupKafka(ctx, t, c, c.Node(c.Spec().NodeCount))
 			defer cleanup()
@@ -1628,9 +1628,9 @@ func registerCDC(r registry.Registry) {
 			feed := ct.newChangefeed(feedArgs{
 				sinkType: kafkaSink,
 				targets:  allTpccTargets,
-				opts:     map[string]string{"initial_scan": "'only'"},
 			})
 			feed.waitForCompletion()
+			ct.waitForWorkload()
 
 			// Check logs on cockroach nodes (skip the last node running workload and
 			// kafka). This test verifies that sarama does mot fetch metadata for all


### PR DESCRIPTION
Previously, the workload duration was too short. Occasionally, changefeeds were
not set up properly before the workload is finished. Since the test checks for
sarama logs, this could lead to failures. To resolve this, this patch extends
the workload duration to ensure sarama is properly set up.

Fixes: https://github.com/cockroachdb/cockroach/issues/119509
Release note: None