### PR TITLE
spanconfig: add a static split point at the start of meta2

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/basic
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/basic
@@ -7,7 +7,8 @@ reconcile
 
 mutations
 ----
-upsert /{Min-System/NodeLiveness}          ttl_seconds=3600 num_replicas=5
+upsert /M{in-eta2}                         ttl_seconds=3600 num_replicas=5
+upsert /{Meta2-System/NodeLiveness}        ttl_seconds=3600 num_replicas=5
 upsert /System/NodeLiveness{-Max}          ttl_seconds=600 num_replicas=5
 upsert /System/{NodeLivenessMax-tsd}       range system
 upsert /System{/tsd-tse}                   range default
@@ -106,7 +107,7 @@ upsert /Table/10{7-8}                      num_replicas=7
 delete /Table/11{2-3}
 upsert /Table/11{2-3}                      num_replicas=7
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -244,7 +245,7 @@ upsert /Table/6{4-5}                       ttl_seconds=100 ignore_strict_gc=true
 delete /Table/6{5-6}
 upsert /Table/6{5-6}                       ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
 
-state offset=5 limit=42
+state offset=6 limit=42
 ----
 ...
 /Table/{0-4}                               ttl_seconds=100 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/indexes
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/indexes
@@ -18,7 +18,7 @@ mutations
 ----
 upsert /Table/10{6-7}                      range default
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -58,7 +58,7 @@ delete /Table/10{6-7}
 upsert /Table/106/{2-3}                    num_replicas=7 num_voters=5
 upsert /Table/10{6/3-7}                    num_replicas=7
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -100,7 +100,7 @@ upsert /Table/106/{2-3}                    ttl_seconds=25 num_replicas=7 num_vot
 delete /Table/10{6/3-7}
 upsert /Table/10{6/3-7}                    ttl_seconds=3600 num_replicas=7
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -132,7 +132,7 @@ exec-sql
 ALTER TABLE db.t CONFIGURE ZONE USING num_replicas = 9
 ----
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -177,7 +177,7 @@ delete /Table/106{-/2}
 delete /Table/106/{2-3}
 delete /Table/10{6/3-7}
 
-state offset=46
+state offset=47
 ----
 ...
 /Table/4{5-6}                              ttl_seconds=7200 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true exclude_data_from_backup=true

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/basic
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/basic
@@ -19,7 +19,7 @@ mutations
 
 # We should observe placeholder entries for both tenants (installed when
 # creating tenant records).
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -102,7 +102,7 @@ upsert /Tenant/10/Table/6{0-1}             database system (tenant)
 upsert /Tenant/10/Table/6{1-2}             database system (tenant)
 upsert /Tenant/10/Table/6{2-3}             database system (tenant)
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -194,7 +194,7 @@ upsert /Tenant/10/Table/10{7-8}            range default
 upsert /Tenant/10/Table/11{2-3}            range default
 upsert /Tenant/10/Table/11{3-4}            range default
 
-state offset=81
+state offset=82
 ----
 ...
 /Tenant/10/Table/2{4-5}                    database system (tenant)

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/protectedts
@@ -16,7 +16,7 @@ mutations
 
 # We should observe placeholder entries for both tenants (installed when
 # creating tenant records).
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -176,9 +176,10 @@ mutations tenant=10
 delete {source=10,target=10}
 
 # All system span config targets should have been removed at this point.
-state limit=4
+state limit=5
 ----
-/{Min-System/NodeLiveness}                 ttl_seconds=3600 num_replicas=5
+/M{in-eta2}                                ttl_seconds=3600 num_replicas=5
+/{Meta2-System/NodeLiveness}               ttl_seconds=3600 num_replicas=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=5
 /System/{NodeLivenessMax-tsd}              range system
 /System{/tsd-tse}                          range default

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/range_tenants
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/range_tenants
@@ -35,7 +35,7 @@ initialize tenant=11
 # We should observe placeholder entries for both tenants (installed when
 # creating tenant records). tenant=11 should start off with whatever RANGE
 # TENANT was at the time.
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -70,7 +70,7 @@ reconcile tenant=10
 mutations discard tenant=10
 ----
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -175,7 +175,7 @@ reconcile tenant=11
 mutations discard tenant=11
 ----
 
-state offset=81
+state offset=82
 ----
 ...
 /Tenant/10/Table/2{4-5}                    database system (tenant)

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/tenant_end_key_split
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/tenant_end_key_split
@@ -14,7 +14,7 @@ initialize tenant=11
 
 # A record IS written for a key that logically belongs to the next tenant,
 # tenant=12, because tenant=12 DOES NOT exist.
-state offset=59
+state offset=60
 ----
 ...
 /Table/{59-60}                             database system (host)
@@ -38,7 +38,7 @@ reconcile tenant=11
 # Peek near the start of the span_configurations table where tenant=11's records
 # are stored. The first one is from the start of its keyspace to start of
 # table with ID=4: /Tenant/11{-/Table/4}.
-state offset=60 limit=3
+state offset=61 limit=3
 ----
 ...
 /Table/6{0-1}                              ttl_seconds=3600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
@@ -49,7 +49,7 @@ state offset=60 limit=3
 # Peek near the end of the span_configurations table where tenant=11's records
 # are stored. The last one is for its last system table. Right now the split is
 # at /Tenant/12. Which is fine.
-state offset=103
+state offset=104
 ----
 ...
 /Tenant/11/Table/5{1-2}                    database system (tenant)
@@ -130,7 +130,7 @@ initialize tenant=10
 
 # A record IS NOT written for a key that logically belongs to the next tenant,
 # tenant=11, because tenant=11 DOES exist.
-state offset=59 limit=5
+state offset=60 limit=5
 ----
 ...
 /Table/{59-60}                             database system (host)

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/named_zones
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/named_zones
@@ -7,9 +7,10 @@ reconcile
 mutations discard
 ----
 
-state limit=5
+state limit=6
 ----
-/{Min-System/NodeLiveness}                 ttl_seconds=3600 num_replicas=5
+/M{in-eta2}                                ttl_seconds=3600 num_replicas=5
+/{Meta2-System/NodeLiveness}               ttl_seconds=3600 num_replicas=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=5
 /System/{NodeLivenessMax-tsd}              range system
 /System{/tsd-tse}                          range default
@@ -51,9 +52,10 @@ upsert /System/{NodeLivenessMax-tsd}       range default
 delete /System{tse-/SystemSpanConfigKeys}
 upsert /System{tse-/SystemSpanConfigKeys}  range default
 
-state limit=5
+state limit=6
 ----
-/{Min-System/NodeLiveness}                 ttl_seconds=3600 num_replicas=5
+/M{in-eta2}                                ttl_seconds=3600 num_replicas=5
+/{Meta2-System/NodeLiveness}               ttl_seconds=3600 num_replicas=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=7
 /System/{NodeLivenessMax-tsd}              range default
 /System{/tsd-tse}                          ttl_seconds=42
@@ -69,14 +71,17 @@ ALTER RANGE timeseries CONFIGURE ZONE DISCARD;
 
 mutations
 ----
-delete /{Min-System/NodeLiveness}
-upsert /{Min-System/NodeLiveness}          range default
+delete /M{in-eta2}
+upsert /M{in-eta2}                         range default
+delete /{Meta2-System/NodeLiveness}
+upsert /{Meta2-System/NodeLiveness}        range default
 delete /System{/tsd-tse}
 upsert /System{/tsd-tse}                   range default
 
-state limit=5
+state limit=6
 ----
-/{Min-System/NodeLiveness}                 range default
+/M{in-eta2}                                range default
+/{Meta2-System/NodeLiveness}               range default
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=7
 /System/{NodeLivenessMax-tsd}              range default
 /System{/tsd-tse}                          range default
@@ -100,8 +105,10 @@ ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = 50;
 
 mutations
 ----
-delete /{Min-System/NodeLiveness}
-upsert /{Min-System/NodeLiveness}          ttl_seconds=50
+delete /M{in-eta2}
+upsert /M{in-eta2}                         ttl_seconds=50
+delete /{Meta2-System/NodeLiveness}
+upsert /{Meta2-System/NodeLiveness}        ttl_seconds=50
 delete /System/{NodeLivenessMax-tsd}
 upsert /System/{NodeLivenessMax-tsd}       ttl_seconds=50
 delete /System{/tsd-tse}
@@ -111,16 +118,17 @@ upsert /System{tse-/SystemSpanConfigKeys}  ttl_seconds=50
 delete /Table/10{6-7}
 upsert /Table/10{6-7}                      ttl_seconds=50
 
-state limit=5
+state limit=6
 ----
-/{Min-System/NodeLiveness}                 ttl_seconds=50
+/M{in-eta2}                                ttl_seconds=50
+/{Meta2-System/NodeLiveness}               ttl_seconds=50
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=7
 /System/{NodeLivenessMax-tsd}              ttl_seconds=50
 /System{/tsd-tse}                          ttl_seconds=50
 /System{tse-/SystemSpanConfigKeys}         ttl_seconds=50
 ...
 
-state offset=46
+state offset=47
 ----
 ...
 /Table/4{5-6}                              ttl_seconds=7200 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true exclude_data_from_backup=true
@@ -154,7 +162,7 @@ mutations
 ----
 upsert /Table/10{7-8}                      ttl_seconds=50
 
-state offset=46
+state offset=47
 ----
 ...
 /Table/4{5-6}                              ttl_seconds=7200 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true exclude_data_from_backup=true
@@ -191,9 +199,10 @@ upsert /System/{NodeLivenessMax-tsd}       ttl_seconds=100
 delete /System{tse-/SystemSpanConfigKeys}
 upsert /System{tse-/SystemSpanConfigKeys}  ttl_seconds=100
 
-state limit=5
+state limit=6
 ----
-/{Min-System/NodeLiveness}                 ttl_seconds=50
+/M{in-eta2}                                ttl_seconds=50
+/{Meta2-System/NodeLiveness}               ttl_seconds=50
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=7
 /System/{NodeLivenessMax-tsd}              ttl_seconds=100
 /System{/tsd-tse}                          ttl_seconds=50

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/partitions
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/partitions
@@ -10,7 +10,7 @@ reconcile
 mutations discard
 ----
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -48,7 +48,7 @@ mutations
 ----
 upsert /Table/10{6-7}                      range default
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -83,7 +83,7 @@ mutations
 delete /Table/10{6-7}
 upsert /Table/10{6-7}                      num_replicas=7 num_voters=5
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -123,7 +123,7 @@ upsert /Table/106/1/{1-2}                  global_reads=true num_replicas=7 num_
 upsert /Table/106/1/{2-3}                  global_reads=true num_replicas=7 num_voters=5
 upsert /Table/10{6/1/3-7}                  num_replicas=7 num_voters=5
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -163,7 +163,7 @@ delete /Table/10{6/1/3-7}
 upsert /Table/106/1/{4-5}                  ttl_seconds=5 num_replicas=7 num_voters=5
 upsert /Table/10{6/1/5-7}                  num_replicas=7 num_voters=5
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -217,7 +217,7 @@ upsert /Table/106/{1/5-2}                  num_replicas=7 num_voters=6
 delete /Table/10{6/1/5-7}
 upsert /Table/10{6/2-7}                    num_replicas=7 num_voters=5
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -269,7 +269,7 @@ upsert /Table/106/1/{4-5}                  ttl_seconds=5 num_replicas=7
 delete /Table/10{6/2-7}
 upsert /Table/10{6/2-7}                    num_replicas=7
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)
@@ -315,7 +315,7 @@ delete /Table/106/1/{4-5}
 delete /Table/106/{1/5-2}
 delete /Table/10{6/2-7}
 
-state offset=47
+state offset=48
 ----
 ...
 /Table/4{6-7}                              database system (host)

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/protectedts
@@ -74,7 +74,7 @@ state limit=3
 {source=1,target=2}                        protection_policies=[{ts: 2}]
 ...
 
-state offset=51
+state offset=52
 ----
 ...
 /Table/4{7-8}                              ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true exclude_data_from_backup=true
@@ -116,10 +116,11 @@ mutations
 ----
 delete {entire-keyspace}
 
-state limit=2
+state limit=3
 ----
 {source=1,target=1}                        protection_policies=[{ts: 2}]
 {source=1,target=2}                        protection_policies=[{ts: 2}]
+/M{in-eta2}                                ttl_seconds=3600 num_replicas=5
 ...
 
 # Release the tenant records.
@@ -135,12 +136,12 @@ delete {source=1,target=2}
 
 state limit=2
 ----
-/{Min-System/NodeLiveness}                 ttl_seconds=3600 num_replicas=5
-/System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=5
+/M{in-eta2}                                ttl_seconds=3600 num_replicas=5
+/{Meta2-System/NodeLiveness}               ttl_seconds=3600 num_replicas=5
 ...
 
 # Take another look at the remaining protected spans.
-state offset=57
+state offset=58
 ----
 ...
 /Table/5{7-8}                              ttl_seconds=3600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
@@ -163,7 +164,7 @@ release record-id=4
 ----
 
 # Observe that they're no longer protected.
-state offset=57
+state offset=58
 ----
 ...
 /Table/5{7-8}                              ttl_seconds=3600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "//pkg/ccl",
         "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/ccl/partitionccl",
+        "//pkg/clusterversion",
         "//pkg/config/zonepb",
         "//pkg/jobs/jobspb",
         "//pkg/roachpb",

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/23_2_24_1_mixed_version/full_translate
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/23_2_24_1_mixed_version/full_translate
@@ -1,30 +1,6 @@
-# Test a full reconciliation pass with default named zone configs, a single
-# database with a single table within it.
-
-exec-sql
-CREATE DATABASE db;
-CREATE SCHEMA sc;
-CREATE TYPE typ AS ENUM();
-CREATE VIEW v AS SELECT 1;
-CREATE TABLE db.t();
-CREATE SEQUENCE db.seq;
-CREATE MATERIALIZED VIEW mv AS SELECT 1;
-----
-
-# We expect only the following spans:
-# - Meta ranges: min -> Liveness range start
-# - Liveness range
-# - System ranges:
-#   - Liveness range end -> Timeseries range start
-#   - Timeseries range end -> system range end
-# - Timeseries range
-# - All system tables (there should be no entry for pseudo IDs or IDs for which
-#   no table exist)
-# - The user created table, sequence, and materialized view.
 full-translate
 ----
-/M{in-eta2}                                ttl_seconds=3600 num_replicas=5
-/{Meta2-System/NodeLiveness}               ttl_seconds=3600 num_replicas=5
+/{Min-System/NodeLiveness}                 ttl_seconds=3600 num_replicas=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=5
 /System/{NodeLivenessMax-tsd}              range system
 /System{/tsd-tse}                          range default
@@ -90,6 +66,3 @@ full-translate
 /Table/6{3-4}                              database system (host)
 /Table/6{4-5}                              database system (host)
 /Table/6{5-6}                              database system (host)
-/Table/11{0-1}                             range default
-/Table/11{1-2}                             range default
-/Table/11{2-3}                             range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate_named_zones_deleted
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/full_translate_named_zones_deleted
@@ -48,7 +48,8 @@ SELECT id FROM system.zones
 
 full-translate
 ----
-/{Min-System/NodeLiveness}                 range default
+/M{in-eta2}                                range default
+/{Meta2-System/NodeLiveness}               range default
 /System/NodeLiveness{-Max}                 range default
 /System/{NodeLivenessMax-tsd}              range default
 /System{/tsd-tse}                          range default

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/system_database
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/system_database
@@ -143,7 +143,8 @@ ALTER RANGE liveness CONFIGURE ZONE USING num_replicas = 5
 
 full-translate
 ----
-/{Min-System/NodeLiveness}                 ttl_seconds=3600 num_replicas=5
+/M{in-eta2}                                ttl_seconds=3600 num_replicas=5
+/{Meta2-System/NodeLiveness}               ttl_seconds=3600 num_replicas=5
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=5
 /System/{NodeLivenessMax-tsd}              range system
 /System{/tsd-tse}                          range default

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -395,6 +395,7 @@ go_test(
         "//pkg/server/status",
         "//pkg/server/status/statuspb",
         "//pkg/settings/cluster",
+        "//pkg/spanconfig",
         "//pkg/sql",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/isql",

--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/listenerutil"
@@ -119,6 +120,14 @@ func TestCollectInfoFromOnlineCluster(t *testing.T) {
 			Insecure:   true,
 			// This logic is specific to the storage layer.
 			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+			Knobs: base.TestingKnobs{
+				SpanConfig: &spanconfig.TestingKnobs{
+					// We're asserting on range counts below, which will be thrown off if
+					// span configurations get reconciled and ranges are split as a
+					// result.
+					ManagerDisableJobCreation: true,
+				},
+			},
 		},
 	})
 	tc.Start(t)

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -305,6 +305,10 @@ const (
 	// splits.
 	V24_1_EstimatedMVCCStatsInSplit
 
+	// V24_1_InstallMeta2StaticSplitPoint installs a static split point between
+	// meta1 and meta2.
+	V24_1_InstallMeta2StaticSplitPoint
+
 	numKeys
 )
 
@@ -372,6 +376,7 @@ var versionTable = [numKeys]roachpb.Version{
 	V24_1_SystemDatabaseSurvivability:          {Major: 23, Minor: 2, Internal: 18},
 	V24_1_GossipMaximumIOOverload:              {Major: 23, Minor: 2, Internal: 20},
 	V24_1_EstimatedMVCCStatsInSplit:            {Major: 23, Minor: 2, Internal: 22},
+	V24_1_InstallMeta2StaticSplitPoint:         {Major: 23, Minor: 2, Internal: 24},
 }
 
 // Latest is always the highest version key. This is the maximum logical cluster

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -463,6 +463,7 @@ func (s *SystemConfig) getZoneEntry(codec keys.SQLCodec, id ObjectID) (zoneEntry
 }
 
 var staticSplits = []roachpb.RKey{
+	roachpb.RKey(keys.Meta2Prefix),                  // end of meta1
 	roachpb.RKey(keys.NodeLivenessPrefix),           // end of meta records / start of node liveness span
 	roachpb.RKey(keys.NodeLivenessKeyMax),           // end of node liveness span
 	roachpb.RKey(keys.TimeseriesPrefix),             // start of timeseries span

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -175,7 +175,7 @@ func (s Server) ServeClusterReplicas(
 			}
 			defer func() { _ = txn.Rollback(txnCtx) }()
 			log.Infof(txnCtx, "serving recovery range descriptors for all ranges")
-			return txn.Iterate(txnCtx, keys.Meta2Prefix, keys.MetaMax, rangeMetadataScanChunkSize,
+			return txn.Iterate(txnCtx, keys.MinKey, keys.MaxKey, rangeMetadataScanChunkSize,
 				func(kvs []kv.KeyValue) error {
 					for _, rangeDescKV := range kvs {
 						var rangeDesc roachpb.RangeDescriptor

--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -57,6 +57,12 @@ func TestReplicaCollection(t *testing.T) {
 			StoreSpecs: []base.StoreSpec{{InMemory: true}},
 			Insecure:   true,
 			Knobs: base.TestingKnobs{
+				SpanConfig: &spanconfig.TestingKnobs{
+					// We're asserting on range counts below, which will be thrown off if
+					// span configurations get reconciled and ranges are split as a
+					// result.
+					ManagerDisableJobCreation: true,
+				},
 				LOQRecovery: &loqrecovery.TestingKnobs{
 					MetadataScanTimeout: 15 * time.Second,
 				},
@@ -126,6 +132,12 @@ func TestStreamRestart(t *testing.T) {
 			StoreSpecs: []base.StoreSpec{{InMemory: true}},
 			Insecure:   true,
 			Knobs: base.TestingKnobs{
+				SpanConfig: &spanconfig.TestingKnobs{
+					// We're asserting on range counts below, which will be thrown off if
+					// span configurations get reconciled and ranges are split as a
+					// result.
+					ManagerDisableJobCreation: true,
+				},
 				LOQRecovery: &loqrecovery.TestingKnobs{
 					MetadataScanTimeout: 15 * time.Second,
 					ForwardReplicaFilter: func(response *serverpb.RecoveryCollectLocalReplicaInfoResponse) error {

--- a/pkg/server/application_api/storage_inspection_test.go
+++ b/pkg/server/application_api/storage_inspection_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/rangetestutils"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srvtestutils"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -41,6 +42,14 @@ func TestAdminAPINonTableStats(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SpanConfig: &spanconfig.TestingKnobs{
+					// We're asserting on range counts below, which will be thrown off if
+					// span configurations get reconciled and ranges are split as a
+					// result.
+					ManagerDisableJobCreation: true,
+				},
+			},
 			DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(110012),
 		},
 	})

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1254,7 +1254,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 
 	// Instantiate a span config manager.
 	spanConfig.sqlTranslatorFactory = spanconfigsqltranslator.NewFactory(
-		execCfg.ProtectedTimestampProvider, codec, spanConfigKnobs,
+		execCfg.ProtectedTimestampProvider, codec, cfg.Settings, spanConfigKnobs,
 	)
 	spanConfig.sqlWatcher = spanconfigsqlwatcher.New(
 		codec,

--- a/pkg/spanconfig/spanconfigsqltranslator/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigsqltranslator/BUILD.bazel
@@ -6,11 +6,13 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigsqltranslator",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/config/zonepb",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/spanconfig",
         "//pkg/sql",
         "//pkg/sql/catalog",

--- a/pkg/util/rangedesc/BUILD.bazel
+++ b/pkg/util/rangedesc/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/spanconfig",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/testcluster",

--- a/pkg/util/rangedesc/rangedesc_test.go
+++ b/pkg/util/rangedesc/rangedesc_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -118,6 +119,14 @@ func TestDataDriven(t *testing.T) {
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
 		ctx := context.Background()
 		server, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SpanConfig: &spanconfig.TestingKnobs{
+					// We're asserting on range counts below, which will be thrown off if
+					// span configurations get reconciled and ranges are split as a
+					// result.
+					ManagerDisableJobCreation: true,
+				},
+			},
 			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 		})
 		defer server.Stopper().Stop(context.Background())


### PR DESCRIPTION
Meta1 is not allowed to split, whereas meta2 is. This could prevent load based splitting from applying to meta2. This patch now installs a static split point at the start of meta2 so that load based splitting can do its thing.

Resolves https://github.com/cockroachdb/cockroach/issues/119421

Release note: None