### PR TITLE
roachtest: increase expected ub sequential ranges 3 to 4

### DIFF
--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -230,9 +230,11 @@ func registerLoadSplits(r registry.Registry) {
 				qpsThreshold: 100,      // 100 queries per second
 				// We expect no splits so require only 1 range. However, in practice we
 				// sometimes see a split or two early in, presumably when the sampling
-				// gets lucky.
+				// gets lucky or due to workload concurrency, where later (>sequence)
+				// requests are serviced quicker than concurrent earlier requests, see
+				// reservoir sampling examples in #118457.
 				minimumRanges: 1,
-				maximumRanges: 3,
+				maximumRanges: 4,
 				load: kvSplitLoad{
 					concurrency:  64, // 64 concurrent workers
 					readPercent:  0,  // 0% reads


### PR DESCRIPTION
`splits/load/sequential/nodes=3` would occasionally flake due to variable request timing between worker threads executing concurrent operations. For example, a later sequence 5 could be evaluated and recorded for load based splitting on the leaseholder prior to an earlier sequence 1. As a result, a load based split point may be returned for a key, because requests have fallen on both the left hand side and right hand side, despite the workload being sequential.

Bump the expected upper bound for ranges from 3 to 4.

Fixes: #118457
Fixes: #119442
Release note: None