### PR TITLE
roachtest: acceptance/multitenant uses virtual cluster roachprod API 

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2115,6 +2115,29 @@ func (c *clusterImpl) StartServiceForVirtualCluster(
 	}
 }
 
+// StopServiceForVirtualClusterE stops the service associated with the
+// virtual cluster identified in the `StopOpts` passed. For shared
+// process virtual clusters, the corresponding service is stopped. For
+// separate process, the OS process is killed.
+func (c *clusterImpl) StopServiceForVirtualClusterE(
+	ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option,
+) error {
+	c.setStatusForClusterOpt("stopping virtual cluster", stopOpts.RoachtestOpts.Worker, opts...)
+	defer c.clearStatusForClusterOpt(stopOpts.RoachtestOpts.Worker)
+
+	return roachprod.StopServiceForVirtualCluster(
+		ctx, l, c.Name(), c.IsSecure(), stopOpts.RoachprodOpts,
+	)
+}
+
+func (c *clusterImpl) StopServiceForVirtualCluster(
+	ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option,
+) {
+	if err := c.StopServiceForVirtualClusterE(ctx, l, stopOpts); err != nil {
+		c.t.Fatal(err)
+	}
+}
+
 func (c *clusterImpl) RefetchCertsFromNode(ctx context.Context, node int) error {
 	var err error
 	c.localCertsDir, err = os.MkdirTemp("", "roachtest-certs")

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -70,6 +70,11 @@ type Cluster interface {
 	StartServiceForVirtualClusterE(ctx context.Context, l *logger.Logger, externalNodes option.NodeListOption, startOpts option.StartOpts, settings install.ClusterSettings, opts ...option.Option) error
 	StartServiceForVirtualCluster(ctx context.Context, l *logger.Logger, externalNodes option.NodeListOption, startOpts option.StartOpts, settings install.ClusterSettings, opts ...option.Option)
 
+	// Stopping virtual clusters.
+
+	StopServiceForVirtualClusterE(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option) error
+	StopServiceForVirtualCluster(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option)
+
 	// Hostnames and IP addresses of the nodes.
 
 	InternalAddr(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -92,6 +92,16 @@ func DefaultStopOpts() StopOpts {
 	return StopOpts{RoachprodOpts: roachprod.DefaultStopOpts()}
 }
 
+// DefaultStopVirtualClusterOpts creates StopOpts that can be used to
+// stop the given virtual cluster and sql instance.
+func DefaultStopVirtualClusterOpts(virtualClusterName string, sqlInstance int) StopOpts {
+	opts := DefaultStopOpts()
+	opts.RoachprodOpts.VirtualClusterName = virtualClusterName
+	opts.RoachprodOpts.SQLInstance = sqlInstance
+
+	return opts
+}
+
 // WithNodes returns a RunOptions that will run on the given nodes.
 func WithNodes(nodes NodeListOption) install.RunOptions {
 	return install.WithNodes(nodes.InstallNodes())


### PR DESCRIPTION
This commit updates the `acceptance/multitenant` roachtest to use the
recently introduced roachprod API to manage virtual clusters.

It also removes the previous log checking, as that logic is
brittle. In addition, we no longer support creating virtual clusters
by ID. The acceptance test just verifies that we are able to create a
new virtual cluster, perform basic queries on it, and terminate it.

Fixes: #117671.

Release note: None