### PR TITLE
rowcontainer: switch to using Fingerprint for in-memory hashing

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tsvector
+++ b/pkg/sql/logictest/testdata/logic_test/tsvector
@@ -457,3 +457,22 @@ SELECT * FROM cte1 GROUP BY cte1.col1;
 ----
 ("",1)
 ("",2)
+
+# Regression test for incorrectly using key-encoding on TSQuery type in the
+# row container infrastructure (we use the row-based windower because json_agg
+# is unsupported as vectorized aggregate function).
+query T rowsort
+WITH
+    cte (col1) AS (VALUES ('foo':::TSQUERY), ('bar':::TSQUERY)),
+    seed AS (SELECT g::INT8 AS _int8, g::STRING::JSONB AS _jsonb FROM generate_series(1, 3) AS g)
+SELECT
+    json_agg(seed._jsonb) OVER (PARTITION BY cte.col1)
+FROM
+    cte, seed;
+----
+[1, 2, 3]
+[1, 2, 3]
+[1, 2, 3]
+[1, 2, 3]
+[1, 2, 3]
+[1, 2, 3]

--- a/pkg/sql/rowcontainer/BUILD.bazel
+++ b/pkg/sql/rowcontainer/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/util/bufalloc",
         "//pkg/util/cancelchecker",
         "//pkg/util/encoding",
+        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/mon",

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -164,7 +164,7 @@ func TestDiskRowContainer(t *testing.T) {
 				}
 				row := randgen.RandEncDatumRowOfTypes(rng, typs)
 				func() {
-					d := MakeDiskRowContainer(diskMonitor, typs, ordering, tempEngine)
+					d, _ := MakeDiskRowContainer(diskMonitor, typs, ordering, tempEngine)
 					defer d.Close(ctx)
 					if err := d.AddRow(ctx, row); err != nil {
 						t.Fatal(err)
@@ -227,7 +227,7 @@ func TestDiskRowContainer(t *testing.T) {
 			types := randgen.RandSortingTypes(rng, numCols)
 			rows := randgen.RandEncDatumRowsOfTypes(rng, numRows, types)
 			func() {
-				d := MakeDiskRowContainer(diskMonitor, types, ordering, tempEngine)
+				d, _ := MakeDiskRowContainer(diskMonitor, types, ordering, tempEngine)
 				defer d.Close(ctx)
 				for i := 0; i < len(rows); i++ {
 					if err := d.AddRow(ctx, rows[i]); err != nil {
@@ -309,7 +309,7 @@ func TestDiskRowContainer(t *testing.T) {
 		// Use random types and random rows.
 		types := randgen.RandSortingTypes(rng, numCols)
 		numRows, rows := makeUniqueRows(t, &evalCtx, rng, numRows, types, ordering)
-		d := MakeDiskRowContainer(diskMonitor, types, ordering, tempEngine)
+		d, _ := MakeDiskRowContainer(diskMonitor, types, ordering, tempEngine)
 		defer d.Close(ctx)
 		d.DoDeDuplicate()
 		addRowsRepeatedly := func() {
@@ -351,7 +351,7 @@ func TestDiskRowContainer(t *testing.T) {
 		types := randgen.RandSortingTypes(rng, numCols)
 		rows := randgen.RandEncDatumRowsOfTypes(rng, numRows, types)
 		// There are no ordering columns when using the numberedRowIterator.
-		d := MakeDiskRowContainer(diskMonitor, types, nil, tempEngine)
+		d, _ := MakeDiskRowContainer(diskMonitor, types, nil, tempEngine)
 		defer d.Close(ctx)
 		for i := 0; i < numRows; i++ {
 			require.NoError(t, d.AddRow(ctx, rows[i]))
@@ -439,7 +439,7 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 	)
 	monitor.Start(ctx, nil, mon.NewStandaloneBudget(0 /* capacity */))
 
-	d := MakeDiskRowContainer(
+	d, _ := MakeDiskRowContainer(
 		monitor,
 		[]*types.T{types.Int},
 		colinfo.ColumnOrdering{colinfo.ColumnOrderInfo{ColIdx: 0, Direction: encoding.Ascending}},
@@ -480,7 +480,7 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 	diskMonitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
 
-	d := MakeDiskRowContainer(diskMonitor, types.OneIntCol, nil /* ordering */, tempEngine)
+	d, _ := MakeDiskRowContainer(diskMonitor, types.OneIntCol, nil /* ordering */, tempEngine)
 	defer d.Close(ctx)
 
 	const numCols = 1
@@ -608,7 +608,7 @@ func TestDiskRowContainerUnsafeReset(t *testing.T) {
 	)
 	monitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 
-	d := MakeDiskRowContainer(monitor, types.OneIntCol, nil /* ordering */, tempEngine)
+	d, _ := MakeDiskRowContainer(monitor, types.OneIntCol, nil /* ordering */, tempEngine)
 	defer d.Close(ctx)
 
 	const (

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -115,6 +115,7 @@ func (e *columnEncoder) init(typs []*types.T, keyCols columns, encodeNull bool) 
 // If the row contains any NULLs and encodeNull is false, hasNull is true and
 // no encoding is returned. If encodeNull is true, hasNull is never set.
 func encodeColumnsOfRow(
+	ctx context.Context,
 	da *tree.DatumAlloc,
 	appendTo []byte,
 	row rowenc.EncDatumRow,
@@ -126,12 +127,25 @@ func encodeColumnsOfRow(
 		if row[colIdx].IsNull() && !encodeNull {
 			return nil, true, nil
 		}
-		// Note: we cannot compare VALUE encodings because they contain column IDs
-		// which can vary.
-		// TODO(radu): we should figure out what encoding is readily available and
-		// use that (though it needs to be consistent across all rows). We could add
-		// functionality to compare VALUE encodings ignoring the column ID.
-		appendTo, err = row[colIdx].Encode(colTypes[i], da, catenumpb.DatumEncoding_ASCENDING_KEY, appendTo)
+		ed := row[colIdx]
+		if t := colTypes[i]; t.Family() == types.JsonFamily {
+			// JSON type is special because for historical reasons it uses value
+			// encoding in Fingerprint, yet we do have key encoding available
+			// (and this is what will be used by the disk row container if we
+			// happen to spill to disk).
+			appendTo, err = row[colIdx].Encode(t, da, catenumpb.DatumEncoding_ASCENDING_KEY, appendTo)
+		} else {
+			// Fingerprint internally might decode the EncDatum and will attempt
+			// to update the memory account accordingly. We don't have a
+			// suitable memory account in scope, so we will ensure to lose the
+			// reference to the decoded datum if it wasn't already present, and
+			// then we can pass nil acc argument.
+			hadDecodedDatum := ed.Datum != nil
+			appendTo, err = ed.Fingerprint(ctx, t, da, appendTo, nil /* acc */)
+			if !hadDecodedDatum {
+				ed.Datum = nil
+			}
+		}
 		if err != nil {
 			return appendTo, false, err
 		}
@@ -146,7 +160,7 @@ func (e *columnEncoder) encodeEqualityCols(
 	ctx context.Context, row rowenc.EncDatumRow, eqCols columns,
 ) ([]byte, error) {
 	encoded, hasNull, err := encodeColumnsOfRow(
-		&e.datumAlloc, e.scratch, row, eqCols, e.keyTypes, e.encodeNull,
+		ctx, &e.datumAlloc, e.scratch, row, eqCols, e.keyTypes, e.encodeNull,
 	)
 	if err != nil {
 		return nil, err
@@ -158,6 +172,8 @@ func (e *columnEncoder) encodeEqualityCols(
 	return encoded, nil
 }
 
+var hashKeyEncodingDirection = encoding.Ascending
+
 // storedEqColsToOrdering returns an ordering based on storedEqCols to be used
 // by the row containers (this will result in rows with the same equality
 // columns occurring contiguously in the keyspace).
@@ -166,7 +182,7 @@ func storedEqColsToOrdering(storedEqCols columns) colinfo.ColumnOrdering {
 	for i := range ordering {
 		ordering[i] = colinfo.ColumnOrderInfo{
 			ColIdx:    int(storedEqCols[i]),
-			Direction: encoding.Ascending,
+			Direction: hashKeyEncodingDirection,
 		}
 	}
 	return ordering
@@ -459,7 +475,7 @@ func (i *hashMemRowIterator) computeKey() error {
 		i.curKey, err = i.scratchEncRow[col].Encode(
 			i.container.types[col],
 			&i.container.columnEncoder.datumAlloc,
-			catenumpb.DatumEncoding_ASCENDING_KEY,
+			rowenc.EncodingDirToDatumEncoding(hashKeyEncodingDirection),
 			i.curKey,
 		)
 		if err != nil {
@@ -548,8 +564,9 @@ func (h *HashDiskRowContainer) Init(
 		)
 	}
 
-	h.DiskRowContainer = MakeDiskRowContainer(h.diskMonitor, storedTypes, storedEqColsToOrdering(storedEqCols), h.engine)
-	return nil
+	var err error
+	h.DiskRowContainer, err = MakeDiskRowContainer(h.diskMonitor, storedTypes, storedEqColsToOrdering(storedEqCols), h.engine)
+	return err
 }
 
 // AddRow adds a row to the HashDiskRowContainer. This row is unmarked by

--- a/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
+++ b/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
@@ -66,12 +66,16 @@ func (b *kvStreamerResultDiskBuffer) Serialize(
 	ctx context.Context, r *kvstreamer.Result,
 ) (resultID int, _ error) {
 	if !b.initialized {
-		b.container = MakeDiskRowContainer(
+		var err error
+		b.container, err = MakeDiskRowContainer(
 			b.monitor,
 			inOrderResultsBufferSpillTypeSchema,
 			colinfo.ColumnOrdering{},
 			b.engine,
 		)
+		if err != nil {
+			return 0, err
+		}
 		b.initialized = true
 		b.rowScratch = make(rowenc.EncDatumRow, len(inOrderResultsBufferSpillTypeSchema))
 	}

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -626,7 +626,10 @@ func (f *DiskBackedRowContainer) SpillToDisk(ctx context.Context) error {
 	if f.UsingDisk() {
 		return errors.New("already using disk")
 	}
-	drc := MakeDiskRowContainer(f.diskMonitor, f.mrc.types, f.mrc.ordering, f.engine)
+	drc, err := MakeDiskRowContainer(f.diskMonitor, f.mrc.types, f.mrc.ordering, f.engine)
+	if err != nil {
+		return err
+	}
 	f.src = &drc
 	f.drc = &drc
 	if f.deDuplicate {


### PR DESCRIPTION
This commit makes it so that we use value encoding for TSQuery and TSVector types in the in-memory hash row container. Previously, we would unconditionally use key encoding and would hit an error in some scenarios (for example in PARTITION BY clauses of window functions that aren't natively supported by the vectorized engine). Since the key encoding support is required for spilling to disk, these queries might still hit an error (but will reference the relevant issue number). Some care had to be taken to handle JSON type separately because it uses value encoding in Fingerprint, but we'll use key encoding if the container spills to disk.

There is no release note given that we haven't seen anyone actually run into this problem (it was caught in the randomized testing).

Fixes: #119567.

Release note: None