### PR TITLE
cli,server: increase `GOGC` by default to 300%, add CLI flag

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -191,6 +191,18 @@ metrics for the entire cluster. This capacity constraint does not affect
 SQL query execution.`,
 	}
 
+	GoGCPercent = FlagInfo{
+		Name: "go-gc-percent",
+		Description: `
+Garbage collection target percentage set on the Go runtime (which is also
+configurable via the GOGC environment variable, but --go-gc-percent has higher
+precedence if both are set). A garbage collection is triggered when the ratio of
+freshly allocated data to live data remaining after the previous collection
+reaches this percentage. If left unspecified, defaults to 300%. If set to a
+negative value, disables the target percentage garbage collection heuristic,
+leaving only the soft memory limit heuristic to trigger garbage collection.`,
+	}
+
 	SQLTempStorage = FlagInfo{
 		Name: "max-disk-temp-storage",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -519,6 +519,10 @@ var startCtx struct {
 	goMemLimitValue          bytesOrPercentageValue
 	diskTempStorageSizeValue bytesOrPercentageValue
 	tsdbSizeValue            bytesOrPercentageValue
+
+	// goGCPercent is used to specify the runtime garbage collection target
+	// percentage. Also configurable with the GOGC environment variable.
+	goGCPercent int
 }
 
 // setStartContextDefaults set the default values in startCtx.  This
@@ -541,6 +545,7 @@ func setStartContextDefaults() {
 	startCtx.goMemLimitValue = makeBytesOrPercentageValue(&goMemLimit, memoryPercentResolver)
 	startCtx.diskTempStorageSizeValue = makeBytesOrPercentageValue(nil /* v */, nil /* percentResolver */)
 	startCtx.tsdbSizeValue = makeBytesOrPercentageValue(&serverCfg.TimeSeriesServerConfig.QueryMemoryMax, memoryPercentResolver)
+	startCtx.goGCPercent = 0
 }
 
 // drainCtx captures the command-line parameters of the `node drain`

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -512,6 +512,7 @@ func init() {
 		cliflagcfg.VarFlag(f, &startCtx.sqlSizeValue, cliflags.SQLMem)
 		cliflagcfg.VarFlag(f, &startCtx.goMemLimitValue, cliflags.GoMemLimit)
 		cliflagcfg.VarFlag(f, &startCtx.tsdbSizeValue, cliflags.TSDBMem)
+		cliflagcfg.IntFlag(f, &startCtx.goGCPercent, cliflags.GoGCPercent)
 		// N.B. diskTempStorageSizeValue.Resolve() will be called after the
 		// stores flag has been parsed and the storage device that a
 		// percentage refers to becomes known.

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -165,8 +165,18 @@ end_test
 
 stop_server $argv
 
-start_test "Check that set GOMEMLIMIT env var without specifying --max-go-memory works"
+start_test "Check that setting GOMEMLIMIT env var without specifying --max-go-memory works"
 send "export GOMEMLIMIT=1GiB;\r"
+eexpect ":/# "
+send "$argv start-single-node --insecure --store=path=logs/mystore\r"
+eexpect "node starting"
+interrupt
+eexpect ":/# "
+stop_server $argv
+end_test
+
+start_test "Check that setting GOGC env var without specifying --go-gc-percent works"
+send "export GOGC=500;\r"
 eexpect ":/# "
 send "$argv start-single-node --insecure --store=path=logs/mystore\r"
 eexpect "node starting"

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -540,7 +540,7 @@ func TestLint(t *testing.T) {
 					":!util/grpcutil",                        // GRPC_GO_* variables
 					":!roachprod",                            // roachprod requires AWS environment variables
 					":!cli/env.go",                           // The CLI needs the PGHOST variable.
-					":!cli/start.go",                         // The CLI needs the GOMEMLIMIT variable.
+					":!cli/start.go",                         // The CLI needs the GOMEMLIMIT and GOGC variables.
 					":!internal/codeowners/codeowners.go",    // For BAZEL_TEST.
 					":!internal/team/team.go",                // For BAZEL_TEST.
 					":!util/log/test_log_scope.go",           // For TEST_UNDECLARED_OUTPUT_DIR, REMOTE_EXEC


### PR DESCRIPTION
Closes #115164.

This commit introduces a new `--go-gc-percent` flag to CLI `start` command which controls the garbage collection target percentage on the Go runtime. The default value for the flag if neither the --go-gc-percent flag nor the GOGC env var is set is 300%.

To avoid introducing new OOMs, we only switch to this new default (up from 100%) if a soft memory limit is set, either manually or automatically.

Release note (cli change): A new flag `--go-gc-percent` is introduced to `start` command. It controls the garbage collection target percentage on the Go runtime, mirroring the existing GOGC environment variable. A garbage collection is triggered when the ratio of freshly allocated data to live data remaining after the previous collection reaches this percentage. If left unspecified and a Go soft memory limit is configured (i.e. not explicitly disabled via --max-go-memory nor GOMEMLIMIT), the GC target percentage defaults to 300%. If set to a negative value, disables the target percentage garbage collection heuristic, leaving only the soft memory limit heuristic to trigger garbage collection.
