### PR TITLE
plpgsql: don't push the inScope for non-root blocks

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_block
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_block
@@ -476,4 +476,36 @@ CREATE PROCEDURE p() AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
+# Regression test for the internal error in #119492.
+subtest regression_119492
+
+statement ok
+CREATE FUNCTION somefunc() RETURNS integer AS $$
+DECLARE
+    outer_quantity integer := 30;
+BEGIN
+    RAISE NOTICE 'Quantity here is %', outer_quantity;  -- Prints 30
+    outer_quantity := 50;
+    --
+    -- Create a subblock
+    --
+    DECLARE
+        inner_quantity integer := 80;
+    BEGIN
+        RAISE NOTICE 'Quantity here is %', inner_quantity;  -- Prints 80
+        RAISE NOTICE 'Outer quantity here is %', outer_quantity;  -- Prints 50
+    END;
+    RAISE NOTICE 'Quantity here is %', outer_quantity;  -- Prints 50
+    RETURN outer_quantity;
+END;
+$$ LANGUAGE plpgsql;
+
+query T noticetrace
+SELECT somefunc();
+----
+NOTICE: Quantity here is 30
+NOTICE: Quantity here is 80
+NOTICE: Outer quantity here is 50
+NOTICE: Quantity here is 50
+
 subtest end

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -315,7 +315,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 			plBuilder := newPLpgSQLBuilder(
 				b, cf.Name.Object(), nil /* colRefs */, paramTypes, funcReturnType,
 			)
-			stmtScope = plBuilder.buildBlock(stmt.AST, bodyScope)
+			stmtScope = plBuilder.buildRootBlock(stmt.AST, bodyScope)
 		})
 		checkStmtVolatility(targetVolatility, stmtScope, stmt)
 

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -307,7 +307,7 @@ func (b *Builder) buildRoutine(
 		var expr memo.RelExpr
 		var physProps *physical.Required
 		plBuilder := newPLpgSQLBuilder(b, def.Name, colRefs, o.Types.(tree.ParamTypes), rtyp)
-		stmtScope := plBuilder.buildBlock(stmt.AST, bodyScope)
+		stmtScope := plBuilder.buildRootBlock(stmt.AST, bodyScope)
 		finishResolveType(stmtScope)
 		expr, physProps, isMultiColDataSource =
 			b.finishBuildLastStmt(stmtScope, bodyScope, isSetReturning, f)

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -6070,3 +6070,189 @@ project
                      │                                                                                                                                                └── projections
                      │                                                                                                                                                     └── const: 10 [as=stmt_return_11:25]
                      └── const: 1
+
+# Regression test for #119492 - don't push the in scope for non-root blocks.
+# Doing so drops the expression that had been built up to that point.
+exec-ddl
+CREATE FUNCTION somefunc() RETURNS integer AS $$
+DECLARE
+    outer_quantity integer := 30;
+BEGIN
+    RAISE NOTICE 'Quantity here is %', outer_quantity;  -- Prints 30
+    outer_quantity := 50;
+    --
+    -- Create a subblock
+    --
+    DECLARE
+        inner_quantity integer := 80;
+    BEGIN
+        RAISE NOTICE 'Quantity here is %', inner_quantity;  -- Prints 80
+        RAISE NOTICE 'Outer quantity here is %', outer_quantity;  -- Prints 50
+    END;
+
+    RAISE NOTICE 'Quantity here is %', outer_quantity;  -- Prints 50
+
+    RETURN outer_quantity;
+END;
+$$ LANGUAGE plpgsql;
+----
+
+build format=show-scalars
+SELECT somefunc();
+----
+project
+ ├── columns: somefunc:21
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: somefunc [as=somefunc:21]
+           └── body
+                └── limit
+                     ├── columns: "_stmt_raise_1":20
+                     ├── project
+                     │    ├── columns: "_stmt_raise_1":20
+                     │    ├── barrier
+                     │    │    ├── columns: outer_quantity:1!null
+                     │    │    └── project
+                     │    │         ├── columns: outer_quantity:1!null
+                     │    │         ├── values
+                     │    │         │    └── tuple
+                     │    │         └── projections
+                     │    │              └── const: 30 [as=outer_quantity:1]
+                     │    └── projections
+                     │         └── udf: _stmt_raise_1 [as="_stmt_raise_1":20]
+                     │              ├── args
+                     │              │    └── variable: outer_quantity:1
+                     │              ├── params: outer_quantity:2
+                     │              └── body
+                     │                   ├── project
+                     │                   │    ├── columns: stmt_raise_2:3
+                     │                   │    ├── values
+                     │                   │    │    └── tuple
+                     │                   │    └── projections
+                     │                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_2:3]
+                     │                   │              ├── const: 'NOTICE'
+                     │                   │              ├── concat
+                     │                   │              │    ├── concat
+                     │                   │              │    │    ├── const: 'Quantity here is '
+                     │                   │              │    │    └── coalesce
+                     │                   │              │    │         ├── cast: STRING
+                     │                   │              │    │         │    └── variable: outer_quantity:2
+                     │                   │              │    │         └── const: '<NULL>'
+                     │                   │              │    └── const: ''
+                     │                   │              ├── const: ''
+                     │                   │              ├── const: ''
+                     │                   │              └── const: '00000'
+                     │                   └── project
+                     │                        ├── columns: "_stmt_raise_7":19
+                     │                        ├── barrier
+                     │                        │    ├── columns: outer_quantity:4!null inner_quantity:10!null
+                     │                        │    └── project
+                     │                        │         ├── columns: inner_quantity:10!null outer_quantity:4!null
+                     │                        │         ├── project
+                     │                        │         │    ├── columns: outer_quantity:4!null
+                     │                        │         │    ├── values
+                     │                        │         │    │    └── tuple
+                     │                        │         │    └── projections
+                     │                        │         │         └── const: 50 [as=outer_quantity:4]
+                     │                        │         └── projections
+                     │                        │              └── const: 80 [as=inner_quantity:10]
+                     │                        └── projections
+                     │                             └── udf: _stmt_raise_7 [as="_stmt_raise_7":19]
+                     │                                  ├── args
+                     │                                  │    ├── variable: outer_quantity:4
+                     │                                  │    └── variable: inner_quantity:10
+                     │                                  ├── params: outer_quantity:11 inner_quantity:12
+                     │                                  └── body
+                     │                                       ├── project
+                     │                                       │    ├── columns: stmt_raise_8:13
+                     │                                       │    ├── values
+                     │                                       │    │    └── tuple
+                     │                                       │    └── projections
+                     │                                       │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_8:13]
+                     │                                       │              ├── const: 'NOTICE'
+                     │                                       │              ├── concat
+                     │                                       │              │    ├── concat
+                     │                                       │              │    │    ├── const: 'Quantity here is '
+                     │                                       │              │    │    └── coalesce
+                     │                                       │              │    │         ├── cast: STRING
+                     │                                       │              │    │         │    └── variable: inner_quantity:12
+                     │                                       │              │    │         └── const: '<NULL>'
+                     │                                       │              │    └── const: ''
+                     │                                       │              ├── const: ''
+                     │                                       │              ├── const: ''
+                     │                                       │              └── const: '00000'
+                     │                                       └── project
+                     │                                            ├── columns: "_stmt_raise_9":18
+                     │                                            ├── values
+                     │                                            │    └── tuple
+                     │                                            └── projections
+                     │                                                 └── udf: _stmt_raise_9 [as="_stmt_raise_9":18]
+                     │                                                      ├── args
+                     │                                                      │    ├── variable: outer_quantity:11
+                     │                                                      │    └── variable: inner_quantity:12
+                     │                                                      ├── params: outer_quantity:14 inner_quantity:15
+                     │                                                      └── body
+                     │                                                           ├── project
+                     │                                                           │    ├── columns: stmt_raise_10:16
+                     │                                                           │    ├── values
+                     │                                                           │    │    └── tuple
+                     │                                                           │    └── projections
+                     │                                                           │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_10:16]
+                     │                                                           │              ├── const: 'NOTICE'
+                     │                                                           │              ├── concat
+                     │                                                           │              │    ├── concat
+                     │                                                           │              │    │    ├── const: 'Outer quantity here is '
+                     │                                                           │              │    │    └── coalesce
+                     │                                                           │              │    │         ├── cast: STRING
+                     │                                                           │              │    │         │    └── variable: outer_quantity:14
+                     │                                                           │              │    │         └── const: '<NULL>'
+                     │                                                           │              │    └── const: ''
+                     │                                                           │              ├── const: ''
+                     │                                                           │              ├── const: ''
+                     │                                                           │              └── const: '00000'
+                     │                                                           └── project
+                     │                                                                ├── columns: nested_block_3:17
+                     │                                                                ├── values
+                     │                                                                │    └── tuple
+                     │                                                                └── projections
+                     │                                                                     └── udf: nested_block_3 [as=nested_block_3:17]
+                     │                                                                          ├── args
+                     │                                                                          │    └── variable: outer_quantity:14
+                     │                                                                          ├── params: outer_quantity:5
+                     │                                                                          └── body
+                     │                                                                               └── project
+                     │                                                                                    ├── columns: "_stmt_raise_4":9
+                     │                                                                                    ├── values
+                     │                                                                                    │    └── tuple
+                     │                                                                                    └── projections
+                     │                                                                                         └── udf: _stmt_raise_4 [as="_stmt_raise_4":9]
+                     │                                                                                              ├── args
+                     │                                                                                              │    └── variable: outer_quantity:5
+                     │                                                                                              ├── params: outer_quantity:6
+                     │                                                                                              └── body
+                     │                                                                                                   ├── project
+                     │                                                                                                   │    ├── columns: stmt_raise_5:7
+                     │                                                                                                   │    ├── values
+                     │                                                                                                   │    │    └── tuple
+                     │                                                                                                   │    └── projections
+                     │                                                                                                   │         └── function: crdb_internal.plpgsql_raise [as=stmt_raise_5:7]
+                     │                                                                                                   │              ├── const: 'NOTICE'
+                     │                                                                                                   │              ├── concat
+                     │                                                                                                   │              │    ├── concat
+                     │                                                                                                   │              │    │    ├── const: 'Quantity here is '
+                     │                                                                                                   │              │    │    └── coalesce
+                     │                                                                                                   │              │    │         ├── cast: STRING
+                     │                                                                                                   │              │    │         │    └── variable: outer_quantity:6
+                     │                                                                                                   │              │    │         └── const: '<NULL>'
+                     │                                                                                                   │              │    └── const: ''
+                     │                                                                                                   │              ├── const: ''
+                     │                                                                                                   │              ├── const: ''
+                     │                                                                                                   │              └── const: '00000'
+                     │                                                                                                   └── project
+                     │                                                                                                        ├── columns: stmt_return_6:8
+                     │                                                                                                        ├── values
+                     │                                                                                                        │    └── tuple
+                     │                                                                                                        └── projections
+                     │                                                                                                             └── variable: outer_quantity:6 [as=stmt_return_6:8]
+                     └── const: 1


### PR DESCRIPTION
Previously, `plpgsqlBuilder.buildBlock` would unconditionally push the input scope before building out the statements within the block. This is necessary for the root block, since otherwise the routine parameters would be considered pass-through columns. However, this could cause internal errors and/or incorrect behavior for non-root blocks, because there may be an input expression for these blocks that gets blown away by pushing the scope.

This commit fixes the bug by wrapping `buildBlock` in a new method, `buildRootBlock`, which pushes the scope before calling into `buildBlock`. This way, `buildBlock` no longer has to push the scope. External callers should use the new `buildRootBlock` method instead of `buildBlock`.

There is no release note, since this bug hasn't made it into any release.

Fixes #119492

Release note: None