### PR TITLE
opt: correctly reconcile column definition list with RECORD-returning UDFs

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_record
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_record
@@ -356,4 +356,76 @@ CREATE OR REPLACE FUNCTION f(n INT) RETURNS RECORD AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
+# Test errors related to a UDF called with a column-definition list.
+subtest column_definition_errors
+
+statement ok
+CREATE TYPE one_typ AS (x INT);
+CREATE TYPE foo_typ AS (x INT, y INT);
+CREATE TYPE bar_typ AS (x INT, y INT);
+
+# Column-definition list cannot be used with a composite UDT.
+statement ok
+DROP FUNCTION f(INT);
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS foo_typ LANGUAGE PLpgSQL AS $$ BEGIN RETURN ROW(1, 2); END $$;
+
+statement error pgcode 42601 pq: a column definition list is redundant for a function returning a named composite type
+SELECT * FROM f() AS g(bar bar_typ);
+
+# Column-definition list cannot be used with a scalar type.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$;
+
+statement error pgcode 42601 pq: a column definition list is only allowed for functions returning \"record\"
+SELECT * FROM f() AS g(bar FLOAT);
+
+# Column-definition list cannot be used with OUT-parameters.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f(OUT x INT, OUT y INT) RETURNS RECORD LANGUAGE PLpgSQL AS $$ BEGIN x := 1; y := 2; RETURN; END $$;
+
+statement error pgcode 42601 pq: a column definition list is redundant for a function with OUT parameters
+SELECT * FROM f() AS g(bar bar_typ);
+
+# The number of result columns must match the number of entries in the column
+# definition list.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS RECORD LANGUAGE PLpgSQL AS $$ BEGIN RETURN (1, 2); END $$;
+
+statement error pgcode 42804 pq: returned record type does not match expected record type
+SELECT * FROM f() AS g(bar INT);
+
+statement error pgcode 42804 pq: returned record type does not match expected record type
+SELECT * FROM f() AS g(foo INT, bar INT, baz INT);
+
+# RECORD-returning UDF requires a column-definition list.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS RECORD LANGUAGE PLpgSQL AS $$ BEGIN RETURN ROW(1, 2); END $$;
+
+statement error pgcode 42601 pq: a column definition list is required for functions returning \"record\"
+SELECT * FROM f();
+
+# A column alias list is insufficient.
+statement error pgcode 42601 pq: a column definition list is required for functions returning \"record\"
+SELECT * FROM f() AS g(bar, baz);
+
+# The result column(s) must be assignment-cast compatible with the
+# column-definition list.
+statement ok
+DROP FUNCTION f;
+
+# Note: postgres doesn't throw this error until executing the UDF.
+statement error pgcode 42804 pq: cannot return non-composite value from function returning composite type
+CREATE FUNCTION f() RETURNS RECORD LANGUAGE PLpgSQL AS $$ BEGIN RETURN True; END $$;
+
+statement ok
+CREATE FUNCTION f() RETURNS RECORD LANGUAGE PLpgSQL AS $$ BEGIN RETURN ROW(True); END $$;
+
+statement error pgcode 42P13 pq: return type mismatch in function declared to return record
+SELECT * FROM f() AS g(bar one_typ);
+
 subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_record
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_record
@@ -80,11 +80,10 @@ CREATE OR REPLACE FUNCTION f() RETURNS RECORD AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
-# TODO(drewk): Postgres returns NULL, not a tuple with a NULL element.
 query T
 SELECT f();
 ----
-()
+NULL
 
 statement ok
 CREATE OR REPLACE FUNCTION f() RETURNS RECORD AS $$

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_record
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_record
@@ -428,4 +428,25 @@ CREATE FUNCTION f() RETURNS RECORD LANGUAGE PLpgSQL AS $$ BEGIN RETURN ROW(True)
 statement error pgcode 42P13 pq: return type mismatch in function declared to return record
 SELECT * FROM f() AS g(bar one_typ);
 
+subtest regression_113186
+
+# Check whether the actual function result types are identical to the types in
+# the column definition, and correctly resolve differences.
+# Regression test for #113186.
+statement ok
+CREATE FUNCTION f113186() RETURNS RECORD LANGUAGE PLpgSQL AS $$ BEGIN RETURN ROW(1.99); END; $$;
+
+query R
+SELECT * FROM f113186() AS foo(x FLOAT);
+----
+1.99
+
+query I
+SELECT * FROM f113186() AS foo(x INT);
+----
+2
+
+statement error pgcode 42P13 pq: return type mismatch in function declared to return record
+SELECT * FROM f113186() AS foo(x TIMESTAMP);
+
 subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_params
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_params
@@ -67,29 +67,28 @@ SELECT f(3);
 ----
 NOTICE: 2
 
-# TODO(120942): figure out why this causes an internal error.
-# query II colnames
-# SELECT * FROM f(3);
-# ----
-# param1 param2
-# 3 2
+query II colnames
+SELECT * FROM f(3);
+----
+param1 param2
+3 2
 
-# query T noticetrace
-# SELECT * FROM f(3);
-# ----
-# NOTICE: 2
+query T noticetrace
+SELECT * FROM f(3);
+----
+NOTICE: 2
 
-# query I colnames
-# SELECT param1 FROM f(3);
-# ----
-# param1
-# 3
+query I colnames
+SELECT param1 FROM f(3);
+----
+param1
+3
 
-# query I colnames
-# SELECT param2 FROM f(3);
-# ----
-# param2
-# 2
+query I colnames
+SELECT param2 FROM f(3);
+----
+param2
+2
 
 statement ok
 DROP FUNCTION f;
@@ -127,19 +126,18 @@ NOTICE: 1 <NULL>
 NOTICE: 3 <NULL>
 NOTICE: 3 4
 
-# TODO(120942): figure this out.
-# query II colnames
-# SELECT * FROM f(1);
-# ----
-# param1 param2
-# 3 4
+query II colnames
+SELECT * FROM f(1);
+----
+param1 param2
+3 4
 
-# query T noticetrace
-# SELECT * FROM f(1);
-# ----
-# NOTICE: 1 <NULL>
-# NOTICE: 3 <NULL>
-# NOTICE: 3 4
+query T noticetrace
+SELECT * FROM f(1);
+----
+NOTICE: 1 <NULL>
+NOTICE: 3 <NULL>
+NOTICE: 3 4
 
 statement ok
 DROP FUNCTION f;

--- a/pkg/internal/sqlsmith/plpgsql.go
+++ b/pkg/internal/sqlsmith/plpgsql.go
@@ -60,7 +60,7 @@ func (s *Smither) makePLpgSQLDeclarations(
 			varName = s.name("decl")
 		}
 		varTyp := s.randType()
-		for types.IsRecordType(varTyp) || varTyp.Family() == types.CollatedStringFamily {
+		for varTyp.Identical(types.AnyTuple) || varTyp.Family() == types.CollatedStringFamily {
 			// TODO(#114874): allow record types here when they are supported.
 			// TODO(#105245): allow collated strings when they are supported.
 			varTyp = s.randType()

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -960,7 +960,7 @@ func (s *Smither) makeCreateFunc() (cf *tree.CreateRoutine, ok bool) {
 		// TODO(#105713): lift the RECORD-type restriction.
 		ptyp := s.randType()
 		for ptyp.Family() == types.CollatedStringFamily ||
-			(lang == tree.RoutineLangPLpgSQL && types.IsRecordType(ptyp)) {
+			(lang == tree.RoutineLangPLpgSQL && ptyp.Identical(types.AnyTuple)) {
 			ptyp = s.randType()
 		}
 		pname := fmt.Sprintf("p%d", i)

--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -809,9 +809,7 @@ func (desc *immutable) ToOverload() (ret *tree.Overload, err error) {
 		ret.RoutineParams = append(ret.RoutineParams, routineParam)
 	}
 	ret.ReturnType = tree.FixedReturnType(desc.ReturnType.Type)
-	// TODO(yuzefovich): we should not be setting ReturnsRecordType to 'true'
-	// when the return type is based on output parameters.
-	ret.ReturnsRecordType = types.IsRecordType(desc.ReturnType.Type)
+	ret.ReturnsRecordType = desc.ReturnType.Type.Identical(types.AnyTuple)
 	ret.Types = signatureTypes
 	ret.Volatility, err = desc.getOverloadVolatility()
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -405,6 +405,8 @@ CREATE PROCEDURE pv() AS 'SELECT 1' STRICT LANGUAGE SQL;
 
 subtest end
 
+subtest not_proc
+
 statement error pgcode 42809 sum is not a procedure
 CALL sum(1);
 
@@ -420,6 +422,8 @@ SELECT oid FROM pg_proc WHERE proname = 'count_rows';
 statement error pgcode 42809 count_rows is not a procedure
 CALL [ FUNCTION $funcOID ] ();
 
+subtest nested_call
+
 statement ok
 CREATE PROCEDURE p_inner(OUT param INTEGER) AS $$ SELECT 1; $$ LANGUAGE SQL;
 
@@ -433,3 +437,86 @@ CREATE PROCEDURE p_outer(OUT param INTEGER) AS $$ CALL p_inner(NULL); $$ LANGUAG
 
 statement ok
 DROP PROCEDURE p_inner;
+
+# Test type-coercion rules for composite return types.
+subtest return_tuple
+
+statement ok
+CREATE TYPE one_typ AS (x INT);
+CREATE TYPE two_typ AS (x INT, y INT);
+
+statement ok
+DROP PROCEDURE p(INT);
+DROP PROCEDURE p;
+
+# Test a procedure returning a composite type with one element.
+statement error pgcode 42P13 pq: return type mismatch in function declared to return record
+CREATE PROCEDURE p(OUT foo one_typ) LANGUAGE SQL AS $$ SELECT 1; $$;
+
+statement ok
+CREATE PROCEDURE p(OUT foo one_typ) LANGUAGE SQL AS $$ SELECT ROW(1); $$;
+
+query T
+CALL p(NULL);
+----
+(1)
+
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p(OUT foo one_typ) LANGUAGE SQL AS $$ SELECT ROW(ROW(1)); $$;
+
+query T
+CALL p(NULL);
+----
+(1)
+
+statement ok
+DROP PROCEDURE p;
+
+# Test a procedure returning a composite type with two elements.
+statement error pgcode 42P13 pq: return type mismatch in function declared to return record
+CREATE PROCEDURE p(OUT foo two_typ) LANGUAGE SQL AS $$ SELECT 1, 2; $$;
+
+statement ok
+CREATE PROCEDURE p(OUT foo two_typ) LANGUAGE SQL AS $$ SELECT ROW(1, 2); $$;
+
+query T
+CALL p(NULL);
+----
+(1,2)
+
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p(OUT foo two_typ) LANGUAGE SQL AS $$ SELECT ROW(ROW(1, 2)); $$;
+
+query T
+CALL p(NULL);
+----
+(1,2)
+
+# Test a procedure with two OUT-parameters.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p(OUT x INT, OUT y INT) LANGUAGE SQL AS $$ SELECT 1, 2; $$;
+
+query II
+CALL p(NULL, NULL);
+----
+1  2
+
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p(OUT x INT, OUT y INT) LANGUAGE SQL AS $$ SELECT ROW(1, 2); $$;
+
+query II
+CALL p(NULL, NULL);
+----
+1  2
+
+statement ok
+DROP PROCEDURE p;
+
+statement error pgcode 42P13 pq: return type mismatch in function declared to return record
+CREATE PROCEDURE p(OUT x INT, OUT y INT) LANGUAGE SQL AS $$ SELECT ROW(ROW(1, 2)); $$;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/procedure_params
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_params
@@ -499,12 +499,11 @@ CREATE TYPE typ AS (a INT, b INT);
 statement ok
 CREATE PROCEDURE p_udt(OUT typ) AS $$ SELECT (1, 2); $$ LANGUAGE SQL;
 
-# TODO(120942): this currently results in an internal error.
-# query T colnames
-# CALL p_udt(NULL);
-# ----
-# column1
-# (1,2)
+query T colnames
+CALL p_udt(NULL);
+----
+column1
+(1,2)
 
 statement error pgcode 2BP01 cannot drop type "typ" because other objects \(\[test.public.p_udt\]\) still depend on it
 DROP TYPE typ;

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -779,13 +779,124 @@ FROM purchase
 1.00   BHD
 10.00  GBP
 
-subtest end
+subtest regression_113186
 
 statement ok
 CREATE FUNCTION f113186() RETURNS RECORD AS $$ SELECT 1.99; $$ LANGUAGE SQL;
 
-# Until #113186 is resolved, the internal error is expected.
 query I
 SELECT * FROM f113186() AS foo(x INT);
 ----
 2
+
+# Test type-coercion rules for composite return types.
+subtest return_tuple
+
+statement ok
+CREATE TYPE one_typ AS (x INT);
+CREATE TYPE two_typ AS (x INT, y INT);
+
+# Test a function returning a composite type with one element.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS one_typ LANGUAGE SQL AS $$ SELECT 1; $$;
+
+query T
+SELECT f();
+----
+(1)
+
+query I
+SELECT * FROM f();
+----
+1
+
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS one_typ LANGUAGE SQL AS $$ SELECT ROW(1); $$;
+
+query T
+SELECT f();
+----
+(1)
+
+query I
+SELECT * FROM f();
+----
+1
+
+statement ok
+DROP FUNCTION f;
+
+statement error pgcode 42P13 pq: return type mismatch in function declared to return one_typ
+CREATE FUNCTION f() RETURNS one_typ LANGUAGE SQL AS $$ SELECT ROW(ROW(1)); $$;
+
+# Test a function returning a composite type with two elements.
+statement ok
+CREATE FUNCTION f() RETURNS two_typ LANGUAGE SQL AS $$ SELECT 1, 2; $$;
+
+query T
+SELECT f();
+----
+(1,2)
+
+query II
+SELECT * FROM f();
+----
+1  2
+
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS two_typ LANGUAGE SQL AS $$ SELECT ROW(1, 2); $$;
+
+query T
+SELECT f();
+----
+(1,2)
+
+query II
+SELECT * FROM f();
+----
+1  2
+
+statement ok
+DROP FUNCTION f;
+
+statement error pgcode 42P13 pq: return type mismatch in function declared to return two_typ
+CREATE FUNCTION f() RETURNS two_typ LANGUAGE SQL AS $$ SELECT ROW(ROW(1, 2)); $$;
+
+# Test a function with two OUT-parameters.
+statement ok
+CREATE FUNCTION f(OUT x INT, OUT y INT) LANGUAGE SQL AS $$ SELECT 1, 2; $$;
+
+query T
+SELECT f();
+----
+(1,2)
+
+query II
+SELECT * FROM f();
+----
+1  2
+
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f(OUT x INT, OUT y INT) LANGUAGE SQL AS $$ SELECT ROW(1, 2); $$;
+
+query T
+SELECT f();
+----
+(1,2)
+
+query II
+SELECT * FROM f();
+----
+1  2
+
+statement ok
+DROP FUNCTION f;
+
+statement error pgcode 42P13 pq: return type mismatch in function declared to return record
+CREATE FUNCTION f(OUT x INT, OUT y INT) LANGUAGE SQL AS $$ SELECT ROW(ROW(1, 2)); $$;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -785,5 +785,7 @@ statement ok
 CREATE FUNCTION f113186() RETURNS RECORD AS $$ SELECT 1.99; $$ LANGUAGE SQL;
 
 # Until #113186 is resolved, the internal error is expected.
-statement error pgcode XX000 internal error: invalid datum type given: DECIMAL, expected INT8
+query I
 SELECT * FROM f113186() AS foo(x INT);
+----
+2

--- a/pkg/sql/logictest/testdata/logic_test/udf_record
+++ b/pkg/sql/logictest/testdata/logic_test/udf_record
@@ -628,4 +628,42 @@ CREATE FUNCTION f() RETURNS RECORD LANGUAGE SQL AS $$ SELECT True; $$;
 statement error pgcode 42P13 pq: return type mismatch in function declared to return record
 SELECT * FROM f() AS g(bar INT);
 
+subtest regression_113186
+
+# Check whether the actual function result types are identical to the types in
+# the column definition, and correctly resolve differences.
+statement ok
+CREATE FUNCTION f113186() RETURNS RECORD LANGUAGE SQL AS $$ SELECT 1.99; $$;
+
+query R colnames
+SELECT * FROM f113186() AS foo(x FLOAT);
+----
+x
+1.99
+
+query I colnames
+SELECT * FROM f113186() AS foo(x INT);
+----
+x
+2
+
+statement error pgcode 42P13 pq: return type mismatch in function declared to return record
+SELECT * FROM f113186() AS foo(x TIMESTAMP);
+
+subtest regression_114846
+
+# Function creation and execution should succeed without internal error due to
+# mismatched types.
+statement ok
+CREATE FUNCTION array_to_set(ANYARRAY) RETURNS SETOF RECORD AS $$
+  SELECT i AS "index", $1[i] AS "value" FROM generate_subscripts($1, 1) i;
+$$ LANGUAGE SQL STRICT IMMUTABLE;
+
+query RT colnames,rowsort
+SELECT * FROM array_to_set(ARRAY['one', 'two']) AS t(f1 NUMERIC(4,2), f2 TEXT);
+----
+f1    f2
+1.00  one
+2.00  two
+
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_record
+++ b/pkg/sql/logictest/testdata/logic_test/udf_record
@@ -211,7 +211,7 @@ $$
 $$ LANGUAGE SQL;
 
 query T
-SELECT * FROM f_udt() AS foo(u udt);
+SELECT * FROM f_udt();
 ----
 a
 
@@ -465,20 +465,24 @@ CREATE FUNCTION imp() RETURNS imp LANGUAGE SQL AS $$
   SELECT k, a, b FROM imp
 $$
 
-query TBT
-SELECT imp(), (1,2,'a')::imp = imp(), pg_typeof(imp())
+# TODO(#58252): pg_typeof(imp_tup_ordered()) is omitted because we get
+# different results for different configurations.
+query TB
+SELECT imp(), (1,2,'a')::imp = imp()
 ----
-(1,2,a)  true  imp
+(1,2,a)  true
 
 statement ok
 CREATE FUNCTION imp_star() RETURNS imp LANGUAGE SQL AS $$
   SELECT * FROM imp
 $$
 
-query TBT
-SELECT imp_star(), (1,2,'a')::imp = imp_star(), pg_typeof(imp_star())
+# TODO(#58252): pg_typeof(imp_tup_ordered()) is omitted because we get
+# different results for different configurations.
+query TB
+SELECT imp_star(), (1,2,'a')::imp = imp_star()
 ----
-(1,2,a)  true  imp
+(1,2,a)  true
 
 statement ok
 INSERT INTO imp VALUES (100, 200, 'z')
@@ -488,8 +492,8 @@ CREATE FUNCTION imp_tup_ordered() RETURNS imp LANGUAGE SQL AS $$
   SELECT (k, a, b) FROM imp ORDER BY b DESC
 $$
 
-# TODO(mgartner): pg_typeof(imp_tup_ordered()) is omitted because we get
-# different results for different configurations, due to #58252.
+# TODO(#58252): pg_typeof(imp_tup_ordered()) is omitted because we get
+# different results for different configurations.
 query TB
 SELECT imp_tup_ordered(), (100,200,'z')::imp = imp_tup_ordered()
 ----
@@ -500,10 +504,12 @@ CREATE FUNCTION imp_ordered() RETURNS imp LANGUAGE SQL AS $$
   SELECT k, a, b FROM imp ORDER BY b DESC
 $$
 
-query TBT
-SELECT imp_ordered(), (100,200,'z')::imp = imp_ordered(), pg_typeof(imp_ordered())
+# TODO(#58252): pg_typeof(imp_ordered()) is omitted because we get
+# different results for different configurations.
+query TB
+SELECT imp_ordered(), (100,200,'z')::imp = imp_ordered()
 ----
-(100,200,z)  true  imp
+(100,200,z)  true
 
 statement ok
 CREATE FUNCTION imp_identity(i imp) RETURNS imp LANGUAGE SQL AS $$
@@ -558,5 +564,68 @@ statement error pgcode 42P13 return type mismatch in function declared to return
 CREATE FUNCTION err(i imp) RETURNS INT LANGUAGE SQL AS $$
   SELECT i
 $$
+
+# Test errors related to a UDF called with a column-definition list.
+subtest column_definition_errors
+
+statement ok
+CREATE TYPE foo_typ AS (x INT, y INT);
+CREATE TYPE bar_typ AS (x INT, y INT);
+
+# Column-definition list cannot be used with a composite UDT.
+statement ok
+CREATE FUNCTION f() RETURNS foo_typ LANGUAGE SQL AS $$ SELECT ROW(1, 2); $$;
+
+statement error pgcode 42601 pq: a column definition list is redundant for a function returning a named composite type
+SELECT * FROM f() AS g(bar bar_typ);
+
+# Column-definition list cannot be used with a scalar type.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1; $$;
+
+statement error pgcode 42601 pq: a column definition list is only allowed for functions returning \"record\"
+SELECT * FROM f() AS g(bar FLOAT);
+
+# Column-definition list cannot be used with OUT-parameters.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f(OUT x INT, OUT y INT) RETURNS RECORD LANGUAGE SQL AS $$ SELECT ROW(1, 2); $$;
+
+statement error pgcode 42601 pq: a column definition list is redundant for a function with OUT parameters
+SELECT * FROM f() AS g(bar bar_typ);
+
+# The number of result columns must match the number of entries in the column
+# definition list.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS RECORD LANGUAGE SQL AS $$ SELECT 1, 2; $$;
+
+statement error pgcode 42804 pq: function return row and query-specified return row do not match
+SELECT * FROM f() AS g(bar INT);
+
+statement error pgcode 42804 pq: function return row and query-specified return row do not match
+SELECT * FROM f() AS g(foo INT, bar INT, baz INT);
+
+# RECORD-returning UDF requires a column-definition list.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS RECORD LANGUAGE SQL AS $$ SELECT ROW(1, 2); $$;
+
+statement error pgcode 42601 pq: a column definition list is required for functions returning \"record\"
+SELECT * FROM f();
+
+# A column alias list is insufficient.
+statement error pgcode 42601 pq: a column definition list is required for functions returning \"record\"
+SELECT * FROM f() AS g(bar, baz);
+
+# The result column(s) must be assignment-cast compatible with the
+# column-definition list.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS RECORD LANGUAGE SQL AS $$ SELECT True; $$;
+
+statement error pgcode 42P13 pq: return type mismatch in function declared to return record
+SELECT * FROM f() AS g(bar INT);
 
 subtest end

--- a/pkg/sql/opt/exec/execbuilder/testdata/call
+++ b/pkg/sql/opt/exec/execbuilder/testdata/call
@@ -72,11 +72,11 @@ call
            │    ├── fd: ()-->(3)
            │    └── (2,)
            └── values
-                ├── columns: column5:5
+                ├── columns: column1:4
                 ├── cardinality: [1 - 1]
                 ├── stats: [rows=1]
                 ├── key: ()
-                ├── fd: ()-->(5)
+                ├── fd: ()-->(4)
                 └── (NULL,)
 
 query T
@@ -110,13 +110,13 @@ call
            │    └── tuple [type=tuple{int}]
            │         └── const: 2 [type=int]
            └── values
-                ├── columns: column5:5(void)
+                ├── columns: column1:4(unknown)
                 ├── cardinality: [1 - 1]
                 ├── stats: [rows=1]
                 ├── key: ()
-                ├── fd: ()-->(5)
-                └── tuple [type=tuple{void}]
-                     └── null [type=void]
+                ├── fd: ()-->(4)
+                └── tuple [type=tuple{unknown}]
+                     └── null [type=unknown]
 
 query T
 EXPLAIN (DISTSQL) CALL foo(3);

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -362,3 +362,23 @@ vectorized: true
   columns: (f88259)
   size: 1 column, 1 row
   row 0, expr 0: f88259(333, 444)
+
+# Regression test for not using actual argument types (#114846).
+statement ok
+CREATE FUNCTION array_to_set(anyarray) RETURNS SETOF RECORD AS $$
+   SELECT i AS "index", $1[i] AS "value" FROM generate_subscripts($1, 1) i
+$$ LANGUAGE SQL STRICT IMMUTABLE;
+
+query T
+EXPLAIN (VERBOSE, TYPES) SELECT * FROM array_to_set(array['one', 'two']) AS t(f1 numeric(4,2), f2 text);
+----
+distribution: local
+vectorized: true
+·
+• project set
+│ columns: (f1 decimal, f2 string)
+│ estimated row count: 1
+│ render 0: (array_to_set((ARRAY[('one')[string],('two')[string]])[string[]]))[tuple{int AS index, string AS value}]
+│
+└── • emptyrow
+      columns: ()

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -378,7 +378,7 @@ vectorized: true
 • project set
 │ columns: (f1 decimal, f2 string)
 │ estimated row count: 1
-│ render 0: (array_to_set((ARRAY[('one')[string],('two')[string]])[string[]]))[tuple{int AS index, string AS value}]
+│ render 0: (array_to_set((ARRAY[('one')[string],('two')[string]])[string[]]))[tuple{decimal AS f1, string AS f2}]
 │
 └── • emptyrow
       columns: ()

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -705,7 +705,7 @@ type UDFDefinition struct {
 	CalledOnNullInput bool
 
 	// MultiColDataSource is true if the function may return multiple columns.
-	// This is only the case if the UDF returns a RECORD type and is used as a
+	// This is only the case if the UDF returns a composite type and is used as a
 	// data source.
 	MultiColDataSource bool
 

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -398,8 +398,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		// TODO(mgartner): stmtScope.cols does not describe the result
 		// columns of the statement. We should use physical.Presentation
 		// instead.
-		isSQLProcedure := cf.IsProcedure && language == tree.RoutineLangSQL
-		err = validateReturnType(b.ctx, b.semaCtx, funcReturnType, stmtScope.cols, isSQLProcedure)
+		err = validateReturnType(b.ctx, b.semaCtx, funcReturnType, stmtScope.cols)
 		if err != nil {
 			panic(err)
 		}
@@ -449,11 +448,7 @@ func formatFuncBodyStmt(
 }
 
 func validateReturnType(
-	ctx context.Context,
-	semaCtx *tree.SemaContext,
-	expected *types.T,
-	cols []scopeColumn,
-	isSQLProcedure bool,
+	ctx context.Context, semaCtx *tree.SemaContext, expected *types.T, cols []scopeColumn,
 ) error {
 	// The return type must be supported by the current cluster version.
 	checkUnsupportedType(ctx, semaCtx, expected)
@@ -485,23 +480,29 @@ func validateReturnType(
 	}
 
 	if len(cols) == 1 {
-		typeToCheck := expected
-		if isSQLProcedure && len(expected.TupleContents()) == 1 {
-			// For SQL procedures with output parameters we get a record type
-			// even with a single column.
-			typeToCheck = expected.TupleContents()[0]
+		if expected.Equivalent(cols[0].typ) ||
+			cast.ValidCast(cols[0].typ, expected, cast.ContextAssignment) {
+			// Postgres allows UDFs to coerce a single result column directly to the
+			// return type. Stored procedures are not allowed to do this (see below).
+			return nil
 		}
-		if !typeToCheck.Equivalent(cols[0].typ) &&
-			!cast.ValidCast(cols[0].typ, typeToCheck, cast.ContextAssignment) {
-			return pgerror.WithCandidateCode(
-				errors.WithDetailf(
-					errors.Newf("return type mismatch in function declared to return %s", expected.Name()),
-					"Actual return type is %s", cols[0].typ.Name(),
-				),
-				pgcode.InvalidFunctionDefinition,
-			)
+		if len(expected.TupleContents()) == 1 {
+			// The routine returns a composite type with one element. This is the case
+			// for a UDF with a composite return type, or a stored procedure with a
+			// single OUT-parameter. In either case, the column can be coerced to the
+			// tuple element type.
+			if expected.TupleContents()[0].Equivalent(cols[0].typ) ||
+				cast.ValidCast(cols[0].typ, expected.TupleContents()[0], cast.ContextAssignment) {
+				return nil
+			}
 		}
-		return nil
+		return pgerror.WithCandidateCode(
+			errors.WithDetailf(
+				errors.Newf("return type mismatch in function declared to return %s", expected.Name()),
+				"Actual return type is %s", cols[0].typ.Name(),
+			),
+			pgcode.InvalidFunctionDefinition,
+		)
 	}
 
 	// If the last statement return multiple columns, then the expected Family

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -931,7 +931,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			procTyp := proc.ResolvedType()
 			colName := scopeColName("").WithMetadataName(b.makeIdentifier("stmt_call"))
 			col := b.ob.synthesizeColumn(callScope, colName, procTyp, nil /* expr */, nil /* scalar */)
-			procScalar, _ := b.ob.buildRoutine(proc, def, callCon.s, callScope, b.colRefs)
+			procScalar := b.ob.buildRoutine(proc, def, callCon.s, callScope, b.colRefs)
 			col.scalar = procScalar
 			b.ob.constructProjectForScope(callCon.s, callScope)
 

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -337,7 +337,7 @@ func (b *plpgsqlBuilder) buildBlock(astBlock *ast.Block, s *scope) *scope {
 			if err != nil {
 				panic(err)
 			}
-			if types.IsRecordType(typ) {
+			if typ.Identical(types.AnyTuple) {
 				panic(recordVarErr)
 			}
 			b.addVariable(dec.Var, typ)
@@ -360,7 +360,7 @@ func (b *plpgsqlBuilder) buildBlock(astBlock *ast.Block, s *scope) *scope {
 			block.cursors[dec.Name] = *dec
 		}
 	}
-	if types.IsRecordType(b.returnType) && types.IsWildcardTupleType(b.returnType) {
+	if b.returnType.Identical(types.AnyTuple) {
 		// For a RECORD-returning routine, infer the concrete type by examining the
 		// RETURN statements. This has to happen after building the declaration
 		// block because RETURN statements can reference declared variables. Only

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -237,7 +237,7 @@ func (b *Builder) buildRoutine(
 	// be concrete in order to decode them correctly. We can determine the types
 	// from the result columns or tuple of the last statement.
 	finishResolveType := func(lastStmtScope *scope) {
-		if types.IsWildcardTupleType(rtyp) {
+		if rtyp.Identical(types.AnyTuple) {
 			if len(lastStmtScope.cols) == 1 &&
 				lastStmtScope.cols[0].typ.Family() == types.TupleFamily {
 				// When the final statement returns a single tuple, we can use
@@ -502,6 +502,10 @@ func (b *Builder) finishBuildLastStmt(
 	expr, physProps = stmtScope.expr, stmtScope.makePhysicalProps()
 	rtyp := f.ResolvedType()
 
+	// Note: since the final return type has already been resolved by this point,
+	// we can't check if this is a RECORD-returning routine by examining rTyp.
+	isRecordReturning := f.ResolvedOverload().ReturnsRecordType
+
 	// Add a LIMIT 1 to the last statement if the UDF is not
 	// set-returning. This is valid because any other rows after the
 	// first can simply be ignored. The limit could be beneficial
@@ -542,21 +546,32 @@ func (b *Builder) finishBuildLastStmt(
 			expr = b.constructProject(expr, elems)
 			physProps = stmtScope.makePhysicalProps()
 		}
-	} else if len(cols) > 1 || (types.IsRecordType(rtyp) && !isSingleTupleResult) {
-		// Only a single column can be returned from a UDF, unless it is used as a
-		// data source (see comment above). If there are multiple columns, combine
-		// them into a tuple. If the last statement is already returning a tuple
-		// and the function has a record return type, then do not wrap the
-		// output in another tuple.
-		elems := make(memo.ScalarListExpr, len(cols))
-		for i := range cols {
-			elems[i] = b.factory.ConstructVariable(cols[i].ID)
+	} else {
+		// Only a single column can be returned from a routine, unless it is a UDF
+		// used as a data source (see comment above). There are three cases in which
+		// we must wrap the column(s) from the last statement into a single tuple:
+		//   1. The last statement has multiple result columns.
+		//   2. The routine returns RECORD, and the last statement does not already
+		//      return a tuple column.
+		//   3. The routine is a stored procedure that returns a non-VOID type, and
+		//      the last statement does not already return a tuple column.
+		overload := f.ResolvedOverload()
+		mustWrapColsInTuple := len(cols) > 1
+		if len(cols) == 1 && !isSingleTupleResult {
+			mustWrapColsInTuple = mustWrapColsInTuple || isRecordReturning ||
+				(rtyp.Family() != types.VoidFamily && overload.Type == tree.ProcedureRoutine)
 		}
-		tup := b.factory.ConstructTuple(elems, rtyp)
-		stmtScope = bodyScope.push()
-		col := b.synthesizeColumn(stmtScope, scopeColName(""), rtyp, nil /* expr */, tup)
-		expr = b.constructProject(expr, []scopeColumn{*col})
-		physProps = stmtScope.makePhysicalProps()
+		if mustWrapColsInTuple {
+			elems := make(memo.ScalarListExpr, len(cols))
+			for i := range cols {
+				elems[i] = b.factory.ConstructVariable(cols[i].ID)
+			}
+			tup := b.factory.ConstructTuple(elems, rtyp)
+			stmtScope = bodyScope.push()
+			col := b.synthesizeColumn(stmtScope, scopeColName(""), rtyp, nil /* expr */, tup)
+			expr = b.constructProject(expr, []scopeColumn{*col})
+			physProps = stmtScope.makePhysicalProps()
+		}
 	}
 
 	// We must preserve the presentation of columns as physical
@@ -569,17 +584,18 @@ func (b *Builder) finishBuildLastStmt(
 	if len(cols) > 0 {
 		returnCol := physProps.Presentation[0].ID
 		returnColMeta := b.factory.Metadata().ColumnMeta(returnCol)
-		if !types.IsRecordType(rtyp) && !isMultiColDataSource && !returnColMeta.Type.Identical(rtyp) {
+		if !isRecordReturning && !isMultiColDataSource &&
+			!returnColMeta.Type.Identical(rtyp) {
 			if !cast.ValidCast(returnColMeta.Type, rtyp, cast.ContextAssignment) {
 				panic(sqlerrors.NewInvalidAssignmentCastError(
 					returnColMeta.Type, rtyp, returnColMeta.Alias))
 			}
-			cast := b.factory.ConstructAssignmentCast(
+			assignCast := b.factory.ConstructAssignmentCast(
 				b.factory.ConstructVariable(physProps.Presentation[0].ID),
 				rtyp,
 			)
 			stmtScope = bodyScope.push()
-			col := b.synthesizeColumn(stmtScope, scopeColName(""), rtyp, nil /* expr */, cast)
+			col := b.synthesizeColumn(stmtScope, scopeColName(""), rtyp, nil /* expr */, assignCast)
 			expr = b.constructProject(expr, []scopeColumn{*col})
 			physProps = stmtScope.makePhysicalProps()
 		}

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -349,11 +349,22 @@ func (b *Builder) buildRoutine(
 			panic(unimplemented.NewWithIssue(88947,
 				"variadiac user-defined functions are not yet supported"))
 		}
+		if len(paramTypes) != len(args) {
+			panic(errors.AssertionFailedf(
+				"different number of static parameters %d and actual arguments %d", len(paramTypes), len(args),
+			))
+		}
 		params = make(opt.ColList, len(paramTypes))
 		for i := range paramTypes {
 			paramType := &paramTypes[i]
 			argColName := funcParamColName(tree.Name(paramType.Name), i)
-			col := b.synthesizeColumn(bodyScope, argColName, paramType.Typ, nil /* expr */, nil /* scalar */)
+			// Use the statically defined parameter type (unless it is a wildcard, in
+			// which case we use the actual argument type).
+			argType := paramType.Typ
+			if argType.IsWildcardType() {
+				argType = args[i].DataType()
+			}
+			col := b.synthesizeColumn(bodyScope, argColName, argType, nil /* expr */, nil /* scalar */)
 			col.setParamOrd(i)
 			params[i] = col.id
 		}

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -574,7 +574,14 @@ func (b *Builder) buildFunction(
 	})
 
 	if overload.Class == tree.GeneratorClass {
-		return b.finishBuildGeneratorFunction(f, overload, out, inScope, outScope, outCol)
+		if overload.ReturnsRecordType {
+			if colDefListTypes := b.getColumnDefinitionListTypes(inScope); colDefListTypes != nil {
+				// Use the types from the column definition list to determine the
+				// function return type.
+				f.SetTypeAnnotation(colDefListTypes)
+			}
+		}
+		return b.finishBuildGeneratorFunction(f, out, inScope, outScope, outCol)
 	}
 
 	// Add a dependency on sequences that are used as a string argument.
@@ -607,6 +614,27 @@ func (b *Builder) buildFunction(
 	}
 
 	return b.finishBuildScalar(f, out, inScope, outScope, outCol)
+}
+
+// getColumnDefinitionListTypes returns a composite type representing the column
+// definition list for the current scope, if any. If one doesn't exist,
+// getColumnDefinitionListTypes returns nil.
+func (b *Builder) getColumnDefinitionListTypes(inScope *scope) *types.T {
+	alias := inScope.alias
+	if alias == nil || len(alias.Cols) == 0 || alias.Cols[0].Type == nil {
+		return nil
+	}
+	contents := make([]*types.T, len(alias.Cols))
+	labels := make([]string, len(alias.Cols))
+	for i, c := range alias.Cols {
+		defTyp, err := tree.ResolveType(b.ctx, c.Type, b.semaCtx.TypeResolver)
+		if err != nil {
+			panic(err)
+		}
+		contents[i] = defTyp
+		labels[i] = string(c.Name)
+	}
+	return types.MakeLabeledTuple(contents, labels)
 }
 
 // buildRangeCond builds a RANGE clause as a simpler expression. Examples:

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -17,10 +17,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // srf represents an srf expression in an expression tree
@@ -189,68 +191,110 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 // (SRF) such as generate_series() or unnest(). It synthesizes new columns in
 // outScope for each of the SRF's output columns.
 func (b *Builder) finishBuildGeneratorFunction(
-	f *tree.FuncExpr,
-	def *tree.Overload,
-	fn opt.ScalarExpr,
-	inScope, outScope *scope,
-	outCol *scopeColumn,
+	f *tree.FuncExpr, fn opt.ScalarExpr, inScope, outScope *scope, outCol *scopeColumn,
 ) (out opt.ScalarExpr) {
-	lastAlias := inScope.alias
-	if def.ReturnsRecordType {
-		if lastAlias == nil {
-			var numOutParams int
-			for _, param := range def.RoutineParams {
-				if param.IsOutParam() {
-					numOutParams++
-				}
-				if numOutParams == 2 {
-					break
-				}
-			}
-			// If we have at least two OUT parameters, they specify an implicit
-			// alias for the RECORD return type.
-			if numOutParams < 2 {
-				panic(pgerror.New(pgcode.Syntax, "a column definition list is required for functions returning \"record\""))
-			}
-		}
-	} else if lastAlias != nil {
-		// Non-record type return with a table alias that includes types is not
-		// permitted.
-		for _, c := range lastAlias.Cols {
-			if c.Type != nil {
-				panic(pgerror.Newf(pgcode.Syntax, "a column definition list is only allowed for functions returning \"record\""))
-			}
-		}
-	}
+	rTyp := f.ResolvedType()
+	b.validateGeneratorFunctionReturnType(f.ResolvedOverload(), rTyp, inScope)
+
 	// Add scope columns.
 	if outCol != nil {
 		// Single-column return type.
 		b.populateSynthesizedColumn(outCol, fn)
-	} else if def.ReturnsRecordType && lastAlias != nil && len(lastAlias.Cols) > 0 {
-		// If we're building a generator function that returns a record type, like
-		// json_to_record, we need to know the alias that was assigned to the
-		// generator function - without that, we won't know the list of columns
-		// to output.
-		for _, c := range lastAlias.Cols {
-			if c.Type == nil {
-				panic(pgerror.Newf(pgcode.Syntax, "a column definition list is required for functions returning \"record\""))
-			}
-			typ, err := tree.ResolveType(b.ctx, c.Type, b.semaCtx.TypeResolver)
-			if err != nil {
-				panic(err)
-			}
-			b.synthesizeColumn(outScope, scopeColName(c.Name), typ, nil, fn)
-		}
 	} else {
-		// Multi-column return type. Use the tuple labels in the SRF's return type
-		// as column aliases.
-		typ := f.ResolvedType()
-		for i := range typ.TupleContents() {
-			b.synthesizeColumn(outScope, scopeColName(tree.Name(typ.TupleLabels()[i])), typ.TupleContents()[i], nil, fn)
+		// Multi-column return type. Note that we already reconciled the function's
+		// return type with the column definition list (if it exists).
+		for i := range rTyp.TupleContents() {
+			colName := scopeColName(tree.Name(rTyp.TupleLabels()[i]))
+			b.synthesizeColumn(outScope, colName, rTyp.TupleContents()[i], nil, fn)
+		}
+	}
+	return fn
+}
+
+// validateGeneratorFunctionReturnType checks for various errors that result
+// from the presence or absence of a column definition list and its
+// compatibility with the actual function return type. This logic mirrors that
+// in postgres.
+func (b *Builder) validateGeneratorFunctionReturnType(
+	overload *tree.Overload, rTyp *types.T, inScope *scope,
+) {
+	lastAlias := inScope.alias
+	hasColumnDefinitionList := false
+	if lastAlias != nil {
+		for _, c := range lastAlias.Cols {
+			if c.Type != nil {
+				hasColumnDefinitionList = true
+				break
+			}
 		}
 	}
 
-	return fn
+	// Validate the column definition list against the concrete return type of the
+	// function.
+	if hasColumnDefinitionList {
+		if !overload.ReturnsRecordType {
+			// Non RECORD-return type with a column definition list is not permitted.
+			for _, param := range overload.RoutineParams {
+				if param.IsOutParam() {
+					panic(pgerror.New(pgcode.Syntax,
+						"a column definition list is redundant for a function with OUT parameters",
+					))
+				}
+			}
+			if rTyp.Family() == types.TupleFamily {
+				panic(pgerror.New(pgcode.Syntax,
+					"a column definition list is redundant for a function returning a named composite type",
+				))
+			} else {
+				panic(pgerror.Newf(pgcode.Syntax,
+					"a column definition list is only allowed for functions returning \"record\"",
+				))
+			}
+		}
+		if len(rTyp.TupleContents()) != len(lastAlias.Cols) {
+			switch overload.Language {
+			case tree.RoutineLangSQL:
+				err := pgerror.New(pgcode.DatatypeMismatch,
+					"function return row and query-specified return row do not match",
+				)
+				panic(errors.WithDetailf(err,
+					"Returned row contains %d attributes, but query expects %d.",
+					len(rTyp.TupleContents()), len(lastAlias.Cols),
+				))
+			case tree.RoutineLangPLpgSQL:
+				err := pgerror.New(pgcode.DatatypeMismatch,
+					"returned record type does not match expected record type",
+				)
+				panic(errors.WithDetailf(err,
+					"Number of returned columns (%d) does not match expected column count (%d).",
+					len(rTyp.TupleContents()), len(lastAlias.Cols),
+				))
+			default:
+				panic(errors.AssertionFailedf(
+					"unexpected language: %s", redact.SafeString(overload.Language),
+				))
+			}
+		}
+	} else if overload.ReturnsRecordType {
+		panic(pgerror.New(pgcode.Syntax,
+			"a column definition list is required for functions returning \"record\"",
+		))
+	}
+
+	// Verify that the function return type can be assignment-casted to the
+	// column definition list type.
+	if hasColumnDefinitionList {
+		colDefListTypes := b.getColumnDefinitionListTypes(inScope)
+		for i := range colDefListTypes.TupleContents() {
+			colTyp, defTyp := rTyp.TupleContents()[i], colDefListTypes.TupleContents()[i]
+			if !colTyp.Identical(defTyp) && !cast.ValidCast(colTyp, defTyp, cast.ContextAssignment) {
+				panic(errors.WithDetailf(pgerror.New(pgcode.InvalidFunctionDefinition,
+					"return type mismatch in function declared to return record",
+				), "Final statement returns %v instead of %v at column %d.",
+					colTyp.SQLStringForError(), defTyp.SQLStringForError(), i+1))
+			}
+		}
+	}
 }
 
 // buildProjectSet builds a ProjectSet, which is a lateral cross join

--- a/pkg/sql/opt/optbuilder/testdata/procedure
+++ b/pkg/sql/opt/optbuilder/testdata/procedure
@@ -38,18 +38,13 @@ call
            │              ├── const: 1
            │              ├── const: 2
            │              └── const: 3
-           └── project
-                ├── columns: column10:10
-                ├── limit
+           └── limit
+                ├── columns: column1:9
+                ├── values
                 │    ├── columns: column1:9
-                │    ├── values
-                │    │    ├── columns: column1:9
-                │    │    └── tuple
-                │    │         └── null
-                │    └── const: 1
-                └── projections
-                     └── assignment-cast: VOID [as=column10:10]
-                          └── variable: column1:9
+                │    └── tuple
+                │         └── null
+                └── const: 1
 
 exec-ddl
 CREATE OR REPLACE PROCEDURE p() LANGUAGE SQL AS $$
@@ -92,18 +87,13 @@ call
            │              ├── const: 7
            │              ├── const: 8
            │              └── const: 9
-           └── project
-                ├── columns: column18:18
-                ├── limit
+           └── limit
+                ├── columns: column1:17
+                ├── values
                 │    ├── columns: column1:17
-                │    ├── values
-                │    │    ├── columns: column1:17
-                │    │    └── tuple
-                │    │         └── null
-                │    └── const: 1
-                └── projections
-                     └── assignment-cast: VOID [as=column18:18]
-                          └── variable: column1:17
+                │    └── tuple
+                │         └── null
+                └── const: 1
 
 # Procedure with arguments.
 exec-ddl
@@ -142,15 +132,10 @@ call
            │         └── projections
            │              └── assignment-cast: INT8 [as=c_cast:12]
            │                   └── variable: column3:11
-           └── project
-                ├── columns: column14:14
-                ├── limit
+           └── limit
+                ├── columns: column1:13
+                ├── values
                 │    ├── columns: column1:13
-                │    ├── values
-                │    │    ├── columns: column1:13
-                │    │    └── tuple
-                │    │         └── null
-                │    └── const: 1
-                └── projections
-                     └── assignment-cast: VOID [as=column14:14]
-                          └── variable: column1:13
+                │    └── tuple
+                │         └── null
+                └── const: 1

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -1123,15 +1123,15 @@ build
 SELECT * FROM t95615, LATERAL ROWS FROM (f95615(), f95615()) WITH ORDINALITY
 ----
 project
- ├── columns: c1:1!null f95615:6 f95615:6 ordinality:9!null
+ ├── columns: c1:1!null f95615:5 f95615:5 ordinality:7!null
  └── inner-join-apply
-      ├── columns: c1:1!null crdb_internal_mvcc_timestamp:2 tableoid:3 f95615:6 ordinality:9!null
+      ├── columns: c1:1!null crdb_internal_mvcc_timestamp:2 tableoid:3 f95615:5 ordinality:7!null
       ├── scan t95615
       │    └── columns: c1:1!null crdb_internal_mvcc_timestamp:2 tableoid:3
       ├── ordinality
-      │    ├── columns: f95615:6 ordinality:9!null
+      │    ├── columns: f95615:5 ordinality:7!null
       │    └── project-set
-      │         ├── columns: f95615:6
+      │         ├── columns: f95615:5
       │         ├── values
       │         │    └── ()
       │         └── zip

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -1123,15 +1123,15 @@ build
 SELECT * FROM t95615, LATERAL ROWS FROM (f95615(), f95615()) WITH ORDINALITY
 ----
 project
- ├── columns: c1:1!null f95615:5 f95615:5 ordinality:7!null
+ ├── columns: c1:1!null f95615:6 f95615:6 ordinality:9!null
  └── inner-join-apply
-      ├── columns: c1:1!null crdb_internal_mvcc_timestamp:2 tableoid:3 f95615:5 ordinality:7!null
+      ├── columns: c1:1!null crdb_internal_mvcc_timestamp:2 tableoid:3 f95615:6 ordinality:9!null
       ├── scan t95615
       │    └── columns: c1:1!null crdb_internal_mvcc_timestamp:2 tableoid:3
       ├── ordinality
-      │    ├── columns: f95615:5 ordinality:7!null
+      │    ├── columns: f95615:6 ordinality:9!null
       │    └── project-set
-      │         ├── columns: f95615:5
+      │         ├── columns: f95615:6
       │         ├── values
       │         │    └── ()
       │         └── zip

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -855,36 +855,41 @@ build format=show-scalars
 SELECT get_abc(3)
 ----
 project
- ├── columns: get_abc:8
+ ├── columns: get_abc:9
  ├── values
  │    └── tuple
  └── projections
-      └── udf: get_abc [as=get_abc:8]
+      └── udf: get_abc [as=get_abc:9]
            ├── args
            │    └── const: 3
            ├── params: i:1
            └── body
                 └── project
-                     ├── columns: column7:7
-                     ├── limit
-                     │    ├── columns: a:2!null b:3 c:4!null
-                     │    ├── internal-ordering: -3
-                     │    ├── project
+                     ├── columns: column8:8
+                     ├── project
+                     │    ├── columns: column7:7
+                     │    ├── limit
                      │    │    ├── columns: a:2!null b:3 c:4!null
-                     │    │    └── select
-                     │    │         ├── columns: a:2!null b:3 c:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-                     │    │         ├── scan abc
-                     │    │         │    └── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
-                     │    │         └── filters
-                     │    │              └── gt
-                     │    │                   ├── variable: c:4
-                     │    │                   └── variable: i:1
-                     │    └── const: 1
+                     │    │    ├── internal-ordering: -3
+                     │    │    ├── project
+                     │    │    │    ├── columns: a:2!null b:3 c:4!null
+                     │    │    │    └── select
+                     │    │    │         ├── columns: a:2!null b:3 c:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │    │    │         ├── scan abc
+                     │    │    │         │    └── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │    │    │         └── filters
+                     │    │    │              └── gt
+                     │    │    │                   ├── variable: c:4
+                     │    │    │                   └── variable: i:1
+                     │    │    └── const: 1
+                     │    └── projections
+                     │         └── tuple [as=column7:7]
+                     │              ├── variable: a:2
+                     │              ├── variable: b:3
+                     │              └── variable: c:4
                      └── projections
-                          └── tuple [as=column7:7]
-                               ├── variable: a:2
-                               ├── variable: b:3
-                               └── variable: c:4
+                          └── assignment-cast: RECORD [as=column8:8]
+                               └── variable: column7:7
 
 exec-ddl
 CREATE FUNCTION get_abc_star(i INT) RETURNS abc LANGUAGE SQL AS $$
@@ -896,36 +901,41 @@ build format=show-scalars
 SELECT get_abc_star(3)
 ----
 project
- ├── columns: get_abc_star:8
+ ├── columns: get_abc_star:9
  ├── values
  │    └── tuple
  └── projections
-      └── udf: get_abc_star [as=get_abc_star:8]
+      └── udf: get_abc_star [as=get_abc_star:9]
            ├── args
            │    └── const: 3
            ├── params: i:1
            └── body
                 └── project
-                     ├── columns: column7:7
-                     ├── limit
-                     │    ├── columns: a:2!null b:3 c:4!null
-                     │    ├── internal-ordering: -3
-                     │    ├── project
+                     ├── columns: column8:8
+                     ├── project
+                     │    ├── columns: column7:7
+                     │    ├── limit
                      │    │    ├── columns: a:2!null b:3 c:4!null
-                     │    │    └── select
-                     │    │         ├── columns: a:2!null b:3 c:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-                     │    │         ├── scan abc
-                     │    │         │    └── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
-                     │    │         └── filters
-                     │    │              └── gt
-                     │    │                   ├── variable: c:4
-                     │    │                   └── variable: i:1
-                     │    └── const: 1
+                     │    │    ├── internal-ordering: -3
+                     │    │    ├── project
+                     │    │    │    ├── columns: a:2!null b:3 c:4!null
+                     │    │    │    └── select
+                     │    │    │         ├── columns: a:2!null b:3 c:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │    │    │         ├── scan abc
+                     │    │    │         │    └── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │    │    │         └── filters
+                     │    │    │              └── gt
+                     │    │    │                   ├── variable: c:4
+                     │    │    │                   └── variable: i:1
+                     │    │    └── const: 1
+                     │    └── projections
+                     │         └── tuple [as=column7:7]
+                     │              ├── variable: a:2
+                     │              ├── variable: b:3
+                     │              └── variable: c:4
                      └── projections
-                          └── tuple [as=column7:7]
-                               ├── variable: a:2
-                               ├── variable: b:3
-                               └── variable: c:4
+                          └── assignment-cast: RECORD [as=column8:8]
+                               └── variable: column7:7
 
 exec-ddl
 CREATE FUNCTION abc_b(i abc) RETURNS INT LANGUAGE SQL AS $$
@@ -1043,11 +1053,11 @@ build format=show-scalars
 SELECT retvoid(1)
 ----
 project
- ├── columns: retvoid:5
+ ├── columns: retvoid:4
  ├── values
  │    └── tuple
  └── projections
-      └── udf: retvoid [as=retvoid:5]
+      └── udf: retvoid [as=retvoid:4]
            ├── args
            │    └── const: 1
            ├── params: i:1
@@ -1058,18 +1068,13 @@ project
                 │    │    └── tuple
                 │    └── projections
                 │         └── variable: i:1 [as=i:2]
-                └── project
-                     ├── columns: column4:4
-                     ├── limit
+                └── limit
+                     ├── columns: column1:3
+                     ├── values
                      │    ├── columns: column1:3
-                     │    ├── values
-                     │    │    ├── columns: column1:3
-                     │    │    └── tuple
-                     │    │         └── null
-                     │    └── const: 1
-                     └── projections
-                          └── assignment-cast: VOID [as=column4:4]
-                               └── variable: column1:3
+                     │    └── tuple
+                     │         └── null
+                     └── const: 1
 
 
 # --------------------------------------------------
@@ -1243,11 +1248,11 @@ build format=show-scalars
 SELECT * FROM (SELECT strict_fn_record(1, 'foo', false)) as bar;
 ----
 project
- ├── columns: strict_fn_record:8
+ ├── columns: strict_fn_record:9
  ├── values
  │    └── tuple
  └── projections
-      └── udf: strict_fn_record [as=strict_fn_record:8]
+      └── udf: strict_fn_record [as=strict_fn_record:9]
            ├── strict
            ├── args
            │    ├── const: 1
@@ -1256,23 +1261,28 @@ project
            ├── params: i:1 t:2 b:3
            └── body
                 └── project
-                     ├── columns: column7:7
-                     ├── limit
-                     │    ├── columns: i:4 t:5 b:6
-                     │    ├── project
+                     ├── columns: column8:8
+                     ├── project
+                     │    ├── columns: column7:7
+                     │    ├── limit
                      │    │    ├── columns: i:4 t:5 b:6
-                     │    │    ├── values
-                     │    │    │    └── tuple
-                     │    │    └── projections
-                     │    │         ├── variable: i:1 [as=i:4]
-                     │    │         ├── variable: t:2 [as=t:5]
-                     │    │         └── variable: b:3 [as=b:6]
-                     │    └── const: 1
+                     │    │    ├── project
+                     │    │    │    ├── columns: i:4 t:5 b:6
+                     │    │    │    ├── values
+                     │    │    │    │    └── tuple
+                     │    │    │    └── projections
+                     │    │    │         ├── variable: i:1 [as=i:4]
+                     │    │    │         ├── variable: t:2 [as=t:5]
+                     │    │    │         └── variable: b:3 [as=b:6]
+                     │    │    └── const: 1
+                     │    └── projections
+                     │         └── tuple [as=column7:7]
+                     │              ├── variable: i:4
+                     │              ├── variable: t:5
+                     │              └── variable: b:6
                      └── projections
-                          └── tuple [as=column7:7]
-                               ├── variable: i:4
-                               ├── variable: t:5
-                               └── variable: b:6
+                          └── assignment-cast: RECORD [as=column8:8]
+                               └── variable: column7:7
 
 
 # --------------------------------------------------
@@ -1315,44 +1325,49 @@ CREATE TABLE tstar2 (
 ----
 
 exec-ddl
-CREATE FUNCTION fn_star2() RETURNS INT LANGUAGE SQL AS 'SELECT * FROM tstar, tstar2 WHERE tstar.a = tstar2.b'
+CREATE FUNCTION fn_star2() RETURNS RECORD LANGUAGE SQL AS 'SELECT * FROM tstar, tstar2 WHERE tstar.a = tstar2.b'
 ----
 
 build format=show-scalars
 SELECT fn_star2()
 ----
 project
- ├── columns: fn_star2:11
+ ├── columns: fn_star2:12
  ├── values
  │    └── tuple
  └── projections
-      └── udf: fn_star2 [as=fn_star2:11]
+      └── udf: fn_star2 [as=fn_star2:12]
            └── body
                 └── project
-                     ├── columns: column10:10
-                     ├── limit
-                     │    ├── columns: tstar.a:1!null tstar2.a:5 b:6!null
-                     │    ├── project
+                     ├── columns: column11:11
+                     ├── project
+                     │    ├── columns: column10:10
+                     │    ├── limit
                      │    │    ├── columns: tstar.a:1!null tstar2.a:5 b:6!null
-                     │    │    └── select
-                     │    │         ├── columns: tstar.a:1!null tstar.rowid:2!null tstar.crdb_internal_mvcc_timestamp:3 tstar.tableoid:4 tstar2.a:5 b:6!null tstar2.rowid:7!null tstar2.crdb_internal_mvcc_timestamp:8 tstar2.tableoid:9
-                     │    │         ├── inner-join (cross)
-                     │    │         │    ├── columns: tstar.a:1 tstar.rowid:2!null tstar.crdb_internal_mvcc_timestamp:3 tstar.tableoid:4 tstar2.a:5 b:6 tstar2.rowid:7!null tstar2.crdb_internal_mvcc_timestamp:8 tstar2.tableoid:9
-                     │    │         │    ├── scan tstar
-                     │    │         │    │    └── columns: tstar.a:1 tstar.rowid:2!null tstar.crdb_internal_mvcc_timestamp:3 tstar.tableoid:4
-                     │    │         │    ├── scan tstar2
-                     │    │         │    │    └── columns: tstar2.a:5 b:6 tstar2.rowid:7!null tstar2.crdb_internal_mvcc_timestamp:8 tstar2.tableoid:9
-                     │    │         │    └── filters (true)
-                     │    │         └── filters
-                     │    │              └── eq
-                     │    │                   ├── variable: tstar.a:1
-                     │    │                   └── variable: b:6
-                     │    └── const: 1
+                     │    │    ├── project
+                     │    │    │    ├── columns: tstar.a:1!null tstar2.a:5 b:6!null
+                     │    │    │    └── select
+                     │    │    │         ├── columns: tstar.a:1!null tstar.rowid:2!null tstar.crdb_internal_mvcc_timestamp:3 tstar.tableoid:4 tstar2.a:5 b:6!null tstar2.rowid:7!null tstar2.crdb_internal_mvcc_timestamp:8 tstar2.tableoid:9
+                     │    │    │         ├── inner-join (cross)
+                     │    │    │         │    ├── columns: tstar.a:1 tstar.rowid:2!null tstar.crdb_internal_mvcc_timestamp:3 tstar.tableoid:4 tstar2.a:5 b:6 tstar2.rowid:7!null tstar2.crdb_internal_mvcc_timestamp:8 tstar2.tableoid:9
+                     │    │    │         │    ├── scan tstar
+                     │    │    │         │    │    └── columns: tstar.a:1 tstar.rowid:2!null tstar.crdb_internal_mvcc_timestamp:3 tstar.tableoid:4
+                     │    │    │         │    ├── scan tstar2
+                     │    │    │         │    │    └── columns: tstar2.a:5 b:6 tstar2.rowid:7!null tstar2.crdb_internal_mvcc_timestamp:8 tstar2.tableoid:9
+                     │    │    │         │    └── filters (true)
+                     │    │    │         └── filters
+                     │    │    │              └── eq
+                     │    │    │                   ├── variable: tstar.a:1
+                     │    │    │                   └── variable: b:6
+                     │    │    └── const: 1
+                     │    └── projections
+                     │         └── tuple [as=column10:10]
+                     │              ├── variable: tstar.a:1
+                     │              ├── variable: tstar2.a:5
+                     │              └── variable: b:6
                      └── projections
-                          └── tuple [as=column10:10]
-                               ├── variable: tstar.a:1
-                               ├── variable: tstar2.a:5
-                               └── variable: b:6
+                          └── assignment-cast: RECORD [as=column11:11]
+                               └── variable: column10:10
 
 
 # --------------------------------------------------
@@ -1740,11 +1755,11 @@ build set=enable_multiple_modifications_of_table=true
 SELECT upd_ups(1, 2, 3)
 ----
 project
- ├── columns: upd_ups:29
+ ├── columns: upd_ups:28
  ├── values
  │    └── ()
  └── projections
-      └── upd_ups(1, 2, 3) [as=upd_ups:29]
+      └── upd_ups(1, 2, 3) [as=upd_ups:28]
 
 exec-ddl
 CREATE FUNCTION ups2(a1 INT, b1 INT, c1 INT, a2 INT, b2 INT, c2 INT) RETURNS BOOL LANGUAGE SQL AS $$
@@ -1803,7 +1818,7 @@ opt format=show-scalars
 SELECT f_fk(100, 1), f_fk(101, 2);
 ----
 values
- ├── columns: f_fk:14 f_fk:28
+ ├── columns: f_fk:15 f_fk:30
  └── tuple
       ├── udf: f_fk
       │    ├── args
@@ -1812,7 +1827,7 @@ values
       │    ├── params: k:1 r:2
       │    └── body
       │         └── project
-      │              ├── columns: column13:13!null
+      │              ├── columns: column14:14!null
       │              ├── insert child
       │              │    ├── columns: c:3!null child.p:4!null
       │              │    ├── insert-mapping:
@@ -1843,47 +1858,49 @@ values
       │              │                             ├── variable: p:9
       │              │                             └── variable: parent.p:10
       │              └── projections
-      │                   └── tuple [as=column13:13]
-      │                        ├── variable: c:3
-      │                        └── variable: child.p:4
+      │                   └── assignment-cast: RECORD [as=column14:14]
+      │                        └── tuple
+      │                             ├── variable: c:3
+      │                             └── variable: child.p:4
       └── udf: f_fk
            ├── args
            │    ├── const: 101
            │    └── const: 2
-           ├── params: k:15 r:16
+           ├── params: k:16 r:17
            └── body
                 └── project
-                     ├── columns: column27:27!null
+                     ├── columns: column29:29!null
                      ├── insert child
-                     │    ├── columns: c:17!null child.p:18!null
+                     │    ├── columns: c:18!null child.p:19!null
                      │    ├── insert-mapping:
-                     │    │    ├── column1:21 => c:17
-                     │    │    └── column2:22 => child.p:18
+                     │    │    ├── column1:22 => c:18
+                     │    │    └── column2:23 => child.p:19
                      │    ├── return-mapping:
-                     │    │    ├── column1:21 => c:17
-                     │    │    └── column2:22 => child.p:18
+                     │    │    ├── column1:22 => c:18
+                     │    │    └── column2:23 => child.p:19
                      │    ├── input binding: &2
                      │    ├── values
-                     │    │    ├── columns: column1:21 column2:22
+                     │    │    ├── columns: column1:22 column2:23
                      │    │    └── tuple
-                     │    │         ├── variable: k:15
-                     │    │         └── variable: r:16
+                     │    │         ├── variable: k:16
+                     │    │         └── variable: r:17
                      │    └── f-k-checks
                      │         └── f-k-checks-item: child(p) -> parent(p)
                      │              └── anti-join (hash)
-                     │                   ├── columns: p:23
+                     │                   ├── columns: p:24
                      │                   ├── with-scan &2
-                     │                   │    ├── columns: p:23
+                     │                   │    ├── columns: p:24
                      │                   │    └── mapping:
-                     │                   │         └──  column2:22 => p:23
+                     │                   │         └──  column2:23 => p:24
                      │                   ├── scan parent
-                     │                   │    ├── columns: parent.p:24!null
+                     │                   │    ├── columns: parent.p:25!null
                      │                   │    └── flags: disabled not visible index feature
                      │                   └── filters
                      │                        └── eq
-                     │                             ├── variable: p:23
-                     │                             └── variable: parent.p:24
+                     │                             ├── variable: p:24
+                     │                             └── variable: parent.p:25
                      └── projections
-                          └── tuple [as=column27:27]
-                               ├── variable: c:17
-                               └── variable: child.p:18
+                          └── assignment-cast: RECORD [as=column29:29]
+                               └── tuple
+                                    ├── variable: c:18
+                                    └── variable: child.p:19

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -181,7 +181,7 @@ func (tc *Catalog) CreateRoutine(c *tree.CreateRoutine) {
 		OutParamTypes:     outParams,
 		DefaultExprs:      defaultExprs,
 	}
-	overload.ReturnsRecordType = types.IsRecordType(retType)
+	overload.ReturnsRecordType = retType.Identical(types.AnyTuple)
 	if c.ReturnType != nil && c.ReturnType.SetOf {
 		overload.Class = tree.GeneratorClass
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
+	"github.com/lib/pq/oid"
 )
 
 func CreateFunction(b BuildCtx, n *tree.CreateRoutine) {
@@ -66,7 +67,7 @@ func CreateFunction(b BuildCtx, n *tree.CreateRoutine) {
 	if n.IsProcedure {
 		if n.ReturnType != nil {
 			returnType := b.ResolveTypeRef(n.ReturnType.Type)
-			if returnType.Type.Family() != types.VoidFamily && !types.IsRecordType(returnType.Type) {
+			if returnType.Type.Family() != types.VoidFamily && returnType.Type.Oid() != oid.T_record {
 				panic(errors.AssertionFailedf(
 					"CreateRoutine.ReturnType is expected to be empty, VOID, or RECORD for procedures",
 				))
@@ -79,7 +80,7 @@ func CreateFunction(b BuildCtx, n *tree.CreateRoutine) {
 		}
 	} else if n.ReturnType != nil {
 		typ = n.ReturnType.Type
-		if returnType := b.ResolveTypeRef(typ); types.IsRecordType(returnType.Type) {
+		if returnType := b.ResolveTypeRef(typ); returnType.Type.Oid() == oid.T_record {
 			// If the function returns a RECORD type, then we need to check
 			// whether its OUT parameters specify labels for the return type.
 			outParamTypes, outParamNames := getOutputParameters(b, n.Params)

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2836,13 +2836,6 @@ func IsWildcardTupleType(t *T) bool {
 	return len(t.TupleContents()) == 1 && t.TupleContents()[0].Family() == AnyFamily
 }
 
-// IsRecordType returns true if this is a RECORD type. This should only be used
-// when processing UDFs. A record differs from AnyTuple in that the tuple
-// contents may contain types other than Any.
-func IsRecordType(typ *T) bool {
-	return typ.Family() == TupleFamily && typ.Oid() == oid.T_record
-}
-
 // collatedStringTypeSQL returns the string representation of a COLLATEDSTRING
 // or []COLLATEDSTRING type. This is tricky in the case of an array of collated
 // string, since brackets must precede the COLLATE identifier:


### PR DESCRIPTION
#### sql: remove usages of `types.IsRecordType`

Previously, the `types.IsRecordType` function was used in different
contexts (with vs without OUT-params, function params vs return type).
This made it difficult to determine whether a particular usage was
correct, and led to a few bugs in cases where additional checks
were necessary.

This commit replaces usages of `types.IsRecordType` with either:
1. `typ.Identical(types.AnyTuple)`, or
2. `typ.Oid() == oid.T_record`

The former should be used for a RECORD-returning routine with no
OUT-parameters, as well as for a RECORD-typed variable. The latter
should be used to match either a RECORD-returning routine, or one
with multiple OUT-parameters.

Informs #114846

Release note: None

#### optbuilder: use actual arg types when building routine with wildcard types

Previously, we would always pass the static parameter types when
building the routine. However, in some cases the static type is
a wildcard, so we actually need to use the actual argument type. Note
that always using the actual argument type can be incorrect (e.g. we'd
lose the tuple labels present in the static type).

Release note: None

#### opt: refactor optbuild paths for routines and generator functions

This commit heavily refactors the type-handling logic for routines and
generator functions. The hope is to make the code more readable, and also
make the changes in the next commit easier.

Informs #114846

Release note: None

#### opt: add assignment casts for UDFs used as a data source

Previously, attempting to use a RECORD-returning UDF as a data source
(e.g. `SELECT * FROM` syntax) would result in an internal error if the
column definition list types didn't match the columns of the last
statement. This commit fixes that by adding validation that the types
are either identical or can be assignment-casted, and adding assignment
casts if necessary.

Fixes #114846
Fixes #113186

Release note (bug fix): Fixed a bug that could cause an internal error of
the form `invalid datum type given: ..., expected ...` when a RECORD-returning
UDF used as a data source was supplied a column definition list with
mismatched types. This bug has existed since v23.1.0.

#### opt/optbuilder: check for coercibility instead of tuple types

This commit changes the handling of tuple-returning routines to mirror
that of postgres. In particular, when the routine return type is a tuple,
postgres first attempts to coerce result columns to the return type of the
routine. Only if that attempt fails, postgres wraps the result column in
a tuple, and again attempts the coercion. This change affects the handling
of routines that return (for example) a single composite-typed column. For
example, the following two logic tests should produce the same result:
```
statement ok
CREATE TYPE two_typ AS (x INT, y INT);
CREATE FUNCTION f() RETURNS two_typ LANGUAGE SQL AS $$ SELECT 1, 2; $$;

query T
SELECT f();
----
(1,2)
```
vs
```
statement ok
CREATE TYPE two_typ AS (x INT, y INT);
CREATE FUNCTION f() RETURNS two_typ LANGUAGE SQL AS $$ SELECT ROW(1, 2); $$;

query T
SELECT f();
----
(1,2)
```
There is not release note, since this shouldn't affect versions prior to 24.1.

Fixes #120942

Release note: None