### PR TITLE
backup,restore: fix missing Close() calls

### DIFF
--- a/pkg/ccl/backupccl/backupdest/backup_destination.go
+++ b/pkg/ccl/backupccl/backupdest/backup_destination.go
@@ -280,13 +280,14 @@ func ReadLatestFile(
 	defer collection.Close()
 
 	latestFile, err := FindLatestFile(ctx, collection)
-
 	if err != nil {
 		if errors.Is(err, cloud.ErrFileDoesNotExist) {
 			return "", pgerror.Wrapf(err, pgcode.UndefinedFile, "path does not contain a completed latest backup")
 		}
 		return "", pgerror.WithCandidateCode(err, pgcode.Io)
 	}
+	defer latestFile.Close(ctx)
+
 	latest, err := ioctx.ReadAll(ctx, latestFile)
 	if err != nil {
 		return "", err

--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -286,16 +286,21 @@ func generateAndSendImportSpans(
 	if err != nil {
 		return err
 	}
+	defer startKeyIt.Close()
 
 	var key roachpb.Key
 
 	fileIterByLayer := make([]bulk.Iterator[*backuppb.BackupManifest_File], 0, len(backups))
+	defer func() {
+		for _, i := range fileIterByLayer {
+			i.Close()
+		}
+	}()
 	for layer := range backups {
 		iter, err := layerToBackupManifestFileIterFactory[layer].NewFileIter(ctx)
 		if err != nil {
 			return err
 		}
-
 		fileIterByLayer = append(fileIterByLayer, iter)
 	}
 
@@ -482,6 +487,12 @@ func newFileSpanStartKeyIterator(
 	}
 	it.reset()
 	return it, nil
+}
+
+func (i *fileSpanStartKeyIterator) Close() {
+	for _, iter := range i.allIters {
+		iter.Close()
+	}
 }
 
 func (i *fileSpanStartKeyIterator) next() {


### PR DESCRIPTION
Release note (bug fix): fixed a condition where some files were not closed  when inspecting backup metadata during BACKUP and RESTORE.
Epic: none.