### PR TITLE
ci: treat staging branches as release branches

### DIFF
--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -257,7 +257,7 @@ tc_build_branch() {
 # function.
 tc_release_branch() {
   branch=$(tc_build_branch)
-  [[ "$branch" == master || "$branch" == release-* || "$branch" == provisional_* ]]
+  [[ "$branch" == master || "$branch" == release-* || "$branch" == provisional_*  || "$branch" == "staging-"* ]]
 }
 
 tc_bors_branch() {


### PR DESCRIPTION
Previously, the staging branches were not included in the list of release branches, what caused unnecessary test runs.

This PR adds the staging branch pattern of release branches.

Epic: none
Release note: None
Release justification: CI changes