### PR TITLE
roachtest: update pg_regress diff

### DIFF
--- a/pkg/cmd/roachtest/tests/pg_regress.go
+++ b/pkg/cmd/roachtest/tests/pg_regress.go
@@ -142,8 +142,10 @@ func initPGRegress(ctx context.Context, t test.Test, c cluster.Cluster) {
 }
 
 func runPGRegress(ctx context.Context, t test.Test, c cluster.Cluster) {
-	// Can't use git clone locally, which is used to get pg_regress from
-	// the postgres repository.
+	// We could have run this test locally if we changed postgresDir to
+	// something like /tmp/postgres, but local runs on a gceworker produce
+	// slightly different results than the ones from the nightlies, so we
+	// explicitly prohibit the local runs for consistency.
 	if c.IsLocal() {
 		t.Fatal("cannot be run in local mode")
 	}


### PR DESCRIPTION
This commit updates the diff based on recent line number changes. The good news is that the internal errors that print the stack trace should be fixed shortly (PR is already out).

I also spent some time trying to understand what would it take to make `pg_regress` a part of the local roachtest run in CI (so that we don't get these nightly failures and, instead, update the diff as part of the change that triggers the diff), but it seems to be a no-go for two reasons:
- we generally want to make CI run faster, and pg_regress takes on the order of 10 minutes on a gceworker which would make it the slowest roachtest that is part of CI I think
- we run local roachtests in CI inside of the docker container, which at least currently doesn't have `sudo` command to install things like postgres needed for this roachtest.

So I think for now we'll need to either update the diff based on the nightly failure or proactively manually kick of a run of pg_regress when we know that the diff might need to be changed.

Fixes: #119626.

Release note: None