### PR TITLE
release: bump latest 22.2 release to v22.2.19

### DIFF
--- a/pkg/testutils/release/cockroach_releases.yaml
+++ b/pkg/testutils/release/cockroach_releases.yaml
@@ -8,7 +8,7 @@
   - 22.1.19
   predecessor: "21.2"
 "22.2":
-  latest: 22.2.18
+  latest: 22.2.19
   withdrawn:
   - 22.2.4
   - 22.2.8


### PR DESCRIPTION
Bumping the latest release version for v22.2 as part of the release process.

Release note: none

Epic: none