### PR TITLE
workflows: for `acceptance`, use a bigger machine

### DIFF
--- a/.github/workflows/experimental-github-actions-testing.yml
+++ b/.github/workflows/experimental-github-actions-testing.yml
@@ -74,7 +74,7 @@ jobs:
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
   acceptance:
-    runs-on: [self-hosted, basic_runner_group]
+    runs-on: [self-hosted, basic_big_runner_group]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Epic: CRDB-8308
Release note: None