### PR TITLE
optbuilder: properly disable RANGE window mode with offsets and NULLS LAST

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -1545,3 +1545,14 @@ build
 SELECT avg(k) OVER (ORDER BY id NULLS LAST RANGE 0 PRECEDING) FROM nulls_last_test
 ----
 error: NULLS LAST with RANGE mode with OFFSET is currently unsupported
+
+# Regression test for incorrectly using temporary nulls-last-handling column for
+# first window function in the second window function (#119188).
+build
+SELECT
+  variance(1) OVER (PARTITION BY id ORDER BY id ASC NULLS LAST),
+  min(v) OVER (PARTITION BY v, id ORDER BY id DESC NULLS FIRST RANGE BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM
+  nulls_last_test;
+----
+error: NULLS LAST with RANGE mode with OFFSET is currently unsupported


### PR DESCRIPTION
This commit completes the fix in 13725d460c149e57a9d881656d6066a58ec4433a where we could have reused the temporary column for IS NULL expression projected for one window function for another window function that has RANGE window mode with offsets and NULLS LAST (which is unsupported at the moment).

There is no release note since it's unlikely someone would run into this.

Fixes: #119188.

Release note: None