### PR TITLE
backup,restore: support prefix-free backups

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -466,6 +466,8 @@ func runBackupProcessor(
 			logClose(ctx, sink, "SST sink")
 		}()
 
+		sink.elideMode = spec.ElidePrefix
+
 		// priority becomes true when we're sending re-attempts of reads far enough
 		// in the past that we want to run them with priority.
 		var priority bool

--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -45,6 +45,7 @@ func distBackupPlanSpecs(
 	kmsEnv cloud.KMSEnv,
 	mvccFilter kvpb.MVCCFilter,
 	startTime, endTime hlc.Timestamp,
+	elide execinfrapb.ElidePrefix,
 ) (map[base.SQLInstanceID]*execinfrapb.BackupDataSpec, error) {
 	var span *tracing.Span
 	ctx, span = tracing.ChildSpan(ctx, "backupccl.distBackupPlanSpecs")
@@ -107,6 +108,7 @@ func distBackupPlanSpecs(
 			BackupStartTime:  startTime,
 			BackupEndTime:    endTime,
 			UserProto:        user.EncodeProto(),
+			ElidePrefix:      elide,
 		}
 		sqlInstanceIDToSpec[partition.SQLInstanceID] = spec
 	}

--- a/pkg/ccl/backupccl/backuppb/BUILD.bazel
+++ b/pkg/ccl/backupccl/backuppb/BUILD.bazel
@@ -31,6 +31,7 @@ go_proto_library(
         "//pkg/multitenant/mtinfopb",
         "//pkg/roachpb",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/execinfrapb",  # keep
         "//pkg/sql/stats",
         "//pkg/util/hlc",
         "@com_github_gogo_protobuf//gogoproto",

--- a/pkg/ccl/backupccl/backuppb/backup.proto
+++ b/pkg/ccl/backupccl/backuppb/backup.proto
@@ -149,7 +149,10 @@ message BackupManifest {
   // since all backups in 23.1+ will write slim manifests.
   bool has_external_manifest_ssts = 27 [(gogoproto.customname) = "HasExternalManifestSSTs"];
 
-  // NEXT ID: 28
+  int32 elided_prefix = 28 [(gogoproto.nullable) = false,
+    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb.ElidePrefix"];
+
+  // NEXT ID: 29.
 }
 
 message BackupPartitionDescriptor{

--- a/pkg/ccl/backupccl/file_sst_sink_test.go
+++ b/pkg/ccl/backupccl/file_sst_sink_test.go
@@ -132,10 +132,11 @@ func TestFileSSTSinkWrite(t *testing.T) {
 	ctx := context.Background()
 
 	type testCase struct {
-		name           string
-		exportSpans    []exportedSpan
-		flushedSpans   []roachpb.Spans
-		unflushedSpans []roachpb.Spans
+		name              string
+		exportSpans       []exportedSpan
+		flushedSpans      []roachpb.Spans
+		elideFlushedSpans []roachpb.Spans
+		unflushedSpans    []roachpb.Spans
 		// errorExplanation, if non-empty, explains why an error is expected when
 		// writing the case inputs, and makes the test case fail if none is hit.
 		errorExplanation string
@@ -172,15 +173,18 @@ func TestFileSSTSinkWrite(t *testing.T) {
 			name: "prefix-differ",
 			exportSpans: []exportedSpan{
 				newExportedSpanBuilder("2/a", "2/c", false).withKVs([]kvAndTS{{key: "2/a", timestamp: 10}, {key: "2/c", timestamp: 10}}).build(),
-				newExportedSpanBuilder("2/b", "2/d", true).withKVs([]kvAndTS{{key: "2/a", timestamp: 10}, {key: "2/d", timestamp: 10}}).build(),
-				newExportedSpanBuilder("3/c", "3/e", true).withKVs([]kvAndTS{{key: "3/b", timestamp: 9}, {key: "3/e", timestamp: 10}}).build(),
+				newExportedSpanBuilder("2/c", "2/d", true).withKVs([]kvAndTS{{key: "2/c", timestamp: 9}, {key: "2/d", timestamp: 10}}).build(),
+				newExportedSpanBuilder("3/c", "3/e", true).withKVs([]kvAndTS{{key: "3/c", timestamp: 9}, {key: "3/d", timestamp: 10}}).build(),
+				newExportedSpanBuilder("2/e", "2/g", true).withKVs([]kvAndTS{{key: "2/e", timestamp: 10}, {key: "2/f", timestamp: 10}}).build(),
 			},
 			flushedSpans: []roachpb.Spans{
-				{roachpb.Span{Key: []byte("2/a"), EndKey: []byte("2/d")}},
-				{roachpb.Span{Key: []byte("3/b"), EndKey: []byte("3/e")}},
+				{roachpb.Span{Key: []byte("2/a"), EndKey: []byte("2/d")}, roachpb.Span{Key: []byte("3/c"), EndKey: []byte("3/e")}},
 			},
-			unflushedSpans:   []roachpb.Spans{{roachpb.Span{Key: []byte("c"), EndKey: []byte("e")}}},
-			errorExplanation: "unsupported write ordering; backup processor should not do this due to one sink per worker and #118990.",
+			elideFlushedSpans: []roachpb.Spans{
+				{roachpb.Span{Key: []byte("2/a"), EndKey: []byte("2/d")}},
+				{roachpb.Span{Key: []byte("3/c"), EndKey: []byte("3/e")}},
+			},
+			unflushedSpans: []roachpb.Spans{{roachpb.Span{Key: []byte("2/e"), EndKey: []byte("2/g")}}},
 		},
 		{
 			name: "extend-key-boundary-1-file",
@@ -287,70 +291,82 @@ func TestFileSSTSinkWrite(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.errorExplanation != "" {
-				return
+		for i := range tt.flushedSpans {
+			for j, sp := range tt.flushedSpans[i] {
+				tt.flushedSpans[i][j].Key = s2k(string(sp.Key))
+				tt.flushedSpans[i][j].EndKey = s2k(string(sp.EndKey))
 			}
-			st := cluster.MakeTestingClusterSettings()
-			targetFileSize.Override(ctx, &st.SV, 10<<10)
-
-			sink, store := fileSSTSinkTestSetUp(ctx, t, st)
-			defer func() {
-				require.NoError(t, sink.Close())
-			}()
-
-			for _, es := range tt.exportSpans {
-				require.NoError(t, sink.write(ctx, es))
+		}
+		for i := range tt.elideFlushedSpans {
+			for j, sp := range tt.elideFlushedSpans[i] {
+				tt.elideFlushedSpans[i][j].Key = s2k(string(sp.Key))
+				tt.elideFlushedSpans[i][j].EndKey = s2k(string(sp.EndKey))
 			}
+		}
+		for i := range tt.unflushedSpans {
+			for j, sp := range tt.unflushedSpans[i] {
+				tt.unflushedSpans[i][j].Key = s2k(string(sp.Key))
+				tt.unflushedSpans[i][j].EndKey = s2k(string(sp.EndKey))
+			}
+		}
 
-			progress := make([]backuppb.BackupManifest_File, 0)
+		for _, elide := range []execinfrapb.ElidePrefix{execinfrapb.ElidePrefix_None, execinfrapb.ElidePrefix_TenantAndTable} {
+			t.Run(fmt.Sprintf("%s/elide=%s", tt.name, elide), func(t *testing.T) {
+				if tt.errorExplanation != "" {
+					return
+				}
+				st := cluster.MakeTestingClusterSettings()
+				targetFileSize.Override(ctx, &st.SV, 10<<10)
 
-		Loop:
-			for {
-				select {
-				case p := <-sink.conf.progCh:
-					var progDetails backuppb.BackupManifest_Progress
-					if err := types.UnmarshalAny(&p.ProgressDetails, &progDetails); err != nil {
-						t.Fatal(err)
+				sink, store := fileSSTSinkTestSetUp(ctx, t, st)
+				defer func() {
+					require.NoError(t, sink.Close())
+				}()
+				sink.elideMode = elide
+
+				for _, es := range tt.exportSpans {
+					require.NoError(t, sink.write(ctx, es))
+				}
+
+				progress := make([]backuppb.BackupManifest_File, 0)
+
+			Loop:
+				for {
+					select {
+					case p := <-sink.conf.progCh:
+						var progDetails backuppb.BackupManifest_Progress
+						if err := types.UnmarshalAny(&p.ProgressDetails, &progDetails); err != nil {
+							t.Fatal(err)
+						}
+
+						progress = append(progress, progDetails.Files...)
+					default:
+						break Loop
 					}
-
-					progress = append(progress, progDetails.Files...)
-				default:
-					break Loop
 				}
-			}
-
-			for i := range tt.flushedSpans {
-				for j, sp := range tt.flushedSpans[i] {
-					tt.flushedSpans[i][j].Key = s2k(string(sp.Key))
-					tt.flushedSpans[i][j].EndKey = s2k(string(sp.EndKey))
+				expectedSpans := tt.flushedSpans
+				eliding := sink.elideMode != execinfrapb.ElidePrefix_None
+				if eliding && len(tt.elideFlushedSpans) > 0 {
+					expectedSpans = tt.elideFlushedSpans
 				}
-			}
-			for i := range tt.unflushedSpans {
-				for j, sp := range tt.unflushedSpans[i] {
-					tt.unflushedSpans[i][j].Key = s2k(string(sp.Key))
-					tt.unflushedSpans[i][j].EndKey = s2k(string(sp.EndKey))
+				// progCh contains the files that have already been created with
+				// flushes. Verify the contents.
+				require.NoError(t, checkFiles(ctx, store, progress, expectedSpans, eliding))
+
+				// flushedFiles contain the files that are in queue to be created on the
+				// next flush. Save these and then flush the sink to check their contents.
+				var actualUnflushedFiles []backuppb.BackupManifest_File
+				actualUnflushedFiles = append(actualUnflushedFiles, sink.flushedFiles...)
+				// We cannot end the test -- by calling flush -- if the sink is mid-key.
+				if len(tt.exportSpans) > 0 && !tt.exportSpans[len(tt.exportSpans)-1].atKeyBoundary {
+					sink.writeWithNoData(newExportedSpanBuilder("z", "zz", true).build())
 				}
-			}
-
-			// progCh contains the files that have already been created with
-			// flushes. Verify the contents.
-			require.NoError(t, checkFiles(ctx, store, progress, tt.flushedSpans))
-
-			// flushedFiles contain the files that are in queue to be created on the
-			// next flush. Save these and then flush the sink to check their contents.
-			var actualUnflushedFiles []backuppb.BackupManifest_File
-			actualUnflushedFiles = append(actualUnflushedFiles, sink.flushedFiles...)
-			// We cannot end the test -- by calling flush -- if the sink is mid-key.
-			if len(tt.exportSpans) > 0 && !tt.exportSpans[len(tt.exportSpans)-1].atKeyBoundary {
-				sink.writeWithNoData(newExportedSpanBuilder("z", "zz", true).build())
-			}
-			require.NoError(t, sink.flush(ctx))
-			require.NoError(t, checkFiles(ctx, store, actualUnflushedFiles, tt.unflushedSpans))
-			require.Empty(t, sink.flushedFiles)
-		})
+				require.NoError(t, sink.flush(ctx))
+				require.NoError(t, checkFiles(ctx, store, actualUnflushedFiles, tt.unflushedSpans, eliding))
+				require.Empty(t, sink.flushedFiles)
+			})
+		}
 	}
-
 }
 
 func s2k(s string) roachpb.Key {
@@ -920,6 +936,7 @@ func checkFiles(
 	store cloud.ExternalStorage,
 	files []backuppb.BackupManifest_File,
 	expectedFileSpans []roachpb.Spans,
+	elided bool,
 ) error {
 	iterOpts := storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsOnly,
@@ -967,7 +984,7 @@ func checkFiles(
 
 			key := iter.UnsafeKey()
 
-			if !endKeyInclusiveSpansContainsKey(spans, key.Key) {
+			if !endKeyInclusiveSpansContainsKey(spans, key.Key, elided) {
 				return errors.Newf("key %v in file %s not contained by its spans [%v]", key.Key, f, spans)
 			}
 		}
@@ -977,8 +994,12 @@ func checkFiles(
 	return nil
 }
 
-func endKeyInclusiveSpansContainsKey(spans roachpb.Spans, key roachpb.Key) bool {
+func endKeyInclusiveSpansContainsKey(spans roachpb.Spans, key roachpb.Key, elided bool) bool {
 	for _, sp := range spans {
+		if elided {
+			sp.Key, _ = keys.StripTablePrefix(sp.Key)
+			sp.EndKey, _ = keys.StripTablePrefix(sp.EndKey)
+		}
 		if sp.ContainsKey(key) {
 			return true
 		}

--- a/pkg/ccl/backupccl/restore_online_test.go
+++ b/pkg/ccl/backupccl/restore_online_test.go
@@ -45,6 +45,9 @@ func TestOnlineRestoreBasic(t *testing.T) {
 	defer cleanupFn()
 	externalStorage := "nodelocal://1/backup"
 
+	// TODO(dt): remove this when OR supports synthesis.
+	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.backup.elide_common_prefix.enabled = false`)
+
 	sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s'", externalStorage))
 
 	params := base.TestClusterArgs{
@@ -93,6 +96,9 @@ func TestOnlineRestoreTenant(t *testing.T) {
 	_, _ = tc, systemDB
 	defer cleanupFn()
 	srv := tc.Server(0)
+
+	// TODO(dt): remove this when OR supports synthesis.
+	systemDB.Exec(t, `SET CLUSTER SETTING bulkio.backup.elide_common_prefix.enabled = false`)
 
 	_ = securitytest.EmbeddedTenantIDs()
 

--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -313,7 +313,8 @@ func generateAndSendImportSpans(
 
 	flush := func(ctx context.Context) error {
 		entry := execinfrapb.RestoreSpanEntry{
-			Span: lastCovSpan,
+			Span:         lastCovSpan,
+			ElidedPrefix: backups[0].ElidedPrefix,
 		}
 		for layer := range covFilesByLayer {
 			for _, f := range covFilesByLayer[layer] {

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -289,6 +289,12 @@ message StreamIngestionFrontierSpec {
   optional StreamIngestionPartitionSpecs partition_specs = 9 [(gogoproto.nullable) = false];
 }
 
+enum ElidePrefix {
+  None = 0;
+  Tenant = 1;
+  TenantAndTable = 2;
+}
+
 message BackupDataSpec {
   // TODO(lidor): job_id is not needed when interoperability with 22.2 is
   // dropped, the new way to send the job tag is using 'job_tag' in the
@@ -311,7 +317,8 @@ message BackupDataSpec {
   // when using FileTable ExternalStorage.
   optional string user_proto = 10 [(gogoproto.nullable) = false, (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/security/username.SQLUsernameProto"];
 
-  // NEXTID: 12.
+  optional ElidePrefix elide_prefix = 12 [(gogoproto.nullable) = false];
+  // NEXTID: 13.
 }
 
 message RestoreFileSpec {
@@ -323,7 +330,6 @@ message RestoreFileSpec {
   optional roachpb.RowCount backup_file_entry_counts = 6 [(gogoproto.nullable) = false];
   optional uint64 backing_file_size = 7 [(gogoproto.nullable) = false];
   optional uint64 approximate_physical_size = 8 [(gogoproto.nullable) = false];
-
   // NEXT ID: 9.
 }
 
@@ -349,6 +355,7 @@ message RestoreSpanEntry {
   optional roachpb.Span span = 1 [(gogoproto.nullable) = false];
   repeated RestoreFileSpec files = 2 [(gogoproto.nullable) = false];
   optional int64 progressIdx = 3 [(gogoproto.nullable) = false];
+  optional ElidePrefix elided_prefix = 4 [(gogoproto.nullable) = false];
 }
 
 message RestoreDataSpec {


### PR DESCRIPTION
This extends 24.1 backups to be produced with the tenant ID and table ID prefix on every key stored in the backup elided from the stored keys. The elided prefix can be derived from the prefix of the span being restored so it can be elided from the individual keys with no loss of information.