### PR TITLE
jobs: remove unused APIs

### DIFF
--- a/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
+++ b/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
@@ -115,7 +115,7 @@ func testJobsProtectedTimestamp(
 	}
 	jMovedToFailed, recMovedToFailed := mkJobAndRecord()
 	require.NoError(t, insqlDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		return jr.Failed(ctx, txn, jMovedToFailed.ID(), io.ErrUnexpectedEOF)
+		return jr.UnsafeFailed(ctx, txn, jMovedToFailed.ID(), io.ErrUnexpectedEOF)
 	}))
 	jFinished, recFinished := mkJobAndRecord()
 	require.NoError(t, insqlDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {

--- a/pkg/jobs/helpers_test.go
+++ b/pkg/jobs/helpers_test.go
@@ -19,8 +19,17 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Functions in this file are exported for test code convience and
+// should not be used in production code.
+
+// CancelRequested marks the job as cancel-requested using the
+// specified txn (may be nil).
 func (r *Registry) CancelRequested(ctx context.Context, txn isql.Txn, id jobspb.JobID) error {
-	return r.cancelRequested(ctx, txn, id)
+	job, err := r.LoadJobWithTxn(ctx, id, txn)
+	if err != nil {
+		return err
+	}
+	return job.WithTxn(txn).CancelRequested(ctx)
 }
 
 // Started is a wrapper around the internal function that moves a job to the

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -346,16 +346,6 @@ func (u Updater) FractionProgressed(ctx context.Context, progressedFn FractionPr
 	})
 }
 
-// Unpaused sets the status of the tracked job to running or reverting iff the
-// job is currently paused. It does not directly resume the job; rather, it
-// expires the job's lease so that a Registry adoption loop detects it and
-// resumes it.
-func (u Updater) Unpaused(ctx context.Context) error {
-	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
-		return ju.Unpaused(ctx, md)
-	})
-}
-
 // CancelRequested sets the status of the tracked job to cancel-requested. It
 // does not directly cancel the job; like job.Paused, it expects the job to call
 // job.Progressed soon, observe a "job is cancel-requested" error, and abort.

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -372,12 +372,6 @@ func (u Updater) CancelRequestedWithReason(ctx context.Context, reason error) er
 // implementation when a pause is requested.
 type onPauseRequestFunc func(ctx context.Context, md JobMetadata, ju *JobUpdater) error
 
-// PauseRequested is like PausedRequestedWithFunc but with no customer
-// job updater function.
-func (u Updater) PauseRequested(ctx context.Context, reason string) error {
-	return u.PauseRequestedWithFunc(ctx, nil /* fn */, reason)
-}
-
 // PauseRequestedWithFunc sets the status of the tracked job to pause-requested.
 // It does not directly pause the job; it expects the node that runs the job will
 // actively cancel it when it notices that it is in state StatusPauseRequested

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -346,28 +346,6 @@ func (u Updater) FractionProgressed(ctx context.Context, progressedFn FractionPr
 	})
 }
 
-// paused sets the status of the tracked job to paused. It is called by the
-// registry adoption loop by the node currently running a job to move it from
-// PauseRequested to paused.
-func (u Updater) paused(ctx context.Context, fn func(context.Context, isql.Txn) error) error {
-	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
-		if md.Status == StatusPaused {
-			// Already paused - do nothing.
-			return nil
-		}
-		if md.Status != StatusPauseRequested {
-			return fmt.Errorf("job with status %s cannot be set to paused", md.Status)
-		}
-		if fn != nil {
-			if err := fn(ctx, txn); err != nil {
-				return err
-			}
-		}
-		ju.UpdateStatus(StatusPaused)
-		return nil
-	})
-}
-
 // Unpaused sets the status of the tracked job to running or reverting iff the
 // job is currently paused. It does not directly resume the job; rather, it
 // expires the job's lease so that a Registry adoption loop detects it and

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -353,18 +353,8 @@ func (u Updater) FractionProgressed(ctx context.Context, progressedFn FractionPr
 // that it is in state StatusCancelRequested and will move it to state
 // StatusReverting.
 func (u Updater) CancelRequested(ctx context.Context) error {
-	return u.CancelRequestedWithReason(ctx, errJobCanceled)
-}
-
-// CancelRequestedWithReason sets the status of the tracked job to cancel-requested. It
-// does not directly cancel the job; like job.Paused, it expects the job to call
-// job.Progressed soon, observe a "job is cancel-requested" error, and abort.
-// Further the node the runs the job will actively cancel it when it notices
-// that it is in state StatusCancelRequested and will move it to state
-// StatusReverting.
-func (u Updater) CancelRequestedWithReason(ctx context.Context, reason error) error {
 	return u.Update(ctx, func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error {
-		return ju.CancelRequestedWithReason(ctx, md, reason)
+		return ju.CancelRequestedWithReason(ctx, md, errJobCanceled)
 	})
 }
 

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1298,17 +1298,21 @@ func (r *Registry) PauseRequested(
 	return job.WithTxn(txn).PauseRequestedWithFunc(ctx, nil, reason)
 }
 
-// Succeeded marks the job with id as succeeded.
-func (r *Registry) Succeeded(ctx context.Context, txn isql.Txn, id jobspb.JobID) error {
+// Unpause changes the paused job with id to running or reverting using the
+// specified txn (may be nil).
+func (r *Registry) Unpause(ctx context.Context, txn isql.Txn, id jobspb.JobID) error {
 	job, err := r.LoadJobWithTxn(ctx, id, txn)
 	if err != nil {
 		return err
 	}
-	return job.WithTxn(txn).succeeded(ctx, nil)
+	return job.WithTxn(txn).Unpaused(ctx)
 }
 
-// Failed marks the job with id as failed.
-func (r *Registry) Failed(
+// UnsafeFailed marks the job with id as failed. Use outside of the
+// job system is discouraged.
+//
+// This function does not stop a currently running Resumer.
+func (r *Registry) UnsafeFailed(
 	ctx context.Context, txn isql.Txn, id jobspb.JobID, causingError error,
 ) error {
 	job, err := r.LoadJobWithTxn(ctx, id, txn)
@@ -1318,14 +1322,13 @@ func (r *Registry) Failed(
 	return job.WithTxn(txn).failed(ctx, causingError)
 }
 
-// Unpause changes the paused job with id to running or reverting using the
-// specified txn (may be nil).
-func (r *Registry) Unpause(ctx context.Context, txn isql.Txn, id jobspb.JobID) error {
+// Succeeded marks the job with id as succeeded.
+func (r *Registry) Succeeded(ctx context.Context, txn isql.Txn, id jobspb.JobID) error {
 	job, err := r.LoadJobWithTxn(ctx, id, txn)
 	if err != nil {
 		return err
 	}
-	return job.WithTxn(txn).Unpaused(ctx)
+	return job.WithTxn(txn).succeeded(ctx, nil)
 }
 
 // Resumer is a resumable job, and is associated with a Job object. Jobs can be

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1286,15 +1286,6 @@ func (r *Registry) DeleteTerminalJobByID(ctx context.Context, id jobspb.JobID) e
 	})
 }
 
-// cancelRequested marks the job as cancel-requested using the specified txn (may be nil).
-func (r *Registry) cancelRequested(ctx context.Context, txn isql.Txn, id jobspb.JobID) error {
-	job, err := r.LoadJobWithTxn(ctx, id, txn)
-	if err != nil {
-		return err
-	}
-	return job.WithTxn(txn).CancelRequested(ctx)
-}
-
 // PauseRequested marks the job with id as paused-requested using the specified txn (may be nil).
 func (r *Registry) PauseRequested(
 	ctx context.Context, txn isql.Txn, id jobspb.JobID, reason string,

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1286,25 +1286,9 @@ func (r *Registry) DeleteTerminalJobByID(ctx context.Context, id jobspb.JobID) e
 	})
 }
 
-// getJobFn attempts to get a resumer from the given job id. If the job id
-// does not have a resumer then it returns an error message suitable for users.
-func (r *Registry) getJobFn(
-	ctx context.Context, txn isql.Txn, id jobspb.JobID,
-) (*Job, Resumer, error) {
-	job, err := r.LoadJobWithTxn(ctx, id, txn)
-	if err != nil {
-		return nil, nil, err
-	}
-	resumer, err := r.createResumer(job)
-	if err != nil {
-		return job, nil, errors.Errorf("job %d is not controllable", id)
-	}
-	return job, resumer, nil
-}
-
 // cancelRequested marks the job as cancel-requested using the specified txn (may be nil).
 func (r *Registry) cancelRequested(ctx context.Context, txn isql.Txn, id jobspb.JobID) error {
-	job, _, err := r.getJobFn(ctx, txn, id)
+	job, err := r.LoadJobWithTxn(ctx, id, txn)
 	if err != nil {
 		return err
 	}
@@ -1315,7 +1299,7 @@ func (r *Registry) cancelRequested(ctx context.Context, txn isql.Txn, id jobspb.
 func (r *Registry) PauseRequested(
 	ctx context.Context, txn isql.Txn, id jobspb.JobID, reason string,
 ) error {
-	job, _, err := r.getJobFn(ctx, txn, id)
+	job, err := r.LoadJobWithTxn(ctx, id, txn)
 	if err != nil {
 		return err
 	}
@@ -1325,7 +1309,7 @@ func (r *Registry) PauseRequested(
 
 // Succeeded marks the job with id as succeeded.
 func (r *Registry) Succeeded(ctx context.Context, txn isql.Txn, id jobspb.JobID) error {
-	job, _, err := r.getJobFn(ctx, txn, id)
+	job, err := r.LoadJobWithTxn(ctx, id, txn)
 	if err != nil {
 		return err
 	}
@@ -1336,7 +1320,7 @@ func (r *Registry) Succeeded(ctx context.Context, txn isql.Txn, id jobspb.JobID)
 func (r *Registry) Failed(
 	ctx context.Context, txn isql.Txn, id jobspb.JobID, causingError error,
 ) error {
-	job, _, err := r.getJobFn(ctx, txn, id)
+	job, err := r.LoadJobWithTxn(ctx, id, txn)
 	if err != nil {
 		return err
 	}
@@ -1346,7 +1330,7 @@ func (r *Registry) Failed(
 // Unpause changes the paused job with id to running or reverting using the
 // specified txn (may be nil).
 func (r *Registry) Unpause(ctx context.Context, txn isql.Txn, id jobspb.JobID) error {
-	job, _, err := r.getJobFn(ctx, txn, id)
+	job, err := r.LoadJobWithTxn(ctx, id, txn)
 	if err != nil {
 		return err
 	}

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -695,7 +695,7 @@ func TestRetriesWithExponentialBackoff(t *testing.T) {
 			if pauseJob {
 				return registry.PauseRequested(ctx, txn, jobID, "")
 			}
-			return registry.cancelRequested(ctx, txn, jobID)
+			return registry.CancelRequested(ctx, txn, jobID)
 		}))
 	}
 	// nextDelay returns the next delay based calculated from the given retryCnt

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -370,6 +370,8 @@ func (ju *JobUpdater) PauseRequestedWithFunc(
 	return nil
 }
 
+// Unpaused sets the status of the tracked job to running or reverting iff the
+// job is currently paused. It does not directly resume the job.
 func (ju *JobUpdater) Unpaused(_ context.Context, md JobMetadata) error {
 	if md.Status == StatusRunning || md.Status == StatusReverting {
 		// Already resumed - do nothing.

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2199,7 +2199,7 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 			if err != nil {
 				return err
 			}
-			if err := sc.jobRegistry.Failed(ctx, txn, jobID, causingError); err != nil {
+			if err := sc.jobRegistry.UnsafeFailed(ctx, txn, jobID, causingError); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
See individual commits.

Further cleanup is possible. Overall I'd like us to clean out as much duplication between `Registry`, `Updater`, `JobUpdater`, and `Job` as possible to force us to notice what is actually being used and how. This is a baby-step in that direction.

