### PR TITLE
backupccl: add backup.after_pre_data pausepoint

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1817,6 +1817,10 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		log.Infof(ctx, "finished restoring the pre-data bundle")
 	}
 
+	if err := p.ExecCfg().JobRegistry.CheckPausepoint("restore.after_pre_data"); err != nil {
+		return err
+	}
+
 	if !preValidateData.isEmpty() {
 		res, err := restoreWithRetry(
 			ctx,


### PR DESCRIPTION
This pause-point allows us to modify the zone configuration before the main data bundle is restored.

Epic: none
Release note: None