### PR TITLE
backupccl: elide tables online restoring tables from in progress imports

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-exp
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-exp
@@ -1,0 +1,191 @@
+# This test ensures that online restore skips restoring tables 
+# undergoing an in progress import
+
+reset test-nodelocal
+----
+
+new-cluster name=s1 disable-tenant
+----
+
+
+# Reads on a table that references a table with an in progress import
+exec-sql
+CREATE DATABASE d;
+USE d;
+CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
+INSERT INTO baz VALUES (1, 'x'),(2,'y'),(3,'z');
+CREATE TABLE foofoo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foofoo VALUES (10, 'x0');
+CREATE TABLE foo (
+  i INT PRIMARY KEY,
+  foofoo_1 INT REFERENCES foofoo (i),
+   s STRING);
+INSERT INTO foo VALUES (3,10,'hey')
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
+----
+
+
+exec-sql
+EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM baz WHERE i = 1;
+----
+NOTICE: EXPORT is not the recommended way to move data out of CockroachDB and may be deprecated in the future. Please consider exporting data with changefeeds instead: https://www.cockroachlabs.com/docs/stable/export-data-with-changefeeds
+
+
+import expect-pausepoint tag=aa
+IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv');
+----
+job paused at pausepoint
+
+
+query-sql
+SELECT * FROM foo
+----
+3 10 hey
+
+exec-sql
+INSERT INTO foo VALUES (4,11,'hello')
+----
+pq: relation "foofoo" is offline: importing
+
+
+query-sql
+SELECT * FROM foo
+----
+3 10 hey
+
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster/';
+----
+
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/cluster/' with new_db_name='d2';
+----
+
+query-sql
+SELECT * FROM d2.foo
+----
+3 10 hey
+
+query-sql
+SELECT * FROM d2.foofoo
+----
+10 x0
+
+exec-sql
+INSERT INTO d2.foofoo VALUES (11, 'x2');
+----
+
+exec-sql
+INSERT INTO d2.foo VALUES (4,11,'hello')
+----
+
+
+
+
+# Conclusion: When we restore an importing table, we must roll it back to its
+# pre-import state to ensure dependent foreign key constraints aren't violated.
+
+###########
+# What about a dependent view?
+
+exec-sql
+CREATE VIEW foo_view (counter) AS SELECT count(*) FROM foo;
+----
+
+query-sql
+SELECT * FROM foo_view
+----
+1
+
+
+# Pause the import job, in order to back up the importing data.
+import expect-pausepoint tag=a
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+query-sql
+SELECT * FROM foo_view
+----
+pq: relation "foo" is offline: importing
+
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster/';
+----
+
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/cluster/' with new_db_name='d3';
+----
+
+exec-sql
+INSERT INTO d3.foofoo VALUES (11, 'x2');
+----
+
+query-sql
+SELECT * FROM d3.foo
+----
+3 10 hey
+
+query-sql
+SELECT * FROM d3.foo_view
+----
+1
+
+exec-sql
+INSERT INTO d3.foo VALUES (4,11,'hello')
+----
+
+
+query-sql
+SELECT * FROM d3.foo_view
+----
+2
+
+# Conclusion: When we restore an importing table, we ought to at least run the schema only restore. 
+
+
+
+
+# Ensure table, database, and cluster full backups capture importing rows.
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster/';
+----
+
+
+# Ensure all ONLINE RESTOREs do not restore foo and foofoo, but that conventional
+# restore can be used to restore these tables.
+new-cluster name=s2 share-io-dir=s1 allow-implicit-access disable-tenant
+----
+
+
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/cluster/' with EXPERIMENTAL DEFERRED COPY;
+----
+
+
+query-sql
+SELECT table_name [SHOW TABLES FROM d] ORDER BY table_name;
+----
+baz
+
+restore
+RESTORE TABLE d.foo, d.foofoo LATEST IN 'nodelocal://1/cluster/' WITH into_db='d';
+----
+
+query-sql
+SELECT * FROM d.foo;
+----
+
+
+query-sql
+SELECT * FROM d.foofoo;
+----
+10 x0
+
+
+reset
+----

--- a/pkg/ccl/backupccl/testdata/backup-restore/online-restore-in-progress-imports
+++ b/pkg/ccl/backupccl/testdata/backup-restore/online-restore-in-progress-imports
@@ -1,0 +1,86 @@
+# This test ensures that online restore skips restoring tables 
+# undergoing an in progress import
+
+reset test-nodelocal
+----
+
+new-cluster name=s1 disable-tenant
+----
+
+
+exec-sql
+CREATE DATABASE d;
+USE d;
+CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
+INSERT INTO baz VALUES (1, 'x'),(2,'y'),(3,'z');
+CREATE TABLE foofoo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foofoo VALUES (10, 'x0');
+CREATE TABLE foo (
+  i INT PRIMARY KEY,
+  foofoo_1 INT REFERENCES foofoo (i),
+   s STRING);
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
+----
+
+
+exec-sql
+EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM baz WHERE i = 1;
+----
+NOTICE: EXPORT is not the recommended way to move data out of CockroachDB and may be deprecated in the future. Please consider exporting data with changefeeds instead: https://www.cockroachlabs.com/docs/stable/export-data-with-changefeeds
+
+# Pause the import job, in order to back up the importing data.
+#import expect-pausepoint tag=a
+#IMPORT INTO foo (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
+#----
+#job paused at pausepoint
+
+
+import expect-pausepoint tag=aa
+IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
+# Ensure table, database, and cluster full backups capture importing rows.
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster/';
+----
+
+
+# Ensure all ONLINE RESTOREs do not restore foo and foofoo, but that conventional
+# restore can be used to restore these tables.
+new-cluster name=s2 share-io-dir=s1 allow-implicit-access disable-tenant
+----
+
+
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/cluster/' with EXPERIMENTAL DEFERRED COPY;
+----
+
+
+query-sql
+SELECT table_name [SHOW TABLES FROM d] ORDER BY table_name;
+----
+baz
+
+restore
+RESTORE TABLE d.foo, d.foofoo LATEST IN 'nodelocal://1/cluster/' WITH into_db='d';
+----
+
+query-sql
+SELECT * FROM d.foo;
+----
+
+
+query-sql
+SELECT * FROM d.foofoo;
+----
+10 x0
+
+
+reset
+----


### PR DESCRIPTION
Currently, online restore will corrupt data from a table with an in progress import, described in detail in #118279. To avoid corruption, this patch ensures online restore skips restoring tables with an in progress import. As a workaround, after the online restore linking phase completes, the user may run a conventional restore on all tables with in-progress imports.

Fixes #118280

Release note: none