### PR TITLE
[WIP, DNM] kvserver: allow DeleteRangeRequests to be pipelined

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -492,7 +492,7 @@ func (tc *TxnCoordSender) Send(
 		return nil, pErr
 	}
 
-	if ba.IsSingleEndTxnRequest() && !tc.interceptorAlloc.txnPipeliner.hasAcquiredLocks() {
+	if ba.IsSingleEndTxnRequest() && !tc.interceptorAlloc.disableEndTxnElision {
 		return nil, tc.finalizeNonLockingTxnLocked(ctx, ba)
 	}
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer_test.go
@@ -65,6 +65,8 @@ func TestTxnCommitterElideEndTxn(t *testing.T) {
 		ba := &kvpb.BatchRequest{}
 		ba.Header = kvpb.Header{Txn: &txn}
 		ba.Add(&kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyA}})
+		// TODO(arul): Not entirely sure what a Put request is doing here if we're
+		// trying to elide the EndTxn request.
 		ba.Add(&kvpb.PutRequest{RequestHeader: kvpb.RequestHeader{Key: keyA}})
 		ba.Add(&kvpb.EndTxnRequest{Commit: commit, LockSpans: nil})
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -469,7 +469,30 @@ func (tp *txnPipeliner) canUseAsyncConsensus(ctx context.Context, ba *kvpb.Batch
 			// tricky. Any read would need to chain on to any write that came
 			// before it in the batch and overlaps. For now, it doesn't seem
 			// worth it.
-			return false
+
+			// TODO(arul): introduce a better concept here instead of this hacky
+			// stuff. For now, allow DeleteRangeRequests to be the only ranged
+			// requests that can be pipelined, as long as we're not dealing with the
+			// last batch (the one that contains the EndTxn request).
+			_, hasET := ba.GetArg(kvpb.EndTxn)
+			if hasET {
+				// DeleteRange requests can only be pipelined if they're not part of the
+				// last batch (the one that contains the EndTxn request).
+				return false
+			}
+			deleteRangeReq, ok := req.(*kvpb.DeleteRangeRequest)
+			if !ok {
+				return false
+			}
+			if deleteRangeReq.UseRangeTombstone {
+				// We'll not get the list of deleted keys if we're using range
+				// tombstones, which means we won't be able to verify whether the
+				// request was successfully replicated or not.
+				return false
+			}
+			// We'll need the list of keys deleted to verify whether replicated
+			// succeeded or not.
+			deleteRangeReq.ReturnKeys = true
 		}
 		// Inhibit async consensus if the batch would push us over the maximum
 		// tracking memory budget. If we allowed async consensus on this batch, its
@@ -730,12 +753,17 @@ func (tp *txnPipeliner) updateLockTrackingInner(
 				// Record any writes that were performed asynchronously. We'll
 				// need to prove that these succeeded sometime before we commit.
 				header := req.Header()
-				tp.ifWrites.insert(header.Key, header.Sequence)
-				// The request is not expected to be a ranged one, as we're only
-				// tracking one key in the ifWrites. Ranged requests do not admit
-				// ba.AsyncConsensus.
 				if kvpb.IsRange(req) {
-					log.Fatalf(ctx, "unexpected range request with AsyncConsensus: %s", req)
+					switch req.(type) {
+					case *kvpb.DeleteRangeRequest:
+						for _, key := range resp.(*kvpb.DeleteRangeResponse).Keys {
+							tp.ifWrites.insert(key, header.Sequence)
+						}
+					default:
+						log.Fatalf(ctx, "unexpected ranged request with AsyncConsensus: %s", req)
+					}
+				} else {
+					tp.ifWrites.insert(header.Key, header.Sequence)
 				}
 			} else {
 				// If the lock acquisitions weren't performed asynchronously

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
@@ -525,6 +525,8 @@ func TestTxnPipelinerReads(t *testing.T) {
 // TestTxnPipelinerRangedWrites tests that txnPipeliner will never perform
 // ranged write operations using async consensus. It also tests that ranged
 // writes will correctly chain on to existing in-flight writes.
+//
+// TODO(arul): update this comment.
 func TestTxnPipelinerRangedWrites(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -541,7 +543,7 @@ func TestTxnPipelinerRangedWrites(t *testing.T) {
 
 	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 		require.Len(t, ba.Requests, 2)
-		require.False(t, ba.AsyncConsensus)
+		require.True(t, ba.AsyncConsensus)
 		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
 		require.IsType(t, &kvpb.DeleteRangeRequest{}, ba.Requests[1].GetInner())
 
@@ -553,8 +555,11 @@ func TestTxnPipelinerRangedWrites(t *testing.T) {
 	br, pErr := tp.SendLocked(ctx, ba)
 	require.Nil(t, pErr)
 	require.NotNil(t, br)
-	// The PutRequest was not run asynchronously, so it is not outstanding.
-	require.Equal(t, 0, tp.ifWrites.len())
+	// The PutRequest was run asynchronously, so it has outstanding writes.
+	require.Equal(t, 1, tp.ifWrites.len())
+
+	// TODO(arul): we can probably just get rid of the first insertion below.
+	tp.ifWrites.clear(true /* reuse */)
 
 	// Add five keys into the in-flight writes set, one of which overlaps with
 	// the Put request and two others which also overlap with the DeleteRange
@@ -570,7 +575,7 @@ func TestTxnPipelinerRangedWrites(t *testing.T) {
 
 	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 		require.Len(t, ba.Requests, 5)
-		require.False(t, ba.AsyncConsensus)
+		require.True(t, ba.AsyncConsensus)
 		require.IsType(t, &kvpb.QueryIntentRequest{}, ba.Requests[0].GetInner())
 		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[1].GetInner())
 		require.IsType(t, &kvpb.QueryIntentRequest{}, ba.Requests[2].GetInner())
@@ -604,7 +609,9 @@ func TestTxnPipelinerRangedWrites(t *testing.T) {
 	br, pErr = tp.SendLocked(ctx, ba)
 	require.Nil(t, pErr)
 	require.NotNil(t, br)
-	require.Equal(t, 2, tp.ifWrites.len())
+	// The put will be added to ifWrites, and the 2 from before that weren't
+	// covered by QueryIntent requests.
+	require.Equal(t, 3, tp.ifWrites.len())
 }
 
 // TestTxnPipelinerNonTransactionalRequests tests that non-transaction requests
@@ -913,7 +920,7 @@ func TestTxnPipelinerIntentMissingError(t *testing.T) {
 		t.Run(fmt.Sprintf("errIdx=%d", errIdx), func(t *testing.T) {
 			mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 				require.Len(t, ba.Requests, 7)
-				require.False(t, ba.AsyncConsensus)
+				require.True(t, ba.AsyncConsensus)
 				require.IsType(t, &kvpb.QueryIntentRequest{}, ba.Requests[0].GetInner())
 				require.IsType(t, &kvpb.PutRequest{}, ba.Requests[1].GetInner())
 				require.IsType(t, &kvpb.QueryIntentRequest{}, ba.Requests[2].GetInner())
@@ -937,6 +944,67 @@ func TestTxnPipelinerIntentMissingError(t *testing.T) {
 			require.Equal(t, kvpb.RETRY_ASYNC_WRITE_FAILURE, pErr.GetDetail().(*kvpb.TransactionRetryError).Reason)
 		})
 	}
+}
+
+// TestTxnPipelinerDeleteRangeRequests ensures the txnPipelineer correctly
+// decides whether to pipeline DeleteRangeRequests. In particular, it ensures
+// DeleteRangeRequests can only be pipelined iff the batch doesn't contain an
+// EndTxn request.
+func TestTxnPipelinerDeleteRangeRequests(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	tp, mockSender := makeMockTxnPipeliner(nil /* iter */)
+
+	txn := makeTxnProto()
+	keyA, keyB, keyD, keyE := roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("d"), roachpb.Key("e")
+
+	ba := &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	ba.Add(&kvpb.DeleteRangeRequest{RequestHeader: kvpb.RequestHeader{Key: keyA, EndKey: keyD}})
+
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 1)
+		require.True(t, ba.AsyncConsensus)
+		require.IsType(t, &kvpb.DeleteRangeRequest{}, ba.Requests[0].GetInner())
+
+		br := ba.CreateReply()
+		br.Txn = ba.Txn
+		resp := br.Responses[0].GetInner()
+		resp.(*kvpb.DeleteRangeResponse).Keys = []roachpb.Key{keyB}
+		return br, nil
+	})
+
+	br, pErr := tp.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+	require.Equal(t, 1, tp.ifWrites.len())
+
+	// Now, create a batch which has (another) DeleteRangRequest and an
+	// EndTxnRequest as well.
+	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	ba.Add(&kvpb.DeleteRangeRequest{RequestHeader: kvpb.RequestHeader{Key: keyD, EndKey: keyE}})
+	ba.Add(&kvpb.EndTxnRequest{Commit: true})
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 3)
+		require.False(t, ba.AsyncConsensus)
+		require.IsType(t, &kvpb.DeleteRangeRequest{}, ba.Requests[0].GetInner())
+		require.IsType(t, &kvpb.QueryIntentRequest{}, ba.Requests[1].GetInner())
+		require.Equal(t, ba.Requests[1].GetInner().(*kvpb.QueryIntentRequest).Key, keyB)
+		require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[2].GetInner())
+
+		br = ba.CreateReply()
+		br.Txn = ba.Txn
+		resp := br.Responses[1].GetInner()
+		resp.(*kvpb.QueryIntentResponse).FoundUnpushedIntent = true
+		return br, nil
+	})
+
+	br, pErr = tp.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+	require.Equal(t, 0, tp.ifWrites.len()) // should be cleared out
 }
 
 // TestTxnPipelinerEnableDisableMixTxn tests that the txnPipeliner behaves


### PR DESCRIPTION
Let this be as long as they're not part of the last batch (the one which contains an EndTxn request).

TODO(arul): add more details.

Release note: None