### PR TITLE
importer: harden internal retry loop

### DIFF
--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1320,6 +1320,15 @@ func ingestWithRetry(
 		}
 
 		maxRetryDuration := retryDuration.Get(&execCtx.ExecCfg().Settings.SV)
+		if !execCtx.ExecCfg().Codec.ForSystemTenant() && flowinfra.IsFlowRetryableError(err) {
+			// If we encountered "could not register flow because the registry
+			// is draining" error in the application virtual cluster, we
+			// calibrate the retry duration. This is the case since DistSQL
+			// physical planning in virtual clusters uses 'sql_instances' table
+			// which currently doesn't have draining information
+			// TODO(#100578): remove this when this problem is addressed.
+			maxRetryDuration *= 30
+		}
 		if timeutil.Since(lastProgressChange) > maxRetryDuration {
 			log.Warningf(ctx, "encountered retryable error but exceeded retry duration, stopping: %+v", err)
 			break


### PR DESCRIPTION
**importer: harden internal retry loop**

This commit adjusts the internal retry loop in `importer.ingestWithRetry` to be time based. Previously, we only performed up to 5 retries and then we paused the job. This commit makes it so that we have 2 minutes (controlled by new `bulkio.import.retry_duration` cluster setting) to make at least 1% progress (max backoff has also been raised to 15s). This should make IMPORTs more reliable.

Release note: None

**importer: adjust retry duration for application VCs around draining**

This commit makes it so that we retry "could not register flow because the registry is draining" errors during IMPORT in virtual clusters for longer (by increasing the retry duration by a factor of 30). This is temporary workaround until #100578 is resolved. In particular, for system tenants we use gossip-backed DistSQL physical planning which is aware of draining state of nodes and will avoid such in `distImport`, but in virtual clusters we use the information from `sql_instances` table that currently is draining-unaware - as a result, the IMPORT is more likely to run out of the "retry budget" before the drain completes. This change effectively gives 60 minutes by default for the drain to complete.

Fixes: #119592.

Release note: None