### PR TITLE
release-23.2: opt/execbuilder: fix EXPORT when input expression has hidden columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/export
+++ b/pkg/sql/logictest/testdata/logic_test/export
@@ -13,3 +13,16 @@ query T noticetrace
 WITH cte AS (EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM t) SELECT filename FROM cte;
 ----
 NOTICE: EXPORT is not the recommended way to move data out of CockroachDB and may be deprecated in the future. Please consider exporting data with changefeeds instead: https://www.cockroachlabs.com/docs/stable/export-data-with-changefeeds
+
+# Regression test for #115290. Correctly handle the case where the Export's
+# input expression has NOT NULL columns that are not part of the presentation of
+# the expression.
+statement ok
+CREATE TABLE t115290 (
+  id INT PRIMARY KEY,
+  a INT NOT NULL,
+  b INT
+);
+
+statement ok
+EXPORT INTO PARQUET 'nodelocal://1/export1/' FROM SELECT b FROM t115290 ORDER BY a;

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -397,9 +397,19 @@ func (b *Builder) buildExport(export *memo.ExportExpr) (execPlan, error) {
 			return execPlan{}, err
 		}
 	}
-	notNullColsSet, err := input.getNodeColumnOrdinalSet(export.Input.Relational().NotNullCols)
-	if err != nil {
-		return execPlan{}, err
+
+	var notNullOrds exec.NodeColumnOrdinalSet
+	notNullCols := export.Input.Relational().NotNullCols
+	for col, ok := notNullCols.Next(0); ok; col, ok = notNullCols.Next(col + 1) {
+		// Ignore NOT NULL columns that are not part of the input execPlan's
+		// output columns. This can happen when applyPresentation projects-away
+		// some output columns of the input expression. For example, a Sort
+		// expression must output a column it orders by, but that column must be
+		// projected-away after the sort if the presentation does not require
+		// the column.
+		if ord, ok := input.outputCols.Get(int(col)); ok {
+			notNullOrds.Add(ord)
+		}
 	}
 
 	node, err := b.factory.ConstructExport(
@@ -407,7 +417,7 @@ func (b *Builder) buildExport(export *memo.ExportExpr) (execPlan, error) {
 		fileName,
 		export.FileFormat,
 		opts,
-		notNullColsSet,
+		notNullOrds,
 	)
 	if err != nil {
 		return execPlan{}, err


### PR DESCRIPTION
Backport 1/2 commits from #119538.

/cc @cockroachdb/release

---

#### opt/execbuilder: fix EXPORT when input expression has hidden columns

Fixes #115290

Release note (bug fix): A bug has been fixed that caused internal errors
when executing EXPORT statement.

---

Release justification: Minimal bug fix for an internal error with
EXPORT statements.

