### PR TITLE
release-23.1: opt/execbuilder: fix EXPORT when input expression has hidden columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/export
+++ b/pkg/sql/logictest/testdata/logic_test/export
@@ -8,3 +8,16 @@ WITH cte AS (EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM t) SELE
 
 statement ok
 WITH cte AS (EXPORT INTO PARQUET 'nodelocal://1/export1/' FROM SELECT * FROM t) SELECT filename FROM cte;
+
+# Regression test for #115290. Correctly handle the case where the Export's
+# input expression has NOT NULL columns that are not part of the presentation of
+# the expression.
+statement ok
+CREATE TABLE t115290 (
+  id INT PRIMARY KEY,
+  a INT NOT NULL,
+  b INT
+);
+
+statement ok
+EXPORT INTO PARQUET 'nodelocal://1/export1/' FROM SELECT b FROM t115290 ORDER BY a;


### PR DESCRIPTION
Backport 1/2 commits from #119538.

/cc @cockroachdb/release

---

#### opt/execbuilder: fix EXPORT when input expression has hidden columns

Fixes #115290

Release note (bug fix): A bug has been fixed that caused internal errors
when executing EXPORT statement.

---

Release justification: Minimal bug fix for an internal error with
EXPORT statements.

