### PR TITLE
release-23.2: roachtest: acceptance/multitenant uses virtual cluster roachprod API

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2118,6 +2118,29 @@ func (c *clusterImpl) StartServiceForVirtualCluster(
 	}
 }
 
+// StopServiceForVirtualClusterE stops the service associated with the
+// virtual cluster identified in the `StopOpts` passed. For shared
+// process virtual clusters, the corresponding service is stopped. For
+// separate process, the OS process is killed.
+func (c *clusterImpl) StopServiceForVirtualClusterE(
+	ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option,
+) error {
+	c.setStatusForClusterOpt("stopping virtual cluster", stopOpts.RoachtestOpts.Worker, opts...)
+	defer c.clearStatusForClusterOpt(stopOpts.RoachtestOpts.Worker)
+
+	return roachprod.StopServiceForVirtualCluster(
+		ctx, l, c.Name(), c.IsSecure(), stopOpts.RoachprodOpts,
+	)
+}
+
+func (c *clusterImpl) StopServiceForVirtualCluster(
+	ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option,
+) {
+	if err := c.StopServiceForVirtualClusterE(ctx, l, stopOpts); err != nil {
+		c.t.Fatal(err)
+	}
+}
+
 func (c *clusterImpl) RefetchCertsFromNode(ctx context.Context, node int) error {
 	var err error
 	c.localCertsDir, err = os.MkdirTemp("", "roachtest-certs")

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -69,6 +69,11 @@ type Cluster interface {
 	StartServiceForVirtualClusterE(ctx context.Context, l *logger.Logger, externalNodes option.NodeListOption, startOpts option.StartOpts, settings install.ClusterSettings, opts ...option.Option) error
 	StartServiceForVirtualCluster(ctx context.Context, l *logger.Logger, externalNodes option.NodeListOption, startOpts option.StartOpts, settings install.ClusterSettings, opts ...option.Option)
 
+	// Stopping virtual clusters.
+
+	StopServiceForVirtualClusterE(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option) error
+	StopServiceForVirtualCluster(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option)
+
 	// Hostnames and IP addresses of the nodes.
 
 	InternalAddr(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -82,3 +82,13 @@ type StopOpts struct {
 func DefaultStopOpts() StopOpts {
 	return StopOpts{RoachprodOpts: roachprod.DefaultStopOpts()}
 }
+
+// DefaultStopVirtualClusterOpts creates StopOpts that can be used to
+// stop the given virtual cluster and sql instance.
+func DefaultStopVirtualClusterOpts(virtualClusterName string, sqlInstance int) StopOpts {
+	opts := DefaultStopOpts()
+	opts.RoachprodOpts.VirtualClusterName = virtualClusterName
+	opts.RoachprodOpts.SQLInstance = sqlInstance
+
+	return opts
+}

--- a/pkg/cmd/roachtest/tests/multitenant.go
+++ b/pkg/cmd/roachtest/tests/multitenant.go
@@ -12,60 +12,58 @@ package tests
 
 import (
 	"context"
-	"path/filepath"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
 func runAcceptanceMultitenant(ctx context.Context, t test.Test, c cluster.Cluster) {
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(install.SecureOption(true)), c.All())
+	// Start the storage layer.
+	storageNodes := c.All()
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), storageNodes)
 
-	const tenantID = 123
-	{
-		_, err := c.Conn(ctx, t.L(), 1).Exec(`SELECT crdb_internal.create_tenant($1::INT)`, tenantID)
-		require.NoError(t, err)
-	}
-
-	const (
-		tenantHTTPPort = 8081
-		tenantSQLPort  = 30258
+	// Start a virtual cluster.
+	const virtualClusterName = "acceptance-tenant"
+	const sqlInstance = 0 // only one instance of this virtual cluster
+	virtualClusterNode := c.Node(1)
+	c.StartServiceForVirtualCluster(
+		ctx, t.L(), virtualClusterNode,
+		option.DefaultStartVirtualClusterOpts(virtualClusterName, sqlInstance),
+		install.MakeClusterSettings(),
+		storageNodes,
 	)
-	const tenantNode = 1
-	tenant := createTenantNode(ctx, t, c, c.All(), tenantID, tenantNode, tenantHTTPPort, tenantSQLPort)
-	tenant.start(ctx, t, c, "./cockroach")
 
-	t.Status("checking that a client can connect to the tenant server")
+	virtualClusterURL := func() string {
+		urls, err := c.ExternalPGUrl(ctx, t.L(), virtualClusterNode, virtualClusterName, sqlInstance)
+		require.NoError(t, err)
 
-	verifySQL(t, tenant.pgURL,
+		return urls[0]
+	}()
+
+	t.L().Printf("checking that a client can connect to the tenant server")
+	verifySQL(t, virtualClusterURL,
 		mkStmt(`CREATE TABLE foo (id INT PRIMARY KEY, v STRING)`),
 		mkStmt(`INSERT INTO foo VALUES($1, $2)`, 1, "bar"),
 		mkStmt(`SELECT * FROM foo LIMIT 1`).
 			withResults([][]string{{"1", "bar"}}))
 
-	t.Status("stopping the server ahead of checking for the tenant server")
+	// Verify that we are able to stop the virtual cluster instance.
+	t.L().Printf("stopping the virtual cluster instance")
+	c.StopServiceForVirtualCluster(
+		ctx, t.L(),
+		option.DefaultStopVirtualClusterOpts(virtualClusterName, sqlInstance),
+		virtualClusterNode,
+	)
 
-	// Stop the server, which also ensures that log files get flushed.
-	tenant.stop(ctx, t, c)
+	db := c.Conn(
+		ctx, t.L(), virtualClusterNode[0], option.TenantName(virtualClusterName), option.SQLInstance(sqlInstance),
+	)
+	defer db.Close()
 
-	t.Status("checking log file contents")
-
-	// Check that the server identifiers are present in the tenant log file.
-	logFile := filepath.Join(tenant.logDir(), "*.log")
-	if err := c.RunE(ctx, c.Node(1),
-		"grep", "-q", "'start\\.go.*clusterID:'", logFile); err != nil {
-		t.Fatal(errors.Wrap(err, "cluster ID not found in log file"))
-	}
-	if err := c.RunE(ctx, c.Node(1),
-		"grep", "-q", "'start\\.go.*tenantID:'", logFile); err != nil {
-		t.Fatal(errors.Wrap(err, "tenant ID not found in log file"))
-	}
-	if err := c.RunE(ctx, c.Node(1),
-		"grep", "-q", "'start\\.go.*instanceID:'", logFile); err != nil {
-		t.Fatal(errors.Wrap(err, "SQL instance ID not found in log file"))
-	}
+	_, err := db.ExecContext(ctx, "CREATE TABLE bar (id INT PRIMARY KEY)")
+	require.Error(t, err)
+	t.L().Printf("after virtual cluster stopped, received error: %v", err)
 }


### PR DESCRIPTION
Backport 2/2 commits from #119598.

/cc @cockroachdb/release

Release justification: test only changes.

---

This commit updates the `acceptance/multitenant` roachtest to use the
recently introduced roachprod API to manage virtual clusters.

It also removes the previous log checking, as that logic is
brittle. In addition, we no longer support creating virtual clusters
by ID. The acceptance test just verifies that we are able to create a
new virtual cluster, perform basic queries on it, and terminate it.

Fixes: #117671.

Release note: None
