### PR TITLE
kvserver: record QPS stats on successful batch request only

### DIFF
--- a/pkg/kv/kvserver/replica_rankings_test.go
+++ b/pkg/kv/kvserver/replica_rankings_test.go
@@ -15,9 +15,11 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
 	aload "github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/load"
@@ -293,6 +295,97 @@ func TestWriteLoadStatsAccounting(t *testing.T) {
 		// than the logical bytes.
 		require.GreaterOrEqual(t, writeBytesAfter, testCase.expectedWBPS)
 	}
+}
+
+// TestLoadQPSStats validates that replica stats consistently accounted when batch request succeeds or fails.
+func TestLoadQPSStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	failBatchReq := atomic.Bool{}
+	failBatchReq.Store(false)
+	var key roachpb.Key
+	var qps, writeBytes float64
+
+	tc := serverutils.StartCluster(t, 1, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &StoreTestingKnobs{
+					TestingRequestFilter: func(_ context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
+						if failBatchReq.Load() {
+							for _, req := range ba.Requests {
+								if req.GetInner().Header().Key.Equal(key) {
+									return kvpb.NewError(fmt.Errorf("failed batch request"))
+								}
+							}
+						}
+						return nil
+					},
+				},
+			},
+		},
+	})
+
+	defer tc.Stopper().Stop(ctx)
+	ts := tc.Server(0)
+	db := ts.DB()
+	conn := tc.ServerConn(0)
+	sqlDB := sqlutils.MakeSQLRunner(conn)
+
+	// Disable the consistency checker, to avoid interleaving requests
+	// artificially inflating QPS due to consistency checking.
+	sqlDB.Exec(t, `SET CLUSTER SETTING server.consistency_check.interval = '0'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.range_split.by_load.enabled = false`)
+
+	key = tc.ScratchRange(t)
+
+	req := &kvpb.PutRequest{
+		RequestHeader: kvpb.RequestHeader{Key: key},
+		Value:         roachpb.MakeValueFromString("value"),
+	}
+	batchReq := &kvpb.BatchRequest{}
+	batchReq.Add(req)
+
+	store, err := ts.GetStores().(*Stores).GetStore(ts.GetFirstStoreID())
+	require.NoError(t, err)
+
+	repl := store.LookupReplica(roachpb.RKey(key))
+	require.NotNil(t, repl)
+	err = db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		failBatchReq.Store(true)
+		// Reset stats before sending request.
+		repl.loadStats.Reset()
+		_, pErr := txn.Send(ctx, batchReq)
+
+		qps = repl.loadStats.TestingGetSum(load.Queries)
+		writeBytes = repl.loadStats.TestingGetSum(load.WriteBytes)
+		failBatchReq.Store(false)
+		return pErr.GoError()
+	})
+
+	// Expected error for filtered out batch request.
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed batch request")
+
+	// Test that for failed batch request, neither QPS, or write keys/bytes stats are accounted for.
+	require.Equal(t, 0.0, qps)
+	require.Equal(t, 0.0, writeBytes)
+
+	err = db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		// Reset stats before sending request.
+		repl.loadStats.Reset()
+		_, pErr := txn.Send(ctx, batchReq)
+		qps = repl.loadStats.TestingGetSum(load.Queries)
+		writeBytes = repl.loadStats.TestingGetSum(load.WriteBytes)
+		return pErr.GoError()
+	})
+	require.NoError(t, err)
+
+	// QPS, write bytes and write keys should be non-zero values.
+	require.Greater(t, qps, 0.0)
+	require.Greater(t, writeBytes, 0.0)
 }
 
 func TestReadLoadMetricAccounting(t *testing.T) {

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -141,9 +141,6 @@ func (r *Replica) SendWithWriteBytes(
 	// recorded regardless of errors that are encountered.
 	startCPU := grunning.Time()
 	defer r.MeasureReqCPUNanos(startCPU)
-	// Record summary throughput information about the batch request for
-	// accounting.
-	r.recordBatchRequestLoad(ctx, ba)
 
 	// If the internal Raft group is quiesced, wake it and the leader.
 	r.maybeUnquiesce(ctx, true /* wakeLeader */, true /* mayCampaign */)
@@ -216,6 +213,9 @@ func (r *Replica) SendWithWriteBytes(
 		r.recordBatchForLoadBasedSplitting(ctx, ba, br, int(grunning.Difference(startCPU, grunning.Time())))
 	}
 
+	// Record summary throughput information about the batch request for
+	// accounting.
+	r.recordBatchRequestLoad(ctx, ba)
 	r.recordRequestWriteBytes(writeBytes)
 	r.recordImpactOnRateLimiter(ctx, br, isReadOnly)
 	return br, writeBytes, pErr


### PR DESCRIPTION
Before, QPS stats for batch request were recorded before request executed,
and it could lead to cases when request failed but calculated QPS is recorded.
This behavior looks inconsistent comparing to other replica stats (ie Write Keys,
or Write Bytes) that recorded only after successful batch request.

This patch changes the order of accounting QPS stats that now recorded after
request completes.
In addition, it calculates QPS on the final batch request (after possible
mutation of it by `maybeStripInFlightWrites` function).

Release note: None

Related issue: https://github.com/cockroachdb/cockroach/issues/119388
Related issue: https://github.com/cockroachdb/cockroach/issues/119206

Epic: None