### PR TITLE
builtins: fix aggregation bug in crdb_internal.merge_aggregated_stmt_…

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4068,12 +4068,18 @@ SELECT crdb_internal.merge_aggregated_stmt_metadata(ARRAY[])
 query T
 SELECT crdb_internal.merge_aggregated_stmt_metadata(ARRAY[ '{ "db": [ "defaultdb", "tpcc" ], "distSQLCount": 1, "failedCount": 2, "fullScanCount": 0, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 33, "vecCount": 0 }'::JSON, '{ "db": ["tpcc"], "distSQLCount": 23, "failedCount": 0, "fullScanCount": 99, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 3, "vecCount": 2 }'::JSON, '{"hello": "world"}'::JSON ])
 ----
-{"appNames": [], "db": ["defaultdb", "tpcc"], "distSQLCount": 47, "failedCount": 2, "fingerprintID": "", "formattedQuery": "", "fullScanCount": 198, "implicitTxn": true, "query": "SELECT 1", "querySummary": "SELECT 1", "stmtType": "TypeDML", "totalCount": 39, "vecCount": 4}
+{"appNames": [], "db": ["defaultdb", "tpcc"], "distSQLCount": 24, "failedCount": 2, "fingerprintID": "", "formattedQuery": "", "fullScanCount": 99, "implicitTxn": false, "query": "", "querySummary": "", "stmtType": "", "totalCount": 36, "vecCount": 2}
 
 query T
 SELECT crdb_internal.merge_aggregated_stmt_metadata(ARRAY[ '{"aMalformedMetadaObj": 123}'::JSON, '{"key": "value"}'::JSON ])
 ----
 {"appNames": [], "db": [], "distSQLCount": 0, "failedCount": 0, "fingerprintID": "", "formattedQuery": "", "fullScanCount": 0, "implicitTxn": false, "query": "", "querySummary": "", "stmtType": "", "totalCount": 0, "vecCount": 0}
+
+# Merge 2 objects with partial data to check that no value is reused between iterations.
+query T
+SELECT crdb_internal.merge_aggregated_stmt_metadata(ARRAY[ '{"distSQLCount": 111, "failedCount": 222, "fullScanCount": 333 }'::JSON, '{"totalCount": 1, "vecCount": 2}'::JSON, '{"key": "value"}'::JSON ])
+----
+{"appNames": [], "db": [], "distSQLCount": 111, "failedCount": 222, "fingerprintID": "", "formattedQuery": "", "fullScanCount": 333, "implicitTxn": false, "query": "", "querySummary": "", "stmtType": "", "totalCount": 1, "vecCount": 2}
 
 subtest end
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4547,9 +4547,8 @@ value if you rely on the HLC for accuracy.`,
 					}
 
 					metadataJSON := tree.MustBeDJSON(metadataDatum).JSON
-					// Ensure we start with an empty slice, otherwise the decode method below
-					// will just append the JSON datum value to what's already there.
-					other.Databases = nil
+					// Ensure we start with a clear slate for the current iteration.
+					other = appstatspb.AggregatedStatementMetadata{}
 					err := sqlstatsutil.DecodeAggregatedMetadataJSON(metadataJSON, &other)
 					//  Failure to decode should NOT return an error. Instead let's just ignore
 					// this JSON object that is not the correct format.


### PR DESCRIPTION
…metdata

The object used to store decoded the datum to
appstatspb.AggregatedStatementMetadata is reused between aggregation iterations. It is not cleared between items and so any field that does not exist on the datum uses the previously written value.

This bug shouldn't be seen frequently in practice because we expect all the JSON values we are aggregating to be from the sql activity metadata columns, which are well formed and contain all fields used in the aggregation.

Epic: None
Fixes: #119533

Release note: None