### PR TITLE
roachtest: fix float comparison so 0 always matches -0 inside arrays

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util_test.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util_test.go
@@ -121,6 +121,14 @@ func TestUnsortedMatricesDiff(t *testing.T) {
 			exactMatch:  false,
 			approxMatch: true,
 		},
+		{
+			name:        "multi row 0 in array matches -0 in array",
+			colTypes:    []string{"[]FLOAT4"},
+			t1:          [][]string{{"NULL"}, {"{1e-45}"}, {"{0,-0}"}, {"{-0.0039,-Inf"}},
+			t2:          [][]string{{"NULL"}, {"{1e-45}"}, {"{-0,0}"}, {"{-0.0039,-Inf"}},
+			exactMatch:  false,
+			approxMatch: true,
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/testutils/floatcmp/floatcmp.go
+++ b/pkg/testutils/floatcmp/floatcmp.go
@@ -97,6 +97,40 @@ func FloatsMatchApprox(expectedString, actualString string) (bool, error) {
 	return EqualApprox(expected, actual, CloseFraction, CloseMargin), nil
 }
 
+// splitFloatArray splits the textual representation of the float array of the
+// form {1.2,3.4,5.6,...} into its elements (in the textual form).
+func splitFloatArray(array string) []string {
+	return strings.Split(strings.Trim(array, "{}"), ",")
+}
+
+// floatArraysMatchImpl is the common logic for verifying whether two float
+// arrays match where per-element verification is done by the provided function.
+func floatArraysMatchImpl(
+	expected, actual string, matchFn func(string, string) (bool, error),
+) (bool, error) {
+	if expected == "NULL" || actual == "NULL" {
+		// Default to string matching for NULL arrays.
+		return expected == actual, nil
+	}
+	exp, act := splitFloatArray(expected), splitFloatArray(actual)
+	if len(exp) != len(act) {
+		return false, nil
+	}
+	for i := range exp {
+		match, err := matchFn(exp[i], act[i])
+		if !match || err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// FloatArraysMatchApprox returns whether two floating point arrays represented
+// as strings are equal within a tolerance.
+func FloatArraysMatchApprox(expectedString, actualString string) (bool, error) {
+	return floatArraysMatchImpl(expectedString, actualString, FloatsMatchApprox)
+}
+
 // FloatsCmp returns -1 if aString is less than bString, 0 if they are equal,
 // and 1 otherwise when aString and bString are parsed as SQL floats. NULL
 // sorts before NaN, which sorts before all other numbers.
@@ -130,6 +164,37 @@ func FloatsCmp(aString, bString string) (int, error) {
 	} else {
 		return 1, nil
 	}
+}
+
+// FloatArraysCmp returns -1 if aString is less than bString, 0 if they are
+// equal, and 1 otherwise when aString and bString are parsed as SQL float
+// arrays. NULL sorts before NaN, which sorts before all other numbers.
+func FloatArraysCmp(aString, bString string) (int, error) {
+	if aString == "NULL" {
+		if bString != "NULL" {
+			return -1, nil
+		}
+		return 0, nil
+	} else if bString == "NULL" {
+		return 1, nil
+	}
+	aFloats, bFloats := splitFloatArray(aString), splitFloatArray(bString)
+	// Comparison of arrays is such that we check the "shared" elements first,
+	// and only if all of them are equal, then we check the lengths of arrays
+	// (see tree.DArray.CompareError).
+	toCheck := min(len(aFloats), len(bFloats))
+	for i := 0; i < toCheck; i++ {
+		cmp, err := FloatsCmp(aFloats[i], bFloats[i])
+		if cmp != 0 || err != nil {
+			return cmp, err
+		}
+	}
+	if len(aFloats) < len(bFloats) {
+		return -1, nil
+	} else if len(aFloats) > len(bFloats) {
+		return 1, nil
+	}
+	return 0, nil
 }
 
 // FloatsMatch returns whether two floating point numbers represented as
@@ -197,6 +262,13 @@ func FloatsMatch(expectedString, actualString string) (bool, error) {
 		actual -= (actual - float64(actDigit)) * 10
 	}
 	return true, nil
+}
+
+// FloatArraysMatch returns whether two floating point number arrays represented
+// as strings have matching 15 significant decimal digits (this is the precision
+// that Postgres supports for 'double precision' type) for each element.
+func FloatArraysMatch(expectedString, actualString string) (bool, error) {
+	return floatArraysMatchImpl(expectedString, actualString, FloatsMatch)
 }
 
 // RoundFloatsInString rounds floats in a given string to the given number of significant figures.

--- a/pkg/testutils/floatcmp/floatcmp_test.go
+++ b/pkg/testutils/floatcmp/floatcmp_test.go
@@ -159,7 +159,7 @@ func TestEqualClose(t *testing.T) {
 	}
 }
 
-// TestFloatsMatch is a unit test for floatsMatch() and floatsMatchApprox()
+// TestFloatsMatch is a unit test for FloatsMatch() and FloatsMatchApprox()
 // functions.
 func TestFloatsMatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -187,7 +187,7 @@ func TestFloatsMatch(t *testing.T) {
 			t.Fatal(err)
 		}
 		if match != tc.match {
-			t.Fatalf("floatsMatch: wrong result on %v", tc)
+			t.Fatalf("FloatsMatch: wrong result on %v", tc)
 		}
 
 		match, err = FloatsMatchApprox(tc.f1, tc.f2)
@@ -195,7 +195,47 @@ func TestFloatsMatch(t *testing.T) {
 			t.Fatal(err)
 		}
 		if match != tc.match {
-			t.Fatalf("floatsMatchApprox: wrong result on %v", tc)
+			t.Fatalf("FloatsMatchApprox: wrong result on %v", tc)
+		}
+	}
+}
+
+// TestFloatArraysMatch is a unit test for FloatArraysMatch() and
+// FloatArraysMatchApprox() functions.
+//
+// Note that since these functions use FloatsMatch and FloatsMatchApprox
+// internally, some edge cases like NaN and infinities aren't tested here.
+func TestFloatArraysMatch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	for _, tc := range []struct {
+		arr1, arr2 string
+		match      bool
+	}{
+		{arr1: "NULL", arr2: "NULL", match: true},
+		{arr1: "NULL", arr2: "{NULL}", match: false},
+		{arr1: "{NULL}", arr2: "NULL", match: false},
+		{arr1: "{NULL}", arr2: "{NULL}", match: true},
+		{arr1: "NULL", arr2: "{0}", match: false},
+		{arr1: "{0}", arr2: "NULL", match: false},
+		{arr1: "{NULL,NULL}", arr2: "{NULL,NULL}", match: true},
+		{arr1: "{NULL,NULL,NULL}", arr2: "{NULL,NULL}", match: false},
+		{arr1: "{-0.0,0.0}", arr2: "{0.0,-0.0}", match: true},
+		{arr1: "{0.1,0.2,0.3}", arr2: "{0.1,0.2,0.3}", match: true},
+	} {
+		match, err := FloatArraysMatch(tc.arr1, tc.arr2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if match != tc.match {
+			t.Fatalf("FloatArraysMatch: wrong result on %v", tc)
+		}
+
+		match, err = FloatArraysMatchApprox(tc.arr1, tc.arr2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if match != tc.match {
+			t.Fatalf("FloatArraysMatchApprox: wrong result on %v", tc)
 		}
 	}
 }


### PR DESCRIPTION
This commit extends the fix from 43c899635ecc86006a07981c97ed7c22a0c47f93 to also apply to float arrays.

Fixes: #119677.

Release note: None