### PR TITLE
release-23.1: changefeedccl: add nil checking for avroDataRecord.refreshTypeMetadata

### DIFF
--- a/pkg/ccl/changefeedccl/encoder_avro.go
+++ b/pkg/ccl/changefeedccl/encoder_avro.go
@@ -220,11 +220,18 @@ func (e *confluentAvroEncoder) EncodeValue(
 	v, ok := e.valueCache.Get(cacheKey)
 	if ok {
 		registered = v.(confluentRegisteredEnvelopeSchema)
-		if err := registered.schema.after.refreshTypeMetadata(updatedRow); err != nil {
-			return nil, err
-		}
 		if prevRow.IsInitialized() && registered.schema.before != nil {
 			if err := registered.schema.before.refreshTypeMetadata(prevRow); err != nil {
+				return nil, err
+			}
+		}
+		if registered.schema.after != nil {
+			if err := registered.schema.after.refreshTypeMetadata(updatedRow); err != nil {
+				return nil, err
+			}
+		}
+		if registered.schema.record != nil {
+			if err := registered.schema.record.refreshTypeMetadata(updatedRow); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -1112,3 +1112,74 @@ func TestParquetEncoder(t *testing.T) {
 	}
 	cdcTest(t, testFn, feedTestForceSink("cloudstorage"))
 }
+
+// TestAvroWithRegionalTable tests how the avro encoder works with regional
+// tables and with different envelope formats. This is a regression test for
+// #119428.
+func TestAvroWithRegionalTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tests := []struct {
+		envelope string
+		payload  []string
+	}{
+		{
+			envelope: "wrapped",
+			payload: []string{
+				`table1: {"a":{"long":1},"crdb_region":{"string":"us-east1"}}->{"after":{"table1":{"a":{"long":1},"crdb_region":{"string":"us-east1"}}}}`,
+				`table1: {"a":{"long":2},"crdb_region":{"string":"us-east1"}}->{"after":{"table1":{"a":{"long":2},"crdb_region":{"string":"us-east1"}}}}`,
+				`table1: {"a":{"long":3},"crdb_region":{"string":"us-east1"}}->{"after":{"table1":{"a":{"long":3},"crdb_region":{"string":"us-east1"}}}}`,
+			},
+		},
+		{
+			envelope: "bare",
+			payload: []string{
+				`table1: {"a":{"long":1},"crdb_region":{"string":"us-east1"}}->{"record":{"table1":{"a":{"long":1},"crdb_region":{"string":"us-east1"}}}}`,
+				`table1: {"a":{"long":2},"crdb_region":{"string":"us-east1"}}->{"record":{"table1":{"a":{"long":2},"crdb_region":{"string":"us-east1"}}}}`,
+				`table1: {"a":{"long":3},"crdb_region":{"string":"us-east1"}}->{"record":{"table1":{"a":{"long":3},"crdb_region":{"string":"us-east1"}}}}`,
+			},
+		},
+		{
+			envelope: "key_only",
+			payload: []string{
+				`table1: {"a":{"long":1},"crdb_region":{"string":"us-east1"}}->`,
+				`table1: {"a":{"long":2},"crdb_region":{"string":"us-east1"}}->`,
+				`table1: {"a":{"long":3},"crdb_region":{"string":"us-east1"}}->`,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.envelope, func(t *testing.T) {
+			// Run the test with one and three(default) workers to test both the
+			// default behaviour and the behaviour when
+			// confluentAvroEncoder.keyCache and confluentAvroEncoder.valueCache
+			// are used. With one worker, the cache is forced to be used during
+			// encoding for the second row.
+			testutils.RunTrueAndFalse(t, "overrideWithSingleWorker", func(t *testing.T, overrideWithSingleWorker bool) {
+				cluster, db, cleanup := startTestCluster(t)
+				defer cleanup()
+				if overrideWithSingleWorker {
+					t.Logf("overriding number of parallel workers to one")
+					changefeedbase.EventConsumerWorkers.Override(
+						context.Background(), &cluster.Server(0).ClusterSettings().SV, 1)
+				}
+
+				sqlDB := sqlutils.MakeSQLRunner(db)
+				sqlDB.Exec(t, `CREATE TABLE table1 (a INT PRIMARY KEY) LOCALITY REGIONAL BY ROW`)
+				schemaReg := cdctest.StartTestSchemaRegistry()
+				defer schemaReg.Close()
+				stmt := fmt.Sprintf(`CREATE CHANGEFEED FOR TABLE table1 WITH format = avro, envelope = %s, 
+	confluent_schema_registry = "%s", schema_change_events = column_changes, schema_change_policy = nobackfill`,
+					test.envelope, schemaReg.URL())
+
+				f := makeKafkaFeedFactory(cluster, db)
+				testFeed := feed(t, f, stmt)
+				defer closeFeed(t, testFeed)
+
+				sqlDB.Exec(t, `INSERT INTO table1(a) values(1), (2), (3)`)
+				assertPayloads(t, testFeed, test.payload)
+			})
+		})
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #119639.

/cc @cockroachdb/release

---

Previously, the "after" field was populated across all envelope formats.
However, in commit c00bf0feb783021b76893b905fb19f8ec4e222bc, row data was moved to the “after” field for envelope
= wrapped and to “record” field for other envelope formats. But the commit did
not add a nil check for registered.schema.after which is only populated for
wrapped envelope. `registered.schema.after` is now nil for other envelope
formats, and calling `refreshTypeMetadata` on it could lead to node panics. In
addition, this commit did not add the logic calling `refreshTypeMetadata` on the
registered.schema.record for other envelope formats.  This patch addresses the
issue by adding a defensive nil check before invoking `refreshTypeMetadata` and
adding `refreshTypeMetadata` for the record field when it's set to match the
original intents of the commit.

Fixes: https://github.com/cockroachdb/cockroach/issues/119428
Release note: None

----

Release justification: low risk bug fix
