### PR TITLE
sqlstats: dont block flush due to sql activity job

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -207,6 +207,11 @@ func (s *PersistedSQLStats) startSQLStatsFlushLoop(ctx context.Context, stopper 
 					return
 				case <-s.drain:
 					return
+				default:
+					// Don't block the flush loop if the sql activity update job is not
+					// ready to receive. We should at least continue to collect and flush
+					// stats for this node.
+					log.Warning(ctx, "sql-stats-worker: unable to signal flush completion")
 				}
 			}
 		}


### PR DESCRIPTION
The sql stats flush worker signals the sql activity update job on flush completion via an unbuffered channel. It currently blocks on sending that signal so if that job is stuck updating stats for some reason this also makes the flush stuck. This commit ensures that the flush worker can continue normally even if the sql activity update job is not ready to receive its next signal. This ensures that the coordinator node for the sql stats activity job can continue to collect sql stats normally.

Epic: none
Fixes: #119751