### PR TITLE
sql: remove unused error return argument around placeholders

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -799,9 +799,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.stmt = stmt
 	p.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 	p.extendedEvalCtx.Annotations = &p.semaCtx.Annotations
-	if err := p.semaCtx.Placeholders.Assign(pinfo, stmt.NumPlaceholders); err != nil {
-		return makeErrEvent(err)
-	}
+	p.semaCtx.Placeholders.Assign(pinfo, stmt.NumPlaceholders)
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
 
 	shouldLogToExecAndAudit := true

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -315,9 +315,7 @@ func (ex *connExecutor) populatePrepared(
 	}
 	stmt := &p.stmt
 
-	if err := p.semaCtx.Placeholders.Init(stmt.NumPlaceholders, placeholderHints); err != nil {
-		return 0, err
-	}
+	p.semaCtx.Placeholders.Init(stmt.NumPlaceholders, placeholderHints)
 	p.extendedEvalCtx.PrepareOnly = true
 	// If the statement is being prepared by a session migration, then we should
 	// not evaluate the AS OF SYSTEM TIME timestamp. During session migration,

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -746,9 +746,7 @@ func newHarness(tb testing.TB, query benchQuery, schemas []string) *harness {
 		}
 	}
 
-	if err := h.semaCtx.Placeholders.Init(len(query.args), nil /* typeHints */); err != nil {
-		tb.Fatal(err)
-	}
+	h.semaCtx.Placeholders.Init(len(query.args), nil /* typeHints */)
 	// Run optbuilder to build the memo for Prepare. Even if we will not be using
 	// the Prepare method, we still want to run the optbuilder to infer any
 	// placeholder types.

--- a/pkg/sql/opt/testutils/build.go
+++ b/pkg/sql/opt/testutils/build.go
@@ -38,9 +38,7 @@ func BuildQuery(
 	semaCtx := tree.MakeSemaContext()
 	semaCtx.FunctionResolver = catalog
 	semaCtx.SearchPath = &evalCtx.SessionData().SearchPath
-	if err := semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */); err != nil {
-		t.Fatalf("%+v", err)
-	}
+	semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */)
 	semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 	o.Init(ctx, evalCtx, catalog)
 	err = optbuilder.New(ctx, &semaCtx, evalCtx, catalog, o.Factory(), stmt.AST).Build()

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -2301,9 +2301,7 @@ func (ot *OptTester) buildExpr(factory *norm.Factory) error {
 	if err != nil {
 		return err
 	}
-	if err := ot.semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */); err != nil {
-		return err
-	}
+	ot.semaCtx.Placeholders.Init(stmt.NumPlaceholders, nil /* typeHints */)
 	ot.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 	ot.semaCtx.TypeResolver = ot.catalog
 	b := optbuilder.New(ot.ctx, &ot.semaCtx, &ot.evalCtx, ot.catalog, factory, stmt.AST)

--- a/pkg/sql/schemachange/alter_column_type.go
+++ b/pkg/sql/schemachange/alter_column_type.go
@@ -210,9 +210,7 @@ func ClassifyConversion(
 
 	// See if there's existing cast logic.  If so, return general.
 	semaCtx := tree.MakeSemaContext()
-	if err := semaCtx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */); err != nil {
-		return ColumnConversionImpossible, err
-	}
+	semaCtx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */)
 
 	// Use a placeholder just to sub in the original type.
 	fromPlaceholder, err := (&tree.Placeholder{Idx: 0}).TypeCheck(ctx, &semaCtx, oldType)

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -275,9 +275,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 	for i, d := range testData {
 		t.Run(fmt.Sprintf("%v/%v", d.exprs, d.overloads), func(t *testing.T) {
 			semaCtx := MakeSemaContext()
-			if err := semaCtx.Placeholders.Init(2 /* numPlaceholders */, nil /* typeHints */); err != nil {
-				t.Fatal(err)
-			}
+			semaCtx.Placeholders.Init(2 /* numPlaceholders */, nil /* typeHints */)
 			desired := types.Any
 			if d.desired != nil {
 				desired = d.desired

--- a/pkg/sql/sem/tree/placeholders.go
+++ b/pkg/sql/sem/tree/placeholders.go
@@ -154,7 +154,7 @@ type PlaceholderInfo struct {
 
 // Init initializes a PlaceholderInfo structure appropriate for the given number
 // of placeholders, and with the given (optional) type hints.
-func (p *PlaceholderInfo) Init(numPlaceholders int, typeHints PlaceholderTypes) error {
+func (p *PlaceholderInfo) Init(numPlaceholders int, typeHints PlaceholderTypes) {
 	if typeHints == nil {
 		p.TypeHints = make(PlaceholderTypes, numPlaceholders)
 		p.Types = make(PlaceholderTypes, numPlaceholders)
@@ -163,17 +163,16 @@ func (p *PlaceholderInfo) Init(numPlaceholders int, typeHints PlaceholderTypes) 
 		p.TypeHints = typeHints
 	}
 	p.Values = nil
-	return nil
 }
 
 // Assign resets the PlaceholderInfo to the contents of src.
 // If src is nil, a new structure is initialized.
-func (p *PlaceholderInfo) Assign(src *PlaceholderInfo, numPlaceholders int) error {
+func (p *PlaceholderInfo) Assign(src *PlaceholderInfo, numPlaceholders int) {
 	if src != nil {
 		*p = *src
-		return nil
+		return
 	}
-	return p.Init(numPlaceholders, nil /* typeHints */)
+	p.Init(numPlaceholders, nil /* typeHints */)
 }
 
 // MaybeExtendTypes is to fill the nil types with the type hints, if exists.

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -37,9 +37,7 @@ func BenchmarkTypeCheck(b *testing.B) {
 		b.Fatalf("%s: %v", expr, err)
 	}
 	ctx := tree.MakeSemaContext()
-	if err := ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */); err != nil {
-		b.Fatal(err)
-	}
+	ctx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */)
 	for i := 0; i < b.N; i++ {
 		_, err := tree.TypeCheck(context.Background(), expr, &ctx, types.Int)
 		if err != nil {
@@ -188,9 +186,7 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 	ctx := context.Background()
 	forEachPerm(test.exprs, 0, func(exprs []copyableExpr) {
 		semaCtx := tree.MakeSemaContext()
-		if err := semaCtx.Placeholders.Init(len(test.ptypes), clonePlaceholderTypes(test.ptypes)); err != nil {
-			t.Fatal(err)
-		}
+		semaCtx.Placeholders.Init(len(test.ptypes), clonePlaceholderTypes(test.ptypes))
 		desired := types.Any
 		if test.desired != nil {
 			desired = test.desired
@@ -345,9 +341,7 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 	for i, d := range testData {
 		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
 			semaCtx := tree.MakeSemaContext()
-			if err := semaCtx.Placeholders.Init(len(d.ptypes), d.ptypes); err != nil {
-				t.Error(err)
-			}
+			semaCtx.Placeholders.Init(len(d.ptypes), d.ptypes)
 			desired := types.Any
 			if d.desired != nil {
 				desired = d.desired
@@ -387,9 +381,7 @@ func TestTypeCheckSameTypedExprsImplicitCastOneWay(t *testing.T) {
 	for i, d := range testData {
 		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
 			semaCtx := tree.MakeSemaContext()
-			if err := semaCtx.Placeholders.Init(len(d.ptypes), d.ptypes); err != nil {
-				t.Error(err)
-			}
+			semaCtx.Placeholders.Init(len(d.ptypes), d.ptypes)
 			desired := types.Any
 			if d.desired != nil {
 				desired = d.desired

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -234,9 +234,7 @@ func TestTypeCheck(t *testing.T) {
 				t.Fatalf("%s: %v", d.expr, err)
 			}
 			semaCtx := tree.MakeSemaContext()
-			if err := semaCtx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */); err != nil {
-				t.Fatal(err)
-			}
+			semaCtx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */)
 			semaCtx.TypeResolver = mapResolver
 			typeChecked, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 			if err != nil {
@@ -413,9 +411,7 @@ func TestTypeCheckVolatility(t *testing.T) {
 
 	ctx := context.Background()
 	semaCtx := tree.MakeSemaContext()
-	if err := semaCtx.Placeholders.Init(len(placeholderTypes), placeholderTypes); err != nil {
-		t.Fatal(err)
-	}
+	semaCtx.Placeholders.Init(len(placeholderTypes), placeholderTypes)
 
 	typeCheck := func(sql string) error {
 		expr, err := parser.ParseExpr(sql)
@@ -463,8 +459,7 @@ func TestTypeCheckCollatedString(t *testing.T) {
 
 	// Hint a normal string type for $1.
 	placeholderTypes := []*types.T{types.String}
-	err := semaCtx.Placeholders.Init(len(placeholderTypes), placeholderTypes)
-	require.NoError(t, err)
+	semaCtx.Placeholders.Init(len(placeholderTypes), placeholderTypes)
 
 	// The collated string constant must be on the LHS for this test, so that
 	// the type-checker chooses the collated string overload first.
@@ -516,8 +511,7 @@ func TestTypeCheckCaseExprWithPlaceholders(t *testing.T) {
 
 	// Hint all int4 types.
 	placeholderTypes := []*types.T{types.Int4, types.Int4, types.Int4, types.Int4, types.Int4}
-	err := semaCtx.Placeholders.Init(len(placeholderTypes), placeholderTypes)
-	require.NoError(t, err)
+	semaCtx.Placeholders.Init(len(placeholderTypes), placeholderTypes)
 
 	expr, err := parser.ParseExpr("case when 1 < $1 then $2 else $3 end = $4")
 	require.NoError(t, err)
@@ -539,8 +533,7 @@ func TestTypeCheckCaseExprWithConstantsAndUnresolvedPlaceholders(t *testing.T) {
 
 	// Hint all int4 types, but leave one of the THEN branches unhinted.
 	placeholderTypes := []*types.T{types.Int4, types.Int4, types.Int4, nil, types.Int4}
-	err := semaCtx.Placeholders.Init(len(placeholderTypes), placeholderTypes)
-	require.NoError(t, err)
+	semaCtx.Placeholders.Init(len(placeholderTypes), placeholderTypes)
 
 	expr, err := parser.ParseExpr("case when 1 < $1 then $2 when 1 < $3 then $4 else 3 end = $5")
 	require.NoError(t, err)
@@ -570,8 +563,7 @@ func TestTypeCheckArrayWithNullAndPlaceholder(t *testing.T) {
 	semaCtx.Properties.Require("", 0 /* flags */)
 
 	placeholderTypes := []*types.T{types.Int}
-	err := semaCtx.Placeholders.Init(len(placeholderTypes), placeholderTypes)
-	require.NoError(t, err)
+	semaCtx.Placeholders.Init(len(placeholderTypes), placeholderTypes)
 
 	expr, err := parser.ParseExpr("array[null, $1]::int[]")
 	require.NoError(t, err)


### PR DESCRIPTION
Noticed this while looking into something else.

Epic: None

Release note: None