### PR TITLE
tree: propagate all routine parameters into the overload

### DIFF
--- a/pkg/sql/catalog/funcdesc/func_desc_test.go
+++ b/pkg/sql/catalog/funcdesc/func_desc_test.go
@@ -673,6 +673,9 @@ func TestToOverload(t *testing.T) {
 				Body:       "ANY QUERIES",
 				Type:       tree.UDFRoutine,
 				Language:   tree.RoutineLangSQL,
+				RoutineParams: tree.RoutineParams{
+					{Name: "arg1", Type: types.Int},
+				},
 			},
 		},
 		{
@@ -697,6 +700,9 @@ func TestToOverload(t *testing.T) {
 				Body:       "ANY QUERIES",
 				Type:       tree.UDFRoutine,
 				Language:   tree.RoutineLangSQL,
+				RoutineParams: tree.RoutineParams{
+					{Name: "arg1", Type: types.Int},
+				},
 			},
 		},
 		{
@@ -722,6 +728,9 @@ func TestToOverload(t *testing.T) {
 				Body:       "ANY QUERIES",
 				Type:       tree.UDFRoutine,
 				Language:   tree.RoutineLangSQL,
+				RoutineParams: tree.RoutineParams{
+					{Name: "arg1", Type: types.Int},
+				},
 			},
 		},
 		{
@@ -748,6 +757,9 @@ func TestToOverload(t *testing.T) {
 				Type:              tree.UDFRoutine,
 				CalledOnNullInput: true,
 				Language:          tree.RoutineLangSQL,
+				RoutineParams: tree.RoutineParams{
+					{Name: "arg1", Type: types.Int},
+				},
 			},
 		},
 		{
@@ -772,6 +784,9 @@ func TestToOverload(t *testing.T) {
 				Body:       "ANY QUERIES",
 				Type:       tree.UDFRoutine,
 				Language:   tree.RoutineLangSQL,
+				RoutineParams: tree.RoutineParams{
+					{Name: "arg1", Type: types.Int},
+				},
 			},
 			err: "function 1 is leakproof but not immutable",
 		},

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -197,8 +197,21 @@ func (b *Builder) finishBuildGeneratorFunction(
 ) (out opt.ScalarExpr) {
 	lastAlias := inScope.alias
 	if def.ReturnsRecordType {
-		if lastAlias == nil && !def.HasNamedReturnColumns {
-			panic(pgerror.New(pgcode.Syntax, "a column definition list is required for functions returning \"record\""))
+		if lastAlias == nil {
+			var numOutParams int
+			for _, param := range def.RoutineParams {
+				if param.IsOutParam() {
+					numOutParams++
+				}
+				if numOutParams == 2 {
+					break
+				}
+			}
+			// If we have at least two OUT parameters, they specify an implicit
+			// alias for the RECORD return type.
+			if numOutParams < 2 {
+				panic(pgerror.New(pgcode.Syntax, "a column definition list is required for functions returning \"record\""))
+			}
 		}
 	} else if lastAlias != nil {
 		// Non-record type return with a table alias that includes types is not

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -84,7 +84,6 @@ func (tc *Catalog) CreateRoutine(c *tree.CreateRoutine) {
 	// Resolve the parameter names and types.
 	paramTypes := make(tree.ParamTypes, len(c.Params))
 	var outParamTypes []*types.T
-	var firstOutParamName string
 	var outParamNames []string
 	for i := range c.Params {
 		param := &c.Params[i]
@@ -96,9 +95,6 @@ func (tc *Catalog) CreateRoutine(c *tree.CreateRoutine) {
 		if param.IsOutParam() {
 			outParamTypes = append(outParamTypes, typ)
 			paramName := string(param.Name)
-			if len(outParamNames) == 0 {
-				firstOutParamName = paramName
-			}
 			if paramName == "" {
 				paramName = fmt.Sprintf("column%d", len(outParamTypes))
 			}
@@ -157,22 +153,19 @@ func (tc *Catalog) CreateRoutine(c *tree.CreateRoutine) {
 	}
 	tc.currUDFOid++
 	overload := &tree.Overload{
-		Oid:                   tc.currUDFOid,
-		Types:                 paramTypes,
-		ReturnType:            tree.FixedReturnType(retType),
-		Body:                  body,
-		Volatility:            v,
-		CalledOnNullInput:     calledOnNullInput,
-		HasNamedReturnColumns: len(outParamNames) > 1,
-		Language:              language,
-		Type:                  routineType,
+		Oid:               tc.currUDFOid,
+		Types:             paramTypes,
+		ReturnType:        tree.FixedReturnType(retType),
+		Body:              body,
+		Volatility:        v,
+		CalledOnNullInput: calledOnNullInput,
+		Language:          language,
+		Type:              routineType,
+		RoutineParams:     c.Params,
 	}
 	overload.ReturnsRecordType = types.IsRecordType(retType)
 	if c.ReturnType != nil && c.ReturnType.SetOf {
 		overload.Class = tree.GeneratorClass
-	}
-	if len(outParamNames) == 1 {
-		overload.NamedReturnColumn = firstOutParamName
 	}
 	prefixedOverload := tree.MakeQualifiedOverload("public", overload)
 	def := &tree.ResolvedFunctionDefinition{

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -262,18 +262,14 @@ type Overload struct {
 	// in a Schema descriptor, which means that the full UDF descriptor need to be
 	// fetched to get more info, e.g. function Body.
 	UDFContainsOnlySignature bool
-	// NamedReturnColumn is non-empty when a user-defined function returns a
-	// single column of non-RECORD type and has named OUT parameter.
-	NamedReturnColumn string
-	// HasNamedReturnColumns is set when a user-defined function has multiple
-	// OUT parameters that specify an implicit alias for the RECORD return type.
-	HasNamedReturnColumns bool
 	// Version is the descriptor version of the descriptor used to construct
 	// this version of the function overload. Only used for UDFs.
 	Version uint64
 	// Language is the function language that was used to define the UDF.
 	// This is currently either SQL or PL/pgSQL.
 	Language RoutineLanguage
+	// RoutineParams contains all parameter information of the routine.
+	RoutineParams RoutineParams
 }
 
 // params implements the overloadImpl interface.


### PR DESCRIPTION
This allows us to remove some of the recently introduced fields and this information will be used by the follow up work.

Epic: None

Release note: None