### PR TITLE
release-23.2: roachtest: port multitenant/tpch to new roachprod API

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1025,7 +1025,7 @@ func attachToExistingCluster(
 		}
 		if !opt.skipWipe {
 			if roachtestflags.ClusterWipe {
-				if err := c.WipeE(ctx, l, false /* preserveCerts */, c.All()); err != nil {
+				if err := roachprod.Wipe(ctx, l, c.MakeNodes(c.All()), false /* preserveCerts */); err != nil {
 					return nil, err
 				}
 			} else {
@@ -2292,8 +2292,8 @@ func (c *clusterImpl) Signal(
 // WipeE wipes a subset of the nodes in a cluster. See cluster.Start() for a
 // description of the nodes parameter.
 func (c *clusterImpl) WipeE(
-	ctx context.Context, l *logger.Logger, preserveCerts bool, nodes ...option.Option,
-) error {
+	ctx context.Context, l *logger.Logger, nodes ...option.Option,
+) (retErr error) {
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "cluster.WipeE")
 	}
@@ -2303,16 +2303,16 @@ func (c *clusterImpl) WipeE(
 	}
 	c.setStatusForClusterOpt("wiping", false, nodes...)
 	defer c.clearStatusForClusterOpt(false)
-	return roachprod.Wipe(ctx, l, c.MakeNodes(nodes...), preserveCerts)
+	return roachprod.Wipe(ctx, l, c.MakeNodes(nodes...), c.IsSecure())
 }
 
 // Wipe is like WipeE, except instead of returning an error, it does
 // c.t.Fatal(). c.t needs to be set.
-func (c *clusterImpl) Wipe(ctx context.Context, preserveCerts bool, nodes ...option.Option) {
+func (c *clusterImpl) Wipe(ctx context.Context, nodes ...option.Option) {
 	if ctx.Err() != nil {
 		return
 	}
-	if err := c.WipeE(ctx, c.l, preserveCerts, nodes...); err != nil {
+	if err := c.WipeE(ctx, c.l, nodes...); err != nil {
 		c.t.Fatal(err)
 	}
 }
@@ -2850,7 +2850,7 @@ func (c *clusterImpl) WipeForReuse(
 		return errors.New("cluster reuse is disabled for local clusters to guarantee a clean slate for each test")
 	}
 	l.PrintfCtx(ctx, "Using existing cluster: %s (arch=%q). Wiping", c.name, c.arch)
-	if err := c.WipeE(ctx, l, false /* preserveCerts */); err != nil {
+	if err := roachprod.Wipe(ctx, l, c.MakeNodes(c.All()), false /* preserveCerts */); err != nil {
 		return err
 	}
 	// We remove the entire shared user directory between tests to ensure we aren't

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -133,8 +133,8 @@ type Cluster interface {
 
 	// Deleting CockroachDB data and logs on nodes.
 
-	WipeE(ctx context.Context, l *logger.Logger, preserveCerts bool, opts ...option.Option) error
-	Wipe(ctx context.Context, preserveCerts bool, opts ...option.Option)
+	WipeE(ctx context.Context, l *logger.Logger, opts ...option.Option) error
+	Wipe(ctx context.Context, opts ...option.Option)
 
 	// DNS
 

--- a/pkg/cmd/roachtest/tests/allocation_bench.go
+++ b/pkg/cmd/roachtest/tests/allocation_bench.go
@@ -324,7 +324,7 @@ func setupStatCollector(
 		if err := c.StopGrafana(ctx, t.L(), t.ArtifactsDir()); err != nil {
 			t.L().ErrorfCtx(ctx, "Error(s) shutting down prom/grafana %s", err)
 		}
-		c.Wipe(ctx, false /* preserveCerts */)
+		c.Wipe(ctx)
 	}
 
 	promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), cfg)

--- a/pkg/cmd/roachtest/tests/autoupgrade.go
+++ b/pkg/cmd/roachtest/tests/autoupgrade.go
@@ -248,7 +248,7 @@ func registerAutoUpgrade(r registry.Registry) {
 
 		// Wipe n3 to exclude it from the dead node check the roachtest harness
 		// will perform after the test.
-		c.Wipe(ctx, false /* preserveCerts */, c.Node(nodeDecommissioned))
+		c.Wipe(ctx, c.Node(nodeDecommissioned))
 	}
 
 	r.Add(registry.TestSpec{

--- a/pkg/cmd/roachtest/tests/cancel.go
+++ b/pkg/cmd/roachtest/tests/cancel.go
@@ -53,7 +53,7 @@ func registerCancel(r registry.Registry) {
 
 			t.Status("restoring TPCH dataset for Scale Factor 1")
 			if err := loadTPCHDataset(
-				ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false /* disableMergeQueue */, false, /* secure */
+				ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false, /* disableMergeQueue */
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/roachtest/tests/cluster_init.go
+++ b/pkg/cmd/roachtest/tests/cluster_init.go
@@ -49,7 +49,7 @@ func runClusterInit(ctx context.Context, t test.Test, c cluster.Cluster) {
 	startOpts.RoachprodOpts.JoinTargets = c.All()
 
 	for _, initNode := range []int{2, 1} {
-		c.Wipe(ctx, false /* preserveCerts */)
+		c.Wipe(ctx)
 		t.L().Printf("starting test with init node %d", initNode)
 		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings())
 

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -751,7 +751,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 			}
 			// Now stop+wipe them for good to keep the logs simple and the dead node detector happy.
 			c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Nodes(targetNodeA, targetNodeB))
-			c.Wipe(ctx, false /* preserveCerts */, c.Nodes(targetNodeA, targetNodeB))
+			c.Wipe(ctx, c.Nodes(targetNodeA, targetNodeB))
 		}
 	}
 
@@ -876,7 +876,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 			t.L().Printf("wiping n%d and adding it back to the cluster as a new node\n", targetNode)
 
 			c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(targetNode))
-			c.Wipe(ctx, false /*preserveCerts */, c.Node(targetNode))
+			c.Wipe(ctx, c.Node(targetNode))
 
 			joinNode := h.getRandNode()
 			internalAddrs, err := c.InternalAddr(ctx, t.L(), c.Node(joinNode))

--- a/pkg/cmd/roachtest/tests/decommission_self.go
+++ b/pkg/cmd/roachtest/tests/decommission_self.go
@@ -31,7 +31,7 @@ func runDecommissionSelf(ctx context.Context, t test.Test, c cluster.Cluster) {
 			// Stop n2 and exclude it from post-test consistency checks,
 			// as this node can't contact cluster any more and operations
 			// on it will hang.
-			u.c.Wipe(ctx, false /* preserveCerts */, c.Node(2))
+			u.c.Wipe(ctx, c.Node(2))
 		},
 		checkOneMembership(1, "decommissioned"),
 	)

--- a/pkg/cmd/roachtest/tests/inconsistency.go
+++ b/pkg/cmd/roachtest/tests/inconsistency.go
@@ -161,5 +161,5 @@ func runInconsistency(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// roachtest checks that no nodes are down when the test finishes, but in this
 	// case we have a down node that we can't restart. Remove the data dir, which
 	// tells roachtest to ignore this node.
-	c.Wipe(ctx, false /* preserveCerts */, c.Node(1))
+	c.Wipe(ctx, c.Node(1))
 }

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -735,7 +735,7 @@ func registerKVScalability(r registry.Registry) {
 		const maxPerNodeConcurrency = 64
 		for i := nodes; i <= nodes*maxPerNodeConcurrency; i += nodes {
 			i := i // capture loop variable
-			c.Wipe(ctx, false /* preserveCerts */, c.Range(1, nodes))
+			c.Wipe(ctx, c.Range(1, nodes))
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, nodes))
 
 			t.Status("running workload")

--- a/pkg/cmd/roachtest/tests/kvbench.go
+++ b/pkg/cmd/roachtest/tests/kvbench.go
@@ -228,7 +228,7 @@ func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSp
 		// Wipe cluster before starting a new run because factors like load-based
 		// splitting can significantly change the underlying layout of the table and
 		// affect benchmark results.
-		c.Wipe(ctx, false /* preserveCerts */, roachNodes)
+		c.Wipe(ctx, roachNodes)
 		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), roachNodes)
 		time.Sleep(restartWait)
 

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2294,7 +2294,7 @@ func (u *CommonTestUtils) resetCluster(
 ) error {
 	l.Printf("resetting cluster using version %q", version.String())
 	expectDeathsFn(len(u.roachNodes))
-	if err := u.cluster.WipeE(ctx, l, true /* preserveCerts */, u.roachNodes); err != nil {
+	if err := u.cluster.WipeE(ctx, l, u.roachNodes); err != nil {
 		return fmt.Errorf("failed to wipe cluster: %w", err)
 	}
 

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -82,7 +82,7 @@ func runMultiTenantTPCH(
 
 	// Restart and wipe the cluster to remove advantage of the second TPCH run.
 	c.Stop(ctx, t.L(), option.DefaultStopOpts())
-	c.Wipe(ctx, secure)
+	c.Wipe(ctx)
 	start()
 	singleTenantConn = c.Conn(ctx, t.L(), 1)
 	// Disable merge queue in the system tenant.

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -12,12 +12,12 @@ package tests
 
 import (
 	"context"
-	gosql "database/sql"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -30,10 +30,9 @@ import (
 func runMultiTenantTPCH(
 	ctx context.Context, t test.Test, c cluster.Cluster, enableDirectScans bool, sharedProcess bool,
 ) {
-	secure := true
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(1))
+	clusterSettings := install.MakeClusterSettings(install.SecureOption(true))
 	start := func() {
-		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(install.SecureOption(secure)), c.All())
+		c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), clusterSettings, c.All())
 	}
 	start()
 
@@ -45,7 +44,8 @@ func runMultiTenantTPCH(
 	// TPCH dataset using the provided connection and then runs each TPCH query
 	// one at a time (using the given url as a parameter to the 'workload run'
 	// command). The runtimes are accumulated in the perf helper.
-	runTPCH := func(conn *gosql.DB, url string, setupIdx int) {
+	runTPCH := func(node int, virtualClusterName string, sqlInstance int, setupIdx int) {
+		conn := c.Conn(ctx, t.L(), node, option.TenantName(virtualClusterName), option.SQLInstance(sqlInstance))
 		setting := fmt.Sprintf("SET CLUSTER SETTING sql.distsql.direct_columnar_scans.enabled = %t", enableDirectScans)
 		t.Status(setting)
 		if _, err := conn.Exec(setting); err != nil {
@@ -53,15 +53,18 @@ func runMultiTenantTPCH(
 		}
 		t.Status("restoring TPCH dataset for Scale Factor 1 in ", setupNames[setupIdx])
 		if err := loadTPCHDataset(
-			ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false /* disableMergeQueue */, secure,
+			ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false, /* disableMergeQueue */
 		); err != nil {
 			t.Fatal(err)
 		}
 		for queryNum := 1; queryNum <= tpch.NumQueries; queryNum++ {
-			cmd := fmt.Sprintf("./workload run tpch %s --secure "+
-				"--concurrency=1 --db=tpch --max-ops=%d --queries=%d",
-				url, numRunsPerQuery, queryNum)
-			result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(1), cmd)
+			cmd := roachtestutil.NewCommand("%s workload run tpch", test.DefaultCockroachPath).
+				Flag("concurrency", 1).
+				Flag("db", "tpch").
+				Flag("max-ops", numRunsPerQuery).
+				Flag("queries", queryNum).
+				Arg("{pgurl:%d:%s}", node, virtualClusterName)
+			result, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(1), cmd.String())
 			workloadOutput := result.Stdout + result.Stderr
 			t.L().Printf(workloadOutput)
 			if err != nil {
@@ -71,69 +74,63 @@ func runMultiTenantTPCH(
 		}
 	}
 
-	// First, use the cluster as a single tenant deployment. It is important to
-	// not create the tenant yet so that the certs directory is not overwritten.
-	singleTenantConn := c.Conn(ctx, t.L(), 1)
+	const sqlInstance = 0
+
+	systemConn := c.Conn(ctx, t.L(), 1)
+	defer systemConn.Close()
+
+	// First, use the cluster as a single tenant deployment.
+	gatewayNode := c.All().RandNode()[0]
 	// Disable merge queue in the system tenant.
-	if _, err := singleTenantConn.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false;"); err != nil {
+	if _, err := systemConn.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false;"); err != nil {
 		t.Fatal(err)
 	}
-	runTPCH(singleTenantConn, "" /* url */, 0 /* setupIdx */)
+	runTPCH(gatewayNode, install.SystemInterfaceName, sqlInstance, 0 /* setupIdx */)
 
 	// Restart and wipe the cluster to remove advantage of the second TPCH run.
-	c.Stop(ctx, t.L(), option.DefaultStopOpts())
 	c.Wipe(ctx)
 	start()
-	singleTenantConn = c.Conn(ctx, t.L(), 1)
 	// Disable merge queue in the system tenant.
-	if _, err := singleTenantConn.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false;"); err != nil {
+	if _, err := systemConn.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false;"); err != nil {
 		t.Fatal(err)
 	}
 
 	// Now we create a tenant and run all TPCH queries within it.
-	if sharedProcess {
-		db := createInMemoryTenantWithConn(ctx, t, c, appTenantName, c.All(), true /* secure */)
-		defer db.Close()
-		url := fmt.Sprintf("{pgurl:1:%s}", appTenantName)
-		runTPCH(db, url, 1 /* setupIdx */)
-	} else {
-		const (
-			tenantID       = 123
-			tenantHTTPPort = 8081
-			tenantSQLPort  = 30258
-			tenantNode     = 1
-		)
-		_, err := singleTenantConn.Exec(`SELECT crdb_internal.create_tenant($1::INT)`, tenantID)
-		if err != nil {
-			t.Fatal(err)
-		}
-		tenant := createTenantNode(ctx, t, c, c.All(), tenantID, tenantNode, tenantHTTPPort, tenantSQLPort)
-		tenant.start(ctx, t, c, "./cockroach")
-		multiTenantConn, err := gosql.Open("postgres", tenant.pgURL)
-		if err != nil {
-			t.Fatal(err)
-		}
-		// Allow the tenant to be able to split tables. We need to run a dummy
-		// split in order to make sure the capability is propagated before
-		// starting the test, otherwise importing tpch may fail.
-		_, err = singleTenantConn.Exec(
-			`ALTER TENANT [$1] SET CLUSTER SETTING sql.split_at.allow_for_secondary_tenant.enabled=true`, tenantID)
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, err = singleTenantConn.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_split=true`, tenantID)
-		if err != nil {
-			t.Fatal(err)
-		}
-		testutils.SucceedsSoon(t, func() error {
-			if _, err := multiTenantConn.Exec(`CREATE TABLE IF NOT EXISTS dummysplit (a INT)`); err != nil {
-				return err
-			}
-			_, err = multiTenantConn.Exec(`ALTER TABLE dummysplit SPLIT AT VALUES (0)`)
-			return err
-		})
-		runTPCH(multiTenantConn, "'"+tenant.secureURL()+"'", 1 /* setupIdx */)
+	startOpts := option.DefaultStartSharedVirtualClusterOpts(appTenantName)
+	var separateProcessNode option.NodeListOption
+	if !sharedProcess {
+		separateProcessNode = c.All().RandNode()
+		gatewayNode = separateProcessNode[0]
+		startOpts = option.DefaultStartVirtualClusterOpts(appTenantName, sqlInstance)
 	}
+	c.StartServiceForVirtualCluster(ctx, t.L(), separateProcessNode, startOpts, clusterSettings)
+
+	// Allow the tenant to be able to split tables. We need to run a dummy
+	// split in order to make sure the capability is propagated before
+	// starting the test, otherwise importing tpch may fail.
+	if _, err := systemConn.Exec(
+		`ALTER TENANT $1 SET CLUSTER SETTING sql.split_at.allow_for_secondary_tenant.enabled=true`, appTenantName,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := systemConn.Exec(
+		`ALTER TENANT $1 GRANT CAPABILITY can_admin_split=true`, appTenantName,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	virtualClusterConn := c.Conn(ctx, t.L(), gatewayNode, option.TenantName(appTenantName), option.SQLInstance(sqlInstance))
+	defer virtualClusterConn.Close()
+
+	testutils.SucceedsSoon(t, func() error {
+		if _, err := virtualClusterConn.Exec(`CREATE TABLE IF NOT EXISTS dummysplit (a INT)`); err != nil {
+			return err
+		}
+		_, err := virtualClusterConn.Exec(`ALTER TABLE dummysplit SPLIT AT VALUES (0)`)
+		return err
+	})
+
+	runTPCH(gatewayNode, appTenantName, sqlInstance, 1 /* setupIdx */)
 
 	// Analyze the runtimes of both setups.
 	perfHelper.compareSetups(t, numRunsPerQuery, nil /* timesCallback */)

--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -109,7 +109,7 @@ func runQueryComparison(
 			return
 		}
 		c.Stop(clusterCtx, t.L(), option.DefaultStopOpts())
-		c.Wipe(clusterCtx, false /* preserveCerts */)
+		c.Wipe(clusterCtx)
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/rapid_restart.go
+++ b/pkg/cmd/roachtest/tests/rapid_restart.go
@@ -38,7 +38,7 @@ func runRapidRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 		return timeutil.Now().After(deadline)
 	}
 	for j := 1; !done(); j++ {
-		c.Wipe(ctx, false /* preserveCerts */, node)
+		c.Wipe(ctx, node)
 
 		// The first 2 iterations we start the cockroach node and kill it right
 		// away. The 3rd iteration we let cockroach run so that we can check after
@@ -96,5 +96,5 @@ func runRapidRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// that consistency checks can be run, but in this case there's not much
 	// there in the first place anyway.
 	c.Stop(ctx, t.L(), option.DefaultStopOpts(), node)
-	c.Wipe(ctx, false /* preserveCerts */, node)
+	c.Wipe(ctx, node)
 }

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -80,7 +80,7 @@ func runTLP(ctx context.Context, t test.Test, c cluster.Cluster) {
 			return
 		}
 		c.Stop(ctx, t.L(), option.DefaultStopOpts())
-		c.Wipe(ctx, false /* preserveCerts */)
+		c.Wipe(ctx)
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/tpc_utils.go
+++ b/pkg/cmd/roachtest/tests/tpc_utils.go
@@ -42,7 +42,6 @@ func loadTPCHDataset(
 	m cluster.Monitor,
 	roachNodes option.NodeListOption,
 	disableMergeQueue bool,
-	secure bool,
 ) (retErr error) {
 	if c.Cloud() != spec.GCE && !c.IsLocal() {
 		t.Skip("uses gs://cockroach-fixtures-us-east1; see https://github.com/cockroachdb/cockroach/issues/105968")

--- a/pkg/cmd/roachtest/tests/tpc_utils.go
+++ b/pkg/cmd/roachtest/tests/tpc_utils.go
@@ -94,7 +94,7 @@ func loadTPCHDataset(
 		// If the scale factor was smaller than the required scale factor, wipe the
 		// cluster and restore.
 		m.ExpectDeaths(int32(c.Spec().NodeCount))
-		c.Wipe(ctx, secure, roachNodes)
+		c.Wipe(ctx, roachNodes)
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), roachNodes)
 		m.ResetDeaths()
 	} else if pqErr := (*pq.Error)(nil); !(errors.As(err, &pqErr) &&

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -1253,7 +1253,7 @@ func loadTPCCBench(
 
 		// If the dataset exists but is not large enough, wipe the cluster
 		// before restoring.
-		c.Wipe(ctx, false /* preserveCerts */, roachNodes)
+		c.Wipe(ctx, roachNodes)
 		startOpts, settings := b.startOpts()
 		c.Start(ctx, t.L(), startOpts, settings, roachNodes)
 	} else if pqErr := (*pq.Error)(nil); !(errors.As(err, &pqErr) &&

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -45,7 +45,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 
 		if err := loadTPCHDataset(
 			ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx, c.Range(1, numNodes-1)),
-			c.Range(1, numNodes-1), true /* disableMergeQueue */, false, /* secure */
+			c.Range(1, numNodes-1), true, /* disableMergeQueue */
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -75,7 +75,7 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 
 		t.Status("setting up dataset")
 		err := loadTPCHDataset(
-			ctx, t, c, conn, b.ScaleFactor, m, roachNodes, true /* disableMergeQueue */, false, /* secure */
+			ctx, t, c, conn, b.ScaleFactor, m, roachNodes, true, /* disableMergeQueue */
 		)
 		if err != nil {
 			return err

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -520,7 +520,7 @@ func runTPCHVec(ctx context.Context, t test.Test, c cluster.Cluster, testCase tp
 
 	t.Status("restoring TPCH dataset for Scale Factor 1")
 	if err := loadTPCHDataset(
-		ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), disableMergeQueue, false, /* secure */
+		ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), disableMergeQueue,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -68,7 +68,7 @@ func runValidateSystemSchemaAfterVersionUpgrade(
 		t.Fatal(err)
 	}
 	expected = obtainSystemSchema(ctx, t.L(), c, 1)
-	c.Wipe(ctx, false /* preserveCerts */, c.All())
+	c.Wipe(ctx, c.All())
 
 	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All(),
 		// Fixtures are generated on a version that's too old for this test.


### PR DESCRIPTION
Backport 2/2 commits from #119679.

/cc @cockroachdb/release

Release justification: test only changes.

---

The test is functionally mostly the same. One notable difference is
that we create tenants by name (not by ID). We also use the new APIs
to build a connection URL to the tenant directly.

Fixes: #117672.

Release note: None
