### PR TITLE
backupccl: fail online restore if target table has in-progres import

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuptestutils"
+	"github.com/cockroachdb/cockroach/pkg/cloud/nodelocal"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -519,6 +520,10 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 		case "reset":
 			ds.cleanup(ctx, t)
 			ds = newDatadrivenTestState()
+			if d.HasArg("test-nodelocal") {
+				nodelocalCleanup := nodelocal.ReplaceNodeLocalForTesting(t.TempDir())
+				ds.cleanupFns = append(ds.cleanupFns, nodelocalCleanup)
+			}
 			return ""
 
 		case "new-cluster":

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -896,9 +896,11 @@ func createImportingDescriptors(
 				offlineSchemas[schema.GetID()] = struct{}{}
 			}
 
-			if eligible, err := backedUpDescriptorWithInProgressImportInto(ctx, p, desc); err != nil {
+			if hasInProgressImportInto, err := backedUpDescriptorWithInProgressImportInto(ctx, p, desc); err != nil {
 				return nil, nil, nil, err
-			} else if !eligible {
+			} else if hasInProgressImportInto && details.ExperimentalOnline {
+				return nil, nil, nil, errors.Newf("table %s (id %d) in restoring backup has an in-progress import, but online restore cannot be run on a table with an in progress import", desc.GetName(), desc.GetID())
+			} else if !hasInProgressImportInto {
 				continue
 			}
 		}

--- a/pkg/ccl/backupccl/testdata/backup-restore/online-restore-in-progress-imports
+++ b/pkg/ccl/backupccl/testdata/backup-restore/online-restore-in-progress-imports
@@ -1,0 +1,35 @@
+# This test ensures that online restore failes when restoring tables 
+# undergoing an in progress import
+
+reset test-nodelocal
+----
+
+new-cluster name=s1 disable-tenant
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
+----
+
+
+# Pause the import job, in order to back up the importing data.
+import expect-pausepoint tag=a
+IMPORT INTO data.bank CSV DATA ('workload:///csv/bank/bank?rows=100&version=1.0.0')
+----
+job paused at pausepoint
+
+
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster/';
+----
+
+
+new-cluster name=s2 share-io-dir=s1 allow-implicit-access disable-tenant
+----
+
+
+exec-sql
+RESTORE DATABASE data FROM LATEST IN 'nodelocal://1/cluster/' with EXPERIMENTAL DEFERRED COPY;
+----
+pq: table bank (id 106) in restoring backup has an in-progress import, but online restore cannot be run on a table with an in progress import


### PR DESCRIPTION
This patch is a stop gap until we have a more elegant way to roll back in progress imports after an online restore.

Informs #118279

Fixes #118280

Release note: none