### PR TITLE
sql: fix a couple of memory leaks around memory monitors

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -711,8 +711,7 @@ func (ib *IndexBackfiller) Close(ctx context.Context) {
 func (ib *IndexBackfiller) GrowBoundAccount(ctx context.Context, growBy int64) error {
 	ib.muBoundAccount.Lock()
 	defer ib.muBoundAccount.Unlock()
-	err := ib.muBoundAccount.boundAccount.Grow(ctx, growBy)
-	return err
+	return ib.muBoundAccount.boundAccount.Grow(ctx, growBy)
 }
 
 // ShrinkBoundAccount shrinks the mutex protected bound account backing the

--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -87,7 +86,6 @@ type IndexBackfillMerger struct {
 
 	evalCtx *eval.Context
 
-	mon            *mon.BytesMonitor
 	muBoundAccount muBoundAccount
 }
 
@@ -105,6 +103,16 @@ const indexBackfillMergeProgressReportInterval = 10 * time.Second
 
 // Run runs the processor.
 func (ibm *IndexBackfillMerger) Run(ctx context.Context, output execinfra.RowReceiver) {
+	// This method blocks until all worker goroutines exit, so it's safe to
+	// close memory monitoring infra in defers.
+	mergerMon := execinfra.NewMonitor(ctx, ibm.flowCtx.Cfg.BackfillerMonitor, "index-backfiller-merger-mon")
+	defer mergerMon.Stop(ctx)
+	ibm.muBoundAccount.boundAccount = mergerMon.MakeBoundAccount()
+	defer func() {
+		ibm.muBoundAccount.Lock()
+		defer ibm.muBoundAccount.Unlock()
+		ibm.muBoundAccount.boundAccount.Close(ctx)
+	}()
 	opName := "IndexBackfillMerger"
 	ctx = logtags.AddTag(ctx, opName, int(ibm.spec.Table.ID))
 	ctx, span := execinfra.ProcessorSpan(ctx, ibm.flowCtx, opName, ibm.processorID)
@@ -512,25 +520,15 @@ func (ibm *IndexBackfillMerger) Resume(output execinfra.RowReceiver) {
 
 // NewIndexBackfillMerger creates a new IndexBackfillMerger.
 func NewIndexBackfillMerger(
-	ctx context.Context,
-	flowCtx *execinfra.FlowCtx,
-	processorID int32,
-	spec execinfrapb.IndexBackfillMergerSpec,
-) (*IndexBackfillMerger, error) {
-	mergerMon := execinfra.NewMonitor(ctx, flowCtx.Cfg.BackfillerMonitor,
-		"index-backfiller-merger-mon")
-
-	ibm := &IndexBackfillMerger{
+	flowCtx *execinfra.FlowCtx, processorID int32, spec execinfrapb.IndexBackfillMergerSpec,
+) *IndexBackfillMerger {
+	return &IndexBackfillMerger{
 		processorID: processorID,
 		spec:        spec,
 		desc:        tabledesc.NewUnsafeImmutable(&spec.Table),
 		flowCtx:     flowCtx,
 		evalCtx:     flowCtx.NewEvalCtx(),
-		mon:         mergerMon,
 	}
-
-	ibm.muBoundAccount.boundAccount = mergerMon.MakeBoundAccount()
-	return ibm, nil
 }
 
 // IndexBackfillMergerTestingKnobs is for testing the distributed processors for

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3167,7 +3167,7 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent, txnErr err
 		transactionFingerprintID :=
 			appstatspb.TransactionFingerprintID(ex.extraTxnState.transactionStatementsHash.Sum())
 
-		err := ex.txnFingerprintIDCache.Add(transactionFingerprintID)
+		err := ex.txnFingerprintIDCache.Add(ctx, transactionFingerprintID)
 		if err != nil {
 			if log.V(1) {
 				log.Warningf(ctx, "failed to enqueue transactionFingerprintID = %d: %s", transactionFingerprintID, err)

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -703,7 +703,7 @@ func TestMergeProcessor(t *testing.T) {
 		sp := tableDesc.IndexSpan(codec, srcIndex.GetID())
 
 		output := fakeReceiver{}
-		im, err := backfill.NewIndexBackfillMerger(ctx, &flowCtx, 0 /* processorID */, execinfrapb.IndexBackfillMergerSpec{
+		im := backfill.NewIndexBackfillMerger(&flowCtx, 0 /* processorID */, execinfrapb.IndexBackfillMergerSpec{
 			Table:            tableDesc.TableDescriptor,
 			TemporaryIndexes: []descpb.IndexID{srcIndex.GetID()},
 			AddedIndexes:     []descpb.IndexID{dstIndex.GetID()},
@@ -711,9 +711,6 @@ func TestMergeProcessor(t *testing.T) {
 			SpanIdx:          []int32{0},
 			MergeTimestamp:   kvDB.Clock().Now(),
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
 
 		im.Run(ctx, &output)
 		if output.err != nil {

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -372,7 +372,7 @@ func NewProcessor(
 		if err := checkNumIn(inputs, 0); err != nil {
 			return nil, err
 		}
-		return backfill.NewIndexBackfillMerger(ctx, flowCtx, processorID, *core.IndexBackfillMerger)
+		return backfill.NewIndexBackfillMerger(flowCtx, processorID, *core.IndexBackfillMerger), nil
 	}
 	if core.Ttl != nil {
 		if err := checkNumIn(inputs, 0); err != nil {


### PR DESCRIPTION
See individual commits for details.

Epic: None

Release note (bug fix): A slow memory leak that can accumulate when opening many new connections has been fixed. The bug is present in 22.2.9+ and 23.1+ versions.