### PR TITLE
backupccl: reset job level retry counter if backup progress has advanced

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -11,6 +11,7 @@ package backupccl
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/url"
 	"path"
 	"reflect"
@@ -313,7 +314,9 @@ func backup(
 			for i := int32(0); i < progDetails.CompletedSpans; i++ {
 				requestFinishedCh <- struct{}{}
 				if execCtx.ExecCfg().TestingKnobs.AfterBackupChunk != nil {
-					execCtx.ExecCfg().TestingKnobs.AfterBackupChunk()
+					if err := execCtx.ExecCfg().TestingKnobs.AfterBackupChunk(); err != nil {
+						return err
+					}
 				}
 			}
 
@@ -816,6 +819,11 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		MaxRetries: 5,
 	}
 
+	if p.ExecCfg().BackupRestoreTestingKnobs != nil &&
+		p.ExecCfg().BackupRestoreTestingKnobs.BackupDistSQLRetryPolicy != nil {
+		retryOpts = *p.ExecCfg().BackupRestoreTestingKnobs.BackupDistSQLRetryPolicy
+	}
+
 	if err := p.ExecCfg().JobRegistry.CheckPausepoint("backup.before.flow"); err != nil {
 		return err
 	}
@@ -823,6 +831,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	// We want to retry a backup if there are transient failures (i.e. worker nodes
 	// dying), so if we receive a retryable error, re-plan and retry the backup.
 	var res roachpb.RowCount
+	var lastProgress float32
 	var numBackupInstances int
 	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		res, numBackupInstances, err = backup(
@@ -866,6 +875,29 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 			defaultStore, details, p.User(), &kmsEnv)
 		if reloadBackupErr != nil {
 			return errors.Wrap(reloadBackupErr, "could not reload backup manifest when retrying")
+		}
+		// Re-load the job in order to update our progress object, which
+		// may have been updated since the flow started.
+		reloadedJob, reloadErr := p.ExecCfg().JobRegistry.LoadClaimedJob(ctx, b.job.ID())
+		if reloadErr != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			log.Warningf(ctx, "BACKUP job %d could not reload job progress when retrying: %+v",
+				b.job.ID(), reloadErr)
+		} else {
+			curProgress := reloadedJob.FractionCompleted()
+			var retryForTest bool
+			if p.ExecCfg().TestingKnobs.BeforeBackupResetRetry != nil {
+				retryForTest = p.ExecCfg().TestingKnobs.BeforeBackupResetRetry()
+			}
+			// If we made decent progress with the BACKUP, reset the last
+			// progress state.
+			if madeProgress := curProgress - lastProgress; retryForTest || madeProgress >= 0.01 {
+				log.Infof(ctx, "backport made %d%% progress, resetting retry duration", int(math.Round(float64(100*madeProgress))))
+				lastProgress = curProgress
+				r.Reset()
+			}
 		}
 	}
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -184,9 +184,8 @@ func TestBackupRestoreSingleNodeLocal(t *testing.T) {
 	params := base.TestClusterArgs{}
 	knobs := base.TestingKnobs{
 		SQLExecutor: &sql.ExecutorTestingKnobs{
-			AfterBackupChunk: func() error {
+			AfterBackupChunk: func() {
 				chunks++
-				return nil
 			},
 		},
 	}
@@ -1640,10 +1639,10 @@ func TestRestoreRetryProcErr(t *testing.T) {
 
 // TestBackupJobRetryReset tests that the job level retry counter
 // resets after the backup progresses. To do so, the test does the following:
-// 1. Intercept the backup job after a backup chunk completes and return a retryable
-// error until the retry counter reaches desired count.
-// 2. Intercept the backup job after receiving retryable error to simulate backup job progress.
-// 3. Assert that more than max retries have been sent, implying that the retry counter reset after progress was made.
+// 1. Intercept the backup job before the flow begins and send a retryable error.
+// 2. After we send MaxRetries-1, allow the job to complete the flow and send a progress update.
+// 3. After progress has been recorded, intercept the backup job again and send retryable errors until the job failed.
+// 4. Assert that more than max retries have been sent, implying that the retry counter reset after progress was made.
 func TestBackupJobRetryReset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1651,32 +1650,36 @@ func TestBackupJobRetryReset(t *testing.T) {
 		syncutil.Mutex
 		retryCount int
 	}{}
-	targetRetryCount := 2
-	maxRetries := 1
+	waitForProgress := make(chan struct{})
+	maxRetries := 4
+
 	params := base.TestClusterArgs{}
 	knobs := base.TestingKnobs{
-		SQLExecutor: &sql.ExecutorTestingKnobs{
-			AfterBackupChunk: func() error {
-				mu.Lock()
-				defer mu.Unlock()
-				if mu.retryCount >= targetRetryCount {
-					return nil
-				}
-				mu.retryCount++
-				return syscall.ECONNRESET
-			},
-			BeforeBackupResetRetry: func() bool {
-				mu.Lock()
-				defer mu.Unlock()
-				return mu.retryCount < targetRetryCount
-			},
-		},
 		BackupRestore: &sql.BackupRestoreTestingKnobs{
 			BackupDistSQLRetryPolicy: &retry.Options{
 				InitialBackoff: time.Microsecond,
 				Multiplier:     2,
 				MaxBackoff:     2 * time.Microsecond,
 				MaxRetries:     maxRetries,
+			},
+			RunBeforeBackupFlow: func() error {
+				mu.Lock()
+				defer mu.Unlock()
+				if mu.retryCount >= maxRetries-1 {
+					return nil
+				}
+				mu.retryCount++
+				// Send a retryable error
+				return syscall.ECONNRESET
+			},
+			RunAfterBackupFlow: func() error {
+				mu.Lock()
+				defer mu.Unlock()
+				// Wait for at least 1% backup job progress, then continue sending retryable errors
+				<-waitForProgress
+				mu.retryCount++
+				// Send a retryable error
+				return syscall.ECONNRESET
 			},
 		},
 		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
@@ -1690,9 +1693,17 @@ func TestBackupJobRetryReset(t *testing.T) {
 	defer cleanupFn()
 	var backupJobId jobspb.JobID
 	sqlDB.QueryRow(t, `BACKUP DATABASE data INTO $1 WITH DETACHED`, localFoo).Scan(&backupJobId)
-
-	jobutils.WaitForJobToSucceed(t, sqlDB, backupJobId)
-	require.Greater(t, mu.retryCount, maxRetries)
+	testutils.SucceedsSoon(t, func() error {
+		jobProgress := jobutils.GetJobProgress(t, sqlDB, backupJobId)
+		if jobProgress.GetFractionCompleted() < 0.01 {
+			return errors.Newf("backup has not made progress yet")
+		}
+		return nil
+	})
+	close(waitForProgress)
+	// Job will fail with exhausted retries: connection reset by peer
+	jobutils.WaitForJobToFail(t, sqlDB, backupJobId)
+	require.Greater(t, mu.retryCount, maxRetries+2)
 }
 
 func createAndWaitForJob(

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1616,7 +1616,7 @@ type ExecutorTestingKnobs struct {
 	)
 
 	// AfterBackupChunk is called after each chunk of a backup is completed.
-	AfterBackupChunk func()
+	AfterBackupChunk func() error
 
 	// AfterBackupCheckpoint if set will be called after a BACKUP-CHECKPOINT
 	// is written.
@@ -1646,6 +1646,10 @@ type ExecutorTestingKnobs struct {
 	// ForceSQLLivenessSession will force the use of a sqlliveness session for
 	// transaction deadlines even in the system tenant.
 	ForceSQLLivenessSession bool
+
+	// BeforeBackupResetRetry is called before backup loop encounters a retryable
+	// error.
+	BeforeBackupResetRetry func() bool
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.
@@ -1758,6 +1762,8 @@ type BackupRestoreTestingKnobs struct {
 	RunBeforeRestoreFlow func() error
 
 	RunAfterRestoreFlow func() error
+
+	BackupDistSQLRetryPolicy *retry.Options
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1616,7 +1616,7 @@ type ExecutorTestingKnobs struct {
 	)
 
 	// AfterBackupChunk is called after each chunk of a backup is completed.
-	AfterBackupChunk func() error
+	AfterBackupChunk func()
 
 	// AfterBackupCheckpoint if set will be called after a BACKUP-CHECKPOINT
 	// is written.
@@ -1646,10 +1646,6 @@ type ExecutorTestingKnobs struct {
 	// ForceSQLLivenessSession will force the use of a sqlliveness session for
 	// transaction deadlines even in the system tenant.
 	ForceSQLLivenessSession bool
-
-	// BeforeBackupResetRetry is called before backup loop encounters a retryable
-	// error.
-	BeforeBackupResetRetry func() bool
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.
@@ -1764,6 +1760,10 @@ type BackupRestoreTestingKnobs struct {
 	RunAfterRestoreFlow func() error
 
 	BackupDistSQLRetryPolicy *retry.Options
+
+	RunBeforeBackupFlow func() error
+
+	RunAfterBackupFlow func() error
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}


### PR DESCRIPTION
This commit hardens the backup's retry loop by resetting the retry counter on
meaningful progress. In details, The retry loop will be reseted if the backup
job encountered a retriable error and it have made at least 1% more progress
than the previous run.

Fixes: https://github.com/cockroachdb/cockroach/issues/119691

Release note: None