### PR TITLE
kvserver: fix typos in rangefeed var names

### DIFF
--- a/pkg/kv/kvserver/rangefeed/budget.go
+++ b/pkg/kv/kvserver/rangefeed/budget.go
@@ -286,7 +286,7 @@ type BudgetFactoryConfig struct {
 	rootMon                 *mon.BytesMonitor
 	provisionalFeedLimit    int64
 	adjustLimit             func(int64) int64
-	totalRangeReedBudget    int64
+	totalRangeFeedBudget    int64
 	histogramWindowInterval time.Duration
 	settings                *settings.Values
 }
@@ -308,13 +308,13 @@ func CreateBudgetFactoryConfig(
 	if rootMon == nil || !useBudgets {
 		return BudgetFactoryConfig{}
 	}
-	totalRangeReedBudget := int64(float64(memoryPoolSize) * totalSharedFeedBudgetFraction)
-	feedSizeLimit := int64(float64(totalRangeReedBudget) * maxFeedFraction)
+	totalRangeFeedBudget := int64(float64(memoryPoolSize) * totalSharedFeedBudgetFraction)
+	feedSizeLimit := int64(float64(totalRangeFeedBudget) * maxFeedFraction)
 	return BudgetFactoryConfig{
 		rootMon:                 rootMon,
 		provisionalFeedLimit:    feedSizeLimit,
 		adjustLimit:             adjustLimit,
-		totalRangeReedBudget:    totalRangeReedBudget,
+		totalRangeFeedBudget:    totalRangeFeedBudget,
 		histogramWindowInterval: histogramWindowInterval,
 		settings:                settings,
 	}
@@ -335,7 +335,7 @@ func NewBudgetFactory(ctx context.Context, config BudgetFactoryConfig) *BudgetFa
 
 	rangeFeedPoolMonitor := mon.NewMonitorInheritWithLimit(
 		"rangefeed-monitor",
-		config.totalRangeReedBudget,
+		config.totalRangeFeedBudget,
 		config.rootMon)
 	rangeFeedPoolMonitor.SetMetrics(metrics.SharedBytesCount, nil /* maxHist */)
 	rangeFeedPoolMonitor.StartNoReserved(ctx, config.rootMon)

--- a/pkg/kv/kvserver/rangefeed/budget_test.go
+++ b/pkg/kv/kvserver/rangefeed/budget_test.go
@@ -295,7 +295,7 @@ func TestBudgetLimits(t *testing.T) {
 			require.Equal(t, provisionalSize, size)
 			return adjustedSize
 		},
-		totalRangeReedBudget:    100000,
+		totalRangeFeedBudget:    100000,
 		histogramWindowInterval: time.Second * 5,
 		settings:                &s.SV,
 	})
@@ -311,7 +311,7 @@ func TestBudgetLimits(t *testing.T) {
 		adjustLimit: func(int64) int64 {
 			return 0
 		},
-		totalRangeReedBudget:    100000,
+		totalRangeFeedBudget:    100000,
 		histogramWindowInterval: time.Second * 5,
 		settings:                &s.SV,
 	})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -688,7 +688,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	kvMemoryMonitor := mon.NewMonitorInheritWithLimit(
 		"kv-mem", 0 /* limit */, sqlMonitorAndMetrics.rootSQLMemoryMonitor)
 	kvMemoryMonitor.StartNoReserved(ctx, sqlMonitorAndMetrics.rootSQLMemoryMonitor)
-	rangeReedBudgetFactory := serverrangefeed.NewBudgetFactory(
+	rangeFeedBudgetFactory := serverrangefeed.NewBudgetFactory(
 		ctx,
 		serverrangefeed.CreateBudgetFactoryConfig(
 			kvMemoryMonitor,
@@ -704,12 +704,12 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 				return limit
 			},
 			&st.SV))
-	if rangeReedBudgetFactory != nil {
-		nodeRegistry.AddMetricStruct(rangeReedBudgetFactory.Metrics())
+	if rangeFeedBudgetFactory != nil {
+		nodeRegistry.AddMetricStruct(rangeFeedBudgetFactory.Metrics())
 	}
 	// Closer order is important with BytesMonitor.
 	stopper.AddCloser(stop.CloserFn(func() {
-		rangeReedBudgetFactory.Stop(ctx)
+		rangeFeedBudgetFactory.Stop(ctx)
 	}))
 	stopper.AddCloser(stop.CloserFn(func() {
 		kvMemoryMonitor.Stop(ctx)
@@ -854,7 +854,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		ProtectedTimestampReader:     protectedTSReader,
 		EagerLeaseAcquisitionLimiter: eagerLeaseAcquisitionLimiter,
 		KVMemoryMonitor:              kvMemoryMonitor,
-		RangefeedBudgetFactory:       rangeReedBudgetFactory,
+		RangefeedBudgetFactory:       rangeFeedBudgetFactory,
 		SharedStorageEnabled:         cfg.SharedStorage != "",
 		SystemConfigProvider:         systemConfigWatcher,
 		SpanConfigSubscriber:         spanConfig.subscriber,


### PR DESCRIPTION
Epic: none
Release note: none