### PR TITLE
sql: fix redaction and visibility of SHOW SESSIONS and SHOW QUERIES

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2674,10 +2674,13 @@ func populateQueriesTable(
 	addRow func(...tree.Datum) error,
 	response *serverpb.ListSessionsResponse,
 ) error {
-	shouldRedactQuery := false
+	shouldRedactOtherUserQuery := false
+	canViewOtherUser := false
 	// Check if the user is admin.
 	if isAdmin, err := p.HasAdminRole(ctx); err != nil {
 		return err
+	} else if isAdmin {
+		canViewOtherUser = true
 	} else if !isAdmin {
 		// If the user is not admin, check the individual VIEWACTIVITY and VIEWACTIVITYREDACTED
 		// privileges.
@@ -2686,16 +2689,24 @@ func populateQueriesTable(
 		} else if hasViewActivityRedacted {
 			// If the user has VIEWACTIVITYREDACTED, redact the query as it takes precedence
 			// over VIEWACTIVITY.
-			shouldRedactQuery = true
-		} else if hasViewActivity, err := p.HasViewActivity(ctx); err != nil {
-			return err
-		} else if !hasViewActivity {
-			// If the user is not admin and does not have VIEWACTIVITY or VIEWACTIVITYREDACTED,
-			// return insufficient privileges error.
-			return noViewActivityOrViewActivityRedactedRoleError(p.User())
+			shouldRedactOtherUserQuery = true
+			canViewOtherUser = true
+		} else if !hasViewActivityRedacted {
+			if hasViewActivity, err := p.HasViewActivity(ctx); err != nil {
+				return err
+			} else if hasViewActivity {
+				canViewOtherUser = true
+			}
 		}
 	}
 	for _, session := range response.Sessions {
+		normalizedUser, err := username.MakeSQLUsernameFromUserInput(session.Username, username.PurposeValidation)
+		if err != nil {
+			return err
+		}
+		if !canViewOtherUser && normalizedUser != p.User() {
+			continue
+		}
 		sessionID := getSessionID(session)
 		for _, query := range session.ActiveQueries {
 			isDistributedDatum := tree.DNull
@@ -2739,8 +2750,9 @@ func populateQueriesTable(
 
 			// Interpolate placeholders into the SQL statement.
 			sql := formatActiveQuery(query)
-			// If the user does not have the correct privileges, show the query without literals or constants.
-			if shouldRedactQuery {
+			// If the user does not have the correct privileges, show the query
+			// without literals or constants.
+			if shouldRedactOtherUserQuery && session.Username != p.SessionData().User().Normalized() {
 				sql = query.SqlNoConstants
 			}
 			if err := addRow(

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2856,7 +2856,7 @@ var crdbInternalLocalSessionsTable = virtualSchemaTable{
 		if err != nil {
 			return err
 		}
-		return populateSessionsTable(ctx, addRow, response)
+		return populateSessionsTable(ctx, p, addRow, response)
 	},
 }
 
@@ -2874,14 +2874,49 @@ var crdbInternalClusterSessionsTable = virtualSchemaTable{
 		if err != nil {
 			return err
 		}
-		return populateSessionsTable(ctx, addRow, response)
+		return populateSessionsTable(ctx, p, addRow, response)
 	},
 }
 
 func populateSessionsTable(
-	ctx context.Context, addRow func(...tree.Datum) error, response *serverpb.ListSessionsResponse,
+	ctx context.Context,
+	p *planner,
+	addRow func(...tree.Datum) error,
+	response *serverpb.ListSessionsResponse,
 ) error {
+	shouldRedactOtherUserQuery := false
+	canViewOtherUser := false
+	// Check if the user is admin.
+	if isAdmin, err := p.HasAdminRole(ctx); err != nil {
+		return err
+	} else if isAdmin {
+		canViewOtherUser = true
+	} else if !isAdmin {
+		// If the user is not admin, check the VIEWACTIVITYREDACTED privilege to
+		// see if constants need to be redacted.
+		if hasViewActivityRedacted, err := p.HasViewActivityRedacted(ctx); err != nil {
+			return err
+		} else if hasViewActivityRedacted {
+			// If the user has VIEWACTIVITYREDACTED, redact the query as it takes precedence
+			// over VIEWACTIVITY.
+			shouldRedactOtherUserQuery = true
+			canViewOtherUser = true
+		} else if !hasViewActivityRedacted {
+			if hasViewActivity, err := p.HasViewActivity(ctx); err != nil {
+				return err
+			} else if hasViewActivity {
+				canViewOtherUser = true
+			}
+		}
+	}
 	for _, session := range response.Sessions {
+		normalizedUser, err := username.MakeSQLUsernameFromUserInput(session.Username, username.PurposeValidation)
+		if err != nil {
+			return err
+		}
+		if !canViewOtherUser && normalizedUser != p.User() {
+			continue
+		}
 		// Generate active_queries and active_query_start
 		var activeQueries bytes.Buffer
 		var activeQueryStart time.Time
@@ -2893,10 +2928,18 @@ func populateSessionsTable(
 			// queries to be executed at once in a session.
 			activeQueryStart = query.Start
 			sql := formatActiveQuery(query)
+			// Never redact queries made by the same user.
+			if shouldRedactOtherUserQuery && session.Username != p.User().Normalized() {
+				sql = query.SqlNoConstants
+			}
 			activeQueries.WriteString(sql)
 		}
+		lastActiveQuery := session.LastActiveQuery
+		// Never redact queries made by the same user.
+		if shouldRedactOtherUserQuery && session.Username != p.User().Normalized() {
+			lastActiveQuery = session.LastActiveQueryNoConstants
+		}
 
-		var err error
 		if activeQueryStart.IsZero() {
 			activeQueryStartDatum = tree.DNull
 		} else {
@@ -2930,7 +2973,7 @@ func populateSessionsTable(
 			tree.NewDString(session.ClientAddress),
 			tree.NewDString(session.ApplicationName),
 			tree.NewDString(activeQueries.String()),
-			tree.NewDString(session.LastActiveQuery),
+			tree.NewDString(lastActiveQuery),
 			tree.NewDInt(tree.DInt(session.NumTxnsExecuted)),
 			startTSDatum,
 			activeQueryStartDatum,

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -1052,7 +1052,8 @@ func TestShowSessionPrivileges(t *testing.T) {
 	}
 }
 
-// TestShowRedactedActiveStatements tests the crdb_internal.cluster_queries table for system permissions.
+// TestShowRedactedActiveStatements tests the crdb_internal.cluster_queries
+// table for system permissions.
 func TestShowRedactedActiveStatements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1184,6 +1185,167 @@ func TestShowRedactedActiveStatements(t *testing.T) {
 					t.Fatalf("expected 1 row, got %d", count)
 				}
 			}
+		})
+	}
+
+	cancel()
+	<-waiter
+}
+
+// TestShowRedactedSessions tests the crdb_internal.cluster_sessions
+// table for system permissions.
+func TestShowRedactedSessions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	params, _ := createTestServerParams()
+	params.Insecure = true
+	ctx, cancel := context.WithCancel(context.Background())
+	s, rawSQLDBroot, _ := serverutils.StartServer(t, params)
+	sqlDBroot := sqlutils.MakeSQLRunner(rawSQLDBroot)
+	defer s.Stopper().Stop(context.Background())
+
+	// Create four users: one with no special permissions, one with the
+	// VIEWACTIVITY role option, one with VIEWACTIVITYREDACTED option,
+	// and one with both permissions.
+	_ = sqlDBroot.Exec(t, `CREATE USER noperms`)
+	_ = sqlDBroot.Exec(t, `CREATE USER onlyviewactivity`)
+	_ = sqlDBroot.Exec(t, `CREATE USER onlyviewactivityredacted`)
+	_ = sqlDBroot.Exec(t, `CREATE USER bothperms`)
+	_ = sqlDBroot.Exec(t, `GRANT SYSTEM VIEWACTIVITY TO onlyviewactivity`)
+	_ = sqlDBroot.Exec(t, `GRANT SYSTEM VIEWACTIVITYREDACTED TO onlyviewactivityredacted`)
+	_ = sqlDBroot.Exec(t, `GRANT SYSTEM VIEWACTIVITY TO bothperms`)
+	_ = sqlDBroot.Exec(t, `GRANT SYSTEM VIEWACTIVITYREDACTED TO bothperms`)
+
+	type user struct {
+		username         string
+		canViewOtherRows bool // Can the user view other users' rows in the table?
+		isQueryRedacted  bool // Are the other userss queries redacted?
+		sqlRunner        *sqlutils.SQLRunner
+	}
+
+	// A user with no permissions should only be able to see their own rows
+	// in the table.
+	// A user with only VIEWACTIVITY should be able to see the whole query.
+	// A user with only VIEWACTIVITYREDACTED should see a redacted query.
+	// A user with both should see the redacted query, as VIEWACTIVITYREDACTED
+	// takes precedence.
+	users := []user{
+		{"onlyviewactivityredacted", true, true, nil},
+		{"onlyviewactivity", true, false, nil},
+		{"noperms", false, false, nil},
+		{"bothperms", true, true, nil},
+	}
+	for i, tc := range users {
+		pgURL := url.URL{
+			Scheme:   "postgres",
+			User:     url.User(tc.username),
+			Host:     s.AdvSQLAddr(),
+			RawQuery: "sslmode=disable",
+		}
+		db, err := gosql.Open("postgres", pgURL.String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		users[i].sqlRunner = sqlutils.MakeSQLRunner(db)
+
+		// Ensure the session is open.
+		users[i].sqlRunner.Exec(t, `SELECT version()`)
+	}
+
+	// Run a long-running sleep query in the background.
+	startSignal := make(chan struct{})
+	waiter := make(chan struct{})
+	go func() {
+		// Signal that we have started the query.
+		close(startSignal)
+		_, _ = rawSQLDBroot.ExecContext(ctx, `SELECT pg_sleep(30)`)
+		// Signal that we have finished the query.
+		close(waiter)
+	}()
+
+	// Wait for the start signal.
+	<-startSignal
+
+	selectRootQuery := `SELECT active_queries FROM [SHOW CLUSTER SESSIONS] WHERE active_queries LIKE 'SELECT pg_sleep%' AND user_name = 'root'`
+
+	testutils.SucceedsSoon(t, func() error {
+		rows := sqlDBroot.Query(t, selectRootQuery)
+		defer rows.Close()
+		count := 0
+		for rows.Next() {
+			count++
+			var query string
+			if err := rows.Scan(&query); err != nil {
+				return err
+			}
+			if query != "SELECT pg_sleep(30)" {
+				return errors.Errorf("Expected `SELECT pg_sleep(30)`, got %s", query)
+			}
+		}
+		if count != 1 {
+			return errors.Errorf("expected 1 row, got %d", count)
+		}
+		return nil
+	})
+
+	for _, u := range users {
+		t.Run(u.username, func(t *testing.T) {
+			rootRows := u.sqlRunner.Query(t, selectRootQuery)
+			defer func() { require.NoError(t, rootRows.Close()) }()
+
+			count := 0
+			for rootRows.Next() {
+				count++
+
+				var query string
+				if err := rootRows.Scan(&query); err != nil {
+					t.Fatal(err)
+				}
+
+				t.Log(query)
+				// Make sure that if the user is supposed to see a redacted query, they do.
+				if u.isQueryRedacted {
+					if !strings.HasPrefix(query, "SELECT pg_sleep(_)") {
+						t.Fatalf("Expected `SELECT pg_sleep(_)`, got %s", query)
+					}
+					// Make sure that if the user is supposed to see the full query, they do.
+				} else {
+					if !strings.HasPrefix(query, "SELECT pg_sleep(30)") {
+						t.Fatalf("Expected `SELECT pg_sleep(30)`, got %s", query)
+					}
+				}
+			}
+			if u.canViewOtherRows {
+				require.Equalf(t, 1, count, "expected 1 row, got %d", count)
+			} else {
+				require.Equalf(t, 0, count, "expected 0 rows, got %d", count)
+			}
+
+			selectOwnQuery := fmt.Sprintf(
+				`SELECT active_queries FROM [SHOW CLUSTER SESSIONS] WHERE active_queries LIKE 'SELECT active_queries FROM%%' AND user_name = '%s'`,
+				u.username,
+			)
+			ownRows := u.sqlRunner.Query(t, selectOwnQuery)
+			defer func() { require.NoError(t, ownRows.Close()) }()
+
+			count = 0
+			for ownRows.Next() {
+				count++
+
+				var query string
+				if err := ownRows.Scan(&query); err != nil {
+					t.Fatal(err)
+				}
+
+				t.Log(query)
+				// Any user can always see their own unredacted queries.
+				if !strings.Contains(query, fmt.Sprintf("user_name = '%s'", u.username)) {
+					t.Fatalf("Expected unredacted query, got %s", query)
+				}
+			}
+			require.Equalf(t, 1, count, "expected 1 row, got %d", count)
 		})
 	}
 


### PR DESCRIPTION
Release note (bug fix): If a user has the VIEWACTIVITYREDACTED
privilege, then they should not be able to see constants inside of
queries that originate from other users in the SHOW SESSIONS result.
This redaction was not occurring, but now this is fixed.

Release note (bug fix): The SHOW QUERIES and SHOW STATEMENTS commands
were incorrectly requiring that the user has the VIEWACTIVITY or
VIEWACTIVITYREDACTED privilege. However, a user always should be able to
view their own queries, even without this privilege. This is fixed now.

Epic: CRDB-35306