### PR TITLE
opt/optbuilder: fix internal error due to default column for unnest

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -1168,3 +1168,14 @@ project
  │         └── t95315.c2:2 = c2:7
  └── projections
       └── 1 [as="?column?":8]
+
+# Regression test for #119612.
+build
+SELECT unnest(ARRAY[ROW(),ROW(),ROW()]);
+----
+project-set
+ ├── columns: unnest:1
+ ├── values
+ │    └── ()
+ └── zip
+      └── unnest(ARRAY[(),(),()])


### PR DESCRIPTION
In 3b455a73b3a6edcb751dbc8ff04ef8168eb19a93 we replace direct pointer comparisons for `*types.T` with calls to `Identical`. This caused a regression due to `shouldCreateDefaultColumn`, which began firing for `unnest` when it shouldn't. This fix updates `shouldCreateDefaultColumn` to explicitly special case the builtin functions that need special handling, rather than checking that the return type is the empty tuple.

Fixes #119612

Release note: None