### PR TITLE
go.mod: fix go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/cockroach
 
-go 1.22
+go 1.22.0
 
 // golang.org/x/* packages are maintained and curated by the go project, just
 // without the backwards compatibility promises the standard library, and thus


### PR DESCRIPTION
Previously this was pointing to 1.22 which isn't a downloadable version which would cause errors of the form:
```
$ go tool pprof
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```

Setting this to go 1.22.0, which is a tagged and downloadable go version, fixes this.

Release note: none.
Epic: none.