### PR TITLE
schemaworkload: Add prometheus metrics

### DIFF
--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -45,6 +45,8 @@ go_library(
         "@com_github_jackc_pgx_v5//pgconn",
         "@com_github_jackc_pgx_v5//pgxpool",
         "@com_github_lib_pq//oid",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_spf13_pflag//:pflag",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel//codes",


### PR DESCRIPTION
This PR adds and exports prometheus success and error counters for the schemachange workload. This will enable us to monitor for success/errors while running the workload on long running clusters with the `tolerate-errors` flag set to true.

Epic: None
Fixes: https://github.com/cockroachdb/cockroach/issues/117701
Release note: None