### PR TITLE
build: use docker mirror

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:focal
+# We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+# See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+FROM us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:focal
 ARG TARGETPLATFORM
 
 RUN apt-get update \

--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+# We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+# See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+FROM us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/registry.access.redhat.com/ubi9/ubi-minimal
 ARG fips_enabled
 
 # For deployment, we need the following additionally installed:

--- a/build/teamcity/internal/cockroach/build/ci/nightly-bazel-builder-update-check.sh
+++ b/build/teamcity/internal/cockroach/build/ci/nightly-bazel-builder-update-check.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-BASE_IMAGE="ubuntu:focal"
+# We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+# See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+BASE_IMAGE="us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:focal"
 BAZEL_IMAGE="us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:latest-do-not-use"
 
 docker pull $BASE_IMAGE && docker pull $BAZEL_IMAGE

--- a/build/teamcity/internal/release/build-and-publish-patched-go.sh
+++ b/build/teamcity/internal/release/build-and-publish-patched-go.sh
@@ -14,9 +14,11 @@ this_dir="$(cd "$(dirname "${0}")"; pwd)"
 toplevel="$(dirname $(dirname $(dirname $(dirname $this_dir))))"
 
 mkdir -p "${toplevel}"/artifacts
+# We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+# See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
 docker run --rm -i ${tty-} -v $this_dir/build-and-publish-patched-go:/bootstrap \
        -v "${toplevel}"/artifacts:/artifacts \
-       ubuntu:focal /bootstrap/impl.sh
+       us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:focal /bootstrap/impl.sh
 tc_end_block "Build Go toolchains"
 
 tc_start_block "Build FIPS Go toolchains (linux/amd64)"

--- a/build/toolchains/toolchainbuild/crosstool-ng/buildtoolchains.sh
+++ b/build/toolchains/toolchainbuild/crosstool-ng/buildtoolchains.sh
@@ -8,6 +8,8 @@ toplevel="$(dirname $(dirname $(dirname $(dirname $this_dir))))"
 mkdir -p "${toplevel}"/artifacts
 
 # note: the Docker image should match the base image of `us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel`.
+# We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+# See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
 docker run --rm -i ${tty-} -v $this_dir:/bootstrap \
        -v "${toplevel}"/artifacts:/artifacts \
-       ubuntu:focal-20210119 /bootstrap/perform-build.sh
+       us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:focal-20210119 /bootstrap/perform-build.sh

--- a/build/toolchains/toolchainbuild/osxcross/buildtoolchains.sh
+++ b/build/toolchains/toolchainbuild/osxcross/buildtoolchains.sh
@@ -8,6 +8,8 @@ toplevel="$(dirname $(dirname $(dirname $(dirname $this_dir))))"
 mkdir -p "${toplevel}"/artifacts
 
 # note: the Docker image should match the base image of `us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel`.
+# We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+# See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
 docker run --rm -i ${tty-} -v $this_dir:/bootstrap \
        -v "${toplevel}"/artifacts:/artifacts \
-       ubuntu:focal-20210119 /bootstrap/perform-build.sh
+       us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:focal-20210119 /bootstrap/perform-build.sh

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -55,22 +55,28 @@ import (
 )
 
 const (
-	defaultImage  = "docker.io/library/ubuntu:focal-20210119"
+	// We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+	// See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+	defaultImage  = "us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:focal-20210119"
 	networkPrefix = "cockroachdb_acceptance"
 )
 
 // DefaultTCP is the default SQL/RPC port specification.
-const DefaultTCP nat.Port = base.DefaultPort + "/tcp"
-const defaultHTTP nat.Port = base.DefaultHTTPPort + "/tcp"
+const (
+	DefaultTCP  nat.Port = base.DefaultPort + "/tcp"
+	defaultHTTP nat.Port = base.DefaultHTTPPort + "/tcp"
+)
 
 // CockroachBinaryInContainer is the container-side path to the CockroachDB
 // binary.
 const CockroachBinaryInContainer = "/cockroach/cockroach"
 
-var cockroachImage = flag.String("i", defaultImage, "the docker image to run")
-var cockroachEntry = flag.String("e", "", "the entry point for the image")
-var waitOnStop = flag.Bool("w", false, "wait for the user to interrupt before tearing down the cluster")
-var maxRangeBytes = *zonepb.DefaultZoneConfig().RangeMaxBytes
+var (
+	cockroachImage = flag.String("i", defaultImage, "the docker image to run")
+	cockroachEntry = flag.String("e", "", "the entry point for the image")
+	waitOnStop     = flag.Bool("w", false, "wait for the user to interrupt before tearing down the cluster")
+	maxRangeBytes  = *zonepb.DefaultZoneConfig().RangeMaxBytes
+)
 
 // CockroachBinary is the path to the host-side binary to use.
 var CockroachBinary = flag.String("b", "", "the host-side binary to run")

--- a/pkg/acceptance/compose/flyway/docker-compose.yml
+++ b/pkg/acceptance/compose/flyway/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3'
 services:
   cockroach:
-    image: ubuntu:xenial-20210804
+    # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+    # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:xenial-20210804
     command: /cockroach/cockroach start-single-node --insecure --listen-addr cockroach
     volumes:
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach

--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -6,7 +6,9 @@ services:
       - ./kdc/start.sh:/start.sh
       - keytab:/keytab
   cockroach:
-    image: ubuntu:xenial-20210804
+    # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+    # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:xenial-20210804
     depends_on:
       - kdc
     command: /cockroach/cockroach --certs-dir=/certs start-single-node --listen-addr cockroach

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -6,7 +6,9 @@ services:
       - ./kdc/start.sh:/start.sh
       - keytab:/keytab
   cockroach:
-    image: ubuntu:xenial-20210804
+    # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+    # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:xenial-20210804
     depends_on:
       - kdc
     command: /cockroach/cockroach --certs-dir=/certs start-single-node --listen-addr cockroach

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -6,17 +6,23 @@ services:
       - POSTGRES_INITDB_ARGS=--locale=C --encoding=UTF8
       - POSTGRES_HOST_AUTH_METHOD=trust
   cockroach1:
-    image: ubuntu:xenial-20170214
+    # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+    # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:xenial-20170214
     command: /cockroach/cockroach start-single-node --insecure --listen-addr cockroach1
     volumes:
       - "${COCKROACH_PATH}:/cockroach/cockroach"
   cockroach2:
-    image: ubuntu:xenial-20170214
+    # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+    # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:xenial-20170214
     command: /cockroach/cockroach start-single-node --insecure --listen-addr cockroach2
     volumes:
       - "${COCKROACH_PATH}:/cockroach/cockroach"
   test:
-    image: ubuntu:xenial-20170214
+    # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+    # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:xenial-20170214
     environment:
       - COCKROACH_DEV_LICENSE=$COCKROACH_DEV_LICENSE
     # compare.test is a binary built by the pkg/compose/prepare.sh in non-bazel builds


### PR DESCRIPTION
Previously, we used upstream docker repositories to pull docker images
in CI/releases. This has been unreliable from time to time.

This PR changes the docker repos we use in CI and release automation to
use our mirror.

Epic: RE-539
Release note: None