### PR TITLE
changefeedccl: deflake TestAlterChangefeedPersistSinkURI

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -710,7 +710,11 @@ func TestAlterChangefeedPersistSinkURI(t *testing.T) {
 	const unredactedSinkURI = "null://blah?AWS_ACCESS_KEY_ID=the_secret"
 
 	ctx := context.Background()
-	srv, rawSQLDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	srv, rawSQLDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
 	defer srv.Stopper().Stop(ctx)
 
 	s := srv.ApplicationLayer()


### PR DESCRIPTION
This patch deflakes `TestAlterChangefeedPersistSinkURI` by setting
`jobs.NewTestingKnobsWithShortIntervals`. Previously, if the changefeed
job's status was set to `pause-requested` before it started running,
the job would record an error when it attempted to start running and
become unclaimed. This had the potential of causing the test to time
out before the job could be reclaimed and properly paused. Now, the job
should be promptly reclaimed and paused.

Fixes #119676

Release note: None