### PR TITLE
kvcoord: don't probe idle replicas with tripped circuit breakers

### DIFF
--- a/pkg/rpc/connection.go
+++ b/pkg/rpc/connection.go
@@ -121,6 +121,10 @@ func (s *neverTripSignal) C() <-chan struct{} {
 	return nil
 }
 
+func (s *neverTripSignal) IsTripped() bool {
+	return false
+}
+
 // ConnectNoBreaker is like Connect but bypasses the circuit breaker, meaning
 // that it will latch onto (or start) an existing connection attempt even if
 // previous attempts have not succeeded. This may be preferable to Connect
@@ -172,6 +176,10 @@ func (s *connFuture) C() <-chan struct{} {
 // Err must only be called after C() has been closed.
 func (s *connFuture) Err() error {
 	return s.err
+}
+
+func (s *connFuture) IsTripped() bool {
+	return s.Resolved()
 }
 
 // Conn must only be called after C() has been closed.


### PR DESCRIPTION
Previously, DistSender circuit breakers would continually probe replicas with tripped circuit breakers. This could result in a large number of concurrent probe goroutines.

To reduce the number of probes, this patch instead only probes replicas that have seen traffic in the past few probe intervals. Otherwise, the probe exits (leaving the breaker tripped), and a new probe will be launched on the next request to the replica. This will increase latency for the first request(s) following recovery, as it must wait for the probe to succeed and the DistSender to retry the replica. In the common case (e.g. with a disk stall), the lease will shortly have moved to a different replica and the DistSender will stop sending requests to it.

Replicas with tripped circuit breakers are also made eligible for garbage collection, but with a higher threshold of 1 hour to avoid overeager GC.

Resolves #119917.
Touches #104262.
Touches https://github.com/cockroachdb/cockroach/issues/105168.
Epic: none
Release note: None