### PR TITLE
rangefeedbuffer: parameterize by generic Event type

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeedbuffer/buffer.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedbuffer/buffer.go
@@ -24,7 +24,7 @@ import (
 // events than the limit the buffer is configured with.
 var ErrBufferLimitExceeded = errors.New("rangefeed buffer limit exceeded")
 
-// Event is the unit of what can be added to the buffer.
+// Event is a contract for the unit of what can be added to the buffer.
 type Event interface {
 	Timestamp() hlc.Timestamp
 }
@@ -33,25 +33,25 @@ type Event interface {
 // accumulates raw events which can then be flushed out in timestamp sorted
 // order en-masse whenever the rangefeed frontier is bumped. If we accumulate
 // more events than the limit allows for, we error out to the caller.
-type Buffer struct {
+type Buffer[E Event] struct {
 	mu struct {
 		syncutil.Mutex
 
-		events
+		events[E]
 		frontier hlc.Timestamp
 		limit    int
 	}
 }
 
 // New constructs a Buffer with the provided limit.
-func New(limit int) *Buffer {
-	b := &Buffer{}
+func New[E Event](limit int) *Buffer[E] {
+	b := &Buffer[E]{}
 	b.mu.limit = limit
 	return b
 }
 
 // Add adds the given entry to the buffer.
-func (b *Buffer) Add(ev Event) error {
+func (b *Buffer[E]) Add(ev E) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -73,7 +73,7 @@ func (b *Buffer) Add(ev Event) error {
 // less than or equal to the provided frontier timestamp. The timestamp is
 // recorded (expected to monotonically increase), and future events with
 // timestamps less than or equal to it are discarded.
-func (b *Buffer) Flush(ctx context.Context, frontier hlc.Timestamp) (events []Event) {
+func (b *Buffer[E]) Flush(ctx context.Context, frontier hlc.Timestamp) (events []E) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -97,17 +97,17 @@ func (b *Buffer) Flush(ctx context.Context, frontier hlc.Timestamp) (events []Ev
 // SetLimit is used to limit the number of events the buffer internally tracks.
 // If already in excess of the limit, future additions will error out (until the
 // buffer is Flush()-ed at least).
-func (b *Buffer) SetLimit(limit int) {
+func (b *Buffer[E]) SetLimit(limit int) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	b.mu.limit = limit
 }
 
-type events []Event
+type events[E Event] []E
 
-var _ sort.Interface = (*events)(nil)
+var _ sort.Interface = (*events[Event])(nil)
 
-func (es *events) Len() int           { return len(*es) }
-func (es *events) Less(i, j int) bool { return (*es)[i].Timestamp().Less((*es)[j].Timestamp()) }
-func (es *events) Swap(i, j int)      { (*es)[i], (*es)[j] = (*es)[j], (*es)[i] }
+func (es *events[E]) Len() int           { return len(*es) }
+func (es *events[E]) Less(i, j int) bool { return (*es)[i].Timestamp().Less((*es)[j].Timestamp()) }
+func (es *events[E]) Swap(i, j int)      { (*es)[i], (*es)[j] = (*es)[j], (*es)[i] }

--- a/pkg/kv/kvclient/rangefeed/rangefeedbuffer/buffer_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedbuffer/buffer_test.go
@@ -30,7 +30,7 @@ func TestBuffer(t *testing.T) {
 
 	ctx := context.Background()
 	const limit = 25
-	buffer := rangefeedbuffer.New(limit)
+	buffer := rangefeedbuffer.New[*testEvent](limit)
 
 	{ // Sanity check the newly initialized rangefeed buffer.
 		events := buffer.Flush(ctx, ts(0))
@@ -62,16 +62,16 @@ func TestBuffer(t *testing.T) {
 		events := buffer.Flush(ctx, ts(14))
 
 		require.True(t, len(events) == 3)
-		require.Equal(t, events[0].(*testEvent).data, "b") // b@11
-		require.Equal(t, events[1].(*testEvent).data, "d") // d@12
-		require.Equal(t, events[2].(*testEvent).data, "a") // a@13
+		require.Equal(t, events[0].data, "b") // b@11
+		require.Equal(t, events[1].data, "d") // d@12
+		require.Equal(t, events[2].data, "a") // a@13
 	}
 
 	{ // Incremental advances should only surface the events until the given timestamp.
 		events := buffer.Flush(ctx, ts(15))
 
 		require.True(t, len(events) == 1)
-		require.Equal(t, events[0].(*testEvent).data, "c") // c@15
+		require.Equal(t, events[0].data, "c") // c@15
 	}
 
 	{ // Adding events with timestamps <= the last flush are discarded.
@@ -90,14 +90,14 @@ func TestBuffer(t *testing.T) {
 
 		events := buffer.Flush(ctx, ts(20))
 		require.True(t, len(events) == 2)
-		require.Equal(t, events[0].(*testEvent).data, "e") // e@18
-		require.Equal(t, events[1].(*testEvent).data, "f") // f@19
+		require.Equal(t, events[0].data, "e") // e@18
+		require.Equal(t, events[1].data, "f") // f@19
 	}
 
 	{ // Ensure that a timestamp greater than any previous event flushes everything.
 		events := buffer.Flush(ctx, ts(100))
 		require.True(t, len(events) == 1)
-		require.Equal(t, events[0].(*testEvent).data, "g") // g@21
+		require.Equal(t, events[0].data, "g") // g@21
 	}
 
 	{ // Sanity check that there are no events left over.
@@ -138,6 +138,6 @@ func (t *testEvent) Timestamp() hlc.Timestamp {
 
 var _ rangefeedbuffer.Event = &testEvent{}
 
-func makeEvent(data string, ts hlc.Timestamp) rangefeedbuffer.Event {
+func makeEvent(data string, ts hlc.Timestamp) *testEvent {
 	return &testEvent{data: data, ts: ts}
 }

--- a/pkg/kv/kvclient/rangefeed/rangefeedbuffer/kvs.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedbuffer/kvs.go
@@ -19,13 +19,12 @@ import (
 
 // RangeFeedValueEventToKV is a function to type assert an Event into a
 // *kvpb.RangeFeedValue and then convert it to a roachpb.KeyValue.
-func RangeFeedValueEventToKV(event Event) roachpb.KeyValue {
-	rfv := event.(*kvpb.RangeFeedValue)
+func RangeFeedValueEventToKV(rfv *kvpb.RangeFeedValue) roachpb.KeyValue {
 	return roachpb.KeyValue{Key: rfv.Key, Value: rfv.Value}
 }
 
 // EventsToKVs converts a slice of Events to a slice of KeyValue pairs.
-func EventsToKVs(events []Event, f func(ev Event) roachpb.KeyValue) []roachpb.KeyValue {
+func EventsToKVs[E Event](events []E, f func(ev E) roachpb.KeyValue) []roachpb.KeyValue {
 	kvs := make([]roachpb.KeyValue, 0, len(events))
 	for _, ev := range events {
 		kvs = append(kvs, f(ev))

--- a/pkg/kv/kvclient/rangefeed/rangefeedbuffer/kvs_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedbuffer/kvs_test.go
@@ -58,8 +58,8 @@ func TestMergeKVs(t *testing.T) {
 		}
 		return kvs
 	}
-	toBuffer := func(t *testing.T, rows []row) *Buffer {
-		buf := New(len(rows))
+	toBuffer := func(t *testing.T, rows []row) *Buffer[*kvpb.RangeFeedValue] {
+		buf := New[*kvpb.RangeFeedValue](len(rows))
 		for _, r := range rows {
 			require.NoError(t, buf.Add(toRangeFeedEvent(r)))
 		}

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedbuffer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -56,11 +55,11 @@ func TestWatchAuthErr(t *testing.T) {
 		[]roachpb.Span{hostScratchSpan},
 		false, /* withPrevValue */
 		true,  /* withRowTSInInitialScan */
-		func(ctx context.Context, kv *kvpb.RangeFeedValue) rangefeedbuffer.Event {
+		func(ctx context.Context, kv *kvpb.RangeFeedValue) (*kvpb.RangeFeedValue, bool) {
 			t.Fatalf("rangefeed should fail before producing results")
-			return nil
+			return nil, false
 		},
-		func(ctx context.Context, update rangefeedcache.Update) {
+		func(ctx context.Context, update rangefeedcache.Update[*kvpb.RangeFeedValue]) {
 			t.Fatalf("rangefeed should fail before producing results")
 		},
 		&rangefeedcache.TestingKnobs{})

--- a/pkg/server/tenantsettingswatcher/watcher.go
+++ b/pkg/server/tenantsettingswatcher/watcher.go
@@ -64,7 +64,7 @@ type Watcher struct {
 
 	// rfc provides access to the underlying rangefeedcache.Watcher for
 	// testing.
-	rfc *rangefeedcache.Watcher
+	rfc *rangefeedcache.Watcher[rangefeedbuffer.Event]
 	mu  struct {
 		syncutil.Mutex
 		// Used by TestingRestart.
@@ -134,30 +134,30 @@ func (w *Watcher) startRangeFeed(
 
 	allOverrides := make(map[roachpb.TenantID][]kvpb.TenantSetting)
 
-	translateEvent := func(ctx context.Context, kv *kvpb.RangeFeedValue) rangefeedbuffer.Event {
+	translateEvent := func(ctx context.Context, kv *kvpb.RangeFeedValue) (rangefeedbuffer.Event, bool) {
 		tenantID, setting, tombstone, err := w.dec.DecodeRow(roachpb.KeyValue{
 			Key:   kv.Key,
 			Value: kv.Value,
 		})
 		if err != nil {
 			log.Warningf(ctx, "failed to decode settings row %v: %v", kv.Key, err)
-			return nil
+			return nil, false
 		}
 		if allOverrides != nil {
 			// We are in the process of doing a full table scan
 			if tombstone {
 				log.Warning(ctx, "unexpected empty value during rangefeed scan")
-				return nil
+				return nil, false
 			}
 			allOverrides[tenantID] = append(allOverrides[tenantID], setting)
 		} else {
 			// We are processing incremental changes.
 			w.store.setTenantOverride(ctx, tenantID, setting)
 		}
-		return nil
+		return nil, false
 	}
 
-	onUpdate := func(ctx context.Context, update rangefeedcache.Update) {
+	onUpdate := func(ctx context.Context, update rangefeedcache.Update[rangefeedbuffer.Event]) {
 		if update.Type == rangefeedcache.CompleteUpdate {
 			// The CompleteUpdate indicates that the table scan is complete.
 			// Henceforth, all calls to translateEvent will be incremental changes,

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -123,7 +123,7 @@ type KVSubscriber struct {
 	knobs    *spanconfig.TestingKnobs
 	settings *cluster.Settings
 
-	rfc *rangefeedcache.Watcher
+	rfc *rangefeedcache.Watcher[*BufferEvent]
 
 	mu struct { // serializes between Start and external threads
 		syncutil.RWMutex
@@ -401,7 +401,7 @@ func (s *KVSubscriber) GetProtectionTimestamps(
 	return protectionTimestamps, s.mu.lastUpdated, nil
 }
 
-func (s *KVSubscriber) handleUpdate(ctx context.Context, u rangefeedcache.Update) {
+func (s *KVSubscriber) handleUpdate(ctx context.Context, u rangefeedcache.Update[*BufferEvent]) {
 	switch u.Type {
 	case rangefeedcache.CompleteUpdate:
 		s.handleCompleteUpdate(ctx, u.Timestamp, u.Events)
@@ -411,11 +411,11 @@ func (s *KVSubscriber) handleUpdate(ctx context.Context, u rangefeedcache.Update
 }
 
 func (s *KVSubscriber) handleCompleteUpdate(
-	ctx context.Context, ts hlc.Timestamp, events []rangefeedbuffer.Event,
+	ctx context.Context, ts hlc.Timestamp, events []*BufferEvent,
 ) {
 	freshStore := spanconfigstore.New(s.fallback, s.settings, s.boundsReader, s.knobs)
 	for _, ev := range events {
-		freshStore.Apply(ctx, false /* dryrun */, ev.(*BufferEvent).Update)
+		freshStore.Apply(ctx, false /* dryrun */, ev.Update)
 	}
 	handlers := func() []handler {
 		s.mu.Lock()
@@ -438,7 +438,7 @@ func (s *KVSubscriber) setLastUpdatedLocked(ts hlc.Timestamp) {
 }
 
 func (s *KVSubscriber) handlePartialUpdate(
-	ctx context.Context, ts hlc.Timestamp, events []rangefeedbuffer.Event,
+	ctx context.Context, ts hlc.Timestamp, events []*BufferEvent,
 ) {
 	// The events we've received from the rangefeed buffer are sorted in
 	// increasing timestamp order. However, any updates with the same timestamp
@@ -456,7 +456,7 @@ func (s *KVSubscriber) handlePartialUpdate(
 		case 1: // ts(i) > ts(j)
 			return false
 		case 0: // ts(i) == ts(j); deletions sort before additions
-			return events[i].(*BufferEvent).Deletion() // no need to worry about the sort being stable
+			return events[i].Deletion() // no need to worry about the sort being stable
 		default:
 			panic("unexpected")
 		}
@@ -469,7 +469,7 @@ func (s *KVSubscriber) handlePartialUpdate(
 			// atomically, the updates need to be non-overlapping. That's not the case
 			// here because we can have deletion events followed by additions for
 			// overlapping spans.
-			s.mu.internal.Apply(ctx, false /* dryrun */, ev.(*BufferEvent).Update)
+			s.mu.internal.Apply(ctx, false /* dryrun */, ev.Update)
 		}
 		s.setLastUpdatedLocked(ts)
 		return s.mu.handlers
@@ -478,7 +478,7 @@ func (s *KVSubscriber) handlePartialUpdate(
 	for i := range handlers {
 		handler := &handlers[i] // mutated by invoke
 		for _, ev := range events {
-			target := ev.(*BufferEvent).Update.GetTarget()
+			target := ev.Update.GetTarget()
 			handler.invoke(ctx, target.KeyspaceTargeted())
 		}
 	}

--- a/pkg/spanconfig/spanconfigsqlwatcher/buffer.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/buffer.go
@@ -34,7 +34,7 @@ type buffer struct {
 		syncutil.Mutex
 
 		// rangefeed.Buffer stores spanconfigsqlwatcher.Events.
-		buffer *rangefeedbuffer.Buffer
+		buffer *rangefeedbuffer.Buffer[event]
 
 		// rangefeedFrontiers tracks the frontier timestamps of individual
 		// rangefeeds established by the SQLWatcher.
@@ -75,7 +75,7 @@ const (
 // newBuffer constructs a new buffer initialized with a starting frontier
 // timestamp.
 func newBuffer(limit int, initialFrontierTS hlc.Timestamp) *buffer {
-	rangefeedBuffer := rangefeedbuffer.New(limit)
+	rangefeedBuffer := rangefeedbuffer.New[event](limit)
 	eventBuffer := &buffer{}
 	eventBuffer.mu.buffer = rangefeedBuffer
 	for i := range eventBuffer.mu.rangefeedFrontiers {
@@ -167,7 +167,7 @@ var _ sort.Interface = &events{}
 // returns  a list of relevant events which were buffered up to that timestamp.
 func (b *buffer) flushEvents(
 	ctx context.Context,
-) (updates []rangefeedbuffer.Event, combinedFrontierTS hlc.Timestamp) {
+) (updates []event, combinedFrontierTS hlc.Timestamp) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	// First we determine the checkpoint timestamp, which is the minimum
@@ -196,7 +196,7 @@ func (b *buffer) flush(
 					ev, prevEv)
 			}
 		}
-		evs = append(evs, ev.(event))
+		evs = append(evs, ev)
 	}
 	// Nil out the underlying slice since we have copied over the events.
 	bufferedEvents = nil


### PR DESCRIPTION
This commit replaces the rangefeedbuffer package's use of Event interface objects with a generic type parameter. In doing so, it avoids having users of the package (e.g. spanconfigkvsubscriber) need to type assert the Event interface objects back to the specific event type they are interested in and know that their TranslateEventFunc has decoded events into.

Epic: None
Release note: None