### PR TITLE
kvserver: unskip `TestBackpressureNotApplied...` under remote exec

### DIFF
--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -42,7 +42,6 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t, "takes >1m under race")
-	skip.UnderRemoteExecutionWithIssue(t, 113032, "probable OOM")
 
 	rRand, _ := randutil.NewTestRand()
 	ctx := context.Background()


### PR DESCRIPTION
There should be enough RAM now.

Epic: CRDB-8308
Release note: None