### PR TITLE
db-console: run `jest` test on `large` pool

### DIFF
--- a/pkg/ui/workspaces/db-console/BUILD.bazel
+++ b/pkg/ui/workspaces/db-console/BUILD.bazel
@@ -190,6 +190,9 @@ jest_test(
     env = {
         "BAZEL_TARGET": "1",
     },
+    exec_properties = {
+        "test.Pool": "large",
+    },
     node_modules = ":node_modules",
     shard_count = 4,
 )


### PR DESCRIPTION
This matches up to what we're already doing with `console-ui`.

Epic: CRDB-8308
Release note: None