### PR TITLE
typedesc: copy composite type elements in `AsTypesT`

### DIFF
--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -764,7 +764,7 @@ func (desc *immutable) AsTypesT() *types.T {
 		contents := make([]*types.T, len(desc.Composite.Elements))
 		labels := make([]string, len(desc.Composite.Elements))
 		for i, e := range desc.Composite.Elements {
-			contents[i] = e.ElementType
+			contents[i] = e.ElementType.CopyForHydrate()
 			labels[i] = e.ElementLabel
 		}
 		return types.NewCompositeType(


### PR DESCRIPTION
This commit adds copying for the elements of a composite type in the `TypeDescriptor.AsTypesT` method. This avoids data races during type hydration.

Fixes #119866

Release note: None