### PR TITLE
release-23.1: changefeedccl: deflake TestAlterChangefeedPersistSinkURI

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -668,6 +668,7 @@ func TestAlterChangefeedPersistSinkURI(t *testing.T) {
 	const unredactedSinkURI = "null://blah?AWS_ACCESS_KEY_ID=the_secret"
 
 	params, _ := tests.CreateTestServerParams()
+	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 	s, rawSQLDB, _ := serverutils.StartServer(t, params)
 	sqlDB := sqlutils.MakeSQLRunner(rawSQLDB)
 	registry := s.JobRegistry().(*jobs.Registry)


### PR DESCRIPTION
Backport 1/1 commits from #119852.

/cc @cockroachdb/release

---

This patch deflakes `TestAlterChangefeedPersistSinkURI` by setting
`jobs.NewTestingKnobsWithShortIntervals`. Previously, if the changefeed
job's status was set to `pause-requested` before it started running,
the job would record an error when it attempted to start running and
become unclaimed. This had the potential of causing the test to time
out before the job could be reclaimed and properly paused. Now, the job
should be promptly reclaimed and paused.

Fixes #119676

Release note: None

---

Release justification: test fix
