### PR TITLE
ui: disallow VIEW type tables from being shown in the db pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
@@ -175,7 +175,7 @@ const getDatabaseTablesQuery: DatabaseDetailsQuery<DatabaseTablesRow> = {
       sql: Format(
         `SELECT table_schema, table_name
          FROM %1.information_schema.tables
-         WHERE table_type != 'SYSTEM VIEW'
+         WHERE table_type NOT IN ('SYSTEM VIEW', 'VIEW')
          ORDER BY table_name`,
         [new Identifier(dbName)],
       ),
@@ -215,7 +215,7 @@ const getDatabaseTablesQuery: DatabaseDetailsQuery<DatabaseTablesRow> = {
         sql: Format(
           `SELECT table_schema, table_name
          FROM %1.information_schema.tables
-         WHERE table_type != 'SYSTEM VIEW'
+         WHERE table_type NOT IN ('SYSTEM VIEW', 'VIEW')
          ORDER BY table_name offset %2`,
           [new Identifier(dbName), dbDetail.tablesResp.tables.length],
         ),


### PR DESCRIPTION
Previously we filtered out `SYSTEM VIEW` tables from being shown in the db pages but not user created views. We now filter out all VIEW type tables from the db pages.

Epic: none
Fixes: #119789

Release note (bug fix): Users will no longer see VIEW type tables from being shown in the db-console databases pages. Previously these would be listed with no info, only displaying errors.

Before:
boo is a view on foo
<img width="1435" alt="Pasted Graphic" src="https://github.com/cockroachdb/cockroach/assets/20136951/61c02ae5-313b-4a72-86dc-4e1e93f6f2b3">
<img width="1039" alt="Cluster id aa0f4c7e-Sdbb-473f-a92f-5da7d017ecSc" src="https://github.com/cockroachdb/cockroach/assets/20136951/8db95c6f-648e-46e5-88c4-26d9793e2968">


After:
<img width="1910" alt="Pasted Graphic 2" src="https://github.com/cockroachdb/cockroach/assets/20136951/03fc63f5-9356-484c-9784-0a62d3b7ef6c">
