### PR TITLE
lint: various fixes and improvements

### DIFF
--- a/build/teamcity/cockroach/nightlies/lint_urls.sh
+++ b/build/teamcity/cockroach/nightlies/lint_urls.sh
@@ -7,7 +7,5 @@ dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-tc_start_block "lint urls"
 BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_VCS_NUMBER -e GITHUB_API_TOKEN -e GITHUB_REPO -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
                                run_bazel build/teamcity/cockroach/nightlies/lint_urls_impl.sh
-tc_end_block "lint urls"

--- a/build/teamcity/cockroach/nightlies/lint_urls_impl.sh
+++ b/build/teamcity/cockroach/nightlies/lint_urls_impl.sh
@@ -4,12 +4,19 @@ set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 
+# GCAssert and unused need generated files in the workspace to work properly.
+# generated files requirements -- begin
+bazel run //pkg/gen:code
+bazel run //pkg/cmd/generate-cgo:generate-cgo --run_under="cd $(bazel info workspace) && "
+# generated files requirements -- end
+
 bazel build //pkg/cmd/bazci --config=ci
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 exit_status=0
 XML_OUTPUT_FILE=/artifacts/test.xml GO_TEST_WRAP_TESTV=1 GO_TEST_WRAP=1 bazel \
-    run --config=ci --config=test --define gotags=bazel,gss,nightly \
+    run --config=ci --config=test --define gotags=bazel,gss,nightly,lint \
     //build/bazelutil:lint || exit_status=$?
 # The schema of the output test.xml will be slightly wrong -- ask `bazci` to fix
 # it up.
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci munge-test-xml /artifacts/test.xml
+exit $exit_status

--- a/pkg/testutils/lint/BUILD.bazel
+++ b/pkg/testutils/lint/BUILD.bazel
@@ -14,8 +14,9 @@ go_library(
 
 go_test(
     name = "lint_test",
+    # keep
     srcs = [
-        "lint_test.go",
+        "gen-lint_test.go",
         "nightly_lint_test.go",
     ],
     data = glob(["testdata/**"]) + [
@@ -24,7 +25,6 @@ go_test(
     ],
     embed = [":lint"],
     embedsrcs = ["gcassert_paths.txt"],
-    gotags = ["lint"],
     tags = [
         "integration",
         "no-remote-exec",
@@ -44,4 +44,11 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_golang_x_tools//go/packages",
     ],
+)
+
+genrule(
+    name = "gen-lint-test",
+    srcs = ["lint_test.go"],
+    outs = ["gen-lint_test.go"],
+    cmd = "cat $< | grep -v '//go:build' | grep -v '// +build' > $@",
 )

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -78,11 +78,8 @@ func vetCmd(t *testing.T, dir, name string, args []string, filters []stream.Filt
 	var b bytes.Buffer
 	cmd.Stdout = &b
 	cmd.Stderr = &b
-	switch err := cmd.Run(); err.(type) {
-	case nil:
-	case *exec.ExitError:
-		// Non-zero exit is expected.
-	default:
+	err := cmd.Run()
+	if err != nil && !errors.HasType(err, (*exec.ExitError)(nil)) {
 		t.Fatal(err)
 	}
 	filters = append([]stream.Filter{
@@ -138,11 +135,11 @@ func TestLint(t *testing.T) {
 	pkgVar, pkgSpecified := os.LookupEnv("PKG")
 
 	var nogoConfig map[string]any
-	nogoJson, err := os.ReadFile(filepath.Join(crdbDir, "build", "bazelutil", "nogo_config.json"))
+	nogoJSON, err := os.ReadFile(filepath.Join(crdbDir, "build", "bazelutil", "nogo_config.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := json.Unmarshal(nogoJson, &nogoConfig); err != nil {
+	if err := json.Unmarshal(nogoJSON, &nogoConfig); err != nil {
 		t.Error(err)
 	}
 


### PR DESCRIPTION
1. Use code generation to remove the `lint` build tag for running lints.
   On the Bazel side, you're not likely to accidentally run these tests
   and build tags just slow things down.
2. Fix the script for the nightly lint to exit with the correct status
   code and generate code before running.
3. Fix some lint errors in `lint_test.go` itself.

Epic: none
Release note: None