### PR TITLE
workflows: run `lint` using RBE for the build in GitHub Actions

### DIFF
--- a/.github/workflows/experimental-github-actions-testing.yml
+++ b/.github/workflows/experimental-github-actions-testing.yml
@@ -176,3 +176,20 @@ jobs:
       - name: clean up
         run: ./cockroach/build/github/cleanup-engflow-keys.sh
         if: always()
+  lint:
+    runs-on: [self-hosted, basic_big_runner_group]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          submodules: true
+      - run: ./build/github/get-engflow-keys.sh
+      - run: ./build/github/prepare-summarize-build.sh
+      - name: run lint tests
+        run: ./build/github/lint.sh
+      - name: upload build results
+        run: ./build/github/summarize-build.sh bes.bin
+        if: always()
+      - name: clean up
+        run: ./build/github/cleanup-engflow-keys.sh
+        if: always()

--- a/build/github/lint.sh
+++ b/build/github/lint.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+WORKSPACE=$(bazel info workspace)
+
+# GCAssert and unused need generated files in the workspace to work properly.
+bazel run //pkg/gen:code \
+    --config crosslinux --jobs 100 \
+    --remote_download_minimal $(./build/github/engflow-args.sh) \
+    --bes_keywords=lint
+bazel run //pkg/cmd/generate-cgo:generate-cgo \
+    --run_under="cd $WORKSPACE && " \
+    --config crosslinux --jobs 100 \
+    --remote_download_minimal $(./build/github/engflow-args.sh) \
+    --bes_keywords=lint
+
+bazel test \
+  //pkg/testutils/lint:lint_test \
+  --config crosslinux \
+  --test_env=CC=$(which gcc) \
+  --test_env=CXX=$(which gcc) \
+  --test_env=HOME \
+  --sandbox_writable_path=$HOME \
+  --test_env=GO_SDK=$(dirname $(dirname $(bazel run @go_sdk//:bin/go --run_under=realpath))) \
+  --test_env=COCKROACH_WORKSPACE=$WORKSPACE \
+  --test_timeout=1800 \
+  --build_event_binary_file=bes.bin \
+  --jobs 100 \
+  --remote_download_minimal $(./build/github/engflow-args.sh) \
+  --bes_keywords=lint


### PR DESCRIPTION
Epic: CRDB-8308
Release note: None