### PR TITLE
timeutil: stack-allocate Timer, remove pooling

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -148,7 +148,7 @@ type backupDataProcessor struct {
 	// Aggregator that aggregates StructuredEvents emitted in the
 	// backupDataProcessors' trace recording.
 	agg      *bulk.TracingAggregator
-	aggTimer *timeutil.Timer
+	aggTimer timeutil.Timer
 
 	// completedSpans tracks how many spans have been successfully backed up by
 	// the backup processor.
@@ -206,7 +206,6 @@ func (bp *backupDataProcessor) Start(ctx context.Context) {
 	// Construct an Aggregator to aggregate and render AggregatorEvents emitted in
 	// bps' trace recording.
 	bp.agg = bulk.TracingAggregatorForContext(ctx)
-	bp.aggTimer = timeutil.NewTimer()
 	// If the aggregator is nil, we do not want the timer to fire.
 	if bp.agg != nil {
 		bp.aggTimer.Reset(15 * time.Second)
@@ -471,7 +470,7 @@ func runBackupProcessor(
 		// priority becomes true when we're sending re-attempts of reads far enough
 		// in the past that we want to run them with priority.
 		var priority bool
-		timer := timeutil.NewTimer()
+		var timer timeutil.Timer
 		defer timer.Stop()
 
 		ctxDone := ctx.Done()

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -83,7 +83,7 @@ type restoreDataProcessor struct {
 	// Aggregator that aggregates StructuredEvents emitted in the
 	// restoreDataProcessors' trace recording.
 	agg      *bulkutil.TracingAggregator
-	aggTimer *timeutil.Timer
+	aggTimer timeutil.Timer
 
 	// qp is a MemoryBackedQuotaPool that restricts the amount of memory that
 	// can be used by this processor to open iterators on SSTs.
@@ -229,7 +229,6 @@ func newRestoreDataProcessor(
 func (rd *restoreDataProcessor) Start(ctx context.Context) {
 	ctx = logtags.AddTag(ctx, "job", rd.spec.JobID)
 	rd.agg = bulkutil.TracingAggregatorForContext(ctx)
-	rd.aggTimer = timeutil.NewTimer()
 	// If the aggregator is nil, we do not want the timer to fire.
 	if rd.agg != nil {
 		rd.aggTimer.Reset(15 * time.Second)

--- a/pkg/cmd/roachtest/tests/jobs.go
+++ b/pkg/cmd/roachtest/tests/jobs.go
@@ -91,7 +91,7 @@ func runJobsStress(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	m.Go(func(ctx context.Context) error {
 		defer close(done)
-		testTimer := timeutil.NewTimer()
+		var testTimer timeutil.Timer
 		testTimer.Reset(workloadDuration)
 		select {
 		case <-earlyExit:
@@ -104,7 +104,7 @@ func runJobsStress(ctx context.Context, t test.Test, c cluster.Cluster) {
 	randomPoller := func(f func(ctx context.Context, t test.Test, c cluster.Cluster, rng *rand.Rand) error) func(ctx context.Context) error {
 
 		return func(ctx context.Context) error {
-			pTimer := timeutil.NewTimer()
+			var pTimer timeutil.Timer
 			defer pTimer.Stop()
 			for {
 				waitTime := time.Duration(rng.Intn(pollerMinFrequencySeconds)+1) * time.Second

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1229,8 +1229,7 @@ func (g *Gossip) bootstrap(rpcContext *rpc.Context) {
 func (g *Gossip) manage(rpcContext *rpc.Context) {
 	ctx := g.AnnotateCtx(context.Background())
 	_ = g.server.stopper.RunAsyncTask(ctx, "gossip-manage", func(ctx context.Context) {
-		cullTimer := timeutil.NewTimer()
-		stallTimer := timeutil.NewTimer()
+		var cullTimer, stallTimer timeutil.Timer
 		defer cullTimer.Stop()
 		defer stallTimer.Stop()
 

--- a/pkg/internal/client/requestbatcher/batcher.go
+++ b/pkg/internal/client/requestbatcher/batcher.go
@@ -518,12 +518,9 @@ func (b *RequestBatcher) run(ctx context.Context) {
 			}
 		}
 		deadline time.Time
-		timer    = timeutil.NewTimer()
+		timer    timeutil.Timer
 	)
-	// In any case, stop the timer when the function returns.
-	// We can't defer timer.Stop directly because we re-assign
-	// timer in maybeSetTimer below.
-	defer func() { timer.Stop() }()
+	defer timer.Stop()
 
 	maybeSetTimer := func() {
 		var nextDeadline time.Time
@@ -538,7 +535,6 @@ func (b *RequestBatcher) run(ctx context.Context) {
 				// Clear the current timer due to a sole batch already sent before
 				// the timer fired.
 				timer.Stop()
-				timer = timeutil.NewTimer()
 			}
 		}
 	}

--- a/pkg/jobs/metricspoller/poller.go
+++ b/pkg/jobs/metricspoller/poller.go
@@ -61,7 +61,7 @@ func (mp *metricsPoller) Resume(ctx context.Context, execCtx interface{}) error 
 	exec := execCtx.(sql.JobExecContext)
 	metrics := exec.ExecCfg().JobRegistry.MetricsStruct().JobSpecificMetrics[jobspb.TypePollJobsStats].(pollerMetrics)
 
-	t := timeutil.NewTimer()
+	var t timeutil.Timer
 	defer t.Stop()
 
 	runTask := func(name string, task func(ctx context.Context, execCtx sql.JobExecContext) error) error {

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1021,8 +1021,8 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 		defer cancel()
 
 		cancelLoopTask(ctx)
-		lc, cleanup := makeLoopController(r.settings, cancelIntervalSetting, r.knobs.IntervalOverrides.Cancel)
-		defer cleanup()
+		lc := makeLoopController(r.settings, cancelIntervalSetting, r.knobs.IntervalOverrides.Cancel)
+		defer lc.cleanup()
 		for {
 			select {
 			case <-lc.updated:
@@ -1053,8 +1053,8 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
 
-		lc, cleanup := makeLoopController(r.settings, gcIntervalSetting, r.knobs.IntervalOverrides.Gc)
-		defer cleanup()
+		lc := makeLoopController(r.settings, gcIntervalSetting, r.knobs.IntervalOverrides.Gc)
+		defer lc.cleanup()
 
 		// Retention duration of terminal job records.
 		retentionDuration := func() time.Duration {
@@ -1092,8 +1092,8 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
-		lc, cleanup := makeLoopController(r.settings, adoptIntervalSetting, r.knobs.IntervalOverrides.Adopt)
-		defer cleanup()
+		lc := makeLoopController(r.settings, adoptIntervalSetting, r.knobs.IntervalOverrides.Adopt)
+		defer lc.cleanup()
 		for {
 			select {
 			case <-lc.updated:

--- a/pkg/keyvisualizer/spanstatscollector/span_stats_collector.go
+++ b/pkg/keyvisualizer/spanstatscollector/span_stats_collector.go
@@ -87,7 +87,8 @@ func (s *SpanStatsCollector) Start(ctx context.Context, stopper *stop.Stopper) {
 	if err := stopper.RunAsyncTask(ctx, "span-stats-collector",
 		func(ctx context.Context) {
 			s.reset()
-			t := timeutil.NewTimer()
+			var t timeutil.Timer
+			defer t.Stop()
 			for {
 				samplePeriod := keyvissettings.SampleInterval.Get(&s.settings.SV)
 				now := timeutil.Now()

--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker.go
@@ -195,7 +195,7 @@ func (d *DistSenderCircuitBreakers) probeStallLoop(ctx context.Context) {
 
 	// We use the probe interval as the scan interval, since we can sort of
 	// consider this to be probing the replicas for a stall.
-	timer := timeutil.NewTimer()
+	var timer timeutil.Timer
 	defer timer.Stop()
 	timer.Reset(CircuitBreakerProbeInterval.Get(&d.settings.SV))
 
@@ -670,7 +670,7 @@ func (r *ReplicaCircuitBreaker) launchProbe(report func(error), done func()) {
 
 		// Continually probe the replica until it succeeds. We probe immediately
 		// since we only trip the breaker on probe failure.
-		timer := timeutil.NewTimer()
+		var timer timeutil.Timer
 		defer timer.Stop()
 		timer.Reset(CircuitBreakerProbeInterval.Get(&r.d.settings.SV))
 

--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -318,7 +318,7 @@ func (p *Prober) Start(ctx context.Context, stopper *stop.Stopper) error {
 			d := func() time.Duration {
 				return withJitter(interval.Get(&p.settings.SV), rnd)
 			}
-			t := timeutil.NewTimer()
+			var t timeutil.Timer
 			defer t.Stop()
 			t.Reset(d())
 

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -5304,7 +5304,7 @@ func TestOptimisticEvalRetry(t *testing.T) {
 		})
 	}()
 	removedLocks := false
-	timer := timeutil.NewTimer()
+	var timer timeutil.Timer
 	timer.Reset(time.Second * 2)
 	defer timer.Stop()
 	done := false

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -242,7 +242,7 @@ func (s *Sender) Run(ctx context.Context, nodeID roachpb.NodeID) {
 				s.buf.Close()
 			}()
 
-			timer := timeutil.NewTimer()
+			var timer timeutil.Timer
 			defer timer.Stop()
 			for {
 				interval := closedts.SideTransportCloseInterval.Get(&s.st.SV)
@@ -251,7 +251,6 @@ func (s *Sender) Run(ctx context.Context, nodeID roachpb.NodeID) {
 				} else {
 					// Disable the side-transport.
 					timer.Stop()
-					timer = timeutil.NewTimer()
 				}
 				select {
 				case <-timer.C:

--- a/pkg/kv/kvserver/concurrency/lock_table_waiter.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_waiter.go
@@ -123,7 +123,8 @@ func (w *lockTableWaiterImpl) WaitOn(
 	ctxDoneC := ctx.Done()
 	shouldQuiesceC := w.stopper.ShouldQuiesce()
 	// Used to delay liveness and deadlock detection pushes.
-	var timer *timeutil.Timer
+	var timer timeutil.Timer
+	defer timer.Stop()
 	var timerC <-chan time.Time
 	var timerWaitingState waitingState
 	// Used to enforce lock timeouts.
@@ -227,10 +228,6 @@ func (w *lockTableWaiterImpl) WaitOn(
 					delay, deadlockOrLivenessPush, timeoutPush, priorityPush, waitPolicyPush)
 
 				if delay > 0 {
-					if timer == nil {
-						timer = timeutil.NewTimer()
-						defer timer.Stop()
-					}
 					timer.Reset(delay)
 					timerC = timer.C
 				} else {
@@ -308,10 +305,8 @@ func (w *lockTableWaiterImpl) WaitOn(
 			// to its state for the entire delay, it should push. It may be the case
 			// that the transaction is part of a dependency cycle or that the lock
 			// holder's coordinator node has crashed.
+			timer.Read = true
 			timerC = nil
-			if timer != nil {
-				timer.Read = true
-			}
 			if w.onPushTimer != nil {
 				w.onPushTimer()
 			}

--- a/pkg/kv/kvserver/protectedts/ptcache/cache.go
+++ b/pkg/kv/kvserver/protectedts/ptcache/cache.go
@@ -169,7 +169,7 @@ func (c *Cache) periodicallyRefreshProtectedtsCache(ctx context.Context) {
 		default:
 		}
 	})
-	timer := timeutil.NewTimer()
+	var timer timeutil.Timer
 	defer timer.Stop()
 	timer.Reset(0) // Read immediately upon startup
 	var lastReset time.Time

--- a/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
@@ -97,7 +97,7 @@ func (r *Reconciler) run(ctx context.Context, stopper *stop.Stopper) {
 		const jitterFrac = .1
 		return time.Duration(float64(interval) * (1 + (rand.Float64()-.5)*jitterFrac))
 	}
-	timer := timeutil.NewTimer()
+	var timer timeutil.Timer
 	defer timer.Stop()
 	for {
 		timer.Reset(timeutil.Until(lastReconciled.Add(getInterval())))

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -1043,7 +1043,7 @@ func (t *RaftTransport) startDroppingFlowTokensForDisconnectedNodes(ctx context.
 					}
 				})
 
-			timer := timeutil.NewTimer()
+			var timer timeutil.Timer
 			defer timer.Stop()
 
 			for {
@@ -1053,7 +1053,6 @@ func (t *RaftTransport) startDroppingFlowTokensForDisconnectedNodes(ctx context.
 				} else {
 					// Disable the mechanism.
 					timer.Stop()
-					timer = timeutil.NewTimer()
 				}
 				select {
 				case <-timer.C:

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -394,7 +394,7 @@ func (r *Replica) getChecksum(ctx context.Context, id uuid.UUID) (CollectChecksu
 
 	// Wait for the checksum computation to start.
 	dur := r.checksumInitialWait(ctx)
-	t := timeutil.NewTimer()
+	var t timeutil.Timer
 	t.Reset(dur)
 	defer t.Stop()
 	var taskCancel context.CancelFunc

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1406,7 +1406,7 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 		// against this in checkRequestTimeRLocked). So instead of assuming
 		// anything, we iterate and check again.
 		pErr = func() (pErr *kvpb.Error) {
-			slowTimer := timeutil.NewTimer()
+			var slowTimer timeutil.Timer
 			defer slowTimer.Stop()
 			slowTimer.Reset(base.SlowRequestThreshold)
 			tBegin := timeutil.Now()

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2344,7 +2344,7 @@ func (s *Store) startRangefeedUpdater(ctx context.Context) {
 			return rangeIDs
 		}
 
-		timer := timeutil.NewTimer()
+		var timer timeutil.Timer
 		defer timer.Stop()
 		errInterrupted := errors.New("waiting interrupted")
 		wait := func(ctx context.Context, until time.Time, interrupt <-chan struct{}) error {

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -299,7 +299,7 @@ func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 	// Start a goroutine that watches and proactively renews certain
 	// expiration-based leases.
 	_ = stopper.RunAsyncTask(ctx, "store-rebalancer", func(ctx context.Context) {
-		timer := timeutil.NewTimer()
+		var timer timeutil.Timer
 		defer timer.Stop()
 		timer.Reset(jitteredInterval(allocator.LoadBasedRebalanceInterval.Get(&sr.st.SV)))
 		for {

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -600,7 +600,7 @@ func (q *Queue) waitForPush(
 	defer func() { metrics.PusherWaitTime.RecordValue(timeutil.Since(tBegin).Nanoseconds()) }()
 
 	slowTimerThreshold := time.Minute
-	slowTimer := timeutil.NewTimer()
+	var slowTimer timeutil.Timer
 	defer slowTimer.Stop()
 	slowTimer.Reset(slowTimerThreshold)
 

--- a/pkg/obs/event_exporter.go
+++ b/pkg/obs/event_exporter.go
@@ -299,7 +299,7 @@ func (s *EventsExporter) Start(ctx context.Context, stopper *stop.Stopper) error
 		defer func() {
 			_ = s.conn.Close() // nolint:grpcconnclose
 		}()
-		timer := timeutil.NewTimer()
+		var timer timeutil.Timer
 		defer timer.Stop()
 		if s.flushInterval != 0 {
 			timer.Reset(s.flushInterval)

--- a/pkg/security/cert_expiry_cache.go
+++ b/pkg/security/cert_expiry_cache.go
@@ -188,7 +188,7 @@ func (c *ClientCertExpirationCache) startPurgePastExpirations(ctx context.Contex
 	return c.stopper.RunAsyncTask(ctx, "purge-cert-expiry-cache", func(context.Context) {
 		const period = time.Hour
 
-		timer := timeutil.NewTimer()
+		var timer timeutil.Timer
 		defer timer.Stop()
 
 		timer.Reset(jitteredInterval(period))

--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -147,7 +147,7 @@ func startSampleEnvironment(
 			goMemStats.Store(&status.GoMemStats{})
 			var collectingMemStats int32 // atomic, 1 when stats call is ongoing
 
-			timer := timeutil.NewTimer()
+			var timer timeutil.Timer
 			defer timer.Stop()
 			timer.Reset(cfg.minSampleInterval)
 

--- a/pkg/server/server_controller_orchestration.go
+++ b/pkg/server/server_controller_orchestration.go
@@ -60,7 +60,7 @@ func (c *serverController) start(ctx context.Context, ie isql.Executor) error {
 		ctx, cancel := c.stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
 
-		timer := timeutil.NewTimer()
+		var timer timeutil.Timer
 		defer timer.Stop()
 
 		for {

--- a/pkg/server/server_controller_sql.go
+++ b/pkg/server/server_controller_sql.go
@@ -134,7 +134,7 @@ func (c *serverController) waitForTenantServer(
 	// waiting longer isn't going to help.
 	opts := singleflight.DoOpts{Stop: c.stopper, InheritCancelation: false}
 	futureRes, _ := c.tenantWaiter.DoChan(ctx, string(name), opts, func(ctx context.Context) (interface{}, error) {
-		t := timeutil.NewTimer()
+		var t timeutil.Timer
 		defer t.Stop()
 		t.Reset(multitenant.WaitForClusterStartTimeout.Get(&c.st.SV))
 		for {

--- a/pkg/server/server_systemlog_gc.go
+++ b/pkg/server/server_systemlog_gc.go
@@ -252,7 +252,7 @@ func startSystemLogsGC(ctx context.Context, sqlServer *SQLServer) error {
 			return period
 		}
 		period := getPeriod()
-		timer := timeutil.NewTimer()
+		var timer timeutil.Timer
 		defer timer.Stop()
 		// The very first period is 25% off the configured period, to
 		// avoid a thundering herd effect on the system table between

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -263,7 +263,7 @@ func (s *KVSubscriber) Start(ctx context.Context, stopper *stop.Stopper) error {
 					}
 				})
 
-			timer := timeutil.NewTimer()
+			var timer timeutil.Timer
 			defer timer.Stop()
 
 			for {
@@ -273,7 +273,6 @@ func (s *KVSubscriber) Start(ctx context.Context, stopper *stop.Stopper) error {
 				} else {
 					// Disable the mechanism.
 					timer.Stop()
-					timer = timeutil.NewTimer()
 				}
 				select {
 				case <-timer.C:

--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -144,7 +144,7 @@ func (m *Manager) run(ctx context.Context) {
 
 	// Periodically check if the span config reconciliation job exists and start
 	// it if it doesn't.
-	timer := timeutil.NewTimer()
+	var timer timeutil.Timer
 	defer timer.Stop()
 
 	triggerJobCheck()

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1464,7 +1464,7 @@ func (m *Manager) PeriodicallyRefreshSomeLeases(ctx context.Context) {
 		} else {
 			refreshTimerDuration = m.storage.jitteredLeaseDuration()
 		}
-		refreshTimer := timeutil.NewTimer()
+		var refreshTimer timeutil.Timer
 		defer refreshTimer.Stop()
 		refreshTimer.Reset(refreshTimerDuration / 2)
 		for {

--- a/pkg/sql/contention/event_store.go
+++ b/pkg/sql/contention/event_store.go
@@ -208,7 +208,7 @@ func (s *eventStore) startResolver(ctx context.Context, stopper *stop.Stopper) {
 	_ = stopper.RunAsyncTask(ctx, "contention-event-resolver", func(ctx context.Context) {
 
 		initialDelay := s.resolutionIntervalWithJitter()
-		timer := timeutil.NewTimer()
+		var timer timeutil.Timer
 		defer timer.Stop()
 
 		timer.Reset(initialDelay)

--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -147,7 +147,7 @@ func clearSpanData(
 	var n int
 	lastKey := span.Key
 	ri := kvcoord.MakeRangeIterator(distSender)
-	timer := timeutil.NewTimer()
+	var timer timeutil.Timer
 	defer timer.Stop()
 
 	for ri.Seek(ctx, span.Key, kvcoord.Ascending); ; ri.Next(ctx) {

--- a/pkg/sql/mvcc_statistics_update_job.go
+++ b/pkg/sql/mvcc_statistics_update_job.go
@@ -131,7 +131,7 @@ func (j *mvccStatisticsUpdateJob) runTenantGlobalMetricsExporter(
 		return nil
 	}
 
-	timer := timeutil.NewTimer()
+	var timer timeutil.Timer
 	defer timer.Stop()
 
 	// Fire the timer immediately to start the initial update.

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -254,7 +254,7 @@ func (s *samplerProcessor) mainLoop(
 
 	var invKeys [][]byte
 	invRow := rowenc.EncDatumRow{rowenc.EncDatum{}}
-	timer := timeutil.NewTimer()
+	var timer timeutil.Timer
 	defer timer.Stop()
 
 	for {

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -329,7 +329,7 @@ func (l *Instance) heartbeatLoopInner(ctx context.Context) error {
 	// don't cancel their ctx.
 	ctx, cancel := l.stopper.WithCancelOnQuiesce(ctx)
 	defer cancel()
-	t := timeutil.NewTimer()
+	var t timeutil.Timer
 	defer t.Stop()
 
 	t.Reset(0)

--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -167,7 +167,7 @@ func (s *PersistedSQLStats) startSQLStatsFlushLoop(ctx context.Context, stopper 
 		})
 
 		initialDelay := s.nextFlushInterval()
-		timer := timeutil.NewTimer()
+		var timer timeutil.Timer
 		timer.Reset(initialDelay)
 
 		log.Infof(ctx, "starting sql-stats-worker with initial delay: %s", initialDelay)

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
@@ -84,7 +84,7 @@ func (j *jobMonitor) start(
 		stopCtx, cancel := stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
 
-		timer := timeutil.NewTimer()
+		var timer timeutil.Timer
 		// Ensure schedule at startup.
 		timer.Reset(0)
 		defer timer.Stop()

--- a/pkg/testutils/lint/passes/timer/testdata/src/a/a.go
+++ b/pkg/testutils/lint/passes/timer/testdata/src/a/a.go
@@ -12,8 +12,27 @@ package a
 
 import "github.com/cockroachdb/cockroach/pkg/util/timeutil"
 
+// Timer value.
 func init() {
-	timer := timeutil.NewTimer()
+	var timer timeutil.Timer
+	for {
+		timer.Reset(0)
+		select {
+		case <-timer.C:
+			timer.Read = true
+		}
+	}
+	for {
+		timer.Reset(0)
+		select {
+		case <-timer.C: // want `must set timer.Read = true after reading from timer.C \(see timeutil/timer.go\)`
+		}
+	}
+}
+
+// Timer pointer.
+func init() {
+	timer := &timeutil.Timer{}
 	for {
 		timer.Reset(0)
 		select {

--- a/pkg/testutils/lint/passes/timer/timer.go
+++ b/pkg/testutils/lint/passes/timer/timer.go
@@ -57,7 +57,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		if !ok {
 			return false
 		}
-		typ := tv.Type.Underlying()
+		typ := tv.Type
 		for {
 			ptr, pok := typ.(*types.Pointer)
 			if !pok {
@@ -69,10 +69,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		if !ok {
 			return false
 		}
-		if named.Obj().Type().String() != "github.com/cockroachdb/cockroach/pkg/util/timeutil.Timer" {
-			return false
-		}
-		return true
+		const timerName = "github.com/cockroachdb/cockroach/pkg/util/timeutil.Timer"
+		return named.Obj().Type().String() == timerName
 	}
 
 	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)

--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -151,7 +151,7 @@ func (p *poller) start() (firstDone <-chan struct{}) {
 	bgCtx := p.AnnotateCtx(context.Background())
 	if p.stopper.RunAsyncTask(bgCtx, "ts-poller", func(ctx context.Context) {
 		ch := ch // goroutine-local copy
-		ticker := timeutil.NewTimer()
+		var ticker timeutil.Timer
 		ticker.Reset(0)
 		defer ticker.Stop()
 		for {

--- a/pkg/util/timeutil/time_source.go
+++ b/pkg/util/timeutil/time_source.go
@@ -27,7 +27,7 @@ type TimerI interface {
 	// Reset will set the timer to notify on Ch() after duration.
 	Reset(duration time.Duration)
 
-	// Stop must only be called one time per timer.
+	// Stop prevents the Timer from firing.
 	Stop() bool
 
 	// Ch returns the channel which will be notified when the timer reaches its
@@ -71,7 +71,7 @@ func (DefaultTimeSource) Since(t time.Time) time.Duration {
 
 // NewTimer returns a TimerI wrapping *Timer.
 func (DefaultTimeSource) NewTimer() TimerI {
-	return (*timer)(NewTimer())
+	return (*timer)(new(Timer))
 }
 
 // NewTicker creates a new ticker.

--- a/pkg/util/timeutil/timer_test.go
+++ b/pkg/util/timeutil/timer_test.go
@@ -67,7 +67,6 @@ func TestTimerStop(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestTimerUninitializedStopNoop(t *testing.T) {

--- a/pkg/util/timeutil/timer_test.go
+++ b/pkg/util/timeutil/timer_test.go
@@ -11,14 +11,9 @@
 package timeutil
 
 import (
-	"context"
 	"fmt"
-	"math/rand"
-	"sync"
 	"testing"
 	"time"
-
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 const timeStep = 10 * time.Millisecond
@@ -145,67 +140,9 @@ func TestTimerMakesProgressInLoop(t *testing.T) {
 	}
 }
 
-// TestIllegalTimerShare is a regression test for sharing the same Timer between
-// multiple users when it was originally allocated on the stack of one of them
-// but then later was put into timerPool on Stop() (see #119593).
-func TestIllegalTimerShare(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	resetTimer := func(t *Timer, rng *rand.Rand) {
-		t.Reset(time.Duration(rng.Intn(100)+1) * time.Nanosecond)
-	}
-
-	var wg sync.WaitGroup
-	// Simulate a pattern of usage of the stack-allocated Timer that is being
-	// stopped each time when the Timer fires.
-	fromStack := func() {
-		defer wg.Done()
-		rng, _ := randutil.NewTestRand()
-		var t Timer
-		defer t.Stop()
-		resetTimer(&t, rng)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				t.Read = true
-				t.Stop()
-				resetTimer(&t, rng)
-			}
-		}
-	}
-	// Simulate the most common pattern where the Timer is taken from the
-	// timerPool, fires repeatedly, and then is stopped in a defer.
-	fromPool := func() {
-		defer wg.Done()
-		rng, _ := randutil.NewTestRand()
-		t := NewTimer()
-		defer t.Stop()
-		resetTimer(t, rng)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				t.Read = true
-				resetTimer(t, rng)
-			}
-		}
-	}
-	// Spin up a few goroutines per each access pattern.
-	wg.Add(6)
-	for i := 0; i < 3; i++ {
-		go fromStack()
-		go fromPool()
-	}
-	wg.Wait()
-}
-
 func BenchmarkTimer(b *testing.B) {
 	run := func() {
-		timer := NewTimer()
+		var timer Timer
 		defer timer.Stop()
 		for i := 0; i < 10; i++ {
 			timer.Reset(10 * time.Microsecond)

--- a/pkg/util/timeutil/timer_test.go
+++ b/pkg/util/timeutil/timer_test.go
@@ -202,3 +202,18 @@ func TestIllegalTimerShare(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func BenchmarkTimer(b *testing.B) {
+	run := func() {
+		timer := NewTimer()
+		defer timer.Stop()
+		for i := 0; i < 10; i++ {
+			timer.Reset(10 * time.Microsecond)
+			<-timer.C
+			timer.Read = true
+		}
+	}
+	for i := 0; i < b.N; i++ {
+		run()
+	}
+}


### PR DESCRIPTION
Informs #119593.
Closes #38055.

This PR removes the pooling of `timeutil.Timer` structs and, in doing so, permits the structs to be stack allocated so that no pooling is necessary. This superfluous (and in hindsight, harmful) memory pooling was introduced in f11ec1c7, which also added very necessary pooling for the internal time.Timer structs.

The pooling was harmful because it mandated a contract where Timer structs could not be used after their Stop method was called. This was surprising (time.Timer has no such limitation) and led to subtle use-after-free bugs over time (#61373 and #119595). It was also unnecessary because the outer Timer structs can be stack allocated. Ironically, the only thing that causes them to escape to the heap was the pooling mechanism itself. Removing pooling solves the issue.

```
name      old time/op    new time/op    delta
Timer-10     153µs ± 1%     152µs ± 1%   ~     (p=0.589 n=10+9)

name      old alloc/op   new alloc/op   delta
Timer-10      200B ± 0%      200B ± 0%   ~     (all equal)

name      old allocs/op  new allocs/op  delta
Timer-10      3.00 ± 0%      3.00 ± 0%   ~     (all equal)
```

----

The PR then improves the memory pooling of the inner `time.Timer` so that it is always recycled. This was originally identified by @andreimatei in https://github.com/cockroachdb/cockroach/pull/13466#pullrequestreview-988660615.

Doing so has a positive impact on the microbenchmark introduced in the first commit, demonstrating that timers can be stack-allocated and require zero heap allocations:
```
name      old time/op    new time/op    delta
Timer-10     152µs ± 1%     153µs ± 1%      ~     (p=0.133 n=9+10)

name      old alloc/op   new alloc/op   delta
Timer-10      200B ± 0%        0B       -100.00%  (p=0.000 n=10+10)

name      old allocs/op  new allocs/op  delta
Timer-10      3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```

----

cc. @andreimatei @ajwerner

Epic: None
Release note: None