### PR TITLE
release-23.1: roachprod: update supported regions for T2A machine types

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -787,9 +787,12 @@ func (p *Provider) Create(
 		if len(providerOpts.Zones) == 0 {
 			zones = []string{"us-central1-a"}
 		} else {
+			supportedT2ARegions := []string{"us-central1", "asia-southeast1", "europe-west4"}
 			for _, zone := range providerOpts.Zones {
-				if !strings.HasPrefix(zone, "us-central1-") {
-					return errors.New("T2A instances are not supported outside of us-central1")
+				for _, region := range supportedT2ARegions {
+					if !strings.HasPrefix(zone, region) {
+						return errors.Newf("T2A instances are not supported outside of [%s]", strings.Join(supportedT2ARegions, ","))
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Backport 1/1 commits from #113802.

/cc @cockroachdb/release

---

Previously, when deploying to Google Cloud, `roachprod` only supported the `us-central1` region when using the `T2A` machine type. Each zone provided by `--gce-zones` was checked for the prefix `us-central1-`. If any zone did not have that prefix, an error was returned.

Google Cloud expanded support for the `T2A` machine type to two new regions, `asia-southeast1` and `europe-west4`. At the time of this writing, the supported regions for the `T2A` machine type are:

- `us-central1`
- `asia-southeast1`
- `europe-west4`

The list of machine types was retrieved from
https://cloud.google.com/compute/docs/regions-zones#available.

This expansion of supported regions meant that `roachprod` incorrectly returned an error when using a `T2A` machine type in a supported region, such as `asia-southeast1`.

```
$ roachprod create test-cluster \
  -n 1 \
  --clouds=gce \
  --gce-zones=asia-southeast1-a \
  --gce-machine-type=t2a-standard-4 \
  --local-ssd=false
18:16:49 roachprod.go:1404: Creating cluster test-cluster with 1 nodes
18:16:49 roachprod.go:1378: Cleaning up partially-created cluster (prev err: in provider: gce: T2A instances are not supported outside of us-central1)
18:16:58 roachprod.go:1382: Cleaning up OK
Error: UNCLASSIFIED_PROBLEM: in provider: gce: T2A instances are not supported outside of us-central1
(1) UNCLASSIFIED_PROBLEM
Wraps: (2) attached stack trace
  -- stack trace:
  | github.com/cockroachdb/cockroach/pkg/roachprod/vm.ForProvider
  | 	github.com/cockroachdb/cockroach/pkg/roachprod/vm/vm.go:584
  | [...repeated from below...]
Wraps: (3) in provider: gce
Wraps: (4) attached stack trace
  -- stack trace:
  | github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce.(*Provider).Create
  | 	github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce/gcloud.go:986
  | github.com/cockroachdb/cockroach/pkg/roachprod/cloud.CreateCluster.func1
  | 	github.com/cockroachdb/cockroach/pkg/roachprod/cloud/cluster_cloud.go:277
  | github.com/cockroachdb/cockroach/pkg/roachprod/vm.ForProvider
  | 	github.com/cockroachdb/cockroach/pkg/roachprod/vm/vm.go:583
  | github.com/cockroachdb/cockroach/pkg/roachprod/vm.ProvidersParallel.func1
  | 	github.com/cockroachdb/cockroach/pkg/roachprod/vm/vm.go:596
  | golang.org/x/sync/errgroup.(*Group).Go.func1
  | 	golang.org/x/sync/errgroup/external/org_golang_x_sync/errgroup/errgroup.go:75
  | runtime.goexit
  | 	src/runtime/asm_amd64.s:1598
Wraps: (5) T2A instances are not supported outside of us-central1
Error types: (1) errors.Unclassified (2) *withstack.withStack (3) *errutil.withPrefix (4) *withstack.withStack (5) *errutil.leafError
```

This patch updates the regions that `roachprod` supports when using a `T2A` machine type. Each zone provided by `--gce-zones` is now checked for the prefix `us-central1` `asia-southeast1`, or `europe-west4`. If any zone does not have one of those prefixes, an error is returned.

Fixes: #113664
Fixes: CRDB-33099

Release note: None

Release justification: Test only change.