### PR TITLE
release-23.1: restore: limit restore spans to 200 files

### DIFF
--- a/pkg/ccl/backupccl/bench_covering_test.go
+++ b/pkg/ccl/backupccl/bench_covering_test.go
@@ -39,7 +39,7 @@ func BenchmarkCoverageChecks(b *testing.B) {
 						b.Run(fmt.Sprintf("numFiles=%d", baseFiles), func(b *testing.B) {
 							for _, hasExternalFilesList := range []bool{true, false} {
 								b.Run(fmt.Sprintf("slim=%t", hasExternalFilesList), func(b *testing.B) {
-									backups, err := MockBackupChain(ctx, numBackups, numSpans, baseFiles, r, hasExternalFilesList, execCfg)
+									backups, err := MockBackupChain(ctx, numBackups, numSpans, baseFiles, 1<<20, r, hasExternalFilesList, execCfg)
 									require.NoError(b, err)
 									b.ResetTimer()
 
@@ -75,7 +75,7 @@ func BenchmarkRestoreEntryCover(b *testing.B) {
 							for _, hasExternalFilesList := range []bool{true, false} {
 								b.Run(fmt.Sprintf("hasExternalFilesList=%t", hasExternalFilesList),
 									func(b *testing.B) {
-										backups, err := MockBackupChain(ctx, numBackups, numSpans, baseFiles, r, hasExternalFilesList, execCfg)
+										backups, err := MockBackupChain(ctx, numBackups, numSpans, baseFiles, 1<<20, r, hasExternalFilesList, execCfg)
 										require.NoError(b, err)
 										b.ResetTimer()
 										for i := 0; i < b.N; i++ {

--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -553,6 +553,7 @@ func generateAndSendImportSpans(
 	// lastCovSpanSize is the size of files added to the right-most span of
 	// the cover so far.
 	var lastCovSpanSize int64
+	var lastCovSpanCount int
 	var lastCovSpan roachpb.Span
 	var covFilesByLayer [][]*backuppb.BackupManifest_File
 	var firstInSpan bool
@@ -629,8 +630,8 @@ func generateAndSendImportSpans(
 				}
 
 				var filesByLayer [][]*backuppb.BackupManifest_File
-				var covSize int64
-				var newCovFilesSize int64
+				var covSize, newCovFilesSize int64
+				var covCount, newCovFilesCount int
 
 				for layer := range newFilesByLayer {
 					for _, file := range newFilesByLayer[layer] {
@@ -640,6 +641,7 @@ func generateAndSendImportSpans(
 						}
 						newCovFilesSize += sz
 					}
+					newCovFilesCount += len(newFilesByLayer[layer])
 					filesByLayer = append(filesByLayer, newFilesByLayer[layer])
 				}
 
@@ -652,6 +654,7 @@ func generateAndSendImportSpans(
 
 						if inclusiveOverlap(coverSpan, file.Span) {
 							covSize += sz
+							covCount++
 							filesByLayer[layer] = append(filesByLayer[layer], file)
 						}
 					}
@@ -661,8 +664,17 @@ func generateAndSendImportSpans(
 					covFilesByLayer = newFilesByLayer
 					lastCovSpan = coverSpan
 					lastCovSpanSize = newCovFilesSize
+					lastCovSpanCount = newCovFilesCount
 				} else {
-					if (newCovFilesSize == 0 || lastCovSpanSize+newCovFilesSize <= filter.targetSize) && !firstInSpan {
+					// We have room to add to the last span if doing so would remain below
+					// both the target byte size and 200 total files. We limit the number
+					// of files since we default to running multiple concurrent workers so
+					// we want to bound sum total open files across all of them to <= 1k.
+					// We bound the span byte size to improve work distribution and make
+					// the progress more granular.
+					fits := lastCovSpanSize+newCovFilesSize <= filter.targetSize && lastCovSpanCount+newCovFilesCount <= 200
+
+					if (newCovFilesCount == 0 || fits) && !firstInSpan {
 						// If there are no new files that cover this span or if we can add the
 						// files in the new span's cover to the last span's cover and still stay
 						// below targetSize, then we should merge the two spans.
@@ -671,6 +683,7 @@ func generateAndSendImportSpans(
 						}
 						lastCovSpan.EndKey = coverSpan.EndKey
 						lastCovSpanSize = lastCovSpanSize + newCovFilesSize
+						lastCovSpanCount = lastCovSpanCount + newCovFilesCount
 					} else {
 						if err := flush(ctx); err != nil {
 							return err
@@ -678,6 +691,7 @@ func generateAndSendImportSpans(
 						lastCovSpan = coverSpan
 						covFilesByLayer = filesByLayer
 						lastCovSpanSize = covSize
+						lastCovSpanCount = covCount
 					}
 				}
 				firstInSpan = false

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -47,7 +47,7 @@ import (
 // Files spans are ordered by start key but may overlap.
 func MockBackupChain(
 	ctx context.Context,
-	length, spans, baseFiles int,
+	length, spans, baseFiles, fileSize int,
 	r *rand.Rand,
 	hasExternalFilesList bool,
 	execCfg sql.ExecutorConfig,
@@ -109,7 +109,7 @@ func MockBackupChain(
 			backups[i].Files[f].Span.Key = encoding.EncodeVarintAscending(k, int64(start))
 			backups[i].Files[f].Span.EndKey = encoding.EncodeVarintAscending(k, int64(end))
 			backups[i].Files[f].Path = fmt.Sprintf("12345-b%d-f%d.sst", i, f)
-			backups[i].Files[f].EntryCounts.DataSize = 1 << 20
+			backups[i].Files[f].EntryCounts.DataSize = int64(fileSize)
 		}
 
 		es, err := execCfg.DistSQLSrv.ExternalStorageFromURI(ctx,
@@ -226,6 +226,9 @@ func checkRestoreCovering(
 	}
 	var spanIdx int
 	for _, c := range cov {
+		if len(c.Files) > 500 {
+			return errors.Errorf("%d files in span %v", len(c.Files), c.Span)
+		}
 		for _, f := range c.Files {
 			if requireSpan, ok := required[f.Path]; ok {
 				requireSpan.Sub(c.Span)
@@ -1048,8 +1051,23 @@ func sanityCheckFileIterator(
 	}
 }
 
+func TestRestoreEntryCoverTinyFiles(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	runTestRestoreEntryCoverForSpanAndFileCounts(t, []int{5}, 5<<10, []int{5}, []int{1000, 5000}, []bool{false})
+}
+
 func TestRestoreEntryCover(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	spans := []int{1, 2, 3, 5, 9, 11, 12}
+	files := []int{0, 1, 2, 3, 4, 10, 12, 50}
+	backupCounts := []int{1, 2, 3, 5, 9, 10, 11, 12}
+	runTestRestoreEntryCoverForSpanAndFileCounts(t, backupCounts, 1<<20, spans, files, []bool{true, false})
+}
+
+func runTestRestoreEntryCoverForSpanAndFileCounts(
+	t *testing.T, backupCounts []int, fileSize int, spanCounts, fileCounts []int, simple []bool,
+) {
 	r, _ := randutil.NewTestRand()
 	ctx := context.Background()
 	tc, _, _, cleanupFn := backupRestoreTestSetup(t, singleNode, 1, InitManualReplication)
@@ -1079,12 +1097,12 @@ func TestRestoreEntryCover(t *testing.T) {
 		return merged
 	}
 
-	for _, numBackups := range []int{1, 2, 3, 5, 9, 10, 11, 12} {
-		for _, spans := range []int{1, 2, 3, 5, 9, 11, 12} {
-			for _, files := range []int{0, 1, 2, 3, 4, 10, 12, 50} {
+	for _, numBackups := range backupCounts {
+		for _, spans := range spanCounts {
+			for _, files := range fileCounts {
 				for _, hasExternalFilesList := range []bool{true, false} {
-					for _, simpleImportSpans := range []bool{true, false} {
-						backups, err := MockBackupChain(ctx, numBackups, spans, files, r, hasExternalFilesList, execCfg)
+					for _, simpleImportSpans := range simple {
+						backups, err := MockBackupChain(ctx, numBackups, spans, files, fileSize, r, hasExternalFilesList, execCfg)
 						require.NoError(t, err)
 						layerToIterFactory, err := backupinfo.GetBackupManifestIterFactories(ctx,
 							execCfg.DistSQLSrv.ExternalStorage, backups, nil, nil)


### PR DESCRIPTION
Backport 1/1 commits from #119840.

/cc @cockroachdb/release

---

Previously we would limit restore spans to 384MB, but if a backup contained many small files, a large number of these files could be grouped into such a span before it hit the 384MB target. Unfortunately this caused the restore process to open all of those files to process the restore span, leading to very large numbers of concurrent connections when restoring a backup consisting of tiny files.

This patch limits the restore spans to 384MB or 200 files, whichever is hit first. Restores of backups with large numbers of tiny files may thus be slightly slower but will better limit their concurrent outbound connections.

Fixes #119785.

NB: This breaks the test cases for the experimental/disabled support for memory-monitored restores. Given we have no plans to actually enable these at this time, but do need to fix this bug in the normal restore path and backport such a fix,  to reduce churn in said backports the tests of the disabled mode are simply skipped in this diff rather modified, in anticipation of removing them completely from the development branch, tracked in #119836.

Release note (bug fix): fix a bug where RESTORE on certain backups would open a very large number of concurrent connections to the backup storage provider.

Epic: none.

Release justification: bug fix.
