### PR TITLE
kvclient: don't backoff with unavailable leaseholder

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2665,6 +2665,7 @@ func (ds *DistSender) sendToReplicas(
 				}
 			case *kvpb.NotLeaseHolderError:
 				ds.metrics.NotLeaseHolderErrCount.Inc(1)
+				var lhRUE bool // lease holder replica unavailable error
 				// If we got some lease information, we use it. If not, we loop around
 				// and try the next replica.
 				if tErr.Lease != nil {
@@ -2682,7 +2683,6 @@ func (ds *DistSender) sendToReplicas(
 					if lh := routing.Leaseholder(); lh != nil {
 						// If we've already tried this replica and it's unavailable due to
 						// a tripped replica circuit breaker, skip it to avoid loops.
-						var lhRUE bool
 						if err := replicaUnavailableError; err != nil {
 							if rue := (*kvpb.ReplicaUnavailableError)(nil); errors.As(err, &rue) {
 								lhRUE = lh.IsSame(rue.Replica)
@@ -2730,6 +2730,11 @@ func (ds *DistSender) sendToReplicas(
 					// there's a lease transfer in progress and the would-be leaseholder
 					// has not yet applied the new lease.
 					//
+					// If the leaseholder is unavailable (lhRUE), we don't backoff since
+					// we aren't trying the leaseholder again, instead we want to cycle
+					// through the remaining replicas to see if they have the lease before
+					// we return to sendPartialBatch.
+					//
 					// TODO(arul): The idea here is for the client to not keep sending
 					// the would-be leaseholder multiple requests and backoff a bit to let
 					// it apply the its lease. Instead of deriving this information like
@@ -2738,7 +2743,7 @@ func (ds *DistSender) sendToReplicas(
 					// the replica we just tried), in which case we should backoff. With
 					// this scheme we'd no longer have to track "updatedLeaseholder" state
 					// when syncing the NLHE with the range cache.
-					shouldBackoff := !updatedLeaseholder && !intentionallySentToFollower
+					shouldBackoff := !updatedLeaseholder && !intentionallySentToFollower && !lhRUE
 					if shouldBackoff {
 						ds.metrics.InLeaseTransferBackoffs.Inc(1)
 						log.VErrEventf(ctx, 2, "backing off due to NotLeaseHolderErr with stale info")


### PR DESCRIPTION
Previously if the leaseholder was unavailable with a ReplicaUnavailableError and we were hitting a NotLeaseHolderError from a different store, we would back off after each failed attempt to the other replicas. This was an unintentional usage of the `InLeaseTransferBackoffs` as it doesn't indicate that the lease is about to move. Instead we should immediately try the next replicas without backoff as long as our cache is up-to-date and the leaseholder is down with a ReplicaUnavailableError.

This PR also updates the test to validate that we are not backing off. Prior to this change we would back off twice on each attempt. A nice benefit is this test runs faster now.

Epic: none

Release note: None