### PR TITLE
kvcoord: fix DistSender circuit breaker probe transport reset

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker.go
@@ -747,6 +747,8 @@ func (r *ReplicaCircuitBreaker) sendProbe(ctx context.Context, transport Transpo
 	sendCtx, cancel := context.WithTimeout(ctx, timeout) // nolint:context
 	defer cancel()
 
+	transport.Reset()
+
 	ba := &kvpb.BatchRequest{}
 	ba.RangeID = r.rangeID
 	ba.Replica = transport.NextReplica()
@@ -755,8 +757,6 @@ func (r *ReplicaCircuitBreaker) sendProbe(ctx context.Context, transport Transpo
 			Key: r.startKey,
 		},
 	})
-
-	transport.Reset()
 
 	log.VEventf(ctx, 2, "sending probe: %s", ba)
 	br, err := transport.SendNext(sendCtx, ba)


### PR DESCRIPTION
The probe transport was only reset after constructing the batch request. This could cause it to use an empty `Replica` if the transport had been exhausted by a previous probe, causing it to always fail with "batch request missing store ID".

Resolves #119939.
Epic: none
Release note: None