### PR TITLE
spanconfigsqltranslatorccl: move test to `large` pool

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
@@ -7,10 +7,7 @@ go_test(
         "main_test.go",
     ],
     data = glob(["testdata/**"]),
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "large"},
-        "//conditions:default": {"test.Pool": "default"},
-    }),
+    exec_properties = {"test.Pool": "large"},
     tags = ["ccl_test"],
     deps = [
         "//pkg/base",


### PR DESCRIPTION
informs: #119908
Epic: CRDB-8308
Release note: None