### PR TITLE
release-23.2: roachprod: add VM label for "spot" instance

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -302,23 +302,27 @@ hosts file.
 			// We use a hacky workaround below to color the empty string.
 			// [1] https://github.com/golang/go/issues/12073
 
-			// Print header.
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
-				"Cluster", "Clouds", "Size", "VM", "Arch",
-				color.HiWhiteString("$/hour"), color.HiWhiteString("$ Spent"),
-				color.HiWhiteString("Uptime"), color.HiWhiteString("TTL"),
-				color.HiWhiteString("$/TTL"))
-			// Print separator.
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
-				"", "", "", "",
-				color.HiWhiteString(""), color.HiWhiteString(""),
-				color.HiWhiteString(""), color.HiWhiteString(""),
-				color.HiWhiteString(""))
+			if !listDetails {
+				// Print header only if we are not printing cluster details.
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
+					"Cluster", "Clouds", "Size", "VM", "Arch",
+					color.HiWhiteString("$/hour"), color.HiWhiteString("$ Spent"),
+					color.HiWhiteString("Uptime"), color.HiWhiteString("TTL"),
+					color.HiWhiteString("$/TTL"))
+				// Print separator.
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
+					"", "", "", "",
+					color.HiWhiteString(""), color.HiWhiteString(""),
+					color.HiWhiteString(""), color.HiWhiteString(""),
+					color.HiWhiteString(""))
+			}
 			totalCostPerHour := 0.0
 			for _, name := range names {
 				c := filteredCloud.Clusters[name]
 				if listDetails {
-					c.PrintDetails(config.Logger)
+					if err = c.PrintDetails(config.Logger); err != nil {
+						return err
+					}
 				} else {
 					// N.B. Tabwriter doesn't support per-column alignment. It looks odd to have the cluster names right-aligned,
 					// so we make it left-aligned.

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -14,8 +14,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"sort"
+	"text/tabwriter"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
@@ -24,6 +26,28 @@ import (
 	"github.com/cockroachdb/errors"
 	"golang.org/x/sync/errgroup"
 )
+
+const (
+	// The following constants are headers that are used for printing the VM details.
+	headerName           = "Name"
+	headerDNS            = "DNS"
+	headerPrivateIP      = "Private IP"
+	headerPublicIP       = "Public IP"
+	headerMachineType    = "Machine Type"
+	headerCPUArch        = "CPU Arch"
+	headerCPUFamily      = "CPU Family"
+	headerProvisionModel = "Provision Model"
+
+	// Provisional models that are used for printing VM details.
+	spotProvisionModel     = "spot"
+	onDemandProvisionModel = "ondemand"
+)
+
+// printDetailsColumnHeaders are the headers to be printed in the defined sequence.
+var printDetailsColumnHeaders = []string{
+	headerName, headerDNS, headerPrivateIP, headerPublicIP, headerMachineType, headerCPUArch, headerCPUFamily,
+	headerProvisionModel,
+}
 
 // Cloud contains information about all known clusters (across multiple cloud
 // providers).
@@ -142,7 +166,7 @@ func (c *Cluster) String() string {
 }
 
 // PrintDetails TODO(peter): document
-func (c *Cluster) PrintDetails(logger *logger.Logger) {
+func (c *Cluster) PrintDetails(logger *logger.Logger) error {
 	logger.Printf("%s: %s ", c.Name, c.Clouds())
 	if !c.IsLocal() {
 		l := c.LifetimeRemaining().Round(time.Second)
@@ -154,9 +178,43 @@ func (c *Cluster) PrintDetails(logger *logger.Logger) {
 	} else {
 		logger.Printf("(no expiration)")
 	}
+	// Align columns left and separate with at least two spaces.
+	tw := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+	logPrettifiedHeader(tw, printDetailsColumnHeaders)
+
 	for _, vm := range c.VMs {
-		logger.Printf("  %s\t%s\t%s\t%s\t%s\t%s\t%s", vm.Name, vm.DNS, vm.PrivateIP, vm.PublicIP, vm.MachineType, vm.CPUArch, vm.CPUFamily)
+		provisionModel := onDemandProvisionModel
+		if vm.Preemptible {
+			provisionModel = spotProvisionModel
+		}
+		fmt.Fprintf(tw, "%s\n", prettifyRow(printDetailsColumnHeaders, map[string]string{
+			headerName: vm.Name, headerDNS: vm.DNS, headerPrivateIP: vm.PrivateIP, headerPublicIP: vm.PublicIP,
+			headerMachineType: vm.MachineType, headerCPUArch: string(vm.CPUArch), headerCPUFamily: vm.CPUFamily,
+			headerProvisionModel: provisionModel,
+		}))
 	}
+	return tw.Flush()
+}
+
+// logPrettifiedHeader writes a prettified row of headers to the tab writer.
+func logPrettifiedHeader(tw *tabwriter.Writer, headers []string) {
+	for _, header := range headers {
+		fmt.Fprintf(tw, "%s\t", header)
+	}
+	fmt.Fprint(tw, "\n")
+}
+
+// prettifyRow returns a prettified row of values. the sequence of the header is maintained.
+func prettifyRow(headers []string, rowMap map[string]string) string {
+	row := ""
+	for _, header := range headers {
+		value := ""
+		if v, ok := rowMap[header]; ok {
+			value = v
+		}
+		row = fmt.Sprintf("%s%s\t", row, value)
+	}
+	return row
 }
 
 // IsLocal returns true if c is a local cluster.

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -597,7 +597,9 @@ func SetupSSH(ctx context.Context, l *logger.Logger, clusterName string) error {
 		return err
 	}
 
-	cloudCluster.PrintDetails(l)
+	if err = cloudCluster.PrintDetails(l); err != nil {
+		return err
+	}
 	// Run ssh-keygen -R serially on each new VM in case an IP address has been recycled
 	for _, v := range cloudCluster.VMs {
 		cmd := exec.Command("ssh-keygen", "-R", v.PublicIP)
@@ -667,8 +669,7 @@ func Extend(l *logger.Logger, clusterName string, lifetime time.Duration) error 
 		return fmt.Errorf("cluster %s does not exist", clusterName)
 	}
 
-	c.PrintDetails(l)
-	return nil
+	return c.PrintDetails(l)
 }
 
 // Default scheduled backup runs a full backup every hour and an incremental

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1108,6 +1108,9 @@ func (p *Provider) Create(
 	time := timeutil.Now().Format(time.RFC3339)
 	time = strings.ToLower(strings.ReplaceAll(time, ":", "_"))
 	m[vm.TagCreated] = time
+	if providerOpts.useSpot {
+		m[vm.TagSpotInstance] = "true"
+	}
 
 	var labelPairs []string
 	addLabel := func(key, value string) {

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -35,6 +35,8 @@ const (
 	TagLifetime = "lifetime"
 	// TagRoachprod is roachprod tag const, value is true & false.
 	TagRoachprod = "roachprod"
+	// TagSpotInstance is a tag added to spot instance vms with value as true.
+	TagSpotInstance = "spot"
 	// TagUsage indicates where a certain resource is used. "roachtest" is used
 	// as the key for roachtest created resources.
 	TagUsage = "usage"


### PR DESCRIPTION
Backport 1/1 commits from #119763.

/cc @cockroachdb/release

---

what was there before: Previously, there was no way to identify spot instances using a label for tracking (billing)
why it needed to change: This was inadequate because the VMs can be tracked for billing using the added label
what you did about it: To address this, this patch adds a new tag as "spot:true"

Fixes: #119629
Epic: none
Release justification: test-only change